### PR TITLE
wallmount gen and sub fixes

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
@@ -21,9 +21,10 @@
         - !type:GivePrototype
           prototype: SheetSteel1
           amount: 5
+        - !type:DeleteEntity {}
       - to: parts
         steps:
-        - material: Cable
+        - material: CableApcStack1
           amount: 5
           doAfter: 2
         - tool: Screwing
@@ -52,7 +53,7 @@
       - to: frame
         completed:
         - !type:GivePrototype
-          prototype: CableHVStack1
+          prototype: Cable
           amount: 5
         steps:
         - tool: Cutting

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
@@ -24,7 +24,7 @@
         - !type:DeleteEntity {}
       - to: parts
         steps:
-        - material: CableApcStack1
+        - material: Cable
           amount: 5
           doAfter: 2
         - tool: Screwing
@@ -53,7 +53,7 @@
       - to: frame
         completed:
         - !type:GivePrototype
-          prototype: Cable
+          prototype: CableApcStack1
           amount: 5
         steps:
         - tool: Cutting

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
@@ -21,6 +21,7 @@
         - !type:GivePrototype
           prototype: SheetSteel1
           amount: 5
+        - !type:DeleteEntity {}
       - to: parts
         steps:
         - material: Cable
@@ -43,7 +44,7 @@
       - to: frame
         completed:
         - !type:GivePrototype
-          prototype: CableHVStack1
+          prototype: CableApcStack1
           amount: 5
         steps:
         - tool: Cutting


### PR DESCRIPTION
## About the PR

Previously welding a wallmount generator/apu frame gave you the steel but left a useless start node recipe thing there, this pr deletes it

**Media**
Before:
![before.webm](https://user-images.githubusercontent.com/39013340/211009604-7fdc1a52-e2a2-43a4-abcf-e613c22af74d.webm)

After:
![after.webm](https://user-images.githubusercontent.com/39013340/211009632-5bcde72e-8614-4275-93f6-aded133cd86b.webm)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame

**Changelog**
:cl:
- fix: fix some deconstruction bugs with wallmount equipment