### PR TITLE
Fix substation units

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -170,7 +170,7 @@
 - type: entity
   parent: BaseSubstation
   id: SubstationBasic
-  suffix: Basic, 2.5MW
+  suffix: Basic, 2.5MJ
   components:
   - type: Battery
     maxCharge: 2500000
@@ -187,7 +187,7 @@
 - type: entity
   parent: BaseSubstationWall
   id: SubstationWallBasic
-  suffix: Basic, 2MW
+  suffix: Basic, 2MJ
   components:
   - type: Battery
     maxCharge: 2000000


### PR DESCRIPTION
## About the PR
Changes the entity spawn menu suffix for substations to report the storage capacity in correct units. Batteries store energy (in Joules) and not power (Joules per second = Watt).

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
N/A