### PR TITLE
Space Damage Increase

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -39,7 +39,7 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.15 #per second, scales with pressure and other constants.
+        Blunt: 0.35 #per second, scales with pressure and other constants.
   - type: DamageOnHighSpeedImpact
     damage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -32,7 +32,7 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.3 #per second, scales with pressure and other constants. Twice as much as humans.
+        Blunt: 0.45 #per second, scales with pressure and other constants. Slighty more than humans.
   - type: Reactive
     groups:
       Flammable: [ Touch ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

Barotrauma damage has been very forgiving for a long time. This only changes the blunt damage you take from space. All non slime races still get over a minute to survive, as long as they have oxygen. Slimes get about 50 or so seconds with nitrogen. The space pen also didn't exist when space damage was nerfed, and you get 20 additional seconds to survive with it. 

**Media**

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://user-images.githubusercontent.com/104418166/212581581-f60d341b-de8e-4987-98e9-9b47d22a77d5.mp4


**Changelog**

:cl:
- tweak: Changed barotrauma damage to be much more deadly. Keep your survival box close. 
