### PR TITLE
Rename migrations to fix CS8981 warnings.

### DIFF
--- a/Content.Server.Database/Migrations/Postgres/20220103235647_whitelist.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220103235647_whitelist.Designer.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Database.Migrations.Postgres
 {
     [DbContext(typeof(PostgresServerDbContext))]
     [Migration("20220103235647_whitelist")]
-    partial class whitelist
+    partial class Whitelist
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/Content.Server.Database/Migrations/Postgres/20220103235647_whitelist.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220103235647_whitelist.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Content.Server.Database.Migrations.Postgres
 {
-    public partial class whitelist : Migration
+    public partial class Whitelist : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {

--- a/Content.Server.Database/Migrations/Postgres/20220108185749_add-species.Designer.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220108185749_add-species.Designer.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Database.Migrations.Postgres
 {
     [DbContext(typeof(PostgresServerDbContext))]
     [Migration("20220108185749_add-species")]
-    partial class addspecies
+    partial class AddSpecies
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/Content.Server.Database/Migrations/Postgres/20220108185749_add-species.cs
+++ b/Content.Server.Database/Migrations/Postgres/20220108185749_add-species.cs
@@ -4,7 +4,7 @@
 
 namespace Content.Server.Database.Migrations.Postgres
 {
-    public partial class addspecies : Migration
+    public partial class AddSpecies : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {

--- a/Content.Server.Database/Migrations/Sqlite/20220103235637_whitelist.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220103235637_whitelist.Designer.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
 {
     [DbContext(typeof(SqliteServerDbContext))]
     [Migration("20220103235637_whitelist")]
-    partial class whitelist
+    partial class Whitelist
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/Content.Server.Database/Migrations/Sqlite/20220103235637_whitelist.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220103235637_whitelist.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Content.Server.Database.Migrations.Sqlite
 {
-    public partial class whitelist : Migration
+    public partial class Whitelist : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {

--- a/Content.Server.Database/Migrations/Sqlite/20220108185734_add-species.Designer.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220108185734_add-species.Designer.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Database.Migrations.Sqlite
 {
     [DbContext(typeof(SqliteServerDbContext))]
     [Migration("20220108185734_add-species")]
-    partial class addspecies
+    partial class AddSpecies
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/Content.Server.Database/Migrations/Sqlite/20220108185734_add-species.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20220108185734_add-species.cs
@@ -4,7 +4,7 @@
 
 namespace Content.Server.Database.Migrations.Sqlite
 {
-    public partial class addspecies : Migration
+    public partial class AddSpecies : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves#cs8981---the-type-name-only-contains-lower-cased-ascii-characters