### PR TITLE
make printed items from lathes automatically stack

### DIFF
--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -5,6 +5,8 @@ using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
 using Robust.Shared.GameStates;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -14,13 +16,15 @@ namespace Content.Shared.Stacks
     [UsedImplicitly]
     public abstract class SharedStackSystem : EntitySystem
     {
+        [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IPrototypeManager _prototype = default!;
+        [Dependency] private readonly IViewVariablesManager _vvm = default!;
         [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
-        [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
         [Dependency] protected readonly SharedHandsSystem HandsSystem = default!;
         [Dependency] protected readonly SharedTransformSystem Xform = default!;
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
-        [Dependency] private readonly IViewVariablesManager _vvm = default!;
+        [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+        [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
 
         public override void Initialize()
         {
@@ -96,6 +100,9 @@ namespace Content.Shared.Stacks
             StackComponent? recipientStack = null)
         {
             transfered = 0;
+            if (donor == recipient)
+                return false;
+
             if (!Resolve(recipient, ref recipientStack, false) || !Resolve(donor, ref donorStack, false))
                 return false;
 
@@ -188,6 +195,35 @@ namespace Content.Shared.Stacks
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Tries to merge a stack into any of the stacks it is touching.
+        /// </summary>
+        /// <returns>Whether or not it was successfully merged into another stack</returns>
+        public bool TryMergeToContacts(EntityUid uid, StackComponent? stack = null, TransformComponent? xform = null)
+        {
+            if (!Resolve(uid, ref stack, ref xform, false))
+                return false;
+
+            var map = xform.MapID;
+            var bounds = _physics.GetWorldAABB(uid);
+            var intersecting = _entityLookup.GetComponentsIntersecting<StackComponent>(map, bounds,
+                LookupFlags.Approximate | LookupFlags.Uncontained);
+
+            var merged = false;
+            foreach (var otherStack in intersecting)
+            {
+                var otherEnt = otherStack.Owner;
+
+                if (!TryMergeStacks(uid, otherEnt, out _, stack, otherStack))
+                    continue;
+                merged = true;
+
+                if (stack.Count <= 0)
+                    break;
+            }
+            return merged;
         }
 
         /// <summary>

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -208,7 +208,7 @@ namespace Content.Shared.Stacks
             var map = xform.MapID;
             var bounds = _physics.GetWorldAABB(uid);
             var intersecting = _entityLookup.GetComponentsIntersecting<StackComponent>(map, bounds,
-                LookupFlags.Approximate | LookupFlags.Uncontained);
+                LookupFlags.Dynamic | LookupFlags.Sundries);
 
             var merged = false;
             foreach (var otherStack in intersecting)

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
 using Robust.Shared.GameStates;
-using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Closes #10402

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Lathes will now automatically stack their output.