### PR TITLE
DoAfter Refactor Fixes

### DIFF
--- a/Content.Server/Botany/Systems/BotanySwabSystem.cs
+++ b/Content.Server/Botany/Systems/BotanySwabSystem.cs
@@ -18,7 +18,7 @@ public sealed class BotanySwabSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<BotanySwabComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<BotanySwabComponent, AfterInteractEvent>(OnAfterInteract);
-        SubscribeLocalEvent<DoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<BotanySwabComponent, DoAfterEvent>(OnDoAfter);
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ public sealed class BotanySwabSystem : EntitySystem
     /// </summary>
     private void OnAfterInteract(EntityUid uid, BotanySwabComponent swab, AfterInteractEvent args)
     {
-        if (args.Target == null || !args.CanReach)
+        if (args.Target == null || !args.CanReach || !HasComp<PlantHolderComponent>(args.Target))
             return;
 
         _doAfterSystem.DoAfter(new DoAfterEventArgs(args.User, swab.SwabDelay, target: args.Target, used: uid)
@@ -57,7 +57,7 @@ public sealed class BotanySwabSystem : EntitySystem
     /// <summary>
     /// Save seed data or cross-pollenate.
     /// </summary>
-    private void OnDoAfter(DoAfterEvent args)
+    private void OnDoAfter(EntityUid uid, BotanySwabComponent component, DoAfterEvent args)
     {
         if (args.Cancelled || args.Handled || !TryComp<PlantHolderComponent>(args.Args.Target, out var plant) || !TryComp<BotanySwabComponent>(args.Args.Used, out var swab))
             return;

--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -40,6 +40,12 @@ namespace Content.Server.Medical.Components
         public float Delay = 3f;
 
         /// <summary>
+        /// Cancel token to prevent rapid healing
+        /// </summary>
+        [DataField("cancelToken")]
+        public CancellationTokenSource? CancelToken;
+
+        /// <summary>
         /// Delay multiplier when healing yourself.
         /// </summary>
         [DataField("selfHealPenaltyMultiplier")]

--- a/Content.Server/Nutrition/Components/DrinkComponent.cs
+++ b/Content.Server/Nutrition/Components/DrinkComponent.cs
@@ -35,6 +35,13 @@ namespace Content.Server.Nutrition.Components
         public SoundSpecifier BurstSound = new SoundPathSpecifier("/Audio/Effects/flash_bang.ogg");
 
         /// <summary>
+        /// Is this drink being forced on someone else?
+        /// </summary>
+        /// <returns></returns>
+        [DataField("forceDrink")]
+        public bool ForceDrink;
+
+        /// <summary>
         /// How long it takes to drink this yourself.
         /// </summary>
         [DataField("delay")]

--- a/Content.Server/Nutrition/Components/FoodComponent.cs
+++ b/Content.Server/Nutrition/Components/FoodComponent.cs
@@ -41,6 +41,13 @@ namespace Content.Server.Nutrition.Components
         public string EatMessage = "food-nom";
 
         /// <summary>
+        /// Is this entity being forcefed?
+        /// Prevents the entity from being forced to eat multiple times if not self
+        /// </summary>
+        [DataField("forceFeed")]
+        public bool ForceFeed;
+
+        /// <summary>
         /// How long it takes to eat the food personally.
         /// </summary>
         [DataField("delay")]

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -217,7 +217,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
         private bool TryDrink(EntityUid user, EntityUid target, DrinkComponent drink, EntityUid item)
         {
-            if (!EntityManager.HasComponent<BodyComponent>(target))
+            if (!EntityManager.HasComponent<BodyComponent>(target) || drink.ForceDrink)
                 return false;
 
             if (!drink.Opened)
@@ -241,9 +241,9 @@ namespace Content.Server.Nutrition.EntitySystems
             if (!_interactionSystem.InRangeUnobstructed(user, item, popup: true))
                 return true;
 
-            var forceDrink = user != target;
+            drink.ForceDrink = user != target;
 
-            if (forceDrink)
+            if (drink.ForceDrink)
             {
                 var userName = Identity.Entity(user, EntityManager);
 
@@ -264,7 +264,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
             var drinkData = new DrinkData(drinkSolution, flavors);
 
-            var doAfterEventArgs = new DoAfterEventArgs(user, forceDrink ? drink.ForceFeedDelay : drink.Delay,
+            var doAfterEventArgs = new DoAfterEventArgs(user, drink.ForceDrink ? drink.ForceFeedDelay : drink.Delay,
                 target: target, used: item)
             {
                 BreakOnUserMove = moveBreak,
@@ -286,6 +286,14 @@ namespace Content.Server.Nutrition.EntitySystems
         /// </summary>
         private void OnDoAfter(EntityUid uid, DrinkComponent component, DoAfterEvent<DrinkData> args)
         {
+            //Special cancel if they're force feeding someone.
+            //Allows self to drink multiple times but prevents force feeding drinks to others rapidly.
+            if (args.Cancelled && component.ForceDrink)
+            {
+                component.ForceDrink = false;
+                return;
+            }
+
             if (args.Handled || args.Cancelled || component.Deleted)
                 return;
 
@@ -295,11 +303,11 @@ namespace Content.Server.Nutrition.EntitySystems
             var transferAmount = FixedPoint2.Min(component.TransferAmount, args.AdditionalData.DrinkSolution.Volume);
             var drained = _solutionContainerSystem.Drain(uid, args.AdditionalData.DrinkSolution, transferAmount);
 
-            var forceDrink = args.Args.Target.Value != args.Args.User;
+            //var forceDrink = args.Args.Target.Value != args.Args.User;
 
             if (!_bodySystem.TryGetBodyOrganComponents<StomachComponent>(args.Args.Target.Value, out var stomachs, body))
             {
-                _popupSystem.PopupEntity(forceDrink ? Loc.GetString("drink-component-try-use-drink-cannot-drink-other") : Loc.GetString("drink-component-try-use-drink-had-enough"), args.Args.Target.Value, args.Args.User);
+                _popupSystem.PopupEntity(component.ForceDrink ? Loc.GetString("drink-component-try-use-drink-cannot-drink-other") : Loc.GetString("drink-component-try-use-drink-had-enough"), args.Args.Target.Value, args.Args.User);
 
                 if (HasComp<RefillableSolutionComponent>(args.Args.Target.Value))
                 {
@@ -320,7 +328,7 @@ namespace Content.Server.Nutrition.EntitySystems
             {
                 _popupSystem.PopupEntity(Loc.GetString("drink-component-try-use-drink-had-enough"), args.Args.Target.Value, args.Args.Target.Value);
 
-                if (forceDrink)
+                if (component.ForceDrink)
                 {
                     _popupSystem.PopupEntity(Loc.GetString("drink-component-try-use-drink-had-enough-other"), args.Args.Target.Value, args.Args.User);
                     _spillableSystem.SpillAt(args.Args.Target.Value, drained, "PuddleSmear");
@@ -334,7 +342,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
             var flavors = args.AdditionalData.FlavorMessage;
 
-            if (forceDrink)
+            if (component.ForceDrink)
             {
                 var targetName = Identity.Entity(args.Args.Target.Value, EntityManager);
                 var userName = Identity.Entity(args.Args.User, EntityManager);
@@ -366,6 +374,7 @@ namespace Content.Server.Nutrition.EntitySystems
             //TODO: Grab the stomach UIDs somehow without using Owner
             _stomachSystem.TryTransferSolution(firstStomach.Value.Comp.Owner, drained, firstStomach.Value.Comp);
 
+            component.ForceDrink = false;
             args.Handled = true;
         }
 

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -86,8 +86,8 @@ namespace Content.Server.Nutrition.EntitySystems
             if (food == user || EntityManager.TryGetComponent<MobStateComponent>(food, out var mobState) && _mobStateSystem.IsAlive(food, mobState)) // Suppresses eating alive mobs
                 return false;
 
-            // Target can't be fed
-            if (!EntityManager.HasComponent<BodyComponent>(target))
+            // Target can't be fed or they're already forcefeeding
+            if (!EntityManager.HasComponent<BodyComponent>(target) || foodComp.ForceFeed)
                 return false;
 
             if (!_solutionContainerSystem.TryGetSolution(food, foodComp.SolutionName, out var foodSolution))
@@ -111,9 +111,9 @@ namespace Content.Server.Nutrition.EntitySystems
             if (!_interactionSystem.InRangeUnobstructed(user, food, popup: true))
                 return true;
 
-            var forceFeed = user != target;
+            foodComp.ForceFeed = user != target;
 
-            if (forceFeed)
+            if (foodComp.ForceFeed)
             {
                 var userName = Identity.Entity(user, EntityManager);
                 _popupSystem.PopupEntity(Loc.GetString("food-system-force-feed", ("user", userName)),
@@ -128,16 +128,16 @@ namespace Content.Server.Nutrition.EntitySystems
                 _adminLogger.Add(LogType.Ingestion, LogImpact.Low, $"{ToPrettyString(target):target} is eating {ToPrettyString(food):food} {SolutionContainerSystem.ToPrettyString(foodSolution)}");
             }
 
-            var moveBreak = user != target;
-
             var foodData = new FoodData(foodSolution, flavors, utensils);
 
-            var doAfterEventArgs = new DoAfterEventArgs(user, forceFeed ? foodComp.ForceFeedDelay : foodComp.Delay, target: target, used: food)
+            var doAfterEventArgs = new DoAfterEventArgs(user, foodComp.ForceFeed ? foodComp.ForceFeedDelay : foodComp.Delay, target: target, used: food)
             {
-                BreakOnUserMove = moveBreak,
+                RaiseOnTarget = foodComp.ForceFeed,
+                RaiseOnUser = !foodComp.ForceFeed,
+                BreakOnUserMove = foodComp.ForceFeed,
                 BreakOnDamage = true,
                 BreakOnStun = true,
-                BreakOnTargetMove = moveBreak,
+                BreakOnTargetMove = foodComp.ForceFeed,
                 MovementThreshold = 0.01f,
                 DistanceThreshold = 1.0f,
                 NeedHand = true
@@ -151,6 +151,13 @@ namespace Content.Server.Nutrition.EntitySystems
 
         private void OnDoAfter(EntityUid uid, FoodComponent component, DoAfterEvent<FoodData> args)
         {
+            //Prevents the target from being force fed food but allows the user to chow down
+            if (args.Cancelled && component.ForceFeed)
+            {
+                component.ForceFeed = false;
+                return;
+            }
+
             if (args.Cancelled || args.Handled || component.Deleted || args.Args.Target == null)
                 return;
 
@@ -166,13 +173,11 @@ namespace Content.Server.Nutrition.EntitySystems
             //TODO: Get the stomach UID somehow without nabbing owner
             var firstStomach = stomachs.FirstOrNull(stomach => _stomachSystem.CanTransferSolution(stomach.Comp.Owner, split));
 
-            var forceFeed = args.Args.Target.Value != args.Args.User;
-
             // No stomach so just popup a message that they can't eat.
             if (firstStomach == null)
             {
                 _solutionContainerSystem.TryAddSolution(uid, args.AdditionalData.FoodSolution, split);
-                _popupSystem.PopupEntity(forceFeed ? Loc.GetString("food-system-you-cannot-eat-any-more-other") : Loc.GetString("food-system-you-cannot-eat-any-more"), args.Args.Target.Value, args.Args.User);
+                _popupSystem.PopupEntity(component.ForceFeed ? Loc.GetString("food-system-you-cannot-eat-any-more-other") : Loc.GetString("food-system-you-cannot-eat-any-more"), args.Args.Target.Value, args.Args.User);
                 args.Handled = true;
                 return;
             }
@@ -182,7 +187,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
             var flavors = args.AdditionalData.FlavorMessage;
 
-            if (forceFeed)
+            if (component.ForceFeed)
             {
                 var targetName = Identity.Entity(args.Args.Target.Value, EntityManager);
                 var userName = Identity.Entity(args.Args.User, EntityManager);

--- a/Content.Server/Tools/Components/TilePryingComponent.cs
+++ b/Content.Server/Tools/Components/TilePryingComponent.cs
@@ -15,5 +15,8 @@ namespace Content.Server.Tools.Components
 
         [DataField("delay")]
         public float Delay = 1f;
+
+        [DataField("cancelToken")]
+        public CancellationTokenSource? CancelToken;
     }
 }

--- a/Content.Shared/Chemistry/Components/SharedInjectorComponent.cs
+++ b/Content.Shared/Chemistry/Components/SharedInjectorComponent.cs
@@ -11,6 +11,12 @@ namespace Content.Shared.Chemistry.Components
     public abstract class SharedInjectorComponent : Component
     {
         /// <summary>
+        /// Checks to see if the entity being injected
+        /// </summary>
+        [DataField("isInjecting")]
+        public bool IsInjecting;
+
+        /// <summary>
         /// Component data used for net updates. Used by client for item status ui
         /// </summary>
         [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

closes #14273

What this fixes:

BotanySwab/Disease Swab - Does not double dip uses (was activating twice because of the swab having a doafter for plants and one for humans). Grabs the disease data now correctly too.
Healing - Prevents multi-use, actually heals the target now.
Drinks - Prevents multi use on force feeding targets
Food - Prevents multi use on force feeding targets
Tile Prying - Prevents multi use on multiple tiles
Door Prying - Fixes an issue where doors wouldn't be able to be pried again if cancelled.
Syringes - Prevents multi use on injecting self/targets.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: BotanySwab/Disease Swab - Does not double dip uses (was activating twice because of the swab having a doafter for plants and one for humans). Grabs the disease data now correctly too.
- fix: Healing - Prevents multi-use, actually heals the target now.
- fix: Drinks - Prevents multi use on force feeding targets
- fix: Food - Prevents multi use on force feeding targets
- fix: Tile Prying - Prevents multi use on multiple tiles
- fix: Door Prying - Fixes an issue where doors wouldn't be able to be pried again if cancelled.
- fix: Syringes - Prevents multi use on injecting self/targets.