### PR TITLE
Don't spawn midi timer for inactive instruments

### DIFF
--- a/Content.Client/Instruments/InstrumentSystem.cs
+++ b/Content.Client/Instruments/InstrumentSystem.cs
@@ -109,10 +109,6 @@ public sealed class InstrumentSystem : SharedInstrumentSystem
         if (component is not InstrumentComponent instrument)
             return;
 
-        // Inactive
-        if (!instrument.IsInputOpen && !instrument.IsMidiOpen && instrument.Renderer == null)
-            return;
-
         if (instrument.IsInputOpen)
         {
             CloseInput(uid, fromStateChange, instrument);
@@ -131,7 +127,9 @@ public sealed class InstrumentSystem : SharedInstrumentSystem
 
         // We dispose of the synth two seconds from now to allow the last notes to stop from playing.
         // Don't use timers bound to the entity in case it is getting deleted.
-        Timer.Spawn(2000, () => { renderer?.Dispose(); });
+        if (renderer != null)
+            Timer.Spawn(2000, () => { renderer?.Dispose(); });
+
         instrument.Renderer = null;
         instrument.MidiEventBuffer.Clear();
 

--- a/Content.Client/Instruments/InstrumentSystem.cs
+++ b/Content.Client/Instruments/InstrumentSystem.cs
@@ -87,7 +87,7 @@ public sealed class InstrumentSystem : SharedInstrumentSystem
         if (!Resolve(uid, ref instrument) || instrument.Renderer == null)
             return;
 
-        instrument.Renderer.TrackingEntity = instrument.Owner;
+        instrument.Renderer.TrackingEntity = uid;
         instrument.Renderer.DisablePercussionChannel = !instrument.AllowPercussion;
         instrument.Renderer.DisableProgramChangeEvent = !instrument.AllowProgramChange;
 
@@ -107,6 +107,10 @@ public sealed class InstrumentSystem : SharedInstrumentSystem
             return;
 
         if (component is not InstrumentComponent instrument)
+            return;
+
+        // Inactive
+        if (!instrument.IsInputOpen && !instrument.IsMidiOpen && instrument.Renderer == null)
             return;
 
         if (instrument.IsInputOpen)

--- a/Content.Client/Instruments/InstrumentSystem.cs
+++ b/Content.Client/Instruments/InstrumentSystem.cs
@@ -128,7 +128,7 @@ public sealed class InstrumentSystem : SharedInstrumentSystem
         // We dispose of the synth two seconds from now to allow the last notes to stop from playing.
         // Don't use timers bound to the entity in case it is getting deleted.
         if (renderer != null)
-            Timer.Spawn(2000, () => { renderer?.Dispose(); });
+            Timer.Spawn(2000, () => { renderer.Dispose(); });
 
         instrument.Renderer = null;
         instrument.MidiEventBuffer.Clear();


### PR DESCRIPTION
@Zumorica not sure if this is the right way to do it; even if the instrument wasn't playing it'd still spawn the timer to dispose of it.