### PR TITLE
Fix cross-map explosion overlay bug.

### DIFF
--- a/Content.Client/Explosion/ExplosionOverlay.cs
+++ b/Content.Client/Explosion/ExplosionOverlay.cs
@@ -35,6 +35,9 @@ public sealed class ExplosionOverlay : Overlay
 
         foreach (var (comp, appearance) in _entMan.EntityQuery<ExplosionVisualsComponent, AppearanceComponent>(true))
         {
+            if (comp.Epicenter.MapId != args.MapId)
+                continue;
+
             if (!appearance.TryGetData(ExplosionAppearanceData.Progress, out int index))
                 continue;
 

--- a/Content.Client/Explosion/ExplosionVisualsComponent.cs
+++ b/Content.Client/Explosion/ExplosionVisualsComponent.cs
@@ -7,12 +7,14 @@ namespace Content.Client.Explosion;
 [ComponentReference(typeof(SharedExplosionVisualsComponent))]
 public sealed class ExplosionVisualsComponent : SharedExplosionVisualsComponent
 {
-    public EntityUid LightEntity;
     /// <summary>
-    ///     How long have we been drawing this explosion, starting from the time the explosion was fully drawn.
+    ///     Uid of the client-side point light entity for this explosion.
     /// </summary>
-    public float Lifetime;
+    public EntityUid LightEntity;
 
+    /// <summary>
+    ///     How intense an explosion needs to be at a given tile in order to progress to the next fire-intensity RSI state. See also <see cref="FireFrames"/>
+    /// </summary>
     public float IntensityPerState;
 
     /// <summary>


### PR DESCRIPTION
Apparently the MapId check was removed when I reworked the explosion visual networking. Also removes an unused component field.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase