### PR TITLE
Fixed missing interaction outline for cardboard boxes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -49,6 +49,7 @@
     - type: Tag
       tags:
         - DoorBumpOpener
+    - type: InteractionOutline
 
 - type: entity
   id: StealthBox


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This pull request resolves #13216, which described a problem where cardboard boxes were missing interaction outlines. This means that hovering over the box with your mouse would not produce a green outline. I ended up fixing it by adding the `InteractionOutline` component to the box entity.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![Box Outline](https://user-images.githubusercontent.com/34360334/210157728-348bc73e-007a-4364-87bb-e814416bfd85.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Added missing interaction outline component to cardboard boxes.
