### PR TITLE
Allows mass scanners and shuttle console radars to resize gracefully

### DIFF
--- a/Content.Client/Shuttles/UI/DockingControl.cs
+++ b/Content.Client/Shuttles/UI/DockingControl.cs
@@ -16,15 +16,15 @@ public class DockingControl : Control
     private readonly IEntityManager _entManager;
     private readonly IMapManager _mapManager;
 
-    private const int MinimapMargin = 4;
-
     private float _range = 8f;
     private float _rangeSquared = 0f;
     private const float GridLinesDistance = 32f;
 
-    private int MidPoint => SizeFull / 2;
-    private int SizeFull => (int) ((RadarControl.MinimapRadius + MinimapMargin) * 2 * UIScale);
-    private int ScaledMinimapRadius => (int) (RadarControl.MinimapRadius * UIScale);
+    private int MinimapRadius => (int) Math.Min(Size.X, Size.Y) / 2;
+
+    private Vector2 MidPoint => Size / 2;
+    private int SizeFull => (int) (MinimapRadius * 2 * UIScale);
+    private int ScaledMinimapRadius => (int) (MinimapRadius * UIScale);
     private float MinimapScale => _range != 0 ? ScaledMinimapRadius / _range : 0f;
 
     public EntityUid? ViewedDock;
@@ -52,8 +52,8 @@ public class DockingControl : Control
 
         var fakeAA = new Color(0.08f, 0.08f, 0.08f);
 
-        handle.DrawCircle((MidPoint, MidPoint), ScaledMinimapRadius + 1, fakeAA);
-        handle.DrawCircle((MidPoint, MidPoint), ScaledMinimapRadius, Color.Black);
+        handle.DrawCircle((MidPoint.X, MidPoint.Y), ScaledMinimapRadius + 1, fakeAA);
+        handle.DrawCircle((MidPoint.X, MidPoint.Y), ScaledMinimapRadius, Color.Black);
 
         var gridLines = new Color(0.08f, 0.08f, 0.08f);
         var gridLinesRadial = 8;
