### PR TITLE
Steering tweaks

### DIFF
--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -320,7 +320,7 @@ public sealed partial class NPCSteeringSystem
         EntityQuery<PhysicsComponent> bodyQuery,
         EntityQuery<TransformComponent> xformQuery)
     {
-        var detectionRadius = MathF.Max(1.5f, agentRadius);
+        var detectionRadius = MathF.Max(1f, agentRadius);
 
         foreach (var ent in _lookup.GetEntitiesInRange(uid, detectionRadius, LookupFlags.Static))
         {
@@ -364,7 +364,7 @@ public sealed partial class NPCSteeringSystem
             for (var i = 0; i < InterestDirections; i++)
             {
                 var dot = Vector2.Dot(norm, Directions[i]);
-                danger[i] = MathF.Max(dot * weight, danger[i]);
+                danger[i] = MathF.Max(dot * weight * 0.9f, danger[i]);
             }
         }
 

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.NPC;
 using Content.Shared.NPC.Events;
+using Content.Shared.Physics;
 using Content.Shared.Weapons.Melee;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
@@ -363,6 +364,7 @@ namespace Content.Server.NPC.Systems
             // This should also implicitly solve tie situations.
             // I think doing this after all the ops above is best?
             // Originally I had it way above but sometimes mobs would overshoot their tile targets.
+
             if (steering.NextSteer > curTime)
             {
                 SetDirection(mover, steering, steering.LastSteerDirection, false);
@@ -396,7 +398,10 @@ namespace Content.Server.NPC.Systems
             // Short-circuit with no path.
             var targetPoly = _pathfindingSystem.GetPoly(steering.Coordinates);
 
-            if (targetPoly != null && steering.Coordinates.Position.Equals(Vector2.Zero) && _interaction.InRangeUnobstructed(steering.Owner, steering.Coordinates.EntityId))
+            // If this still causes issues future sloth adjust the collision mask.
+            if (targetPoly != null &&
+                steering.Coordinates.Position.Equals(Vector2.Zero) &&
+                _interaction.InRangeUnobstructed(steering.Owner, steering.Coordinates.EntityId, range: 30f))
             {
                 steering.CurrentPath.Clear();
                 steering.CurrentPath.Enqueue(targetPoly);


### PR DESCRIPTION
- Fix the direct-path so NPCs. This is most noticeable when moving diagonally on planetmaps (given the current pathfinder is cardinal)
- Reduce static collision avoidance weight and distance. This seems to reduce instances of getting stuck on railings.

:cl:
- fix: NPCs will take straightline paths in more instances. This makes them less likely to get outrun in open areas.