### PR TITLE
Fix rsi sprite access for verbs

### DIFF
--- a/Content.Client/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Client/Administration/Systems/AdminVerbSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Verbs;
 using Robust.Client.Console;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Administration.Systems
 {
@@ -26,7 +27,7 @@ namespace Content.Client.Administration.Systems
                 Verb verb = new();
                 verb.Category = VerbCategory.Debug;
                 verb.Text = "View Variables";
-                verb.IconTexture = "/Textures/Interface/VerbIcons/vv.svg.192dpi.png";
+                verb.Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/vv.svg.192dpi.png"));
                 verb.Act = () => _clientConsoleHost.ExecuteCommand($"vv {args.Target}");
                 verb.ClientExclusive = true; // opening VV window is client-side. Don't ask server to run this verb.
                 args.Verbs.Add(verb);

--- a/Content.Client/Examine/ExamineButton.cs
+++ b/Content.Client/Examine/ExamineButton.cs
@@ -49,11 +49,9 @@ public sealed class ExamineButton : ContainerButton
             SetHeight = ElementHeight
         };
 
-        if (verb.IconTexture != null)
+        if (verb.Icon != null)
         {
-            var icon = new SpriteSpecifier.Texture(new ResourcePath(verb.IconTexture));
-
-            Icon.Texture = icon.Frame0();
+            Icon.Texture = verb.Icon.Frame0();
             Icon.Stretch = TextureRect.StretchMode.KeepAspectCentered;
 
             AddChild(Icon);

--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -49,7 +49,7 @@ namespace Content.Client.Examine
             CommandBinds.Builder
                 .Bind(ContentKeyFunctions.ExamineEntity, new PointerInputCmdHandler(HandleExamine, outsidePrediction: true))
                 .Register<ExamineSystem>();
-            
+
             _idCounter = 0;
         }
 
@@ -117,7 +117,7 @@ namespace Content.Client.Examine
             // Center it on the entity if they use the verb instead.
             verb.Act = () => DoExamine(args.Target, false);
             verb.Text = Loc.GetString("examine-verb-name");
-            verb.IconTexture = "/Textures/Interface/VerbIcons/examine.svg.192dpi.png";
+            verb.Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/examine.svg.192dpi.png"));
             verb.ShowOnExamineTooltip = false;
             verb.ClientExclusive = true;
             args.Verbs.Add(verb);
@@ -132,7 +132,7 @@ namespace Content.Client.Examine
             // Prevent updating a new tooltip.
             if (ev.Id != 0 && ev.Id != _idCounter)
                 return;
-            
+
             // Tooltips coming in from the server generally prioritize
             // opening at the old tooltip rather than the cursor/another entity,
             // since there's probably one open already if it's coming in from the server.
@@ -286,7 +286,7 @@ namespace Content.Client.Examine
                 if (verb is not ExamineVerb examine)
                     continue;
 
-                if (examine.IconTexture == null)
+                if (examine.Icon == null)
                     continue;
 
                 if (!examine.ShowOnExamineTooltip)

--- a/Content.Client/Guidebook/GuidebookSystem.cs
+++ b/Content.Client/Guidebook/GuidebookSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Guidebook;
 
@@ -56,7 +57,7 @@ public sealed class GuidebookSystem : EntitySystem
         args.Verbs.Add(new()
         {
             Text = Loc.GetString("guide-help-verb"),
-            IconTexture = "/Textures/Interface/VerbIcons/information.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/information.svg.192dpi.png")),
             Act = () => OpenGuidebook(component.Guides, includeChildren: component.IncludeChildren, selected: component.Guides[0]),
             ClientExclusive = true,
             CloseMenu = true

--- a/Content.Client/Pointing/PointingSystem.cs
+++ b/Content.Client/Pointing/PointingSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Pointing;
 using Content.Shared.Verbs;
 using Robust.Client.GameObjects;
+using Robust.Shared.Utility;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
 
 namespace Content.Client.Pointing;
@@ -54,7 +55,7 @@ public sealed class PointingSystem : SharedPointingSystem
         Verb verb = new()
         {
             Text = Loc.GetString("pointing-verb-get-data-text"),
-            IconTexture = "/Textures/Interface/VerbIcons/point.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/point.svg.192dpi.png")),
             ClientExclusive = true,
             Act = () => RaiseNetworkEvent(new PointingAttemptEvent(args.Target))
         };

--- a/Content.Server/Access/Systems/IdExaminableSystem.cs
+++ b/Content.Server/Access/Systems/IdExaminableSystem.cs
@@ -36,7 +36,7 @@ public sealed class IdExaminableSystem : EntitySystem
             Category = VerbCategory.Examine,
             Disabled = !detailsRange,
             Message = Loc.GetString("id-examinable-component-verb-disabled"),
-            IconTexture = "/Textures/Interface/VerbIcons/information.svg.192dpi.png"
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/information.svg.192dpi.png"))
         };
 
         args.Verbs.Add(verb);

--- a/Content.Server/Administration/Notes/AdminNotesSystem.cs
+++ b/Content.Server/Administration/Notes/AdminNotesSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Database;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Console;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Administration.Notes;
 
@@ -33,7 +34,7 @@ public sealed class AdminNotesSystem : EntitySystem
         {
             Text = Loc.GetString("admin-notes-verb-text"),
             Category = VerbCategory.Admin,
-            IconTexture = "/Textures/Interface/VerbIcons/examine.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/examine.svg.192dpi.png")),
             Act = () => _console.RemoteExecuteCommand(user, $"{OpenAdminNotesCommand.CommandName} \"{target.UserId}\""),
             Impact = LogImpact.Low
         };

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -6,6 +6,7 @@ using Content.Shared.Database;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Administration.Systems;
 
@@ -35,7 +36,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Make Traitor",
             Category = VerbCategory.Antag,
