### PR TITLE
make apc events only affect single station APCs

### DIFF
--- a/Content.Server/StationEvents/Events/BreakerFlip.cs
+++ b/Content.Server/StationEvents/Events/BreakerFlip.cs
@@ -31,21 +31,24 @@ public sealed class BreakerFlip : StationEventSystem
         var chosenStation = RobustRandom.Pick(StationSystem.Stations.ToList());
 
         var allApcs = EntityQuery<ApcComponent, TransformComponent>().ToList();
-        allApcs = allApcs.FindAll((ent) => 
+        var stationApcs = new List<ApcComponent>();
+        foreach (var (apc, transform) in allApcs) 
         {
-            var (apc, transform) = ent;
-            return apc.MainBreakerEnabled && CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == chosenStation;
-        });
-        var toDisable = Math.Min(RobustRandom.Next(3, 7), allApcs.Count);
+            if (apc.MainBreakerEnabled && CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == chosenStation)
+            {
+                stationApcs.Add(apc);
+            }
+        }
+        
+        var toDisable = Math.Min(RobustRandom.Next(3, 7), stationApcs.Count);
         if (toDisable == 0)
             return;
 
-        RobustRandom.Shuffle(allApcs);
+        RobustRandom.Shuffle(stationApcs);
 
         for (var i = 0; i < toDisable; i++)
         {
-            var (apc, _) = allApcs[i];
-            _apcSystem.ApcToggleBreaker(apc.Owner, apc);
+            _apcSystem.ApcToggleBreaker(stationApcs[i].Owner, stationApcs[i]);
         }
     }
 }

--- a/Content.Server/StationEvents/Events/BreakerFlip.cs
+++ b/Content.Server/StationEvents/Events/BreakerFlip.cs
@@ -30,9 +30,8 @@ public sealed class BreakerFlip : StationEventSystem
             return;
         var chosenStation = RobustRandom.Pick(StationSystem.Stations.ToList());
 
-        var allApcs = EntityQuery<ApcComponent, TransformComponent>().ToList();
         var stationApcs = new List<ApcComponent>();
-        foreach (var (apc, transform) in allApcs) 
+        foreach (var (apc, transform) in EntityQuery<ApcComponent, TransformComponent>()) 
         {
             if (apc.MainBreakerEnabled && CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == chosenStation)
             {

--- a/Content.Server/StationEvents/Events/PowerGridCheck.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheck.cs
@@ -44,7 +44,7 @@ namespace Content.Server.StationEvents.Events
                 return;
             var chosenStation = RobustRandom.Pick(StationSystem.Stations.ToList());
 
-            foreach (var (apc, transform) in EntityManager.EntityQuery<ApcComponent, TransformComponent>(true))
+            foreach (var (apc, transform) in EntityQuery<ApcComponent, TransformComponent>(true))
             {
                 if (apc.MainBreakerEnabled && CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == chosenStation)
                     _powered.Add(apc.Owner);

--- a/Content.Server/StationEvents/Events/PowerGridCheck.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheck.cs
@@ -6,6 +6,9 @@ using Robust.Shared.Utility;
 using System.Threading;
 using Content.Server.Power.EntitySystems;
 using Timer = Robust.Shared.Timing.Timer;
+using System.Linq;
+using Robust.Shared.Random;
+using Content.Server.Station.Components;
 
 namespace Content.Server.StationEvents.Events
 {
@@ -37,10 +40,14 @@ namespace Content.Server.StationEvents.Events
 
         public override void Started()
         {
-            foreach (var component in EntityManager.EntityQuery<ApcComponent>(true))
+            if (StationSystem.Stations.Count == 0)
+                return;
+            var chosenStation = RobustRandom.Pick(StationSystem.Stations.ToList());
+
+            foreach (var (apc, transform) in EntityManager.EntityQuery<ApcComponent, TransformComponent>(true))
             {
-                if (component.MainBreakerEnabled)
-                    _powered.Add(component.Owner);
+                if (apc.MainBreakerEnabled && CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == chosenStation)
+                    _powered.Add(apc.Owner);
             }
 
             RobustRandom.Shuffle(_powered);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
Makes APC events (BreakerFlip & PowerGridCheck) only affect single station APCs

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Peek 2023-01-25 11-32](https://user-images.githubusercontent.com/40753025/214519329-5eba0abb-3f45-4f6c-8add-baa5c53bfb0a.gif)
for showcase I set amount of affected APCs to maximum and also fired event many times
![Peek 2023-01-25 11-44](https://user-images.githubusercontent.com/40753025/214519341-1427a9f9-4f1c-4e74-a75b-b373cd0e1dbf.gif)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: apc events now only affect single station APCs (no power shut offs on shuttles)
