### PR TITLE
add fuel indicator to ame fuel jar, minor refactor

### DIFF
--- a/Content.Server/AME/AMEFuelContainerSystem.cs
+++ b/Content.Server/AME/AMEFuelContainerSystem.cs
@@ -1,0 +1,30 @@
+using Content.Server.AME.Components;
+using Content.Shared.Examine;
+
+namespace Content.Shared.AME.Systems;
+
+/// <summary>
+/// Adds fuel level info to examine on fuel jars and handles network state.
+/// </summary>
+public sealed class AMEFuelContainerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AMEFuelContainerComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(EntityUid uid, AMEFuelContainerComponent comp, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        // less than 25%: amount < capacity / 4 = amount * 4 < capacity
+        var low = comp.FuelAmount * 4 < comp.FuelCapacity;
+        args.PushMarkup(Loc.GetString("ame-fuel-container-component-on-examine-detailed-message",
+            ("colorName", low ? "darkorange" : "orange"),
+            ("amount", comp.FuelAmount),
+            ("capacity", comp.FuelCapacity)));
+    }
+}

--- a/Content.Server/AME/AMESystem.Fuel.cs
+++ b/Content.Server/AME/AMESystem.Fuel.cs
@@ -1,7 +1,7 @@
 using Content.Server.AME.Components;
 using Content.Shared.Examine;
 
-namespace Content.Shared.AME.Systems;
+namespace Content.Shared.AME;
 
 /// <summary>
 /// Adds fuel level info to examine on fuel jars and handles network state.

--- a/Content.Server/AME/AMESystem.Fuel.cs
+++ b/Content.Server/AME/AMESystem.Fuel.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.AME.Systems;
 /// <summary>
 /// Adds fuel level info to examine on fuel jars and handles network state.
 /// </summary>
-public sealed class AMEFuelContainerSystem : EntitySystem
+public sealed partial class AMESystem
 {
     public override void Initialize()
     {

--- a/Content.Server/AME/AMESystem.Fuel.cs
+++ b/Content.Server/AME/AMESystem.Fuel.cs
@@ -8,14 +8,12 @@ namespace Content.Shared.AME.Systems;
 /// </summary>
 public sealed partial class AMESystem
 {
-    public override void Initialize()
+    private void InitializeFuel()
     {
-        base.Initialize();
-
-        SubscribeLocalEvent<AMEFuelContainerComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<AMEFuelContainerComponent, ExaminedEvent>(OnFuelExamined);
     }
 
-    private void OnExamined(EntityUid uid, AMEFuelContainerComponent comp, ExaminedEvent args)
+    private void OnFuelExamined(EntityUid uid, AMEFuelContainerComponent comp, ExaminedEvent args)
     {
         if (!args.IsInDetailsRange)
             return;

--- a/Content.Server/AME/AMESystem.Fuel.cs
+++ b/Content.Server/AME/AMESystem.Fuel.cs
@@ -1,7 +1,7 @@
 using Content.Server.AME.Components;
 using Content.Shared.Examine;
 
-namespace Content.Shared.AME;
+namespace Content.Server.AME;
 
 /// <summary>
 /// Adds fuel level info to examine on fuel jars and handles network state.

--- a/Content.Server/AME/AMESystem.cs
+++ b/Content.Server/AME/AMESystem.cs
@@ -16,7 +16,7 @@ using JetBrains.Annotations;
 namespace Content.Server.AME
 {
     [UsedImplicitly]
-    public sealed class AntimatterEngineSystem : EntitySystem
+    public sealed partial class AMESystem : EntitySystem
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;

--- a/Content.Server/AME/AMESystem.cs
+++ b/Content.Server/AME/AMESystem.cs
@@ -29,9 +29,12 @@ namespace Content.Server.AME
         public override void Initialize()
         {
             base.Initialize();
+
             SubscribeLocalEvent<AMEControllerComponent, PowerChangedEvent>(OnAMEPowerChange);
             SubscribeLocalEvent<AMEControllerComponent, InteractUsingEvent>(OnInteractUsing);
             SubscribeLocalEvent<AMEPartComponent, InteractUsingEvent>(OnPartInteractUsing);
+
+            InitializeFuel();
         }
 
         public override void Update(float frameTime)

--- a/Content.Server/AME/Components/AMEFuelContainerComponent.cs
+++ b/Content.Server/AME/Components/AMEFuelContainerComponent.cs
@@ -1,37 +1,18 @@
-namespace Content.Server.AME.Components
+namespace Content.Server.AME.Components;
+
+// TODO: network and put in shared
+[RegisterComponent]
+public sealed class AMEFuelContainerComponent : Component
 {
-    [RegisterComponent]
-    public sealed class AMEFuelContainerComponent : Component
-    {
-        private int _fuelAmount;
-        private int _maxFuelAmount;
+    /// <summary>
+    /// The amount of fuel in the jar.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("fuelAmount")]
+    public int FuelAmount = 1000;
 
-        /// <summary>
-        ///     The amount of fuel in the jar.
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        public int FuelAmount
-        {
-            get => _fuelAmount;
-            set => _fuelAmount = value;
-        }
-
-        /// <summary>
-        ///     The maximum fuel capacity of the jar.
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        public int MaxFuelAmount
-        {
-            get => _maxFuelAmount;
-            set => _maxFuelAmount = value;
-        }
-
-        protected override void Initialize()
-        {
-            base.Initialize();
-            _maxFuelAmount = 1000;
-            _fuelAmount = 1000;
-        }
-
-    }
+    /// <summary>
+    /// The maximum fuel capacity of the jar.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("fuelCapacity")]
+    public int FuelCapacity = 1000;
 }

--- a/Resources/Locale/en-US/ame/components/ame-fuel-container-component.ftl
+++ b/Resources/Locale/en-US/ame/components/ame-fuel-container-component.ftl
@@ -1,0 +1,1 @@
+ame-fuel-container-component-on-examine-detailed-message = Fuel: [color={$colorName}]{$amount}/{$capacity}[/color]


### PR DESCRIPTION
## About the PR
adds a simple amount/capacity fuel indicator, salvaged from #10245 and made code nicer

rest of ame shitcode untouched it scares me

also done purely serverside since my attempts to network it on shared failed it still got desynced even with state handling aaaa

**Media**
full:
![00:04:15](https://user-images.githubusercontent.com/39013340/224484432-d7bf13e8-ec97-4258-9161-13c3fe9befa0.png)

low fuel:
![00:10:07](https://user-images.githubusercontent.com/39013340/224484427-c6d73f32-e482-4459-a8ad-c7af5a3d8e9d.png)

even works in guidebook:
![00:04:32](https://user-images.githubusercontent.com/39013340/224484441-22289a6b-3ad3-490e-bd27-c305629b286f.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame

**Changelog**
:cl:
- tweak: AME fuel jars now show their fuel level when examined.
