### PR TITLE
Fix verb menu not loading

### DIFF
--- a/Content.Client/ContextMenu/UI/ContextMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/ContextMenuUIController.cs
@@ -108,7 +108,6 @@ namespace Content.Client.ContextMenu.UI
             CancelOpen?.Cancel();
             CancelOpen = new();
             Timer.Spawn(HoverDelay, () => OpenSubMenu(element), CancelOpen.Token);
-            OnContextMouseEntered?.Invoke(element);
         }
 
         /// <summary>
@@ -170,7 +169,7 @@ namespace Content.Client.ContextMenu.UI
             // open pop-up adjacent to the parent element. We want the sub-menu elements to align with this element
             // which depends on the panel container style margins.
             var altPos = element.GlobalPosition;
-            var pos = altPos + (element.Width + 2*ContextMenuElement.ElementMargin, - 2*ContextMenuElement.ElementMargin);
+            var pos = altPos + (element.Width + 2 * ContextMenuElement.ElementMargin, -2 * ContextMenuElement.ElementMargin);
             element.SubMenu.Open(UIBox2.FromDimensions(pos, (1, 1)), altPos);
 
             // draw on top of other menus

--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -64,7 +64,6 @@ namespace Content.Client.ContextMenu.UI
         {
             _updating = true;
             _cfg.OnValueChanged(CCVars.EntityMenuGroupingType, OnGroupingChanged, true);
-            _context.OnContextMouseEntered += OnMouseEntered;
             _context.OnContextKeyEvent += OnKeyBindDown;
 
             CommandBinds.Builder
@@ -77,7 +76,6 @@ namespace Content.Client.ContextMenu.UI
             _updating = false;
             Elements.Clear();
             _cfg.UnsubValueChanged(CCVars.EntityMenuGroupingType, OnGroupingChanged);
-            _context.OnContextMouseEntered -= OnMouseEntered;
             _context.OnContextKeyEvent -= OnKeyBindDown;
             CommandBinds.Unregister<EntityMenuUIController>();
         }
@@ -99,25 +97,6 @@ namespace Content.Client.ContextMenu.UI
 
             var box = UIBox2.FromDimensions(_userInterfaceManager.MousePositionScaled.Position, (1, 1));
             _context.RootMenu.Open(box);
-        }
-
-        public void OnMouseEntered(ContextMenuElement element)
-        {
-            if (element is not EntityMenuElement entityElement)
-                return;
-
-            // get an entity associated with this element
-            var entity = entityElement.Entity;
-
-            // if there is none, this is a group, so don't open verbs
-            if (entity == null)
-                return;
-
-            // Deleted() automatically checks for null & existence.
-            if (_entityManager.Deleted(entity))
-                return;
-
-            _verb.OpenVerbMenu(entity.Value, popup: element.SubMenu);
         }
 
         public void OnKeyBindDown(ContextMenuElement element, GUIBoundKeyEventArgs args)
@@ -241,6 +220,9 @@ namespace Content.Client.ContextMenu.UI
                 {
                     var element = new EntityMenuElement(entity);
                     element.SubMenu = new ContextMenuPopup(_context, element);
+                    element.SubMenu.OnPopupOpen += () => _verb.OpenVerbMenu(entity, popup: element.SubMenu);
+                    element.SubMenu.OnPopupHide += element.SubMenu.MenuBody.DisposeAllChildren;
+
                     _context.AddElement(_context.RootMenu, element);
                     Elements.TryAdd(entity, element);
                 }
@@ -258,6 +240,8 @@ namespace Content.Client.ContextMenu.UI
                 // this group only has a single entity, add a simple menu element
                 var element = new EntityMenuElement(group[0]);
                 element.SubMenu = new ContextMenuPopup(_context, element);
+                element.SubMenu.OnPopupOpen += () => _verb.OpenVerbMenu(group[0], popup: element.SubMenu);
+                element.SubMenu.OnPopupHide += element.SubMenu.MenuBody.DisposeAllChildren;
                 _context.AddElement(_context.RootMenu, element);
                 Elements.TryAdd(group[0], element);
             }


### PR DESCRIPTION
Requires space-wizards/RobustToolbox/pull/3685

This fixes an issue where the verb menu would sometimes get stuck "waiting for server".
Currently the context menu will request verbs as soon as the mouse enters the control. Because there is a short delay before the sub-menu is opened, If the latency is low enough (e.g. release vs debug mode) then this can cause the server-side verbs to be received before the verb menu ever opens, causing the verb message to just be ignored.

This fixes that by just deferring getting the verbs until after the pop-up has actually opened. This should also stop people from being able to spam somewhat expensive verb requests by just wiggling the mouse around the context menu.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- fix: Fixed a bug that causes the verb menu to get stuck waiting for the server.
