### PR TITLE
More NPC steering tweaks

### DIFF
--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -37,6 +37,15 @@ public sealed class NPCSteeringComponent : Component
     #endregion
 
     /// <summary>
+    /// Next time we can change our steering direction.
+    /// </summary>
+    public TimeSpan NextSteer = TimeSpan.Zero;
+
+    public Vector2 LastSteerDirection = Vector2.Zero;
+
+    public const int SteeringFrequency = 10;
+
+    /// <summary>
     /// Have we currently requested a path.
     /// </summary>
     [ViewVariables]

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
@@ -32,11 +32,11 @@ public sealed partial class NPCCombatSystem
             if (cdRemaining < TimeSpan.FromSeconds(1f / weapon.AttackRate) * 0.5f)
                 return;
 
-            if (!_physics.TryGetNearestPoints(uid, component.Target, out _, out var pointB))
+            if (!_physics.TryGetNearestPoints(uid, component.Target, out var pointA, out var pointB))
                 return;
 
-            var idealDistance = weapon.Range * 1.25f;
-            var obstacleDirection = pointB - args.WorldPosition;
+            var idealDistance = weapon.Range * 1.5f;
+            var obstacleDirection = pointB - pointA;
             var obstacleDistance = obstacleDirection.Length;
 
             if (obstacleDistance > idealDistance || obstacleDistance == 0f)

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
@@ -36,7 +36,7 @@ public sealed partial class NPCCombatSystem
                 return;
 
             var idealDistance = weapon.Range * 1.5f;
-            var obstacleDirection = pointB - pointA;
+            var obstacleDirection = pointB - args.WorldPosition;
             var obstacleDistance = obstacleDirection.Length;
 
             if (obstacleDistance > idealDistance || obstacleDistance == 0f)

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -320,7 +320,7 @@ public sealed partial class NPCSteeringSystem
         EntityQuery<PhysicsComponent> bodyQuery,
         EntityQuery<TransformComponent> xformQuery)
     {
-        var detectionRadius = MathF.Max(1.5f, agentRadius + moveSpeed / 4f);
+        var detectionRadius = MathF.Max(1.5f, agentRadius);
 
         foreach (var ent in _lookup.GetEntitiesInRange(uid, detectionRadius, LookupFlags.Static))
         {
@@ -338,11 +338,23 @@ public sealed partial class NPCSteeringSystem
             if (!_physics.TryGetNearestPoints(uid, ent, out var pointA, out var pointB, xform, xformQuery.GetComponent(ent)))
                 continue;
 
-            var obstacleDirection = pointB - worldPos;
+            var obstacleDirection = pointB - pointA;
             var obstableDistance = obstacleDirection.Length;
 
-            if (obstableDistance > detectionRadius || obstableDistance == 0f)
+            if (obstableDistance > detectionRadius)
                 continue;
+
+            // Fallback to worldpos if we're colliding.
+            if (obstableDistance == 0f)
+            {
+                obstacleDirection = pointB - worldPos;
+                obstableDistance = obstacleDirection.Length;
+
+                if (obstableDistance == 0f)
+                    continue;
+
+                obstableDistance = agentRadius;
+            }
 
             dangerPoints.Add(pointB);
             obstacleDirection = offsetRot.RotateVec(obstacleDirection);

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -206,16 +206,19 @@ namespace Content.Server.NPC.Systems
 
             var npcs = EntityQuery<ActiveNPCComponent, NPCSteeringComponent, InputMoverComponent, TransformComponent>()
                 .ToArray();
+
+            // Dependency issues across threads.
             var options = new ParallelOptions
             {
-                MaxDegreeOfParallelism = _parallel.ParallelProcessCount,
+                MaxDegreeOfParallelism = 1,
             };
+            var curTime = _timing.CurTime;
 
             Parallel.For(0, npcs.Length, options, i =>
             {
                 var (_, steering, mover, xform) = npcs[i];
 
-                Steer(steering, mover, xform, modifierQuery, bodyQuery, xformQuery, frameTime);
+                Steer(steering, mover, xform, modifierQuery, bodyQuery, xformQuery, frameTime, curTime);
             });
 
 
@@ -262,7 +265,8 @@ namespace Content.Server.NPC.Systems
             EntityQuery<MovementSpeedModifierComponent> modifierQuery,
             EntityQuery<PhysicsComponent> bodyQuery,
             EntityQuery<TransformComponent> xformQuery,
-            float frameTime)
+            float frameTime,
+            TimeSpan curTime)
         {
             if (Deleted(steering.Coordinates.EntityId))
             {
@@ -355,6 +359,18 @@ namespace Content.Server.NPC.Systems
                 resultDirection = new Angle(desiredDirection * InterestRadians).ToVec();
             }
 
+            // Don't steer too frequently to avoid twitchiness.
+            // This should also implicitly solve tie situations.
+            // I think doing this after all the ops above is best?
+            // Originally I had it way above but sometimes mobs would overshoot their tile targets.
+            if (steering.NextSteer > curTime)
+            {
+                SetDirection(mover, steering, steering.LastSteerDirection, false);
+                return;
+            }
+
+            steering.NextSteer = curTime + TimeSpan.FromSeconds(1f / NPCSteeringComponent.SteeringFrequency);
+            steering.LastSteerDirection = resultDirection;
             DebugTools.Assert(!float.IsNaN(resultDirection.X));
             SetDirection(mover, steering, resultDirection, false);
         }

--- a/Resources/Prototypes/Entities/Structures/Walls/railing.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/railing.yml
@@ -18,7 +18,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.49,-0.49,0.49,-0.45"
+        bounds: "-0.49,-0.49,0.49,-0.25"
       density: 1000
       mask:
       - TableMask
@@ -70,7 +70,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.49,-0.49,0.49,-0.45"
+        bounds: "-0.49,-0.49,0.49,-0.25"
       density: 1000
       mask:
       - TableMask
@@ -78,7 +78,7 @@
       - TableLayer
     - shape:
         !type:PhysShapeAabb
-        bounds: "0.49,0.49,0.45,-0.49"
+        bounds: "0.49,0.49,0.25,-0.49"
       density: 1000
       mask:
       - TableMask
@@ -130,7 +130,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.49,0.49,-0.45,0.45"
+        bounds: "-0.49,0.49,-0.25,0.25"
       density: 1000
       mask:
       - TableMask


### PR DESCRIPTION
- Tentatively re-implement steering cooldown
- Adjust railing bounds so they actually get considered for breadcrumbs (at least until I refactor pathfinder for the 3rd time)
- Bump ideal distance for melee slightly
- Use the shorter distance for collision avoidance as default. Nyano implemented this but forgot it will return 0-length vectors for colliding mobs.
- Fast mobs should be a little less twitchy with context steering.
- Not sure if it fixes mobs getting stuck in corners (I believe that was the collisionavoidance slightly outweighting the priority to get to a corner tile).
- I set parallelism to 1 due to dependencies not working well across threads.

:cl:
- fix: Fix NPCs not pathfinding around railings.
- fix: Fix NPCs dancing in some instances.
- fix: Fix NPC steering crashing in some instances.