### PR TITLE
Remove server-side sprites from ExpendableLightComponent

### DIFF
--- a/Content.Client/Light/Visualizers/ExpendableLightVisualizer.cs
+++ b/Content.Client/Light/Visualizers/ExpendableLightVisualizer.cs
@@ -8,12 +8,25 @@ namespace Content.Client.Light.Visualizers
     [UsedImplicitly]
     public sealed class ExpendableLightVisualizer : AppearanceVisualizer
     {
+        [DataField("iconStateSpent")]
+        public string IconStateSpent { get; set; } = string.Empty;
+
+        [DataField("iconStateOn")]
+        public string IconStateLit { get; set; } = string.Empty;
+
         [Obsolete("Subscribe to AppearanceChangeEvent instead.")]
         public override void OnChangeData(AppearanceComponent component)
         {
             base.OnChangeData(component);
 
             var entities = IoCManager.Resolve<IEntityManager>();
+
+            if (!entities.TryGetComponent(component.Owner, out ExpendableLightComponent? expendableLight))
+                    return;
+
+            if (!entities.TryGetComponent(component.Owner, out SpriteComponent? sprite))
+                    return;
+
             if (component.TryGetData(ExpendableLightVisuals.Behavior, out string lightBehaviourID))
             {
                 if (entities.TryGetComponent(component.Owner, out LightBehaviourComponent? lightBehaviour))
@@ -31,22 +44,36 @@ namespace Content.Client.Light.Visualizers
                 }
             }
 
-            if (component.TryGetData(ExpendableLightVisuals.State, out ExpendableLightState state)
-                && entities.TryGetComponent(component.Owner, out ExpendableLightComponent? expendableLight))
+            if (!component.TryGetData(ExpendableLightVisuals.State, out ExpendableLightState state))
+                return;
+
+            switch (state)
             {
-                switch (state)
-                {
-                    case ExpendableLightState.Lit:
-                        expendableLight.PlayingStream?.Stop();
-                        expendableLight.PlayingStream = entities.EntitySysManager.GetEntitySystem<SharedAudioSystem>().PlayPvs(
-                            expendableLight.LoopedSound,
-                            expendableLight.Owner,
-                            SharedExpendableLightComponent.LoopedSoundParams);
-                        break;
-                    case ExpendableLightState.Dead:
-                        expendableLight.PlayingStream?.Stop();
-                        break;
-                }
+                case ExpendableLightState.Lit:
+                    expendableLight.PlayingStream?.Stop();
+                    expendableLight.PlayingStream = entities.EntitySysManager.GetEntitySystem<SharedAudioSystem>().PlayPvs(
+                        expendableLight.LoopedSound,
+                        expendableLight.Owner,
+                        SharedExpendableLightComponent.LoopedSoundParams);
+                    if (IconStateLit != string.Empty)
+                    {
+                        sprite.LayerSetState(2, IconStateLit);
+                        sprite.LayerSetShader(2, "shaded");
+                    }
+
+                    sprite.LayerSetVisible(1, true);
+
+                    break;
+                case ExpendableLightState.Dead:
+                    expendableLight.PlayingStream?.Stop();
+                    if (!string.IsNullOrEmpty(IconStateSpent))
+                    {
+                        sprite.LayerSetState(0, IconStateSpent);
+                        sprite.LayerSetShader(0, "shaded");
+                    }
+
+                    sprite.LayerSetVisible(1, false);
+                    break;
             }
         }
     }

--- a/Content.Client/Light/Visualizers/ExpendableLightVisualizer.cs
+++ b/Content.Client/Light/Visualizers/ExpendableLightVisualizer.cs
@@ -9,10 +9,10 @@ namespace Content.Client.Light.Visualizers
     public sealed class ExpendableLightVisualizer : AppearanceVisualizer
     {
         [DataField("iconStateSpent")]
-        public string IconStateSpent { get; set; } = string.Empty;
+        public string? IconStateSpent { get; set; }
 
         [DataField("iconStateOn")]
-        public string IconStateLit { get; set; } = string.Empty;
+        public string? IconStateLit { get; set; }
 
         [Obsolete("Subscribe to AppearanceChangeEvent instead.")]
         public override void OnChangeData(AppearanceComponent component)
@@ -55,7 +55,7 @@ namespace Content.Client.Light.Visualizers
                         expendableLight.LoopedSound,
                         expendableLight.Owner,
                         SharedExpendableLightComponent.LoopedSoundParams);