-            IconTexture = "/Textures/Structures/Wallmounts/posters.rsi/poster5_contraband.png",
+            Icon = new SpriteSpecifier.Rsi((new ResourcePath("/Textures/Structures/Wallmounts/posters.rsi")), "poster5_contraband"),
             Act = () =>
             {
                 if (targetMindComp.Mind == null || targetMindComp.Mind.Session == null)
@@ -52,7 +53,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Make Zombie",
             Category = VerbCategory.Antag,
-            IconTexture = "/Textures/Structures/Wallmounts/signs.rsi/bio.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Structures/Wallmounts/signs.rsi"), "bio"),
             Act = () =>
             {
                 TryComp(args.Target, out MindComponent? mindComp);
@@ -71,7 +72,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Make nuclear operative",
             Category = VerbCategory.Antag,
-            IconTexture = "/Textures/Structures/Wallmounts/signs.rsi/radiation.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Structures/Wallmounts/signs.rsi"), "radiation"),
             Act = () =>
             {
                 if (targetMindComp.Mind == null || targetMindComp.Mind.Session == null)
@@ -88,7 +89,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Make Pirate",
             Category = VerbCategory.Antag,
-            IconTexture = "/Textures/Clothing/Head/Hats/pirate.rsi/icon.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Clothing/Head/Hats/pirate.rsi"), "icon"),
             Act = () =>
             {
                 if (targetMindComp.Mind == null || targetMindComp.Mind.Session == null)

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -50,6 +50,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.Administration.Systems;
@@ -71,7 +72,6 @@ public sealed partial class AdminVerbSystem
     [Dependency] private readonly InventorySystem _inventorySystem = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifierSystem = default!;
     [Dependency] private readonly PolymorphableSystem _polymorphableSystem = default!;
-    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly MobThresholdSystem _mobThresholdSystem = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
@@ -98,7 +98,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Explode",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")),
             Act = () =>
             {
                 var coords = Transform(args.Target).MapPosition;
@@ -118,7 +118,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Chess Dimension",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Objects/Fun/Tabletop/chessboard.rsi/chessboard.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Fun/Tabletop/chessboard.rsi"), "chessboard"),
             Act = () =>
             {
                 _godmodeSystem.EnableGodmode(args.Target); // So they don't suffocate.
@@ -146,7 +146,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Set Alight",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Interface/Alerts/Fire/fire.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/Alerts/Fire/fire.png")),
                 Act = () =>
                 {
                     // Fuck you. Burn Forever.
@@ -168,7 +168,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Monkeyify",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Mobs/Animals/monkey.rsi/dead.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Mobs/Animals/monkey.rsi"), "dead"),
             Act = () =>
             {
                 _polymorphableSystem.PolymorphEntity(args.Target, "AdminMonkeySmite");
@@ -182,7 +182,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Garbage Can",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Structures/Piping/disposal.rsi/disposal.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Structures/Piping/disposal.rsi"), "disposal"),
             Act = () =>
             {
                 _polymorphableSystem.PolymorphEntity(args.Target, "AdminDisposalsSmite");
@@ -198,7 +198,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Lung Cancer",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Mobs/Species/Human/organs.rsi/lung-l.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Mobs/Species/Human/organs.rsi"), "lung-l"),
                 Act = () =>
                 {
                     _diseaseSystem.TryInfect(carrier, _prototypeManager.Index<DiseasePrototype>("StageIIIALungCancer"),
@@ -211,13 +211,13 @@ public sealed partial class AdminVerbSystem
         }
 
         if (TryComp<DamageableComponent>(args.Target, out var damageable) &&
-            TryComp<MobStateComponent>(args.Target, out var mobState))
+            HasComp<MobStateComponent>(args.Target))
         {
             Verb hardElectrocute = new()
             {
                 Text = "Electrocute",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Clothing/Hands/Gloves/Color/yellow.rsi/icon.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Clothing/Hands/Gloves/Color/yellow.rsi"), "icon"),
                 Act = () =>
                 {
                     int damageToDeal;
@@ -262,7 +262,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Creampie",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Objects/Consumable/Food/Baked/pie.rsi/plain-slice.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Consumable/Food/Baked/pie.rsi"), "plain-slice"),
                 Act = () =>
                 {
                     _creamPieSystem.SetCreamPied(args.Target, creamPied, true);
@@ -279,7 +279,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Remove blood",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Fluids/tomato_splat.rsi/puddle-1.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Fluids/tomato_splat.rsi"), "puddle-1"),
                 Act = () =>
                 {
                     _bloodstreamSystem.SpillAllSolutions(args.Target, bloodstream);
@@ -302,7 +302,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Vomit organs",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Fluids/vomit_toxin.rsi/vomit_toxin-1.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Fluids/vomit_toxin.rsi"), "vomit_toxin-1"),
                 Act = () =>
                 {
                     _vomitSystem.Vomit(args.Target, -1000, -1000); // You feel hollow!
@@ -331,7 +331,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Remove hands",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Interface/AdminActions/remove-hands.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/remove-hands.png")),
                 Act = () =>
                 {
                     var baseXform = Transform(args.Target);
@@ -353,7 +353,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Remove hands",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Interface/AdminActions/remove-hand.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/remove-hand.png")),
                 Act = () =>
                 {
                     var baseXform = Transform(args.Target);
@@ -376,7 +376,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Stomach Removal",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Mobs/Species/Human/organs.rsi/stomach.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Mobs/Species/Human/organs.rsi"), "stomach"),
                 Act = () =>
                 {
                     foreach (var (component, _) in _bodySystem.GetBodyOrganComponents<StomachComponent>(args.Target, body))
@@ -396,7 +396,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Lungs Removal",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Mobs/Species/Human/organs.rsi/lung-r.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Mobs/Species/Human/organs.rsi"), "lung-r"),
                 Act = () =>
                 {
                     foreach (var (component, _) in _bodySystem.GetBodyOrganComponents<LungComponent>(args.Target, body))
@@ -419,7 +419,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Pinball",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Objects/Fun/toys.rsi/basketball.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Fun/toys.rsi"), "basketball"),
                 Act = () =>
                 {
                     var xform = Transform(args.Target);
@@ -453,7 +453,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Yeet",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Interface/VerbIcons/eject.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/eject.svg.192dpi.png")),
                 Act = () =>
                 {
                     var xform = Transform(args.Target);
@@ -484,7 +484,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Become Bread",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Objects/Consumable/Food/Baked/bread.rsi/plain.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Consumable/Food/Baked/bread.rsi"), "plain"),
             Act = () =>
             {
                 _polymorphableSystem.PolymorphEntity(args.Target, "AdminBreadSmite");
@@ -498,7 +498,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Become Mouse",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Mobs/Animals/mouse.rsi/icon-0.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Mobs/Animals/mouse.rsi"), "icon-0"),
             Act = () =>
             {
                 _polymorphableSystem.PolymorphEntity(args.Target, "AdminMouseSmite");
@@ -514,7 +514,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Ghostkick",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Interface/gavel.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/gavel.svg.192dpi.png")),
                 Act = () =>
                 {
                     _ghostKickManager.DoDisconnect(actorComponent.PlayerSession.ConnectedClient, "Smitten.");
@@ -530,7 +530,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Nyanify",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Clothing/Head/Hats/catears.rsi/icon.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Clothing/Head/Hats/catears.rsi"), "icon"),
                 Act = () =>
                 {
                     var ears = Spawn("ClothingHeadHatCatEars", Transform(args.Target).Coordinates);
@@ -547,7 +547,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Kill sign",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Objects/Misc/killsign.rsi/icon.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Misc/killsign.rsi"), "icon"),
                 Act = () =>
                 {
                     EnsureComp<KillSignComponent>(args.Target);
@@ -562,7 +562,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Clown",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Objects/Fun/bikehorn.rsi/icon.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Fun/bikehorn.rsi"), "icon"),
                 Act = () =>
                 {
                     SetOutfitCommand.SetOutfit(args.Target, "ClownGear", EntityManager, (_, clothing) =>
@@ -581,7 +581,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Maid",
                 Category = VerbCategory.Smite,
-                IconTexture = "/Textures/Clothing/Uniforms/Jumpskirt/janimaid.rsi/icon.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Clothing/Uniforms/Jumpskirt/janimaid.rsi"), "icon"),
                 Act = () =>
                 {
                     SetOutfitCommand.SetOutfit(args.Target, "JanitorMaidGear", EntityManager, (_, clothing) =>
@@ -595,15 +595,13 @@ public sealed partial class AdminVerbSystem
                 Message = Loc.GetString("admin-smite-maid-description")
             };
             args.Verbs.Add(maiden);
-
-
         }
 
         Verb angerPointingArrows = new()
         {
             Text = "Anger Pointing Arrows",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/Misc/pointing.rsi/pointing.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Interface/Misc/pointing.rsi"), "pointing"),
             Act = () =>
             {
                 EnsureComp<PointingArrowAngeringComponent>(args.Target);
@@ -617,7 +615,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Dust",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Objects/Materials/materials.rsi/ash.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Materials/materials"), "ash"),
             Act = () =>
             {
                 EntityManager.QueueDeleteEntity(args.Target);
@@ -633,7 +631,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Buffering",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/Misc/buffering_smite_icon.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/Misc/buffering_smite_icon.png")),
             Act = () =>
             {
                 EnsureComp<BufferingComponent>(args.Target);
@@ -647,7 +645,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Become Instrument",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Objects/Fun/Instruments/h_synthesizer.rsi/icon.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Fun/Instruments/h_synthesizer.rsi"), "icon"),
             Act = () =>
             {
                 _polymorphableSystem.PolymorphEntity(args.Target, "AdminInstrumentSmite");
@@ -661,7 +659,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Remove gravity",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Structures/Machines/gravity_generator.rsi/off.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Structures/Machines/gravity_generator.rsi"), "off"),
             Act = () =>
             {
                 var grav = EnsureComp<MovementIgnoreGravityComponent>(args.Target);
@@ -678,7 +676,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Reptilian Species Swap",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Objects/Fun/toys.rsi/plushie_lizard.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Fun/toys.rsi"), "plushie_lizard"),
             Act = () =>
             {
                 _polymorphableSystem.PolymorphEntity(args.Target, "AdminLizardSmite");
@@ -692,7 +690,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Locker stuff",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Structures/Storage/closet.rsi/generic.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Structures/Storage/closet.rsi"), "generic"),
             Act = () =>
             {
                 var xform = Transform(args.Target);
@@ -714,7 +712,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Headstand",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/VerbIcons/refresh.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/refresh.svg.192dpi.png")),
             Act = () =>
             {
                 EnsureComp<HeadstandComponent>(args.Target);
@@ -728,7 +726,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Zoom in",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/AdminActions/zoom.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/zoom.png")),
             Act = () =>
             {
                 var eye = EnsureComp<EyeComponent>(args.Target);
@@ -746,7 +744,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Flip eye",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/AdminActions/flip.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/flip.png")),
             Act = () =>
             {
                 var eye = EnsureComp<EyeComponent>(args.Target);
@@ -764,7 +762,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Run Walk Swap",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/AdminActions/run-walk-swap.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/run-walk-swap.png")),
             Act = () =>
             {
                 var movementSpeed = EnsureComp<MovementSpeedModifierComponent>(args.Target);
@@ -784,7 +782,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Speak Backwards",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/AdminActions/help-backwards.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/help-backwards.png")),
             Act = () =>
             {
                 EnsureComp<BackwardsAccentComponent>(args.Target);
@@ -798,7 +796,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Disarm Prone",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/Actions/disarm.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/Actions/disarm.png")),
             Act = () =>
             {
                 EnsureComp<DisarmProneComponent>(args.Target);
@@ -812,7 +810,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Super speed",
             Category = VerbCategory.Smite,
-            IconTexture = "/Textures/Interface/AdminActions/super_speed.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/super_speed.png")),
             Act = () =>
             {
                 var movementSpeed = EnsureComp<MovementSpeedModifierComponent>(args.Target);

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -36,6 +36,7 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Administration.Systems;
 
@@ -68,9 +69,9 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = airlock.BoltsDown ? "Unbolt" : "Bolt",
                     Category = VerbCategory.Tricks,
-                    IconTexture = airlock.BoltsDown
-                        ? "/Textures/Interface/AdminActions/unbolt.png"
-                        : "/Textures/Interface/AdminActions/bolt.png",
+                    Icon = airlock.BoltsDown
+                        ? new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/unbolt.png"))
+                        : new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/bolt.png")),
                     Act = () =>
                     {
                         _airlockSystem.SetBoltsWithAudio(args.Target, airlock, !airlock.BoltsDown);
@@ -88,7 +89,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = airlock.EmergencyAccess ? "Emergency Access Off" : "Emergency Access On",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Interface/AdminActions/emergency_access.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/emergency_access.png")),
                     Act = () =>
                     {
                         _airlockSystem.ToggleEmergencyAccess(args.Target, airlock);
@@ -110,7 +111,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Rejuvenate",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Interface/AdminActions/rejuvenate.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/rejuvenate.png")),
                     Act = () =>
                     {
                         RejuvenateCommand.PerformRejuvenate(args.Target);
@@ -128,7 +129,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Make Indestructible",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Interface/VerbIcons/plus.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")),
                     Act = () =>
                     {
                         _godmodeSystem.EnableGodmode(args.Target);
@@ -145,7 +146,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Make Vulnerable",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Interface/VerbIcons/plus.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")),
                     Act = () =>
                     {
                         _godmodeSystem.DisableGodmode(args.Target);
@@ -163,7 +164,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Refill Battery",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Interface/AdminActions/fill_battery.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/fill_battery.png")),
                     Act = () =>
                     {
                         battery.CurrentCharge = battery.MaxCharge;
@@ -179,7 +180,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Drain Battery",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Interface/AdminActions/drain_battery.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/drain_battery.png")),
                     Act = () =>
                     {
                         battery.CurrentCharge = 0;
@@ -195,7 +196,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Infinite Battery",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Interface/AdminActions/infinite_battery.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/infinite_battery.png")),
                     Act = () =>
                     {
                         var recharger = EnsureComp<BatterySelfRechargerComponent>(args.Target);
@@ -215,7 +216,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Block Unanchoring",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Interface/VerbIcons/anchor.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/anchor.svg.192dpi.png")),
                     Act = () =>
                     {
                         RemComp(args.Target, anchor);
@@ -233,7 +234,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Refill Internals Oxygen",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Tanks/oxygen.rsi/icon.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Tanks/oxygen.rsi"), "icon"),
                     Act = () =>
                     {
                         RefillGasTank(args.Target, Gas.Oxygen, tank);
@@ -248,7 +249,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Refill Internals Nitrogen",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Tanks/red.rsi/icon.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Tanks/red.rsi"), "icon"),
                     Act = () =>
                     {
                         RefillGasTank(args.Target, Gas.Nitrogen, tank);
@@ -263,7 +264,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Refill Internals Plasma",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Tanks/plasma.rsi/icon.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Tanks/plasma.rsi"), "icon"),
                     Act = () =>
                     {
                         RefillGasTank(args.Target, Gas.Plasma, tank);
@@ -275,13 +276,13 @@ public sealed partial class AdminVerbSystem
                 args.Verbs.Add(refillInternalsPlasma);
             }
 
