### PR TITLE
Another round of DoAfter fixes

### DIFF
--- a/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
+++ b/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
@@ -88,7 +88,7 @@ namespace Content.IntegrationTests.Tests.DoAfter
             });
 
             await server.WaitRunTicks(3);
-            Assert.That(data.Cancelled, Is.False);
+            Assert.That(data.Cancelled, Is.True);
 
             await pairTracker.CleanReturnAsync();
         }

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -582,6 +582,7 @@ namespace Content.Server.Construction
             {
                 RaiseLocalEvent(args.Args.Target.Value, args.AdditionalData.CancelEvent);
                 args.Handled = true;
+                return;
             }
 
             RaiseLocalEvent(args.Args.Target.Value, args.AdditionalData.CompleteEvent);

--- a/Content.Server/Fluids/EntitySystems/MoppingSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/MoppingSystem.cs
@@ -270,7 +270,17 @@ public sealed class MoppingSystem : SharedMoppingSystem
 
     private void OnDoAfter(EntityUid uid, AbsorbentComponent component, DoAfterEvent<AbsorbantData> args)
     {
-        if (args.Handled || args.Cancelled || args.Args.Target == null)
+        if (args.Args.Target == null)
+            return;
+
+        if (args.Cancelled)
+        {
+            //Remove the interacting entities or else it breaks the mop
+            component.InteractingEntities.Remove(args.Args.Target.Value);
+            return;
+        }
+
+        if (args.Handled)
             return;
 
         _audio.PlayPvs(args.AdditionalData.Sound, uid);

--- a/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
@@ -73,12 +73,19 @@ namespace Content.Server.Kitchen.EntitySystems
             if (TryComp<ButcherableComponent>(args.Args.Target.Value, out var butcherable))
                 butcherable.BeingButchered = false;
 
-            if (args.Handled || args.Cancelled)
+            if (args.Cancelled)
+            {
+                component.InUse = false;
+                return;
+            }
+
+            if (args.Handled)
                 return;
 
             if (Spikeable(uid, args.Args.User, args.Args.Target.Value, component, butcherable))
                 Spike(uid, args.Args.User, args.Args.Target.Value, component);
 
+            component.InUse = false;
             args.Handled = true;
         }
 

--- a/Content.Server/Resist/CanEscapeInventoryComponent.cs
+++ b/Content.Server/Resist/CanEscapeInventoryComponent.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Content.Server.Resist;
 
 [RegisterComponent]
@@ -8,4 +10,9 @@ public sealed class CanEscapeInventoryComponent : Component
     /// </summary>
     [DataField("baseResistTime")]
     public float BaseResistTime = 5f;
+
+    [DataField("isEscaping")]
+    public bool IsEscaping;
+
+    public CancellationTokenSource? CancelToken;
 }

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Content.Server.DoAfter;
 using Content.Server.Contests;
 using Robust.Shared.Containers;
