### PR TITLE
Don't preload content maps in tests

### DIFF
--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -51,6 +51,9 @@ public static class PoolManager
         (CCVars.SysWinTickPeriod.Name, "0", true),
         (CCVars.ThreadParallelCount.Name, "1", true),
         (CCVars.GameRoleTimers.Name, "false", false),
+        (CCVars.CargoShuttles.Name, "false", false),
+        (CCVars.EmergencyShuttleEnabled.Name, "false", false),
+        (CCVars.ProcgenPreload.Name, "false", false),
     };
 
     private static int PairId;

--- a/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
@@ -265,6 +265,9 @@ public sealed partial class CargoSystem
 
     private void OnCargoOrderStartup(EntityUid uid, StationCargoOrderDatabaseComponent component, ComponentStartup args)
     {
+        if (!_enabled)
+            return;
+
         // Stations get created first but if any are added at runtime then do this.
         AddShuttle(component);
     }


### PR DESCRIPTION
Cargo + emergency + dungeon load as the CCVars aren't set in the test environment.