### PR TITLE
Unique Hardsuit Light Colors

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -30,6 +30,8 @@
       - state: equipped-head
       - state: equipped-head-unshaded
         shader: unshaded
+  - type: PointLight
+    color: "#59ffac"
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 10000
@@ -85,6 +87,8 @@
     sprite: Clothing/Head/Hardsuits/engineering.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/engineering.rsi
+  - type: PointLight
+    color: "#ffba59"
   - type: PressureProtection
     highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000
@@ -100,6 +104,8 @@
     sprite: Clothing/Head/Hardsuits/engineering-white.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/engineering-white.rsi
+  - type: PointLight
+    color: "#d0ff59"
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -130,6 +136,8 @@
     sprite: Clothing/Head/Hardsuits/medical.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/medical.rsi
+  - type: PointLight
+    color: "#59c8ff"
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 5500
@@ -147,6 +155,8 @@
     sprite: Clothing/Head/Hardsuits/rd.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/rd.rsi
+  - type: PointLight
+    color: "#a659ff"
   - type: PressureProtection
     highPressureMultiplier: 0.60
     lowPressureMultiplier: 5500
@@ -186,6 +196,8 @@
     sprite: Clothing/Head/Hardsuits/security.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/security.rsi
+  - type: PointLight
+    color: "#ff5959"
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 10000
@@ -207,6 +219,8 @@
     sprite: Clothing/Head/Hardsuits/security-red.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/security-red.rsi
+  - type: PointLight
+    color: "#ff5959"
   - type: PressureProtection
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 10000
@@ -253,6 +267,8 @@
     sprite: Clothing/Head/Hardsuits/wizard.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/wizard.rsi
+  - type: PointLight
+    color: "#ff59d6"
   - type: PressureProtection
     highPressureMultiplier: 0.27
     lowPressureMultiplier: 1000
@@ -427,6 +443,8 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertleader.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertleader.rsi
+  - type: PointLight
+    color: "#5983ff"
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitERTLeader
@@ -437,6 +455,8 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertengineer.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertengineer.rsi
+  - type: PointLight
+    color: "#baff59"
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitERTLeader
@@ -447,6 +467,8 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertmedical.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertmedical.rsi
+  - type: PointLight
+    color: "#a8ffda"
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitERTLeader
@@ -457,6 +479,8 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertsecurity.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertsecurity.rsi
+  - type: PointLight
+    color: "#ff5959"
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitERTLeader
@@ -467,3 +491,5 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertjanitor.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertjanitor.rsi
+  - type: PointLight
+    color: "#bd59ff"

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -31,7 +31,7 @@
       - state: equipped-head-unshaded
         shader: unshaded
   - type: PointLight
-    color: "#59ffac"
+    color: "#adffe6"
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 10000
@@ -88,7 +88,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/engineering.rsi
   - type: PointLight
-    color: "#ffba59"
+    color: "#ffdbad"
   - type: PressureProtection
     highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000
@@ -105,7 +105,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/engineering-white.rsi
   - type: PointLight
-    color: "#d0ff59"
+    color: "#daffad"
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -137,7 +137,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/medical.rsi
   - type: PointLight
-    color: "#59c8ff"
+    color: "#adf1ff"
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 5500
@@ -156,7 +156,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/rd.rsi
   - type: PointLight
-    color: "#a659ff"
+    color: "#d6adff"
   - type: PressureProtection
     highPressureMultiplier: 0.60
     lowPressureMultiplier: 5500
@@ -197,7 +197,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/security.rsi
   - type: PointLight
-    color: "#ff5959"
+    color: "#ffadad"
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 10000
@@ -220,7 +220,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/security-red.rsi
   - type: PointLight
-    color: "#ff5959"
+    color: "#ffadad"
   - type: PressureProtection
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 10000
@@ -268,7 +268,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/wizard.rsi
   - type: PointLight
-    color: "#ff59d6"
+    color: "#ffadfb"
   - type: PressureProtection
     highPressureMultiplier: 0.27
     lowPressureMultiplier: 1000
@@ -444,7 +444,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertleader.rsi
   - type: PointLight
-    color: "#5983ff"
+    color: "#addbff"
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitERTLeader
@@ -456,7 +456,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertengineer.rsi
   - type: PointLight
-    color: "#baff59"
+    color: "#f4ffad"
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitERTLeader
@@ -468,7 +468,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertmedical.rsi
   - type: PointLight
-    color: "#a8ffda"
+    color: "#adffec"
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitERTLeader
@@ -480,7 +480,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertsecurity.rsi
   - type: PointLight
-    color: "#ff5959"
+    color: "#ffadc6"
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitERTLeader
@@ -492,4 +492,4 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertjanitor.rsi
   - type: PointLight
-    color: "#bd59ff"
+    color: "#cbadff"


### PR DESCRIPTION
## About the PR
Changes the light colors on most hardsuits to make them more stylish.
Suits effected; Atmos, Engineer, CE, CMO, RD, Security, HoS, Wizard, and every ERT suit.

It could cause some problem with identifying syndicate from crew, colorblindness and just generally being able to see with more obtrusive colors like purple and blue.

I am very open to feedback on this due to it's rather unnecessary nature and the problems it might cause.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.
![image](https://user-images.githubusercontent.com/110078045/213886551-44933a0c-b445-4c72-b687-d9cb53a9b65c.png)
![image](https://user-images.githubusercontent.com/110078045/213886554-5cfc1300-419e-4fdb-9542-2a375700ae74.png)
![image](https://user-images.githubusercontent.com/110078045/213886556-d3d52a48-145c-4071-84dd-54f9e88357bc.png)

The last three shown are for reference reasons. Left to right being the syndicate bloodred, syndicate elite and original light color.

**Changelog**
:cl:
- tweak: Changed most hardsuit light colors to be unique.
