### PR TITLE
Fix playglobalsound with a volume parameter being too loud

### DIFF
--- a/Content.Server/Audio/ServerGlobalSoundSystem.cs
+++ b/Content.Server/Audio/ServerGlobalSoundSystem.cs
@@ -76,7 +76,7 @@ public sealed class ServerGlobalSoundSystem : SharedGlobalSoundSystem
     public void PlayGlobalSoundCommand(IConsoleShell shell, string argStr, string[] args)
     {
         Filter filter;
-        var audio = AudioParams.Default.WithVolume(-8);
+        var audio = AudioParams.Default;
 
         bool replay = true;
 
@@ -139,6 +139,7 @@ public sealed class ServerGlobalSoundSystem : SharedGlobalSoundSystem
                 break;
         }
 
+        audio = audio.AddVolume(-8);
         PlayAdminGlobal(filter, args[0], audio, replay);
     }
 }


### PR DESCRIPTION
## About the PR
Applies the -8 volume change at the end of the method, instead of letting it be overridden.
1 is now the default.

**Media**
**(Enable sound on the video player)**

https://user-images.githubusercontent.com/10968691/211642042-0d8928bd-be9c-4d5e-acf1-64f6f0c41981.mp4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed admins blowing out your eardrums when playing a global sound.

