### PR TITLE
Remove ConfigPresets/ from client packaged resources.

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/centipede.toml
+++ b/Resources/ConfigPresets/WizardsDen/centipede.toml
@@ -1,0 +1,4 @@
+﻿# Configuration preset used on Wizard's Den Centipede
+
+[game]
+hostname = "[EN] Wizard's Den Centipede [Oceania]"

--- a/Resources/ConfigPresets/WizardsDen/lizard.toml
+++ b/Resources/ConfigPresets/WizardsDen/lizard.toml
@@ -1,0 +1,7 @@
+﻿# Configuration preset used on Wizard's Den Lizard
+
+# Nothing specific yet
+
+[game]
+hostname = "[EN] Wizard's Den Lizard [US West]"
+soft_max_players = 100

--- a/Resources/ConfigPresets/WizardsDen/miros.toml
+++ b/Resources/ConfigPresets/WizardsDen/miros.toml
@@ -1,0 +1,4 @@
+﻿# Configuration preset used on Wizard's Den Miros
+
+[game]
+hostname = "[EN] Wizard's Den Miros [EU West 2]"

--- a/Resources/ConfigPresets/WizardsDen/salamander.toml
+++ b/Resources/ConfigPresets/WizardsDen/salamander.toml
@@ -1,0 +1,16 @@
+﻿# Configuration preset used on Wizard's Den Salamander
+
+[game]
+desc = "Official English Space Station 14 servers. Roleplay required, you must be whitelisted through Discord to play."
+hostname = "[EN] Wizard's Den Salamander [US West RP]"
+
+[server]
+rules_file = "RP_Rules.txt"
+rules_header = "ui-rules-header-rp"
+
+[whitelist]
+enabled = true
+reason = "whitelist-not-whitelisted-rp"
+
+[ic]
+flavor_text = true

--- a/Resources/ConfigPresets/WizardsDen/spider.toml
+++ b/Resources/ConfigPresets/WizardsDen/spider.toml
@@ -1,0 +1,4 @@
+﻿# Configuration preset used on Wizard's Den Spider
+
+[game]
+hostname = "[EN] Wizard's Den Spider [EU West 1]"

--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -1,0 +1,5 @@
+﻿# Base configuration preset used on all Wizard's Den servers.
+# Loaded before server-specific config presets by configuration.
+
+[game]
+desc = "Official English Space Station 14 servers. Vanilla, low roleplay."

--- a/Tools/package_client_build.py
+++ b/Tools/package_client_build.py
@@ -37,6 +37,7 @@ SHARED_IGNORED_RESOURCES = {
 
 CLIENT_IGNORED_RESOURCES = {
     "Maps",
+    "ConfigPresets",
     "emotes.xml",
     "Groups",
     "engineCommandPerms.yml"


### PR DESCRIPTION
Means per-server configuration can be tracked in Git, and you won't need to bother me to raise the player count on Lizard anymore.