### PR TITLE
Fix zipties

### DIFF
--- a/Content.Server/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Server/Cuffs/Components/CuffableComponent.cs
@@ -31,16 +31,6 @@ namespace Content.Server.Cuffs.Components
         [Dependency] private readonly IComponentFactory _componentFactory = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
 
-        /// <summary>
-        /// How many of this entity's hands are currently cuffed.
-        /// </summary>
-        [ViewVariables]
-        public int CuffedHandCount => Container.ContainedEntities.Count * 2;
-
-        public EntityUid LastAddedCuffs => Container.ContainedEntities[^1];
-
-        public IReadOnlyList<EntityUid> StoredEntities => Container.ContainedEntities;
-
         private bool _uncuffing;
 
         protected override void Initialize()
@@ -102,14 +92,7 @@ namespace Content.Server.Cuffs.Components
             sys.TryDrop(user, handcuff);
 
             Container.Insert(handcuff);
-            CanStillInteract = _entMan.TryGetComponent(Owner, out HandsComponent? ownerHands) && ownerHands.Hands.Count() > CuffedHandCount;
-            _entMan.EntitySysManager.GetEntitySystem<ActionBlockerSystem>().UpdateCanMove(Owner);
-
-            var ev = new CuffedStateChangeEvent();
-            _entMan.EventBus.RaiseLocalEvent(Owner, ref ev, true);
-            UpdateAlert();
             UpdateHeldItems(handcuff);
-            Dirty(_entMan);
             return true;
         }
 
@@ -269,6 +252,7 @@ namespace Content.Server.Cuffs.Components
             SoundSystem.Play(cuff.EndUncuffSound.GetSound(), Filter.Pvs(Owner), Owner);
 
             _entMan.EntitySysManager.GetEntitySystem<HandVirtualItemSystem>().DeleteInHandsMatching(user, cuffsToRemove);
+            Container.Remove(cuffsToRemove);
 
             if (cuff.BreakOnRemove)
             {
@@ -280,14 +264,6 @@ namespace Content.Server.Cuffs.Components
             {
                 _entMan.EntitySysManager.GetEntitySystem<SharedHandsSystem>().PickupOrDrop(user, cuffsToRemove);
             }
-
-            CanStillInteract = _entMan.TryGetComponent(Owner, out HandsComponent? handsComponent) && handsComponent.SortedHands.Count() > CuffedHandCount;
-            _entMan.EntitySysManager.GetEntitySystem<ActionBlockerSystem>().UpdateCanMove(Owner);
-
-            var ev = new CuffedStateChangeEvent();
-            _entMan.EventBus.RaiseLocalEvent(Owner, ref ev, true);
-            UpdateAlert();
-            Dirty(_entMan);
 
             if (CuffedHandCount == 0)
             {

--- a/Content.Server/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Server/Cuffs/Components/CuffableComponent.cs
@@ -96,13 +96,6 @@ namespace Content.Server.Cuffs.Components
             return true;
         }
 
-        public void CuffedStateChanged()
-        {
-            UpdateAlert();
-            var ev = new CuffedStateChangeEvent();
-            _entMan.EventBus.RaiseLocalEvent(Owner, ref ev, true);
-        }
-
         /// <summary>
         ///     Adds virtual cuff items to the user's hands.
         /// </summary>

--- a/Content.Server/Cuffs/CuffableSystem.cs
+++ b/Content.Server/Cuffs/CuffableSystem.cs
@@ -193,10 +193,7 @@ namespace Content.Server.Cuffs
 
             if (dirty)
             {
-                cuffable.CanStillInteract = handCount > cuffable.CuffedHandCount;
-                _actionBlockerSystem.UpdateCanMove(cuffable.Owner);
-                cuffable.CuffedStateChanged();
-                Dirty(cuffable);
+                UpdateCuffState(owner, cuffable);
             }
         }
     }

--- a/Content.Shared/Cuffs/Components/SharedCuffableComponent.cs
+++ b/Content.Shared/Cuffs/Components/SharedCuffableComponent.cs
@@ -14,6 +14,16 @@ namespace Content.Shared.Cuffs.Components
         [Dependency] private readonly IComponentFactory _componentFactory = default!;
 
         /// <summary>
+        /// How many of this entity's hands are currently cuffed.
+        /// </summary>
+        [ViewVariables]
+        public int CuffedHandCount => Container.ContainedEntities.Count * 2;
+
+        public EntityUid LastAddedCuffs => Container.ContainedEntities[^1];
+
+        public IReadOnlyList<EntityUid> StoredEntities => Container.ContainedEntities;
+
+        /// <summary>
         ///     Container of various handcuffs currently applied to the entity.
         /// </summary>
         [ViewVariables(VVAccess.ReadOnly)]


### PR DESCRIPTION
Zip ties weren't properly being removed because of the use of `QueueDeleteEntity` not removing the cuffs immediately.

This PR moves the cuffable updating logic to trigger when cuffs are added or removed from the cuff container, which should stop that from happening again. Also makes the rejuvenate verb remove all cuffs.

https://user-images.githubusercontent.com/60421075/213590578-e7a8ffc1-601c-49c8-bcd4-eb5a5faf3fab.mp4


:cl:
- fix: Fixed zipties not not being properly removeable.