-                    if (IconStateLit != string.Empty)
+                    if (!string.IsNullOrWhiteSpace(IconStateLit))
                     {
                         sprite.LayerSetState(2, IconStateLit);
                         sprite.LayerSetShader(2, "shaded");
@@ -66,7 +66,7 @@ namespace Content.Client.Light.Visualizers
                     break;
                 case ExpendableLightState.Dead:
                     expendableLight.PlayingStream?.Stop();
-                    if (!string.IsNullOrEmpty(IconStateSpent))
+                    if (!string.IsNullOrWhiteSpace(IconStateSpent))
                     {
                         sprite.LayerSetState(0, IconStateSpent);
                         sprite.LayerSetShader(0, "shaded");

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -65,7 +65,7 @@ namespace Content.Server.Light.EntitySystems
 
                         _tagSystem.AddTag(component.Owner, "Trash");
 
-                        UpdateSpriteAndSounds(component);
+                        UpdateSounds(component);
                         UpdateVisualizer(component);
 
                         if (TryComp<ItemComponent>(component.Owner, out var item))
@@ -93,7 +93,7 @@ namespace Content.Server.Light.EntitySystems
                 component.CurrentState = ExpendableLightState.Lit;
                 component.StateExpiryTime = component.GlowDuration;
 
-                UpdateSpriteAndSounds(component);
+                UpdateSounds(component);
                 UpdateVisualizer(component);
 
                 return true;
@@ -124,43 +124,25 @@ namespace Content.Server.Light.EntitySystems
             }
         }
 
-        private void UpdateSpriteAndSounds(ExpendableLightComponent component)
+        private void UpdateSounds(ExpendableLightComponent component)
         {
-            if (TryComp<SpriteComponent>(component.Owner, out var sprite))
+            var uid = component.Owner;
+
+            switch (component.CurrentState)
             {
-                switch (component.CurrentState)
-                {
-                    case ExpendableLightState.Lit:
-                        _audio.PlayPvs(component.LitSound, component.Owner);
-                        if (component.IconStateLit != string.Empty)
-                        {
-                            sprite.LayerSetState(2, component.IconStateLit);
-                            sprite.LayerSetShader(2, "shaded");
-                        }
-
-                        sprite.LayerSetVisible(1, true);
-                        break;
-                    case ExpendableLightState.Fading:
-                    {
-                        break;
-                    }
-                    default:
-                    case ExpendableLightState.Dead:
-                        _audio.PlayPvs(component.DieSound, component.Owner);
-                        if (!string.IsNullOrEmpty(component.IconStateSpent))
-                        {
-                            sprite.LayerSetState(0, component.IconStateSpent);
-                            sprite.LayerSetShader(0, "shaded");
-                        }
-
-                        sprite.LayerSetVisible(1, false);
-                        break;
-                }
+                case ExpendableLightState.Lit:
+                    _audio.PlayPvs(component.LitSound, uid);
+                    break;
+                case ExpendableLightState.Fading:
+                    break;
+                default:
+                    _audio.PlayPvs(component.DieSound, uid);
+                    break;
             }
 
-            if (TryComp<ClothingComponent>(component.Owner, out var clothing))
+            if (TryComp<ClothingComponent>(uid, out var clothing))
             {
-                _clothing.SetEquippedPrefix(component.Owner, component.Activated ? "Activated" : string.Empty, clothing);
+                _clothing.SetEquippedPrefix(uid, component.Activated ? "Activated" : string.Empty, clothing);
             }
         }
 

--- a/Content.Shared/Light/Component/SharedExpendableLightComponent.cs
+++ b/Content.Shared/Light/Component/SharedExpendableLightComponent.cs
@@ -46,12 +46,6 @@ namespace Content.Shared.Light.Component
         [DataField("spentName")]
         public string SpentName { get; set; } = string.Empty;
 
-        [DataField("iconStateSpent")]
-        public string IconStateSpent { get; set; } = string.Empty;
-
-        [DataField("iconStateOn")]
-        public string IconStateLit { get; set; } = string.Empty;
-
         [DataField("litSound")]
         public SoundSpecifier? LitSound { get; set; }
 

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -11,8 +11,6 @@
       spentDesc: expendable-light-spent-glowstick-desc
       glowDuration: 900 # time in seconds
       fadeOutDuration: 300
-      iconStateOn: glowstick_lit
-      iconStateSpent: glowstick_unlit
       turnOnBehaviourID: turn_on
       fadeOutBehaviourID: fade_out
       litSound:
@@ -33,6 +31,8 @@
     - type: Appearance
       visuals:
         - type: ExpendableLightVisualizer
+          iconStateOn: glowstick_lit
+          iconStateSpent: glowstick_unlit
     - type: PointLight
       enabled: false
       color: "#00FF00"
@@ -70,17 +70,9 @@
   components:
     - type: ExpendableLight
       spentName: expendable-light-spent-red-glowstick-name
-      spentDesc: expendable-light-spent-glowstick-desc
-      glowDuration: 900
-      fadeOutDuration: 300
-      iconStateOn: glowstick_lit
-      iconStateSpent: glowstick_unlit
-      turnOnBehaviourID: turn_on
-      fadeOutBehaviourID: fade_out
-      litSound:
-        path: /Audio/Items/Handcuffs/rope_breakout.ogg
+      glowDuration: 10 # time in seconds
+      fadeOutDuration: 5
     - type: Sprite
