### PR TITLE
Add power debug verbs

### DIFF
--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -57,6 +57,14 @@ namespace Content.Server.Administration.Managers
             return null;
         }
 
+        public AdminData? GetAdminData(EntityUid uid, bool includeDeAdmin = false)
+        {
+            if (_playerManager.TryGetSessionByEntity(uid, out var session) && session is IPlayerSession playerSession)
+                return GetAdminData(playerSession, includeDeAdmin);
+
+            return null;
+        }
+
         public void DeAdmin(IPlayerSession session)
         {
             if (!_admins.TryGetValue(session, out var reg))

--- a/Content.Server/Administration/Managers/IAdminManager.cs
+++ b/Content.Server/Administration/Managers/IAdminManager.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Administration;
+using Content.Shared.Administration;
 using Robust.Server.Player;
 
 
@@ -46,6 +46,26 @@ namespace Content.Server.Administration.Managers
         /// </param>
         /// <returns><see langword="null" /> if the player is not an admin.</returns>
         AdminData? GetAdminData(IPlayerSession session, bool includeDeAdmin = false);
+
+        /// <summary>
+        ///     Gets the admin data for a player, if they are an admin.
+        /// </summary>
+        /// <param name="uid">The entity being controlled by the player.</param>
+        /// <param name="includeDeAdmin">
+        ///     Whether to return admin data for admins that are current de-adminned.
+        /// </param>
+        /// <returns><see langword="null" /> if the player is not an admin.</returns>
+        AdminData? GetAdminData(EntityUid uid, bool includeDeAdmin = false);
+
+        /// <summary>
+        ///     See if a player has an admin flag.
+        /// </summary>
+        /// <returns>True if the player is and admin and has the specified flags.</returns>
+        bool HasAdminFlag(EntityUid player, AdminFlags flag)
+        {
+            var data = GetAdminData(player);
+            return data != null && data.HasFlag(flag);
+        }
 
         /// <summary>
         ///     See if a player has an admin flag.

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Cargo.Systems;
 using Content.Server.Power.Components;
 using Content.Shared.Examine;
+using Content.Shared.Rejuvenate;
 using JetBrains.Annotations;
 
 namespace Content.Server.Power.EntitySystems
@@ -13,10 +14,22 @@ namespace Content.Server.Power.EntitySystems
             base.Initialize();
 
             SubscribeLocalEvent<ExaminableBatteryComponent, ExaminedEvent>(OnExamine);
+            SubscribeLocalEvent<PowerNetworkBatteryComponent, RejuvenateEvent>(OnNetBatteryRejuvenate);
+            SubscribeLocalEvent<BatteryComponent, RejuvenateEvent>(OnBatteryRejuvenate);
             SubscribeLocalEvent<BatteryComponent, PriceCalculationEvent>(CalculateBatteryPrice);
 
             SubscribeLocalEvent<NetworkBatteryPreSync>(PreSync);
             SubscribeLocalEvent<NetworkBatteryPostSync>(PostSync);
+        }
+
+        private void OnNetBatteryRejuvenate(EntityUid uid, PowerNetworkBatteryComponent component, RejuvenateEvent args)
+        {
+            component.NetworkBattery.CurrentStorage = component.NetworkBattery.Capacity;
+        }
+
+        private void OnBatteryRejuvenate(EntityUid uid, BatteryComponent component, RejuvenateEvent args)
+        {
+            component.CurrentCharge = component.MaxCharge;
         }
 
         private void OnExamine(EntityUid uid, ExaminableBatteryComponent component, ExaminedEvent args)

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -7,14 +7,18 @@ using Content.Shared.Verbs;
 using Content.Shared.Database;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
