### PR TITLE
Jetpack 2 line balance update

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -183,7 +183,7 @@
     - type: GasTank
       outputPressure: 42.6
       air:
-        volume: 4
+        volume: 20
 
 # Filled mini
 - type: entity
@@ -248,6 +248,7 @@
     sprite: Objects/Tanks/Jetpacks/void.rsi
     slots:
       - Back
+      - suitStorage      
 
 # Filled void
 - type: entity


### PR DESCRIPTION
make mini jetpacks have 5x capacity, this is still 350% less than normal jetpacks

make CEs jetpack able to go in suit storage so its a more attractive steal

reasons for these changes: nobody uses mini jetpacks because its better to just throw them for momentum in space. CEs jetpack generally just sits in his locker all game, this would make it a useful item for people to steal or use, it also has a special sprite and is visually way smaller than all others. 

i will not argue about these balance changes just know that i am correct always trust me bro

skub