### PR TITLE
Nerfed base electronic board price

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
@@ -13,4 +13,4 @@
       tags:
         - DroneUsable
     - type: StaticPrice
-      price: 100
+      price: 10


### PR DESCRIPTION
Signed-off-by: vanx <vanx#5477>

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Nerfed base electronic board price (100 -> 10) in an attempt to combat cargo protolathe abuse, that allows cargo to basically print money in form of basic electronic boards (intercoms etc.).

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [+] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Electronic boards are now cheaper, central command doesn't need that many!