-            if (TryComp<InventoryComponent>(args.Target, out var inventory))
+            if (HasComp<InventoryComponent>(args.Target))
             {
                 Verb refillInternalsO2 = new()
                 {
                     Text = "Refill Internals Oxygen",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Tanks/oxygen.rsi/icon.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Tanks/oxygen.rsi"), "icon"),
                     Act = () =>
                     {
                         foreach (var slot in _inventorySystem.GetSlots(args.Target))
@@ -289,7 +290,7 @@ public sealed partial class AdminVerbSystem
                             if (!_inventorySystem.TryGetSlotEntity(args.Target, slot.Name, out var entity))
                                 continue;
 
-                            if (!TryComp<GasTankComponent>(entity, out var tank))
+                            if (!TryComp(entity, out tank))
                                 continue;
 
                             RefillGasTank(entity.Value, Gas.Oxygen, tank);
@@ -297,7 +298,7 @@ public sealed partial class AdminVerbSystem
 
                         foreach (var held in _handsSystem.EnumerateHeld(args.Target))
                         {
-                            if (!TryComp<GasTankComponent>(held, out var tank))
+                            if (!TryComp(held, out tank))
                                 continue;
 
                             RefillGasTank(held, Gas.Oxygen, tank);
@@ -313,7 +314,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Refill Internals Nitrogen",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Tanks/red.rsi/icon.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Tanks/red.rsi"), "icon"),
                     Act = () =>
                     {
                         foreach (var slot in _inventorySystem.GetSlots(args.Target))
@@ -321,7 +322,7 @@ public sealed partial class AdminVerbSystem
                             if (!_inventorySystem.TryGetSlotEntity(args.Target, slot.Name, out var entity))
                                 continue;
 
-                            if (!TryComp<GasTankComponent>(entity, out var tank))
+                            if (!TryComp(entity, out tank))
                                 continue;
 
                             RefillGasTank(entity.Value, Gas.Nitrogen, tank);
@@ -329,7 +330,7 @@ public sealed partial class AdminVerbSystem
 
                         foreach (var held in _handsSystem.EnumerateHeld(args.Target))
                         {
-                            if (!TryComp<GasTankComponent>(held, out var tank))
+                            if (!TryComp(held, out tank))
                                 continue;
 
                             RefillGasTank(held, Gas.Nitrogen, tank);
@@ -345,7 +346,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Refill Internals Plasma",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Tanks/plasma.rsi/icon.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Tanks/plasma.rsi"), "icon"),
                     Act = () =>
                     {
                         foreach (var slot in _inventorySystem.GetSlots(args.Target))
@@ -353,7 +354,7 @@ public sealed partial class AdminVerbSystem
                             if (!_inventorySystem.TryGetSlotEntity(args.Target, slot.Name, out var entity))
                                 continue;
 
-                            if (!TryComp<GasTankComponent>(entity, out var tank))
+                            if (!TryComp(entity, out tank))
                                 continue;
 
                             RefillGasTank(entity.Value, Gas.Plasma, tank);
@@ -361,7 +362,7 @@ public sealed partial class AdminVerbSystem
 
                         foreach (var held in _handsSystem.EnumerateHeld(args.Target))
                         {
-                            if (!TryComp<GasTankComponent>(held, out var tank))
+                            if (!TryComp(held, out tank))
                                 continue;
 
                             RefillGasTank(held, Gas.Plasma, tank);
@@ -378,7 +379,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Send to test arena",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Interface/VerbIcons/eject.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/eject.svg.192dpi.png")),
 
                 Act = () =>
                 {
@@ -399,7 +400,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Grant All Access",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Misc/id_cards.rsi/centcom.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Misc/id_cards.rsi"), "centcom"),
                     Act = () =>
                     {
                         GiveAllAccess(activeId.Value);
@@ -414,7 +415,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Revoke All Access",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Misc/id_cards.rsi/default.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Misc/id_cards.rsi"), "default"),
                     Act = () =>
                     {
                         RevokeAllAccess(activeId.Value);
@@ -432,7 +433,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Grant All Access",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Misc/id_cards.rsi/centcom.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Misc/id_cards.rsi"), "centcom"),
                     Act = () =>
                     {
                         GiveAllAccess(args.Target);
@@ -447,7 +448,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Revoke All Access",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Objects/Misc/id_cards.rsi/default.png",
+                    Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Misc/id_cards.rsi"), "default"),
                     Act = () =>
                     {
                         RevokeAllAccess(args.Target);
@@ -466,7 +467,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Adjust Stack",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Interface/AdminActions/adjust-stack.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/adjust-stack.png")),
                 Act = () =>
                 {
                     // Unbounded intentionally.
@@ -485,7 +486,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Fill Stack",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Interface/AdminActions/fill-stack.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/fill-stack.png")),
                 Act = () =>
                 {
                     _stackSystem.SetCount(args.Target, _stackSystem.GetMaxCount(stack), stack);
@@ -501,7 +502,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Rename",
             Category = VerbCategory.Tricks,
-            IconTexture = "/Textures/Interface/AdminActions/rename.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/rename.png")),
             Act = () =>
             {
                 _quickDialog.OpenDialog(player, "Rename", "Name", (string newName) =>
@@ -519,7 +520,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Redescribe",
             Category = VerbCategory.Tricks,
-            IconTexture = "/Textures/Interface/AdminActions/redescribe.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/redescribe.png")),
             Act = () =>
             {
                 _quickDialog.OpenDialog(player, "Redescribe", "Description", (LongString newDescription) =>
@@ -537,7 +538,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "Redescribe",
             Category = VerbCategory.Tricks,
-            IconTexture = "/Textures/Interface/AdminActions/rename_and_redescribe.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/rename_and_redescribe.png")),
             Act = () =>
             {
                 _quickDialog.OpenDialog(player, "Rename & Redescribe", "Name", "Description",
@@ -562,7 +563,7 @@ public sealed partial class AdminVerbSystem
                 {
                     Text = "Bar job slots",
                     Category = VerbCategory.Tricks,
-                    IconTexture = "/Textures/Interface/AdminActions/bar_jobslots.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/bar_jobslots.png")),
                     Act = () =>
                     {
                         foreach (var (job, _) in _stationJobsSystem.GetJobs(args.Target))
@@ -581,7 +582,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Locate Cargo Shuttle",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Clothing/Head/Soft/cargosoft.rsi/icon.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Clothing/Head/Soft/cargosoft.rsi"), "icon"),
                 Act = () =>
                 {
                     var shuttle = Comp<StationCargoOrderDatabaseComponent>(args.Target).Shuttle;
@@ -604,7 +605,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Refill Battery",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Interface/AdminActions/fill_battery.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/fill_battery.png")),
                 Act = () =>
                 {
                     foreach (var ent in childEnum)
@@ -626,7 +627,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Drain Battery",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Interface/AdminActions/drain_battery.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/drain_battery.png")),
                 Act = () =>
                 {
                     foreach (var ent in childEnum)
@@ -648,7 +649,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Infinite Battery",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Interface/AdminActions/infinite_battery.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/infinite_battery.png")),
                 Act = () =>
                 {
                     // this kills the sloth
@@ -677,7 +678,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Halt Movement",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Interface/AdminActions/halt.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/halt.png")),
                 Act = () =>
                 {
                     _physics.SetLinearVelocity(args.Target, Vector2.Zero, body: physics);
@@ -700,7 +701,7 @@ public sealed partial class AdminVerbSystem
                     {
                         Text = "Unpause Map",
                         Category = VerbCategory.Tricks,
-                        IconTexture = "/Textures/Interface/AdminActions/play.png",
+                        Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/play.png")),
                         Act = () =>
                         {
                             _mapManager.SetMapPaused(map.WorldMap, false);
@@ -717,7 +718,7 @@ public sealed partial class AdminVerbSystem
                     {
                         Text = "Pause Map",
                         Category = VerbCategory.Tricks,
-                        IconTexture = "/Textures/Interface/AdminActions/pause.png",
+                        Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/pause.png")),
                         Act = () =>
                         {
                             _mapManager.SetMapPaused(map.WorldMap, true);
@@ -737,7 +738,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Snap Joints",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Interface/AdminActions/snap_joints.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/AdminActions/snap_joints.png")),
                 Act = () =>
                 {
                     _jointSystem.ClearJoints(joints);
@@ -755,7 +756,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Make Minigun",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Objects/Weapons/Guns/HMGs/minigun.rsi/icon.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Weapons/Guns/HMGs/minigun.rsi"), "icon"),
                 Act = () =>
                 {
                     gun.FireRate = 15;
@@ -773,7 +774,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Set Bullet Amount",
                 Category = VerbCategory.Tricks,
-                IconTexture = "/Textures/Objects/Fun/caps.rsi/mag-6.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Objects/Fun/caps.rsi"), "mag-6"),
                 Act = () =>
                 {
                     _quickDialog.OpenDialog(player, "Set Bullet Amount", $"Amount (max {ballisticAmmo.Capacity}):", (int amount) =>

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -29,6 +29,7 @@ using Robust.Shared.Console;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 using static Content.Shared.Configurable.ConfigurationComponent;
 
 namespace Content.Server.Administration.Systems
@@ -79,7 +80,7 @@ namespace Content.Server.Administration.Systems
                     Verb verb = new();
                     verb.Text = Loc.GetString("ahelp-verb-get-data-text");
                     verb.Category = VerbCategory.Admin;
-                    verb.IconTexture = "/Textures/Interface/gavel.svg.192dpi.png";
+                    verb.Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/gavel.svg.192dpi.png"));
                     verb.Act = () =>
                         _console.RemoteExecuteCommand(player, $"openahelp \"{targetActor.PlayerSession.UserId}\"");
                     verb.Impact = LogImpact.Low;
@@ -89,7 +90,7 @@ namespace Content.Server.Administration.Systems
                     Verb prayerVerb = new();
                     prayerVerb.Text = Loc.GetString("prayer-verbs-subtle-message");
                     prayerVerb.Category = VerbCategory.Admin;
-                    prayerVerb.IconTexture = "/Textures/Interface/pray.svg.png";
+                    prayerVerb.Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/pray.svg.png"));
                     prayerVerb.Act = () =>
                     {
                         _quickDialog.OpenDialog(player, "Subtle Message", "Message", "Popup Message", (string message, string popupMessage) =>
@@ -109,7 +110,7 @@ namespace Content.Server.Administration.Systems
                             ? Loc.GetString("admin-verbs-unfreeze")
                             : Loc.GetString("admin-verbs-freeze"),
                         Category = VerbCategory.Admin,
-                        IconTexture = "/Textures/Interface/VerbIcons/snow.svg.192dpi.png",
+                        Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
                         Act = () =>
                         {
                             if (frozen)
@@ -145,7 +146,7 @@ namespace Content.Server.Administration.Systems
                 {
                     Text = Loc.GetString("admin-verbs-teleport-to"),
                     Category = VerbCategory.Admin,
-                    IconTexture = "/Textures/Interface/VerbIcons/open.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/open.svg.192dpi.png")),
                     Act = () => _console.ExecuteCommand(player, $"tpto {args.Target}"),
                     Impact = LogImpact.Low
                 });
@@ -155,7 +156,7 @@ namespace Content.Server.Administration.Systems
                 {
                     Text = Loc.GetString("admin-verbs-teleport-here"),
                     Category = VerbCategory.Admin,
-                    IconTexture = "/Textures/Interface/VerbIcons/close.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/close.svg.192dpi.png")),
                     Act = () => _console.ExecuteCommand(player, $"tpto {args.Target} {args.User}"),
                     Impact = LogImpact.Low
                 });
