### PR TITLE
Remove reference to deleted mind

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -183,6 +183,9 @@ namespace Content.Server.GameTicking
                 ? Transform(playerEntity.Value).Coordinates
                 : GetObserverSpawnPoint();
 
+            if (position == default)
+                return false;
+
             // Ok, so, this is the master place for the logic for if ghosting is "too cheaty" to allow returning.
             // There's no reason at this time to move it to any other place, especially given that the 'side effects required' situations would also have to be moved.
             // + If CharacterDeadPhysically applies, we're physically dead. Therefore, ghosting OK, and we can return (this is critical for gibbing)

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -107,6 +107,7 @@ public sealed class MindSystem : EntitySystem
                     {
                         // This should be an error, if it didn't cause tests to start erroring when they delete a player.
                         Logger.WarningS("mind", $"Entity \"{ToPrettyString(uid)}\" for {mind.Mind?.CharacterName} was deleted, and no applicable spawn location is available.");
+                        mind.Mind?.TransferTo(null);
                         return;
                     }
 


### PR DESCRIPTION
Fixes a bug where a player's entity isn't properly cleared when an entity gets deleted. Also stops game ticker from trying to spawn ghosts in nullspace