-      sprite: Objects/Misc/glowstick.rsi
       layers:
         - state: glowstick_base
         - state: glowstick_glow
@@ -89,9 +81,6 @@
           shader: unshaded
         - state: glowstick_unlit
           color: "#FF0000"
-    - type: Item
-      sprite: Objects/Misc/glowstick.rsi
-      heldPrefix: unlit
     - type: PointLight
       enabled: false
       color: "#FF0000"
@@ -105,17 +94,7 @@
   components:
     - type: ExpendableLight
       spentName: expendable-light-spent-purple-glowstick-name
-      spentDesc: expendable-light-spent-glowstick-desc
-      glowDuration: 900
-      fadeOutDuration: 300
-      iconStateOn: glowstick_lit
-      iconStateSpent: glowstick_unlit
-      turnOnBehaviourID: turn_on
-      fadeOutBehaviourID: fade_out
-      litSound:
-        path: /Audio/Items/Handcuffs/rope_breakout.ogg
     - type: Sprite
-      sprite: Objects/Misc/glowstick.rsi
       layers:
         - state: glowstick_base
         - state: glowstick_glow
@@ -124,9 +103,6 @@
           shader: unshaded
         - state: glowstick_unlit
           color: "#FF00FF"
-    - type: Item
-      sprite: Objects/Misc/glowstick.rsi
-      heldPrefix: unlit
     - type: PointLight
       enabled: false
       color: "#FF00FF"
@@ -140,15 +116,6 @@
   components:
     - type: ExpendableLight
       spentName: expendable-light-spent-yellow-glowstick-name
-      spentDesc: expendable-light-spent-glowstick-desc
-      glowDuration: 900
-      fadeOutDuration: 300
-      iconStateOn: glowstick_lit
-      iconStateSpent: glowstick_unlit
-      turnOnBehaviourID: turn_on
-      fadeOutBehaviourID: fade_out
-      litSound:
-        path: /Audio/Items/Handcuffs/rope_breakout.ogg
     - type: Sprite
       sprite: Objects/Misc/glowstick.rsi
       layers:
@@ -159,9 +126,6 @@
           shader: unshaded
         - state: glowstick_unlit
           color: "#FFFF00"
-    - type: Item
-      sprite: Objects/Misc/glowstick.rsi
-      heldPrefix: unlit
     - type: PointLight
       enabled: false
       color: "#FFFF00"
@@ -175,15 +139,6 @@
   components:
     - type: ExpendableLight
       spentName: expendable-light-spent-blue-glowstick-name
-      spentDesc: expendable-light-spent-glowstick-desc
-      glowDuration: 900
-      fadeOutDuration: 300
-      iconStateOn: glowstick_lit
-      iconStateSpent: glowstick_unlit
-      turnOnBehaviourID: turn_on
-      fadeOutBehaviourID: fade_out
-      litSound:
-        path: /Audio/Items/Handcuffs/rope_breakout.ogg
     - type: Sprite
       sprite: Objects/Misc/glowstick.rsi
       layers:
@@ -194,8 +149,6 @@
           shader: unshaded
         - state: glowstick_unlit
           color: "#0000FF"
-    - type: Item
-      sprite: Objects/Misc/glowstick.rsi
       heldPrefix: unlit
     - type: PointLight
       enabled: false
@@ -210,6 +163,7 @@
   name: light pulse test
   parent: BaseItem
   id: LightBehaviourTest1
+  noSpawn: true
   components:
     - type: Sprite
       sprite: Objects/Misc/glowstick.rsi
@@ -240,6 +194,7 @@
   name: color cycle test
   parent: BaseItem
   id: LightBehaviourTest2
+  noSpawn: true
   components:
     - type: Sprite
       sprite: Objects/Misc/glowstick.rsi
@@ -271,6 +226,7 @@
   name: multi-behaviour light test
   parent: BaseItem
   id: LightBehaviourTest3
+  noSpawn: true
   components:
     - type: Sprite
       sprite: Objects/Misc/glowstick.rsi
@@ -310,6 +266,7 @@
   name: light fade in test
   parent: BaseItem
   id: LightBehaviourTest4
+  noSpawn: true
   components:
     - type: Sprite
       sprite: Objects/Misc/glowstick.rsi
@@ -340,6 +297,7 @@
   name: light pulse radius test
   parent: BaseItem
   id: LightBehaviourTest5
+  noSpawn: true
   components:
     - type: Sprite
       sprite: Objects/Misc/glowstick.rsi
@@ -371,6 +329,7 @@
   name: light randomize radius test
   parent: BaseItem
   id: LightBehaviourTest6
+  noSpawn: true
   components:
     - type: Sprite
       sprite: Objects/Misc/glowstick.rsi


### PR DESCRIPTION
Moves the sprite logic into the existing visualizer. This doesn't port it to a visualizer system, I just want to kill server sprite comp for now.
