### PR TITLE
Adds gravity artifact effect

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GravityWellArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GravityWellArtifactComponent.cs
@@ -1,40 +1,50 @@
+using Content.Server.Singularity.Components;
+
 namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
 
+/// <summary>
+/// A component used to apply variation to the properties of a gravity well produced by an artifact.
+/// The most of the properties of this component correspond 1:1 with properties of an actual <see cref="GravityWellComponent"/>
+/// and define the range of possible values the corresponding property may have.
+/// </summary>
 [RegisterComponent]
 public sealed class GravityWellArtifactComponent : Component
 {
     /// <summary>
     /// The bounds on the outer range of the produced gravity well.
+    /// The upper bound should be lower than the lower bound for <see cref="MaxRange"/>.
+    /// See <see cref="GravityWellComponent.MaxRange"/> for the property this corresponds to.
     /// </summary>
     [DataField("minRange")]
     public (float min, float max) MinRange = (0f, 0f);
 
     /// <summary>
-    ///  The bounds on the inner range of the produced gravity well.
+    /// The bounds on the inner range of the produced gravity well.
+    /// The lower bound should be higher than the upper bound for <see cref="MinRange"/>.
+    /// See <see cref="GravityWellComponent.MinRange"/> for the property this corresponds to.
     /// </summary>
     [DataField("maxRange")]
     public (float min, float max) MaxRange = (0f, 0f);
 
     /// <summary>
     /// The bounds on the amount of radial acceleration the produced gravity well causes.
+    /// See <see cref="GravityWellComponent.BaseRadialAcceleration"/> for the property this corresponds to.
     /// </summary>
     [DataField("radialAcceleration")]
     public (float min, float max) RadialAcceleration = (0f, 0f);
 
     /// <summary>
     /// The bounds on the amount of tangential acceleration the produced gravity well causes.
+    /// See <see cref="GravityWellComponent.BaseTangentialAcceleration"/> for the property this corresponds to.
     /// </summary>
     [DataField("tangentialAcceleration")]
     public (float min, float max) TangentialAcceleration = (0f, 0f);
 
     /// <summary>
     /// The bounds on the amount of time between gravitational pulses produced by the artifact.
+    /// This also scales the amount of impulse applied to everything in range upon pulsing.
+    /// See <see cref="GravityWellComponent.TargetPulsePeriod"/> for the property this corresponds to.
     /// </summary>
     [DataField("pulsePeriod")]
     public (TimeSpan min, TimeSpan max) PulsePeriod = (TimeSpan.FromSeconds(.5f), TimeSpan.FromSeconds(.5f));
-
-    /// <summary>
-    /// Whether the artifact was already a gravity well when this was applied.
-    /// </summary>
-    public bool EntityWasAlreadyAGravityWell = false;
 }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GravityWellArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GravityWellArtifactComponent.cs
@@ -1,0 +1,40 @@
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+[RegisterComponent]
+public sealed class GravityWellArtifactComponent : Component
+{
+    /// <summary>
+    /// The bounds on the outer range of the produced gravity well.
+    /// </summary>
+    [DataField("minRange")]
+    public (float min, float max) MinRange = (0f, 0f);
+
+    /// <summary>
+    ///  The bounds on the inner range of the produced gravity well.
+    /// </summary>
+    [DataField("maxRange")]
+    public (float min, float max) MaxRange = (0f, 0f);
+
+    /// <summary>
+    /// The bounds on the amount of radial acceleration the produced gravity well causes.
+    /// </summary>
+    [DataField("radialAcceleration")]
+    public (float min, float max) RadialAcceleration = (0f, 0f);
+
+    /// <summary>
+    /// The bounds on the amount of tangential acceleration the produced gravity well causes.
+    /// </summary>
+    [DataField("tangentialAcceleration")]
+    public (float min, float max) TangentialAcceleration = (0f, 0f);
+
+    /// <summary>
+    /// The bounds on the amount of time between gravitational pulses produced by the artifact.
+    /// </summary>
+    [DataField("pulsePeriod")]
+    public (TimeSpan min, TimeSpan max) PulsePeriod = (TimeSpan.FromSeconds(.5f), TimeSpan.FromSeconds(.5f));
+
+    /// <summary>
+    /// Whether the artifact was already a gravity well when this was applied.
+    /// </summary>
+    public bool EntityWasAlreadyAGravityWell = false;
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/GravityWellArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/GravityWellArtifactSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Singularity.Components;
 using Content.Server.Singularity.EntitySystems;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
 using Robust.Shared.Random;
 
 namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
@@ -16,19 +17,21 @@ public sealed class GravityWellArtifactSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<GravityWellArtifactComponent, ComponentStartup>(SetupGravityWell);
-        SubscribeLocalEvent<GravityWellArtifactComponent, ComponentShutdown>(ShutdownGravityWell);
+        SubscribeLocalEvent<GravityWellArtifactComponent, ArtifactNodeEnteredEvent>(SetupGravityWell);
     }
 
