### PR TITLE
Pizza crate price tweaks

### DIFF
--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -38,12 +38,11 @@ public sealed class CargoTest
                     var ent = entManager.SpawnEntity(proto.Product, new MapCoordinates(Vector2.Zero, mapId));
                     var price = pricing.GetPrice(ent);
 
-                    Assert.That(price, Is.LessThan(proto.PointCost), $"Found arbitrage on {proto.ID} cargo product! Cost is {proto.PointCost} but sell is {price}!");
+                    Assert.That(price, Is.AtMost(proto.PointCost), $"Found arbitrage on {proto.ID} cargo product! Cost is {proto.PointCost} but sell is {price}!");
                     entManager.DeleteEntity(ent);
                 }
-
             });
-            
+
             mapManager.DeleteMap(mapId);
         });
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita
   product: CrateFoodPizza
-  cost: 550
+  cost: 450
   category: Food
   group: market
 
@@ -47,7 +47,7 @@
   cost: 750
   category: Food
   group: market
-    
+
 - type: cargoProduct
   id: FoodCrateKvassTank
   icon:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -164,6 +164,8 @@
     - type: StorageVisualizer
       state_open: box-open
       state_closed: box
+  - type: StaticPrice
+    price: 0
 
 - type: entity
   name: pizza box
@@ -176,8 +178,6 @@
     - state: box
     - state: box-open
       map: ["enum.StorageVisualLayers.Door"]
-  - type: StaticPrice
-    price: 0
   - type: StorageFill
     contents:
     - id: FoodPizzaArnold

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -176,6 +176,8 @@
     - state: box
     - state: box-open
       map: ["enum.StorageVisualLayers.Door"]
+  - type: StaticPrice
+    price: 0
   - type: StorageFill
     contents:
     - id: FoodPizzaArnold

--- a/Resources/Prototypes/Entities/Objects/Decoration/lidsalami.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/lidsalami.yml
@@ -10,3 +10,5 @@
       - state: icon
   - type: Item
     size: 1001
+  - type: StaticPrice
+    price: 0

--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -51,6 +51,8 @@
     tags:
       - Plastic
       - Trash
+  - type: StaticPrice
+    price: 0
 
 - type: entity
   parent: UtensilBase
@@ -110,3 +112,5 @@
     types:
     - Knife
     breakChance: 0.20
+  - type: StaticPrice
+    price: 0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Because the contents of the pizza crate are mostly random, the no arbitrage test could sometimes fail. I made the plastic fork/knife, salami lid, and the (empty) pizza box cost 0 instead of the inherited 20 because they are trash, and then as a consequence I lowered the pizza crate price. I made sure that the most expensive combination of pizzas is still below the order price, so no arbitrage.

I also changed the arbitrage test to use less than or equals, instead of strictly less than, so that it will still pass if the sell and buy price are exactly the same (as there is still no arbitrage).

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Emergency pizza delivery now costs 450 spacebucks instead of 550