### PR TITLE
Made gasthermomachines connection pipes rotatable again 

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -254,6 +254,8 @@
           pipeDirection: South
     - type: StaticPrice
       price: 500
+    - type: Transform
+      noRot: false
 
 - type: entity
   parent: BaseGasThermoMachine

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -230,6 +230,7 @@
     - type: Sprite
       netsync: false
       sprite: Structures/Piping/Atmospherics/thermomachine.rsi
+      noRot: true
     - type: Appearance
     - type: PipeColorVisuals
     - type: Rotatable


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Freezers and heaters were stuck in the default (south) position make proper piping sometime harder than necessary.
This PR make their conncetion pipes rotatable again.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] This PR does not require an ingame showcase, but i did it anyway.

*Eye facing south*
![Content Client_JFyLk9m3DL](https://user-images.githubusercontent.com/7117411/220932426-df47439e-ac20-4580-b051-ac0a3723f43c.png)

*Rotated 90 degrees*
![Content Client_94Vg8cRIZU](https://user-images.githubusercontent.com/7117411/220932525-fb2d5b39-7915-4f66-8968-79c5a6ec809f.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Recent progress in atmos machines materials made heaters and freezers connection pipes rotatable again.
