### PR TITLE
Stimpacks 1.1.1 - Intended Behavior Edition

### DIFF
--- a/Resources/Locale/en-US/flavors/flavor-profiles.ftl
+++ b/Resources/Locale/en-US/flavors/flavor-profiles.ftl
@@ -39,6 +39,7 @@ flavor-base-fizzy = fizzy
 flavor-base-shocking = shocking
 flavor-base-cheap = cheap
 flavor-base-piquant = piquant
+flavor-base-sharp = sharp
 
 # lmao
 flavor-base-terrible = terrible
@@ -175,3 +176,4 @@ flavor-complex-medicine = like medicine
 flavor-complex-carpet = like a handful of fur
 flavor-complex-bee = unbeelievable
 flavor-complex-sax = like jazz
+flavor-complex-bottledlightning = like lightning in a bottle

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -153,7 +153,7 @@
             Quantity: 20
   - type: Tag
     tags: []
-    
+
 - type: entity
   name: stimulant injector
   parent: ChemicalMedipen
@@ -170,9 +170,14 @@
         reagents:
         - ReagentId: Stimulants
           Quantity: 60
+  - type: Hypospray
+    solutionName: pen
+    transferAmount: 60
+  - type: StaticPrice
+    price: 500
   - type: Tag
     tags: []
-    
+
 - type: entity
   name: stimulant microinjector
   parent: ChemicalMedipen
@@ -189,9 +194,11 @@
         reagents:
         - ReagentId: Stimulants
           Quantity: 15
+  - type: StaticPrice
+    price: 100
   - type: Tag
     tags: []
-    
+
 - type: entity
   name: experimental stimulant injector
   parent: ChemicalMedipen
@@ -208,6 +215,11 @@
         reagents:
         - ReagentId: ExperimentalStimulants
           Quantity: 60
+  - type: Hypospray
+    solutionName: pen
+    transferAmount: 60
+  - type: StaticPrice
+    price: 1000
   - type: Tag
     tags: []
 

--- a/Resources/Prototypes/Flavors/flavors.yml
+++ b/Resources/Prototypes/Flavors/flavors.yml
@@ -155,6 +155,11 @@
   description: flavor-base-terrible
 
 - type: flavor
+  id: sharp
+  flavorType: Base
+  description: flavor-base-sharp
+
+- type: flavor
   id: nothing
   flavorType: Complex
   description: flavor-complex-nothing
@@ -658,3 +663,8 @@
   id: garlic
   flavorType: Complex
   description: flavor-complex-garlic
+
+- type: flavor
+  id: bottledlightning
+  flavorType: Complex
+  description: flavor-complex-bottledlightning

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -149,7 +149,7 @@
   group: Narcotics
   desc: reagent-desc-experimental-stimulants
   physicalDesc: reagent-physical-desc-exhilarating
-  flavor: bottled lightning
+  flavor: bottledlightning
   color: "#AE0101"
   boilingPoint: 212.0
   meltingPoint: 170.0
@@ -158,13 +158,22 @@
       metabolismRate: 0.25 # lasts for 4 minutes instead of 5
       effects:
       - !type:MovespeedModifier # nyoom
+        conditions:
+        - !type:ReagentThreshold
+          min: 10
         walkSpeedModifier: 1.8
         sprintSpeedModifier: 1.8
+      - !type:MovespeedModifier # antinyoom
+        conditions:
+        - !type:ReagentThreshold
+          max: 10 # ghetto withdrawal
+        walkSpeedModifier: 0.7
+        sprintSpeedModifier: 0.7
       - !type:Electrocute
         conditions:
           - !type:ReagentThreshold
             max: 10 # ghetto withdrawal effect
-        probability: 0.3 # get stunlocked nerd
+        probability: 0.1 # get stunlocked nerd
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -177,32 +186,40 @@
         component: StutteringAccent
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 10
+        - !type:ReagentThreshold
+          min: 10
         damage:
           types:
             Poison: 1 # You will be laying on the floor in crit in 100 seconds if you don't have antitoxin meds (Ideally this should deal twice as much damage but since nukies don't have access to stellbinin it would kill them)
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 60.1 #so nukies don't take a tick of 8 poison damage when it first gets injected
+        - !type:ReagentThreshold
+          min: 60
         damage:
           types:
             Poison: 8 # TODO this should ideally kill your liver instead
       # effectively negates stamcrits
       - !type:GenericStatusEffect
         conditions:
-          - !type:ReagentThreshold
-            min: 10
+        - !type:ReagentThreshold
+          min: 10
         key: Stun
         time: 6
         type: Remove
       - !type:GenericStatusEffect
         conditions:
-          - !type:ReagentThreshold
-            min: 10
+        - !type:ReagentThreshold
+          min: 10
         key: KnockedDown
         time: 6
+        type: Remove
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          min: 10
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
         type: Remove
     Medicine:
       metabolismRate: 0.25
@@ -217,7 +234,7 @@
           - !type:ReagentThreshold
             min: 10
           damage:
-            types:
+            groups:
               Brute: -4
               Burn: -4
         # stops CMOs from hypoing you with lexorin and sec from filling you with tranq shells


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR fixes:
- stimpacks not injecting their entire contents
- no threshold on experimental stimpack movement speed
- being effectively stunlocked during experimental stimulant withdrawal (you now have a flat slowdown to compensate)
- experimental stimulants not actually healing brute and burn damage, since I classified them as types, not groups (why linter didnt throw an error for this I have no idea)
- missing flavors
- all the indentation inconsistencies

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: The faulty injector needles and formula errors in Donk Co.'s line of stimpack products have been fixed.