### PR TITLE
Fix random fails on NoCargoOrderArbitrage Test

### DIFF
--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -20,6 +20,8 @@ public sealed class CargoTest
         await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings() {NoClient = true});
         var server = pairTracker.Pair.Server;
 
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+
         var entManager = server.ResolveDependency<IEntityManager>();
         var mapManager = server.ResolveDependency<IMapManager>();
         var protoManager = server.ResolveDependency<IPrototypeManager>();
@@ -27,7 +29,7 @@ public sealed class CargoTest
 
         await server.WaitAssertion(() =>
         {
-            var mapId = mapManager.CreateMap();
+            var mapId = testMap.MapId;
 
             foreach (var proto in protoManager.EnumeratePrototypes<CargoProductPrototype>())
             {
@@ -50,13 +52,15 @@ public sealed class CargoTest
         await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true});
         var server = pairTracker.Pair.Server;
 
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+
         var entManager = server.ResolveDependency<IEntityManager>();
         var mapManager = server.ResolveDependency<IMapManager>();
         var protoManager = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
         {
-            var mapId = mapManager.CreateMap();
+            var mapId = testMap.MapId;
             var grid = mapManager.CreateGrid(mapId);
             var coord = new EntityCoordinates(grid.Owner, 0, 0);
 
@@ -73,8 +77,10 @@ public sealed class CargoTest
                     && stackpricecomp.Price > 0)
                 {
                     if (entManager.TryGetComponent<StaticPriceComponent>(ent, out var staticpricecomp))
+                    {
                         Assert.That(staticpricecomp.Price, Is.EqualTo(0),
-                                    $"The prototype {proto} have a StackPriceComponent and StaticPriceComponent whose values are not compatible with each other.");
+                            $"The prototype {proto} have a StackPriceComponent and StaticPriceComponent whose values are not compatible with each other.");
+                    }
                 }
                 entManager.DeleteEntity(ent);
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Kept seeing random fails on NoCargoOrderArbitrage test. These tweaks seem to fix it.
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

no cl no fun

