### PR TITLE
Shooting target tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Security/target.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/target.yml
@@ -29,7 +29,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 500
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -51,22 +51,6 @@
   - type: Sprite
     sprite: Objects/Specific/Security/target.rsi
     state: target_h
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          SheetSteel:
-            min: 10
-            max: 10
-      - !type:PlaySoundBehavior
-        sound:
-          path: /Audio/Effects/metalbreak.ogg
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
 
 - type: entity
   name: syndicate target
@@ -77,22 +61,6 @@
   - type: Sprite
     sprite: Objects/Specific/Security/target.rsi
     state: target_s
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          SheetSteel:
-            min: 10
-            max: 10
-      - !type:PlaySoundBehavior
-        sound:
-          path: /Audio/Effects/metalbreak.ogg
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
 
 - type: entity
   name: clown target
@@ -103,22 +71,6 @@
   - type: Sprite
     sprite: Objects/Specific/Security/target.rsi
     state: target_c
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          SheetSteel:
-            min: 10
-            max: 10
-      - !type:PlaySoundBehavior
-        sound:
-          path: /Audio/Effects/metalbreak.ogg
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
 
 # put it on a salvage or something
 - type: entity

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -150,7 +150,7 @@
   completetime: 5
   applyMaterialDiscount: false # ingredients dropped when destroyed
   materials:
-    Steel: 10
+    Steel: 500
 
 - type: latheRecipe
   id: TargetClown
@@ -158,7 +158,7 @@
   completetime: 5
   applyMaterialDiscount: false # ingredients dropped when destroyed
   materials:
-    Steel: 10
+    Steel: 500
 
 - type: latheRecipe
   id: TargetSyndicate
@@ -166,7 +166,7 @@
   completetime: 5
   applyMaterialDiscount: false # ingredients dropped when destroyed
   materials:
-    Steel: 10
+    Steel: 500
 
 - type: latheRecipe
   id: MagazineBoxPistol


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Broken shooting targets no longer drop 100 times more steel than they cost.
Also removed some already parented code.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Broken shooting targets no longer drop 100 times more steel than they cost.
