### PR TITLE
Misc replay related changes

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -71,13 +71,23 @@ public partial class ChatBox : UIWidget
         UpdateSelectedChannel();
     }
 
+    public void Repopulate()
+    {
+        Contents.Clear();
+
+        foreach (var message in _controller.History)
+        {
+            OnMessageAdded(message.Item2);
+        }
+    }
+
     private void OnChannelFilter(ChatChannel channel, bool active)
     {
         Contents.Clear();
 
         foreach (var message in _controller.History)
         {
-            OnMessageAdded(message);
+            OnMessageAdded(message.Item2);
         }
 
         if (active)

--- a/Content.Server/Administration/GamePrototypeLoadManager.cs
+++ b/Content.Server/Administration/GamePrototypeLoadManager.cs
@@ -3,6 +3,8 @@ using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Replays;
+using Robust.Shared.Serialization.Markdown.Mapping;
 
 namespace Content.Server.Administration;
 
@@ -11,6 +13,7 @@ namespace Content.Server.Administration;
 /// </summary>
 public sealed class GamePrototypeLoadManager : IGamePrototypeLoadManager
 {
+    [Dependency] private readonly IReplayRecordingManager _replay = default!;
     [Dependency] private readonly IServerNetManager _netManager = default!;
     [Dependency] private readonly IAdminManager _adminManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -18,11 +21,22 @@ public sealed class GamePrototypeLoadManager : IGamePrototypeLoadManager
     [Dependency] private readonly ILocalizationManager _localizationManager = default!;
 
     private readonly List<string> _loadedPrototypes = new();
+    public IReadOnlyList<string> LoadedPrototypes => _loadedPrototypes;
 
     public void Initialize()
     {
         _netManager.RegisterNetMessage<GamePrototypeLoadMessage>(ClientLoadsPrototype);
         _netManager.Connected += NetManagerOnConnected;
+        _replay.OnRecordingStarted += OnStartReplayRecording;
+    }
+
+    private void OnStartReplayRecording((MappingDataNode, List<object>) initReplayData)
+    {
+        // replays will need information about currently loaded prototypes
+        foreach (var prototype in _loadedPrototypes)
+        {
+            initReplayData.Item2.Add(new ReplayPrototypeUploadMsg { PrototypeData = prototype });
+        }
     }
 
     public void SendGamePrototype(string prototype)
@@ -47,6 +61,9 @@ public sealed class GamePrototypeLoadManager : IGamePrototypeLoadManager
     private void LoadPrototypeData(string prototypeData)
     {
         _loadedPrototypes.Add(prototypeData);
+
+        _replay.QueueReplayMessage(new ReplayPrototypeUploadMsg { PrototypeData = prototypeData });
+
         var msg = new GamePrototypeLoadMessage
         {
             PrototypeData = prototypeData

--- a/Content.Server/Administration/NetworkResourceManager.cs
+++ b/Content.Server/Administration/NetworkResourceManager.cs
@@ -5,6 +5,8 @@ using Content.Shared.CCVar;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
+using Robust.Shared.Replays;
+using Robust.Shared.Serialization.Markdown.Mapping;
 
 namespace Content.Server.Administration;
 
@@ -15,6 +17,7 @@ public sealed class NetworkResourceManager : SharedNetworkResourceManager
     [Dependency] private readonly IServerNetManager _serverNetManager = default!;
     [Dependency] private readonly IConfigurationManager _cfgManager = default!;
     [Dependency] private readonly IServerDbManager _serverDb = default!;
+    [Dependency] private readonly IReplayRecordingManager _replay = default!;
 
     [ViewVariables] public bool Enabled { get; private set; } = true;
     [ViewVariables] public float SizeLimit { get; private set; } = 0f;
@@ -30,6 +33,16 @@ public sealed class NetworkResourceManager : SharedNetworkResourceManager
         _cfgManager.OnValueChanged(CCVars.ResourceUploadingStoreEnabled, value => StoreUploaded = value, true);
 
         AutoDelete(_cfgManager.GetCVar(CCVars.ResourceUploadingStoreDeletionDays));
+        _replay.OnRecordingStarted += OnStartReplayRecording;
+    }
+
+    private void OnStartReplayRecording((MappingDataNode, List<object>) initReplayData)
+    {
+        // replays will need information about currently loaded extra resources
+        foreach (var (path, data) in ContentRoot.GetAllFiles())
+        {
+            initReplayData.Item2.Add(new ReplayResourceUploadMsg { RelativePath = path, Data = data });
+        }
     }
 
     /// <summary>
@@ -62,6 +75,8 @@ public sealed class NetworkResourceManager : SharedNetworkResourceManager
         {
             channel.SendMessage(msg);
         }
+
+        _replay.QueueReplayMessage(new ReplayResourceUploadMsg { RelativePath = msg.RelativePath, Data = msg.Data });
 
         if (!StoreUploaded)
             return;

--- a/Content.Server/Fluids/EntitySystems/SpraySystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpraySystem.cs
@@ -20,6 +20,7 @@ public sealed class SpraySystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
     [Dependency] private readonly VaporSystem _vaporSystem = default!;
 
@@ -118,7 +119,7 @@ public sealed class SpraySystem : EntitySystem
             _vaporSystem.Start(vaporComponent, vaporXform, impulseDirection, component.SprayVelocity, target, component.SprayAliveTime, args.User);
         }
 
-        SoundSystem.Play(component.SpraySound.GetSound(), Filter.Pvs(uid), uid, AudioHelpers.WithVariation(0.125f));
+        _audio.PlayPvs(component.SpraySound, uid, component.SpraySound.Params.WithVariation(0.125f));
 
         RaiseLocalEvent(uid,
             new RefreshItemCooldownEvent(curTime, curTime + TimeSpan.FromSeconds(component.CooldownTime)), true);

--- a/Content.Shared/Administration/IGamePrototypeLoadManager.cs
+++ b/Content.Shared/Administration/IGamePrototypeLoadManager.cs
@@ -1,7 +1,19 @@
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
 namespace Content.Shared.Administration;
 
 public interface IGamePrototypeLoadManager
 {
     public void Initialize();
     public void SendGamePrototype(string prototype);
+}
+
+// TODO REPLAYS
+// Figure out a way to just directly save NetMessage objects to replays. This just uses IRobustSerializer as a crutch.
+
+[Serializable, NetSerializable]
+public sealed class ReplayPrototypeUploadMsg
+{
+    public string PrototypeData = default!;
 }

--- a/Content.Shared/Administration/SharedNetworkResourceManager.cs
+++ b/Content.Shared/Administration/SharedNetworkResourceManager.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.ContentPack;
 using Robust.Shared.Network;
+using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Administration;
@@ -37,5 +38,15 @@ public abstract class SharedNetworkResourceManager : IDisposable
         // This is called automatically when the IoCManager's dependency collection is cleared.
         // MemoryContentRoot uses a ReaderWriterLockSlim, which we need to dispose of.
         ContentRoot.Dispose();
+    }
+
+    // TODO REPLAYS
+    // Figure out a way to just directly save NetMessage objects to replays. This just uses IRobustSerializer as a crutch.
+
+    [Serializable, NetSerializable]
+    public sealed class ReplayResourceUploadMsg
+    {
+        public byte[] Data = default!;
+        public ResourcePath RelativePath = default!;
     }
 }

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -77,6 +77,9 @@ public abstract partial class SharedHandsSystem : EntitySystem
         if (!TryComp(session?.AttachedEntity, out SharedHandsComponent? component))
             return;
 
