### PR TITLE
Fixes mass scanner UIs being smol by default by defining a setsize

### DIFF
--- a/Content.Client/Shuttles/UI/RadarConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/RadarConsoleWindow.xaml
@@ -2,6 +2,7 @@
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:ui="clr-namespace:Content.Client.Shuttles.UI"
                       Title="{Loc 'radar-console-window-title'}"
+                      SetSize="648 648"
                       MinSize="256 256">
     <ui:RadarControl Name="RadarScreen"
                      Margin="4"


### PR DESCRIPTION
## About the PR
This is something we forgot to commit in #13241. Because this was missing, mass scanners on live are small by default! This PR simply defines a setsize for the mass scanner console that roughly matches up with their original static size of 640x640 (excluding margins of 4px). Shuttle consoles already have their setsize defined with this same treatment.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

(#13241's changelog didn't get properly added to the ingame changelog for some reason! We're suspecting that this was due to the presence of `&` in the author field, as some bots get confused by non-alphanumeric characters. So the changelog here includes a duplicate of that PR's changelog but without the `&`, which in theory should work due to author names with spaces being present in the changelog just fine.)

:cl: Bhijn and Myr
- add: The radar shown in mass scanners and shuttle consoles now resizes gracefully, scaling as expected with whatever breathing room it has! (Originally merged on December 30, 2022)
- tweak: The mass scanner and shuttle consoles now have minimum and default sizes to keep things relatively sane-looking (Originally merged on December 30, 2022)
- fix: The mass scanner UI now actually has a default size defined. This was left out of the original PR by mistake

