### PR TITLE
fix wallmount board cheesing (fix #13994)

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
@@ -31,6 +31,7 @@
           doAfter: 2
 
     - node: parts
+      entity: BaseGeneratorWallmountFrame
       edges:
       - to: electronics
         steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
@@ -31,6 +31,7 @@
           doAfter: 2
 
     - node: parts
+      entity: BaseSubstationWallFrame
       edges:
       - to: electronics
         steps:


### PR DESCRIPTION
## About the PR
prying board from wallmounts now turns them back into a frame
don't know if how i did it is the "correct" way but it works with no regressions (that i have seen)

**Media**
TODO record
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed wallmounts working when boards are removed.