### PR TITLE
Fix inaccurate tip

### DIFF
--- a/Resources/Prototypes/Datasets/tips.yml
+++ b/Resources/Prototypes/Datasets/tips.yml
@@ -5,7 +5,7 @@
   - "You can view and edit all keybindings used ingame at any time through the Options menu."
   - "You can access the ingame guidebook through the escape menu, or by pressing Numpad 0 by default."
   - "Some entities ingame have guidebook entries associated with them, which you can view by examining the entity and clicking the question mark icon."
-  - "You can make a rough examination of someone's health by examining them and clicking the plus icon."
+  - "You can make a rough examination of someone's health by examining them and clicking the heart icon."
   - "Artifacts have the ability to gain permanent effects for some triggered nodes, including becoming an intercom or an extremely efficient generator."
   - "You can avoid slipping on most puddles by walking. However, some strong chemicals like space lube will slip people anyway."
   - "As a Botanist, you can mutate and crossbreed plants together to create more potent produce that also has higher yields."


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
tip says "plus" icon, it's actually a heart.
don't kill me ik it's a webedit

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun