### PR TITLE
Add non-players button to log viewer

### DIFF
--- a/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml
+++ b/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml
@@ -32,6 +32,8 @@
                     <BoxContainer Orientation="Vertical" MinWidth="200">
                         <LineEdit Name="PlayerSearch" Access="Public" StyleClasses="actionSearchBox"
                                   HorizontalExpand="true" PlaceHolder="{Loc admin-logs-search-players-placeholder}"/>
+                        <Button Name="IncludeNonPlayersButton" Text="{Loc admin-logs-include-non-player}"
+                                MinWidth="100" StyleClasses="ButtonSquare" ToggleMode="True" />
                         <BoxContainer Orientation="Horizontal">
                             <Button Name="SelectAllPlayersButton" Text="{Loc admin-logs-select-all}"
                                     MinWidth="100" StyleClasses="ButtonSquare" />

--- a/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
@@ -34,6 +34,7 @@ public sealed partial class AdminLogsControl : Control
         SelectAllTypesButton.OnPressed += SelectAllTypes;
         SelectNoTypesButton.OnPressed += SelectNoTypes;
 
+        IncludeNonPlayersButton.OnPressed += IncludeNonPlayers;
         SelectAllPlayersButton.OnPressed += SelectAllPlayers;
         SelectNoPlayersButton.OnPressed += SelectNoPlayers;
 
@@ -53,6 +54,7 @@ public sealed partial class AdminLogsControl : Control
     public string Search => LogSearch.Text;
     private int ShownLogs { get; set; }
     private int TotalLogs { get; set; }
+    public bool IncludeNonPlayerLogs { get; set; }
 
     public HashSet<LogType> SelectedTypes { get; } = new();
 
@@ -135,6 +137,13 @@ public sealed partial class AdminLogsControl : Control
             type.Pressed = false;
             type.Visible = ShouldShowType(type);
         }
+
+        UpdateLogs();
+    }
+
+    private void IncludeNonPlayers(ButtonEventArgs args)
+    {
+        IncludeNonPlayerLogs = args.Button.Pressed;
 
         UpdateLogs();
     }
