### PR TITLE
Medical Wall Locker Hotfix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -18,6 +18,7 @@
 
 - type: entity
   id: LockerWallMedicalFilled
+  name: medicine wall locker
   suffix: Filled
   parent: LockerWallMedical
   components:
@@ -72,6 +73,7 @@
 
 - type: entity
   id: LockerWallMedicalDoctorFilled
+  name: medical doctor's wall locker
   suffix: Filled
   parent: ["LockerWallMedical", "LockerMedicalFilled"]
 

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/wall_lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/wall_lockers.yml
@@ -168,7 +168,7 @@
 - type: entity
   id: LockerWallMedical
   parent: BaseWallLocker
-  name: medical doctor's wall locker
+  name: medical wall locker
   components:
   - type: Appearance
     visuals:


### PR DESCRIPTION
Changelog: 
- Fixes locker names (After the last fix, this was still wrong.)

Before:
![Screenshot 2023-02-23 094430](https://user-images.githubusercontent.com/107660393/220957554-6a73694a-2552-42e1-88a8-1d376dfe584f.jpg)

After:
![Screenshot 2023-02-23 094512](https://user-images.githubusercontent.com/107660393/220957777-c7160dca-2a46-4516-afd0-6a4db3fdf720.jpg)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase