### PR TITLE
change speech emotes

### DIFF
--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -2,22 +2,30 @@
 - type: emote
   id: Scream
   category: Vocal
-  chatMessages: [screams, yells]
+  chatMessages: [screams!]
   chatTriggers:
     - scream
     - screams
+    - screams.
+    - screams!
     - screaming
     - screamed
     - shriek
     - shrieks
+    - shrieks.
+    - shrieks!
     - shrieking
     - shrieked
     - screech
-    - screechs
+    - screeches
+    - screeches.
+    - screeches!
     - screeching
     - screeched
     - yell
     - yells
+    - yells.
+    - yells!
     - yelled
     - yelling
 
@@ -28,14 +36,20 @@
   chatTriggers:
     - laugh
     - laughs
+    - laughs.
+    - laughs!
     - laughing
     - laughed
     - chuckle
     - chuckles
+    - chuckles.
+    - chuckles!
     - chuckled
     - chuckling
     - giggle
     - giggles
+    - giggles.
+    - giggles!
     - giggling
     - giggled
 
@@ -43,17 +57,19 @@
 - type: emote
   id: Clap
   category: Hands
-  chatMessages: [claps]
+  chatMessages: [claps!]
   chatTriggers:
     - clap
     - claps
+    - claps.
+    - claps!
     - clapping
     - clapped
 
 - type: emote
   id: Snap
   category: Hands
-  chatMessages: [snaps fingers]
+  chatMessages: [snaps fingers] # snaps <{THEIR($ent)}> fingers?
   chatTriggers:
     - snap
     - snaps
@@ -61,6 +77,11 @@
     - snapped
     - snap fingers
     - snaps fingers
+    - snaps fingers.
+    - snaps fingers!
+    - snaps their fingers
+    - snaps their fingers.
+    - snaps their fingers!
     - snapping fingers
     - snapped fingers
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR makes vocal emotes slightly more like ss13's.

My only complaint? ALL OF THIS could be fixed with some kind of String.includes in `EmoteSystem`. I'm genuinely surprised this was missed in reviews, and I'm not going to change it because any conceivable way I'd fix it would be improper and against the coding style.

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: router
- tweak: Made sound emotes not abhorrent. You can now add some punctuation marks after some emotes.
