### PR TITLE
Make anomaly generator 1x3 instead of 3x3

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -163,10 +163,12 @@
   placement:
     mode: AlignTileAny
   components:
+  - type: SpriteFade
   - type: Sprite
     netsync: false
     sprite: Structures/Machines/Anomaly/anomaly_generator.rsi
-    snapCardinals: true
+    offset: 0,1
+    drawdepth: Mobs
     layers:
     - state: base
     - state: panel
@@ -201,7 +203,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-1.3,-1.3,1.3,1.3"
+        bounds: "-1.5,-0.5,1.5,0.6"
       density: 50
       mask:
       - LargeMobMask

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -12,10 +12,10 @@
     range: 7
     sound:
       path: /Audio/Ambience/Objects/gravity_gen_hum.ogg
+
   - type: Sprite
     netsync: false
     sprite: Structures/Machines/gravity_generator.rsi
-    snapCardinals: true
     layers:
       - state: on
         map: ["enum.GravityGeneratorVisualLayers.Base"]


### PR DESCRIPTION
- More consistent with other tall sprites (e.g. trees)
- More gameplay (can actually hide stuff behind it)
- Aligns more closely with the sprite silhouette
- Also made gravity gen not snap at cardinals for consistency

![image](https://user-images.githubusercontent.com/31366439/212822093-9e47b01f-b0b0-4cf4-acb0-ce1b2e36ba06.png)

:cl:
- tweak: Anomaly generator now occupies 1x3 space instead of 3x3 and also doesn't snap with camera rotation.