### PR TITLE
implant locale + priority tweaks

### DIFF
--- a/Resources/Locale/en-US/implant/implant.ftl
+++ b/Resources/Locale/en-US/implant/implant.ftl
@@ -15,11 +15,11 @@ implanter-label = [color=white]Implant: {$currentEntities}{$lineBreak}Mode: {$mo
 
 ## Implanter Actions
 
-open-storage-implant-action-name = open storage implant
-open-storage-implant-action-description = opens the storage implant embedded under your skin
+open-storage-implant-action-name = Open Storage Implant
+open-storage-implant-action-description = Opens the storage implant embedded under your skin
 
-activate-micro-bomb-action-name = activate micro bomb
-activate-micro-bomb-action-description = activates your internal microbomb, completely destroying you and your equipment
+activate-micro-bomb-action-name = Activate Microbomb
+activate-micro-bomb-action-description = Activates your internal microbomb, completely destroying you and your equipment
 
-use-freedom-implant-action-name = use freedom implant
-use-freedom-implant-action-description = activating the implant will free you from any hand restraints
+use-freedom-implant-action-name = Break Free
+use-freedom-implant-action-description = Activating your freedom implant will free you from any hand restraints

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -39,7 +39,7 @@
   description: activate-micro-bomb-action-description
   checkCanInteract: false
   itemIconStyle: BigAction
-  priority: -21
+  priority: -20
   icon:
     sprite: Actions/Implants/implants.rsi
     state: explosive
@@ -52,7 +52,7 @@
   charges: 3
   checkCanInteract: false
   itemIconStyle: BigAction
-  priority: -22
+  priority: -20
   icon:
     sprite: Actions/Implants/implants.rsi
     state: freedom

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -27,6 +27,7 @@
   name: open-storage-implant-action-name
   description: open-storage-implant-action-description
   itemIconStyle: BigAction
+  priority: -20
   icon:
     sprite: Clothing/Back/Backpacks/backpack.rsi
     state: icon
@@ -38,6 +39,7 @@
   description: activate-micro-bomb-action-description
   checkCanInteract: false
   itemIconStyle: BigAction
+  priority: -21
   icon:
     sprite: Actions/Implants/implants.rsi
     state: explosive
@@ -50,6 +52,7 @@
   charges: 3
   checkCanInteract: false
   itemIconStyle: BigAction
+  priority: -22
   icon:
     sprite: Actions/Implants/implants.rsi
     state: freedom


### PR DESCRIPTION
## About the PR
moves implant actions to the bottom of the ui, tweaks their names

**Media**

microbomb implant before changes, breaks combat mode muscle memory with potentially *explosive* consequences (i have blown myself up **several** times while working on ninja, and relogging with storage implant messed action order up)
![101505](https://user-images.githubusercontent.com/39013340/219622232-8ee1b1cb-a26d-420b-9c77-801e20213ca4.png)

they go at the bottom now

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun