### PR TITLE
Fix decal error

### DIFF
--- a/Content.Client/Decals/DecalSystem.cs
+++ b/Content.Client/Decals/DecalSystem.cs
@@ -13,6 +13,8 @@ namespace Content.Client.Decals
         [Dependency] private readonly SpriteSystem _sprites = default!;
 
         private DecalOverlay _overlay = default!;
+
+        // TODO move this data to the component
         public readonly Dictionary<EntityUid, SortedDictionary<int, SortedDictionary<uint, Decal>>> DecalRenderIndex = new();
         private readonly Dictionary<EntityUid, Dictionary<uint, int>> _decalZIndexIndex = new();
 
@@ -25,8 +27,6 @@ namespace Content.Client.Decals
 
             SubscribeLocalEvent<DecalGridComponent, ComponentHandleState>(OnHandleState);
             SubscribeNetworkEvent<DecalChunkUpdateEvent>(OnChunkUpdate);
-            SubscribeLocalEvent<GridInitializeEvent>(OnGridInitialize);
-            SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoval);
         }
 
         public void ToggleOverlay()
@@ -41,16 +41,18 @@ namespace Content.Client.Decals
             }
         }
 
-        private void OnGridRemoval(GridRemovalEvent ev)
+        protected override void OnCompRemove(EntityUid uid, DecalGridComponent component, ComponentRemove args)
         {
-            DecalRenderIndex.Remove(ev.EntityUid);
-            _decalZIndexIndex.Remove(ev.EntityUid);
+            DecalRenderIndex.Remove(uid);
+            _decalZIndexIndex.Remove(uid);
+            base.OnCompRemove(uid, component, args);
         }
 
-        private void OnGridInitialize(GridInitializeEvent ev)
+        protected override void OnCompAdd(EntityUid uid, DecalGridComponent component, ComponentAdd args)
         {
-            DecalRenderIndex[ev.EntityUid] = new();
-            _decalZIndexIndex[ev.EntityUid] = new();
+            DecalRenderIndex[uid] = new();
+            _decalZIndexIndex[uid] = new();
+            base.OnCompAdd(uid, component, args);
         }
 
         public override void Shutdown()

--- a/Content.Server/Decals/DecalSystem.cs
+++ b/Content.Server/Decals/DecalSystem.cs
@@ -29,7 +29,6 @@ namespace Content.Server.Decals
         [Dependency] private readonly ChunkingSystem _chunking = default!;
         [Dependency] private readonly IConfigurationManager _conf = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
-        [Dependency] private readonly IDependencyCollection _dependencies = default!;
 
         private readonly Dictionary<EntityUid, HashSet<Vector2i>> _dirtyChunks = new();
         private readonly Dictionary<IPlayerSession, Dictionary<EntityUid, HashSet<Vector2i>>> _previousSentChunks = new();


### PR DESCRIPTION
Fixes #13466. Issue was that decals were applying state before the grid was ever initialized, which can happen now that grids aren't given special treatment by game state code. Fixed by moving the initialization logic out of the grid-init event and into the component-add events.