### PR TITLE
Fixing MobState issues

### DIFF
--- a/Content.Shared/Alert/AlertsSystem.cs
+++ b/Content.Shared/Alert/AlertsSystem.cs
@@ -16,6 +16,12 @@ public abstract class AlertsSystem : EntitySystem
             : null;
     }
 
+    public short GetSeverityRange(AlertType alertType)
+    {
+        var minSeverity = _typeToAlert[alertType].MinSeverity;
+        return (short)MathF.Min(minSeverity,_typeToAlert[alertType].MaxSeverity - minSeverity);
+    }
+
     public short GetMaxSeverity(AlertType alertType)
     {
         return _typeToAlert[alertType].MaxSeverity;

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -24,6 +24,7 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, BeforeGettingStrippedEvent>(OnGettingStripped);
         SubscribeLocalEvent<MobStateComponent, ChangeDirectionAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, UseAttemptEvent>(CheckAct);
+        SubscribeLocalEvent<MobStateComponent, AttackAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, InteractionAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, ThrowAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, SpeakAttemptEvent>(CheckAct);

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -301,10 +301,12 @@ public sealed class MobThresholdSystem : EntitySystem
                 var severity = _alerts.GetMinSeverity(AlertType.HumanHealth);
                 if (TryGetIncapPercentage(target, damageable.TotalDamage, out var percentage))
                 {
-                    severity = (short) MathF.Floor(percentage.Value.Float() *
-                                                   _alerts.GetMaxSeverity(AlertType.HumanHealth));
-                }
 
+
+                    severity = (short) MathF.Floor(percentage.Value.Float() *
+                                                   _alerts.GetSeverityRange(AlertType.HumanHealth));
+                    severity += _alerts.GetMinSeverity(AlertType.HumanHealth);
+                }
                 _alerts.ShowAlert(target, AlertType.HumanHealth, severity);
                 break;
             }

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -178,7 +178,7 @@
     state: health7
   name: alerts-health-name
   description: alerts-health-desc
-  minSeverity: 0
+  minSeverity: 1
   maxSeverity: 6
 
 - type: alert


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes an issue where players in crit would rapidly swap between crit and alive for a single tick after receiving damage.
Fixes #13461
**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: fixed constant thudding sound playing when in crit
- fix: fixed being able to attack while downed/dead
- fix: fix for health alert not showing properly on spawn
- fix: fixed improper sprite being shown on the hud for full health