### PR TITLE
Set flora decals to snapcardinals

### DIFF
--- a/Resources/Prototypes/Decals/flora.yml
+++ b/Resources/Prototypes/Decals/flora.yml
@@ -1,6 +1,7 @@
 - type: decal
   id: Grassa1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassa1
@@ -8,6 +9,7 @@
 - type: decal
   id: Grassa2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassa2
@@ -15,6 +17,7 @@
 - type: decal
   id: Grassa3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassa3
@@ -22,6 +25,7 @@
 - type: decal
   id: Grassa4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassa4
@@ -29,6 +33,7 @@
 - type: decal
   id: Grassa5
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassa5
@@ -36,6 +41,7 @@
 - type: decal
   id: Grassb1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassb1
@@ -43,6 +49,7 @@
 - type: decal
   id: Grassb2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassb2
@@ -50,6 +57,7 @@
 - type: decal
   id: Grassb3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassb3
@@ -57,6 +65,7 @@
 - type: decal
   id: Grassb4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassb4
@@ -64,6 +73,7 @@
 - type: decal
   id: Grassb5
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassb5
@@ -71,6 +81,7 @@
 - type: decal
   id: Grassc1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassc1
@@ -78,6 +89,7 @@
 - type: decal
   id: Grassc2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassc2
@@ -85,6 +97,7 @@
 - type: decal
   id: Grassc3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassc3
@@ -92,6 +105,7 @@
 - type: decal
   id: Grassc4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassc4
@@ -99,6 +113,7 @@
 - type: decal
   id: Grassd1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassd1
@@ -106,6 +121,7 @@
 - type: decal
   id: Grassd2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassd2
@@ -113,6 +129,7 @@
 - type: decal
   id: Grassd3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grassd3
@@ -120,6 +137,7 @@
 - type: decal
   id: Grasse1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grasse1
@@ -127,6 +145,7 @@
 - type: decal
   id: Grasse2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grasse2
@@ -134,6 +153,7 @@
 - type: decal
   id: Grasse3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grass.rsi
     state: grasse3
@@ -141,6 +161,7 @@
 - type: decal
   id: grasssnow
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow
@@ -148,6 +169,7 @@
 - type: decal
   id: grasssnow01
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow01
@@ -155,6 +177,7 @@
 - type: decal
   id: grasssnow02
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow02
@@ -162,6 +185,7 @@
 - type: decal
   id: grasssnow03
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow03
@@ -169,6 +193,7 @@
 - type: decal
   id: grasssnow04
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow04
@@ -176,6 +201,7 @@
 - type: decal
   id: grasssnow05
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow05
@@ -183,6 +209,7 @@
 - type: decal
   id: grasssnow06
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow06
@@ -190,6 +217,7 @@
 - type: decal
   id: grasssnow07
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow07
@@ -197,6 +225,7 @@
 - type: decal
   id: grasssnow08
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow08
@@ -204,6 +233,7 @@
 - type: decal
   id: grasssnow09
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow09
@@ -211,6 +241,7 @@
 - type: decal
   id: grasssnow10
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow10
@@ -218,6 +249,7 @@
 - type: decal
   id: grasssnow11
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow11
@@ -225,6 +257,7 @@
 - type: decal
   id: grasssnow12
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow12
@@ -232,6 +265,7 @@
 - type: decal
   id: grasssnow13
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnow13
@@ -239,6 +273,7 @@
 - type: decal
   id: grasssnowa1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnowa1
@@ -246,6 +281,7 @@
 - type: decal
   id: grasssnowa2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnowa2
@@ -253,6 +289,7 @@
 - type: decal
   id: grasssnowa3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnowa3
@@ -260,6 +297,7 @@
 - type: decal
   id: grasssnowb1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnowb1
@@ -267,6 +305,7 @@
 - type: decal
   id: grasssnowb2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnowb2
@@ -274,6 +313,7 @@
 - type: decal
   id: grasssnowb3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnowb3
@@ -281,6 +321,7 @@
 - type: decal
   id: grasssnowc1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnowc1
@@ -288,6 +329,7 @@
 - type: decal
   id: grasssnowc2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnowc2
@@ -295,6 +337,7 @@
 - type: decal
   id: grasssnowc3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_grasssnow.rsi
     state: grasssnowc3
