### PR TITLE
Remove use delay cancellation tokens

### DIFF
--- a/Content.Shared/Timing/UseDelayComponent.cs
+++ b/Content.Shared/Timing/UseDelayComponent.cs
@@ -25,9 +25,7 @@ namespace Content.Shared.Timing
         [DataField("remainingDelay")]
         public TimeSpan? RemainingDelay;
 
-        public CancellationTokenSource? CancellationTokenSource;
-
-        public bool ActiveDelay => CancellationTokenSource is { Token: { IsCancellationRequested: false } };
+        public bool ActiveDelay => DelayEndTime != null;
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
They don't really work with client-side prediction and are currently unused. Fixes #14340