### PR TITLE
Add SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 contact_links:
-  - name: Report a Security Exploit
-    url: https://discord.gg/MwDDf6t
-    about: Please report serious security exploits and vulnerabilities to @PJB3005 (PJB#3005/97089048065097728 on Discord).
+  - name: Report a Security Vulnerability
+    url: https://github.com/space-wizards/space-station-14/blob/master/SECURITY.md
+    about: Please report security vulnerabilities privately so we can fix them before they are publicly disclosed.
   - name: Request a Feature
     url: https://discord.gg/rGvu9hKffJ
     about: Submit feature requests on our Discord server (https://discord.gg/rGvu9hKffJ).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting a security vulnerability
+You can report a security vulnerability through Discord or through email.
+
+If you want to send an email, you can contact us at <telecommunications@spacestation14.com>.
+If you want to contact us through Discord, you can join [our server](https://discord.gg/MwDDf6t)
+and then **privately** message anyone with the `@Wizard` or `@SS14 Maintainer` role.
+
+In either case, **do not publicly disclose the vulnerability until we explicitly give
+you permission to do so**.


### PR DESCRIPTION
Adds a markdown file describing how to file security vulnerabilities, and gives people the possibility to do so without a Discord account.