### PR TITLE
Fix AHelp window being recentered when opened through the verb

### DIFF
--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -253,6 +253,17 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
         Control?.OnBwoink(message.UserId);
     }
 
+    private void OpenWindow()
+    {
+        if (Window == null)
+            return;
+
+        if (EverOpened)
+            Window.Open();
+        else
+            Window.OpenCentered();
+    }
+
     public void Close()
     {
         Window?.Close();
@@ -282,18 +293,9 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
         EnsurePanel(_ownerId);
 
         if (IsOpen)
-        {
             Close();
-        }
         else
-        {
-            if (EverOpened)
-                Window!.Open();
-            else
-                Window!.OpenCentered();
-
-            EverOpened = true;
-        }
+            OpenWindow();
     }
 
     public event Action? OnClose;
@@ -303,7 +305,7 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
     public void Open(NetUserId channelId)
     {
         SelectChannel(channelId);
-        Window?.OpenCentered();
+        OpenWindow();
     }
 
     public void OnRequestClosed(WindowRequestClosedEventArgs args)


### PR DESCRIPTION
## About the PR
**Media**

https://user-images.githubusercontent.com/10968691/220614752-d37e76a3-fdad-4ea3-a1bf-82bf3a61cfca.mp4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed the AHelp window being recentered when opened through the verb for admins.
