### PR TITLE
Stop RecordedSplitContainer memory leak

### DIFF
--- a/Content.Client/UserInterface/Controls/RecordedSplitContainer.cs
+++ b/Content.Client/UserInterface/Controls/RecordedSplitContainer.cs
@@ -16,36 +16,12 @@ public sealed class RecordedSplitContainer : SplitContainer
     protected override Vector2 ArrangeOverride(Vector2 finalSize)
     {
         if (ResizeMode == SplitResizeMode.RespectChildrenMinSize
-            && DesiredSplitCenter != null)
+            && DesiredSplitCenter != null
+            && !finalSize.Equals(Vector2.Zero))
         {
-            var secondMin = GetChild(1).DesiredSize;
-            double minSize = Orientation == SplitOrientation.Vertical
-                ? secondMin.Y
-                : secondMin.X;
-            double finalSizeComponent = Orientation == SplitOrientation.Vertical
-                ? finalSize.Y
-                : finalSize.X;
+            SplitFraction = (float) DesiredSplitCenter.Value;
 
-            var firstTotalFractional = (finalSizeComponent - minSize - SplitWidth - SplitEdgeSeparation) / finalSizeComponent;
-            DesiredSplitCenter = Math.Round(DesiredSplitCenter.Value, 2, MidpointRounding.ToZero);
-
-            // total space the split center takes up must fit the available space percentage given to the first child
-            var canFirstFit = DesiredSplitCenter <= firstTotalFractional;
-
-            if (DesiredSplitCenter > 1 || DesiredSplitCenter < 0 || !canFirstFit)
-            {
-                DesiredSplitCenter = Math.Round(firstTotalFractional, 2, MidpointRounding.ToZero);
-            }
-
-            // don't need anything more than two digits of precision for this
-            var currentSplitFraction = Math.Round(SplitFraction, 2, MidpointRounding.ToZero);
-
-            // brute force it
-            if (currentSplitFraction != DesiredSplitCenter.Value)
-            {
-                SplitFraction = (float) DesiredSplitCenter.Value;
-            }
-            else
+            if (!Size.Equals(Vector2.Zero))
             {
                 DesiredSplitCenter = null;
             }


### PR DESCRIPTION
instead checks if the final size of the container is supposed to be bigger than zero: if it is, then it will continue to attempt to set the split fraction until the size is no longer zero, then it will do it once last time before stopping

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
ooouuughhh the edge cases

this should stop RecordedSplitContainer from causing an infinite loop if it never meets its desired split: instead, now it checks if the control hasn't been sized yet (and if its final size isn't meant to be zero), and if it has been sized, it'll do the split resize one last time before stopping
**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

N/A