+        if (!_actionBlocker.CanInteract(session.AttachedEntity.Value, null))
+            return;
+
         if (component.ActiveHand == null || component.Hands.Count < 2)
             return;
 

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -32,7 +32,7 @@ namespace Content.Shared.Projectiles
         }
 
         [NetSerializable, Serializable]
-        protected sealed class ProjectileComponentState : ComponentState
+        public sealed class ProjectileComponentState : ComponentState
         {
             public ProjectileComponentState(EntityUid shooter, bool ignoreShooter)
             {
@@ -45,7 +45,7 @@ namespace Content.Shared.Projectiles
         }
 
         [Serializable, NetSerializable]
-        protected sealed class ImpactEffectEvent : EntityEventArgs
+        public sealed class ImpactEffectEvent : EntityEventArgs
         {
             public string Prototype;
             public EntityCoordinates Coordinates;

--- a/Content.Shared/Spawners/EntitySystems/SharedTimedDespawnSystem.cs
+++ b/Content.Shared/Spawners/EntitySystems/SharedTimedDespawnSystem.cs
@@ -7,6 +7,12 @@ public abstract class SharedTimedDespawnSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
 
+    public override void Initialize()
+    {
+        base.Initialize();
+        UpdatesOutsidePrediction = true;
+    }
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -404,7 +404,7 @@ public abstract partial class SharedGunSystem : EntitySystem
     /// Used for animated effects on the client.
     /// </summary>
     [Serializable, NetSerializable]
-    protected sealed class HitscanEvent : EntityEventArgs
+    public sealed class HitscanEvent : EntityEventArgs
     {
         public List<(EntityCoordinates coordinates, Angle angle, SpriteSpecifier Sprite, float Distance)> Sprites = new();
     }


### PR DESCRIPTION
This PR has misc changes related to getting working replay recordings & a client. Requires space-wizards/RobustToolbox/pull/3509

- Makes `GamePrototypeLoadManager` and `NetworkResourceManager` add uploaded data to replays.
- Chat history now also stores the tick at which a message was received.
- Added a function to refresh/repopupate chat controls.
- Adds a missing hand interaction check
- Fixes timed despawns not working when prediction is disabled.
- Makes some protected events/states public.