### PR TITLE
Add layers field to construction prototype

### DIFF
--- a/Content.Client/Construction/ConstructionPlacementHijack.cs
+++ b/Content.Client/Construction/ConstructionPlacementHijack.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Content.Shared.Construction;
 using Content.Shared.Construction.Prototypes;
 using Robust.Client.Graphics;
@@ -45,20 +46,28 @@ namespace Content.Client.Construction
             return true;
         }
 
+        private List<IDirectionalTextureProvider>? GetFrames()
+        {
+            if (_prototype == null)
+            {
+                return null;
+            }
+
+            // Use multiple sprite if layers is defined
+            if (_prototype.Layers != null)
+            {
+                return _prototype.Layers.Select(sprite => sprite.DirFrame0()).ToList();
+            }
+
+            // Use the construction prototype icon
+            return new List<IDirectionalTextureProvider>{_prototype.Icon.DirFrame0()};
+        }
+
         /// <inheritdoc />
         public override void StartHijack(PlacementManager manager)
         {
             base.StartHijack(manager);
-
-            var frame = _prototype?.Icon.DirFrame0();
-            if (frame == null)
-            {
-                manager.CurrentTextures = null;
-            }
-            else
-            {
-                manager.CurrentTextures = new List<IDirectionalTextureProvider> {frame};
-            }
+            manager.CurrentTextures = GetFrames();
         }
     }
 }

--- a/Content.Client/Construction/ConstructionPlacementHijack.cs
+++ b/Content.Client/Construction/ConstructionPlacementHijack.cs
@@ -46,28 +46,11 @@ namespace Content.Client.Construction
             return true;
         }
 
-        private List<IDirectionalTextureProvider>? GetFrames()
-        {
-            if (_prototype == null)
-            {
-                return null;
-            }
-
-            // Use multiple sprite if layers is defined
-            if (_prototype.Layers != null)
-            {
-                return _prototype.Layers.Select(sprite => sprite.DirFrame0()).ToList();
-            }
-
-            // Use the construction prototype icon
-            return new List<IDirectionalTextureProvider>{_prototype.Icon.DirFrame0()};
-        }
-
         /// <inheritdoc />
         public override void StartHijack(PlacementManager manager)
         {
             base.StartHijack(manager);
-            manager.CurrentTextures = GetFrames();
+            manager.CurrentTextures = _prototype?.Layers.Select(sprite => sprite.DirFrame0()).ToList();
         }
     }
 }

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -180,24 +180,13 @@ namespace Content.Client.Construction
             var sprite = EntityManager.GetComponent<SpriteComponent>(ghost);
             sprite.Color = new Color(48, 255, 48, 128);
 
-            if (prototype.Layers != null)
+            for (int i = 0; i < prototype.Layers.Count; i++)
             {
-                for (int i = 0; i < prototype.Layers.Count; i++)
-                {
-                    sprite.AddBlankLayer(i); // There is no way to actually check if this already exists, so we blindly insert a new one
-                    sprite.LayerSetSprite(i, prototype.Layers[i]);
-                    sprite.LayerSetShader(i, "unshaded");
-                    sprite.LayerSetVisible(i, true);
-                }
+                sprite.AddBlankLayer(i); // There is no way to actually check if this already exists, so we blindly insert a new one
+                sprite.LayerSetSprite(i, prototype.Layers[i]);
+                sprite.LayerSetShader(i, "unshaded");
+                sprite.LayerSetVisible(i, true);
             }
-            else
-            {
-                sprite.AddBlankLayer(0); // There is no way to actually check if this already exists, so we blindly insert a new one
-                sprite.LayerSetSprite(0, prototype.Icon);
-                sprite.LayerSetShader(0, "unshaded");
-                sprite.LayerSetVisible(0, true);
-            }
-
 
             if (prototype.CanBuildInImpassable)
                 EnsureComp<WallMountComponent>(ghost).Arc = new(Math.Tau);

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -179,10 +179,25 @@ namespace Content.Client.Construction
             _ghosts.Add(comp.GhostId, comp);
             var sprite = EntityManager.GetComponent<SpriteComponent>(ghost);
             sprite.Color = new Color(48, 255, 48, 128);
