### PR TITLE
Buffs the syndicate minibomb to be more devastating

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -22,13 +22,13 @@ uplink-fire-axe-flaming-desc = A classic-style weapon infused with advanced atmo
 
 # Explosives
 uplink-explosive-grenade-name = Explosive Grenade
-uplink-explosive-grenade-desc = Grenade that creates a small but devastating explosion.
+uplink-explosive-grenade-desc = A basic grenade that that does minimal damage to walls and floors, but has a large blast radius.
 
 uplink-flash-grenade-name = Flashbang
-uplink-flash-grenade-desc = Eeeeeeeeeeeeeeeeeeeeee
+uplink-flash-grenade-desc = A specalized grenade that will temporarily blind & slow anyone without protection.
 
 uplink-mini-bomb-name = Minibomb
-uplink-mini-bomb-desc = A precision sabotage explosive for quickly destroying a machine, dead body, or whatever else needs to go.
+uplink-mini-bomb-desc = A powerful explosive that is designed to breach & deal heavy damage to small rooms.
 
 uplink-penguin-grenade-name = Grenade Penguin
 uplink-penguin-grenade-desc = A small penguin with a grenade strapped around its neck. Harvested by the Syndicate from icy shit-hole planets.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -102,7 +102,7 @@
   description: uplink-mini-bomb-desc
   productEntity: SyndieMiniBomb
   cost:
-    Telecrystal: 6
+    Telecrystal: 8
   categories:
     - UplinkExplosives
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -2,7 +2,7 @@
 
 - type: entity
   name: explosive grenade
-  description: Grenade that creates a small but devastating explosion.
+  description: A simple grenade that creates a small but devastating explosion.
   parent: BaseItem
   id: ExGrenade
   components:
@@ -40,10 +40,11 @@
   - type: Appearance
     visuals:
     - type: TimerTriggerVisualizer
+    
 
 - type: entity
   name: flashbang
-  description: Eeeeeeeeeeeeeeeeeeeeee
+  description: Eeeeeeeeeee
   parent: BaseItem
   id: GrenadeFlashBang
   components:
@@ -85,7 +86,7 @@
 
 - type: entity
   name: Syndicate minibomb
-  description: A precision sabotage explosive for quickly destroying a machine, dead body, or whatever else needs to go.
+  description: A compact bomb that is designed to breach & deal heavy damage to small rooms.
   parent: BaseItem
   id: SyndieMiniBomb
   components:
@@ -100,9 +101,9 @@
     delay: 10
   - type: Explosive
     explosionType: Default
-    totalIntensity: 200
-    intensitySlope: 30 #Will destroy the tile under it reliably, space 1-2 more to rods. Only does any significant damage in a 5-tile cross.
-    maxIntensity: 60
+    totalIntensity: 700
+    intensitySlope: 16 #If it's any lower then it feels really weak. If you're nerfing the minibomb, probably don't change just this value!
+    maxIntensity: 295 
   - type: ExplodeOnTrigger
   - type: Damageable
     damageContainer: Inorganic


### PR DESCRIPTION
## About the PR
...and changes some other syndicate explosive descriptions to be more descriptive. Couldn't fit it in the PR title, sorry!

It's no secret - the minibomb fucking _sucks._ For 6 TC, you get something that is basically just a glorified atmos drainer / body gibber. Despite having niche uses, I believe most players would consider it an utter waste of telecrystals when you could usually just break windows to space a room.

This turns the Syndicate minibomb into a tool designed to breach & _ruin_ small rooms. It does mediocre damage to walls,
but will easily tear sizable holes through the floor and cause entire rooms to be uninhabitable until they can be fixed by engineering / atmos.
To compensate for the massively increased breaching power, the price of the bomb has been nerfed down to 8tc.

**Media**

[Content.Client_UrC1vYQfNv.webm](https://user-images.githubusercontent.com/78941145/214610474-5593ddd3-5dfa-4dfb-96b0-725b5eb21667.webm)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: The syndicate minibomb has been buffed.
- tweak: The syndicate has re-described several entries in their explosives catalog.
