### PR TITLE
Salvage machine parts spawners

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
@@ -50,6 +50,52 @@
       offset: 0.0
 
 - type: entity
+  name: Salvage T2 Machine Parts Spawner
+  id: SalvagePartsT2Spawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Objects/Misc/stock_parts.rsi
+          state: advanced_matter_bin
+    - type: RandomSpawner
+      prototypes:
+        - AdvancedCapacitorStockPart
+        - AdvancedScanningModuleStockPart
+        - NanoManipulatorStockPart
+        - HighPowerMicroLaserStockPart
+        - AdvancedMatterBinStockPart
+      offset: 0.0
+
+- type: entity
+  name: Salvage T3/4 Machine Parts Spawner
+  id: SalvagePartsT3Spawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Objects/Misc/stock_parts.rsi
+          state: super_matter_bin
+    - type: RandomSpawner
+      rarePrototypes:
+        - QuadraticCapacitorStockPart
+        - TriphasicScanningModuleStockPart
+        - FemtoManipulatorStockPart
+        - QuadUltraMicroLaserStockPart
+        - BluespaceMatterBinStockPart
+      rareChance: 0.05
+      prototypes:
+        - SuperCapacitorStockPart
+        - PhasicScanningModuleStockPart
+        - PicoManipulatorStockPart
+        - UltraHighPowerMicroLaserStockPart
+        - SuperMatterBinStockPart
+      chance: 0.95
+      offset: 0.0
+
+- type: entity
   name: Salvage Mob Spawner
   id: SalvageMobSpawner
   parent: MarkerBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
adds 2 machine parts spawners for salvages. One spawns a t2 part at random, the other spawns a t3 part at random with a 5% chance of spawning a t4 part

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

I made a video to prove it works but github is being ass and failed to upload it 5 times so just ping me on discord or something if you want video proof of it working
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
- added machine parts spawners for salvages