### PR TITLE
Make emitter use guncode

### DIFF
--- a/Content.Server/Singularity/Components/EmitterComponent.cs
+++ b/Content.Server/Singularity/Components/EmitterComponent.cs
@@ -15,19 +15,11 @@ namespace Content.Server.Singularity.Components
         // Whether the power switch is on AND the machine has enough power (so is actively firing)
         [ViewVariables] public bool IsPowered;
 
-        // For the "emitter fired" sound
-        public const float Variation = 0.25f;
-        public const float Volume = 0.5f;
-        public const float Distance = 6f;
-
         /// <summary>
         /// counts the number of consecutive shots fired.
         /// </summary>
         [ViewVariables]
         public int FireShotCounter;
-
-        [DataField("fireSound")]
-        public SoundSpecifier FireSound = new SoundPathSpecifier("/Audio/Weapons/emitter.ogg");
 
         /// <summary>
         /// The entity that is spawned when the emitter fires.

--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -6,16 +6,17 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.Projectiles;
 using Content.Server.Singularity.Components;
 using Content.Server.Storage.Components;
+using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared.Database;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Content.Shared.Singularity.Components;
+using Content.Shared.Weapons.Ranged.Components;
 using JetBrains.Annotations;
-using Robust.Shared.Audio;
+using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
-using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using Timer = Robust.Shared.Timing.Timer;
@@ -28,10 +29,9 @@ namespace Content.Server.Singularity.EntitySystems
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-        [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly ProjectileSystem _projectile = default!;
-        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+        [Dependency] private readonly GunSystem _gun = default!;
 
         public override void Initialize()
         {
@@ -207,33 +207,16 @@ namespace Content.Server.Singularity.EntitySystems
         private void Fire(EmitterComponent component)
         {
             var uid = component.Owner;
-            var projectile = EntityManager.SpawnEntity(component.BoltType, EntityManager.GetComponent<TransformComponent>(uid).Coordinates);
-
-            if (!EntityManager.TryGetComponent<PhysicsComponent?>(projectile, out var physicsComponent))
-            {
-                Logger.Error("Emitter tried firing a bolt, but it was spawned without a PhysicsComponent");
+            if (!TryComp<GunComponent>(uid, out var guncomp))
                 return;
-            }
 
-            physicsComponent.BodyStatus = BodyStatus.InAir;
+            var xform = Transform(uid);
+            var ent = Spawn(component.BoltType, xform.Coordinates);
+            var proj = EnsureComp<ProjectileComponent>(ent);
+            _projectile.SetShooter(proj, uid);
 
-            if (!EntityManager.TryGetComponent<ProjectileComponent?>(projectile, out var projectileComponent))
-            {
-                Logger.Error("Emitter tried firing a bolt, but it was spawned without a ProjectileComponent");
-                return;
-            }
-
-            _projectile.SetShooter(projectileComponent, component.Owner);
-
-            var worldRotation = Transform(uid).WorldRotation;
-            _physics.SetLinearVelocity(physicsComponent, worldRotation.ToWorldVec() * 20f);
-            Transform(projectile).WorldRotation = worldRotation;
-
-            // TODO: Move to projectile's code.
-            Timer.Spawn(3000, () => EntityManager.DeleteEntity(projectile));
-
-            _audio.PlayPvs(component.FireSound, component.Owner,
-                AudioParams.Default.WithVariation(EmitterComponent.Variation).WithVolume(EmitterComponent.Volume).WithMaxDistance(EmitterComponent.Distance));
+            var targetPos = new EntityCoordinates(uid, (0, -1));
+            _gun.Shoot(guncomp, ent, xform.Coordinates, targetPos);
         }
 
         private void UpdateAppearance(EmitterComponent component)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -222,6 +222,7 @@
       - state: projectile
         shader: unshaded
   - type: Ammo
+    muzzleFlash: null
   - type: Physics
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -243,6 +243,8 @@
   - type: Tag
     tags:
     - EmitterBolt
+  - type: TimedDespawn
+    lifetime: 3
 
 - type: entity
   id: BulletKinetic

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -34,6 +34,13 @@
       shader: unshaded
       visible: false
   - type: Emitter
+  - type: Gun
+    fireRate: 10 #just has to be fast enough to keep up with upgrades
+    selectedMode: SemiAuto
+    availableModes:
+      - SemiAuto
+    soundGunshot:
+      path: /Audio/Weapons/emitter.ogg
   - type: PowerConsumer
     voltage: Medium
   - type: NodeContainer


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
https://user-images.githubusercontent.com/98561806/210162327-d98f2db0-dbb7-4fbd-bab1-876357ceea39.mp4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

no cl no fun

