### PR TITLE
Revert "Make jetpacks wearable in suit storage"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -48,7 +48,6 @@
       quickEquip: false
       slots:
         - Back
-        - suitStorage
     - type: GasTank
       outputPressure: 21.27825
       air:
@@ -83,7 +82,6 @@
     sprite: Objects/Tanks/Jetpacks/blue.rsi
     slots:
       - Back
-      - suitStorage
 
 # Filled blue
 - type: entity
@@ -116,7 +114,6 @@
     sprite: Objects/Tanks/Jetpacks/black.rsi
     slots:
       - Back
-      - suitStorage
 
 # Filled black
 - type: entity
@@ -147,7 +144,6 @@
     sprite: Objects/Tanks/Jetpacks/captain.rsi
     slots:
       - Back
-      - suitStorage
   - type: Item
     sprite: Objects/Tanks/Jetpacks/captain.rsi
     size: 30
@@ -220,7 +216,6 @@
     sprite: Objects/Tanks/Jetpacks/security.rsi
     slots:
       - Back
-      - suitStorage
 
 #Filled security
 - type: entity
@@ -253,7 +248,6 @@
     sprite: Objects/Tanks/Jetpacks/void.rsi
     slots:
       - Back
-      - suitStorage
 
 # Filled void
 - type: entity


### PR DESCRIPTION
Reverts space-wizards/space-station-14#14168

- Jetpacks are objectively better than mini as a result and they're already more frequent.
- It's supposed to be a trade-off of putting the jetpack on your backpack slot (putting your bag in hands) or using your jetpack inhands.
- It just creeps inventory space more so people have ample space to carry everything they need.