### PR TITLE
Nerf L6 firerate

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -19,7 +19,7 @@
     maxAngle: 20
     angleIncrease: 4
     angleDecay: 16
-    fireRate: 8
+    fireRate: 5
     selectedMode: FullAuto
     availableModes:
       - FullAuto


### PR DESCRIPTION
So it actually matches rifles coz its main advantage is supposed to be big clip and caliber.

:cl:
- tweak: Change L6 firerate from 8 to 5 in line with rifles.