### PR TITLE
add tabletop layer to cell recharger

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -46,7 +46,9 @@
         bounds: "-0.10,-0.10,0.10,0.10"
       density: 500
       mask:
-        - TabletopMachineMask
+      - TabletopMachineMask
+      layer:
+      - TabletopMachineLayer
   - type: ItemSlots
     slots:
       charger_slot:


### PR DESCRIPTION
## About the PR
fixes #13853

**Media**
fairly self explanatory, verified ingame that can pull both kinds of unanchored chargers

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Fixed not being able to pull cell rechargers.
