### PR TITLE
Lexorin + Hypopen 1984

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -160,7 +160,7 @@
   - type: SolutionContainerManager
     solutions:
       hypospray:
-        maxVol: 15
+        maxVol: 10
   - type: RefillableSolution
     solution: hypospray
   - type: ExaminableSolution

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -231,9 +231,9 @@
     Tricordrazine: 2
 
 - type: reaction
-  id: HeartbreakerToxin #heat to 37C once temperatures supported
+  id: HeartbreakerToxin
   reactants:
-    Dexalin:
+    DexalinPlus:
       amount: 1
     MindbreakerToxin:
       amount: 1
@@ -256,7 +256,7 @@
   id: Lexorin
   impact: High
   reactants:
-    Ammonia:
+    HeartbreakerToxin:
       amount: 1
     Plasma:
       amount: 1
@@ -277,6 +277,7 @@
 
 - type: reaction
   id: MindbreakerToxin
+  mintemp: 370
   reactants:
     Silicon:
       amount: 1

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -277,7 +277,7 @@
 
 - type: reaction
   id: MindbreakerToxin
-  mintemp: 370
+  minTemp: 370
   reactants:
     Silicon:
       amount: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Lexorin now requires Heartbreaker Toxin instead of ammonia to make, and you need to heat up the chemical mixture to make Mindbreaker Toxin. Lexorin is stupidly easy to make considering it's one of the best poisons in the game, so this fixes that. And in my neverending quest to get people to buy something other than the hypopen, I lowered the chem capacity of it to 10u so you have to stop and refill it to inject a lethal dose of Lexorin.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: After the Hypopen Incident of 2556, The recipe for Lexorin now requires Heartbreaker Toxin instead of Ammonia.
- tweak: You need to heat up the chemicals for Mindbreaker Toxin to get them to react.
- tweak: Due to budget cuts, the Syndicate is now offering an inferior version of the hypopen that only holds 10 units of chemicals.
