### PR TITLE
Bump upload limit to 10MB

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -20,3 +20,6 @@ max_connections = 1024
 
 [vote]
 restart_required_ratio = 0.7
+
+[netres]
+limit = 10


### PR DESCRIPTION
we live in a cibilization where internet is fast. we arent on dialup anymore pog. this pr bumps the max filesize upload to 10 MB 

**Media**

this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Nanotrasen finally installed more ram for adminbus mainframes after several years of requests. Nanotrasen will dock the pay of all heads of staff to cover installation costs.
