### PR TITLE
Add midipanic to client permissions.

### DIFF
--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -29,6 +29,7 @@
     - resetallents
     - cvar
     - fuckrules
+    - midipanic
 
 - Flags: DEBUG
   Commands:


### PR DESCRIPTION
Useful for when there are stuck MIDI notes.
Can be used without perms.