### PR TITLE
Add cooldown to hypospray

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
@@ -109,8 +109,8 @@ namespace Content.Server.Chemistry.EntitySystems
 
             _audio.PlayPvs(component.InjectSound, user);
 
-            // Not the best place to put the delay
             // Medipens and such use this system and don't have a delay, requiring extra checks
+            // BeginDelay function returns if item is already on delay
             if (delayComp is not null)
                 _useDelay.BeginDelay(uid, delayComp);
 

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
@@ -11,8 +11,8 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Weapons.Melee.Events;
-using Robust.Shared.Player;
 using Content.Shared.Timing;
+using Robust.Shared.Player;
 
 namespace Content.Server.Chemistry.EntitySystems
 {

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -18,6 +18,8 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+  - type: UseDelay
+    delay: 0.25
   - type: StaticPrice
     price: 750
 
@@ -41,6 +43,8 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+  - type: UseDelay
+    delay: 0.25
 
 - type: entity
   name: chemical medipen
@@ -166,5 +170,7 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+  - type: UseDelay
+    delay: 0.5
   - type: StaticPrice # A new shitcurity meta
     price: 75

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -19,7 +19,7 @@
     solution: hypospray
   - type: Hypospray
   - type: UseDelay
-    delay: 0.25
+    delay: 0.5
   - type: StaticPrice
     price: 750
 
@@ -44,7 +44,7 @@
     solution: hypospray
   - type: Hypospray
   - type: UseDelay
-    delay: 0.25
+    delay: 0.5
 
 - type: entity
   name: chemical medipen


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Added a short (0.5 seconds) cooldown on the hypospray and its variants. This is due to a massive amount of arguing and support for the change in the discord.

Due to my lack of knowledge on C#, there are numerous issues in the code. Despite these, the code still works!
The issues are listed here:

- [X] Random dependancy
- [X] Variable definition in the middle of a bunch of checks
- [x] Check for delay is probably not in the ideal order
- [X] Nested if-statements to prevent C# from throwing an error (most likely very easy to fix but I don't know how)
- [x] Cooldown is started twice if hypo is used via hand interact
- [x] The bit that starts the delay probably isn't in the best spot
- [x] Actual cooldown numbers are not thought through well and likely need changing

Help fixing these is appreciated!

**Media**


https://user-images.githubusercontent.com/113810873/216882576-36e568c1-b4cc-4332-8861-6d05c297664e.mp4



<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Hypospray Nerfer
- tweak: Hypospray, Hypopen, and Gorlax Hypospray now all have short cooldowns.