@@ -194,7 +195,7 @@ namespace Content.Server.Administration.Systems
                 {
                     Text = Loc.GetString("delete-verb-get-data-text"),
                     Category = VerbCategory.Debug,
-                    IconTexture = "/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png")),
                     Act = () => EntityManager.DeleteEntity(args.Target),
                     Impact = LogImpact.Medium,
                     ConfirmationPopup = true
@@ -209,7 +210,7 @@ namespace Content.Server.Administration.Systems
                 {
                     Text = Loc.GetString("rejuvenate-verb-get-data-text"),
                     Category = VerbCategory.Debug,
-                    IconTexture = "/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png")),
                     Act = () => RejuvenateCommand.PerformRejuvenate(args.Target),
                     Impact = LogImpact.Medium
                 };
@@ -268,7 +269,7 @@ namespace Content.Server.Administration.Systems
                 {
                     Text = Loc.GetString("make-sentient-verb-get-data-text"),
                     Category = VerbCategory.Debug,
-                    IconTexture = "/Textures/Interface/VerbIcons/sentient.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/sentient.svg.192dpi.png")),
                     Act = () => MakeSentientCommand.MakeSentient(args.Target, EntityManager),
                     Impact = LogImpact.Medium
                 };
@@ -283,7 +284,7 @@ namespace Content.Server.Administration.Systems
                 {
                     Text = Loc.GetString("set-outfit-verb-get-data-text"),
                     Category = VerbCategory.Debug,
-                    IconTexture = "/Textures/Interface/VerbIcons/outfit.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/outfit.svg.192dpi.png")),
                     Act = () => _euiManager.OpenEui(new SetOutfitEui(args.Target), player),
                     Impact = LogImpact.Medium
                 };
@@ -297,7 +298,7 @@ namespace Content.Server.Administration.Systems
                 {
                     Text = Loc.GetString("in-range-unoccluded-verb-get-data-text"),
                     Category = VerbCategory.Debug,
-                    IconTexture = "/Textures/Interface/VerbIcons/information.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/information.svg.192dpi.png")),
                     Act = () =>
                     {
                         var message = args.User.InRangeUnOccluded(args.Target)
@@ -317,7 +318,7 @@ namespace Content.Server.Administration.Systems
                 {
                     Text = Loc.GetString("tube-direction-verb-get-data-text"),
                     Category = VerbCategory.Debug,
-                    IconTexture = "/Textures/Interface/VerbIcons/information.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/information.svg.192dpi.png")),
                     Act = () => tube.PopupDirections(args.User)
                 };
                 args.Verbs.Add(verb);
@@ -343,7 +344,7 @@ namespace Content.Server.Administration.Systems
                 Verb verb = new()
                 {
                     Text = Loc.GetString("configure-verb-get-data-text"),
-                    IconTexture = "/Textures/Interface/VerbIcons/settings.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/settings.svg.192dpi.png")),
                     Category = VerbCategory.Debug,
                     Act = () => _uiSystem.TryOpen(args.Target, ConfigurationUiKey.Key, actor.PlayerSession)
                 };
@@ -358,7 +359,7 @@ namespace Content.Server.Administration.Systems
                 {
                     Text = Loc.GetString("edit-solutions-verb-get-data-text"),
                     Category = VerbCategory.Debug,
-                    IconTexture = "/Textures/Interface/VerbIcons/spill.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/spill.svg.192dpi.png")),
                     Act = () => OpenEditSolutionsEui(player, args.Target),
                     Impact = LogImpact.Medium // maybe high depending on WHAT reagents they add...
                 };

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Verbs;
 using Content.Server.Popups;
 using Content.Server.DoAfter;
 using Content.Shared.DoAfter;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Body.Systems;
 
@@ -48,7 +49,7 @@ public sealed class InternalsSystem : EntitySystem
                 ToggleInternals(uid, args.User, false, component);
             },
             Message = Loc.GetString("action-description-internals-toggle"),
-            IconTexture = "/Textures/Interface/VerbIcons/dot.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/dot.svg.192dpi.png")),
             Text = Loc.GetString("action-name-internals-toggle"),
         };
 

--- a/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
+++ b/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
@@ -15,6 +15,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Vehicle.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.GameStates;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Buckle.Systems;
 
@@ -44,7 +45,7 @@ public sealed partial class BuckleSystem
         {
             Act = () => TryUnbuckle(uid, args.User, buckle: component),
             Text = Loc.GetString("verb-categories-unbuckle"),
-            IconTexture = "/Textures/Interface/VerbIcons/unbuckle.svg.192dpi.png"
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/unbuckle.svg.192dpi.png"))
         };
 
         if (args.Target == args.User && args.Using == null)

--- a/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
+++ b/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Clothing.Systems;
 
@@ -47,7 +48,7 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
         args.Verbs.Add(new InteractionVerb()
         {
             Text = Loc.GetString("chameleon-component-verb-text"),
-            IconTexture = "/Textures/Interface/VerbIcons/settings.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/settings.svg.192dpi.png")),
             Act = () => TryOpenUi(uid, args.User, component)
         });
     }

--- a/Content.Server/Construction/ConstructionSystem.Guided.cs
+++ b/Content.Server/Construction/ConstructionSystem.Guided.cs
@@ -6,6 +6,7 @@ using Content.Shared.Examine;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Robust.Shared.Player;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Construction
 {
@@ -44,7 +45,8 @@ namespace Content.Server.Construction
             //verb.Category = VerbCategories.Construction;
             //TODO VERBS add more construction verbs? Until then, removing construction category
             verb.Text = Loc.GetString("deconstructible-verb-begin-deconstruct");
-            verb.IconTexture = "/Textures/Interface/hammer_scaled.svg.192dpi.png";
+            verb.Icon = new SpriteSpecifier.Texture(
+                new ResourcePath("/Textures/Interface/hammer_scaled.svg.192dpi.png"));
 
             verb.Act = () =>
             {

--- a/Content.Server/Construction/ConstructionSystem.Machine.cs
+++ b/Content.Server/Construction/ConstructionSystem.Machine.cs
@@ -53,7 +53,7 @@ public sealed partial class ConstructionSystem
             Text = Loc.GetString("machine-upgrade-examinable-verb-text"),
             Message = Loc.GetString("machine-upgrade-examinable-verb-message"),
             Category = VerbCategory.Examine,
-            IconTexture = "/Textures/Interface/VerbIcons/pickup.svg.192dpi.png"
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/pickup.svg.192dpi.png"))
         };
 
         args.Verbs.Add(verb);

--- a/Content.Server/DetailExaminable/DetailExaminableystem.cs
+++ b/Content.Server/DetailExaminable/DetailExaminableystem.cs
@@ -32,7 +32,7 @@ namespace Content.Server.DetailExaminable
                 Category = VerbCategory.Examine,
                 Disabled = !detailsRange,
                 Message = Loc.GetString("detail-examinable-verb-disabled"),
-                IconTexture = "/Textures/Interface/VerbIcons/examine.svg.192dpi.png"
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/examine.svg.192dpi.png"))
             };
 
             args.Verbs.Add(verb);

--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -1,20 +1,17 @@
 using System.Linq;
 using Content.Server.DeviceNetwork.Components;
-using Content.Server.UserInterface;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Database;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.Interaction;
-using Content.Shared.Interaction.Events;
-using Content.Shared.Movement;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Server.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
+using Robust.Shared.Utility;
 
 namespace Content.Server.DeviceNetwork.Systems;
 
@@ -56,14 +53,16 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
 
         foreach (var component in EntityManager.EntityQuery<NetworkConfiguratorComponent>())
         {
+            var uid = component.Owner;
+
             if (component.ActiveDeviceList != null && EntityManager.EntityExists(component.ActiveDeviceList.Value) &&
-                _interactionSystem.InRangeUnobstructed(component.Owner, component.ActiveDeviceList.Value))
+                _interactionSystem.InRangeUnobstructed(uid, component.ActiveDeviceList.Value))
             {
-                return;
+                continue;
             }
 
             //The network configurator is a handheld device. There can only ever be an ui session open for the player holding the device.
-            _uiSystem.GetUiOrNull(component.Owner, NetworkConfiguratorUiKey.Configure)?.CloseAll();
+            _uiSystem.GetUiOrNull(uid, NetworkConfiguratorUiKey.Configure)?.CloseAll();
         }
     }
 
@@ -138,7 +137,7 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
 
     private void OnComponentRemoved(EntityUid uid, DeviceListComponent component, ComponentRemove args)
     {
-        _uiSystem.GetUiOrNull(component.Owner, NetworkConfiguratorUiKey.Configure)?.CloseAll();
+        _uiSystem.GetUiOrNull(uid, NetworkConfiguratorUiKey.Configure)?.CloseAll();
     }
 
     #region Interactions
@@ -177,7 +176,9 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         UtilityVerb verb = new()
         {
             Text = Loc.GetString(isDeviceList ? "network-configurator-configure" : "network-configurator-save-device"),
-            IconTexture = isDeviceList ? "/Textures/Interface/VerbIcons/settings.svg.192dpi.png" : "/Textures/Interface/VerbIcons/in.svg.192dpi.png",
+            Icon = isDeviceList ?
+                new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/settings.svg.192dpi.png")) :
+                new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/in.svg.192dpi.png")),
             Act = () => OnUsed(uid, component, args.Target, args.User),
             Impact = LogImpact.Low
         };
