### PR TITLE
Fix cardboard box remote control exploits

### DIFF
--- a/Content.Server/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Server/CardboardBox/CardboardBoxSystem.cs
@@ -59,8 +59,6 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
             }
         }
 
-        component.Mover = null;
-
         // If this box has a stealth/chameleon effect, disable the stealth effect while the box is open.
         _stealth.SetEnabled(uid, false);
     }

--- a/Content.Server/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Server/CardboardBox/CardboardBoxSystem.cs
@@ -32,6 +32,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         SubscribeLocalEvent<CardboardBoxComponent, StorageAfterCloseEvent>(AfterStorageClosed);
         SubscribeLocalEvent<CardboardBoxComponent, InteractedNoHandEvent>(OnNoHandInteracted);
         SubscribeLocalEvent<CardboardBoxComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
+        SubscribeLocalEvent<CardboardBoxComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
 
         SubscribeLocalEvent<CardboardBoxComponent, DamageChangedEvent>(OnDamage);
     }
@@ -50,7 +51,6 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         //Remove the mover after the box is opened and play the effect if it hasn't been played yet.
         if (component.Mover != null)
         {
-            RemComp<RelayInputMoverComponent>(component.Mover.Value);
             if (_timing.CurTime > component.EffectCooldown)
             {
                 RaiseNetworkEvent(new PlayBoxEffectMessage(component.Owner, component.Mover.Value), Filter.PvsExcept(component.Owner));
@@ -101,5 +101,18 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         var relay = EnsureComp<RelayInputMoverComponent>(args.Entity);
         _mover.SetRelay(args.Entity, uid, relay);
         component.Mover = args.Entity;
+    }
+
+    /// <summary>
+    /// Through e.g. teleporting, it's possible for the mover to exit the box without opening it.
+    /// Handle those situations but don't play the sound.
+    /// </summary>
+    private void OnEntRemoved(EntityUid uid, CardboardBoxComponent component, EntRemovedFromContainerMessage args)
+    {
+        if (args.Entity != component.Mover)
+            return;
+
+        RemComp<RelayInputMoverComponent>(component.Mover.Value);
+        component.Mover = null;
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
It assumes that opening the box is the only way the box's mover can exit the box. If you have some method of teleportation, or entering another container inside the box, or anything that will change your parent container from the box, currently it will let you keep controlling the box.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Rane
- fix: Fixed exploits that would let you continue controlling a cardboard box after exiting it.
