### PR TITLE
Make paused poweredlights enabled

### DIFF
--- a/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
@@ -34,8 +34,14 @@ namespace Content.Server.Light.EntitySystems
 
         private void OnEmergencyPower(EntityUid uid, EmergencyLightComponent component, ref PowerChangedEvent args)
         {
-            if (MetaData(uid).EntityLifeStage >= EntityLifeStage.Terminating)
+            var meta = MetaData(uid);
+
+            // TODO: PowerChangedEvent shouldn't be issued for paused ents but this is the world we live in.
+            if (meta.EntityLifeStage >= EntityLifeStage.Terminating ||
+                meta.EntityPaused)
+            {
                 return;
+            }
 
             UpdateState(component);
         }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -333,6 +333,10 @@ namespace Content.Server.Light.EntitySystems
 
         private void OnPowerChanged(EntityUid uid, PoweredLightComponent component, ref PowerChangedEvent args)
         {
+            // TODO: Power moment
+            if (MetaData(uid).EntityPaused)
+                return;
+
             UpdateLight(uid, component);
         }
 

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -107,6 +107,8 @@
   components:
   - type: Sprite
     state: off
+  - type: PointLight
+    enabled: true
   - type: PoweredLight
     hasLampOnSpawn: LightTube
     damage:
@@ -276,6 +278,8 @@
   components:
   - type: Sprite
     state: off
+  - type: PointLight
+    enabled: true
   - type: PoweredLight
     hasLampOnSpawn: LightBulb
     damage:


### PR DESCRIPTION
Even if they have no power in range. I think this is preferable over keeping them in darkness? Power stuff shouldn't be running when the sim is paused so atm they just check for whether they're paused; doesn't seem to cause issues with mapinitTM. Worst case we just revert and wait for power to be fixed. Alternatively you could have a command to toggle it but uhhh not sure.

Needs https://github.com/space-wizards/RobustToolbox/pull/3806 but not a hard requirement.

:cl:
- tweak: Paused lights will no longer be in darkness by default.
