### PR TITLE
fixes radar UI improperly scaling with ui scaling

### DIFF
--- a/Content.Client/Shuttles/UI/DockingControl.cs
+++ b/Content.Client/Shuttles/UI/DockingControl.cs
@@ -22,7 +22,7 @@ public class DockingControl : Control
 
     private int MinimapRadius => (int) Math.Min(Size.X, Size.Y) / 2;
 
-    private Vector2 MidPoint => Size / 2;
+    private Vector2 MidPoint => (Size / 2) * UIScale;
     private int SizeFull => (int) (MinimapRadius * 2 * UIScale);
     private int ScaledMinimapRadius => (int) (MinimapRadius * UIScale);
     private float MinimapScale => _range != 0 ? ScaledMinimapRadius / _range : 0f;

--- a/Content.Client/Shuttles/UI/RadarControl.cs
+++ b/Content.Client/Shuttles/UI/RadarControl.cs
@@ -47,7 +47,7 @@ public sealed class RadarControl : Control
     public float MaxRadarRange { get; private set; } = 256f * 10f;
 
     private int MinimapRadius => (int) Math.Min(Size.X, Size.Y) / 2;
-    private Vector2 MidPoint => Size / 2;
+    private Vector2 MidPoint => (Size / 2) * UIScale;
     private int SizeFull => (int) (MinimapRadius * 2 * UIScale);
     private int ScaledMinimapRadius => (int) (MinimapRadius * UIScale);
     private float MinimapScale => RadarRange != 0 ? ScaledMinimapRadius / RadarRange : 0f;


### PR DESCRIPTION
## About the PR 
The original PR worked on local!!!

This PR does exactly as it says on the tin; makes the radar UI scale properly with ui scaling settings that stray from the default!

**Media**
![image](https://user-images.githubusercontent.com/6356337/211111327-e65414c8-8b61-4a37-a638-ca9b2a7bb111.png)
![image](https://user-images.githubusercontent.com/6356337/211111424-cdbb717e-d910-4dfa-bc8a-bf1129fefdd5.png)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**


:cl: Bhijn and Myr
- fix: The radar shown in mass scanners and shuttle consoles now properly scales with your UI scaling setting!

