### PR TITLE
Fix cuffing in harm mode sometimes not working

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -29,6 +29,12 @@ public sealed class MeleeWeaponComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("nextAttack", customTypeSerializer:typeof(TimeOffsetSerializer))]
     public TimeSpan NextAttack;
 
+    /// <summary>
+    /// Starts attack cooldown when equipped if true.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("resetOnHandSelected")]
+    public bool ResetOnHandSelected = true;
+
     /*
      * Melee combat works based around 2 types of attacks:
      * 1. Click attacks with left-click. This attacks whatever is under your mnouse

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -75,6 +75,9 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (component.AttackRate.Equals(0f))
             return;
 
+        if (!component.ResetOnHandSelected)
+            return;
+
         // If someone swaps to this weapon then reset its cd.
         var curTime = Timing.CurTime;
         var minimum = curTime + TimeSpan.FromSeconds(1 / component.AttackRate);

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -16,6 +16,7 @@
     tags:
     - Handcuffs
   - type: MeleeWeapon
+    resetOnHandSelected: false
     animation: WeaponArcDisarm
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -17,6 +17,7 @@
     - Handcuffs
   - type: MeleeWeapon
     animation: WeaponArcDisarm
+    attackRate: 5
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -17,7 +17,6 @@
     - Handcuffs
   - type: MeleeWeapon
     animation: WeaponArcDisarm
-    attackRate: 5
     damage:
       types:
         Blunt: 0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
PR #12838 made it possible to cuff in harm mode, but it sometimes feels like it doesn't work. That's because of the attack cooldown.

When you take the cuffs out of your bag, you have to wait a bit before you can cuff in harm mode. ~Increasing the attack speed reduces that time enough to be insignificant.~ Added a field to WeaponComponent that skips the cooldown for cuffs.

This might not be needed if #13614 is done.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Handcuffing in combat mode should feel more responsive