### PR TITLE
Anomaly events & science point gen tweaks

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -82,7 +82,7 @@ public sealed partial class AnomalySystem
         UpdateGeneratorUi(uid, component);
     }
 
-    private void SpawnOnRandomGridLocation(EntityUid grid, string toSpawn)
+    public void SpawnOnRandomGridLocation(EntityUid grid, string toSpawn)
     {
         if (!TryComp<MapGridComponent>(grid, out var gridComp))
             return;

--- a/Content.Server/Anomaly/AnomalySystem.Scanner.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Scanner.cs
@@ -95,7 +95,7 @@ public sealed partial class AnomalySystem
         component.TokenSource = null;
 
         Audio.PlayPvs(component.CompleteSound, uid);
-        _popup.PopupEntity(Loc.GetString("anomaly-scanner-component-scan-complete"), uid);
+        Popup.PopupEntity(Loc.GetString("anomaly-scanner-component-scan-complete"), uid);
         UpdateScannerWithNewAnomaly(uid, args.Anomaly, component);
 
         if (TryComp<ActorComponent>(args.User, out var actor))

--- a/Content.Server/Anomaly/AnomalySystem.Vessel.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Vessel.cs
@@ -21,6 +21,7 @@ public sealed partial class AnomalySystem
         SubscribeLocalEvent<AnomalyVesselComponent, ComponentShutdown>(OnVesselShutdown);
         SubscribeLocalEvent<AnomalyVesselComponent, MapInitEvent>(OnVesselMapInit);
         SubscribeLocalEvent<AnomalyVesselComponent, RefreshPartsEvent>(OnRefreshParts);
+        SubscribeLocalEvent<AnomalyVesselComponent, UpgradeExamineEvent>(OnUpgradeExamine);
         SubscribeLocalEvent<AnomalyVesselComponent, InteractUsingEvent>(OnVesselInteractUsing);
         SubscribeLocalEvent<AnomalyVesselComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<AnomalyVesselComponent, ResearchServerGetPointsPerSecondEvent>(OnVesselGetPointsPerSecond);
@@ -57,6 +58,11 @@ public sealed partial class AnomalySystem
     {
         var modifierRating = args.PartRatings[component.MachinePartPointModifier] - 1;
         component.PointMultiplier = MathF.Pow(component.PartRatingPointModifier, modifierRating);
+    }
+
+    private void OnUpgradeExamine(EntityUid uid, AnomalyVesselComponent component, UpgradeExamineEvent args)
+    {
+        args.AddPercentageUpgrade("anomaly-vessel-component-upgrade-output", component.PointMultiplier);
     }
 
     private void OnVesselInteractUsing(EntityUid uid, AnomalyVesselComponent component, InteractUsingEvent args)

--- a/Content.Server/Anomaly/AnomalySystem.Vessel.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Vessel.cs
@@ -74,7 +74,7 @@ public sealed partial class AnomalySystem
         component.Anomaly = scanner.ScannedAnomaly;
         anomalyComponent.ConnectedVessel = uid;
         UpdateVesselAppearance(uid,  component);
-        _popup.PopupEntity(Loc.GetString("anomaly-vessel-component-anomaly-assigned"), uid);
+        Popup.PopupEntity(Loc.GetString("anomaly-vessel-component-anomaly-assigned"), uid);
     }
 
     private void OnVesselGetPointsPerSecond(EntityUid uid, AnomalyVesselComponent component, ref ResearchServerGetPointsPerSecondEvent args)

--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -7,6 +7,9 @@ using Content.Server.Materials;
 using Content.Server.Popups;
 using Content.Shared.Anomaly;
 using Content.Shared.Anomaly.Components;