@@ -199,7 +200,7 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         AlternativeVerb verb = new()
         {
             Text = Loc.GetString("network-configurator-save-device"),
-            IconTexture = "/Textures/Interface/VerbIcons/in.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/in.svg.192dpi.png")),
             Act = () => TryAddNetworkDevice(args.Target, args.Using.Value, args.User),
             Impact = LogImpact.Low
         };

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -31,6 +31,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Disposal.Unit.EntitySystems
 {
@@ -96,7 +97,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
                 AlternativeVerb flushVerb = new();
                 flushVerb.Act = () => Engage(uid, component);
                 flushVerb.Text = Loc.GetString("disposal-flush-verb-get-data-text");
-                flushVerb.IconTexture = "/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png";
+                flushVerb.Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png"));
                 flushVerb.Priority = 1;
                 args.Verbs.Add(flushVerb);
 

--- a/Content.Server/Foldable/FoldableSystem.cs
+++ b/Content.Server/Foldable/FoldableSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Storage.Components;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Foldable
 {
@@ -32,9 +33,9 @@ namespace Content.Server.Foldable
                 args.Cancelled = true;
         }
 
-        public bool TryToggleFold(FoldableComponent comp)
+        public bool TryToggleFold(EntityUid uid, FoldableComponent comp)
         {
-            return TrySetFolded(comp, !comp.IsFolded);
+            return TrySetFolded(uid, comp, !comp.IsFolded);
         }
 
         public bool CanToggleFold(EntityUid uid, FoldableComponent? fold = null)
@@ -62,18 +63,15 @@ namespace Content.Server.Foldable
         /// <summary>
         /// Try to fold/unfold
         /// </summary>
-        /// <param name="comp"></param>
-        /// <param name="state">Folded state we want</param>
-        /// <returns>True if successful</returns>
-        public bool TrySetFolded(FoldableComponent comp, bool state)
+        public bool TrySetFolded(EntityUid uid, FoldableComponent comp, bool state)
         {
             if (state == comp.IsFolded)
                 return false;
 
-            if (!CanToggleFold(comp.Owner, comp))
+            if (!CanToggleFold(uid, comp))
                 return false;
 
-            SetFolded(comp, state);
+            SetFolded(uid, comp, state);
             return true;
         }
 
@@ -82,12 +80,12 @@ namespace Content.Server.Foldable
         /// </summary>
         /// <param name="component"></param>
         /// <param name="folded">If true, the component will become folded, else unfolded</param>
-        public override void SetFolded(FoldableComponent component, bool folded)
+        public override void SetFolded(EntityUid uid, FoldableComponent component, bool folded)
         {
-            base.SetFolded(component, folded);
+            base.SetFolded(uid, component, folded);
 
             // You can't buckle an entity to a folded object
-            _buckle.StrapSetEnabled(component.Owner, !component.IsFolded);
+            _buckle.StrapSetEnabled(uid, !component.IsFolded);
         }
 
         public void OnStoreThisAttempt(EntityUid uid, FoldableComponent comp, ref StoreMobInItemContainerAttemptEvent args)
@@ -107,9 +105,9 @@ namespace Content.Server.Foldable
 
             AlternativeVerb verb = new()
             {
-                Act = () => TryToggleFold(component),
+                Act = () => TryToggleFold(uid, component),
                 Text = component.IsFolded ? Loc.GetString("unfold-verb") : Loc.GetString("fold-verb"),
-                IconTexture = "/Textures/Interface/VerbIcons/fold.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/fold.svg.192dpi.png")),
 
                 // If the object is unfolded and they click it, they want to fold it, if it's folded, they want to pick it up
                 Priority = component.IsFolded ? 0 : 2,

--- a/Content.Server/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Server/HealthExaminable/HealthExaminableSystem.cs
@@ -36,7 +36,7 @@ public sealed class HealthExaminableSystem : EntitySystem
             Category = VerbCategory.Examine,
             Disabled = !detailsRange,
             Message = Loc.GetString("health-examinable-verb-disabled"),
-            IconTexture = "/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png"
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png"))
         };
 
         args.Verbs.Add(verb);

--- a/Content.Server/Humanoid/Systems/HumanoidSystem.Modifier.cs
+++ b/Content.Server/Humanoid/Systems/HumanoidSystem.Modifier.cs
@@ -4,6 +4,7 @@ using Content.Shared.Humanoid;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Humanoid;
 
@@ -28,7 +29,7 @@ public sealed partial class HumanoidAppearanceSystem
         {
             Text = "Modify markings",
             Category = VerbCategory.Tricks,
-            IconTexture = "/Textures/Mobs/Customization/reptilian_parts.rsi/tail_smooth.png",
+            Icon = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Mobs/Customization/reptilian_parts.rsi"), "tail_smooth"),
             Act = () =>
             {
                 _uiSystem.TryOpen(uid, HumanoidMarkingModifierKey.Key, actor.PlayerSession);

--- a/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
@@ -1,4 +1,4 @@
-using Content.Server.Body.Systems;
+﻿using Content.Server.Body.Systems;
 using Content.Server.DoAfter;
 using Content.Server.Kitchen.Components;
 using Content.Shared.Body.Components;
@@ -13,6 +13,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Robust.Server.Containers;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Kitchen.EntitySystems;
 
@@ -149,7 +150,7 @@ public sealed class SharpSystem : EntitySystem
             },
             Message = message,
             Disabled = disabled,
-            IconTexture = "/Textures/Interface/VerbIcons/cutlery.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/cutlery.svg.192dpi.png")),
             Text = Loc.GetString("butcherable-verb-name"),
         };
 

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -11,6 +11,7 @@ using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Light.EntitySystems
 {
@@ -183,7 +184,7 @@ namespace Content.Server.Light.EntitySystems
             ActivationVerb verb = new()
             {
                 Text = Loc.GetString("expendable-light-start-verb"),
-                IconTexture = "/Textures/Interface/VerbIcons/light.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/light.svg.192dpi.png")),
                 Act = () => TryActivate(component)
             };
             args.Verbs.Add(verb);

--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Light.EntitySystems
             EntInsertedIntoContainerMessage args)
         {
             // Not guaranteed to be the correct container for our slot, I don't care.
-            UpdateLevel(component);
+            UpdateLevel(uid, component);
         }
 
         private void OnEntRemoved(
@@ -67,7 +67,7 @@ namespace Content.Server.Light.EntitySystems
             EntRemovedFromContainerMessage args)
         {
             // Ditto above
-            UpdateLevel(component);
+            UpdateLevel(uid, component);
         }
 
         private void OnGetActions(EntityUid uid, HandheldLightComponent component, GetItemActionsEvent args)
@@ -88,24 +88,24 @@ namespace Content.Server.Light.EntitySystems
                 return;
 
             if (component.Activated)
-                TurnOff(component);
+                TurnOff(uid, component);
             else
-                TurnOn(args.Performer, component);
+                TurnOn(args.Performer, uid, component);
 
             args.Handled = true;
         }
 
         private void OnGetState(EntityUid uid, HandheldLightComponent component, ref ComponentGetState args)
         {
-            args.State = new HandheldLightComponent.HandheldLightComponentState(component.Activated, GetLevel(component));
+            args.State = new HandheldLightComponent.HandheldLightComponentState(component.Activated, GetLevel(uid, component));
         }
 
-        private byte? GetLevel(HandheldLightComponent component)
+        private byte? GetLevel(EntityUid uid, HandheldLightComponent component)
         {
             // Curently every single flashlight has the same number of levels for status and that's all it uses the charge for
             // Thus we'll just check if the level changes.
 
-            if (!_powerCell.TryGetBatteryFromSlot(component.Owner, out var battery))
+            if (!_powerCell.TryGetBatteryFromSlot(uid, out var battery))
                 return null;
 
             if (MathHelper.CloseToPercent(battery.CurrentCharge, 0) || component.Wattage > battery.CurrentCharge)
@@ -121,9 +121,10 @@ namespace Content.Server.Light.EntitySystems
 
         private void OnActivate(EntityUid uid, HandheldLightComponent component, ActivateInWorldEvent args)
         {
-            if (args.Handled) return;
+            if (args.Handled)
+                return;
 
-            if (ToggleStatus(args.User, component))
+            if (ToggleStatus(args.User, uid, component))
                 args.Handled = true;
         }
 
@@ -131,9 +132,9 @@ namespace Content.Server.Light.EntitySystems
         ///     Illuminates the light if it is not active, extinguishes it if it is active.
         /// </summary>
         /// <returns>True if the light's status was toggled, false otherwise.</returns>
-        public bool ToggleStatus(EntityUid user, HandheldLightComponent component)
+        public bool ToggleStatus(EntityUid user, EntityUid uid, HandheldLightComponent component)
         {
-            return component.Activated ? TurnOff(component) : TurnOn(user, component);
+            return component.Activated ? TurnOff(uid, component) : TurnOn(user, uid, component);
         }
 
         private void OnExamine(EntityUid uid, HandheldLightComponent component, ExaminedEvent args)
@@ -155,14 +156,16 @@ namespace Content.Server.Light.EntitySystems
 
             foreach (var handheld in _activeLights)
             {
+                var uid = handheld.Owner;
+
                 if (handheld.Deleted)
                 {
                     toRemove.Add(handheld);
                     continue;
                 }
 
-                if (Paused(handheld.Owner)) continue;
-                TryUpdate(handheld, frameTime);
+                if (Paused(uid)) continue;
+                TryUpdate(uid, handheld, frameTime);
             }
 
             foreach (var light in toRemove)
@@ -173,46 +176,47 @@ namespace Content.Server.Light.EntitySystems
 
         private void AddToggleLightVerb(EntityUid uid, HandheldLightComponent component, GetVerbsEvent<ActivationVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract) return;
+            if (!args.CanAccess || !args.CanInteract)
+                return;
 
             ActivationVerb verb = new()
             {
                 Text = Loc.GetString("verb-common-toggle-light"),
-                IconTexture = "/Textures/Interface/VerbIcons/light.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/light.svg.192dpi.png")),
                 Act = component.Activated
-                    ? () => TurnOff(component)
-                    : () => TurnOn(args.User, component)
+                    ? () => TurnOff(uid, component)
+                    : () => TurnOn(args.User, uid,  component)
             };
 
             args.Verbs.Add(verb);
         }
 
-        public bool TurnOff(HandheldLightComponent component, bool makeNoise = true)
+        public bool TurnOff(EntityUid uid, HandheldLightComponent component, bool makeNoise = true)
         {
-            if (!component.Activated || !TryComp<PointLightComponent>(component.Owner, out var pointLightComponent))
+            if (!component.Activated || !TryComp<PointLightComponent>(uid, out var pointLightComponent))
             {
                 return false;
             }
 
             pointLightComponent.Enabled = false;
-            SetActivated(component.Owner, false, component, makeNoise);
+            SetActivated(uid, false, component, makeNoise);
             component.Level = null;
             _activeLights.Remove(component);
             return true;
         }
 
