### PR TITLE
Fix strip menu opening on regular click

### DIFF
--- a/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
+++ b/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
@@ -76,7 +76,8 @@ public sealed partial class BuckleSystem
 
     private void HandleInteractHand(EntityUid uid, BuckleComponent component, InteractHandEvent args)
     {
-        args.Handled = TryUnbuckle(uid, args.User, buckle: component);
+        if (TryUnbuckle(uid, args.User, buckle: component))
+            args.Handled = true;
     }
 
     private void MoveEvent(EntityUid uid, BuckleComponent buckle, ref MoveEvent ev)

--- a/Content.Server/Interaction/InteractionPopupSystem.cs
+++ b/Content.Server/Interaction/InteractionPopupSystem.cs
@@ -34,6 +34,8 @@ public sealed class InteractionPopupSystem : EntitySystem
         if (HasComp<SleepingComponent>(uid))
             return;
 
+        args.Handled = true;
+
         var curTime = _gameTiming.CurTime;
 
         if (curTime < component.LastInteractTime + component.InteractDelay)
@@ -85,6 +87,5 @@ public sealed class InteractionPopupSystem : EntitySystem
         }
 
         component.LastInteractTime = curTime;
-        args.Handled = true;
     }
 }


### PR DESCRIPTION
Thanks to ShadowCommander for helping me out on discord, I would say they did all the hard work

This fixes a bug that bugged me (ha) where every time you tried to hug or pet the stripping menu opened along with the interaction

Closes #14072 
Closes #14252

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Vasilis
- fix: Hugging/Petting no longer opens the strip menu.
