### PR TITLE
Fix wire components in admin testing arena

### DIFF
--- a/Resources/Maps/Test/admin_test_arena.yml
+++ b/Resources/Maps/Test/admin_test_arena.yml
@@ -1314,8 +1314,7 @@ entities:
 - uid: 155
   type: CableMV
   components:
-  - rot: 3.141592653589793 rad
-    pos: -8.5,6.5
+  - pos: -8.5,6.5
     parent: 104
     type: Transform
 - uid: 156


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Closes #14304 

Without the rot component on the top-left MV wire (under the substation) the admin arena can load correctly. The substation still works afterwards (when I empty the battery of the APC it's connected to, the APC immediately starts charging so obviously the MV wire is still functioning), and the MV wire visually connects to its neighboring wire correctly.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

