### PR TITLE
Add:Fixes bear hide not being visible by adding an equippedPrefix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -158,6 +158,7 @@
     heldPrefix: bear
   - type: Clothing
     sprite: Clothing/Head/Misc/hides.rsi
+    equippedPrefix: bear
     slots:
       - HEAD
 


### PR DESCRIPTION
Added a equippedPrefix to the clothing component for bear hides.
This makes bear hides actually visible when you wear them. 
![image](https://user-images.githubusercontent.com/17504309/213353299-031fc5ba-eb3e-4c1d-9c38-39706ed5e75a.png)
![image](https://user-images.githubusercontent.com/17504309/213353314-48c718df-c5d7-4d8d-a7c3-26dad09def77.png)
