### PR TITLE
Hand teleporter / portal tweaks

### DIFF
--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -1,4 +1,6 @@
-﻿using Content.Shared.Interaction.Events;
+﻿using System.Threading;
+using Content.Server.DoAfter;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Systems;
 using Robust.Server.GameObjects;
@@ -12,11 +14,26 @@ public sealed class HandTeleporterSystem : EntitySystem
 {
     [Dependency] private readonly LinkedEntitySystem _link = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly DoAfterSystem _doafter = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeLocalEvent<HandTeleporterComponent, UseInHandEvent>(OnUseInHand);
+
+        SubscribeLocalEvent<HandTeleporterComponent, HandTeleporterSuccessEvent>(OnPortalSuccess);
+        SubscribeLocalEvent<HandTeleporterComponent, HandTeleporterCancelledEvent>(OnPortalCancelled);
+    }
+
+    private void OnPortalSuccess(EntityUid uid, HandTeleporterComponent component, HandTeleporterSuccessEvent args)
+    {
+        component.CancelToken = null;
+        HandlePortalUpdating(uid, component, args.User);
+    }
+
+    private void OnPortalCancelled(EntityUid uid, HandTeleporterComponent component, HandTeleporterCancelledEvent args)
+    {
+        component.CancelToken = null;
     }
 
     private void OnUseInHand(EntityUid uid, HandTeleporterComponent component, UseInHandEvent args)
@@ -27,19 +44,67 @@ public sealed class HandTeleporterSystem : EntitySystem
         if (Deleted(component.SecondPortal))
             component.SecondPortal = null;
 
+        if (component.CancelToken != null)
+        {
+            component.CancelToken.Cancel();
+            return;
+        }
+
+        if (component.FirstPortal != null && component.SecondPortal != null)
+        {
+            // handle removing portals immediately as opposed to a doafter
+            HandlePortalUpdating(uid, component, args.User);
+        }
+        else
+        {
+            var xform = Transform(args.User);
+            if (xform.ParentUid != xform.GridUid)
+                return;
+
+            component.CancelToken = new CancellationTokenSource();
+            var doafterArgs = new DoAfterEventArgs(args.User, component.PortalCreationDelay,
+                component.CancelToken.Token, used: uid)
+            {
+                BreakOnDamage = true,
+                BreakOnStun = true,
+                BreakOnUserMove = true,
+                MovementThreshold = 0.5f,
+                UsedCancelledEvent = new HandTeleporterCancelledEvent(),
+                UsedFinishedEvent = new HandTeleporterSuccessEvent(args.User)
+            };
+
+            _doafter.DoAfter(doafterArgs);
+        }
+    }
+
+
+    /// <summary>
+    ///     Creates or removes a portal given the state of the hand teleporter.
+    /// </summary>
+    private void HandlePortalUpdating(EntityUid uid, HandTeleporterComponent component, EntityUid user)
+    {
+        if (Deleted(user))
+            return;
+
+        var xform = Transform(user);
+
         // Create the first portal.
         if (component.FirstPortal == null && component.SecondPortal == null)
         {
-            var timeout = EnsureComp<PortalTimeoutComponent>(args.User);
+            // don't portal
+            if (xform.ParentUid != xform.GridUid)
+                return;
+
+            var timeout = EnsureComp<PortalTimeoutComponent>(user);
             timeout.EnteredPortal = null;
-            component.FirstPortal = Spawn(component.FirstPortalPrototype, Transform(args.User).Coordinates);
+            component.FirstPortal = Spawn(component.FirstPortalPrototype, Transform(user).Coordinates);
             _audio.PlayPvs(component.NewPortalSound, uid);
         }
         else if (component.SecondPortal == null)
         {
-            var timeout = EnsureComp<PortalTimeoutComponent>(args.User);
+            var timeout = EnsureComp<PortalTimeoutComponent>(user);
             timeout.EnteredPortal = null;
-            component.SecondPortal = Spawn(component.SecondPortalPrototype, Transform(args.User).Coordinates);
+            component.SecondPortal = Spawn(component.SecondPortalPrototype, Transform(user).Coordinates);
             _link.TryLink(component.FirstPortal!.Value, component.SecondPortal.Value, true);
             _audio.PlayPvs(component.NewPortalSound, uid);
         }

--- a/Content.Shared/Teleportation/Components/HandTeleporterComponent.cs
+++ b/Content.Shared/Teleportation/Components/HandTeleporterComponent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Audio;
+﻿using System.Threading;
+using Content.Shared.Audio;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -33,4 +34,22 @@ public sealed class HandTeleporterComponent : Component
 
     [DataField("clearPortalsSound")]
     public SoundSpecifier ClearPortalsSound = new SoundPathSpecifier("/Audio/Machines/button.ogg");
+
+    /// <summary>
+    ///     Delay for creating the portals in seconds.
+    /// </summary>
+    [DataField("portalCreationDelay")]
+    public float PortalCreationDelay = 2.5f;
+
+    public CancellationTokenSource? CancelToken = null;
 }
+
+/// <summary>
+///     Raised on doafter success for creating a portal.
+/// </summary>
+public record HandTeleporterSuccessEvent(EntityUid User);
+
+/// <summary>
+///     Raised on doafter cancel for creating a portal.
+/// </summary>
+public record HandTeleporterCancelledEvent;

--- a/Content.Shared/Teleportation/Components/PortalComponent.cs
+++ b/Content.Shared/Teleportation/Components/PortalComponent.cs
@@ -27,5 +27,5 @@ public sealed class PortalComponent : Component
     ///     If no portals are linked, the subject will be teleported a random distance at maximum this far away.
     /// </summary>
     [DataField("maxRandomRadius")]
-    public float MaxRandomRadius = 10.0f;
+    public float MaxRandomRadius = 7.0f;
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

see clog

impetus behind doafter change as opposed to battery/charge/whatever is that im mostly just concerned about people getting shafted by unintentionally entering portals. a doafter gives enough notice that it's coming and people can't driveby teleport others using it now. if people want to intentionally fuck themselves over by entering a portal after the fact thats their problem

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


https://user-images.githubusercontent.com/19853115/210314072-e858051e-e524-4931-996b-f77e8709ecf2.mp4



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Hand teleporter now requires a doafter, and can't be used when inside anything.
- tweak: Portal random teleport now teleports you less farther away at maximum.
