### PR TITLE
Bandaid InRangeUnoccluded length checks

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -162,7 +162,8 @@ namespace Content.Shared.Examine
             var length = dir.Length;
 
             // If range specified also check it
-            if (range > 0f && length > range) return false;
+            // TODO: This rounding check is here because the API is kinda eh
+            if (range > 0f && length > range + 0.01f) return false;
 
             if (MathHelper.CloseTo(length, 0)) return true;
 


### PR DESCRIPTION
The real fix is refactoring InRangeUnoccluded to avoid the floating point issue.
This should fix popup flickering for now.

:cl:
- fix: Fix popup flickering.