### PR TITLE
Strip menu will no longer open when trying to wake sleeping players

### DIFF
--- a/Content.Server/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Server/Bed/Sleep/SleepingSystem.cs
@@ -148,10 +148,11 @@ namespace Content.Server.Bed.Sleep
         /// </summary>
         private void OnInteractHand(EntityUid uid, SleepingComponent component, InteractHandEvent args)
         {
+            args.Handled = true;
+
             if (!TryWakeCooldown(uid))
                 return;
 
-            args.Handled = true;
             TryWaking(args.Target, user: args.User);
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
(copying from my other pr since I had forgotten to merge upstream :p) I don't know if #14272 brought this with it or if it was there before. But it now should not jumpscare you with the strip menu if you try to wake someone up when clicking on them. 

Not sure if this should have a changelog but I'm adding one. Tell me to remove it if you don't think it needs it

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Vasilis
- fix: Strip menu won't open when trying to wake sleeping players.
