### PR TITLE
glass 1984

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -76,6 +76,7 @@
     damage:
       types:
         Piercing: 5
+  - type: DeleteOnTrigger
   - type: StaticPrice
     price: 0
 


### PR DESCRIPTION
## About the PR
fixes #14012 by making glass shards use DeleteOnTrigger, which exists already but wasn't used for some reason


**Media**
[X] I would record funny clown slipping on glass but can't be bothered, it works though

:cl:
- tweak: Glass shards are destroyed when stepped on, no more infinite death traps. Piep!
