### PR TITLE
Add panic bunker toggle to admin menu

### DIFF
--- a/Content.Client/Administration/UI/Tabs/ServerTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/ServerTab.xaml
@@ -5,7 +5,6 @@
     MinSize="50 50">
     <GridContainer
         Columns="4" >
-        <cc:CommandButton Command="restart" Text="{Loc server-reboot}" />
         <cc:CommandButton Command="shutdown" Text="{Loc server-shutdown}" />
         <cc:CommandButton Name="SetOocButton" Command="setooc" Text="{Loc server-ooc-toggle}" ToggleMode="True" />
         <cc:CommandButton Name="SetLoocButton" Command="setlooc" Text="{Loc server-looc-toggle}" ToggleMode="True" />

--- a/Content.Client/Administration/UI/Tabs/ServerTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/ServerTab.xaml
@@ -9,5 +9,6 @@
         <cc:CommandButton Command="shutdown" Text="{Loc server-shutdown}" />
         <cc:CommandButton Name="SetOocButton" Command="setooc" Text="{Loc server-ooc-toggle}" ToggleMode="True" />
         <cc:CommandButton Name="SetLoocButton" Command="setlooc" Text="{Loc server-looc-toggle}" ToggleMode="True" />
+        <cc:CommandButton Name="SetPanicbunkerButton" Command="panicbunker" Text="{Loc server-panicbunker-toggle}" ToggleMode="True" />
     </GridContainer>
 </Control>

--- a/Content.Client/Administration/UI/Tabs/ServerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/ServerTab.xaml.cs
@@ -44,6 +44,7 @@ namespace Content.Client.Administration.UI.Tabs
             {
                 _config.UnsubValueChanged(CCVars.OocEnabled, OocEnabledChanged);
                 _config.UnsubValueChanged(CCVars.LoocEnabled, LoocEnabledChanged);
+                _config.UnsubValueChanged(CCVars.PanicBunkerEnabled, BunkerEnabledChanged);
             }
         }
     }

--- a/Content.Client/Administration/UI/Tabs/ServerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/ServerTab.xaml.cs
@@ -18,6 +18,7 @@ namespace Content.Client.Administration.UI.Tabs
 
             _config.OnValueChanged(CCVars.OocEnabled, OocEnabledChanged, true);
             _config.OnValueChanged(CCVars.LoocEnabled, LoocEnabledChanged, true);
+            _config.OnValueChanged(CCVars.PanicBunkerEnabled, BunkerEnabledChanged, true);
         }
 
         private void OocEnabledChanged(bool value)
@@ -28,6 +29,11 @@ namespace Content.Client.Administration.UI.Tabs
         private void LoocEnabledChanged(bool value)
         {
             SetLoocButton.Pressed = value;
+        }
+
+        private void BunkerEnabledChanged(bool value)
+        {
+            SetPanicbunkerButton.Pressed = value;
         }
 
         protected override void Dispose(bool disposing)

--- a/Content.Server/Administration/Commands/PanicBunkerCommand.cs
+++ b/Content.Server/Administration/Commands/PanicBunkerCommand.cs
@@ -15,15 +15,13 @@ public sealed class PanicBunkerCommand : IConsoleCommand
     public string Help => "panicbunker";
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        var cfg = IoCManager.Resolve<IConfigurationManager>();
-
         if (args.Length > 1)
         {
             shell.WriteError(Loc.GetString("shell-need-between-arguments",("lower", 0), ("upper", 1)));
             return;
         }
 
-        var enabled = cfg.GetCVar(CCVars.PanicBunkerEnabled);
+        var enabled = _cfg.GetCVar(CCVars.PanicBunkerEnabled);
         
         if (args.Length == 0)
         {

--- a/Content.Server/Administration/Commands/PanicBunkerCommand.cs
+++ b/Content.Server/Administration/Commands/PanicBunkerCommand.cs
@@ -12,21 +12,32 @@ public sealed class PanicBunkerCommand : IConsoleCommand
 
     public string Command => "panicbunker";
     public string Description => "Enables or disables the panic bunker functionality.";
-    public string Help => "panicbunker <enabled>";
+    public string Help => "panicbunker";
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        if (args.Length != 1)
+        var cfg = IoCManager.Resolve<IConfigurationManager>();
+
+        if (args.Length > 1)
         {
-            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            shell.WriteError(Loc.GetString("shell-need-between-arguments",("lower", 0), ("upper", 1)));
             return;
         }
 
-        if (!bool.TryParse(args[0], out var enabled))
+        var enabled = cfg.GetCVar(CCVars.PanicBunkerEnabled);
+        
+        if (args.Length == 0)
         {
-            shell.WriteError(Loc.GetString("shell-invalid-bool"));
+            enabled = !enabled;
+        }
+        
+        if (args.Length == 1 && !bool.TryParse(args[0], out enabled))
+        {
+            shell.WriteError(Loc.GetString("shell-argument-must-be-boolean"));
             return;
         }
 
         _cfg.SetCVar(CCVars.PanicBunkerEnabled, enabled);
+        
+        shell.WriteLine(Loc.GetString(enabled ? "panicbunker-command-enabled" : "panicbunker-command-disabled"));
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -250,7 +250,7 @@ namespace Content.Shared.CCVar
         /// Whether or not panic bunker is currently enabled.
         /// </summary>
         public static readonly CVarDef<bool> PanicBunkerEnabled =
-            CVarDef.Create("game.panic_bunker.enabled", false, CVar.SERVERONLY);
+            CVarDef.Create("game.panic_bunker.enabled", false, CVar.NOTIFY | CVar.REPLICATED);
 
         /// <summary>
         /// Show reason of disconnect for user or not.

--- a/Resources/Locale/en-US/administration/commands/panicbunker.ftl
+++ b/Resources/Locale/en-US/administration/commands/panicbunker.ftl
@@ -1,2 +1,2 @@
-panicbunker-command-enabled = Panic nubker has been enabled.
-panicbunker-command-disabled = Panic nubker has been disabled.
+panicbunker-command-enabled = Panic bunker has been enabled.
+panicbunker-command-disabled = Panic bunker has been disabled.

--- a/Resources/Locale/en-US/administration/commands/panicbunker.ftl
+++ b/Resources/Locale/en-US/administration/commands/panicbunker.ftl
@@ -1,0 +1,2 @@
+panicbunker-command-enabled = Panic nubker has been enabled.
+panicbunker-command-disabled = Panic nubker has been disabled.

--- a/Resources/Locale/en-US/administration/ui/tabs/server-tab.ftl
+++ b/Resources/Locale/en-US/administration/ui/tabs/server-tab.ftl
@@ -1,4 +1,3 @@
-server-reboot = Reboot
 server-shutdown = Shutdown
 server-ooc-toggle = Toggle OOC
 server-looc-toggle = Toggle LOOC

--- a/Resources/Locale/en-US/administration/ui/tabs/server-tab.ftl
+++ b/Resources/Locale/en-US/administration/ui/tabs/server-tab.ftl
@@ -2,3 +2,4 @@ server-reboot = Reboot
 server-shutdown = Shutdown
 server-ooc-toggle = Toggle OOC
 server-looc-toggle = Toggle LOOC
+server-panicbunker-toggle = Toggle Panic bunker


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
A very useful feature that admins forget about

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/14136326/212208468-05ebf537-7d5a-43eb-9ebb-ea40e4e7ccc1.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