+using Content.Shared.Damage;
+using Content.Shared.Interaction;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Server.GameObjects;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Random;
@@ -19,6 +22,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
 {
     [Dependency] private readonly AmbientSoundSystem _ambient = default!;
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly ExplosionSystem _explosion = default!;
     [Dependency] private readonly MaterialStorageSystem _material = default!;
@@ -37,9 +41,29 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         SubscribeLocalEvent<AnomalyComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<AnomalyComponent, StartCollideEvent>(OnStartCollide);
 
+        SubscribeLocalEvent<AnomalyComponent, InteractHandEvent>(OnInteractHand);
+        SubscribeLocalEvent<AnomalyComponent, AttackedEvent>(OnAttacked);
+
         InitializeGenerator();
         InitializeScanner();
         InitializeVessel();
+    }
+
+    private void OnInteractHand(EntityUid uid, AnomalyComponent component, InteractHandEvent args)
+    {
+        DoAnomalyBurnDamage(uid, args.User, component);
+        args.Handled = true;
+    }
+
+    private void OnAttacked(EntityUid uid, AnomalyComponent component, AttackedEvent args)
+    {
+        DoAnomalyBurnDamage(uid, args.User, component);
+    }
+
+    public void DoAnomalyBurnDamage(EntityUid source, EntityUid target, AnomalyComponent component)
+    {
+        Audio.PlayPvs(component.AnomalyContactDamageSound, source);
+        _damageable.TryChangeDamage(target, component.AnomalyContactDamage, true);
     }
 
     private void OnMapInit(EntityUid uid, AnomalyComponent component, MapInitEvent args)
@@ -99,9 +123,9 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
 
         var multiplier = 1f;
         if (component.Stability > component.GrowthThreshold)
-            multiplier = 1.25f; //more points for unstable
+            multiplier = component.GrowingPointMultiplier; //more points for unstable
         else if (component.Stability < component.DecayThreshold)
-            multiplier = 0.75f; //less points if it's dying
+            multiplier = component.DecayingPointMultiplier; //less points if it's dying
 
         //penalty of up to 50% based on health
         multiplier *= MathF.Pow(1.5f, component.Health) - 0.5f;

--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -4,12 +4,8 @@ using Content.Server.Audio;
 using Content.Server.DoAfter;
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Materials;
-using Content.Server.Popups;
 using Content.Shared.Anomaly;
 using Content.Shared.Anomaly.Components;
-using Content.Shared.Damage;
-using Content.Shared.Interaction;
-using Content.Shared.Weapons.Melee.Events;
 using Robust.Server.GameObjects;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Random;
