### PR TITLE
Fix appearance system

### DIFF
--- a/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
@@ -68,14 +68,14 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
             return;
         }
 
-        if (!_appearance.TryGetData<Color>(uid, PipeColorVisuals.Color, out var color, args.Component))
-            color = Color.White;
-
         if (!_appearance.TryGetData<PipeDirection>(uid, PipeVisuals.VisualState, out var worldConnectedDirections, args.Component))
         {
             HideAllPipeConnection(args.Sprite);
             return;
         }
+
+        if (!_appearance.TryGetData<Color>(uid, PipeColorVisuals.Color, out var color, args.Component))
+            color = Color.White;
 
         // transform connected directions to local-coordinates
         var connectedDirections = worldConnectedDirections.RotatePipeDirection(-Transform(uid).LocalRotation);

--- a/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
@@ -44,6 +44,18 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
         }
     }
 
+    private void HideAllPipeConnection(SpriteComponent sprite)
+    {
+        foreach (PipeConnectionLayer layerKey in Enum.GetValues(typeof(PipeConnectionLayer)))
+        {
+            if (!sprite.LayerMapTryGet(layerKey, out var key))
+                continue;
+
+            var layer = sprite[key];
+            layer.Visible = false;
+        }
+    }
+
     private void OnAppearanceChanged(EntityUid uid, PipeAppearanceComponent component, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -60,7 +72,10 @@ public sealed class AtmosPipeAppearanceSystem : EntitySystem
             color = Color.White;
 
         if (!_appearance.TryGetData<PipeDirection>(uid, PipeVisuals.VisualState, out var worldConnectedDirections, args.Component))
+        {
+            HideAllPipeConnection(args.Sprite);
             return;
+        }
 
         // transform connected directions to local-coordinates
         var connectedDirections = worldConnectedDirections.RotatePipeDirection(-Transform(uid).LocalRotation);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

The entity spawn menu was the only case where there was a pipe without any PipeVisuals.VisualState. Before this patch, all pipeConnector were displayed at the same time.

**Media**

https://user-images.githubusercontent.com/32521367/222984910-1a347075-7996-44e7-a1f9-828ee2d9b759.mp4



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Fixed entity spawn menu preview for pipes