@@ -235,10 +244,25 @@ public sealed partial class AdminLogsControl : Control
 
     private bool ShouldShowLog(AdminLogLabel label)
     {
-        return SelectedTypes.Contains(label.Log.Type) &&
-               (SelectedPlayers.Count + label.Log.Players.Length == 0 || SelectedPlayers.Overlaps(label.Log.Players)) &&
-               SelectedImpacts.Contains(label.Log.Impact) &&
-               label.Log.Message.Contains(LogSearch.Text, StringComparison.OrdinalIgnoreCase);
+        // Check log type
+        if (!SelectedTypes.Contains(label.Log.Type))
+            return false;
+
+        // Check players
+        if (!(IncludeNonPlayerLogs && SelectedPlayers.Count + label.Log.Players.Length == 0 ||
+             IncludeNonPlayerLogs && label.Log.Players.Length == 0 ||
+             SelectedPlayers.Overlaps(label.Log.Players)))
+            return false;
+
+        // Check impact
+        if (!SelectedImpacts.Contains(label.Log.Impact))
+            return false;
+
+        // Check search
+        if (!label.Log.Message.Contains(LogSearch.Text, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return true;
     }
 
     private void TypeButtonPressed(ButtonEventArgs args)
@@ -455,6 +479,7 @@ public sealed partial class AdminLogsControl : Control
         SelectAllTypesButton.OnPressed -= SelectAllTypes;
         SelectNoTypesButton.OnPressed -= SelectNoTypes;
 
+        IncludeNonPlayersButton.OnPressed -= IncludeNonPlayers;
         SelectAllPlayersButton.OnPressed -= SelectAllPlayers;
         SelectNoPlayersButton.OnPressed -= SelectNoPlayers;
 

--- a/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
@@ -242,6 +242,14 @@ public sealed partial class AdminLogsControl : Control
                button.Text.Contains(PlayerSearch.Text, StringComparison.OrdinalIgnoreCase);
     }
 
+    private bool LogMatchesPlayerFilter(AdminLogLabel label)
+    {
+        if (label.Log.Players.Length == 0)
+            return SelectedPlayers.Count == 0 || IncludeNonPlayerLogs;
+
+        return SelectedPlayers.Overlaps(label.Log.Players);
+    }
+
     private bool ShouldShowLog(AdminLogLabel label)
     {
         // Check log type
@@ -249,9 +257,7 @@ public sealed partial class AdminLogsControl : Control
             return false;
 
         // Check players
-        if (!(IncludeNonPlayerLogs && SelectedPlayers.Count + label.Log.Players.Length == 0 ||
-             IncludeNonPlayerLogs && label.Log.Players.Length == 0 ||
-             SelectedPlayers.Overlaps(label.Log.Players)))
+        if (!LogMatchesPlayerFilter(label))
             return false;
 
         // Check impact

--- a/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
@@ -53,6 +53,7 @@ public sealed class AdminLogsEui : BaseEui
             null,
             LogsControl.SelectedPlayers.ToArray(),
             null,
+            LogsControl.IncludeNonPlayerLogs,
             null,
             DateOrder.Descending);
 

--- a/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
@@ -51,6 +51,7 @@ public sealed class AdminLogsEui : BaseEui
             null,
             null,
             null,
+            LogsControl.SelectedPlayers.Count != 0,
             LogsControl.SelectedPlayers.ToArray(),
             null,
             LogsControl.IncludeNonPlayerLogs,

--- a/Content.Server/Administration/Logs/AdminLogManager.Cache.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.Cache.cs
@@ -122,14 +122,25 @@ public sealed partial class AdminLogManager
             query = query.Where(log => log.Date > filter.After);
         }
 
-        if (filter.AnyPlayers != null)
+        if (filter.IncludePlayers)
         {
-            query = query.Where(log => filter.AnyPlayers.Any(filterPlayer => log.Players.Contains(filterPlayer)) || log.Players.Length == 0 && filter.IncludeNonPlayers);
-        }
+            if (filter.AnyPlayers != null)
+            {
+                query = query.Where(log =>
+                    filter.AnyPlayers.Any(filterPlayer => log.Players.Contains(filterPlayer)) ||
+                    log.Players.Length == 0 && filter.IncludeNonPlayers);
+            }
 
-        if (filter.AllPlayers != null)
+            if (filter.AllPlayers != null)
+            {
+                query = query.Where(log =>
+                    filter.AllPlayers.All(filterPlayer => log.Players.Contains(filterPlayer)) ||
+                    log.Players.Length == 0 && filter.IncludeNonPlayers);
+            }
+        }
+        else
         {
-            query = query.Where(log => filter.AllPlayers.All(filterPlayer => log.Players.Contains(filterPlayer)) || log.Players.Length == 0 && filter.IncludeNonPlayers);
+            query = query.Where(log => log.Players.Length == 0);
         }
 
         if (filter.LogsSent != 0)

--- a/Content.Server/Administration/Logs/AdminLogManager.Cache.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.Cache.cs
@@ -124,12 +124,12 @@ public sealed partial class AdminLogManager
 
         if (filter.AnyPlayers != null)
         {
-            query = query.Where(log => filter.AnyPlayers.Any(filterPlayer => log.Players.Contains(filterPlayer)));
+            query = query.Where(log => filter.AnyPlayers.Any(filterPlayer => log.Players.Contains(filterPlayer)) || log.Players.Length == 0 && filter.IncludeNonPlayers);
         }
 
         if (filter.AllPlayers != null)
         {
-            query = query.Where(log => filter.AllPlayers.All(filterPlayer => log.Players.Contains(filterPlayer)));
+            query = query.Where(log => filter.AllPlayers.All(filterPlayer => log.Players.Contains(filterPlayer)) || log.Players.Length == 0 && filter.IncludeNonPlayers);
         }
 
         if (filter.LogsSent != 0)

