### PR TITLE
Bugfixing potted plants

### DIFF
--- a/Content.Server/Storage/EntitySystems/SecretStashSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SecretStashSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Item;
 using Robust.Shared.Containers;
-using Robust.Shared.Player;
 
 namespace Content.Server.Storage.EntitySystems
 {
@@ -29,7 +28,7 @@ namespace Content.Server.Storage.EntitySystems
 
         private void OnDestroyed(EntityUid uid, SecretStashComponent component, DestructionEventArgs args)
         {
-            component.ItemContainer.EmptyContainer();
+            _containerSystem.EmptyContainer(component.ItemContainer, attachToGridOrMap: true);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If you put something in a plant and destroy the plant, item will be destroyed too since by default items on container empty are put into non-existence. This PR fixes such behavior.
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Prentor
- bug: destroying potted plants now drops it's content

