### PR TITLE
Tile fixes

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -9,12 +9,10 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Maps
 {
-    [UsedImplicitly]
     [Prototype("tile")]
     public sealed class ContentTileDefinition : IPrototype, IInheritingPrototype, ITileDefinition
     {
         public const string SpaceID = "Space";
-        private string _name = string.Empty;
 
         [ParentDataFieldAttribute(typeof(AbstractPrototypeIdArraySerializer<ContentTileDefinition>))]
         public string[]? Parents { get; private set; }
@@ -53,7 +51,7 @@ namespace Content.Shared.Maps
         /// </summary>
         [DataField("barestepSounds")] public SoundSpecifier? BarestepSounds { get; } = new SoundCollectionSpecifier("BarestepHard");
 
-        [DataField("friction")] public float Friction { get; set; }
+        [DataField("friction")] public float Friction { get; set; } = 0.3f;
 
         [DataField("variants")] public byte Variants { get; set; } = 1;
 
@@ -62,7 +60,7 @@ namespace Content.Shared.Maps
         /// </summary>
         [DataField("placementVariants")] public byte[] PlacementVariants { get; set; } = new byte[1] { 0 };
 
-        [DataField("thermalConductivity")] public float ThermalConductivity { get; set; } = 0.05f;
+        [DataField("thermalConductivity")] public float ThermalConductivity = 0.04f;
 
         // Heat capacity is opt-in, not opt-out.
         [DataField("heatCapacity")] public float HeatCapacity = Atmospherics.MinimumHeatCapacity;

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -10,9 +10,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -27,9 +25,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -44,9 +40,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -61,9 +55,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -78,9 +70,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -97,7 +87,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -114,7 +103,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -131,7 +119,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -148,7 +135,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -163,9 +149,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemSteel
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -182,9 +166,7 @@
     collection: FootstepWood
   barestepSounds:
     collection: BarestepWood
-  friction: 0.30
   itemDrop: FloorTileItemWood
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -201,7 +183,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -218,7 +199,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -235,7 +215,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -252,7 +231,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -269,7 +247,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -286,7 +263,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -303,7 +279,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -320,7 +295,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -337,7 +311,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -354,7 +327,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -369,9 +341,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -386,9 +356,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -403,9 +371,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -420,9 +386,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -439,7 +403,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -456,7 +419,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -473,7 +435,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -490,7 +451,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -507,7 +467,6 @@
     collection: FootstepTile
   friction: 0.25
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -522,9 +481,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemDark
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -537,9 +494,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepHull
-  friction: 0.30
   itemDrop: FloorTileItemTechmaint
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -552,9 +507,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepHull
-  friction: 0.30
   itemDrop: FloorTileItemReinforced
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -567,9 +520,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemMono
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -582,9 +533,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemLino
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -597,9 +546,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepPlating
-  friction: 0.30
   itemDrop: FloorTileItemDirty
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -612,9 +559,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepHull
-  friction: 0.30
   itemDrop: FloorTileItemElevatorShaft
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -627,9 +572,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepHull
-  friction: 0.30
   itemDrop: FloorTileItemMetalDiamond
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -642,9 +585,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
   itemDrop: FloorTileItemRockVault
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -657,9 +598,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemBlue
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 # Departamental
@@ -673,9 +612,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepHull
-  friction: 0.30
   itemDrop: FloorTileItemFreezer
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -688,9 +625,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemShowroom
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -703,9 +638,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemHydro
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -720,9 +653,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemBar
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -735,9 +666,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemClown
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -750,9 +679,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemMime
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -765,9 +692,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemKitchen
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -780,9 +705,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemLaundry
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 # Carpets (non smoothing)
@@ -800,7 +723,6 @@
     collection: BarestepCarpet
   friction: 0.40
   itemDrop: FloorTileItemArcadeBlue
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -817,7 +739,6 @@
     collection: BarestepCarpet
   friction: 0.40
   itemDrop: FloorTileItemArcadeBlue2
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -834,7 +755,6 @@
     collection: BarestepCarpet
   friction: 0.40
   itemDrop: FloorTileItemArcadeRed
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -851,7 +771,6 @@
     collection: BarestepCarpet
   friction: 0.40
   itemDrop: FloorTileItemEighties
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -868,7 +787,6 @@
     collection: BarestepCarpet
   friction: 0.40
   itemDrop: FloorTileItemCarpetClown
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -885,7 +803,6 @@
     collection: BarestepCarpet
   friction: 0.40
   itemDrop: FloorTileItemCarpetOffice
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -902,7 +819,6 @@
     collection: FootstepFloor
   friction: 0.40
   itemDrop: FloorTileItemBoxing
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -919,7 +835,6 @@
     collection: FootstepFloor
   friction: 0.40
   itemDrop: FloorTileItemGym
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 # Shuttle
@@ -933,9 +848,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemShuttleWhite
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -948,9 +861,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemShuttleBlue
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -963,9 +874,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemShuttleOrange
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -978,9 +887,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemShuttlePurple
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -993,9 +900,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepFloor
-  friction: 0.30
   itemDrop: FloorTileItemShuttleRed
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 
@@ -1010,9 +915,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemGold
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -1025,9 +928,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: FloorTileItemSilver
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -1040,9 +941,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: SheetGlass1
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -1055,9 +954,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepTile
-  friction: 0.30
   itemDrop: SheetRGlass1
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 # Circuits
@@ -1071,9 +968,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepHull
-  friction: 0.30
   itemDrop: FloorTileItemGCircuit
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -1086,9 +981,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepHull
-  friction: 0.30
   itemDrop: FloorTileItemBCircuit
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 # Terrain
@@ -1102,9 +995,7 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepGrass
-  friction: 0.30
   itemDrop: FloorTileItemGrass
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1118,9 +1009,7 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepGrass
-  friction: 0.30
   itemDrop: FloorTileItemGrassJungle
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1136,8 +1025,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepGrass
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1153,8 +1040,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepGrass
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1170,8 +1055,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1186,8 +1069,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1201,8 +1082,6 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1218,8 +1097,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1245,8 +1122,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1260,8 +1135,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1275,8 +1148,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1290,8 +1161,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1305,8 +1174,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -1323,8 +1190,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -1339,8 +1204,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -1356,7 +1219,6 @@
   footstepSounds:
     collection: BarestepCarpet
   friction: 0.20 #slippy
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -1369,9 +1231,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepHull
-  friction: 0.30
   itemDrop: FloorTileItemSteelMaint
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -1386,9 +1246,7 @@
   canCrowbar: true
   footstepSounds:
     collection: FootstepHull
-  friction: 0.30
   itemDrop: FloorTileItemGratingMaint
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -1405,7 +1263,5 @@
     collection: FootstepWood
   barestepSounds:
     collection: BarestepWood
-  friction: 0.30
   itemDrop: FloorTileItemWoodPattern
-  thermalConductivity: 0.04
   heatCapacity: 10000

--- a/Resources/Prototypes/Tiles/planet.yml
+++ b/Resources/Prototypes/Tiles/planet.yml
@@ -1,3 +1,16 @@
+- type: tile
+  id: FloorPlanetDirt
+  name: tiles-dirt-floor
+  sprite: /Textures/Tiles/dirt.png
+  variants: 4
+  placementVariants: [0, 1, 2, 3]
+  isSubfloor: true
+  canCrowbar: false
+  footstepSounds:
+    collection: FootstepAsteroid
+  heatCapacity: 10000
+  weather: true
+
 # Desert
 - type: tile
   id: FloorDesert
@@ -9,8 +22,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -24,8 +35,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -41,14 +50,12 @@
   cardinalSprites:
   - /Textures/Tiles/Planet/Grass/double_edge.png
   baseTurfs:
-  - FloorDirt
+  - FloorPlanetDirt
   isSubfloor: true
   canCrowbar: false
   footstepSounds:
     collection: FootstepGrass
-  friction: 0.30
   itemDrop: FloorTileItemGrass
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -61,8 +68,6 @@
   canCrowbar: false
   footstepSounds:
     collection: FootstepAsteroid
-  friction: 0.30
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 
@@ -82,7 +87,6 @@
   footstepSounds:
     collection: FootstepSnow
   friction: 0.20
-  thermalConductivity: 0.04
   heatCapacity: 10000
   weather: true
 

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -8,7 +8,6 @@
   footstepSounds:
     collection: FootstepPlating
   friction: 0.5
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 - type: tile
@@ -24,7 +23,6 @@
   friction: 0.5
   isSpace: true
   itemDrop: PartRodMetal1
-  thermalConductivity: 0.04
   heatCapacity: 10000
 
 # The final step in underplating's deprecation before it gets completely wiped from the codebase.

--- a/Resources/Prototypes/biomes.yml
+++ b/Resources/Prototypes/biomes.yml
@@ -97,7 +97,7 @@
     # Fill remainder with sand.
     - !type:BiomeTileLayer
       threshold: 0
-      tile: FloorAsteroidSand
+      tile: FloorPlanetDirt
     - !type:BiomeTileLayer
       threshold: 0.5
       tile: FloorPlanetGrass


### PR DESCRIPTION
- Set some of the defaults in the definition to what we use for most prototypes
- Added planet variant for dirt to avoid black space
- Dirt looks like literal poop but will have another sprite for it soon

:cl:
- fix: Fix breaking planet tiles leading to the void.