--- a/Content.Server/Administration/Logs/AdminLogsEui.cs
+++ b/Content.Server/Administration/Logs/AdminLogsEui.cs
@@ -120,6 +120,7 @@ public sealed class AdminLogsEui : BaseEui
                     After = request.After,
                     AnyPlayers = request.AnyPlayers,
                     AllPlayers = request.AllPlayers,
+                    IncludeNonPlayers = request.IncludeNonPlayers,
                     LastLogId = 0,
                     Limit = _clientBatchSize
                 };

--- a/Content.Server/Administration/Logs/AdminLogsEui.cs
+++ b/Content.Server/Administration/Logs/AdminLogsEui.cs
@@ -118,6 +118,7 @@ public sealed class AdminLogsEui : BaseEui
                     Impacts = request.Impacts,
                     Before = request.Before,
                     After = request.After,
+                    IncludePlayers = request.IncludePlayers,
                     AnyPlayers = request.AnyPlayers,
                     AllPlayers = request.AllPlayers,
                     IncludeNonPlayers = request.IncludeNonPlayers,

--- a/Content.Server/Administration/Logs/LogFilter.cs
+++ b/Content.Server/Administration/Logs/LogFilter.cs
@@ -20,7 +20,7 @@ public sealed class LogFilter
 
     public DateTime? After { get; set; }
 
-    public bool IncludePlayers { get; set; }
+    public bool IncludePlayers  { get; set; } = true;
 
     public Guid[]? AnyPlayers { get; set; }
 

--- a/Content.Server/Administration/Logs/LogFilter.cs
+++ b/Content.Server/Administration/Logs/LogFilter.cs
@@ -20,6 +20,8 @@ public sealed class LogFilter
 
     public DateTime? After { get; set; }
 
+    public bool IncludePlayers { get; set; }
+
     public Guid[]? AnyPlayers { get; set; }
 
     public Guid[]? AllPlayers { get; set; }

--- a/Content.Server/Administration/Logs/LogFilter.cs
+++ b/Content.Server/Administration/Logs/LogFilter.cs
@@ -24,6 +24,8 @@ public sealed class LogFilter
 
     public Guid[]? AllPlayers { get; set; }
 
+    public bool IncludeNonPlayers { get; set; }
+
     public int? LastLogId { get; set; }
 
     public int LogsSent { get; set; }

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -742,12 +742,12 @@ namespace Content.Server.Database
 
             if (filter.AnyPlayers != null)
             {
-                query = query.Where(log => log.Players.Any(p => filter.AnyPlayers.Contains(p.PlayerUserId)));
+                query = query.Where(log => log.Players.Any(p => filter.AnyPlayers.Contains(p.PlayerUserId)) || log.Players.Count == 0 && filter.IncludeNonPlayers);
             }
 
             if (filter.AllPlayers != null)
             {
-                query = query.Where(log => log.Players.All(p => filter.AllPlayers.Contains(p.PlayerUserId)));
+                query = query.Where(log => log.Players.All(p => filter.AllPlayers.Contains(p.PlayerUserId)) || log.Players.Count == 0 && filter.IncludeNonPlayers);
             }
 
             if (filter.LastLogId != null)

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -740,14 +740,25 @@ namespace Content.Server.Database
                 query = query.Where(log => log.Date > filter.After);
             }
 
-            if (filter.AnyPlayers != null)
+            if (filter.IncludePlayers)
             {
-                query = query.Where(log => log.Players.Any(p => filter.AnyPlayers.Contains(p.PlayerUserId)) || log.Players.Count == 0 && filter.IncludeNonPlayers);
-            }
+                if (filter.AnyPlayers != null)
+                {
+                    query = query.Where(log =>
+                        log.Players.Any(p => filter.AnyPlayers.Contains(p.PlayerUserId)) ||
+                        log.Players.Count == 0 && filter.IncludeNonPlayers);
+                }
 