-        public bool TurnOn(EntityUid user, HandheldLightComponent component)
+        public bool TurnOn(EntityUid user, EntityUid uid, HandheldLightComponent component)
         {
-            if (component.Activated || !TryComp<PointLightComponent>(component.Owner, out var pointLightComponent))
+            if (component.Activated || !TryComp<PointLightComponent>(uid, out var pointLightComponent))
             {
                 return false;
             }
 
-            if (!_powerCell.TryGetBatteryFromSlot(component.Owner, out var battery) &&
-                !TryComp(component.Owner, out battery))
+            if (!_powerCell.TryGetBatteryFromSlot(uid, out var battery) &&
+                !TryComp(uid, out battery))
             {
-                _audio.PlayPvs(_audio.GetSound(component.TurnOnFailSound), component.Owner);
-                _popup.PopupEntity(Loc.GetString("handheld-light-component-cell-missing-message"), component.Owner, user);
+                _audio.PlayPvs(_audio.GetSound(component.TurnOnFailSound), uid);
+                _popup.PopupEntity(Loc.GetString("handheld-light-component-cell-missing-message"), uid, user);
                 return false;
             }
 
@@ -221,52 +225,52 @@ namespace Content.Server.Light.EntitySystems
             // Simple enough.
             if (component.Wattage > battery.CurrentCharge)
             {
-                _audio.PlayPvs(_audio.GetSound(component.TurnOnFailSound), component.Owner);
-                _popup.PopupEntity(Loc.GetString("handheld-light-component-cell-dead-message"), component.Owner, user);
+                _audio.PlayPvs(_audio.GetSound(component.TurnOnFailSound), uid);
+                _popup.PopupEntity(Loc.GetString("handheld-light-component-cell-dead-message"), uid, user);
                 return false;
             }
 
             pointLightComponent.Enabled = true;
-            SetActivated(component.Owner, true, component, true);
+            SetActivated(uid, true, component, true);
             _activeLights.Add(component);
 
             return true;
         }
 
-        public void TryUpdate(HandheldLightComponent component, float frameTime)
+        public void TryUpdate(EntityUid uid, HandheldLightComponent component, float frameTime)
         {
-            if (!_powerCell.TryGetBatteryFromSlot(component.Owner, out var battery) &&
-                !TryComp(component.Owner, out battery))
+            if (!_powerCell.TryGetBatteryFromSlot(uid, out var battery) &&
+                !TryComp(uid, out battery))
             {
-                TurnOff(component, false);
+                TurnOff(uid, component, false);
                 return;
             }
 
-            var appearanceComponent = EntityManager.GetComponent<AppearanceComponent>(component.Owner);
+            var appearanceComponent = EntityManager.GetComponentOrNull<AppearanceComponent>(uid);
 
             var fraction = battery.CurrentCharge / battery.MaxCharge;
             if (fraction >= 0.30)
             {
-                _appearance.SetData(component.Owner, HandheldLightVisuals.Power, HandheldLightPowerStates.FullPower, appearanceComponent);
+                _appearance.SetData(uid, HandheldLightVisuals.Power, HandheldLightPowerStates.FullPower, appearanceComponent);
             }
             else if (fraction >= 0.10)
             {
-                _appearance.SetData(component.Owner, HandheldLightVisuals.Power, HandheldLightPowerStates.LowPower, appearanceComponent);
+                _appearance.SetData(uid, HandheldLightVisuals.Power, HandheldLightPowerStates.LowPower, appearanceComponent);
             }
             else
             {
-                _appearance.SetData(component.Owner, HandheldLightVisuals.Power, HandheldLightPowerStates.Dying, appearanceComponent);
+                _appearance.SetData(uid, HandheldLightVisuals.Power, HandheldLightPowerStates.Dying, appearanceComponent);
             }
 
             if (component.Activated && !battery.TryUseCharge(component.Wattage * frameTime))
-                TurnOff(component, false);
+                TurnOff(uid, component, false);
 
-            UpdateLevel(component);
+            UpdateLevel(uid, component);
         }
 
-        private void UpdateLevel(HandheldLightComponent comp)
+        private void UpdateLevel(EntityUid uid, HandheldLightComponent comp)
         {
-            var level = GetLevel(comp);
+            var level = GetLevel(uid, comp);
 
             if (level == comp.Level)
                 return;

--- a/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
+++ b/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Light.EntitySystems
 {
@@ -48,7 +49,7 @@ namespace Content.Server.Light.EntitySystems
 
             ActivationVerb verb = new();
             verb.Text = Loc.GetString("toggle-flashlight-verb-get-data-text");
-            verb.IconTexture = "/Textures/Interface/VerbIcons/light.svg.192dpi.png";
+            verb.Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/light.svg.192dpi.png"));
             verb.Act = () => ToggleLight(uid, component);
             verb.Priority = -1; // For things like PDA's, Open-UI and other verbs that should be higher priority.
 

--- a/Content.Server/MachineLinking/System/TwoWayLeverSystem.cs
+++ b/Content.Server/MachineLinking/System/TwoWayLeverSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Interaction;
 using Content.Shared.MachineLinking;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
+using Robust.Shared.Utility;
 
 namespace Content.Server.MachineLinking.System
 {
@@ -65,7 +66,7 @@ namespace Content.Server.MachineLinking.System
                 Category = VerbCategory.Lever,
                 Message = Loc.GetString("two-way-lever-cant"),
                 Disabled = component.State == TwoWayLeverState.Left,
-                IconTexture = $"/Textures/Interface/VerbIcons/{_leftToggleImage}",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath($"/Textures/Interface/VerbIcons/{_leftToggleImage}")),
                 Text = Loc.GetString("two-way-lever-left"),
             };
 
@@ -86,7 +87,7 @@ namespace Content.Server.MachineLinking.System
                 Category = VerbCategory.Lever,
                 Message = Loc.GetString("two-way-lever-cant"),
                 Disabled = component.State == TwoWayLeverState.Right,
-                IconTexture = $"/Textures/Interface/VerbIcons/{_rightToggleImage}",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath($"/Textures/Interface/VerbIcons/{_rightToggleImage}")),
                 Text = Loc.GetString("two-way-lever-right"),
             };
 

--- a/Content.Server/Medical/Stethoscope/StethoscopeSystem.cs
+++ b/Content.Server/Medical/Stethoscope/StethoscopeSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Verbs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.DoAfter;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Medical
 {
@@ -82,7 +83,7 @@ namespace Content.Server.Medical
                     StartListening(component.Stethoscope, uid, args.Target, stetho); // start doafter
                 },
                 Text = Loc.GetString("stethoscope-verb"),
-                IconTexture = "Clothing/Neck/Misc/stethoscope.rsi/icon.png",
+                Icon = new SpriteSpecifier.Rsi(new ResourcePath("Clothing/Neck/Misc/stethoscope.rsi"), "icon"),
                 Priority = 2
             };
             args.Verbs.Add(verb);

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -387,7 +387,7 @@ namespace Content.Server.Nutrition.EntitySystems
                 {
                     TryDrink(ev.User, ev.User, component, uid);
                 },
-                IconTexture = "/Textures/Interface/VerbIcons/drink.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/drink.svg.192dpi.png")),
                 Text = Loc.GetString("drink-system-verb-drink"),
                 Priority = 2
             };

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -264,7 +264,7 @@ namespace Content.Server.Nutrition.EntitySystems
                 {
                     TryFeed(ev.User, ev.User, uid, component);
                 },
-                IconTexture = "/Textures/Interface/VerbIcons/cutlery.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/cutlery.svg.192dpi.png")),
                 Text = Loc.GetString("food-system-verb-eat"),
                 Priority = -1
             };

--- a/Content.Server/Power/EntitySystems/CableMultitoolSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableMultitoolSystem.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Power.EntitySystems
                     Message = Loc.GetString("cable-multitool-system-verb-tooltip"),
                     Text = Loc.GetString("cable-multitool-system-verb-name"),
                     Category = VerbCategory.Examine,
-                    IconTexture = "/Textures/Interface/VerbIcons/zap.svg.192dpi.png",
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/zap.svg.192dpi.png")),
                     Act = () =>
                     {
                         var markup = FormattedMessage.FromMarkup(GenerateCableMarkup(uid));

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -9,6 +9,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Content.Server.Administration.Managers;
 using Content.Shared.Administration;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Power.EntitySystems
 {
@@ -45,7 +46,7 @@ namespace Content.Server.Power.EntitySystems
             {
                 Text = Loc.GetString("verb-debug-toggle-need-power"),
                 Category = VerbCategory.Debug,
-                IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png", // "smite" is a lightning bolt
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")), // "smite" is a lightning bolt
                 Act = () => component.NeedsPower = !component.NeedsPower
             });
         }
@@ -126,7 +127,7 @@ namespace Content.Server.Power.EntitySystems
                 {
                     TogglePower(uid, user: args.User);
                 },
-                IconTexture = "/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
                 Text = Loc.GetString("power-switch-component-toggle-verb"),
                 Priority = -3
             };

--- a/Content.Server/Prayer/PrayableComponent.cs
+++ b/Content.Server/Prayer/PrayableComponent.cs
@@ -1,4 +1,6 @@
-﻿namespace Content.Server.Prayer
+﻿using Robust.Shared.Utility;
+
+namespace Content.Server.Prayer
 {
     /// <summary>
     /// Allows an entity to be prayed on in the context menu
@@ -39,7 +41,7 @@
         /// </summary>
         [DataField("verbImage")]
         [ViewVariables(VVAccess.ReadOnly)]
-        public string VerbImage = "/Textures/Interface/pray.svg.png";
+        public SpriteSpecifier? VerbImage = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/pray.svg.png"));
     }
 }
 

