### PR TITLE
Don't give maps shuttlecomponent

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -98,6 +98,9 @@ namespace Content.Server.Shuttles.Systems
 
         private void OnGridInit(GridInitializeEvent ev)
         {
+            if (HasComp<MapComponent>(ev.EntityUid))
+                return;
+
             EntityManager.EnsureComponent<ShuttleComponent>(ev.EntityUid);
         }
 


### PR DESCRIPTION
Easiest way to tell what is a moveable grid and what isn't