### PR TITLE
Fix sprite of newly-spawned empty power cells

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -71,6 +71,10 @@
   - type: Battery
     maxCharge: 360
     startingCharge: 0
+  - type: Sprite
+    layers:
+      - map: [ "enum.PowerCellVisualLayers.Base" ]
+        state: small
 
 - type: entity
   name: medium-capacity power cell
@@ -98,6 +102,10 @@
   - type: Battery
     maxCharge: 720
     startingCharge: 0
+  - type: Sprite
+    layers:
+      - map: [ "enum.PowerCellVisualLayers.Base" ]
+        state: medium
 
 - type: entity
   name: high-capacity power cell
@@ -125,6 +133,10 @@
   - type: Battery
     maxCharge: 1080
     startingCharge: 0
+  - type: Sprite
+    layers:
+      - map: [ "enum.PowerCellVisualLayers.Base" ]
+        state: high
 
 - type: entity
   name: hyper-capacity power cell
@@ -152,6 +164,10 @@
   - type: Battery
     maxCharge: 1800
     startingCharge: 0
+  - type: Sprite
+    layers:
+      - map: [ "enum.PowerCellVisualLayers.Base" ]
+        state: hyper
 
 - type: entity
   name: small microreactor cell

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -68,13 +68,17 @@
   suffix: Empty
   parent: PowerCellSmall
   components:
-  - type: Battery
-    maxCharge: 360
-    startingCharge: 0
   - type: Sprite
     layers:
       - map: [ "enum.PowerCellVisualLayers.Base" ]
         state: small
+      - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+        state: o2
+        shader: unshaded
+        visible: false
+  - type: Battery
+    maxCharge: 360
+    startingCharge: 0
 
 - type: entity
   name: medium-capacity power cell
@@ -99,13 +103,17 @@
   suffix: Empty
   parent: PowerCellMedium
   components:
-  - type: Battery
-    maxCharge: 720
-    startingCharge: 0
   - type: Sprite
     layers:
       - map: [ "enum.PowerCellVisualLayers.Base" ]
         state: medium
+      - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+        state: o2
+        shader: unshaded
+        visible: false
+  - type: Battery
+    maxCharge: 720
+    startingCharge: 0
 
 - type: entity
   name: high-capacity power cell
@@ -130,13 +138,17 @@
   suffix: Empty
   parent: PowerCellHigh
   components:
-  - type: Battery
-    maxCharge: 1080
-    startingCharge: 0
   - type: Sprite
     layers:
       - map: [ "enum.PowerCellVisualLayers.Base" ]
         state: high
+      - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+        state: o2
+        shader: unshaded
+        visible: false
+  - type: Battery
+    maxCharge: 1080
+    startingCharge: 0
 
 - type: entity
   name: hyper-capacity power cell
@@ -161,13 +173,17 @@
   suffix: Empty
   parent: PowerCellHyper
   components:
-  - type: Battery
-    maxCharge: 1800
-    startingCharge: 0
   - type: Sprite
     layers:
       - map: [ "enum.PowerCellVisualLayers.Base" ]
         state: hyper
+      - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+        state: o2
+        shader: unshaded
+        visible: false
+  - type: Battery
+    maxCharge: 1800
+    startingCharge: 0
 
 - type: entity
   name: small microreactor cell


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixes #14251 

Looks to me like `PowerCellHighPrinted` inherits properties from `PowerCellHigh`, which includes this bit which applies the green light to a fully-charged pack. Overriding that seems to fix the issue.



**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Image of admin item spawn panel before this fix:
![image](https://user-images.githubusercontent.com/1471542/221073909-2b30a050-7e17-4e95-b5ac-9914cf9cf4ab.png)

Image of admin item spawn panel after this fix:
![image](https://user-images.githubusercontent.com/1471542/221073775-f319aec8-ff04-4943-aae8-6dc941fcd18a.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Freshly-printed powercells no longer look like they're fully charged.
