### PR TITLE
Toilets cost 20 steel.

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
@@ -9,7 +9,7 @@
             - !type:SnapToGrid { }
           steps:
             - material: Steel
-              amount: 5
+              amount: 20
               doAfter: 1
     - node: toilet
       entity: ToiletEmpty
@@ -18,7 +18,7 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
-              amount: 5
+              amount: 20
             - !type:EmptyAllContainers {}
             - !type:DestroyEntity {}
           conditions:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Toilets cost 20 steel
<!-- What does it change? What other things could this impact? -->
Should reduce the amount of toilets that can are spam built at once. Engineers/Science will be more willing to recover the scrap used to build these as well.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Whisper
- tweak: Toilets now cost 20 steel to build. They will also return 20 steel on deconstruct.
