### PR TITLE
Fix ambiguous Dumpable behaviour

### DIFF
--- a/Content.Server/Storage/EntitySystems/DumpableSystem.cs
+++ b/Content.Server/Storage/EntitySystems/DumpableSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Storage.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<DumpableComponent, AfterInteractEvent>(OnAfterInteract);
+            SubscribeLocalEvent<DumpableComponent, AfterInteractEvent>(OnAfterInteract, after: new[]{ typeof(StorageSystem) });
             SubscribeLocalEvent<DumpableComponent, GetVerbsEvent<AlternativeVerb>>(AddDumpVerb);
             SubscribeLocalEvent<DumpableComponent, GetVerbsEvent<UtilityVerb>>(AddUtilityVerbs);
             SubscribeLocalEvent<DumpCompletedEvent>(OnDumpCompleted);
@@ -36,7 +36,7 @@ namespace Content.Server.Storage.EntitySystems
             if (!TryComp<ServerStorageComponent>(args.Used, out var storage))
                 return;
 
-            if (storage.StoredEntities == null || storage.StoredEntities.Count == 0)
+            if (storage.StoredEntities == null || storage.StoredEntities.Count == 0 || storage.CancelToken != null)
                 return;
 
             if (HasComp<DisposalUnitComponent>(args.Target) || HasComp<PlaceableSurfaceComponent>(args.Target))

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -316,8 +316,8 @@ namespace Content.Server.Storage.EntitySystems
                 {
                     if (entity == args.User
                         || !itemQuery.HasComponent(entity)
-                        || !_interactionSystem.InRangeUnobstructed(args.User, entity)
-                        || !CanInsert(uid, entity, out _, storageComp))
+                        || !CanInsert(uid, entity, out _, storageComp)
+                        || !_interactionSystem.InRangeUnobstructed(args.User, entity))
                         continue;
 
                     validStorables.Add(entity);

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -316,7 +316,8 @@ namespace Content.Server.Storage.EntitySystems
                 {
                     if (entity == args.User
                         || !itemQuery.HasComponent(entity)
-                        || !_interactionSystem.InRangeUnobstructed(args.User, entity))
+                        || !_interactionSystem.InRangeUnobstructed(args.User, entity)
+                        || !CanInsert(uid, entity, out _, storageComp))
                         continue;
 
                     validStorables.Add(entity);


### PR DESCRIPTION
Fixes #13733 by prioritizing area insert over dumping when they conflict on `AfterInteract`.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![dumping-fixed](https://user-images.githubusercontent.com/16370842/214918914-4989847d-9be4-44e2-a7b3-6db1d68b8ec6.gif)



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed weird behaviour when clicking on a table using a dumpable storage item.
