### PR TITLE
Change Icon to Sprite for random humanoid spawner protos

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -7,9 +7,6 @@
   name: ERT leader
   components:
     - type: Sprite
-      sprite: Mobs/Species/Human/parts.rsi
-      state: full
-    - type: Icon
       sprite: Markers/jobs.rsi
       state: ertleader
     - type: RandomMetadata
@@ -39,7 +36,7 @@
   name: ERT leader
   suffix: EVA
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: ertleadereva
     - type: RandomHumanoidSpawner
@@ -62,7 +59,7 @@
   parent: RandomHumanoidSpawnerERTLeader
   name: ERT janitor
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: ertjanitor
     - type: RandomMetadata
@@ -92,7 +89,7 @@
   name: ERT janitor
   suffix: EVA
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: ertjanitoreva
     - type: RandomHumanoidSpawner
@@ -115,7 +112,7 @@
   parent: RandomHumanoidSpawnerERTLeader
   name: ERT engineer
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: ertengineer
     - type: RandomMetadata
@@ -145,7 +142,7 @@
   name: ERT engineer
   suffix: EVA
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: ertengineereva
     - type: RandomHumanoidSpawner
@@ -168,7 +165,7 @@
   parent: RandomHumanoidSpawnerERTLeader
   name: ERT security
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: ertsecurity
     - type: RandomMetadata
@@ -198,7 +195,7 @@
   name: ERT security
   suffix: EVA
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: ertsecurityeva
     - type: RandomHumanoidSpawner
@@ -221,7 +218,7 @@
   parent: RandomHumanoidSpawnerERTLeader
   name: ERT medic
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: ertmedical
     - type: RandomMetadata
@@ -251,7 +248,7 @@
   name: ERT medic
   suffix: EVA
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: ertmedicaleva
     - type: RandomHumanoidSpawner
@@ -273,7 +270,7 @@
   id: RandomHumanoidSpawnerCBURNUnit
   name: CBURN Agent
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: cburn
     - type: RandomHumanoidSpawner
@@ -297,7 +294,7 @@
   name: CentCom official
   id: RandomHumanoidSpawnerCentcomOfficial
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Markers/jobs.rsi
       state: centcom
     - type: RandomHumanoidSpawner
@@ -318,7 +315,7 @@
   id: RandomHumanoidSpawnerSyndicateAgent
   name: Syndicate Agent
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Mobs/Species/Human/parts.rsi
       state: full
     - type: RandomMetadata
@@ -336,7 +333,7 @@
   id: RandomHumanoidSpawnerNukeOp
   name: Nuclear Operative
   components:
-    - type: Icon
+    - type: Sprite
       sprite: Mobs/Species/Human/parts.rsi
       state: full
     - type: RandomHumanoidSpawner

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -7,6 +7,7 @@
   name: ERT leader
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertleader
     - type: RandomMetadata
@@ -37,6 +38,7 @@
   suffix: EVA
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertleadereva
     - type: RandomHumanoidSpawner
@@ -60,6 +62,7 @@
   name: ERT janitor
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertjanitor
     - type: RandomMetadata
@@ -90,6 +93,7 @@
   suffix: EVA
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertjanitoreva
     - type: RandomHumanoidSpawner
@@ -113,6 +117,7 @@
   name: ERT engineer
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertengineer
     - type: RandomMetadata
@@ -143,6 +148,7 @@
   suffix: EVA
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertengineereva
     - type: RandomHumanoidSpawner
@@ -166,6 +172,7 @@
   name: ERT security
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertsecurity
     - type: RandomMetadata
@@ -196,6 +203,7 @@
   suffix: EVA
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertsecurityeva
     - type: RandomHumanoidSpawner
@@ -219,6 +227,7 @@
   name: ERT medic
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertmedical
     - type: RandomMetadata
@@ -249,6 +258,7 @@
   suffix: EVA
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: ertmedicaleva
     - type: RandomHumanoidSpawner
@@ -271,6 +281,7 @@
   name: CBURN Agent
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: cburn
     - type: RandomHumanoidSpawner
@@ -295,6 +306,7 @@
   id: RandomHumanoidSpawnerCentcomOfficial
   components:
     - type: Sprite
+      netsync: false
       sprite: Markers/jobs.rsi
       state: centcom
     - type: RandomHumanoidSpawner
@@ -316,6 +328,7 @@
   name: Syndicate Agent
   components:
     - type: Sprite
+      netsync: false
       sprite: Mobs/Species/Human/parts.rsi
       state: full
     - type: RandomMetadata
@@ -334,6 +347,7 @@
   name: Nuclear Operative
   components:
     - type: Sprite
+      netsync: false
       sprite: Mobs/Species/Human/parts.rsi
       state: full
     - type: RandomHumanoidSpawner

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -6,6 +6,9 @@
   id: RandomHumanoidSpawnerERTLeader
   name: ERT leader
   components:
+    - type: Sprite
+      sprite: Mobs/Species/Human/parts.rsi
+      state: full
     - type: Icon
       sprite: Markers/jobs.rsi
       state: ertleader


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Changes the prototypes for random humanoid mob spawners to use a Sprite component rather than Icon, so that the placement manager does not crash while attempting to draw the entities.

I think this is a small fix, but let me know if I need to include images or videos of this working.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Client-side placement mode crash while placing random humanoid mobs
