### PR TITLE
Allow fax machines on top of tables.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: Structures/Machines/fax_machine.rsi
+    drawdepth: SmallObjects
     netsync: false
     layers:
     - state: icon
@@ -23,9 +24,9 @@
         bounds: "-0.25,-0.25,0.25,0.25"
       density: 25
       mask:
-      - MachineMask
+      - TabletopMachineMask
       layer:
-      - MachineLayer
+      - TabletopMachineLayer
   - type: ActivatableUI
     key: enum.FaxUiKey.Key
   - type: ActivatableUIRequiresPower


### PR DESCRIPTION
Fax machine collision was conflicting with tables. Paper won't sit on top of it anymore, but you can at least place them on tables now.