-            sprite.AddBlankLayer(0); // There is no way to actually check if this already exists, so we blindly insert a new one
-            sprite.LayerSetSprite(0, prototype.Icon);
-            sprite.LayerSetShader(0, "unshaded");
-            sprite.LayerSetVisible(0, true);
+
+            if (prototype.Layers != null)
+            {
+                for (int i = 0; i < prototype.Layers.Count; i++)
+                {
+                    sprite.AddBlankLayer(i); // There is no way to actually check if this already exists, so we blindly insert a new one
+                    sprite.LayerSetSprite(i, prototype.Layers[i]);
+                    sprite.LayerSetShader(i, "unshaded");
+                    sprite.LayerSetVisible(i, true);
+                }
+            }
+            else
+            {
+                sprite.AddBlankLayer(0); // There is no way to actually check if this already exists, so we blindly insert a new one
+                sprite.LayerSetSprite(0, prototype.Icon);
+                sprite.LayerSetShader(0, "unshaded");
+                sprite.LayerSetVisible(0, true);
+            }
+
 
             if (prototype.CanBuildInImpassable)
                 EnsureComp<WallMountComponent>(ghost).Arc = new(Math.Tau);

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
@@ -50,7 +50,7 @@ namespace Content.Shared.Construction.Prototypes
         ///     Texture paths used for the construction ghost.
         /// </summary>
         [DataField("layers")]
-        public List<SpriteSpecifier>? Layers { get; }
+        private List<SpriteSpecifier>? _layers;
 
         /// <summary>
         ///     If you can start building or complete steps on impassable terrain.
@@ -76,6 +76,7 @@ namespace Content.Shared.Construction.Prototypes
         public bool CanRotate { get; } = true;
 
         public IReadOnlyList<IConstructionCondition> Conditions => _conditions;
+        public IReadOnlyList<SpriteSpecifier> Layers => _layers ?? new List<SpriteSpecifier>{Icon};
     }
 
     public enum ConstructionType

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
@@ -47,6 +47,12 @@ namespace Content.Shared.Construction.Prototypes
         public SpriteSpecifier Icon { get; } = SpriteSpecifier.Invalid;
 
         /// <summary>
+        ///     Texture paths used for the construction ghost.
+        /// </summary>
+        [DataField("layers")]
+        public List<SpriteSpecifier>? Layers { get; }
+
+        /// <summary>
         ///     If you can start building or complete steps on impassable terrain.
         /// </summary>
         [DataField("canBuildInImpassable")]

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -581,6 +581,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/vent.rsi
     state: vent_off
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeStraight
+  - sprite: Structures/Piping/Atmospherics/vent.rsi
+    state: vent_off
   conditions:
     - !type:TileNotBlocked {}
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -412,6 +412,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/vent.rsi
     state: vent_off
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeHalf
+  - sprite: Structures/Piping/Atmospherics/vent.rsi
+    state: vent_off
   conditions:
     - !type:TileNotBlocked {}
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -497,6 +497,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpVolume
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeStraight
+  - sprite: Structures/Piping/Atmospherics/pump.rsi
+    state: pumpVolume
   conditions:
     - !type:TileNotBlocked {}
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -476,6 +476,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpPressure
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeStraight
+  - sprite: Structures/Piping/Atmospherics/pump.rsi
+    state: pumpPressure
   conditions:
     - !type:TileNotBlocked {}
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -391,6 +391,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/vent.rsi
     state: vent_off
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeHalf
+  - sprite: Structures/Piping/Atmospherics/vent.rsi
+    state: vent_off
   conditions:
     - !type:TileNotBlocked {}
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -454,6 +454,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/outletinjector.rsi
     state: injector
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeHalf
+  - sprite: Structures/Piping/Atmospherics/outletinjector.rsi
+    state: injector
   conditions:
     - !type:TileNotBlocked {}
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -539,6 +539,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpManualValve
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeStraight
+  - sprite: Structures/Piping/Atmospherics/pump.rsi
+    state: pumpManualValve
   conditions:
     - !type:TileNotBlocked {}
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -433,6 +433,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/scrubber.rsi
     state: scrub_off
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeHalf
+  - sprite: Structures/Piping/Atmospherics/scrubber.rsi
+    state: scrub_off
   conditions:
     - !type:TileNotBlocked {}
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -518,6 +518,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpPassiveGate
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeStraight
+  - sprite: Structures/Piping/Atmospherics/pump.rsi
+    state: pumpPassiveGate
   conditions:
     - !type:TileNotBlocked {}
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -560,6 +560,11 @@
   icon:
     sprite: Structures/Piping/Atmospherics/gascanisterport.rsi
     state: gasCanisterPort
+  layers:
+  - sprite: Structures/Piping/Atmospherics/pipe.rsi
+    state: pipeHalf
+  - sprite: Structures/Piping/Atmospherics/gascanisterport.rsi
+    state: gasCanisterPort
   conditions:
     - !type:TileNotBlocked {}
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR adds the optional field Layers to ConstructionPrototype. Most of the atmos utilities display now the pipe underneath (useful when you want to place a scrubber).

PS: mixer, filter and pneumatic valve haven´t been changed because with the current implementation you can't use a default rotation.

**Media**

https://user-images.githubusercontent.com/32521367/220711223-31b6df44-8a79-4721-b9bd-02dd3eaf6fea.mp4

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Added the pipe layer in construction mode for the majority of atmos utilities
