### PR TITLE
Fix nested context menu popup

### DIFF
--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -260,6 +260,8 @@ namespace Content.Client.ContextMenu.UI
             {
                 var subElement = new EntityMenuElement(entity);
                 subElement.SubMenu = new ContextMenuPopup(_context, subElement);
+                subElement.SubMenu.OnPopupOpen += () => _verb.OpenVerbMenu(group[0], popup: subElement.SubMenu);
+                subElement.SubMenu.OnPopupHide += subElement.SubMenu.MenuBody.DisposeAllChildren;
                 _context.AddElement(subMenu, subElement);
                 Elements.TryAdd(entity, subElement);
             }


### PR DESCRIPTION
Fixes #13565, which is a bug I introduced.

:cl:
- fix: Fixed verb menu sometimes not appearing. when using the context menu,