@@ -302,6 +345,7 @@
 - type: decal
   id: Busha1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: busha1
@@ -309,6 +353,7 @@
 - type: decal
   id: Busha2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: busha2
@@ -316,6 +361,7 @@
 - type: decal
   id: Busha3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: busha3
@@ -323,6 +369,7 @@
 - type: decal
   id: Bushb1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushb1
@@ -330,6 +377,7 @@
 - type: decal
   id: Bushb2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushb2
@@ -337,6 +385,7 @@
 - type: decal
   id: Bushb3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushb3
@@ -344,6 +393,7 @@
 - type: decal
   id: Bushc1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushc1
@@ -351,6 +401,7 @@
 - type: decal
   id: Bushc2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushc2
@@ -358,6 +409,7 @@
 - type: decal
   id: Bushc3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushc3
@@ -365,6 +417,7 @@
 - type: decal
   id: Bushd1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushd1
@@ -372,6 +425,7 @@
 - type: decal
   id: Bushd2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushd2
@@ -379,6 +433,7 @@
 - type: decal
   id: Bushd3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushd3
@@ -386,6 +441,7 @@
 - type: decal
   id: Bushd4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushd4
@@ -393,6 +449,7 @@
 - type: decal
   id: Bushe1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushe1
@@ -400,6 +457,7 @@
 - type: decal
   id: Bushe2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushe2
@@ -407,6 +465,7 @@
 - type: decal
   id: Bushe3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushe3
@@ -414,6 +473,7 @@
 - type: decal
   id: Bushe4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushe4
@@ -421,6 +481,7 @@
 - type: decal
   id: Bushf1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushf1
@@ -428,6 +489,7 @@
 - type: decal
   id: Bushf2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushf2
@@ -435,6 +497,7 @@
 - type: decal
   id: Bushf3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushf3
@@ -442,6 +505,7 @@
 - type: decal
   id: Bushg1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushg1
@@ -449,6 +513,7 @@
 - type: decal
   id: Bushg2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushg2
@@ -456,6 +521,7 @@
 - type: decal
   id: Bushg3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushg3
@@ -463,6 +529,7 @@
 - type: decal
   id: Bushg4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushg4
@@ -470,6 +537,7 @@
 - type: decal
   id: Bushh1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushh1
@@ -477,6 +545,7 @@
 - type: decal
   id: Bushh2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushh2
@@ -484,6 +553,7 @@
 - type: decal
   id: Bushh3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushh3
@@ -491,6 +561,7 @@
 - type: decal
   id: Bushi1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushi1
@@ -498,6 +569,7 @@
 - type: decal
   id: Bushi2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushi2
@@ -505,6 +577,7 @@
 - type: decal
   id: Bushi3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushi3
@@ -512,6 +585,7 @@
 - type: decal
   id: Bushi4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushi4
@@ -519,6 +593,7 @@
 - type: decal
   id: Bushj1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushj1
@@ -526,6 +601,7 @@
 - type: decal
   id: Bushj2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushj2
@@ -533,6 +609,7 @@
 - type: decal
   id: Bushj3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushj3
@@ -540,6 +617,7 @@
 - type: decal
   id: Bushk1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushk1
@@ -547,6 +625,7 @@
 - type: decal
   id: Bushk2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushk2
@@ -554,6 +633,7 @@
 - type: decal
   id: Bushk3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushk3
@@ -561,6 +641,7 @@
 - type: decal
   id: Bushl1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushl1
@@ -568,6 +649,7 @@
 - type: decal
   id: Bushl2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushl2
@@ -575,6 +657,7 @@
 - type: decal
   id: Bushl3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushl3
@@ -582,6 +665,7 @@
 - type: decal
   id: Bushl4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushl4
@@ -589,6 +673,7 @@
 - type: decal
   id: Bushm1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushm1
@@ -596,6 +681,7 @@
 - type: decal
   id: Bushm2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushm2
@@ -603,6 +689,7 @@
 - type: decal
   id: Bushm3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushm3
@@ -610,6 +697,7 @@
 - type: decal
   id: Bushm4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushm4
@@ -617,6 +705,7 @@
 - type: decal
   id: Bushn1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushes.rsi
     state: bushn1
@@ -624,6 +713,7 @@
 - type: decal
   id: bushsnowa1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushessnow.rsi
     state: bushsnowa1
