### PR TITLE
Reword the PR template to be more concise

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 <!-- 
 PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
 Small fixes/refactors are exempt.
-If you include media in your pull request, we may potentially use it in the SS14 progress reports, with clear credit given.
+Any media may be used in SS14 progress reports, with clear credit given.
 
 If you're unsure whether your PR will require media, ask a maintainer.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Check the box below to confirm that you have in fact seen this (put an X in the 
 <!--
 Here you can fill out a changelog that will automatically be added to the game when your PR is merged.
 
-Only put changes that are important to the player on the changelog.
+Only put changes that are important and visible to the player on the changelog.
 
 Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
 bad: - add: a new tool for engineers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Check the box below to confirm that you have in fact seen this (put an X in the 
 <!--
 Here you can fill out a changelog that will automatically be added to the game when your PR is merged.
 
-Only put changes that are important and visible to the player on the changelog.
+Only put changes that are visible and important to the player on the changelog.
 
 Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
 bad: - add: a new tool for engineers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,39 +1,39 @@
-<!-- The text between the arrows are comments - they will not be visible on your PR. -->
 <!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
+<!-- The text between the arrows are comments - they will not be visible on your PR. -->
 
-## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
+## About the PR
+<!-- What does it change? What other things could this impact? -->
+
 
 **Media**
 <!-- 
-If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
-(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
-This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
-may potentially use it in the SS14 progress reports, with clear credit given.
+PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
+Small fixes/refactors are exempt.
+If you include media in your pull request, we may potentially use it in the SS14 progress reports, with clear credit given.
 
-Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
 If you're unsure whether your PR will require media, ask a maintainer.
 
-Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
+Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
 -->
 
 - [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
 
 **Changelog**
 <!--
-Here you can fill out a changelog that will automatically be added to the game when your PR is merged
-There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.
+Here you can fill out a changelog that will automatically be added to the game when your PR is merged.
 
-You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
-Like so: :cl: PJB
+Only put changes that are important to the player on the changelog.
 
-Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.
-
-For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
+Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
 bad: - add: a new tool for engineers
 good: - add: added a new tool for engineers
+
+Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
+Like so: :cl: PJB
 -->
 
 :cl:
 - add: Added fun!
 - remove: Removed fun!
-
+- tweak: Changed fun!
+- fix: Fixed fun!


### PR DESCRIPTION
## About the PR
It is a bit of a clusterfuck:
![image](https://user-images.githubusercontent.com/10968691/211636857-ef274cf0-2f7d-4dba-83cb-570c73219b25.png)

Some of the information has been moved to https://docs.spacestation14.io/en/getting-started/pr-guideline, since I don't think we need to remind people how to take a screenshot directly on the PR template.

1499 vs 2153 characters (it now fits in a discord message without Nitro)

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

