### PR TITLE
Fix emergency shuttle spawning

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -260,9 +260,6 @@ namespace Content.Server.GameTicking
 
             _taskManager.BlockWaitOnTask(task);
             RoundId = task.GetAwaiter().GetResult();
-
-            var startingEvent = new RoundStartingEvent(RoundId);
-            RaiseLocalEvent(startingEvent);
         }
     }
 

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -180,6 +180,8 @@ namespace Content.Server.GameTicking
 
             RoundLengthMetric.Set(0);
 
+            var startingEvent = new RoundStartingEvent(RoundId);
+            RaiseLocalEvent(startingEvent);
             var readyPlayers = new List<IPlayerSession>();
             var readyPlayerProfiles = new Dictionary<NetUserId, HumanoidCharacterProfile>();
 


### PR DESCRIPTION
I moved this event back to its previous spot. The round increment PR moved it though this causes issues with some systems that expect the maps to be loaded.

:cl:
- fix: Fix the emergency shuttle not loading.