### PR TITLE
Ensure that we can change the local rotation when anchoring

### DIFF
--- a/Content.Server/Construction/AnchorableSystem.cs
+++ b/Content.Server/Construction/AnchorableSystem.cs
@@ -83,7 +83,14 @@ namespace Content.Server.Construction
 
             // Snap rotation to cardinal (multiple of 90)
             var rot = xform.LocalRotation;
-            xform.LocalRotation = Math.Round(rot / (Math.PI / 2)) * (Math.PI / 2);
+            var snappedAngle = Math.Round(rot / (Math.PI / 2)) * Math.PI * 2;
+            // We want to override the local rotation to `snappedAngle` regardless
+            // of the xforms `NoLocalRotation` setting, so temporarily allow a
+            // local rotation and restore it
+            var oldLocalRotation = xform.NoLocalRotation;
+            xform.NoLocalRotation = false;
+            xform.LocalRotation = snappedAngle;
+            xform.NoLocalRotation = oldLocalRotation;
 
             if (TryComp<SharedPullableComponent>(uid, out var pullable) && pullable.Puller != null)
             {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Always allow local rotation changes when anchoring an object. Fixes #13183. Not 100% sure what the use-case for the NoLocalRotation setting is for -- those objects probably need a more general fix for when they start to overlap a new grid, but this change at least allows players to anchor an object to realign it's transform so that it fits through doors etc.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Anchoring large objects now aligns them to their new grid

