### PR TITLE
Stimpacks 1.1 - Intended Behavior Edition

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -170,6 +170,11 @@
         reagents:
         - ReagentId: Stimulants
           Quantity: 60
+  - type: Hypospray
+    solutionName: pen
+    transferAmount: 60
+  - type: StaticPrice
+    price: 500
   - type: Tag
     tags: []
     
@@ -189,6 +194,8 @@
         reagents:
         - ReagentId: Stimulants
           Quantity: 15
+  - type: StaticPrice
+    price: 100
   - type: Tag
     tags: []
     
@@ -208,6 +215,11 @@
         reagents:
         - ReagentId: ExperimentalStimulants
           Quantity: 60
+  - type: Hypospray
+    solutionName: pen
+    transferAmount: 60
+  - type: StaticPrice
+    price: 1000
   - type: Tag
     tags: []
 

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -97,7 +97,7 @@
   name: reagent-name-stimulants
   group: Narcotics
   desc: reagent-desc-stimulants
-  physicalDesc: reagant-physical-desc-energized
+  physicalDesc: reagant-physical-desc-energizing
   flavor: sharp
   color: "#9A040E"
   boilingPoint: 212.0
@@ -160,11 +160,17 @@
       - !type:MovespeedModifier # nyoom
         walkSpeedModifier: 1.8
         sprintSpeedModifier: 1.8
+      - !type:MovespeedModifier # antinyoom
+        walkSpeedModifier: 0.7
+        sprintSpeedModifier: 0.7
+        conditions:
+          - !type:ReagentThreshold
+            max: 10 # ghetto withdrawal
       - !type:Electrocute
         conditions:
           - !type:ReagentThreshold
             max: 10 # ghetto withdrawal effect
-        probability: 0.3 # get stunlocked nerd
+        probability: 0.05 # get stunlocked nerd
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -175,6 +181,15 @@
           max: 10 # ghetto withdrawal
         key: Stutter
         component: StutteringAccent
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          max: 10 # ghetto withdrawal
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 1.5
+        refresh: false
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
@@ -185,7 +200,7 @@
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
-            min: 60.1 #so nukies don't take a tick of 8 poison damage when it first gets injected
+            min: 60
         damage:
           types:
             Poison: 8 # TODO this should ideally kill your liver instead

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -158,14 +158,17 @@
       metabolismRate: 0.25 # lasts for 4 minutes instead of 5
       effects:
       - !type:MovespeedModifier # nyoom
+        conditions:
+          - !type:ReagentThreshold
+            min: 10
         walkSpeedModifier: 1.8
         sprintSpeedModifier: 1.8
       - !type:MovespeedModifier # antinyoom
-        walkSpeedModifier: 0.7
-        sprintSpeedModifier: 0.7
         conditions:
           - !type:ReagentThreshold
             max: 10 # ghetto withdrawal
+        walkSpeedModifier: 0.7
+        sprintSpeedModifier: 0.7
       - !type:Electrocute
         conditions:
           - !type:ReagentThreshold
@@ -232,7 +235,7 @@
           - !type:ReagentThreshold
             min: 10
           damage:
-            types:
+            groups:
               Brute: -4
               Burn: -4
         # stops CMOs from hypoing you with lexorin and sec from filling you with tranq shells

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -111,8 +111,8 @@
         sprintSpeedModifier: 1.3
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 80 #please wait 3 minutes before using another stimpack
+        - !type:ReagentThreshold
+          min: 80 #please wait 3 minutes before using another stimpack
         damage:
           types:
             Poison: 1
@@ -159,20 +159,20 @@
       effects:
       - !type:MovespeedModifier # nyoom
         conditions:
-          - !type:ReagentThreshold
-            min: 10
+        - !type:ReagentThreshold
+          min: 10
         walkSpeedModifier: 1.8
         sprintSpeedModifier: 1.8
       - !type:MovespeedModifier # antinyoom
         conditions:
-          - !type:ReagentThreshold
-            max: 10 # ghetto withdrawal
+        - !type:ReagentThreshold
+          max: 10 # ghetto withdrawal
         walkSpeedModifier: 0.7
         sprintSpeedModifier: 0.7
       - !type:Electrocute
         conditions:
-          - !type:ReagentThreshold
-            max: 10 # ghetto withdrawal effect
+        - !type:ReagentThreshold
+          max: 10 # ghetto withdrawal effect
         probability: 0.05 # get stunlocked nerd
       - !type:Jitter
         conditions:
@@ -195,30 +195,30 @@
         refresh: false
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 10
+        - !type:ReagentThreshold
+          min: 10
         damage:
           types:
             Poison: 1 # You will be laying on the floor in crit in 100 seconds if you don't have antitoxin meds (Ideally this should deal twice as much damage but since nukies don't have access to stellbinin it would kill them)
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 60
+        - !type:ReagentThreshold
+          min: 60
         damage:
           types:
             Poison: 8 # TODO this should ideally kill your liver instead
       # effectively negates stamcrits
       - !type:GenericStatusEffect
         conditions:
-          - !type:ReagentThreshold
-            min: 10
+        - !type:ReagentThreshold
+          min: 10
         key: Stun
         time: 6
         type: Remove
       - !type:GenericStatusEffect
         conditions:
-          - !type:ReagentThreshold
-            min: 10
+        - !type:ReagentThreshold
+          min: 10
         key: KnockedDown
         time: 6
         type: Remove


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
whoops

this PR fixes:
- stimpacks not injecting their entire contents
- stimulants having a missing description
- no threshold on experimental stimpack movement speed
- being effectively stunlocked during experimental stimulant "withdrawal"
- experimental stimulants not actually healing brute and burn damage, since I classified them as types, not groups (why linter didnt throw an error for this I have no idea)
- all the indentation inconsistencies

yes yes webedit I know I just want this fixed

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Donk Co. has addressed the formula errors and faulty injection needles in the line of stimpack products, returning them to their previously intended behaviors. We apologize for the inconvenience.

