### PR TITLE
make harmonica take mask slot

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
@@ -58,6 +58,8 @@
   components:
   - type: Instrument
     program: 22
+  - type: ActivatableUI
+    inHandsOnly: false
   - type: Sprite
     sprite: Objects/Fun/Instruments/harmonica.rsi
     state: icon
@@ -67,6 +69,16 @@
   - type: Tag
     tags:
     - WoodwindInstrument
+  - type: Clothing
+    slots: [ mask ]
+  - type: IngestionBlocker
+  - type: Mask
+    toggleAction:
+      name: action-name-mask
+      description: action-description-mask-toggle
+      icon: { sprite: Clothing/Mask/gas.rsi, state: icon }
+      iconOn: Interface/Default/blocked.png
+      event: !type:ToggleMaskEvent
 
 - type: entity
   parent: BaseHandheldInstrument


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Per Beridot from #ideaguys, make harmonica equipable in mask slot, so players can play it hands free.
It also blocks eating and drinking while on.
Still needs:
harmonica mask sprite
**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://user-images.githubusercontent.com/31364560/223309580-0d2364dc-139c-4a42-8528-e0390a750163.mp4


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: furontier
- tweak: Spessmen now knows how to play harmonica without holding them in hand! Live out your inner blues!
