### PR TITLE
Change ID examine icon to character outline icon

### DIFF
--- a/Content.Server/Access/Systems/IdExaminableSystem.cs
+++ b/Content.Server/Access/Systems/IdExaminableSystem.cs
@@ -36,7 +36,7 @@ public sealed class IdExaminableSystem : EntitySystem
             Category = VerbCategory.Examine,
             Disabled = !detailsRange,
             Message = Loc.GetString("id-examinable-component-verb-disabled"),
-            IconTexture = "/Textures/Interface/VerbIcons/information.svg.192dpi.png"
+            IconTexture = "/Textures/Interface/character.svg.192dpi.png"
         };
 
         args.Verbs.Add(verb);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Since the guidebook now uses the question mark icon, issue #13505 suggests changing the icon. This PR changes it to the character outline icon. However, would a more ID card looking icon be better instead? 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:
![image](https://media.discordapp.net/attachments/828300058377191464/1069341497243222036/image.png) ![image](https://media.discordapp.net/attachments/828300058377191464/1069341903520288798/image.png)
After:
![image](https://media.discordapp.net/attachments/828300058377191464/1069345497267052645/image.png) ![image](https://media.discordapp.net/attachments/828300058377191464/1069345583250288780/image.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- tweak: Changed ID card examine icon to avoid matching the guidebook icon.