--- a/Content.Server/Prayer/PrayerSystem.cs
+++ b/Content.Server/Prayer/PrayerSystem.cs
@@ -45,7 +45,7 @@ public sealed class PrayerSystem : EntitySystem
         var prayerVerb = new ActivationVerb
         {
             Text = Loc.GetString(comp.Verb),
-            IconTexture = comp.VerbImage == "" ? null : comp.VerbImage,
+            Icon = comp.VerbImage,
             Act = () =>
             {
                 if (comp.BibleUserOnly && !EntityManager.TryGetComponent<BibleUserComponent>(args.User, out var bibleUser))

--- a/Content.Server/Rotatable/RotatableSystem.cs
+++ b/Content.Server/Rotatable/RotatableSystem.cs
@@ -1,8 +1,10 @@
+using Content.Server.Popups;
 using Content.Shared.Popups;
 using Content.Shared.Rotatable;
 using Content.Shared.Verbs;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Rotatable
 {
@@ -11,6 +13,8 @@ namespace Content.Server.Rotatable
     /// </summary>
     public sealed class RotatableSystem : EntitySystem
     {
+        [Dependency] private readonly PopupSystem _popup = default!;
+
         public override void Initialize()
         {
             SubscribeLocalEvent<FlippableComponent, GetVerbsEvent<Verb>>(AddFlipVerb);
@@ -19,13 +23,15 @@ namespace Content.Server.Rotatable
 
         private void AddFlipVerb(EntityUid uid, FlippableComponent component, GetVerbsEvent<Verb> args)
         {
-            if (!args.CanAccess || !args.CanInteract || component.MirrorEntity == null)
+            if (!args.CanAccess || !args.CanInteract)
                 return;
 
-            Verb verb = new();
-            verb.Act = () => TryFlip(component, args.User);
-            verb.Text = Loc.GetString("flippable-verb-get-data-text");
-            verb.DoContactInteraction = true;
+            Verb verb = new()
+            {
+                Act = () => TryFlip(uid, component, args.User),
+                Text = Loc.GetString("flippable-verb-get-data-text"),
+                DoContactInteraction = true
+            };
             // TODO VERB ICONS Add Uno reverse card style icon?
             args.Verbs.Add(verb);
         }
@@ -39,16 +45,16 @@ namespace Content.Server.Rotatable
 
             // Check if the object is anchored, and whether we are still allowed to rotate it.
             if (!component.RotateWhileAnchored &&
-                EntityManager.TryGetComponent(component.Owner, out PhysicsComponent? physics) &&
+                EntityManager.TryGetComponent(uid, out PhysicsComponent? physics) &&
                 physics.BodyType == BodyType.Static)
                 return;
 
             Verb resetRotation = new ()
             {
                 DoContactInteraction = true,
-                Act = () => EntityManager.GetComponent<TransformComponent>(component.Owner).LocalRotation = Angle.Zero,
+                Act = () => EntityManager.GetComponent<TransformComponent>(uid).LocalRotation = Angle.Zero,
                 Category = VerbCategory.Rotate,
-                IconTexture = "/Textures/Interface/VerbIcons/refresh.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/refresh.svg.192dpi.png")),
                 Text = "Reset",
                 Priority = -2, // show CCW, then CW, then reset
                 CloseMenu = false,
@@ -58,9 +64,9 @@ namespace Content.Server.Rotatable
             // rotate clockwise
             Verb rotateCW = new()
             {
-                Act = () => EntityManager.GetComponent<TransformComponent>(component.Owner).LocalRotation -= component.Increment,
+                Act = () => EntityManager.GetComponent<TransformComponent>(uid).LocalRotation -= component.Increment,
                 Category = VerbCategory.Rotate,
-                IconTexture =  "/Textures/Interface/VerbIcons/rotate_cw.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/rotate_cw.svg.192dpi.png")),
                 Priority = -1,
                 CloseMenu = false, // allow for easy double rotations.
             };
@@ -69,9 +75,9 @@ namespace Content.Server.Rotatable
             // rotate counter-clockwise
             Verb rotateCCW = new()
             {
-                Act = () => EntityManager.GetComponent<TransformComponent>(component.Owner).LocalRotation += component.Increment,
+                Act = () => EntityManager.GetComponent<TransformComponent>(uid).LocalRotation += component.Increment,
                 Category = VerbCategory.Rotate,
-                IconTexture = "/Textures/Interface/VerbIcons/rotate_ccw.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/rotate_ccw.svg.192dpi.png")),
                 Priority = 0,
                 CloseMenu = false, // allow for easy double rotations.
             };
@@ -81,21 +87,21 @@ namespace Content.Server.Rotatable
         /// <summary>
         ///     Replace a flippable entity with it's flipped / mirror-symmetric entity.
         /// </summary>
-        public void TryFlip(FlippableComponent component, EntityUid user)
+        public void TryFlip(EntityUid uid, FlippableComponent component, EntityUid user)
         {
-            if (EntityManager.TryGetComponent(component.Owner, out PhysicsComponent? physics) &&
+            if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physics) &&
                 physics.BodyType == BodyType.Static)
             {
-                component.Owner.PopupMessage(user, Loc.GetString("flippable-component-try-flip-is-stuck"));
+                _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), uid, user);
                 return;
             }
 
-            var oldTransform = EntityManager.GetComponent<TransformComponent>(component.Owner);
+            var oldTransform = EntityManager.GetComponent<TransformComponent>(uid);
             var entity = EntityManager.SpawnEntity(component.MirrorEntity, oldTransform.Coordinates);
             var newTransform = EntityManager.GetComponent<TransformComponent>(entity);
             newTransform.LocalRotation = oldTransform.LocalRotation;
             newTransform.Anchored = false;
-            EntityManager.DeleteEntity(component.Owner);
+            EntityManager.DeleteEntity(uid);
         }
     }
 }

--- a/Content.Server/Sticky/Systems/StickySystem.cs
+++ b/Content.Server/Sticky/Systems/StickySystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Sticky.Systems;
 
@@ -57,7 +58,7 @@ public sealed class StickySystem : EntitySystem
         {
             DoContactInteraction = true,
             Text = Loc.GetString("comp-sticky-unstick-verb-text"),
-            IconTexture = "/Textures/Interface/VerbIcons/eject.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/eject.svg.192dpi.png")),
             Act = () => StartUnsticking(uid, args.User, component)
         });
     }

--- a/Content.Server/Storage/EntitySystems/DumpableSystem.cs
+++ b/Content.Server/Storage/EntitySystems/DumpableSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Placeable;
 using Content.Shared.Storage;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Storage.EntitySystems
 {
@@ -54,7 +55,7 @@ namespace Content.Server.Storage.EntitySystems
                     StartDoAfter(uid, null, args.User, dumpable);//Had multiplier of 0.6f
                 },
                 Text = Loc.GetString("dump-verb-name"),
-                IconTexture = "/Textures/Interface/VerbIcons/drop.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png")),
             };
             args.Verbs.Add(verb);
         }

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -117,12 +117,14 @@ namespace Content.Server.Storage.EntitySystems
             if (component.Open)
             {
                 verb.Text = Loc.GetString("verb-common-close");
-                verb.IconTexture = "/Textures/Interface/VerbIcons/close.svg.192dpi.png";
+                verb.Icon = new SpriteSpecifier.Texture(
+                    new ResourcePath("/Textures/Interface/VerbIcons/close.svg.192dpi.png"));
             }
             else
             {
                 verb.Text = Loc.GetString("verb-common-open");
-                verb.IconTexture = "/Textures/Interface/VerbIcons/open.svg.192dpi.png";
+                verb.Icon = new SpriteSpecifier.Texture(
+                    new ResourcePath("/Textures/Interface/VerbIcons/open.svg.192dpi.png"));
             }
             verb.Act = () => _entityStorage.ToggleOpen(args.User, args.Target, component);
             args.Verbs.Add(verb);
@@ -147,12 +149,14 @@ namespace Content.Server.Storage.EntitySystems
             if (uiOpen)
             {
                 verb.Text = Loc.GetString("verb-common-close-ui");
-                verb.IconTexture = "/Textures/Interface/VerbIcons/close.svg.192dpi.png";
+                verb.Icon = new SpriteSpecifier.Texture(
+                    new ResourcePath("/Textures/Interface/VerbIcons/close.svg.192dpi.png"));
             }
             else
             {
                 verb.Text = Loc.GetString("verb-common-open-ui");
-                verb.IconTexture = "/Textures/Interface/VerbIcons/open.svg.192dpi.png";
+                verb.Icon = new SpriteSpecifier.Texture(
+                    new ResourcePath("/Textures/Interface/VerbIcons/open.svg.192dpi.png"));
             }
             args.Verbs.Add(verb);
         }

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Ensnaring.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Strip;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Strip
 {
@@ -132,7 +133,7 @@ namespace Content.Server.Strip
             Verb verb = new()
             {
                 Text = Loc.GetString("strip-verb-get-data-text"),
-                IconTexture = "/Textures/Interface/VerbIcons/outfit.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/outfit.svg.192dpi.png")),
                 Act = () => StartOpeningStripper(args.User, component, true),
             };
             args.Verbs.Add(verb);
@@ -149,7 +150,7 @@ namespace Content.Server.Strip
             ExamineVerb verb = new()
             {
                 Text = Loc.GetString("strip-verb-get-data-text"),
-                IconTexture = "/Textures/Interface/VerbIcons/outfit.svg.192dpi.png",
+                Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/outfit.svg.192dpi.png")),
                 Act = () => StartOpeningStripper(args.User, component, true),
                 Category = VerbCategory.Examine,
             };

--- a/Content.Server/Tabletop/TabletopSystem.cs
+++ b/Content.Server/Tabletop/TabletopSystem.cs
@@ -8,6 +8,7 @@ using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Tabletop
 {
@@ -58,7 +59,7 @@ namespace Content.Server.Tabletop
 
             ActivationVerb verb = new();
             verb.Text = Loc.GetString("tabletop-verb-play-game");
-            verb.IconTexture = "/Textures/Interface/VerbIcons/die.svg.192dpi.png";
+            verb.Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/die.svg.192dpi.png"));
             verb.Act = () => OpenSessionFor(actor.PlayerSession, uid);
             args.Verbs.Add(verb);
         }

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -26,6 +26,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Players;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Weapons.Melee;
 
@@ -74,7 +75,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             Text = Loc.GetString("damage-examinable-verb-text"),
             Message = Loc.GetString("damage-examinable-verb-message"),
             Category = VerbCategory.Examine,
-            IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png"
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")),
         };
 
         args.Verbs.Add(verb);

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Battery.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Battery.cs
@@ -6,6 +6,7 @@ using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Weapons.Ranged.Systems;
 
@@ -38,11 +39,13 @@ public sealed partial class GunSystem
 
     private void UpdateShots(EntityUid uid, BatteryAmmoProviderComponent component)
     {
-        if (!TryComp<BatteryComponent>(uid, out var battery)) return;
-        UpdateShots(component, battery);
+        if (!TryComp<BatteryComponent>(uid, out var battery))
+            return;
+
+        UpdateShots(uid, component, battery);
     }
 
-    private void UpdateShots(BatteryAmmoProviderComponent component, BatteryComponent battery)
+    private void UpdateShots(EntityUid uid, BatteryAmmoProviderComponent component, BatteryComponent battery)
     {
         var shots = (int) (battery.CurrentCharge / component.FireCost);
         var maxShots = (int) (battery.MaxCharge / component.FireCost);
@@ -54,7 +57,7 @@ public sealed partial class GunSystem
 
         component.Shots = shots;
         component.Capacity = maxShots;
-        UpdateBatteryAppearance(component.Owner, component);
+        UpdateBatteryAppearance(uid, component);
     }
 
     private void OnBatteryExaminableVerb(EntityUid uid, BatteryAmmoProviderComponent component, GetVerbsEvent<ExamineVerb> args)
@@ -91,7 +94,7 @@ public sealed partial class GunSystem
             Text = Loc.GetString("damage-examinable-verb-text"),
             Message = Loc.GetString("damage-examinable-verb-message"),
             Category = VerbCategory.Examine,
