### PR TITLE
Prevent a possible future game state bug

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
@@ -26,7 +26,7 @@ using Robust.Shared.Utility;
 namespace Content.Server.Atmos.EntitySystems
 {
     [UsedImplicitly]
-    internal sealed class GasTileOverlaySystem : SharedGasTileOverlaySystem
+    public sealed class GasTileOverlaySystem : SharedGasTileOverlaySystem
     {
         [Robust.Shared.IoC.Dependency] private readonly IGameTiming _gameTiming = default!;
         [Robust.Shared.IoC.Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -65,6 +65,14 @@ namespace Content.Server.Atmos.EntitySystems
 
             SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<GasTileOverlayComponent, ComponentGetState>(OnGetState);
+            SubscribeLocalEvent<GasTileOverlayComponent, ComponentStartup>(OnStartup);
+        }
+
+        private void OnStartup(EntityUid uid, GasTileOverlayComponent component, ComponentStartup args)
+        {
+            // This **shouldn't** be required, but just in case we ever get entity prototypes that have gas overlays, we
+            // need to ensure that we send an initial full state to players.
+            Dirty(component);
         }
 
         public override void Shutdown()

--- a/Content.Shared/Decals/SharedDecalSystem.cs
+++ b/Content.Shared/Decals/SharedDecalSystem.cs
@@ -38,6 +38,10 @@ namespace Content.Shared.Decals
                     component.DecalIndex[decalUid] = indices;
                 }
             }
+
+            // This **shouldn't** be required, but just in case we ever get entity prototypes that have decal grids, we
+            // need to ensure that we send an initial full state to players.
+            Dirty(component);
         }
 
         protected Dictionary<Vector2i, DecalChunk>? ChunkCollection(EntityUid gridEuid, DecalGridComponent? comp = null)


### PR DESCRIPTION
Currently state handling will error if the client receives a component delta state without having ever received a full state. However the game state logic will avoid sending component states if an entity is unchanged from its prototype, as the client can just reconstruct those states by itself, meaning that it never sends an initial full state. So the combination of these two behaviours mean that either the get-state logic for components that use delta states has to be in shared code, or the server has to ensure that it always sends an initial state. 

Both of the described behaviours are desirable, but I can't think of a nice way to somehow ensure that this issue doesn't come up. Because of this, and some other issues, component delta states are just somewhat janky and prone to bugs if not properly used. If somebody can think of a fix or just a better way of implementing delta states, please help.

This PR just ensures that the server dirties decal & gas tile components on start-up, even though its not strictly required at the moment because because we have no entity prototype grids. 
