### PR TITLE
Remove clownbackpack honk

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -32,9 +32,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/clown.rsi
-  - type: Storage
-    storageOpenSound:
-      collection: BikeHorn
 
 - type: entity
   parent: ClothingBackpack


### PR DESCRIPTION
It's spammable and although the storage one also needs nerfing for spam this is far more obnoxious.

:cl:
- fix: Remove honk sound on clowns opening backpacks due to too many people spamming it.