### PR TITLE
Add missing DataField for currentTemperature

### DIFF
--- a/Content.Server/Temperature/Components/TemperatureComponent.cs
+++ b/Content.Server/Temperature/Components/TemperatureComponent.cs
@@ -15,6 +15,7 @@ namespace Content.Server.Temperature.Components
     public sealed class TemperatureComponent : Component
     {
         [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("currentTemperature")]
         public float CurrentTemperature { get; set; } = Atmospherics.T20C;
 
         [DataField("heatDamageThreshold")]


### PR DESCRIPTION
## About the PR
The `currentTemperature` field is used by mob prototypes to start mobs at 310K instead of the default 293K. Unfortunately, because `TemperatureComponent` is missing this DataField, this doesn't actually work. Fix by adding the DataField.

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
N/A