### PR TITLE
360 PDA Light

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -40,7 +40,6 @@
     enabled: false
     radius: 1.5
     softness: 5
-    mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
   - type: Ringer
   - type: DeviceNetwork


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Per #12110
Removed the cone mask from PDA and left the brightness the same. Kind've bright for PDA but its not too bad.
<!-- What does it change? What other things could this impact? -->


**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Before
![image](https://user-images.githubusercontent.com/29801840/212806550-7c1fd072-e752-42b5-99a7-a53ee8ae236c.png)

After
![image](https://user-images.githubusercontent.com/29801840/212806755-dee16798-ba95-4b54-a8d0-1c378a39dd32.png)

**Changelog**

:cl: gus
- add: Added 360 PDA lights.