### PR TITLE
Locksystem cleanup

### DIFF
--- a/Content.Server/Lock/LockSystem.cs
+++ b/Content.Server/Lock/LockSystem.cs
@@ -41,7 +41,7 @@ namespace Content.Server.Lock
         {
             if (EntityManager.TryGetComponent(lockComp.Owner, out AppearanceComponent? appearance))
             {
-                _appearanceSystem.SetData(lockComp.Owner, StorageVisuals.CanLock, true, appearance);
+                _appearanceSystem.SetData(uid, StorageVisuals.CanLock, true, appearance);
             }
         }
 
@@ -93,17 +93,17 @@ namespace Content.Server.Lock
             if (!HasUserAccess(uid, user, quiet: false))
                 return false;
 
-            _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-do-lock-success", ("entityName", EntityManager.GetComponent<MetaDataComponent>(lockComp.Owner).EntityName)), lockComp.Owner, user);
+            _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-do-lock-success", ("entityName", EntityManager.GetComponent<MetaDataComponent>(uid).EntityName)), uid, user);
             lockComp.Locked = true;
 
             if(lockComp.LockSound != null)
             {
-                _audio.PlayPvs(_audio.GetSound(lockComp.LockSound), lockComp.Owner, AudioParams.Default.WithVolume(-5));
+                _audio.PlayPvs(_audio.GetSound(lockComp.LockSound), uid, AudioParams.Default.WithVolume(-5));
             }
 
-            if (EntityManager.TryGetComponent(lockComp.Owner, out AppearanceComponent? appearanceComp))
+            if (EntityManager.TryGetComponent(uid, out AppearanceComponent? appearanceComp))
             {
-                _appearanceSystem.SetData(lockComp.Owner, StorageVisuals.Locked, true, appearanceComp);
+                _appearanceSystem.SetData(uid, StorageVisuals.Locked, true, appearanceComp);
             }
 
             RaiseLocalEvent(lockComp.Owner, new LockToggledEvent(true), true);
@@ -118,19 +118,19 @@ namespace Content.Server.Lock
 
             if (user is { Valid: true })
             {
-                _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-do-unlock-success", ("entityName", EntityManager.GetComponent<MetaDataComponent>(lockComp.Owner).EntityName)), lockComp.Owner, user.Value);
+                _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-do-unlock-success", ("entityName", EntityManager.GetComponent<MetaDataComponent>(uid).EntityName)), uid, user.Value);
             }
 
             lockComp.Locked = false;
 
             if (lockComp.UnlockSound != null)
             {
-                _audio.PlayPvs(_audio.GetSound(lockComp.UnlockSound), lockComp.Owner, AudioParams.Default.WithVolume(-5));
+                _audio.PlayPvs(_audio.GetSound(lockComp.UnlockSound), uid, AudioParams.Default.WithVolume(-5));
             }
 
             if (EntityManager.TryGetComponent(lockComp.Owner, out AppearanceComponent? appearanceComp))
             {
-                _appearanceSystem.SetData(lockComp.Owner, StorageVisuals.Locked, false, appearanceComp);
+                _appearanceSystem.SetData(uid, StorageVisuals.Locked, false, appearanceComp);
             }
 
             RaiseLocalEvent(lockComp.Owner, new LockToggledEvent(false), true);
@@ -196,16 +196,16 @@ namespace Content.Server.Lock
 
         private void OnEmagged(EntityUid uid, LockComponent component, GotEmaggedEvent args)
         {
-            if (component.Locked == true)
+            if (component.Locked)
             {
                 if (component.UnlockSound != null)
                 {
-                    _audio.PlayPvs(_audio.GetSound(component.UnlockSound), component.Owner, AudioParams.Default.WithVolume(-5));
+                    _audio.PlayPvs(_audio.GetSound(component.UnlockSound), uid, AudioParams.Default.WithVolume(-5));
                 }
 
                 if (EntityManager.TryGetComponent(component.Owner, out AppearanceComponent? appearanceComp))
                 {
-                    _appearanceSystem.SetData(component.Owner, StorageVisuals.Locked, false, appearanceComp);
+                    _appearanceSystem.SetData(uid, StorageVisuals.Locked, false, appearanceComp);
                 }
                 EntityManager.RemoveComponent<LockComponent>(uid); //Literally destroys the lock as a tell it was emagged
                 args.Handled = true;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
cleans up some obsolete code in LockSystem
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->
-cleans up some obsolete code in LockSystem