-            IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png"
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")),
         };
 
         args.Verbs.Add(verb);
@@ -125,9 +128,10 @@ public sealed partial class GunSystem
 
     protected override void TakeCharge(EntityUid uid, BatteryAmmoProviderComponent component)
     {
-        if (!TryComp<BatteryComponent>(uid, out var battery)) return;
+        if (!TryComp<BatteryComponent>(uid, out var battery))
+            return;
 
         battery.CurrentCharge -= component.FireCost;
-        UpdateShots(component, battery);
+        UpdateShots(uid, component, battery);
     }
 }

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Cartridges.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Cartridges.cs
@@ -5,6 +5,7 @@ using Content.Shared.Projectiles;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Weapons.Ranged.Systems;
 
@@ -37,7 +38,7 @@ public sealed partial class GunSystem
             Text = Loc.GetString("damage-examinable-verb-text"),
             Message = Loc.GetString("damage-examinable-verb-message"),
             Category = VerbCategory.Examine,
-            IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png"
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")),
         };
 
         args.Verbs.Add(verb);

--- a/Content.Shared/Cabinet/SharedItemCabinetSystem.cs
+++ b/Content.Shared/Cabinet/SharedItemCabinetSystem.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Cabinet;
 
@@ -105,12 +106,14 @@ public abstract class SharedItemCabinetSystem : EntitySystem
         if (cabinet.Opened)
         {
             toggleVerb.Text = Loc.GetString("verb-common-close");
-            toggleVerb.IconTexture = "/Textures/Interface/VerbIcons/close.svg.192dpi.png";
+            toggleVerb.Icon =
+                new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/close.svg.192dpi.png"));
         }
         else
         {
             toggleVerb.Text = Loc.GetString("verb-common-open");
-            toggleVerb.IconTexture = "/Textures/Interface/VerbIcons/open.svg.192dpi.png";
+            toggleVerb.Icon =
+                new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/open.svg.192dpi.png"));
         }
         args.Verbs.Add(toggleVerb);
     }

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -499,14 +499,18 @@ namespace Content.Shared.Containers.ItemSlots
                 if (slot.InsertVerbText != null)
                 {
                     insertVerb.Text = Loc.GetString(slot.InsertVerbText);
-                    insertVerb.IconTexture = "/Textures/Interface/VerbIcons/insert.svg.192dpi.png";
+                    insertVerb.Icon =
+                        new SpriteSpecifier.Texture(
+                            new ResourcePath("/Textures/Interface/VerbIcons/insert.svg.192dpi.png"));
                 }
                 else if(slot.EjectOnInteract)
                 {
                     // Inserting/ejecting is a primary interaction for this entity. Instead of using the insert
                     // category, we will use a single "Place <item>" verb.
                     insertVerb.Text = Loc.GetString("place-item-verb-text", ("subject", verbSubject));
-                    insertVerb.IconTexture = "/Textures/Interface/VerbIcons/drop.svg.192dpi.png";
+                    insertVerb.Icon =
+                        new SpriteSpecifier.Texture(
+                            new ResourcePath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png"));
                 }
                 else
                 {

--- a/Content.Shared/Examine/ExamineSystemShared.Group.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.Group.cs
@@ -38,7 +38,7 @@ namespace Content.Shared.Examine
                     Text = group.ContextText,
                     Message = group.HoverMessage,
                     Category = VerbCategory.Examine,
-                    IconTexture = group.Icon
+                    Icon = new SpriteSpecifier.Texture(new ResourcePath(group.Icon)),
                 };
 
                 args.Verbs.Add(examineVerb);
@@ -149,7 +149,7 @@ namespace Content.Shared.Examine
                 Text = verbText,
                 Message = hoverMessage,
                 Category = VerbCategory.Examine,
-                IconTexture = iconTexture
+                Icon = new SpriteSpecifier.Texture(new ResourcePath(iconTexture)),
             };
 
             verbsEvent.Verbs.Add(examineVerb);

--- a/Content.Shared/Foldable/SharedFoldableSystem.cs
+++ b/Content.Shared/Foldable/SharedFoldableSystem.cs
@@ -32,24 +32,25 @@ public abstract class SharedFoldableSystem : EntitySystem
             return;
 
         if (state.IsFolded != component.IsFolded)
-            SetFolded(component, state.IsFolded);
+            SetFolded(uid, component, state.IsFolded);
     }
 
     private void OnFoldableInit(EntityUid uid, FoldableComponent component, ComponentInit args)
     {
-        SetFolded(component, component.IsFolded);
+        SetFolded(uid, component, component.IsFolded);
     }
 
     /// <summary>
     /// Set the folded state of the given <see cref="FoldableComponent"/>
     /// </summary>
-    /// <param name="component"></param>
-    /// <param name="folded">If true, the component will become folded, else unfolded</param>
-    public virtual void SetFolded(FoldableComponent component, bool folded)
+    public virtual void SetFolded(EntityUid uid, FoldableComponent component, bool folded)
     {
+        if (component.IsFolded == folded)
+            return;
+
         component.IsFolded = folded;
         Dirty(component);
-        Appearance.SetData(component.Owner, FoldedVisuals.State, folded);
+        Appearance.SetData(uid, FoldedVisuals.State, folded);
     }
 
     private void OnInsertEvent(EntityUid uid, FoldableComponent component, ContainerGettingInsertedAttemptEvent args)

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Ghost;
 using Content.Shared.Movement.Events;
 using Content.Shared.Verbs;
 using Robust.Shared.Map;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Follower;
 
@@ -37,7 +38,7 @@ public sealed class FollowerSystem : EntitySystem
             }),
             Impact = LogImpact.Low,
             Text = Loc.GetString("verb-follow-text"),
-            IconTexture = "/Textures/Interface/VerbIcons/open.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/open.svg.192dpi.png")),
         };
 
         ev.Verbs.Add(verb);

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Inventory.Events;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Item;
 
@@ -118,7 +119,7 @@ public abstract class SharedItemSystem : EntitySystem
         InteractionVerb verb = new();
         verb.Act = () => _handsSystem.TryPickupAnyHand(args.User, args.Target, checkActionBlocker: false,
             handsComp: args.Hands, item: component);
-        verb.IconTexture = "/Textures/Interface/VerbIcons/pickup.svg.192dpi.png";
+        verb.Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/pickup.svg.192dpi.png"));
 
         // if the item already in a container (that is not the same as the user's), then change the text.
         // this occurs when the item is in their inventory or in an open backpack

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Lock;
 
@@ -224,7 +225,9 @@ public sealed class LockSystem : EntitySystem
                 () => TryUnlock(uid, args.User, component) :
                 () => TryLock(uid, args.User, component),
             Text = Loc.GetString(component.Locked ? "toggle-lock-verb-unlock" : "toggle-lock-verb-lock"),
-            IconTexture = component.Locked ? "/Textures/Interface/VerbIcons/unlock.svg.192dpi.png" : "/Textures/Interface/VerbIcons/lock.svg.192dpi.png"
+            Icon = component.Locked ?
+                new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/unlock.svg.192dpi.png")) :
+                new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/lock.svg.192dpi.png")),
         };
         args.Verbs.Add(verb);
     }

--- a/Content.Shared/Verbs/Verb.cs
+++ b/Content.Shared/Verbs/Verb.cs
@@ -71,12 +71,7 @@ namespace Content.Shared.Verbs
         /// <summary>
         ///     Sprite of the icon that the user sees on the verb button.
         /// </summary>
-        [field: NonSerialized]
-        public SpriteSpecifier? Icon
-        {
-            get;
-            set;
-        }
+        public SpriteSpecifier? Icon;
 
         /// <summary>
         ///     Name of the category this button is under. Used to group verbs in the context menu.

--- a/Content.Shared/Verbs/Verb.cs
+++ b/Content.Shared/Verbs/Verb.cs
@@ -71,14 +71,12 @@ namespace Content.Shared.Verbs
         /// <summary>
         ///     Sprite of the icon that the user sees on the verb button.
         /// </summary>
+        [field: NonSerialized]
         public SpriteSpecifier? Icon
         {
-            get => _icon ??=
-                IconTexture == null ? null : new SpriteSpecifier.Texture(new ResourcePath(IconTexture));
-            set => _icon = value;
+            get;
+            set;
         }
-        [NonSerialized]
-        private SpriteSpecifier? _icon;
 
         /// <summary>
         ///     Name of the category this button is under. Used to group verbs in the context menu.
@@ -113,11 +111,6 @@ namespace Content.Shared.Verbs
         ///     Bigger is higher priority (appears first, gets executed preferentially).
         /// </remarks>
         public int Priority;
-
-        /// <summary>
-        ///     Raw texture path used to load the <see cref="Icon"/> for displaying on the client.
-        /// </summary>
-        public string? IconTexture;
 
         /// <summary>
         ///     If this is not null, and no icon or icon texture were specified, a sprite view of this entity will be
@@ -211,7 +204,7 @@ namespace Content.Shared.Verbs
             }
 
             // Finally, compare icon texture paths. Note that this matters for verbs that don't have any text (e.g., the rotate-verbs)
-            return string.Compare(IconTexture, otherVerb.IconTexture, StringComparison.CurrentCulture);
+            return string.Compare(Icon?.ToString(), otherVerb.Icon?.ToString(), StringComparison.CurrentCulture);
         }
 
         /// <summary>

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -35,7 +35,7 @@ public abstract partial class SharedGunSystem
         {
             Act = () => SelectFire(component, nextMode, args.User),
             Text = Loc.GetString("gun-selector-verb", ("mode", GetLocSelector(nextMode))),
-            IconTexture = "/Textures/Interface/VerbIcons/fold.svg.192dpi.png",
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/fold.svg.192dpi.png")),
         };
 
         args.Verbs.Add(verb);

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
@@ -60,7 +60,7 @@
     sentMessage: prayer-popup-notify-centcom-sent
     notifiactionPrefix: prayer-chat-notify-centcom
     verb: prayer-verbs-call
-    verbImage: ""
+    verbImage: null
 
 - type: entity
   parent: BaseHandheldInstrument
@@ -168,4 +168,4 @@
     sentMessage: prayer-popup-notify-honkmother-sent
     notifiactionPrefix: prayer-chat-notify-honkmother
     verb: prayer-verbs-call
-    verbImage: ""
+    verbImage: null


### PR DESCRIPTION
Shows up in console on first right-click. Checked the verb categories still worked ingame.
Also noticed an incorrect return in NetworkConfiguratorSystem.cs

:cl:
- fix: Fix console warnings about rsi sprite access
- fix: Fix issue with device configurators out of line-of-sight not closing properly.