### PR TITLE
Fixed the wrapped nutribricks being 20$ instead of 50

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -307,6 +307,8 @@
       - id: FoodSnackNutribrickOpen
     sound:
       path: /Audio/Effects/unwrap.ogg
+  - type: StaticPrice
+    price: 20
 
 - type: entity
   id: FoodSnackNutribrickOpen
@@ -329,6 +331,8 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 25
+  - type: StaticPrice
+    price: -30
 
 - type: entity
   id: FoodSnackMREBrownie
@@ -346,6 +350,7 @@
       - id: FoodSnackMREBrownieOpen
     sound:
       path: /Audio/Effects/unwrap.ogg
+
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -308,7 +308,7 @@
     sound:
       path: /Audio/Effects/unwrap.ogg
   - type: StaticPrice
-    price: 20
+    price: 50
 
 - type: entity
   id: FoodSnackNutribrickOpen
@@ -331,8 +331,6 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 25
-  - type: StaticPrice
-    price: -30
 
 - type: entity
   id: FoodSnackMREBrownie


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
The nutribricks are actually supposed to be 50 spacebucks, so i simply increased the price of the wrapped nutribrick to match it.
I already double checked and the price of the MRE crate is still fair, costing 1000 to purchase and 960 to sell.
**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->


- fix: Fixed the price problem of wrapped nutribricks being worth 20$ instead of 50