### PR TITLE
make bread slice smaller

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -25,6 +25,8 @@
   id: FoodBreadSliceBase
   abstract: true
   components:
+  - type: Item
+    size: 1
   - type: FlavorProfile
     flavors:
       - bread


### PR DESCRIPTION
## About the PR
5 slices (loaf) is 5 slots so naturally 1 slice should be 1 slot

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: You can now fit more bread in your bag.