### PR TITLE
Crayonsystem cleanup

### DIFF
--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -71,7 +71,6 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
         if (component.UseSound != null)
             _audio.PlayPvs(_audio.GetSound(component.UseSound), uid, AudioHelpers.WithVariation(0.125f));
-//            SoundSystem.Play(component.UseSound.GetSound(), Filter.Pvs(uid), uid, AudioHelpers.WithVariation(0.125f));
 
         // Decrease "Ammo"
         component.Charges--;
@@ -92,12 +91,10 @@ public sealed class CrayonSystem : SharedCrayonSystem
         if (!TryComp<ActorComponent>(args.User, out var actor)) return;
 
         _uiSystem.ToggleUi(component.UserInterface!, actor.PlayerSession);
-//        component.UserInterface?.Toggle(actor.PlayerSession);
 
         if (component.UserInterface?.SubscribedSessions.Contains(actor.PlayerSession) == true)
         {
             // Tell the user interface the selected stuff
-//            component.UserInterface.SetState(new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color));
             _uiSystem.SetUiState(component.UserInterface, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color));
         }
 
@@ -140,7 +137,6 @@ public sealed class CrayonSystem : SharedCrayonSystem
     {
         if (TryComp<ActorComponent>(args.User, out var actor))
             _uiSystem.CloseUi(component.UserInterface!, actor!.PlayerSession);
-            //component.UserInterface?.Close(actor.PlayerSession);
     }
 
     private void UseUpCrayon(EntityUid uid, EntityUid user)

--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -23,6 +23,8 @@ public sealed class CrayonSystem : SharedCrayonSystem
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly DecalSystem _decals = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
 
     public override void Initialize()
     {
@@ -68,7 +70,8 @@ public sealed class CrayonSystem : SharedCrayonSystem
             return;
 
         if (component.UseSound != null)
-            SoundSystem.Play(component.UseSound.GetSound(), Filter.Pvs(uid), uid, AudioHelpers.WithVariation(0.125f));
+            _audio.PlayPvs(_audio.GetSound(component.UseSound), uid, AudioHelpers.WithVariation(0.125f));
+//            SoundSystem.Play(component.UseSound.GetSound(), Filter.Pvs(uid), uid, AudioHelpers.WithVariation(0.125f));
 
         // Decrease "Ammo"
         component.Charges--;
@@ -88,12 +91,14 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
         if (!TryComp<ActorComponent>(args.User, out var actor)) return;
 
-        component.UserInterface?.Toggle(actor.PlayerSession);
+        _uiSystem.ToggleUi(component.UserInterface!, actor.PlayerSession);
+//        component.UserInterface?.Toggle(actor.PlayerSession);
 
-        if (component.UserInterface?.SessionHasOpen(actor.PlayerSession) == true)
+        if (component.UserInterface?.SubscribedSessions.Contains(actor.PlayerSession) == true)
         {
             // Tell the user interface the selected stuff
-            component.UserInterface.SetState(new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color));
+//            component.UserInterface.SetState(new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color));
+            _uiSystem.SetUiState(component.UserInterface, new CrayonBoundUserInterfaceState(component.SelectedState, component.SelectableColor, component.Color));
         }
 
         args.Handled = true;
@@ -134,7 +139,8 @@ public sealed class CrayonSystem : SharedCrayonSystem
     private void OnCrayonDropped(EntityUid uid, CrayonComponent component, DroppedEvent args)
     {
         if (TryComp<ActorComponent>(args.User, out var actor))
-            component.UserInterface?.Close(actor.PlayerSession);
+            _uiSystem.CloseUi(component.UserInterface!, actor!.PlayerSession);
+            //component.UserInterface?.Close(actor.PlayerSession);
     }
 
     private void UseUpCrayon(EntityUid uid, EntityUid user)

--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -88,9 +88,13 @@ public sealed class CrayonSystem : SharedCrayonSystem
         if (args.Handled)
             return;
 
-        if (!TryComp<ActorComponent>(args.User, out var actor)) return;
+        if (!TryComp<ActorComponent>(args.User, out var actor) ||
+            component.UserInterface == null)
+        {
+            return;
+        }
 
-        _uiSystem.ToggleUi(component.UserInterface!, actor.PlayerSession);
+        _uiSystem.ToggleUi(component.UserInterface, actor.PlayerSession);
 
         if (component.UserInterface?.SubscribedSessions.Contains(actor.PlayerSession) == true)
         {
@@ -136,7 +140,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
     private void OnCrayonDropped(EntityUid uid, CrayonComponent component, DroppedEvent args)
     {
         if (TryComp<ActorComponent>(args.User, out var actor))
-            _uiSystem.CloseUi(component.UserInterface!, actor!.PlayerSession);
+            _uiSystem.TryClose(uid, SharedCrayonComponent.CrayonUiKey.Key, actor.PlayerSession);
     }
 
     private void UseUpCrayon(EntityUid uid, EntityUid user)

--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -70,7 +70,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
             return;
 
         if (component.UseSound != null)
-            _audio.PlayPvs(_audio.GetSound(component.UseSound), uid, AudioHelpers.WithVariation(0.125f));
+            _audio.PlayPvs(component.UseSound, uid, AudioHelpers.WithVariation(0.125f));
 
         // Decrease "Ammo"
         component.Charges--;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
cleans up obsolete stuff in crayonsystem
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->
-cleans up crayonsystem