@@ -61,14 +61,14 @@ public class DockingControl : Control
 
         for (var i = 1; i < gridLinesEquatorial + 1; i++)
         {
-            handle.DrawCircle((MidPoint, MidPoint), GridLinesDistance * MinimapScale * i, gridLines, false);
+            handle.DrawCircle((MidPoint.X, MidPoint.Y), GridLinesDistance * MinimapScale * i, gridLines, false);
         }
 
         for (var i = 0; i < gridLinesRadial; i++)
         {
             Angle angle = (Math.PI / gridLinesRadial) * i;
             var aExtent = angle.ToVec() * ScaledMinimapRadius;
-            handle.DrawLine((MidPoint, MidPoint) - aExtent, (MidPoint, MidPoint) + aExtent, gridLines);
+            handle.DrawLine((MidPoint.X, MidPoint.Y) - aExtent, (MidPoint.X, MidPoint.Y) + aExtent, gridLines);
         }
 
         if (Coordinates == null ||

--- a/Content.Client/Shuttles/UI/RadarConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/RadarConsoleWindow.xaml
@@ -1,6 +1,10 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:ui="clr-namespace:Content.Client.Shuttles.UI"
-                      Title="{Loc 'radar-console-window-title'}">
-    <ui:RadarControl Name="RadarScreen"/>
+                      Title="{Loc 'radar-console-window-title'}"
+                      MinSize="256 256">
+    <ui:RadarControl Name="RadarScreen"
+                     Margin="4"
+                     HorizontalExpand = "True"
+                     VerticalExpand = "True"/>
 </controls:FancyWindow>

--- a/Content.Client/Shuttles/UI/RadarControl.cs
+++ b/Content.Client/Shuttles/UI/RadarControl.cs
@@ -23,9 +23,6 @@ public sealed class RadarControl : Control
     [Dependency] private readonly IMapManager _mapManager = default!;
 
     private const float ScrollSensitivity = 8f;
-
-    public const int MinimapRadius = 320;
-    private const int MinimapMargin = 4;
     private const float GridLinesDistance = 32f;
 
     /// <summary>
@@ -49,8 +46,9 @@ public sealed class RadarControl : Control
     /// </summary>
     public float MaxRadarRange { get; private set; } = 256f * 10f;
 
-    private int MidPoint => SizeFull / 2;
-    private int SizeFull => (int) ((MinimapRadius + MinimapMargin) * 2 * UIScale);
+    private int MinimapRadius => (int) Math.Min(Size.X, Size.Y) / 2;
+    private Vector2 MidPoint => Size / 2;
+    private int SizeFull => (int) (MinimapRadius * 2 * UIScale);
     private int ScaledMinimapRadius => (int) (MinimapRadius * UIScale);
     private float MinimapScale => RadarRange != 0 ? ScaledMinimapRadius / RadarRange : 0f;
 
@@ -130,8 +128,8 @@ public sealed class RadarControl : Control
 
         var fakeAA = new Color(0.08f, 0.08f, 0.08f);
 
-        handle.DrawCircle((MidPoint, MidPoint), ScaledMinimapRadius + 1, fakeAA);
-        handle.DrawCircle((MidPoint, MidPoint), ScaledMinimapRadius, Color.Black);
+        handle.DrawCircle((MidPoint.X, MidPoint.Y), ScaledMinimapRadius + 1, fakeAA);
+        handle.DrawCircle((MidPoint.X, MidPoint.Y), ScaledMinimapRadius, Color.Black);
 
         // No data
         if (_coordinates == null || _rotation == null)
@@ -146,14 +144,14 @@ public sealed class RadarControl : Control
 
         for (var i = 1; i < gridLinesEquatorial + 1; i++)
         {
-            handle.DrawCircle((MidPoint, MidPoint), GridLinesDistance * MinimapScale * i, gridLines, false);
+            handle.DrawCircle((MidPoint.X, MidPoint.Y), GridLinesDistance * MinimapScale * i, gridLines, false);
         }
 
         for (var i = 0; i < gridLinesRadial; i++)
         {
             Angle angle = (Math.PI / gridLinesRadial) * i;
             var aExtent = angle.ToVec() * ScaledMinimapRadius;
-            handle.DrawLine((MidPoint, MidPoint) - aExtent, (MidPoint, MidPoint) + aExtent, gridLines);
+            handle.DrawLine((MidPoint.X, MidPoint.Y) - aExtent, (MidPoint.X, MidPoint.Y) + aExtent, gridLines);
         }
 
         var metaQuery = _entManager.GetEntityQuery<MetaDataComponent>();

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
@@ -1,7 +1,9 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:ui="clr-namespace:Content.Client.Shuttles.UI"
-                      Title="{Loc 'shuttle-console-window-title'}">
+                      Title="{Loc 'shuttle-console-window-title'}"
+                      SetSize="1180 648"
+                      MinSize="788 320">
     <GridContainer Columns="3"
                   HorizontalAlignment="Stretch"
                   Margin="5 5 5 5">
@@ -9,6 +11,7 @@
                       VerticalAlignment="Top"
                       HorizontalAlignment="Left"
                       MinWidth="256"
+                      MaxWidth="256"
                       Align="Center"
                       Orientation="Vertical">
             <BoxContainer Orientation="Vertical">
@@ -26,17 +29,27 @@
                               Orientation="Vertical"/>
             </BoxContainer>
         </BoxContainer>
-        <PanelContainer>
+        <PanelContainer MinSize="256 256"
+                        HorizontalAlignment = "Stretch"
+                        HorizontalExpand = "True"
+                        VerticalExpand = "True">
             <ui:RadarControl Name="RadarScreen"
-                             MouseFilter="Stop"/>
+                             MouseFilter="Stop"
+                             Margin="4"
+                             HorizontalExpand = "True"
+                             VerticalExpand = "True"/>
             <ui:DockingControl Name="DockingScreen"
                                Visible="False"
-                               MouseFilter="Stop"/>
+                               MouseFilter="Stop"
+                               Margin="4"
+                               HorizontalExpand = "True"
+                               VerticalExpand = "True"/>
         </PanelContainer>
         <BoxContainer Name="RightDisplay"
                       VerticalAlignment="Top"
                       HorizontalAlignment="Right"
                       MinWidth="256"
+                      MaxWidth="256"
                       Align="Center"
                       Orientation="Vertical">
             <controls:StripeBack>


### PR DESCRIPTION
## About the PR 
Instead of sitting down and writing a description, we shall show a video alone, as this PR is exactly what it says on the tin.

**Media**

https://user-images.githubusercontent.com/6356337/210114165-26b83d6a-77ce-4a55-a4e3-4bd38250a8a8.mp4



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Bhijn & Myr
- add: The radar shown in mass scanners and shuttle consoles now resizes gracefully, scaling as expected with whatever breathing room it has!
- tweak: The mass scanner and shuttle consoles now have minimum and default sizes to keep things relatively sane-looking