### PR TITLE
make pins 1 size

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -1,5 +1,14 @@
 - type: entity
   parent: ClothingNeckBase
+  id: ClothingNeckPinBase
+  name: pin
+  description: be nothing do crime
+  components:
+  - type: Item
+    size: 1
+
+- type: entity
+  parent: ClothingNeckPinBase
   id: ClothingNeckLGBTPin
   name: LGBT pin
   description: be gay do crime
@@ -15,7 +24,7 @@
       - state: lgbt-equipped
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckPinBase
   id: ClothingNeckAromanticPin
   name: aromantic pin
   description: be aro do crime
@@ -31,7 +40,7 @@
       - state: aro-equipped
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckPinBase
   id: ClothingNeckAsexualPin
   name: asexual pin
   description: be ace do crime
@@ -47,7 +56,7 @@
       - state: asex-equipped
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckPinBase
   id: ClothingNeckBisexualPin
   name: bisexual pin
   description: be bi do crime
@@ -63,7 +72,7 @@
       - state: bi-equipped
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckPinBase
   id: ClothingNeckIntersexPin
   name: intersex pin
   description: be intersex do crime
@@ -79,7 +88,7 @@
       - state: inter-equipped
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckPinBase
   id: ClothingNeckLesbianPin
   name: lesbian pin
   description: be lesbian do crime
@@ -95,7 +104,7 @@
       - state: les-equipped
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckPinBase
   id: ClothingNeckNonBinaryPin
   name: non-binary pin
   description: "01100010 01100101 00100000 01100101 01101110 01100010 01111001 00100000 01100100 01101111 00100000 01100011 01110010 01101001 01101101 01100101"
@@ -111,7 +120,7 @@
       - state: non-equipped
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckPinBase
   id: ClothingNeckPansexualPin
   name: pansexual pin
   description: be pan do crime
@@ -127,7 +136,7 @@
       - state: pan-equipped
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckPinBase
   id: ClothingNeckTransPin
   name: transgender pin
   description: be trans do crime

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -1,6 +1,7 @@
 - type: entity
   parent: ClothingNeckBase
   id: ClothingNeckPinBase
+  abstract: true
   name: pin
   description: be nothing do crime
   components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

cause it's dumb for pins to be size 10

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: eclips_e
- fix: Pins no longer weigh as much as a crowbar
