### PR TITLE
Fix access mispredicts when having a remote in hand

### DIFF
--- a/Content.Server/Access/Systems/AgentIDCardSystem.cs
+++ b/Content.Server/Access/Systems/AgentIDCardSystem.cs
@@ -1,10 +1,9 @@
-using Content.Shared.Access.Components;
 using Content.Server.Access.Components;
-using Content.Shared.Access.Systems;
-using Content.Shared.Interaction;
 using Content.Server.Popups;
 using Content.Server.UserInterface;
-using Robust.Shared.Player;
+using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems;
+using Content.Shared.Interaction;
 using Robust.Server.GameObjects;
 
 namespace Content.Server.Access.Systems
@@ -42,11 +41,15 @@ namespace Content.Server.Access.Systems
                 _popupSystem.PopupEntity(Loc.GetString("agent-id-no-new", ("card", args.Target)), args.Target.Value, args.User);
                 return;
             }
-            else if (addedLength == 1)
+
+            Dirty(access);
+
+            if (addedLength == 1)
             {
                 _popupSystem.PopupEntity(Loc.GetString("agent-id-new-1", ("card", args.Target)), args.Target.Value, args.User);
                 return;
             }
+
             _popupSystem.PopupEntity(Loc.GetString("agent-id-new", ("number", addedLength), ("card", args.Target)), args.Target.Value, args.User);
         }
 

--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Kitchen.Components;
 using Content.Server.Popups;
@@ -6,10 +7,8 @@ using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Database;
 using Content.Shared.Popups;
-using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using System.Linq;
 
 namespace Content.Server.Access.Systems
 {
@@ -57,7 +56,10 @@ namespace Content.Server.Access.Systems
                 if (randomPick <= 0.25f)
                 {
                     _popupSystem.PopupEntity(Loc.GetString("id-card-component-microwave-bricked", ("id", uid)), uid);
+
                     access.Tags.Clear();
+                    Dirty(access);
+
                     _adminLogger.Add(LogType.Action, LogImpact.Medium,
                         $"{ToPrettyString(args.Microwave)} cleared access on {ToPrettyString(uid):entity}");
                 }
@@ -68,7 +70,9 @@ namespace Content.Server.Access.Systems
 
                 // Give them a wonderful new access to compensate for everything
                 var random = _random.Pick(_prototypeManager.EnumeratePrototypes<AccessLevelPrototype>().ToArray());
+
                 access.Tags.Add(random.ID);
+                Dirty(access);
 
                 _adminLogger.Add(LogType.Action, LogImpact.Medium,
                         $"{ToPrettyString(args.Microwave)} added {random.ID} access to {ToPrettyString(uid):entity}");

--- a/Content.Shared/Access/Systems/SharedAccessSystem.cs
+++ b/Content.Shared/Access/Systems/SharedAccessSystem.cs
@@ -48,6 +48,7 @@ namespace Content.Shared.Access.Systems
                     continue;
 
                 component.Tags.UnionWith(proto.Tags);
+                Dirty(component);
             }
         }
 
@@ -111,6 +112,7 @@ namespace Content.Shared.Access.Systems
 
             access.Tags.Clear();
             access.Tags.UnionWith(prototype.Access);
+            Dirty(access);
 
             TryAddGroups(uid, prototype.AccessGroups, access);
 


### PR DESCRIPTION
## About the PR
Fixes https://github.com/space-wizards/space-station-14/issues/14397
MapInitEvent is not run on the client so the tags were never getting synced.

**Media**

https://user-images.githubusercontent.com/10968691/223205025-bcf2a7cd-7c23-48d3-90a4-1c33abf27c63.mp4


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fix incorrect access denied popup when trying to open a locker with a remote in hand,
