### PR TITLE
Fix entity group menu (right-click menu)

### DIFF
--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -260,7 +260,7 @@ namespace Content.Client.ContextMenu.UI
             {
                 var subElement = new EntityMenuElement(entity);
                 subElement.SubMenu = new ContextMenuPopup(_context, subElement);
-                subElement.SubMenu.OnPopupOpen += () => _verb.OpenVerbMenu(group[0], popup: subElement.SubMenu);
+                subElement.SubMenu.OnPopupOpen += () => _verb.OpenVerbMenu(entity, popup: subElement.SubMenu);
                 subElement.SubMenu.OnPopupHide += subElement.SubMenu.MenuBody.DisposeAllChildren;
                 _context.AddElement(subMenu, subElement);
                 Elements.TryAdd(entity, subElement);

--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -216,16 +216,7 @@ namespace Content.Client.ContextMenu.UI
             // If there is only a single group. We will just directly list individual entities
             if (entityGroups.Count == 1)
             {
-                foreach (var entity in entityGroups[0])
-                {
-                    var element = new EntityMenuElement(entity);
-                    element.SubMenu = new ContextMenuPopup(_context, element);
-                    element.SubMenu.OnPopupOpen += () => _verb.OpenVerbMenu(entity, popup: element.SubMenu);
-                    element.SubMenu.OnPopupHide += element.SubMenu.MenuBody.DisposeAllChildren;
-
-                    _context.AddElement(_context.RootMenu, element);
-                    Elements.TryAdd(entity, element);
-                }
+                AddGroupToMenu(entityGroups[0], _context.RootMenu);
                 return;
             }
 
@@ -234,16 +225,12 @@ namespace Content.Client.ContextMenu.UI
                 if (group.Count > 1)
                 {
                     AddGroupToUI(group);
-                    continue;
                 }
-
-                // this group only has a single entity, add a simple menu element
-                var element = new EntityMenuElement(group[0]);
-                element.SubMenu = new ContextMenuPopup(_context, element);
-                element.SubMenu.OnPopupOpen += () => _verb.OpenVerbMenu(group[0], popup: element.SubMenu);
-                element.SubMenu.OnPopupHide += element.SubMenu.MenuBody.DisposeAllChildren;
-                _context.AddElement(_context.RootMenu, element);
-                Elements.TryAdd(group[0], element);
+                else
+                {
+                    // this group only has a single entity, add a simple menu element
+                    AddEntityToMenu(group[0], _context.RootMenu);
+                }
             }
 
         }
@@ -256,18 +243,34 @@ namespace Content.Client.ContextMenu.UI
             EntityMenuElement element = new();
             ContextMenuPopup subMenu = new(_context, element);
 
-            foreach (var entity in group)
-            {
-                var subElement = new EntityMenuElement(entity);
-                subElement.SubMenu = new ContextMenuPopup(_context, subElement);
-                subElement.SubMenu.OnPopupOpen += () => _verb.OpenVerbMenu(entity, popup: subElement.SubMenu);
-                subElement.SubMenu.OnPopupHide += subElement.SubMenu.MenuBody.DisposeAllChildren;
-                _context.AddElement(subMenu, subElement);
-                Elements.TryAdd(entity, subElement);
-            }
+            AddGroupToMenu(group, subMenu);
 
             UpdateElement(element);
             _context.AddElement(_context.RootMenu, element);
+        }
+
+        /// <summary>
+        ///     Add the group of entities to the menu
+        /// </summary>
+        private void AddGroupToMenu(List<EntityUid> group, ContextMenuPopup menu)
+        {
+            foreach (var entity in group)
+            {
+                AddEntityToMenu(entity, menu);
+            }
+        }
+
+        /// <summary>
+        ///     Add the entity to the menu
+        /// </summary>
+        private void AddEntityToMenu(EntityUid entity, ContextMenuPopup menu)
+        {
+            var element = new EntityMenuElement(entity);
+            element.SubMenu = new ContextMenuPopup(_context, element);
+            element.SubMenu.OnPopupOpen += () => _verb.OpenVerbMenu(entity, popup: element.SubMenu);
+            element.SubMenu.OnPopupHide += element.SubMenu.MenuBody.DisposeAllChildren;
+            _context.AddElement(menu, element);
+            Elements.TryAdd(entity, element);
         }
 
         /// <summary>


### PR DESCRIPTION
## About the PR

I have split this PR in two atomic commits:
* Fix a bug that prevent the submenu to display entity specific action
* Refactor the AddToUI method

To trigger the bug you need two entity groups, one of the group of entity must have an anchor and unanchor entity.

**Media**
before:

https://user-images.githubusercontent.com/32521367/220372802-cc753bab-c80a-4402-898e-689bedbab1ba.mp4

after:

https://user-images.githubusercontent.com/32521367/220372835-b79f8fc1-a949-4d52-8bcf-78b014f95f4a.mp4


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Fixed entity sub menu (right-click menu)
