### PR TITLE
More portal fixes

### DIFF
--- a/Content.Server/Explosion/Components/TriggerOnCollideComponent.cs
+++ b/Content.Server/Explosion/Components/TriggerOnCollideComponent.cs
@@ -5,5 +5,11 @@ namespace Content.Server.Explosion.Components
     {
 		[DataField("fixtureID", required: true)]
 		public string FixtureID = String.Empty;
+
+        /// <summary>
+        ///     Doesn't trigger if the other colliding fixture is nonhard.
+        /// </summary>
+        [DataField("ignoreOtherNonHard")]
+        public bool IgnoreOtherNonHard = true;
     }
 }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -102,7 +102,7 @@ namespace Content.Server.Explosion.EntitySystems
 
         private void OnTriggerCollide(EntityUid uid, TriggerOnCollideComponent component, ref StartCollideEvent args)
         {
-			if(args.OurFixture.ID == component.FixtureID)
+			if(args.OurFixture.ID == component.FixtureID && (!component.IgnoreOtherNonHard || args.OtherFixture.Hard))
 				Trigger(component.Owner);
         }
 

--- a/Content.Shared/Teleportation/Systems/LinkedEntitySystem.cs
+++ b/Content.Shared/Teleportation/Systems/LinkedEntitySystem.cs
@@ -40,7 +40,7 @@ public sealed class LinkedEntitySystem : EntitySystem
         // Remove any links to this entity when deleted.
         foreach (var ent in component.LinkedEntities.ToArray())
         {
-            if (LifeStage(ent) < EntityLifeStage.Terminating && TryComp<LinkedEntityComponent>(ent, out var link))
+            if (!Deleted(ent) && LifeStage(ent) < EntityLifeStage.Terminating && TryComp<LinkedEntityComponent>(ent, out var link))
             {
                 TryUnlink(uid, ent, component, link);
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

fixes #13338 
fixes #13337 (leet as fuck)

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://user-images.githubusercontent.com/19853115/211113775-a198a56a-b148-4403-8d6f-f6881c92f2f5.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Rockets can now pass through portals
