### PR TITLE
Dont refresh movespeed in clothing handler

### DIFF
--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -56,13 +56,13 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
         if (args.Current is not ClothingSpeedModifierComponentState state)
             return;
 
-        component.WalkModifier = state.WalkModifier;
-        component.SprintModifier = state.SprintModifier;
-        component.Enabled = state.Enabled;
-
         var diff = component.Enabled != state.Enabled ||
                    !MathHelper.CloseTo(component.SprintModifier, state.SprintModifier) ||
                    !MathHelper.CloseTo(component.WalkModifier, state.WalkModifier);
+
+        component.WalkModifier = state.WalkModifier;
+        component.SprintModifier = state.SprintModifier;
+        component.Enabled = state.Enabled;
 
         if (diff && _container.TryGetContainingContainer(uid, out var container))
         {

--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -64,6 +64,8 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
         component.SprintModifier = state.SprintModifier;
         component.Enabled = state.Enabled;
 
+        // Avoid raising the event for the container if nothing changed.
+        // We'll still set the values in case they're slightly different but within tolerance.
         if (diff && _container.TryGetContainingContainer(uid, out var container))
         {
             _movementSpeed.RefreshMovementSpeedModifiers(container.Owner);

--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -53,16 +53,20 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
 
     private void OnHandleState(EntityUid uid, ClothingSpeedModifierComponent component, ref ComponentHandleState args)
     {
-        if (args.Current is ClothingSpeedModifierComponentState state)
-        {
-            component.WalkModifier = state.WalkModifier;
-            component.SprintModifier = state.SprintModifier;
-            component.Enabled = state.Enabled;
+        if (args.Current is not ClothingSpeedModifierComponentState state)
+            return;
 
-            if (_container.TryGetContainingContainer(uid, out var container))
-            {
-                _movementSpeed.RefreshMovementSpeedModifiers(container.Owner);
-            }
+        component.WalkModifier = state.WalkModifier;
+        component.SprintModifier = state.SprintModifier;
+        component.Enabled = state.Enabled;
+
+        var diff = component.Enabled != state.Enabled ||
+                   !MathHelper.CloseTo(component.SprintModifier, state.SprintModifier) ||
+                   !MathHelper.CloseTo(component.WalkModifier, state.WalkModifier);
+
+        if (diff && _container.TryGetContainingContainer(uid, out var container))
+        {
+            _movementSpeed.RefreshMovementSpeedModifiers(container.Owner);
         }
     }
 


### PR DESCRIPTION
If the values are the same we shouldn't be needing to raise these on our parent container.