-            if (filter.AllPlayers != null)
+                if (filter.AllPlayers != null)
+                {
+                    query = query.Where(log =>
+                        log.Players.All(p => filter.AllPlayers.Contains(p.PlayerUserId)) ||
+                        log.Players.Count == 0 && filter.IncludeNonPlayers);
+                }
+            }
+            else
             {
-                query = query.Where(log => log.Players.All(p => filter.AllPlayers.Contains(p.PlayerUserId)) || log.Players.Count == 0 && filter.IncludeNonPlayers);
+                query = query.Where(log => log.Players.Count == 0);
             }
 
             if (filter.LastLogId != null)

--- a/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
+++ b/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
@@ -52,6 +52,7 @@ public static class AdminLogsEuiMsg
             HashSet<LogImpact>? impacts,
             DateTime? before,
             DateTime? after,
+            bool includePlayers,
             Guid[]? anyPlayers,
             Guid[]? allPlayers,
             bool includeNonPlayers,
@@ -64,6 +65,7 @@ public static class AdminLogsEuiMsg
             Impacts = impacts;
             Before = before;
             After = after;
+            IncludePlayers = includePlayers;
             AnyPlayers = anyPlayers is { Length: > 0 } ? anyPlayers : null;
             AllPlayers = allPlayers is { Length: > 0 } ? allPlayers : null;
             IncludeNonPlayers = includeNonPlayers;
@@ -77,6 +79,7 @@ public static class AdminLogsEuiMsg
         public HashSet<LogImpact>? Impacts { get; set; }
         public DateTime? Before { get; set; }
         public DateTime? After { get; set; }
+        public bool IncludePlayers { get; set; }
         public Guid[]? AnyPlayers { get; set; }
         public Guid[]? AllPlayers { get; set; }
         public bool IncludeNonPlayers { get; set; }

--- a/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
+++ b/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
@@ -54,6 +54,7 @@ public static class AdminLogsEuiMsg
             DateTime? after,
             Guid[]? anyPlayers,
             Guid[]? allPlayers,
+            bool includeNonPlayers,
             int? lastLogId,
             DateOrder dateOrder)
         {
@@ -65,6 +66,7 @@ public static class AdminLogsEuiMsg
             After = after;
             AnyPlayers = anyPlayers is { Length: > 0 } ? anyPlayers : null;
             AllPlayers = allPlayers is { Length: > 0 } ? allPlayers : null;
+            IncludeNonPlayers = includeNonPlayers;
             LastLogId = lastLogId;
             DateOrder = dateOrder;
         }
@@ -77,6 +79,7 @@ public static class AdminLogsEuiMsg
         public DateTime? After { get; set; }
         public Guid[]? AnyPlayers { get; set; }
         public Guid[]? AllPlayers { get; set; }
+        public bool IncludeNonPlayers { get; set; }
         public int? LastLogId { get; set; }
         public DateOrder DateOrder { get; set; }
     }

--- a/Resources/Locale/en-US/administration/ui/admin-logs.ftl
+++ b/Resources/Locale/en-US/administration/ui/admin-logs.ftl
@@ -15,6 +15,7 @@ admin-logs-select-none = None
 # Players
 admin-logs-search-players-placeholder = Search Players (OR)
 admin-logs-select-none = None
+admin-logs-include-non-player = Include Non-players
 
 # Logs
 admin-logs-search-logs-placeholder = Search Logs


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes #12851 by adding a toggle button to include non-player logs in results.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/119664036/218586506-2decc921-547a-43a5-a323-9cb6d18dc78e.png)
![image](https://user-images.githubusercontent.com/119664036/218586541-f6866805-3f25-4a20-85a8-b6c999274e08.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase