### PR TITLE
Move artifact verbs from admin menu to debug menu

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -119,29 +119,6 @@ namespace Content.Server.Administration.Systems
                     });
                 }
 
-                // XenoArcheology
-                if (TryComp<ArtifactComponent>(args.Target, out var artifact))
-                {
-                    // make artifact always active (by adding timer trigger)
-                    args.Verbs.Add(new Verb()
-                    {
-                        Text = Loc.GetString("artifact-verb-make-always-active"),
-                        Category = VerbCategory.Admin,
-                        Act = () => EntityManager.AddComponent<ArtifactTimerTriggerComponent>(args.Target),
-                        Disabled = EntityManager.HasComponent<ArtifactTimerTriggerComponent>(args.Target),
-                        Impact = LogImpact.High
-                    });
-
-                    // force to activate artifact ignoring timeout
-                    args.Verbs.Add(new Verb()
-                    {
-                        Text = Loc.GetString("artifact-verb-activate"),
-                        Category = VerbCategory.Admin,
-                        Act = () => _artifactSystem.ForceActivateArtifact(args.Target, component: artifact),
-                        Impact = LogImpact.High
-                    });
-                }
-
                 // TeleportTo
                 args.Verbs.Add(new Verb
                 {
@@ -236,6 +213,29 @@ namespace Content.Server.Administration.Systems
                     ConfirmationPopup = true
                 };
                 args.Verbs.Add(verb);
+            }
+
+            // XenoArcheology
+            if (TryComp<ArtifactComponent>(args.Target, out var artifact))
+            {
+                // make artifact always active (by adding timer trigger)
+                args.Verbs.Add(new Verb()
+                {
+                    Text = Loc.GetString("artifact-verb-make-always-active"),
+                    Category = VerbCategory.Debug,
+                    Act = () => EntityManager.AddComponent<ArtifactTimerTriggerComponent>(args.Target),
+                    Disabled = EntityManager.HasComponent<ArtifactTimerTriggerComponent>(args.Target),
+                    Impact = LogImpact.High
+                });
+
+                // force to activate artifact ignoring timeout
+                args.Verbs.Add(new Verb()
+                {
+                    Text = Loc.GetString("artifact-verb-activate"),
+                    Category = VerbCategory.Debug,
+                    Act = () => _artifactSystem.ForceActivateArtifact(args.Target, component: artifact),
+                    Impact = LogImpact.High
+                });
             }
 
             // Make Sentient verb


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Moves artifact activation verbs from admin menu to debug. They'd fit better in tricks but they'd need icons for that and activating the artifact can technically be used for debugging.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase