### PR TITLE
Comfy Chair and Pilot Seat steel reduction

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
@@ -34,12 +34,12 @@
         - to: chairComfy
           steps:
             - material: Steel
-              amount: 5
+              amount: 2
               doAfter: 1
         - to: chairPilotSeat
           steps:
             - material: Steel
-              amount: 5
+              amount: 2
               doAfter: 1
         - to: chairWood
           steps:
@@ -118,11 +118,11 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
-              amount: 5
+              amount: 2
           steps:
             - tool: Screwing
               doAfter: 1
-              
+
     - node: chairPilotSeat
       entity: ChairPilotSeat
       edges:
@@ -130,7 +130,7 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
-              amount: 5
+              amount: 2
           steps:
             - tool: Screwing
               doAfter: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Simply changes the cost of making comfy chairs and pilot chairs to 2 steel from 5. Also returns 2 steel when deconstructed.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Alekshhh
- tweak: Changed comfy chair and pilot seat crafting cost and yield.
