### PR TITLE
Salvage magnet shows cooldown time on Examine (revived)

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -147,7 +147,7 @@ namespace Content.Server.Salvage
             if (!args.IsInDetailsRange)
                 return;
 
-            if (EntityManager.GetComponent<TransformComponent>(component.Owner).GridUid is EntityUid gridId &&
+            if (Transform(uid).GridUid is EntityUid gridId &&
                 _salvageGridStates.TryGetValue(gridId, out var salvageGridState))
             {
                 remainingTime = component.MagnetState.Until - salvageGridState.CurrentTime;

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -141,8 +141,22 @@ namespace Content.Server.Salvage
 
         private void OnExamined(EntityUid uid, SalvageMagnetComponent component, ExaminedEvent args)
         {
+            var gotGrid = false;
+            var remainingTime = TimeSpan.Zero;
+
             if (!args.IsInDetailsRange)
                 return;
+
+            if (EntityManager.GetComponent<TransformComponent>(component.Owner).GridUid is EntityUid gridId &&
+                _salvageGridStates.TryGetValue(gridId, out var salvageGridState))
+            {
+                remainingTime = component.MagnetState.Until - salvageGridState.CurrentTime;
+                gotGrid = true;
+            }
+            else
+            {
+                Logger.WarningS("salvage", "Failed to load salvage grid state, can't display remaining time");
+            }
             switch (component.MagnetState.StateType)
             {
                 case MagnetStateType.Inactive:
@@ -155,19 +169,12 @@ namespace Content.Server.Salvage
                     args.PushMarkup(Loc.GetString("salvage-system-magnet-examined-releasing"));
                     break;
                 case MagnetStateType.CoolingDown:
-                    args.PushMarkup(Loc.GetString("salvage-system-magnet-examined-cooling-down"));
+                    if (gotGrid)
+                        args.PushMarkup(Loc.GetString("salvage-system-magnet-examined-cooling-down", ("timeLeft", Math.Ceiling(remainingTime.TotalSeconds))));
                     break;
                 case MagnetStateType.Holding:
-                    var magnetTransform = EntityManager.GetComponent<TransformComponent>(component.Owner);
-                    if (magnetTransform.GridUid is EntityUid gridId && _salvageGridStates.TryGetValue(gridId, out var salvageGridState))
-                    {
-                        var remainingTime = component.MagnetState.Until - salvageGridState.CurrentTime;
+                    if (gotGrid)
                         args.PushMarkup(Loc.GetString("salvage-system-magnet-examined-active", ("timeLeft", Math.Ceiling(remainingTime.TotalSeconds))));
-                    }
-                    else
-                    {
-                        Logger.WarningS("salvage", "Failed to load salvage grid state, can't display remaining time");
-                    }
                     break;
                 default:
                     throw new NotImplementedException("Unexpected magnet state type");

--- a/Resources/Locale/en-US/salvage/salvage-system.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-system.ftl
@@ -18,4 +18,4 @@ salvage-system-magnet-examined-active = The salvage magnet is holding salvage in
     *[other] { $timeLeft } seconds.
 }
 salvage-system-magnet-examined-releasing = The salvage magnet is releasing the salvage.
-salvage-system-magnet-examined-cooling-down = The salvage magnet is cooling down.
+salvage-system-magnet-examined-cooling-down = The salvage magnet is cooling down. It will be ready in: {$timeLeft} seconds.


### PR DESCRIPTION
## About the PR
revival of #13214

**Media**
working with current master, on Aspid (:rocket:)
![magnet](https://user-images.githubusercontent.com/39013340/217892494-d5baad95-183e-49e0-a98d-09a4c5689c3b.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- tweak: Salvage magnet shows remaining cooldown time when examined.