### PR TITLE
Add APC power meter

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml
@@ -8,6 +8,7 @@
             <Label Text="{Loc 'apc-menu-breaker-label'}"/>
             <Button Name="BreakerButton" Text="{Loc 'apc-menu-breaker-button'}"></Button>
         </BoxContainer>
+        <Label Name="PowerLabel"/>
         <BoxContainer Orientation="Horizontal">
             <Label Text="{Loc 'apc-menu-external-label'}"/>
             <Label Name="ExternalPowerStateLabel" Text="{Loc 'apc-menu-power-state-good'}"/>

--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -32,6 +32,11 @@ namespace Content.Client.Power.APC.UI
                 BreakerButton.Pressed = castState.MainBreaker;
             }
 
+            if (PowerLabel != null)
+            {
+                PowerLabel.Text = Loc.GetString("apc-menu-power-label", ("power", castState.Power));
+            }
+
             if (ExternalPowerStateLabel != null)
             {
                 switch (castState.ApcExternalPower)

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -135,9 +135,12 @@ namespace Content.Server.Power.EntitySystems
             if (!Resolve(uid, ref apc, ref battery, ref ui))
                 return;
 
+            var netBattery = Comp<PowerNetworkBatteryComponent>(uid);
+            float power = netBattery is not null ? netBattery.CurrentSupply : 0f;
+
             if (_userInterfaceSystem.GetUiOrNull(uid, ApcUiKey.Key, ui) is { } bui)
             {
-                bui.SetState(new ApcBoundInterfaceState(apc.MainBreakerEnabled, apc.LastExternalState, battery.CurrentCharge / battery.MaxCharge));
+                bui.SetState(new ApcBoundInterfaceState(apc.MainBreakerEnabled, (int)MathF.Ceiling(power), apc.LastExternalState, battery.CurrentCharge / battery.MaxCharge));
             }
         }
 

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -57,12 +57,14 @@ namespace Content.Shared.APC
     public sealed class ApcBoundInterfaceState : BoundUserInterfaceState
     {
         public readonly bool MainBreaker;
+        public readonly int Power;
         public readonly ApcExternalPowerState ApcExternalPower;
         public readonly float Charge;
 
-        public ApcBoundInterfaceState(bool mainBreaker, ApcExternalPowerState apcExternalPower, float charge)
+        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge)
         {
             MainBreaker = mainBreaker;
+            Power = power;
             ApcExternalPower = apcExternalPower;
             Charge = charge;
         }

--- a/Resources/Locale/en-US/ui/power-apc.ftl
+++ b/Resources/Locale/en-US/ui/power-apc.ftl
@@ -1,6 +1,7 @@
 apc-menu-title = APC
 apc-menu-breaker-label = Main Breaker:{" "}
 apc-menu-breaker-button = Toggle
+apc-menu-power-label = Power: {$power} W
 apc-menu-external-label = External Power:{" "}
 apc-menu-charge-label = Charge:{" "}
 


### PR DESCRIPTION
## About the PR
This adds a power meter to the APC, which indicates the total load of all devices drawing from the APC. This is good for <s>billing or threatening to shut off high energy usage departments</s> reducing a station's energy footprint and reducing space warming.

While you could already do this by using a multitool-examine on the LV cable coming out of the APC, that is clunky and inconvenient. Since APC's are effectively electricity meters (like the one your utility uses to bill you) in the real world, it also makes sense to add a power meter to the UI.

**Media**
![powermeter](https://user-images.githubusercontent.com/3229565/220200135-b2c323f4-ca22-4f0a-bcf5-2f3a6445d7fa.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: notafet
- add: APCs now show the power being drawn from them.