### PR TITLE
Fix ContentTileDefinition prototype reloads

### DIFF
--- a/Content.Shared/Entry/EntryPoint.cs
+++ b/Content.Shared/Entry/EntryPoint.cs
@@ -23,6 +23,11 @@ namespace Content.Shared.Entry
             SharedContentIoC.Register();
         }
 
+        public override void Shutdown()
+        {
+            _prototypeManager.PrototypesReloaded -= PrototypeReload;
+        }
+
         public override void Init()
         {
         }
@@ -48,6 +53,8 @@ namespace Content.Shared.Entry
 
         private void InitTileDefinitions()
         {
+            _prototypeManager.PrototypesReloaded += PrototypeReload;
+
             // Register space first because I'm a hard coding hack.
             var spaceDef = _prototypeManager.Index<ContentTileDefinition>(ContentTileDefinition.SpaceID);
 
@@ -74,6 +81,15 @@ namespace Content.Shared.Entry
             }
 
             _tileDefinitionManager.Initialize();
+        }
+
+        private void PrototypeReload(PrototypesReloadedEventArgs obj)
+        {
+            // Need to re-allocate tiledefs due to how prototype reloads work
+            foreach (var def in _prototypeManager.EnumeratePrototypes<ContentTileDefinition>())
+            {
+                def.AssignTileId(_tileDefinitionManager[def.ID].TileId);
+            }
         }
     }
 }


### PR DESCRIPTION
These IDs aren't re-assigned so they all get set to 0 on any reload. Somehow this hasn't been noticed before except causes immediate problems for biomes who sorta rely on tiles working.

Requires https://github.com/space-wizards/RobustToolbox/pull/3778

:cl:
- fix: Fix tile definition reloads.