### PR TITLE
Service Worker Hydro Access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -12,6 +12,7 @@
   - Maintenance
   - Bar
   - Kitchen
+  extendedAccess:
   - Hydroponics
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -12,6 +12,7 @@
   - Maintenance
   - Bar
   - Kitchen
+  - Hydroponics
 
 - type: startingGear
   id: ServiceWorkerGear


### PR DESCRIPTION
## About the PR
Adds hydroponics to the service worker's starting access. Because they didn't have it before for some reason.

**Media**
- [X] This PR does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changed service worker's extended access to include hydro.
