### PR TITLE
Fix action callbacks when switching ui layout

### DIFF
--- a/Content.Client/UserInterface/Systems/Alerts/AlertsUIController.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/AlertsUIController.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Alerts;
+using Content.Client.Alerts;
 using Content.Client.Gameplay;
 using Content.Client.UserInterface.Systems.Alerts.Widgets;
 using Content.Shared.Alert;
@@ -26,7 +26,17 @@ public sealed class AlertsUIController : UIController, IOnStateEntered<GameplayS
     private void SystemOnSyncAlerts(object? sender, IReadOnlyDictionary<AlertKey, AlertState> e)
     {
         if (sender is ClientAlertsSystem system)
+        {
             UI?.SyncControls(system, system.AlertOrder, e);
+        }
+
+        // The UI can change underneath us if the user switches between HUD layouts
+        // So ensure we're subscribed to the AlertPressed callback.
+        if (UI != null)
+        {
+            UI.AlertPressed -= OnAlertPressed; // Ensure we don't hook into the callback twice
+            UI.AlertPressed += OnAlertPressed;
+        }
     }
 
     public void OnSystemLoaded(ClientAlertsSystem system)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This fixes a bug discussed recently on #11949 where, after changing UI layout between "Seperated" and "Default," the actions on the right hand side of the screen couldn't be clicked[1].

The AlertsUIController only hooked up the "alert click" callback when the game UI was being initialized. When the user switches the HUD layout, the UI instance in use was changed, but the AlertsUIController wasn't re-registering the callback. 

[1] I never even knew they could be!

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:

