### PR TITLE
Fixed forensic scanner being able to break open locked lockers

### DIFF
--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -69,7 +69,7 @@ public sealed class ResistLockerSystem : EntitySystem
 
     private void OnDoAfter(EntityUid uid, ResistLockerComponent component, DoAfterEvent args)
     {
-        if (args.Cancelled)
+        if (args.Cancelled & component.IsResisting == true)
         {
             component.IsResisting = false;
             component.CancelToken = null;

--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -69,7 +69,7 @@ public sealed class ResistLockerSystem : EntitySystem
 
     private void OnDoAfter(EntityUid uid, ResistLockerComponent component, DoAfterEvent args)
     {
-        if (args.Cancelled)
+        if (args.Cancelled || args.Args.User == uid)
         {
             component.IsResisting = false;
             component.CancelToken = null;
@@ -77,6 +77,8 @@ public sealed class ResistLockerSystem : EntitySystem
             return;
         }
 
+        if (args.Args.User != uid)
+            return;
         if (args.Handled || args.Args.Target == null)
             return;
 

--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -77,9 +77,7 @@ public sealed class ResistLockerSystem : EntitySystem
             return;
         }
 
-        if (args.Args.User != uid)
-            return;
-        if (args.Handled || args.Args.Target == null)
+        if (args.Handled || args.Args.Target == null || args.Args.Used != null) //if using something (like a forensic scanner) it doesn't break the door
             return;
 
         component.IsResisting = false;

--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -69,7 +69,7 @@ public sealed class ResistLockerSystem : EntitySystem
 
     private void OnDoAfter(EntityUid uid, ResistLockerComponent component, DoAfterEvent args)
     {
-        if (args.Cancelled || args.Args.User == uid)
+        if (args.Cancelled)
         {
             component.IsResisting = false;
             component.CancelToken = null;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
fixes #14450 , forensic scanner no longer open a locked locker on doafter.
But I don't know whether my way of doing this is terrible or not.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Resisting a locked locker is still functional

https://user-images.githubusercontent.com/31364560/223925638-88ac9763-2c15-46dd-a241-340e5fd4048c.mp4

Forensic scanner no longer break open locks, also cancelling the doafter no longer have the pop up of "failed to kick open the door" 

https://user-images.githubusercontent.com/31364560/223925648-0e88157d-fedf-4434-8bf5-4aa0defda5eb.mp4



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: furontier
- fix: Forensic scanners no longer functions as an emag.
