### PR TITLE
Add encryption keys to the PTech

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -92,7 +92,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockPTechFilled
-  cost: 800
+  cost: 1000
   category: Service
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -92,7 +92,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockPTechFilled
-  cost: 1000
+  cost: 1200
   category: Service
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -8,3 +8,9 @@
     RubberStampApproved: 1
     RubberStampDenied: 1
     Paper: 10
+    EncryptionKeyCargo: 2
+    EncryptionKeyEngineering: 2
+    EncryptionKeyMedical: 2
+    EncryptionKeyScience: 2
+    EncryptionKeySecurity: 1
+    EncryptionKeyService: 3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This will add encryption keys to the HoP's PTech vending machine so that they can grant crew access to other radios, either when someone changes their job, or if a head requests it.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/44417085/216790592-448ed790-a309-443d-b271-ae6ac4ca47f5.png)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- tweak: Added various encryption keys to the PTech.