-    private void SetupGravityWell(EntityUid uid, GravityWellArtifactComponent comp, ComponentStartup args)
+    /// <summary>
+    /// Sets up the state of the <see cref="GravityWellComponent"/> involved in granting an artifact a gravity well as an effect.
+    /// </summary>
+    /// <param name="uid">The uid of the artifact being given a gravity well.</param>
+    /// <param name="comp">The state of the gravity well effect the artifact has.</param>
+    /// <param name="args">The prompt to initialize the effects of the current node.</param>
+    private void SetupGravityWell(EntityUid uid, GravityWellArtifactComponent comp, ArtifactNodeEnteredEvent args)
     {
-        if (HasComp<GravityWellComponent>(uid))
-        {
-            comp.EntityWasAlreadyAGravityWell = true;
+        GravityWellComponent? gravWell = null;
+        if(!Resolve(uid, ref gravWell))
             return;
-        }
 
-        var gravWell = AddComp<GravityWellComponent>(uid);
         gravWell.MinRange = _random.NextFloat(comp.MinRange.min, comp.MinRange.max);
         gravWell.MaxRange = _random.NextFloat(comp.MaxRange.min, comp.MaxRange.max);
         gravWell.BaseRadialAcceleration = _random.NextFloat(comp.RadialAcceleration.min, comp.RadialAcceleration.max);
@@ -38,14 +41,5 @@ public sealed class GravityWellArtifactSystem : EntitySystem
             TimeSpan.FromSeconds(_random.NextFloat((float)comp.PulsePeriod.min.TotalSeconds, (float)comp.PulsePeriod.max.TotalSeconds)),
             gravWell
         );
-    }
-
-    private void ShutdownGravityWell(EntityUid uid, GravityWellArtifactComponent comp, ComponentShutdown args)
-    {
-        if (comp.EntityWasAlreadyAGravityWell)
-            return;
-
-        /// Can't source-track so just assume that we are reponsible for making the entity a gravity well.
-        RemComp<GravityWellComponent>(uid);
     }
 }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/GravityWellArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/GravityWellArtifactSystem.cs
@@ -1,0 +1,51 @@
+using Content.Server.Singularity.Components;
+using Content.Server.Singularity.EntitySystems;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Robust.Shared.Random;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class GravityWellArtifactSystem : EntitySystem
+{
+    #region Dependencies
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly GravityWellSystem _gravWellSystem = default!;
+    #endregion Dependencies
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GravityWellArtifactComponent, ComponentStartup>(SetupGravityWell);
+        SubscribeLocalEvent<GravityWellArtifactComponent, ComponentShutdown>(ShutdownGravityWell);
+    }
+
+    private void SetupGravityWell(EntityUid uid, GravityWellArtifactComponent comp, ComponentStartup args)
+    {
+        if (HasComp<GravityWellComponent>(uid))
+        {
+            comp.EntityWasAlreadyAGravityWell = true;
+            return;
+        }
+
+        var gravWell = AddComp<GravityWellComponent>(uid);
+        gravWell.MinRange = _random.NextFloat(comp.MinRange.min, comp.MinRange.max);
+        gravWell.MaxRange = _random.NextFloat(comp.MaxRange.min, comp.MaxRange.max);
+        gravWell.BaseRadialAcceleration = _random.NextFloat(comp.RadialAcceleration.min, comp.RadialAcceleration.max);
+        gravWell.BaseTangentialAcceleration = _random.NextFloat(comp.TangentialAcceleration.min, comp.TangentialAcceleration.max);
+        _gravWellSystem.SetPulsePeriod(
+            uid,
+            TimeSpan.FromSeconds(_random.NextFloat((float)comp.PulsePeriod.min.TotalSeconds, (float)comp.PulsePeriod.max.TotalSeconds)),
+            gravWell
+        );
+    }
+
+    private void ShutdownGravityWell(EntityUid uid, GravityWellArtifactComponent comp, ComponentShutdown args)
+    {
+        if (comp.EntityWasAlreadyAGravityWell)
+            return;
+
+        /// Can't source-track so just assume that we are reponsible for making the entity a gravity well.
+        RemComp<GravityWellComponent>(uid);
+    }
+}

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -419,6 +419,23 @@
   - type: IgniteArtifact
 
 - type: artifactEffect
+  id: EffectGravityWell
+  targetDepth: 3
+  effectHint: artifact-effect-hint-environment
+  components:
+  - type: GravityWellArtifact
+    maxRange:
+      5.0: 10.0
+    minRange:
+      0.0: 3.0
+    radialAcceleration:
+      -50.0: 50.0
+    tangentialAcceleration:
+      -50.0: 50.0
+    pulsePeriod:
+      0.5: 5.0
+
+- type: artifactEffect
   id: EffectMitosis
   targetDepth: 4
   effectHint: artifact-effect-hint-creation

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -423,17 +423,13 @@
   targetDepth: 3
   effectHint: artifact-effect-hint-environment
   components:
+  - type: GravityWell # Required for the actual effect to function. Do not add as a permanent effect elsewhere or things will break.
   - type: GravityWellArtifact
-    maxRange:
-      5.0: 10.0
-    minRange:
-      0.0: 3.0
-    radialAcceleration:
-      -50.0: 50.0
-    tangentialAcceleration:
-      -50.0: 50.0
-    pulsePeriod:
-      0.5: 5.0
+    maxRange: {5.0: 10.0} # Weird syntax required because tuples cannot be parsed from sequences. Key is Item1, value is Item2.
+    minRange: {0.0: 3.0}
+    radialAcceleration: {-50.0: 50.0}
+    tangentialAcceleration: {-50.0: 50.0}
+    pulsePeriod: {0.5: 5.0}
 
 - type: artifactEffect
   id: EffectMitosis


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an artifact effect which generates a gravity well similar to a singularity.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase TODO

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added gravity wells as a possible artifact effect.

