### PR TITLE
Remove server-sprite references from handcuffs

### DIFF
--- a/Content.Server/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Server/Cuffs/Components/HandcuffComponent.cs
@@ -7,6 +7,8 @@ using Content.Shared.Popups;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Cuffs.Components
 {
@@ -48,6 +50,12 @@ namespace Content.Server.Cuffs.Components
         public bool BreakOnRemove { get; set; }
 
         /// <summary>
+        ///     Will the cuffs break when removed?
+        /// </summary>
+        [DataField("brokenPrototype", customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
+        public string? BrokenPrototype { get; set; }
+
+        /// <summary>
         ///     The path of the RSI file used for the player cuffed overlay.
         /// </summary>
         [DataField("cuffedRSI")]
@@ -58,42 +66,6 @@ namespace Content.Server.Cuffs.Components
         /// </summary>
         [DataField("bodyIconState")]
         public string? OverlayIconState { get; set; } = "body-overlay";
-
-        /// <summary>
-        ///     The iconstate used for broken handcuffs
-        /// </summary>
-        [DataField("brokenIconState")]
-        public string? BrokenState { get; set; }
-
-        /// <summary>
-        ///     The iconstate used for broken handcuffs
-        /// </summary>
-        [DataField("brokenName", readOnly: true)]
-        public string BrokenName { get; private set; } = "";
-
-        /// <summary>
-        ///     The iconstate used for broken handcuffs
-        /// </summary>
-        [DataField("brokenDesc", readOnly: true)]
-        public string BrokenDesc { get; private set; } = "";
-
-        [ViewVariables]
-        public bool Broken
-        {
-            get
-            {
-                return _isBroken;
-            }
-            set
-            {
-                if (_isBroken != value)
-                {
-                    _isBroken = value;
-
-                    Dirty();
-                }
-            }
-        }
 
         [DataField("startCuffSound")]
         public SoundSpecifier StartCuffSound { get; set; } = new SoundPathSpecifier("/Audio/Items/Handcuffs/cuff_start.ogg");
@@ -112,18 +84,10 @@ namespace Content.Server.Cuffs.Components
         [DataField("color")]
         public Color Color { get; set; } = Color.White;
 
-        // Non-exposed data fields
-        private bool _isBroken = false;
-
         /// <summary>
         ///     Used to prevent DoAfter getting spammed.
         /// </summary>
         public bool Cuffing;
-
-        public override ComponentState GetComponentState()
-        {
-            return new HandcuffedComponentState(Broken ? BrokenState : string.Empty);
-        }
 
         /// <summary>
         /// Update the cuffed state of an entity

--- a/Content.Server/Cuffs/CuffableSystem.cs
+++ b/Content.Server/Cuffs/CuffableSystem.cs
@@ -86,12 +86,6 @@ namespace Content.Server.Cuffs
             if (component.Cuffing || !EntityManager.TryGetComponent<CuffableComponent>(target, out var cuffed))
                 return;
 
-            if (component.Broken)
-            {
-                _popup.PopupEntity(Loc.GetString("handcuff-component-cuffs-broken-error"), user, user);
-                return;
-            }
-
             if (!EntityManager.TryGetComponent<HandsComponent?>(target, out var hands))
             {
                 _popup.PopupEntity(Loc.GetString("handcuff-component-target-has-no-hands-error",("targetName", target)), user, user);

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
@@ -60,9 +60,14 @@ public abstract partial class SharedHandsSystem : EntitySystem
         // animation
         var xform = Transform(uid);
         var coordinateEntity = xform.ParentUid.IsValid() ? xform.ParentUid : uid;
-        var initialPosition = EntityCoordinates.FromMap(EntityManager, coordinateEntity, Transform(entity).MapPosition);
 
-        PickupAnimation(entity, initialPosition, xform.LocalPosition, animateUser ? null : uid);
+        var itemPos = Transform(entity).MapPosition;
+        if (itemPos.MapId == xform.MapID)
+        {
+            // TODO max range for animation?
+            var initialPosition = EntityCoordinates.FromMap(coordinateEntity, itemPos, EntityManager);
+            PickupAnimation(entity, initialPosition, xform.LocalPosition, animateUser ? null : uid);
+        }
         DoPickup(uid, hand, entity, handsComp);
 
         return true;

--- a/Resources/Locale/en-US/cuffs/components/handcuff-broken.ftl
+++ b/Resources/Locale/en-US/cuffs/components/handcuff-broken.ftl
@@ -1,4 +1,0 @@
-handcuff-broken-cables-name = broken cables
-handcuff-broken-cables-desc = These cables are broken in several places and don't seem very useful.
-handcuff-broken-zipties-name = broken zipties
-handcuff-broken-zipties-desc = These zipties look like they tried to manage the wrong cables.

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -35,9 +35,7 @@
     bodyIconState: body-overlay
     color: red
     breakOnRemove: true
-    brokenIconState: cuff-broken
-    brokenName: handcuff-broken-cables-name
-    brokenDesc: handcuff-broken-cables-desc
+    brokenPrototype: CablecuffsBroken
     startCuffSound:
       path: /Audio/Items/Handcuffs/rope_start.ogg
     endCuffSound:
@@ -69,9 +67,7 @@
     cuffedRSI: Objects/Misc/cablecuffs.rsi  # cablecuffs will look fine
     bodyIconState: body-overlay
     breakOnRemove: true
-    brokenIconState: cuff-broken
-    brokenName: handcuff-broken-zipties-name
-    brokenDesc: handcuff-broken-zipties-desc
+    brokenPrototype: ZiptiesBroken
     startCuffSound:
       path: /Audio/Items/Handcuffs/ziptie_start.ogg
     endCuffSound:
@@ -85,3 +81,30 @@
   - type: Sprite
     sprite: Objects/Misc/zipties.rsi
     state: cuff
+
+- type: entity
+  name: broken zipties
+  description: These zipties look like they tried to manage the wrong cables.
+  id: ZiptiesBroken
+  parent: BaseItem
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/zipties.rsi
+    state: cuff-broken
+  - type: Item
+    size: 2
+  - type: Recyclable
+
+- type: entity
+  name: broken cables
+  description: These cables are broken in several places and don't seem very useful.
+  id: CablecuffsBroken
+  parent: BaseItem
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/cablecuffs.rsi
+    state: cuff-broken
+    color: red
+  - type: Item
+    size: 2
+  - type: Recyclable


### PR DESCRIPTION
When they break handcuffs now just spawn a trash entity instead of irrevocably modifying the existing entity.

Also fixes an error in PickupOrDrop hand code that would error when trying to animate a pickup from null-space