### PR TITLE
RPG-7 Icon Visual fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -80,8 +80,8 @@
       path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
   - type: MagazineVisuals
     magState: mag
-    steps: 1
-    zeroVisible: true
+    steps: 2
+    zeroVisible: false
   - type: Appearance
 
 - type: entity


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes the icon  on RPG-7 always showing the rocket.
(iirc you can't update in-hand sprite thru yaml so this as much as I could do)
Relating to #13093 

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![rpgUpdateSS14](https://user-images.githubusercontent.com/29801840/212801275-34430159-1341-4a72-9326-c430b9cb5025.gif)


:cl: gus
- fix: Fixed RPG-7 icon not updating correctly.