@@ -22,11 +18,9 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
 {
     [Dependency] private readonly AmbientSoundSystem _ambient = default!;
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
-    [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly ExplosionSystem _explosion = default!;
     [Dependency] private readonly MaterialStorageSystem _material = default!;
-    [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
@@ -41,29 +35,9 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         SubscribeLocalEvent<AnomalyComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<AnomalyComponent, StartCollideEvent>(OnStartCollide);
 
-        SubscribeLocalEvent<AnomalyComponent, InteractHandEvent>(OnInteractHand);
-        SubscribeLocalEvent<AnomalyComponent, AttackedEvent>(OnAttacked);
-
         InitializeGenerator();
         InitializeScanner();
         InitializeVessel();
-    }
-
-    private void OnInteractHand(EntityUid uid, AnomalyComponent component, InteractHandEvent args)
-    {
-        DoAnomalyBurnDamage(uid, args.User, component);
-        args.Handled = true;
-    }
-
-    private void OnAttacked(EntityUid uid, AnomalyComponent component, AttackedEvent args)
-    {
-        DoAnomalyBurnDamage(uid, args.User, component);
-    }
-
-    public void DoAnomalyBurnDamage(EntityUid source, EntityUid target, AnomalyComponent component)
-    {
-        Audio.PlayPvs(component.AnomalyContactDamageSound, source);
-        _damageable.TryChangeDamage(target, component.AnomalyContactDamage, true);
     }
 
     private void OnMapInit(EntityUid uid, AnomalyComponent component, MapInitEvent args)

--- a/Content.Server/StationEvents/Events/AnomalySpawn.cs
+++ b/Content.Server/StationEvents/Events/AnomalySpawn.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using Content.Server.Anomaly;
+using Content.Server.Station.Components;
+using Robust.Shared.Random;
+
+namespace Content.Server.StationEvents.Events;
+
+public sealed class AnomalySpawn : StationEventSystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly AnomalySystem _anomaly = default!;
+
+    public override string Prototype => "AnomalySpawn";
+
+    public readonly string AnomalySpawnerPrototype = "RandomAnomalySpawner";
+
+    public readonly List<string> PossibleSighting = new()
+    {
+        "anomaly-spawn-sighting-1",
+        "anomaly-spawn-sighting-2",
+        "anomaly-spawn-sighting-3",
+        "anomaly-spawn-sighting-4",
+        "anomaly-spawn-sighting-5"
+    };
+
+    public override void Added()
+    {
+        base.Added();
+
+        var str = Loc.GetString("anomaly-spawn-event-announcement",
+            ("sighting", Loc.GetString(_random.Pick(PossibleSighting))));
+        ChatSystem.DispatchGlobalAnnouncement(str, colorOverride: Color.FromHex("#18abf5"));
+    }
+
+    public override void Started()
+    {
+        base.Started();
+
+        if (StationSystem.Stations.Count == 0)
+            return; // No stations
+        var chosenStation = RobustRandom.Pick(StationSystem.Stations.ToList());
+        if (!TryComp<StationDataComponent>(chosenStation, out var stationData))
+            return;
+
+        EntityUid? grid = null;
+        foreach (var g in stationData.Grids.Where(HasComp<BecomesStationComponent>))
+        {
+            grid = g;
+        }
+
+        if (grid is not { })
+            return;
+
+        var amountToSpawn = Math.Max(1, (int) MathF.Round(GetSeverityModifier() / 2));
+        for (var i = 0; i < amountToSpawn; i++)
+        {
+            _anomaly.SpawnOnRandomGridLocation(grid.Value, AnomalySpawnerPrototype);
+        }
+    }
+}

--- a/Content.Server/StationEvents/Events/AnomalySpawn.cs
+++ b/Content.Server/StationEvents/Events/AnomalySpawn.cs
@@ -14,21 +14,12 @@ public sealed class AnomalySpawn : StationEventSystem
 
     public readonly string AnomalySpawnerPrototype = "RandomAnomalySpawner";
 
-    public readonly List<string> PossibleSighting = new()
-    {
-        "anomaly-spawn-sighting-1",
-        "anomaly-spawn-sighting-2",
-        "anomaly-spawn-sighting-3",
-        "anomaly-spawn-sighting-4",
-        "anomaly-spawn-sighting-5"
-    };
-
     public override void Added()
     {
         base.Added();
 
         var str = Loc.GetString("anomaly-spawn-event-announcement",
-            ("sighting", Loc.GetString(_random.Pick(PossibleSighting))));
+            ("sighting", Loc.GetString($"anomaly-spawn-sighting-{_random.Next(1, 6)}")));
         ChatSystem.DispatchGlobalAnnouncement(str, colorOverride: Color.FromHex("#18abf5"));
     }
 

--- a/Content.Server/StationEvents/Events/BluespaceArtifact.cs
+++ b/Content.Server/StationEvents/Events/BluespaceArtifact.cs
@@ -34,13 +34,16 @@ public sealed class BluespaceArtifact : StationEventSystem
     public override void Started()
     {
         base.Started();
+        var amountToSpawn = Math.Max(1, (int) MathF.Round(GetSeverityModifier() / 1.5f));
+        for (var i = 0; i < amountToSpawn; i++)
+        {
+            if (!TryFindRandomTile(out _, out _, out _, out var coords))
+                return;
 
-        if (!TryFindRandomTile(out _, out _, out _, out var coords))
-            return;
+            EntityManager.SpawnEntity(ArtifactSpawnerPrototype, coords);
+            EntityManager.SpawnEntity(ArtifactFlashPrototype, coords);
 
-        EntityManager.SpawnEntity(ArtifactSpawnerPrototype, coords);
-        EntityManager.SpawnEntity(ArtifactFlashPrototype, coords);
-
-        Sawmill.Info($"Spawning random artifact at {coords}");
+            Sawmill.Info($"Spawning random artifact at {coords}");
+        }
     }
 }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -51,6 +51,25 @@ public sealed class ArtifactComponent : Component
     /// </summary>
     [DataField("lastActivationTime", customTypeSerializer: typeof(TimespanSerializer))]
     public TimeSpan LastActivationTime;
