### PR TITLE
Circuit imprinters now show the correct icons for the boards

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -32,7 +32,6 @@
 
 - type: latheRecipe
   id: IntercomElectronics
-  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
   result: IntercomElectronics
   completetime: 2
   materials:
@@ -84,7 +83,6 @@
 
 - type: latheRecipe
   id: CryoPodMachineCircuitboard
-  icon: Objects/Misc/module.rsi/id_mod.png
   result: CryoPodMachineCircuitboard
   completetime: 4
   materials:
@@ -228,7 +226,6 @@
 
 - type: latheRecipe
   id: HotplateMachineCircuitboard
-  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
   result: HotplateMachineCircuitboard
   completetime: 4
   materials:
@@ -246,7 +243,6 @@
 
 - type: latheRecipe
   id: TechDiskComputerCircuitboard
-  icon: { sprite: Objects/Misc/module.rsi, state: cpu_science }
   result: TechDiskComputerCircuitboard
   completetime: 4
   materials:
@@ -307,7 +303,6 @@
 
 - type: latheRecipe
   id: RipleyCentralElectronics
-  icon: Objects/Misc/module.rsi/mainboard.png
   result: RipleyCentralElectronics
   completetime: 4
   materials:
@@ -317,7 +312,6 @@
 
 - type: latheRecipe
   id: RipleyPeripheralsElectronics
-  icon: Objects/Misc/module.rsi/id_mod.png
   result: RipleyPeripheralsElectronics
   completetime: 4
   materials:
@@ -488,7 +482,6 @@
 
 - type: latheRecipe
   id: ThrusterMachineCircuitboard
-  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
   result: ThrusterMachineCircuitboard
   completetime: 4
   materials:
@@ -497,7 +490,6 @@
 
 - type: latheRecipe
   id: GyroscopeMachineCircuitboard
-  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
   result: GyroscopeMachineCircuitboard
   completetime: 4
   materials:
@@ -522,7 +514,6 @@
 
 - type: latheRecipe
   id: BoozeDispenserMachineCircuitboard
-  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
   result: BoozeDispenserMachineCircuitboard
   completetime: 4
   materials:
@@ -531,7 +522,6 @@
 
 - type: latheRecipe
   id: SodaDispenserMachineCircuitboard
-  icon: { sprite: Objects/Misc/module.rsi, state: id_mod }
   result: SodaDispenserMachineCircuitboard
   completetime: 4
   materials:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Removes in hardcoded icons for the circuit imprinter, so it now shows the right icons. This affects most of the new machine boards.

**Media**
Before:
![image](https://user-images.githubusercontent.com/44417085/215144728-c36493f0-fccb-4ff6-afe0-1c0c104c767f.png)
After: 
![image](https://user-images.githubusercontent.com/44417085/215144822-846979a8-a7be-4e9b-a854-d9342f667a3d.png)
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- fix: Circuit imprinters now show the correct icons for the boards
