### PR TITLE
Make admin ahelp window remember its last position

### DIFF
--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -2,12 +2,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Client.Administration.Managers;
 using Content.Client.Administration.Systems;
-using Content.Client.Administration.UI;
 using Content.Client.Administration.UI.Bwoink;
-using Content.Client.Administration.UI.CustomControls;
 using Content.Client.Gameplay;
 using Content.Client.UserInterface.Controls;
-using Content.Client.UserInterface.Systems.Info;
 using Content.Shared.Administration;
 using Content.Shared.Input;
 using JetBrains.Annotations;
@@ -22,7 +19,6 @@ using Robust.Shared.Input.Binding;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
-using BwoinkPanel = Content.Client.Administration.UI.Bwoink.BwoinkPanel;
 
 namespace Content.Client.UserInterface.Systems.Bwoink;
 
@@ -220,7 +216,7 @@ public sealed class AHelpUIController: UIController, IOnStateChanged<GameplaySta
 }
 
 // please kill all this indirection
-public interface IAHelpUIHandler: IDisposable
+public interface IAHelpUIHandler : IDisposable
 {
     public bool IsAdmin { get; }
     public bool IsOpen { get; }
@@ -242,6 +238,7 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
     private readonly Dictionary<NetUserId, BwoinkPanel> _activePanelMap = new();
     public bool IsAdmin => true;
     public bool IsOpen => Window is { Disposed: false, IsOpen: true } || ClydeWindow is { IsDisposed: false };
+    private bool _everOpened;
 
     public BwoinkWindow? Window;
     public WindowRoot? WindowRoot;
@@ -282,13 +279,19 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
     public void ToggleWindow()
     {
         EnsurePanel(_ownerId);
+
         if (IsOpen)
         {
             Close();
         }
         else
         {
-            Window!.OpenCentered();
+            if (_everOpened)
+                Window!.Open();
+            else
+                Window!.OpenCentered();
+
+            _everOpened = true;
         }
     }
 
@@ -315,7 +318,11 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
         Window = new BwoinkWindow();
         Control = Window.Bwoink;
         Window.OnClose += () => { OnClose?.Invoke(); };
-        Window.OnOpen += () => { OnOpen?.Invoke(); };
+        Window.OnOpen += () =>
+        {
+            OnOpen?.Invoke();
+            _everOpened = true;
+        };
 
         // need to readd any unattached panels..
         foreach (var (_, panel) in _activePanelMap)


### PR DESCRIPTION
## About the PR
See https://github.com/space-wizards/space-station-14/issues/12583

**Media**

https://user-images.githubusercontent.com/10968691/220436751-bdec1333-94f7-4d05-90c4-984b18030648.mp4


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Admin ahelp window now remembers its last position.