+
+    /// <summary>
+    /// The base price of each node for an artifact
+    /// </summary>
+    [DataField("pricePerNode")]
+    public int PricePerNode = 500;
+
+    /// <summary>
+    /// The base amount of research points for each artifact node.
+    /// </summary>
+    [DataField("pointsPerNode")]
+    public int PointsPerNode = 5000;
+
+    /// <summary>
+    /// A multiplier that is raised to the power of the average depth of a node.
+    /// Used for calculating the research point value of an artifact node.
+    /// </summary>
+    [DataField("pointDangerMultiplier")]
+    public float PointDangerMultiplier = 1.35f;
 }
 
 /// <summary>

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -17,9 +17,6 @@ public sealed partial class ArtifactSystem : EntitySystem
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
-    private const int PricePerNode = 500;
-    private const int PointsPerNode = 5000;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -34,7 +31,7 @@ public sealed partial class ArtifactSystem : EntitySystem
 
     private void OnInit(EntityUid uid, ArtifactComponent component, MapInitEvent args)
     {
-        RandomizeArtifact(component);
+        RandomizeArtifact(uid, component);
     }
 
     /// <summary>
@@ -43,16 +40,20 @@ public sealed partial class ArtifactSystem : EntitySystem
     /// </summary>
     /// <remarks>
     /// General balancing (for fully unlocked artifacts):
-    /// Simple (1-2 Nodes): 1-2K
-    /// Medium (5-8 Nodes): 6-7K
-    /// Complex (7-12 Nodes): 10-11K
+    /// Simple (1-2 Nodes): ~10K
+    /// Medium (5-8 Nodes): ~30-40K
+    /// Complex (7-12 Nodes): ~60-80K
+    ///
+    /// Simple artifacts should be enough to unlock a few techs.
+    /// Medium should get you partway through a tree.
+    /// Complex should get you through a full tree and then some.
     /// </remarks>
     private void GetPrice(EntityUid uid, ArtifactComponent component, ref PriceCalculationEvent args)
     {
         if (component.NodeTree == null)
             return;
 
-        var price = component.NodeTree.AllNodes.Sum(GetNodePrice);
+        var price = component.NodeTree.AllNodes.Sum(x => GetNodePrice(x, component));
 
         // 25% bonus for fully exploring every node.
         var fullyExploredBonus = component.NodeTree.AllNodes.Any(x => !x.Triggered) ? 1 : 1.25f;
@@ -60,7 +61,7 @@ public sealed partial class ArtifactSystem : EntitySystem
         args.Price =+ price * fullyExploredBonus;
     }
 
-    private float GetNodePrice(ArtifactNode node)
+    private float GetNodePrice(ArtifactNode node, ArtifactComponent component)
     {
         if (!node.Discovered) //no money for undiscovered nodes.
             return 0;
@@ -70,7 +71,7 @@ public sealed partial class ArtifactSystem : EntitySystem
         //the danger is the average of node depth, effect danger, and trigger danger.
         var nodeDanger = (node.Depth + node.Effect.TargetDepth + node.Trigger.TargetDepth) / 3;
 
-        var price = MathF.Pow(2f, nodeDanger) * PricePerNode * priceMultiplier;
+        var price = MathF.Pow(2f, nodeDanger) * component.PricePerNode * priceMultiplier;
         return price;
     }
 
@@ -85,36 +86,38 @@ public sealed partial class ArtifactSystem : EntitySystem
         if (!Resolve(uid, ref component) || component.NodeTree == null)
             return 0;
 
-        var sumValue = component.NodeTree.AllNodes.Sum(GetNodePointValue);
+        var sumValue = component.NodeTree.AllNodes.Sum(n => GetNodePointValue(n, component));
         var fullyExploredBonus = component.NodeTree.AllNodes.Any(x => !x.Triggered) ? 1 : 1.25f;
 
         var pointValue = (int) (sumValue * fullyExploredBonus);
         return pointValue;
     }
 
-    private float GetNodePointValue(ArtifactNode node)
+    /// <summary>
+    /// Gets the point value for an individual node
+    /// </summary>
+    private float GetNodePointValue(ArtifactNode node, ArtifactComponent component)
     {
         if (!node.Discovered)
             return 0;
 
-        var valueDeduction = !node.Triggered ? 0.5f : 1;
+        var valueDeduction = !node.Triggered ? 0.25f : 1;
         var nodeDanger = (node.Depth + node.Effect.TargetDepth + node.Trigger.TargetDepth) / 3;
-
-        return (nodeDanger+1) * PointsPerNode * valueDeduction;
+        return component.PointsPerNode * MathF.Pow(component.PointDangerMultiplier, nodeDanger) * valueDeduction;
     }
 
     /// <summary>
     /// Randomize a given artifact.
     /// </summary>
     [PublicAPI]
