### PR TITLE
no longer able to validhunt based on voice mask description

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -107,7 +107,6 @@
   id: ClothingMaskGasVoiceMasker
   name: gas mask
   suffix: Voice Mask
-  description: A face-covering mask that can be connected to an air supply. There are switches and knobs underneath the mask.
   components:
     - type: VoiceMasker
 


### PR DESCRIPTION
## About the PR
simple fix to #13963, just removes the unique description for voice mask.

**Media**
![look ma, not valid!](https://user-images.githubusercontent.com/39013340/217106377-eaba6c81-5e54-4809-ba00-839bef24abcd.png)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame

**Changelog**
:cl:
- tweak: The Syndicate has done a better job of hiding switches on Voice Masks.
