### PR TITLE
Fix AHelp erroring when sending empty avatar and footer icon urls

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -295,10 +295,10 @@ namespace Content.Server.Administration.Systems
             return new WebhookPayload
             {
                 Username = username,
-                AvatarUrl = _avatarUrl,
+                AvatarUrl = string.IsNullOrWhiteSpace(_avatarUrl) ? null : _avatarUrl,
                 Embeds = new List<Embed>
                 {
-                    new Embed
+                    new()
                     {
                         Description = messages,
                         Color = color,
@@ -438,7 +438,7 @@ namespace Content.Server.Administration.Systems
             public string Username { get; set; } = "";
 
             [JsonPropertyName("avatar_url")]
-            public string AvatarUrl { get; set; } = "";
+            public string? AvatarUrl { get; set; } = "";
 
             [JsonPropertyName("embeds")]
             public List<Embed>? Embeds { get; set; } = null;

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -305,7 +305,7 @@ namespace Content.Server.Administration.Systems
                         Footer = new EmbedFooter
                         {
                             Text = $"{serverName} ({round})",
-                            IconUrl = _footerIconUrl,
+                            IconUrl = string.IsNullOrWhiteSpace(_footerIconUrl) ? null : _footerIconUrl
                         },
                     },
                 },
@@ -479,7 +479,7 @@ namespace Content.Server.Administration.Systems
             public string Text { get; set; } = "";
 
             [JsonPropertyName("icon_url")]
-            public string IconUrl { get; set; } = "";
+            public string? IconUrl { get; set; }
 
             public EmbedFooter()
             {


### PR DESCRIPTION
## About the PR 
From Grafana:
![image](https://user-images.githubusercontent.com/10968691/211605537-da233001-2a36-4d3f-8b43-1f7b12bd454b.png)

avatar_url and footer_url are not required:
https://discord.com/developers/docs/resources/webhook

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://user-images.githubusercontent.com/10968691/211608486-f4345818-d0d7-46bd-81cc-2f468c722a35.png)

**Changelog**
:cl:
- fix: Fixed AHelp relay to discord not working.

