### PR TITLE
Minor artifact fixes

### DIFF
--- a/Content.Server/Construction/AnchorableSystem.cs
+++ b/Content.Server/Construction/AnchorableSystem.cs
@@ -123,7 +123,7 @@ namespace Content.Server.Construction
             {
                 if (!bodyQuery.TryGetComponent(ent, out var body) ||
                     !body.CanCollide ||
-                    (!body.Hard && body.BodyType != BodyType.Static))
+                    !body.Hard)
                 {
                     continue;
                 }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/PhasingArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/PhasingArtifactComponent.cs
@@ -5,6 +5,6 @@
 ///     and such.
 /// </summary>
 [RegisterComponent]
-public sealed class ClearFixturesArtifactComponent : Component
+public sealed class PhasingArtifactComponent : Component
 {
 }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/PhasingArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/PhasingArtifactSystem.cs
@@ -2,35 +2,35 @@
 using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
 using Content.Shared.Physics;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
 
 /// <summary>
 ///     Handles allowing activated artifacts to phase through walls.
 /// </summary>
-public sealed class ClearFixturesArtifactSystem : EntitySystem
+public sealed class PhasingArtifactSystem : EntitySystem
 {
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+
     /// <inheritdoc/>
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<ClearFixturesArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+        SubscribeLocalEvent<PhasingArtifactComponent, ArtifactActivatedEvent>(OnActivate);
     }
 
-    private void OnActivate(EntityUid uid, ClearFixturesArtifactComponent component, ArtifactActivatedEvent args)
+    private void OnActivate(EntityUid uid, PhasingArtifactComponent component, ArtifactActivatedEvent args)
     {
-        if (!TryComp<FixturesComponent>(uid, out var fixtures))
+        if (!TryComp<FixturesComponent>(uid, out var fixtures) || !TryComp<PhysicsComponent>(uid, out var phys))
             return;
 
         foreach (var (_, fixture) in fixtures.Fixtures)
         {
-            if (!fixture.Hard)
-                continue;
-
-            fixture.CollisionLayer = (int) CollisionGroup.None;
-            fixture.CollisionMask = (int) CollisionGroup.None;
+            _physics.SetHard(fixture, false, fixtures);
         }
     }
 }

--- a/Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl
+++ b/Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl
@@ -16,7 +16,7 @@ artifact-effect-hint-storage = Internal chamber
 artifact-effect-hint-drill = Serrated rotator
 artifact-effect-hint-soap = Lubricated surface
 artifact-effect-hint-communication = Long-distance communication
-artifact-effect-hint-fixtures = Structural phasing
+artifact-effect-hint-phasing = Structural phasing
 artifact-effect-hint-sentience = Neurological activity
 
 # the triggers should be more obvious than the effects

--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -48,11 +48,11 @@
     capacity: 50
 
 - type: artifactEffect
-  id: EffectClearFixtures
+  id: EffectPhasing
   targetDepth: 2
-  effectHint: artifact-effect-hint-fixtures
+  effectHint: artifact-effect-hint-phasing
   permanentComponents:
-  - type: ClearFixturesArtifact
+  - type: PhasingArtifact
 
 - type: artifactEffect
   id: EffectWandering

--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -58,6 +58,9 @@
   id: EffectWandering
   targetDepth: 2
   effectHint: artifact-effect-hint-displacement
+  blacklist:
+    components:
+    - Item # item artifacts can't be anchored, so wanderers can't really be scanned properly
   permanentComponents:
   - type: RandomWalk
     minSpeed: 12


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- rename `ClearFixturesArtifact` to `PhasingArtifact`
- phasing now just sets fixtures to nonhard instead of clearing, so it can still collide with the artifact analyzer and be scannable
- anchorable ignores nonhard entirely now for `TileFree`. idk why it only ignored it sometimes so @metalgearsloth i assume there was a reason for that but i cant think of one. this way artifacts can actually be anchored down onto the analyzer which fixes wandering artifacts being impossible to scan

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://user-images.githubusercontent.com/19853115/211121542-e65a14dc-269e-4762-845c-ebabacf83e65.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Phasing artifacts are now scannable again.
- fix: Artifacts can now be anchored onto the scanner, so wandering artifacts are no longer essentially impossible to scan.
