### PR TITLE
Remove roundstart powergamer bait from Youtool.

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -11,5 +11,4 @@
     GasAnalyzer: 5
     FlashlightLantern: 5
     ClothingHandsGlovesColorYellowBudget: 5
-    ClothingBeltUtility: 3
     AirlockPainter: 3


### PR DESCRIPTION
Why are we handing out utility belts like candy.

:cl:
- remove: Youtool no longer has free utility belts.