### PR TITLE
Add verb to open entity logs

### DIFF
--- a/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
@@ -174,6 +174,32 @@ public sealed partial class AdminLogsControl : Control
         UpdateLogs();
     }
 
+    public void SetTypesSelection(HashSet<LogType> selectedTypes, bool invert = false)
+    {
+        SelectedTypes.Clear();
+
+        foreach (var control in TypesContainer.Children)
+        {
+            if (control is not AdminLogTypeButton type)
+            {
+                continue;
+            }
+
+            if (selectedTypes.Contains(type.Type) ^ invert)
+            {
+                type.Pressed = true;
+                SelectedTypes.Add(type.Type);
+            }
+            else
+            {
+                type.Pressed = false;
+                type.Visible = ShouldShowType(type);
+            }
+        }
+
+        UpdateLogs();
+    }
+
     public void UpdateTypes()
     {
         foreach (var control in TypesContainer.Children)

--- a/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
@@ -137,6 +137,15 @@ public sealed class AdminLogsEui : BaseEui
 
                 LogsControl.NextButton.Disabled = !newLogs.HasNext;
                 break;
+
+            case SetLogFilter setLogFilter:
+                if (setLogFilter.Search != null)
+                    LogsControl.LogSearch.SetText(setLogFilter.Search);
+
+                if (setLogFilter.Types != null)
+                    LogsControl.SetTypesSelection(setLogFilter.Types, setLogFilter.InvertTypes);
+
+                break;
         }
     }
 

--- a/Content.Server/Administration/Logs/AdminLogsEui.cs
+++ b/Content.Server/Administration/Logs/AdminLogsEui.cs
@@ -7,6 +7,7 @@ using Content.Server.GameTicking;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CCVar;
+using Content.Shared.Database;
 using Content.Shared.Eui;
 using Microsoft.Extensions.ObjectPool;
 using Robust.Shared.Configuration;
@@ -138,6 +139,16 @@ public sealed class AdminLogsEui : BaseEui
                 break;
             }
         }
+    }
+
+    public void SetLogFilter(string? search = null, bool invertTypes = false, HashSet<LogType>? types = null)
+    {
+        var message = new SetLogFilter(
+            search,
+            invertTypes,
+            types);
+
+        SendMessage(message);
     }
 
     private async void SendLogs(bool replace)

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration.Commands;
+using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Server.Administration.UI;
 using Content.Server.Chemistry.Components.SolutionManager;
@@ -48,6 +49,7 @@ namespace Content.Server.Administration.Systems
         [Dependency] private readonly ArtifactSystem _artifactSystem = default!;
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
         [Dependency] private readonly PrayerSystem _prayerSystem = default!;
+        [Dependency] private readonly EuiManager _eui = default!;
 
         private readonly Dictionary<IPlayerSession, EditSolutionsEui> _openSolutionUis = new();
 
@@ -117,6 +119,25 @@ namespace Content.Server.Administration.Systems
                         },
                         Impact = LogImpact.Medium,
                     });
+                }
+
+                // Admin Logs
+                if (_adminManager.HasAdminFlag(player, AdminFlags.Logs))
+                {
+                    Verb logsVerbEntity = new()
+                    {
+                        Priority = -2,
+                        Text = Loc.GetString("admin-verbs-admin-logs-entity"),
+                        Category = VerbCategory.Admin,
+                        Act = () =>
+                        {
+                            var ui = new AdminLogsEui();
+                            _eui.OpenEui(ui, player);
+                            ui.SetLogFilter(search:args.Target.GetHashCode().ToString());
+                        },
+                        Impact = LogImpact.Low
+                    };
+                    args.Verbs.Add(logsVerbEntity);
                 }
 
                 // TeleportTo

--- a/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
+++ b/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
@@ -28,6 +28,21 @@ public static class AdminLogsEuiMsg
     }
 
     [Serializable, NetSerializable]
+    public sealed class SetLogFilter : EuiMessageBase
+    {
+        public SetLogFilter(string? search = null, bool invertTypes = false, HashSet<LogType>? types = null)
+        {
+            Search = search;
+            InvertTypes = invertTypes;
+            Types = types;
+        }
+
+        public string? Search { get; set; }
+        public bool InvertTypes { get; set; }
+        public HashSet<LogType>? Types { get; set; }
+    }
+
+    [Serializable, NetSerializable]
     public sealed class NewLogs : EuiMessageBase
     {
         public NewLogs(List<SharedAdminLog> logs, bool replace, bool hasNext)

--- a/Resources/Locale/en-US/administration/admin-verbs.ftl
+++ b/Resources/Locale/en-US/administration/admin-verbs.ftl
@@ -2,6 +2,7 @@ delete-verb-get-data-text = Delete
 edit-solutions-verb-get-data-text = Edit Solutions
 explode-verb-get-data-text = Explode
 ahelp-verb-get-data-text = Message
+admin-verbs-admin-logs-entity = Entity Logs
 admin-verbs-teleport-to = Teleport To
 admin-verbs-teleport-here = Teleport Here
 admin-verbs-freeze = Freeze


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adds a verb to the admin verb category to open logs for that entity. Technically a little janky because it uses text search instead of a proper filter but this is how entity logs are currently brought up in the game.

There is unused code related to setting the type filter. It works, but I decided to not add verbs that use it because it would clutter the menu without having a subcategory, which is not currently supported. I'll remove the code if it's preferred, but I figured I'd leave it in since I wrote it and it's working.

I wanted to and was working on also adding a verb to open logs filtered to the player, but I wasn't able to get it working. I think it needs some changes to the way the log window works as far as updating the list of players.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase