### PR TITLE
Always reload NPCs on prototype reload

### DIFF
--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -96,12 +96,6 @@ public sealed class HTNSystem : EntitySystem
 
     private void OnPrototypeLoad(PrototypesReloadedEventArgs obj)
     {
-        if (!obj.ByType.ContainsKey(typeof(HTNCompoundTask)) &&
-            !obj.ByType.ContainsKey(typeof(HTNPrimitiveTask)))
-        {
-            return;
-        }
-
         OnLoad();
     }
 


### PR DESCRIPTION
Because of the dictionary caching that was added after this pr we need to invalidate any plans in progress.

:cl:
- fix: Fix NPC prototype reloading for realsies.
