### PR TITLE
Don't play ambience for paused ents

### DIFF
--- a/Content.Client/Audio/AmbientSoundSystem.cs
+++ b/Content.Client/Audio/AmbientSoundSystem.cs
@@ -41,7 +41,7 @@ namespace Content.Client.Audio
         private float _ambienceVolume = 0.0f;
 
         private static AudioParams _params = AudioParams.Default.WithVariation(0.01f).WithLoop(true).WithAttenuation(Attenuation.LinearDistance);
-            
+
         /// <summary>
         /// How many times we can be playing 1 particular sound at once.
         /// </summary>
@@ -221,13 +221,18 @@ namespace Content.Client.Audio
         private void ProcessNearbyAmbience(TransformComponent playerXform)
         {
             var query = GetEntityQuery<TransformComponent>();
+            var metaQuery = GetEntityQuery<MetaDataComponent>();
             var mapPos = playerXform.MapPosition;
 
             // Remove out-of-range ambiences
             foreach (var (comp, sound) in _playingSounds)
             {
                 var entity = comp.Owner;
-                if (comp.Enabled && query.TryGetComponent(entity, out var xform) && xform.MapID == playerXform.MapID)
+
+                if (comp.Enabled &&
+                    query.TryGetComponent(entity, out var xform) &&
+                    xform.MapID == playerXform.MapID &&
+                    !metaQuery.GetComponent(entity).EntityPaused)
                 {
                     var distance = (xform.ParentUid == playerXform.ParentUid)
                         ? xform.LocalPosition - playerXform.LocalPosition
@@ -265,7 +270,10 @@ namespace Content.Client.Audio
 
                 foreach (var (_, comp) in sources)
                 {
-                    if (_playingSounds.ContainsKey(comp))
+                    var uid = comp.Owner;
+
+                    if (_playingSounds.ContainsKey(comp) ||
+                        metaQuery.GetComponent(uid).EntityPaused)
                         continue;
 
                     var audioParams = _params
@@ -274,7 +282,7 @@ namespace Content.Client.Audio
                         .WithPlayOffset(_random.NextFloat(0.0f, 100.0f))
                         .WithMaxDistance(comp.Range);
 
-                    var stream = _audio.PlayPvs(comp.Sound, comp.Owner, audioParams);
+                    var stream = _audio.PlayPvs(comp.Sound, uid, audioParams);
                     if (stream == null)
                         continue;
 


### PR DESCRIPTION
No more emergency light spam.

:cl:
- tweak: Ambient sounds no longer play for paused entities.