### PR TITLE
Fix happy honk meal sometimes causing tests to fail

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -388,7 +388,7 @@
     - type: BagOpenCloseVisualizer
       openIcon: box-open
   - type: Storage
-    capacity: 35
+    capacity: 30
   - type: Tag
     tags:
     - Trash

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -388,7 +388,7 @@
     - type: BagOpenCloseVisualizer
       openIcon: box-open
   - type: Storage
-    capacity: 30
+    capacity: 35
   - type: Tag
     tags:
     - Trash
@@ -435,8 +435,6 @@
       - id: ToySkeleton
         orGroup: GiftPool
       - id: FoamBlade
-        orGroup: GiftPool
-      - id: ToySkeleton
         orGroup: GiftPool
       - id: ClothingHeadHatBunny
         orGroup: GiftPool
@@ -577,8 +575,6 @@
       - id: ToySkeleton
         orGroup: GiftPool
       - id: FoamBlade
-        orGroup: GiftPool
-      - id: ToySkeleton
         orGroup: GiftPool
       - id: ClothingHeadHatBunny
         orGroup: GiftPool

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -594,7 +594,7 @@
       types:
         Blunt: 0
   - type: Item
-    size: 24
+    size: 20
     sprite: Objects/Fun/toys.rsi
     heldPrefix: foamblade
   - type: ItemCooldown


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
~~I increased the capacity of the happy honk meal to 35, as the size of 30 was too small to fit every the foamblade + burger + drink (size of 34 in total).~~ Decreased foamblade size instead.

I also removed the duplicate ToySkeleton entries.

This would [cause tests to randomly fail](https://github.com/space-wizards/space-station-14/actions/runs/3982455775/jobs/6826937651), because they would try to insert a foamblade into the happy honk meal while there was not enough space.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed a bug where the happy honk meal could not spawn with the foamblade