+using Content.Server.Administration.Managers;
+using Content.Shared.Administration;
 
 namespace Content.Server.Power.EntitySystems
 {
     public sealed class PowerReceiverSystem : EntitySystem
     {
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly IAdminManager _adminManager = default!;
         [Dependency] private readonly AppearanceSystem _appearance = default!;
         [Dependency] private readonly AudioSystem _audio = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -27,7 +31,23 @@ namespace Content.Server.Power.EntitySystems
             SubscribeLocalEvent<ApcPowerProviderComponent, ExtensionCableSystem.ReceiverConnectedEvent>(OnReceiverConnected);
             SubscribeLocalEvent<ApcPowerProviderComponent, ExtensionCableSystem.ReceiverDisconnectedEvent>(OnReceiverDisconnected);
 
+            SubscribeLocalEvent<ApcPowerReceiverComponent, GetVerbsEvent<Verb>>(OnGetVerbs);
             SubscribeLocalEvent<PowerSwitchComponent, GetVerbsEvent<AlternativeVerb>>(AddSwitchPowerVerb);
+        }
+
+        private void OnGetVerbs(EntityUid uid, ApcPowerReceiverComponent component, GetVerbsEvent<Verb> args)
+        {
+            if (!_adminManager.HasAdminFlag(args.User, AdminFlags.Admin))
+                return;
+
+            // add debug verb to toggle power requirements
+            args.Verbs.Add(new()
+            {
+                Text = Loc.GetString("verb-debug-toggle-need-power"),
+                Category = VerbCategory.Debug,
+                IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png", // "smite" is a lightning bolt
+                Act = () => component.NeedsPower = !component.NeedsPower
+            });
         }
 
         ///<summary>

--- a/Content.Server/PowerCell/PowerCellSystem.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Containers;
 using System.Diagnostics.CodeAnalysis;
 using Content.Server.Kitchen.Components;
 using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Rejuvenate;
 
 namespace Content.Server.PowerCell;
 
@@ -29,12 +30,18 @@ public sealed class PowerCellSystem : SharedPowerCellSystem
 
         SubscribeLocalEvent<PowerCellComponent, ChargeChangedEvent>(OnChargeChanged);
         SubscribeLocalEvent<PowerCellComponent, SolutionChangedEvent>(OnSolutionChange);
+        SubscribeLocalEvent<PowerCellComponent, RejuvenateEvent>(OnRejuvenate);
 
         SubscribeLocalEvent<PowerCellComponent, ExaminedEvent>(OnCellExamined);
 
         // funny
         SubscribeLocalEvent<PowerCellSlotComponent, BeingMicrowavedEvent>(OnSlotMicrowaved);
         SubscribeLocalEvent<BatteryComponent, BeingMicrowavedEvent>(OnMicrowaved);
+    }
+
+    private void OnRejuvenate(EntityUid uid, PowerCellComponent component, RejuvenateEvent args)
+    {
+        component.IsRigged = false;
     }
 
     private void OnSlotMicrowaved(EntityUid uid, PowerCellSlotComponent component, BeingMicrowavedEvent args)

--- a/Content.Shared/PowerCell/SharedPowerCellSystem.cs
+++ b/Content.Shared/PowerCell/SharedPowerCellSystem.cs
@@ -1,16 +1,30 @@
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.PowerCell.Components;
+using Content.Shared.Rejuvenate;
 using Robust.Shared.Containers;
 
 namespace Content.Shared.PowerCell;
 
 public abstract class SharedPowerCellSystem : EntitySystem
 {
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+
     public override void Initialize()
     {
         base.Initialize();
+        SubscribeLocalEvent<PowerCellSlotComponent, RejuvenateEvent>(OnRejuventate);
         SubscribeLocalEvent<PowerCellSlotComponent, EntInsertedIntoContainerMessage>(OnCellInserted);
         SubscribeLocalEvent<PowerCellSlotComponent, EntRemovedFromContainerMessage>(OnCellRemoved);
         SubscribeLocalEvent<PowerCellSlotComponent, ContainerIsInsertingAttemptEvent>(OnCellInsertAttempt);
+    }
+
+    private void OnRejuventate(EntityUid uid, PowerCellSlotComponent component, RejuvenateEvent args)
+    {
+        if (!_itemSlots.TryGetSlot(uid, component.CellSlotId, out ItemSlot? itemSlot) || !itemSlot.Item.HasValue)
+            return;
+
+        // charge entity batteries and remove booby traps.
+        RaiseLocalEvent(uid, args);
     }
 
     private void OnCellInsertAttempt(EntityUid uid, PowerCellSlotComponent component, ContainerIsInsertingAttemptEvent args)

--- a/Content.Shared/PowerCell/SharedPowerCellSystem.cs
+++ b/Content.Shared/PowerCell/SharedPowerCellSystem.cs
@@ -24,7 +24,7 @@ public abstract class SharedPowerCellSystem : EntitySystem
             return;
 
         // charge entity batteries and remove booby traps.
-        RaiseLocalEvent(uid, args);
+        RaiseLocalEvent(itemSlot.Item.Value, args);
     }
 
     private void OnCellInsertAttempt(EntityUid uid, PowerCellSlotComponent component, ContainerIsInsertingAttemptEvent args)

--- a/Resources/Locale/en-US/power/verb.ftl
+++ b/Resources/Locale/en-US/power/verb.ftl
@@ -1,0 +1,2 @@
+# debug verb for allowing devices to work without requiring power.
+verb-debug-toggle-need-power = Toggle Power


### PR DESCRIPTION
- Adds a toggle power debug verb. More convenient than having to VV the power receiver component.
- Makes the rejuvenate verb also refill batteries.
- Adds some variants of existing admin manager functions that take in an entity uid instead of a player session.

https://user-images.githubusercontent.com/60421075/220492125-b5293b67-a964-4c41-b669-200e3fcecb83.mp4

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