@@ -65,11 +66,16 @@ public sealed class EscapeInventorySystem : EntitySystem
 
     private void AttemptEscape(EntityUid user, EntityUid container, CanEscapeInventoryComponent component, float multiplier = 1f)
     {
+        if (component.IsEscaping)
+            return;
+
+        component.CancelToken = new CancellationTokenSource();
+        component.IsEscaping = true;
         var escapeEvent = new EscapeInventoryEvent();
-        var doAfterEventArgs = new DoAfterEventArgs(user, component.BaseResistTime * multiplier, target:container)
+        var doAfterEventArgs = new DoAfterEventArgs(user, component.BaseResistTime * multiplier, cancelToken: component.CancelToken.Token, target:container)
         {
             BreakOnTargetMove = false,
-            BreakOnUserMove = false,
+            BreakOnUserMove = true,
             BreakOnDamage = true,
             BreakOnStun = true,
             NeedHand = false
@@ -82,17 +88,26 @@ public sealed class EscapeInventorySystem : EntitySystem
 
     private void OnEscape(EntityUid uid, CanEscapeInventoryComponent component, DoAfterEvent<EscapeInventoryEvent> args)
     {
-        if (args.Handled || args.Cancelled)
+        if (args.Cancelled)
+        {
+            component.CancelToken = null;
+            component.IsEscaping = false;
+            return;
+        }
+
+        if (args.Handled)
             return;
 
         Transform(uid).AttachParentToContainerOrGrid(EntityManager);
 
+        component.CancelToken = null;
+        component.IsEscaping = false;
         args.Handled = true;
     }
 
     private void OnDropped(EntityUid uid, CanEscapeInventoryComponent component, DroppedEvent args)
     {
-        //TODO: Enter cancel logic here
+        component.CancelToken = null;
     }
 
     private sealed class EscapeInventoryEvent : EntityEventArgs

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -107,6 +107,7 @@ public sealed class EscapeInventorySystem : EntitySystem
 
     private void OnDropped(EntityUid uid, CanEscapeInventoryComponent component, DroppedEvent args)
     {
+        component.CancelToken?.Cancel();
         component.CancelToken = null;
     }
 

--- a/Content.Server/Resist/ResistLockerComponent.cs
+++ b/Content.Server/Resist/ResistLockerComponent.cs
@@ -18,8 +18,5 @@ public sealed class ResistLockerComponent : Component
     [ViewVariables]
     public bool IsResisting = false;
 
-    /// <summary>
-    /// Used to cancel the DoAfter when a locker is open
-    /// </summary>
-    public Shared.DoAfter.DoAfter? DoAfter;
+    public CancellationTokenSource? CancelToken;
 }

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -467,7 +467,7 @@ public sealed class WiresSystem : EntitySystem
         }
         else if (!component.IsScrewing && _toolSystem.HasQuality(args.Used, "Screwing", tool))
         {
-            var toolEvData = new ToolEventData(new WireToolFinishedEvent(uid, args.User));
+            var toolEvData = new ToolEventData(new WireToolFinishedEvent(uid, args.User), cancelledEv: new WireToolCanceledEvent(uid));
 
             component.IsScrewing = _toolSystem.UseTool(args.Used, args.User, uid, ScrewTime, new[] { "Screwing" }, toolEvData, toolComponent: tool);
             args.Handled = component.IsScrewing;

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -191,7 +191,6 @@ public abstract class SharedDoAfterSystem : EntitySystem
     private DoAfter CreateDoAfter(DoAfterEventArgs eventArgs)
     {
         // Setup
-        eventArgs.CancelToken = new CancellationToken();
         var doAfter = new DoAfter(eventArgs, EntityManager);
         // Caller's gonna be responsible for this I guess
         var doAfterComponent = Comp<DoAfterComponent>(eventArgs.User);

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -179,13 +179,11 @@ public abstract class SharedDoAfterSystem : EntitySystem
     ///     Use this if you don't have any extra data to send with the DoAfter
     /// </summary>
     /// <param name="eventArgs">The DoAfterEventArgs</param>
-    public DoAfter DoAfter(DoAfterEventArgs eventArgs)
+    public void DoAfter(DoAfterEventArgs eventArgs)
     {
         var doAfter = CreateDoAfter(eventArgs);
 
         doAfter.Done = cancelled => { Send(cancelled, eventArgs); };
-
-        return doAfter;
     }
 
     private DoAfter CreateDoAfter(DoAfterEventArgs eventArgs)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

closes #14289 

Walls and construction now properly cancel out of a doafter.
Cancelling screwing doors or anything with wires won't prevent further doafters from running anymore.
EscapeInventory can no longer spam and cancels on drop again.
Mopping won't break anymore if cancelled
Meatspikes won't break anymore on use or if cancelled.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Walls and construction now properly cancel out of a doafter.
- fix: Cancelling screwing doors or anything with wires won't prevent further doafters from running anymore.
- fix: EscapeInventory can no longer spam and cancels on drop again.
- fix: Mopping won't break anymore if cancelled
- fix: Meatspikes won't break anymore on use or if cancelled.