### PR TITLE
Added orderable crates for various light tubes

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/service-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/service-crates.ftl
@@ -4,6 +4,15 @@ ent-CrateServiceJanitorialSupplies = Janitorial supplies crate
 ent-CrateServiceReplacementLights = Replacement lights crate
     .desc = May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs.
 
+ent-CrateServiceLedLights = LED lights crate
+    .desc = May the light of Aether shine upon this station! Those lights are extra-bright.
+
+ent-CrateServiceExteriorLights = Exterior lights crate
+    .desc = May the light of Aether shine upon this station! Now with a blue tint.
+
+ent-CrateServiceSodiumLights = Sodium lights crate
+    .desc = May the light of Aether shine upon this station! Now with a orange tint.
+
 ent-CrateMousetrapBoxes = Mousetraps crate
     .desc = Mousetraps, for when all of service is being haunted by an entire horde of rats. Use sparingly... or not.
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -19,6 +19,36 @@
   group: market
 
 - type: cargoProduct
+  id: ServiceLightsLed
+  icon:
+    sprite: Objects/Power/light_bulb.rsi
+    state: normal
+  product: CrateServiceLedLights
+  cost: 500
+  category: Service
+  group: market
+
+- type: cargoProduct
+  id: ServiceLightsExterior
+  icon:
+    sprite: Objects/Power/light_bulb.rsi
+    state: normal
+  product: CrateServiceExteriorLights
+  cost: 500
+  category: Service
+  group: market
+
+- type: cargoProduct
+  id: ServiceLightsSodium
+  icon:
+    sprite: Objects/Power/light_bulb.rsi
+    state: normal
+  product: CrateServiceSodiumLights
+  cost: 500
+  category: Service
+  group: market
+
+- type: cargoProduct
   id: MousetrapBoxes
   icon:
     sprite: Objects/Devices/mousetrap.rsi

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -69,6 +69,36 @@
       - DroneUsable
 
 - type: entity
+  name: led lighttube box
+  parent: BoxLighttube
+  id: BoxLedLighttube
+  components:
+  - type: StorageFill
+    contents:
+      - id: LedLightTube
+        amount: 12
+
+- type: entity
+  name: exterior lighttube box
+  parent: BoxLighttube
+  id: BoxExteriorLighttube
+  components:
+  - type: StorageFill
+    contents:
+      - id: ExteriorLightTube
+        amount: 12
+
+- type: entity
+  name: sodium lighttube box
+  parent: BoxLighttube
+  id: BoxSodiumLighttube
+  components:
+  - type: StorageFill
+    contents:
+      - id: SodiumLightTube
+        amount: 12
+
+- type: entity
   name: mixed lights box
   parent: BoxCardboard
   id: BoxLightMixed

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -21,13 +21,40 @@
 
 - type: entity
   id: CrateServiceReplacementLights
-  parent: CrateGenericSteel
+  parent: CratePlastic
   components:
   - type: StorageFill
     contents:
       - id: BoxLighttube
         amount: 1
       - id: BoxLightbulb
+        amount: 1
+
+- type: entity
+  id: CrateServiceLedLights
+  parent: CrateServiceReplacementLights
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxLedLighttube
+        amount: 1
+
+- type: entity
+  id: CrateServiceExteriorLights
+  parent: CrateServiceReplacementLights
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxExteriorLighttube
+        amount: 1
+
+- type: entity
+  id: CrateServiceSodiumLights
+  parent: CrateServiceReplacementLights
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxSodiumLighttube
         amount: 1
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

In response to #11303

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: LED, exterior, and sodium light tubes now can be ordered from cargo
