### PR TITLE
More opportunities to implement wizards!

### DIFF
--- a/Resources/Locale/en-US/magic/spells-actions.ftl
+++ b/Resources/Locale/en-US/magic/spells-actions.ftl
@@ -1,6 +1,15 @@
 ﻿action-name-spell-rune-flash = Flash Rune
 action-description-spell-rune-flash = Summons a rune that flashes if used.
 
+action-name-spell-rune-explosion = Explosion Rune
+action-description-spell-rune-explosion = Summons a rune that explodes if used.
+
+action-name-spell-rune-ignite = Ignite Rune
+action-description-spell-rune-ignite = Summons a rune that ignites if used.
+
+action-name-spell-rune-stun = Stun Rune
+action-description-spell-rune-stun = Summons a rune that stuns if used.
+
 action-name-spell-forcewall = Forcewall
 action-description-spell-forcewall = Creates a magical barrier.
 action-speech-spell-forcewall = TARCOL MINTI ZHERI

--- a/Resources/Prototypes/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/books.yml
@@ -91,3 +91,20 @@
   - type: Spellbook
     worldSpells:
       Fireball: -1
+
+- type: entity
+  id: ScrollRunes
+  name: scroll of runes
+  parent: BaseSpellbook
+  components:
+  - type: Sprite
+    netsync: false
+    sprite: Objects/Magic/magicactions.rsi
+    layers:
+    - state: spell_default
+  - type: Spellbook
+    instantSpells:
+      FlashRune: -1
+      ExplosionRune: -1
+      IgniteRune: -1
+      StunRune: -1

--- a/Resources/Prototypes/Magic/rune_spells.yml
+++ b/Resources/Prototypes/Magic/rune_spells.yml
@@ -9,3 +9,39 @@
     state: spell_default
   serverEvent: !type:InstantSpawnSpellEvent
     prototype: FlashRune
+
+- type: instantAction
+  id: ExplosionRune
+  name: action-name-spell-rune-explosion
+  description: action-description-spell-rune-explosion
+  useDelay: 20
+  itemIconStyle: BigAction
+  icon:
+    sprite: Objects/Magic/magicactions.rsi
+    state: spell_default
+  serverEvent: !type:InstantSpawnSpellEvent
+    prototype: ExplosionRune
+
+- type: instantAction
+  id: IgniteRune
+  name: action-name-spell-rune-ignite
+  description: action-description-spell-rune-ignite
+  useDelay: 15
+  itemIconStyle: BigAction
+  icon:
+    sprite: Objects/Magic/magicactions.rsi
+    state: spell_default
+  serverEvent: !type:InstantSpawnSpellEvent
+    prototype: IgniteRune
+
+- type: instantAction
+  id: StunRune
+  name: action-name-spell-rune-stun
+  description: action-description-spell-rune-stun
+  useDelay: 10
+  itemIconStyle: BigAction
+  icon:
+    sprite: Objects/Magic/magicactions.rsi
+    state: spell_default
+  serverEvent: !type:InstantSpawnSpellEvent
+    prototype: StunRune


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

This PR is about the fact that now a scroll will appear in the game, with which you can make runes, for example, for the implementation of drawing runes to wizards or something else.

**Media**

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
Video:
https://drive.google.com/file/d/1RtcG5IC3jsqRAMNxfhI44PqjMJCbDdYU/view?usp=sharing

**Changelog**

:cl: @NULL882
- add: A scroll of runes for the implementation of drawing!
