### PR TITLE
Cargo Hauler Mech

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/vehicles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/vehicles.yml
@@ -39,3 +39,26 @@
   - type: ConditionalSpawner
     prototypes:
       - VehicleATV
+      
+- type: entity
+  name: Hauler APLU Spawner
+  id: SpawnMechHauler
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - sprite: Objects/Vehicles/Specific/Mech/mecha.rsi
+        state: hauler_open
+  - type: ConditionalSpawner
+    prototypes:
+      - MechHauler
+
+- type: entity
+  id: SpawnMechHaulerBattery
+  parent: SpawnMechHauler
+  suffix: Battery
+  components:
+  - type: ConditionalSpawner
+    prototypes:
+      - MechHaulerBattery

--- a/Resources/Prototypes/Entities/Markers/Spawners/vehicles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/vehicles.yml
@@ -48,8 +48,8 @@
   - type: Sprite
     layers:
       - state: green
-      - sprite: Objects/Vehicles/Specific/Mech/mecha.rsi
-        state: hauler_open
+      - sprite: Objects/Specific/Mech/mecha_equipment.rsi
+        state: mecha_clamp
   - type: ConditionalSpawner
     prototypes:
       - MechHauler

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -75,7 +75,7 @@
 - type: entity
   id: MechRipley
   parent: BaseMech
-  name: Ripley "APLU"
+  name: Ripley APLU
   description: A versatile, lightly armored mech.
   components:
   - type: FootstepModifier
@@ -102,7 +102,7 @@
 - type: entity
   id: MechHauler
   parent: MechRipley
-  name: Hauler "APLU"
+  name: Hauler APLU
   description: A cheaper, more lightweight version of the RIPLEY mech. Designed for use in cargo transfer.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -75,8 +75,8 @@
 - type: entity
   id: MechRipley
   parent: BaseMech
-  name: ripley
-  description: Cargo's favorite robotic box hauling friend.
+  name: Ripley "APLU"
+  description: A versatile, lightly armored mech.
   components:
   - type: FootstepModifier
     footstepSoundCollection:
@@ -98,3 +98,41 @@
     brokenState: ripley-broken
     startingBattery: PowerCellHigh
     mechToPilotDamageMultiplier: 0.5
+    
+- type: entity
+  id: MechHauler
+  parent: MechRipley
+  name: Hauler "APLU"
+  description: A cheaper, more lightweight version of the RIPLEY mech. Designed for use in cargo transfer.
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Mech/mecha.rsi
+    layers:
+    - map: [ "enum.MechVisualLayers.Base" ]
+      state: hauler
+  - type: Mech
+    baseState: hauler
+    openState: hauler-open
+    brokenState: hauler-broken
+    mechToPilotDamageMultiplier: 0.80
+  - type: MeleeWeapon
+    hidden: true
+    attackRate: 1
+    damage:
+      types:
+        Blunt: 13
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 1.5
+    baseSprintSpeed: 3
+    
+- type: entity
+  id: MechHaulerBattery
+  parent: MechHauler
+  suffix: Battery
+  components:
+  - type: Mech
+    baseState: hauler
+    openState: hauler-open
+    brokenState: hauler-broken
+    startingBattery: PowerCellHigh
+    mechToPilotDamageMultiplier: 0.75

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -114,10 +114,10 @@
     baseState: hauler
     openState: hauler-open
     brokenState: hauler-broken
-    mechToPilotDamageMultiplier: 0.80
+    mechToPilotDamageMultiplier: 0.85
   - type: MeleeWeapon
     hidden: true
-    attackRate: 1
+    attackRate: 0.80
     damage:
       types:
         Blunt: 13


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds the Hauler APLU, a lightweight variant of the Ripley that is tailored towards speed for efficient cargo work. However, due to the decreased load, it has much worse armor and melee attacks, making it mediocre for melee combat (its punches are roughly equal to that of a crowbar, but slower.)

Intentionally not printable and intended to be mapped in Cargo. Hopefully, this should make moving items like crates and lockers significantly less unbearable, and give cargo themselves a way to make money other than just printing items. 

Also renames the "ripley" to the "Ripley APLU", as the old one was not capitalized (and that's what it was called in SS13.)

**Media**
(I have no clue how the audio got so delayed, but it's not like it matters anyways.)

[Content.Client_z2loJdcT9R.webm](https://user-images.githubusercontent.com/78941145/219926282-0ff66f61-e3a6-4f74-8f59-908b947c3819.webm)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added the Hauler APLU, a special lightweight version of the Ripley that can only be found inside of Cargo.
- tweak: Renamed the "ripley" to "Ripley APLU."
