### PR TITLE
Make default/autocall shuttle time 10 minutes

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -40,7 +40,7 @@ namespace Content.Server.RoundEnd
         /// <summary>
         /// Countdown to use where there is no station alert countdown to be found.
         /// </summary>
-        public TimeSpan DefaultCountdownDuration { get; set; } = TimeSpan.FromMinutes(4);
+        public TimeSpan DefaultCountdownDuration { get; set; } = TimeSpan.FromMinutes(10);
         public TimeSpan DefaultRestartRoundDuration { get; set; } = TimeSpan.FromMinutes(2);
 
         private CancellationTokenSource? _countdownTokenSource = null;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
As far as I know, this only affects the preset used in the admin menu and the auto called shuttle. Currently, there is less time to recall the auto called shuttle than if the shuttle was called on red. My understanding is that the auto call is meant to either remind the crew that it's been a bit, or get the shuttle to the station in situations where the crew is unable to call it, not get the shuttle to come when someone wasn't fast enough to recall. While I don't recall ever seeing it come because someone wasn't able to recall fast enough, this change reduces the likelihood of it happening and reduces the pressure to drop everything to immediately recall if the crew wants to stay when an auto call happens.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Automatically called shuttles will take 10 minutes to get to the station instead of 4.