-    public void RandomizeArtifact(ArtifactComponent component)
+    public void RandomizeArtifact(EntityUid uid, ArtifactComponent component)
     {
         var nodeAmount = _random.Next(component.NodesMin, component.NodesMax);
 
         component.NodeTree = new ArtifactTree();
 
-        GenerateArtifactNodeTree(component.Owner, ref component.NodeTree, nodeAmount);
-        EnterNode(component.Owner, ref component.NodeTree.StartNode, component);
+        GenerateArtifactNodeTree(uid, ref component.NodeTree, nodeAmount);
+        EnterNode(uid, ref component.NodeTree.StartNode, component);
     }
 
     /// <summary>
@@ -166,21 +169,21 @@ public sealed partial class ArtifactSystem : EntitySystem
         component.CurrentNode.Triggered = true;
         if (component.CurrentNode.Edges.Any())
         {
-            var newNode = GetNewNode(component);
+            var newNode = GetNewNode(uid, component);
             if (newNode == null)
                 return;
             EnterNode(uid, ref newNode, component);
         }
     }
 
-    private ArtifactNode? GetNewNode(ArtifactComponent component)
+    private ArtifactNode? GetNewNode(EntityUid uid, ArtifactComponent component)
     {
         if (component.CurrentNode == null)
             return null;
 
         var allNodes = component.CurrentNode.Edges;
 
-        if (TryComp<BiasedArtifactComponent>(component.Owner, out var bias) &&
+        if (TryComp<BiasedArtifactComponent>(uid, out var bias) &&
             TryComp<TraversalDistorterComponent>(bias.Provider, out var trav) &&
             _random.Prob(trav.BiasChance) &&
             this.IsPowered(bias.Provider, EntityManager))

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -40,13 +40,9 @@ public sealed partial class ArtifactSystem : EntitySystem
     /// </summary>
     /// <remarks>
     /// General balancing (for fully unlocked artifacts):
-    /// Simple (1-2 Nodes): ~10K
-    /// Medium (5-8 Nodes): ~30-40K
-    /// Complex (7-12 Nodes): ~60-80K
-    ///
-    /// Simple artifacts should be enough to unlock a few techs.
-    /// Medium should get you partway through a tree.
-    /// Complex should get you through a full tree and then some.
+    /// Simple (1-2 Nodes): 1-2K
+    /// Medium (5-8 Nodes): 6-7K
+    /// Complex (7-12 Nodes): 10-11K
     /// </remarks>
     private void GetPrice(EntityUid uid, ArtifactComponent component, ref PriceCalculationEvent args)
     {
@@ -79,7 +75,14 @@ public sealed partial class ArtifactSystem : EntitySystem
     /// Calculates how many research points the artifact is worht
     /// </summary>
     /// <remarks>
-    /// Rebalance this shit at some point. Definitely OP.
+    /// General balancing (for fully unlocked artifacts):
+    /// Simple (1-2 Nodes): ~10K
+    /// Medium (5-8 Nodes): ~30-40K
+    /// Complex (7-12 Nodes): ~60-80K
+    ///
+    /// Simple artifacts should be enough to unlock a few techs.
+    /// Medium should get you partway through a tree.
+    /// Complex should get you through a full tree and then some.
     /// </remarks>
     public int GetResearchPointValue(EntityUid uid, ArtifactComponent? component = null)
     {

--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.Audio;
+﻿using Content.Shared.Damage;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -200,8 +201,36 @@ public sealed class AnomalyComponent : Component
     /// This doesn't include the point bonus for being unstable.
     /// </summary>
     [DataField("maxPointsPerSecond")]
-    public int MaxPointsPerSecond = 100;
+    public int MaxPointsPerSecond = 65;
+
+    /// <summary>
+    /// The multiplier applied to the point value for the
+    /// anomaly being above the <see cref="GrowthThreshold"/>
+    /// </summary>
+    [DataField("growingPointMultiplier")]
+    public float GrowingPointMultiplier = 1.2f;
+
+    /// <summary>
+    /// The multiplier applied to the point value for the
+    /// anomaly being below the <see cref="DecayThreshold"/>
+    /// </summary>
+    [DataField("decayingPointMultiplier")]
+    public float DecayingPointMultiplier = 0.75f;
     #endregion
+
+    /// <summary>
+    /// The amount of damage dealt when either a player touches the anomaly
+    /// directly or by hitting the anomaly.
+    /// </summary>
+    [DataField("anomalyContactDamage", required: true)]
+    public DamageSpecifier AnomalyContactDamage = default!;
+
+    /// <summary>
+    /// The sound effect played when a player
+    /// burns themselves on an anomaly via contact.
+    /// </summary>
+    [DataField("anomalyContactDamageSound")]
+    public SoundSpecifier AnomalyContactDamageSound = new SoundPathSpecifier("/Audio/Effects/lightburn.ogg");
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -106,6 +106,13 @@ public sealed class AnomalyComponent : Component
     public float PulseVariation = .1f;
 
     /// <summary>
+    /// The largest value by which the anomaly will vary in stability for each pulse.
+    /// In simple terms, every pulse, stability changes from a range of -this_value to this_value
+    /// </summary>
+    [DataField("pulseStabilityVariation")]
+    public float PulseStabilityVariation = 0.05f;
+
+    /// <summary>
     /// The sound played when an anomaly pulses
     /// </summary>
     [DataField("pulseSound")]

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -127,12 +127,9 @@ public abstract class SharedAnomalySystem : EntitySystem
         {
             ChangeAnomalySeverity(uid, GetSeverityIncreaseFromGrowth(component), component);
         }
-        else
-        {
-            // just doing this to update the scanner ui
-            // as they hook into these events
-            ChangeAnomalySeverity(uid, 0);
-        }
+
+        var stability = Random.NextFloat(-component.PulseStabilityVariation, component.PulseStabilityVariation);
+        ChangeAnomalyStability(uid, stability, component);
 
         Log.Add(LogType.Anomaly, LogImpact.Medium, $"Anomaly {ToPrettyString(uid)} pulsed with severity {component.Severity}.");
         Audio.PlayPvs(component.PulseSound, uid);

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -1,6 +1,10 @@
 ﻿using Content.Shared.Administration.Logs;
 using Content.Shared.Anomaly.Components;
+using Content.Shared.Damage;
 using Content.Shared.Database;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Random;
@@ -15,8 +19,10 @@ public abstract class SharedAnomalySystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] protected readonly IRobustRandom Random = default!;
     [Dependency] protected readonly ISharedAdminLogManager Log = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
+    [Dependency] protected readonly SharedPopupSystem Popup = default!;
 
     public override void Initialize()
     {
@@ -26,6 +32,8 @@ public abstract class SharedAnomalySystem : EntitySystem
         SubscribeLocalEvent<AnomalyComponent, ComponentHandleState>(OnAnomalyHandleState);
         SubscribeLocalEvent<AnomalySupercriticalComponent, ComponentGetState>(OnSupercriticalGetState);
         SubscribeLocalEvent<AnomalySupercriticalComponent, ComponentHandleState>(OnSupercriticalHandleState);
+        SubscribeLocalEvent<AnomalyComponent, InteractHandEvent>(OnInteractHand);
+        SubscribeLocalEvent<AnomalyComponent, AttackedEvent>(OnAttacked);
 
         SubscribeLocalEvent<AnomalyComponent, EntityUnpausedEvent>(OnAnomalyUnpause);
         SubscribeLocalEvent<AnomalyPulsingComponent, EntityUnpausedEvent>(OnPulsingUnpause);
@@ -67,6 +75,26 @@ public abstract class SharedAnomalySystem : EntitySystem
 
         component.EndTime = state.EndTime;
         component.SupercriticalDuration = state.Duration;
+    }
+
+    private void OnInteractHand(EntityUid uid, AnomalyComponent component, InteractHandEvent args)
+    {
+        DoAnomalyBurnDamage(uid, args.User, component);
+        args.Handled = true;
+    }
+
+    private void OnAttacked(EntityUid uid, AnomalyComponent component, AttackedEvent args)
+    {
+        DoAnomalyBurnDamage(uid, args.User, component);
+    }
+
+    public void DoAnomalyBurnDamage(EntityUid source, EntityUid target, AnomalyComponent component)
+    {
+        _damageable.TryChangeDamage(target, component.AnomalyContactDamage, true);
+        if (!Timing.IsFirstTimePredicted || _net.IsServer)
+            return;
+        Audio.PlayPvs(component.AnomalyContactDamageSound, source);
+        Popup.PopupEntity(Loc.GetString("anomaly-component-contact-damage"), target, target);
     }
 
     private void OnAnomalyUnpause(EntityUid uid, AnomalyComponent component, ref EntityUnpausedEvent args)

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -3,6 +3,7 @@ anomaly-component-contact-damage = The anomaly sears off your skin!
 anomaly-vessel-component-anomaly-assigned = Anomaly assigned to vessel.
 anomaly-vessel-component-not-assigned = This vessel is not assigned to any anomaly. Try using a scanner on it.
 anomaly-vessel-component-assigned = This vessel is currently assigned to an anomaly.
+anomaly-vessel-component-upgrade-output = point output
 
 anomaly-particles-delta = Delta particles
 anomaly-particles-epsilon = Epsilon particles

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -1,3 +1,5 @@
+anomaly-component-contact-damage = The anomaly sears off your skin!
+
 anomaly-vessel-component-anomaly-assigned = Anomaly assigned to vessel.
 anomaly-vessel-component-not-assigned = This vessel is not assigned to any anomaly. Try using a scanner on it.
 anomaly-vessel-component-assigned = This vessel is currently assigned to an anomaly.

--- a/Resources/Locale/en-US/station-events/events/anomaly-spawn.ftl
+++ b/Resources/Locale/en-US/station-events/events/anomaly-spawn.ftl
@@ -1,0 +1,7 @@
+anomaly-spawn-event-announcement = Our readings have detected a dangerous interspacial anomaly. Please inform the research team of { $sighting }.
+
+anomaly-spawn-sighting-1 = low pulsating sounds heard throughout the station
+anomaly-spawn-sighting-2 = strange sources of light
+anomaly-spawn-sighting-3 = inexplicable shapes
+anomaly-spawn-sighting-4 = forms causing severe mental distress
+anomaly-spawn-sighting-5 = strange effects on the local environment

--- a/Resources/Locale/en-US/station-events/events/bluespace-artifact.ftl
+++ b/Resources/Locale/en-US/station-events/events/bluespace-artifact.ftl
@@ -1,4 +1,4 @@
-bluespace-artifact-event-announcement = Our readings have detected an incoming anomalous object. Please inform the research team of { $sighting }.
+bluespace-artifact-event-announcement = Our readings have detected an incoming object of alien origin. Please inform the research team of { $sighting }.
 
 bluespace-artifact-sighting-1 = bright flashes of light
 bluespace-artifact-sighting-2 = strange sounds coming from maintenance tunnels

--- a/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
@@ -9,6 +9,9 @@
       collection: RadiationPulse
       params:
         volume: 5
+    anomalyContactDamage:
+      types:
+        Radiation: 10
   - type: AmbientSound
     range: 5
     volume: -5
@@ -35,8 +38,6 @@
   - type: InteractionOutline
   - type: Clickable
   - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
   - type: Appearance
   - type: EmitSoundOnSpawn
     sound: 

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -1,4 +1,13 @@
 ﻿- type: gameRule
+  id: AnomalySpawn
+  config:
+    !type:StationEventRuleConfiguration
+    id: AnomalySpawn
+    weight: 10
+    startAfter: 30
+    endAfter: 35
+
+- type: gameRule
   id: BluespaceArtifact
   config:
     !type:StationEventRuleConfiguration


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
- added station event for anomaly spawning and made bluespace artifact event work with severity
- nerfed the shit out artifact point value. like holy shit what was i thinking. a single node could be close to 20000 points
- also nerfed anomaly value a bit. this should incentivize using both subdepartments, as well as expanding and getting more vessels.
- made anomalies burn you on touch and on hit. stop fucking hitting them you idiots.
- adds missing upgrade text for vessels
- makes anomaly stability randomly fluctuate on each pulse.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Reduced point output for both anomalies and artifacts
- tweak: Added a station event for anomalies to spawn.
- tweak: The superheated anomalous surface of an anomaly imparts nasty burns, even through protective covering.
- fix: The bluespace artifact station event now scales properly with survival rounds.
- fix: Fixed missing upgrade examine text on the anomaly vessel.
- add: Anomalies now slightly fluctuate in stability on each pulse. Better hope you don't push it over the edge.
