### PR TITLE
Update Golden Toolbox

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -88,9 +88,6 @@
   - type: StorageFill
     contents:
       - id: IngotGold
-        amount: 5
+        amount: 1
       - id: DrinkGoldenCup
         prob: 0.05
-        orGroup: CupOrGold
-      - id: IngotGold
-        orGroup: CupOrGold


### PR DESCRIPTION
## About the PR
Discussed with Emisse and emo, science should not start with 18k gold material. Golden toolbox has been reduced to one gold stack. 


**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
Before:
![Before](https://user-images.githubusercontent.com/29801840/212819157-05b5147c-95d7-40b4-8874-27ff6831d4c2.png)
After:
![After](https://user-images.githubusercontent.com/29801840/212819222-44b9f5fd-5852-47fb-af54-7ee22f7604f2.png)

:cl: gus
- tweak: Changed golden toolbox to have a reasonable amount of gold