### PR TITLE
Legal closets have Judge Robes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -82,6 +82,7 @@
     contents:
       - id: BriefcaseBrownFilled
         prob: 0.80
+      - id: ClothingOuterRobesJudge
 
 - type: entity
   id: LockerBotanistFilled


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR changes the filled version of the legal closet so it has a set of Judge robes. This is a bit of a bodge since not all maps have the filled version of the legal closet, or a closet at all but I guess it now falls on mappers on whether they want them or not?

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/32041239/218162240-71bc053e-1363-4f73-925c-f668432106c7.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Nanotrasen has delivered new Judge robes to the courtrooms of certain stations.
