### PR TITLE
Arcade tweak

### DIFF
--- a/Content.Client/Arcade/SpaceVillainArcadeMenu.cs
+++ b/Content.Client/Arcade/SpaceVillainArcadeMenu.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Arcade.UI;
+using Content.Client.Arcade.UI;
 using Content.Shared.Arcade;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
@@ -20,11 +20,11 @@ namespace Content.Client.Arcade
         private readonly Button[] _gameButtons = new Button[3]; //used to disable/enable all game buttons
         public SpaceVillainArcadeMenu(SpaceVillainArcadeBoundUserInterface owner)
         {
-            MinSize = SetSize = (300, 225);
+            MinSize = SetSize = (420, 225);
             Title = Loc.GetString("spacevillain-menu-title");
             Owner = owner;
 
-            var grid = new GridContainer {Columns = 1};
+            var grid = new GridContainer {Columns = 1, HorizontalAlignment = HAlignment.Center};
 
             var infoGrid = new GridContainer {Columns = 3};
             infoGrid.AddChild(new Label{ Text = Loc.GetString("spacevillain-menu-label-player"), Align = Label.AlignMode.Center });

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -58,6 +58,8 @@
   - type: SpaceVillainArcade
     rewardMinAmount: 5
     rewardMaxAmount: 8
+    rewardSpecialMinAmount: 1
+    rewardSpecialMaxAmount: 2
     
 - type: entity
   id: BlockGameArcade


### PR DESCRIPTION
Space Villain Arcade prizes now separated into normal and special prizes. Each arcade can give 1-2 toy weapon to you.

* Prize list is now separated into normal and special. Number of special prizes can be adjusted (both in prototype and ingame).
* Number of normal prizes is "number of prizes - number of special prizes".
* Special prize dropped with 30% chance by default. It can be adjusted also. If you don't get special prize still, then keep playing and you get it.
* Window minimum size was increased to make action text fit into window fully. Content is centered now.
~~* Elements of window don't align properly still.~~

- [X] This PR does not require an ingame showcase

:cl: Jack Rost
- tweak: arcade now guarantees that you get 1-2 toy weapons by default.
- tweak: minimum size of window is a little bigger. Window content is centered now.