### PR TITLE
Make pricing system aware of SpawnItemsOnUseComponent

### DIFF
--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -3,7 +3,6 @@ using Content.Server.Administration;
 using Content.Server.Body.Systems;
 using Content.Server.Cargo.Components;
 using Content.Server.Chemistry.Components.SolutionManager;
-using Content.Server.Storage.Components;
 using Content.Shared.Administration;
 using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.Reagent;
@@ -16,8 +15,6 @@ using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
-
-using static Content.Shared.Storage.EntitySpawnCollection;
 
 namespace Content.Server.Cargo.Systems;
 
@@ -90,6 +87,9 @@ public sealed class PricingSystem : EntitySystem
 
     private void CalculateMobPrice(EntityUid uid, MobPriceComponent component, ref PriceCalculationEvent args)
     {
+        if (args.Handled)
+            return;
+
         if (!TryComp<BodyComponent>(uid, out var body) || !TryComp<MobStateComponent>(uid, out var state))
         {
             Logger.ErrorS("pricing", $"Tried to get the mob price of {ToPrettyString(uid)}, which has no {nameof(BodyComponent)} and no {nameof(MobStateComponent)}.");
@@ -108,6 +108,9 @@ public sealed class PricingSystem : EntitySystem
 
     private void CalculateStackPrice(EntityUid uid, StackPriceComponent component, ref PriceCalculationEvent args)
     {
+        if (args.Handled)
+            return;
+
         if (!TryComp<StackComponent>(uid, out var stack))
         {
             Logger.ErrorS("pricing", $"Tried to get the stack price of {ToPrettyString(uid)}, which has no {nameof(StackComponent)}.");
@@ -119,6 +122,9 @@ public sealed class PricingSystem : EntitySystem
 
     private void CalculateSolutionPrice(EntityUid uid, SolutionContainerManagerComponent component, ref PriceCalculationEvent args)
     {
+        if (args.Handled)
+            return;
+
         var price = 0f;
 
         foreach (var solution in component.Solutions.Values)
@@ -135,6 +141,9 @@ public sealed class PricingSystem : EntitySystem
 
     private void CalculateStaticPrice(EntityUid uid, StaticPriceComponent component, ref PriceCalculationEvent args)
     {
+        if (args.Handled)
+            return;
+
         args.Price += component.Price;
     }
 
@@ -186,43 +195,11 @@ public sealed class PricingSystem : EntitySystem
     /// </remarks>
     public double GetPrice(EntityUid uid)
     {
-        // If this item has a SpawnItemsOnUseComponent, we ignore everything else (including StaticPrice) and just
-        // return combined price of the items that would be spawned on use
-        if (TryComp<SpawnItemsOnUseComponent>(uid, out var spawnItemsOnUse))
-        {
-            double price = 0;
-            var ungrouped = CollectOrGroups(spawnItemsOnUse.Items, out var orGroups);
-
-            foreach (var entry in ungrouped)
-            {
-                var protUid = Spawn(entry.PrototypeId, MapCoordinates.Nullspace);
-
-                // Calculate the average price of the possible spawned items
-                price += GetPrice(protUid) * entry.SpawnProbability * entry.GetAmount(getAverage: true);
-
-                EntityManager.DeleteEntity(protUid);
-            }
-
-            foreach (var group in orGroups)
-            {
-                foreach (var entry in group.Entries)
-                {
-                    var protUid = Spawn(entry.PrototypeId, MapCoordinates.Nullspace);
-
-                    // Calculate the average price of the possible spawned items
-                    price += GetPrice(protUid) *
-                             (entry.SpawnProbability / group.CumulativeProbability) *
-                             entry.GetAmount(getAverage: true);
-
-                    EntityManager.DeleteEntity(protUid);
-                }
-            }
-
-            return price;
-        }
-
         var ev = new PriceCalculationEvent();
         RaiseLocalEvent(uid, ref ev);
+
+        if (ev.Handled)
+            return ev.Price;
 
         //TODO: Add an OpaqueToAppraisal component or similar for blocking the recursive descent into containers, or preventing material pricing.
 
@@ -285,6 +262,11 @@ public struct PriceCalculationEvent
     /// The total price of the entity.
     /// </summary>
     public double Price = 0;
+
+    /// <summary>
+    /// Whether this event was already handled.
+    /// </summary>
+    public bool Handled = false;
 
     public PriceCalculationEvent() { }
 }

--- a/Content.Server/Storage/Components/SpawnItemsOnUseComponent.cs
+++ b/Content.Server/Storage/Components/SpawnItemsOnUseComponent.cs
@@ -12,7 +12,6 @@ namespace Content.Server.Storage.Components
         /// <summary>
         ///     The list of entities to spawn, with amounts and orGroups.
         /// </summary>
-        /// <returns></returns>
         [DataField("items", required: true)]
         public List<EntitySpawnEntry> Items = new();
 
@@ -25,7 +24,6 @@ namespace Content.Server.Storage.Components
         /// <summary>
         ///     How many uses before the item should delete itself.
         /// </summary>
-        /// <returns></returns>
         [DataField("uses")]
         public int Uses = 1;
     }

--- a/Content.Shared/Storage/EntitySpawnEntry.cs
+++ b/Content.Shared/Storage/EntitySpawnEntry.cs
@@ -1,6 +1,6 @@
-﻿using Robust.Shared.Prototypes;
+﻿using System.Linq;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Storage;
@@ -62,7 +62,7 @@ public struct EntitySpawnEntry
 
 public static class EntitySpawnCollection
 {
-    private sealed class OrGroup
+    public sealed class OrGroup
     {
         public List<EntitySpawnEntry> Entries { get; set; } = new();
         public float CumulativeProbability { get; set; } = 0f;
@@ -84,34 +84,16 @@ public static class EntitySpawnCollection
         IoCManager.Resolve(ref random);
 
         var spawned = new List<string?>();
-        var orGroupedSpawns = new Dictionary<string, OrGroup>();
+        var ungrouped = CollectOrGroups(entries, out var orGroupedSpawns);
 
-        // collect groups together, create singular items that pass probability
-        foreach (var entry in entries)
+        foreach (var entry in ungrouped)
         {
-            // Handle "Or" groups
-            if (!string.IsNullOrEmpty(entry.GroupId))
-            {
-                if (!orGroupedSpawns.TryGetValue(entry.GroupId, out OrGroup? orGroup))
-                {
-                    orGroup = new();
-                    orGroupedSpawns.Add(entry.GroupId, orGroup);
-                }
-
-                orGroup.Entries.Add(entry);
-                orGroup.CumulativeProbability += entry.SpawnProbability;
-                continue;
-            }
-
-            // else
             // Check random spawn
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (entry.SpawnProbability != 1f && !random.Prob(entry.SpawnProbability)) continue;
+            if (entry.SpawnProbability != 1f && !random.Prob(entry.SpawnProbability))
+                continue;
 
-            var amount = entry.Amount;
-
-            if (entry.MaxAmount > amount)
-                amount = random.Next(amount, entry.MaxAmount);
+            var amount = (int) entry.GetAmount(random);
 
             for (var i = 0; i < amount; i++)
             {
@@ -119,25 +101,25 @@ public static class EntitySpawnCollection
             }
         }
 
-        // handle orgroup spawns
-        foreach (var spawnValue in orGroupedSpawns.Values)
+        // Handle OrGroup spawns
+        foreach (var spawnValue in orGroupedSpawns)
         {
             // For each group use the added cumulative probability to roll a double in that range
-            double diceRoll = random.NextDouble() * spawnValue.CumulativeProbability;
+            var diceRoll = random.NextDouble() * spawnValue.CumulativeProbability;
+
             // Add the entry's spawn probability to this value, if equals or lower, spawn item, otherwise continue to next item.
             var cumulative = 0.0;
+
             foreach (var entry in spawnValue.Entries)
             {
                 cumulative += entry.SpawnProbability;
-                if (diceRoll > cumulative) continue;
+                if (diceRoll > cumulative)
+                    continue;
+
                 // Dice roll succeeded, add item and break loop
+                var amount = (int) entry.GetAmount(random);
 
-                var amount = entry.Amount;
-
-                if (entry.MaxAmount > amount)
-                    amount = random.Next(amount, entry.MaxAmount);
-
-                for (var index = 0; index < amount; index++)
+                for (var i = 0; i < amount; i++)
                 {
                     spawned.Add(entry.PrototypeId);
                 }
@@ -147,5 +129,59 @@ public static class EntitySpawnCollection
         }
 
         return spawned;
+    }
+
+    /// <summary>
+    /// Collects all entries that belong together in an OrGroup, and then returns the leftover ungrouped entries.
+    /// </summary>
+    /// <param name="entries">A list of entries that will be collected into OrGroups.</param>
+    /// <param name="orGroups">A list of entries collected into OrGroups.</param>
+    /// <returns>A list of entries that are not in an OrGroup.</returns>
+    public static List<EntitySpawnEntry> CollectOrGroups(IEnumerable<EntitySpawnEntry> entries, out List<OrGroup> orGroups)
+    {
+        var ungrouped = new List<EntitySpawnEntry>();
+        var orGroupsDict = new Dictionary<string, OrGroup>();
+
+        foreach (var entry in entries)
+        {
+            // If the entry is in a group, collect it into an OrGroup. Otherwise just add it to a list of ungrouped
+            // entries.
+            if (!string.IsNullOrEmpty(entry.GroupId))
+            {
+                // Create a new OrGroup if necessary
+                if (!orGroupsDict.TryGetValue(entry.GroupId, out var orGroup))
+                {
+                    orGroup = new OrGroup();
+                    orGroupsDict.Add(entry.GroupId, orGroup);
+                }
+
+                orGroup.Entries.Add(entry);
+                orGroup.CumulativeProbability += entry.SpawnProbability;
+            }
+            else
+            {
+                ungrouped.Add(entry);
+            }
+        }
+
+        // We don't really need the group IDs anymore, so just return the values as a list
+        orGroups = orGroupsDict.Values.ToList();
+
+        return ungrouped;
+    }
+
+    public static double GetAmount(this EntitySpawnEntry entry, IRobustRandom? random = null, bool getAverage = false)
+    {
+        // Max amount is less or equal than amount, so just return the amount
+        if (entry.MaxAmount <= entry.Amount)
+            return entry.Amount;
+
+        // If we want the average, just calculate the expected amount
+        if (getAverage)
+            return (entry.Amount + entry.MaxAmount) / 2.0;
+
+        // Otherwise get a random value in between
+        IoCManager.Resolve(ref random);
+        return random.Next(entry.Amount, entry.MaxAmount);
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -247,8 +247,6 @@
       - id: FoodTinMREOpen
     sound:
       path: /Audio/Items/can_open3.ogg
-  - type: StaticPrice
-    price: 50
 
 
 - type: entity


### PR DESCRIPTION
## About the PR
Fixes #12640, related to #13587.

If an entity has a SpawnItemsOnUseComponent, then PricingSystem will now calculate the sum of the prices of the spawned items. In doing this it takes into account spawn probability (such that if an item has 0.5 change of spawning then only half of the price is added), amount of items spawned, and OrGroups.

I refactored EntitySpawnEntry a bit to avoid code duplication.

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed a bug where an unwrapped nutribrick was worth more than a wrapped one