### PR TITLE
Fix NPC prototype reloads

### DIFF
--- a/Content.Server/NPC/HTN/HTNBranch.cs
+++ b/Content.Server/NPC/HTN/HTNBranch.cs
@@ -12,8 +12,6 @@ public sealed class HTNBranch
     [DataField("preconditions")]
     public List<HTNPrecondition> Preconditions = new();
 
-    [ViewVariables] public List<HTNTask> Tasks = new();
-
     /// <summary>
     /// Due to how serv3 works we need to defer getting the actual tasks until after they have all been serialized.
     /// </summary>

--- a/Content.Server/NPC/HTN/HTNPlanJob.cs
+++ b/Content.Server/NPC/HTN/HTNPlanJob.cs
@@ -11,6 +11,7 @@ namespace Content.Server.NPC.HTN;
 /// </summary>
 public sealed class HTNPlanJob : Job<HTNPlan>
 {
+    private readonly HTNSystem _htn;
     private readonly HTNCompoundTask _rootTask;
     private NPCBlackboard _blackboard;
 
@@ -21,11 +22,13 @@ public sealed class HTNPlanJob : Job<HTNPlan>
 
     public HTNPlanJob(
         double maxTime,
+        HTNSystem htn,
         HTNCompoundTask rootTask,
         NPCBlackboard blackboard,
         List<int>? branchTraversal,
         CancellationToken cancellationToken = default) : base(maxTime, cancellationToken)
     {
+        _htn = htn;
         _rootTask = rootTask;
         _blackboard = blackboard;
         _branchTraversal = branchTraversal;
@@ -156,6 +159,8 @@ public sealed class HTNPlanJob : Job<HTNPlan>
     /// </summary>
     private bool TryFindSatisfiedMethod(HTNCompoundTask compound, Queue<HTNTask> tasksToProcess, NPCBlackboard blackboard, ref int mtrIndex)
     {
+        var compBranches = _htn.CompoundBranches[compound];
+
         for (var i = mtrIndex; i < compound.Branches.Count; i++)
         {
             var branch = compound.Branches[i];
@@ -173,7 +178,9 @@ public sealed class HTNPlanJob : Job<HTNPlan>
             if (!isValid)
                 continue;
 
-            foreach (var task in branch.Tasks)
+            var branchTasks = compBranches[i];
+
+            foreach (var task in branchTasks)
             {
                 tasksToProcess.Enqueue(task);
             }

--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -27,6 +27,10 @@ public sealed class HTNSystem : EntitySystem
 
     private readonly HashSet<ICommonSession> _subscribers = new();
 
+    // hngngghghgh
+    public IReadOnlyDictionary<HTNCompoundTask, List<HTNTask>[]> CompoundBranches => _compoundBranches;
+    private Dictionary<HTNCompoundTask, List<HTNTask>[]> _compoundBranches = new();
+
     // Hierarchical Task Network
     public override void Initialize()
     {
@@ -75,6 +79,8 @@ public sealed class HTNSystem : EntitySystem
             }
         }
 
+        _compoundBranches.Clear();
+
         // Add dependencies for all operators.
         // We put code on operators as I couldn't think of a clean way to put it on systems.
         foreach (var compound in _prototypeManager.EnumeratePrototypes<HTNCompoundTask>())
@@ -111,21 +117,25 @@ public sealed class HTNSystem : EntitySystem
 
     private void UpdateCompound(HTNCompoundTask compound)
     {
-        foreach (var branch in compound.Branches)
+        var branchies = new List<HTNTask>[compound.Branches.Count];
+        _compoundBranches.Add(compound, branchies);
+
+        for (var i = 0; i < compound.Branches.Count; i++)
         {
-            branch.Tasks.Clear();
-            branch.Tasks.EnsureCapacity(branch.TaskPrototypes.Count);
+            var branch = compound.Branches[i];
+            var brancho = new List<HTNTask>(branch.TaskPrototypes.Count);
+            branchies[i] = brancho;
 
             // Didn't do this in a typeserializer because we can't recursively grab our own prototype during it, woohoo!
             foreach (var proto in branch.TaskPrototypes)
             {
                 if (_prototypeManager.TryIndex<HTNCompoundTask>(proto, out var compTask))
                 {
-                    branch.Tasks.Add(compTask);
+                    brancho.Add(compTask);
                 }
                 else if (_prototypeManager.TryIndex<HTNPrimitiveTask>(proto, out var primTask))
                 {
-                    branch.Tasks.Add(primTask);
+                    brancho.Add(primTask);
                 }
                 else
                 {
@@ -330,6 +340,7 @@ public sealed class HTNSystem : EntitySystem
 
         var job = new HTNPlanJob(
             0.02,
+            this,
             _prototypeManager.Index<HTNCompoundTask>(component.RootTask),
             component.Blackboard.ShallowClone(), branchTraversal, cancelToken.Token);
 
@@ -360,13 +371,17 @@ public sealed class HTNSystem : EntitySystem
         else if (task is HTNCompoundTask compound)
         {
             builder.AppendLine(buffer + $"Compound: {task.ID}");
+            var compoundBranches = CompoundBranches[compound];
 
-            foreach (var branch in compound.Branches)
+            for (var i = 0; i < compound.Branches.Count; i++)
             {
+                var branch = compound.Branches[i];
+
                 builder.AppendLine(buffer + "  branch:");
                 indent++;
+                var branchTasks = compoundBranches[i];
 
-                foreach (var branchTask in branch.Tasks)
+                foreach (var branchTask in branchTasks)
                 {
                     AppendDomain(builder, branchTask, ref indent);
                 }


### PR DESCRIPTION
serv3 hates me and reloads all the prototypes. I just store the data on HTNSystem instead so it doesn't get destroyed and rebuild on reloads.

:cl:
- fix: Fix NPCs breaking on prototype reloads.