@@ -631,6 +721,7 @@
 - type: decal
   id: bushsnowa2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushessnow.rsi
     state: bushsnowa2
@@ -638,6 +729,7 @@
 - type: decal
   id: bushsnowa3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushessnow.rsi
     state: bushsnowa3
@@ -645,6 +737,7 @@
 - type: decal
   id: bushsnowb1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushessnow.rsi
     state: bushsnowb1
@@ -652,6 +745,7 @@
 - type: decal
   id: bushsnowb2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushessnow.rsi
     state: bushsnowb2
@@ -659,6 +753,7 @@
 - type: decal
   id: bushsnowb3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_bushessnow.rsi
     state: bushsnowb3
@@ -666,6 +761,7 @@
 - type: decal
   id: Rock01
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_rocks.rsi
     state: rock01
@@ -673,6 +769,7 @@
 - type: decal
   id: Rock02
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_rocks.rsi
     state: rock02
@@ -680,6 +777,7 @@
 - type: decal
   id: Rock03
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_rocks.rsi
     state: rock03
@@ -687,6 +785,7 @@
 - type: decal
   id: Rock04
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_rocks.rsi
     state: rock04
@@ -694,6 +793,7 @@
 - type: decal
   id: Rock05
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_rocks.rsi
     state: rock05
@@ -701,6 +801,7 @@
 - type: decal
   id: Rock06
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_rocks.rsi
     state: rock06
@@ -708,6 +809,7 @@
 - type: decal
   id: Rock07
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_rocks.rsi
     state: rock07
@@ -715,6 +817,7 @@
 - type: decal
   id: Flowersbr1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowersbr1
@@ -722,6 +825,7 @@
 - type: decal
   id: Flowersbr2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowersbr2
@@ -729,6 +833,7 @@
 - type: decal
   id: Flowersbr3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowersbr3
@@ -736,6 +841,7 @@
 - type: decal
   id: Flowerspv1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowerspv1
@@ -743,6 +849,7 @@
 - type: decal
   id: Flowerspv2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowerspv2
@@ -750,6 +857,7 @@
 - type: decal
   id: Flowerspv3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowerspv3
@@ -757,6 +865,7 @@
 - type: decal
   id: Flowersy1
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowersy1
@@ -764,6 +873,7 @@
 - type: decal
   id: Flowersy2
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowersy2
@@ -771,6 +881,7 @@
 - type: decal
   id: Flowersy3
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowersy3
@@ -778,6 +889,7 @@
 - type: decal
   id: Flowersy4
   tags: ["flora"]
+  snapCardinals: true
   sprite:
     sprite: Decals/Flora/flora_flowers.rsi
     state: flowersy4

--- a/Resources/Prototypes/Decals/planet.yml
+++ b/Resources/Prototypes/Decals/planet.yml
@@ -1,18 +1,21 @@
 # Flowers
 - type: decal
   id: FlowersBROne
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_flowers.rsi
     state: flowersbr1
 
 - type: decal
   id: FlowersBRTwo
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_flowers.rsi
     state: flowersbr2
 
 - type: decal
   id: FlowersBRThree
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_flowers.rsi
     state: flowersbr3
@@ -20,54 +23,63 @@
 # Grass
 - type: decal
   id: BushAOne
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_bushes.rsi
     state: busha1
 
 - type: decal
   id: BushATwo
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_bushes.rsi
     state: busha2
 
 - type: decal
   id: BushAThree
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_bushes.rsi
     state: busha3
 
 - type: decal
   id: BushCOne
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_bushes.rsi
     state: bushc1
 
 - type: decal
   id: BushCTwo
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_bushes.rsi
     state: bushc2
 
 - type: decal
   id: BushCThree
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_bushes.rsi
     state: bushc3
 
 - type: decal
   id: BushDOne
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_bushes.rsi
     state: bushd1
 
 - type: decal
   id: BushDTwo
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_bushes.rsi
     state: bushd2
 
 - type: decal
   id: BushDThree
+  snapCardinals: true
   sprite:
     sprite: /Textures/Decals/Flora/flora_bushes.rsi
     state: bushd3


### PR DESCRIPTION
If the dungeon procgen spawns rotated decals these look better right-side up so we might as well just always force it.

:cl:
- tweak: Flora decals will now always face upright to the camera.