### PR TITLE
Mechs now subscribe and handle UpdateCanMove Events.

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -6,12 +6,15 @@ using Content.Server.Mech.Components;
 using Content.Server.Power.Components;
 using Content.Server.Tools;
 using Content.Server.Wires;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Mech;
 using Content.Shared.Mech.Components;
 using Content.Shared.Mech.EntitySystems;
+using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Events;
 using Content.Shared.Tools.Components;
 using Content.Shared.Verbs;
 using Robust.Server.Containers;
@@ -29,6 +32,7 @@ public sealed class MechSystem : SharedMechSystem
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly IMapManager _map = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     private ISawmill _sawmill = default!;
 
@@ -53,6 +57,8 @@ public sealed class MechSystem : SharedMechSystem
         SubscribeLocalEvent<MechComponent, DamageChangedEvent>(OnDamageChanged);
         SubscribeLocalEvent<MechComponent, MechEquipmentRemoveMessage>(OnRemoveEquipmentMessage);
 
+        SubscribeLocalEvent<MechComponent, UpdateCanMoveEvent>(OnMechMoveEvent);
+
         SubscribeLocalEvent<MechPilotComponent, ToolUserAttemptUseEvent>(OnToolUseAttempt);
         SubscribeLocalEvent<MechPilotComponent, InhaleLocationEvent>(OnInhale);
         SubscribeLocalEvent<MechPilotComponent, ExhaleLocationEvent>(OnExhale);
@@ -63,6 +69,14 @@ public sealed class MechSystem : SharedMechSystem
         #endregion
     }
 
+    private void OnMechMoveEvent(EntityUid uid, MechComponent component , UpdateCanMoveEvent args)
+    {
+        if (component.BatterySlot == null || component.Broken || component.Integrity >= 0)
+            return;
+
+        args.Cancel();
+    }
+
     private void OnInteractUsing(EntityUid uid, MechComponent component, InteractUsingEvent args)
     {
         if (TryComp<WiresComponent>(uid, out var wires) && !wires.IsPanelOpen)
@@ -71,6 +85,7 @@ public sealed class MechSystem : SharedMechSystem
         if (component.BatterySlot.ContainedEntity == null && TryComp<BatteryComponent>(args.Used, out var battery))
         {
             InsertBattery(uid, args.Used, component, battery);
+            _actionBlocker.UpdateCanMove(uid);
             return;
         }
 
@@ -93,8 +108,8 @@ public sealed class MechSystem : SharedMechSystem
     private void OnRemoveBatteryFinished(EntityUid uid, MechComponent component, MechRemoveBatteryFinishedEvent args)
     {
         component.EntryTokenSource = null;
-
         RemoveBattery(uid, component);
+        _actionBlocker.UpdateCanMove(uid);
     }
 
     private void OnRemoveBatteryCancelled(EntityUid uid, MechComponent component, MechRemoveBatteryCancelledEvent args)

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -72,7 +72,7 @@ public sealed class MechSystem : SharedMechSystem
 
     private void OnMechCanMoveEvent(EntityUid uid, MechComponent component , UpdateCanMoveEvent args)
     {
-        if (component.Broken || component.Integrity >= 0 || component.Energy >= 0)
+        if (component.Broken || component.Integrity <= 0 || component.Energy <= 0)
             args.Cancel();
     }
     private void OnInteractUsing(EntityUid uid, MechComponent component, InteractUsingEvent args)

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -72,10 +72,8 @@ public sealed class MechSystem : SharedMechSystem
 
     private void OnMechCanMoveEvent(EntityUid uid, MechComponent component , UpdateCanMoveEvent args)
     {
-        if (!component.Broken && component.Integrity > 0 && component.Energy > 0)
-            return;
-
-        args.Cancel();
+        if (component.Broken || component.Integrity >= 0 || component.Energy >= 0)
+            args.Cancel();
     }
     private void OnInteractUsing(EntityUid uid, MechComponent component, InteractUsingEvent args)
     {
@@ -228,6 +226,7 @@ public sealed class MechSystem : SharedMechSystem
     {
         component.EntryTokenSource = null;
         TryInsert(uid, args.User, component);
+        _actionBlocker.UpdateCanMove(uid);
     }
 
     private void OnExitFinished(EntityUid uid, MechComponent component, MechExitFinishedEvent args)


### PR DESCRIPTION

## About the PR
Mechs now use actionblocker's event system to handle blocking events when the mech is broken/has no power

**Media**

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: 
- tweak: mechs now do not move if broken or are unpowered.
