### PR TITLE
Fix reset ghost preview when a craft is selected

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -286,7 +286,14 @@ namespace Content.Client.Construction.UI
 
         private void UpdateGhostPlacement()
         {
-            if (_selected == null || _selected.Type != ConstructionType.Structure) return;
+            if (_selected == null)
+                return;
+
+            if (_selected.Type != ConstructionType.Structure)
+            {
+                _placementManager.Clear();
+                return;
+            }
 
             var constructSystem = _systemManager.GetEntitySystem<ConstructionSystem>();
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The ghost preview wasn't reset when selecting a craft.


**Media**
Before:

https://user-images.githubusercontent.com/32521367/223180854-f99f65aa-54ff-4f5e-95a9-212b242b823f.mp4

After:

https://user-images.githubusercontent.com/32521367/223180876-0a5a56d9-b86d-4efa-9591-1f9d492ada3f.mp4



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: (Construction Menu) Reset ghost preview when selecting a craft
