### PR TITLE
log error when trying to set invalid solution ratio and clamp it 

### DIFF
--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -18,6 +18,15 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
         if (!args.Sprite.LayerMapTryGet(component.Layer, out var fillLayer))
             return;
 
+        // Currently some solution methods such as overflowing will try to update appearance with a
+        // volume greater than the max volume. We'll clamp it so players don't see
+        // a giant error sign and error for debug.
+        if (fraction > 1f)
+        {
+            Logger.Error("Attempted to set solution container visuals volume ratio on " + ToPrettyString(uid) + " to a value greater than 100% of it's max volume.");
+            fraction = 1f;
+        }
+
         var closestFillSprite = (int) Math.Round(fraction * component.MaxFillLevels);
 
         if (closestFillSprite > 0)

--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -23,7 +23,7 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
         // a giant error sign and error for debug.
         if (fraction > 1f)
         {
-            Logger.Error("Attempted to set solution container visuals volume ratio on " + ToPrettyString(uid) + " to a value greater than 100% of it's max volume.");
+            Logger.Error("Attempted to set solution container visuals volume ratio on " + ToPrettyString(uid) + " to a value greater than 1. Volume should never be greater than max volume!");
             fraction = 1f;
         }
 


### PR DESCRIPTION
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://user-images.githubusercontent.com/60792108/214177848-97ea359f-37e9-47f3-be40-39ea25017db3.png)

I know TryMixAndOverflow will do this but there may be more and this might help track when it happens. I have definitely seen it with e.g. janitor stuff which doesn't use that

makes this look not ugly for end users and more likely to inform the people who actually need to be aware of it