### PR TITLE
diagnoser-no-cures locale fix

### DIFF
--- a/Resources/Locale/en-US/disease/diagnoser.ftl
+++ b/Resources/Locale/en-US/disease/diagnoser.ftl
@@ -10,7 +10,7 @@ diagnoser-disease-report-cureresist-none = Spaceacillin Resistance: [color=green
 diagnoser-disease-report-cureresist-low = Spaceacillin Resistance: [color=yellow]Low[/color]
 diagnoser-disease-report-cureresist-medium = Spaceacillin Resistance: [color=orange]Medium[/color]
 diagnoser-disease-report-cureresist-high = Spaceacillin Resistance: [color=red]High[/color]
-diagnoser-cure-none = The disease has no specific cures.
+diagnoser-no-cures = The disease has no specific cures.
 diagnoser-cure-has = The disease has the following cures:
 diagnoser-cure-bedrest = Rest in bed for {$time} seconds, or {$sleep} seconds if sleeping.
 diagnoser-cure-reagent = Consume at least {$units}u of {$reagent}.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Closes #11627

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: diagnoser now properly displays no-cure text
