### PR TITLE
Improve port selector UI.

### DIFF
--- a/Content.Client/MachineLinking/UI/SignalPortSelectorMenu.xaml
+++ b/Content.Client/MachineLinking/UI/SignalPortSelectorMenu.xaml
@@ -1,12 +1,14 @@
-<DefaultWindow xmlns="https://spacestation14.io" Title="{Loc signal-port-selector-menu-title}" MinSize="400 200">
+<DefaultWindow xmlns="https://spacestation14.io" Title="{Loc signal-port-selector-menu-title}" MinSize="400 200" SetSize="600 300">
     <BoxContainer Orientation="Vertical" VerticalExpand="True">
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True">
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="0.3">
+                <Label Text="{Loc signal-port-selector-menu-transmitter}" />
                 <RichTextLabel Name="HeaderLeft"/>
                 <BoxContainer Name="ButtonContainerLeft" Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True"/>
             </BoxContainer>
             <BoxContainer Name="ContainerMiddle" Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="0.2"/>
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="0.3">
+                <Label Text="{Loc signal-port-selector-menu-receiver}" />
                 <RichTextLabel Name="HeaderRight"/>
                 <BoxContainer Name="ButtonContainerRight" Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True"/>
             </BoxContainer>

--- a/Resources/Locale/en-US/machine-linking/port-selector.ftl
+++ b/Resources/Locale/en-US/machine-linking/port-selector.ftl
@@ -1,3 +1,5 @@
 signal-port-selector-menu-title = Port Selector
 signal-port-selector-menu-clear = Clear
 signal-port-selector-menu-link-defaults = Link defaults
+signal-port-selector-menu-transmitter = Transmitter
+signal-port-selector-menu-receiver = Receiver

--- a/Resources/Prototypes/MachineLinking/transmitter_ports.yml
+++ b/Resources/Prototypes/MachineLinking/transmitter_ports.yml
@@ -44,11 +44,13 @@
   id: CloningPodSender
   name: signal-port-name-pod-receiver
   description: signal-port-description-pod-sender
+  defaultLinks: [ CloningPodReceiver ]
 
 - type: transmitterPort
   id: MedicalScannerSender
   name: signal-port-name-med-scanner-sender
   description: signal-port-description-med-scanner-sender
+  defaultLinks: [ MedicalScannerReceiver ]
 
 - type: transmitterPort
   id: ArtifactAnalyzerSender


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1. Expand the window by default.
2. Label which side is the transmitter and which is the receiver.
3. Allow cloning pod and medical scanner to be linked to their defaults with the `Link defaults` button.

**Media**

Before:

![image](https://user-images.githubusercontent.com/114301317/210840290-185b126a-2d96-4830-9ace-a47ca8c2a997.png)

After:

![image](https://user-images.githubusercontent.com/114301317/210840312-32832d55-13ca-427b-9c36-2f96e58f3fd9.png)


**Changelog**


:cl:
- tweak: The port selector UI should now display the connections without needing to manually resize the window.
- add: Cloning pods and medical scanners may now make use of the link defaults feature of the port selector.

