### PR TITLE
clipping and extracting put seeds in the users hands

### DIFF
--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -250,7 +250,7 @@ namespace Content.Server.Botany.Systems
                 }
 
                 component.Seed.Unique = false;
-                var seed = _botanySystem.SpawnSeedPacket(component.Seed, Transform(args.User).Coordinates);
+                var seed = _botanySystem.SpawnSeedPacket(component.Seed, Transform(args.User).Coordinates, args.User);
                 seed.RandomOffset(0.25f);
                 var displayName = Loc.GetString(component.Seed.DisplayName);
                 _popupSystem.PopupCursor(Loc.GetString("plant-holder-component-take-sample-message",
@@ -547,7 +547,8 @@ namespace Content.Server.Botany.Systems
             }
             else if (component.Age < 0) // Revert back to seed packet!
             {
-                _botanySystem.SpawnSeedPacket(component.Seed, Transform(uid).Coordinates);
+                // will put it in the trays hands if it has any, please do not try doing this
+                _botanySystem.SpawnSeedPacket(component.Seed, Transform(uid).Coordinates, uid);
                 RemovePlant(uid, component);
                 component.ForceUpdate = true;
                 Update(uid, component);

--- a/Content.Server/Botany/Systems/SeedExtractorSystem.cs
+++ b/Content.Server/Botany/Systems/SeedExtractorSystem.cs
@@ -50,7 +50,7 @@ public sealed class SeedExtractorSystem : EntitySystem
 
         for (var i = 0; i < amount; i++)
         {
-            _botanySystem.SpawnSeedPacket(seed, coords);
+            _botanySystem.SpawnSeedPacket(seed, coords, args.User);
         }
     }
 


### PR DESCRIPTION
## About the PR
instead of the breab baking shuffle:
1. clip plant
2. move a bit
3. pick up seed packet

you now just clip it and the seed goes in your other hand

also when you extract seeds they will try to fill your hands if possible.

**Media**

https://user-images.githubusercontent.com/39013340/222389257-eb899285-5529-434c-8a97-dc2b6c45ae06.mp4



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Clipping a plant puts the seed packet in your hands instead of on the floor.
- tweak: Extracting seeds now tries to put the packets in your hands.
