### PR TITLE
fix shotgun start node not being named start

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -115,7 +115,7 @@
     capacity: 2
   - type: Construction
     graph: ShotgunSawn
-    node: shotgundoublebarreled
+    node: start
     deconstructionTarget: null
 
 - type: entity

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/shotgunsawn.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/shotgunsawn.yml
@@ -1,8 +1,8 @@
 - type: constructionGraph
   id: ShotgunSawn
-  start: shotgundoublebarreled
+  start: start
   graph:
-    - node: shotgundoublebarreled
+    - node: start
       edges:
         - to: shotgunsawn
           steps:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
I'm back!


sike.


Spent some time running tests on my fork to update to a semi recent master and got an error with the DeconstructionIsValid test...turns out all start nodes need to be named start for this test to pass and the sawnoff shotgun didn't have that...it can't be deconstructed anyway but hey, thought I'd fix the test took like a second. Storytime over, maybe I'll upload some of these ancient branches I have sitting on my desktop sometime.

I went from 7 errors to 4 with this one fix so maybe there's two other tests it affected too but I only got the one screenshot.

**Media**
Before the fix screenshot, even though tests were passing on master...idk maybe a downstream will thank me, I know I would have. Does not affect in game.
![before](https://user-images.githubusercontent.com/78795277/224571601-1aa2a2a5-5cae-4d80-91ba-d540b3e9e2c2.PNG)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Feel free to just close this if it's a non issue, just thought it should be brought up non the less and I had to fix it downstream to stop the error so.