### PR TITLE
Fix rotation visualizer

### DIFF
--- a/Content.Client/Rotation/RotationVisualizerSystem.cs
+++ b/Content.Client/Rotation/RotationVisualizerSystem.cs
@@ -45,7 +45,6 @@ public sealed class RotationVisualizerSystem : VisualizerSystem<RotationVisualsC
         {
             AnimationSystem.Stop(animationComp, animationKey);
         }
-        spriteComp.Rotation = rotation;
 
         var animation = new Animation
         {


### PR DESCRIPTION
So I bisected it down to https://github.com/space-wizards/space-station-14/pull/13094

The issue was in the old code if there was no animationplayer it just set the rotation and returned, but in the new code it ensures the component and then the rotation set was accidentally ported before playing the animation so there's nothing to lerp from / to.

Fixes https://github.com/space-wizards/space-station-14/issues/13564

:cl:
- fix: Fix rotation visualizers not lerping properly (bed buckling and knockdown).