### PR TITLE
Removing more hardcoded icons in the lathes

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/botany.yml
+++ b/Resources/Prototypes/Recipes/Lathes/botany.yml
@@ -32,9 +32,6 @@
     
 - type: latheRecipe
   id: Clippers
-  icon:
-    sprite: Objects/Tools/Hydroponics/clippers.rsi
-    state: icon
   result: HydroponicsToolClippers
   completetime: 2
   materials:

--- a/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
@@ -1,8 +1,5 @@
 - type: latheRecipe
   id: RipleyHarness
-  icon:
-     sprite: Objects/Specific/Mech/ripley_construction.rsi
-     state: ripley_harness
   result: RipleyHarness
   completetime: 10
   materials:
@@ -11,9 +8,6 @@
 
 - type: latheRecipe
   id: RipleyLArm
-  icon:
-     sprite: Objects/Specific/Mech/ripley_construction.rsi
-     state: ripley_l_arm
   result: RipleyLArm
   completetime: 10
   materials:
@@ -22,9 +16,6 @@
 
 - type: latheRecipe
   id: RipleyLLeg
-  icon:
-     sprite: Objects/Specific/Mech/ripley_construction.rsi
-     state: ripley_l_leg
   result: RipleyLLeg
   completetime: 10
   materials:
@@ -33,9 +24,6 @@
 
 - type: latheRecipe
   id: RipleyRLeg
-  icon:
-     sprite: Objects/Specific/Mech/ripley_construction.rsi
-     state: ripley_r_leg
   result: RipleyRLeg
   completetime: 10
   materials:
@@ -44,9 +32,6 @@
 
 - type: latheRecipe
   id: RipleyRArm
-  icon:
-     sprite: Objects/Specific/Mech/ripley_construction.rsi
-     state: ripley_r_arm
   result: RipleyRArm
   completetime: 10
   materials:
@@ -55,9 +40,6 @@
 
 - type: latheRecipe
   id: MechEquipmentGrabber
-  icon:
-     sprite: Objects/Specific/Mech/mecha_equipment.rsi
-     state: mecha_clamp
   result: MechEquipmentGrabber
   completetime: 10
   materials:

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -71,9 +71,6 @@
 
 - type: latheRecipe
   id: NodeScanner
-  icon:
-    sprite: Objects/Specific/Xenoarchaeology/node_scanner.rsi
-    state: icon
   result: NodeScanner
   completetime: 2
   materials:

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -165,9 +165,6 @@
 
 - type: latheRecipe
   id: MiningDrill
-  icon:
-    sprite: Objects/Tools/handdrill.rsi
-    state: handdrill
   result: MiningDrill
   completetime: 3
   materials:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Basically more of #12944 and #13751, removing the hardcoded icons. Nothing should be changed visually as a result. It's very possible some of these were needed for a reason, so it might not be the best idea to remove them.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->