### PR TITLE
prevent crash if disabling stealth with outline

### DIFF
--- a/Content.Client/Stealth/StealthSystem.cs
+++ b/Content.Client/Stealth/StealthSystem.cs
@@ -44,7 +44,7 @@ public sealed class StealthSystem : SharedStealthSystem
         if (!enabled)
         {
             if (component.HadOutline)
-                AddComp<InteractionOutlineComponent>(uid);
+                EnsureComp<InteractionOutlineComponent>(uid);
             return;
         }
 


### PR DESCRIPTION
## About the PR
happened a few times while doing ninja stuff, very annoying having to remove outline or defer stealth component

**Media**
- [X] This PR does not require an ingame showcase

**Changelog**
no