### PR TITLE
Removes IOnStateChanged calls from GameplayStateLoadController

### DIFF
--- a/Content.Client/UserInterface/Systems/Gameplay/GameplayStateLoadController.cs
+++ b/Content.Client/UserInterface/Systems/Gameplay/GameplayStateLoadController.cs
@@ -3,20 +3,10 @@ using Robust.Client.UserInterface.Controllers;
 
 namespace Content.Client.UserInterface.Systems.Gameplay;
 
-public sealed class GameplayStateLoadController : UIController, IOnStateChanged<GameplayState>
+public sealed class GameplayStateLoadController : UIController
 {
     public Action? OnScreenLoad;
     public Action? OnScreenUnload;
-
-    public void OnStateEntered(GameplayState state)
-    {
-        LoadScreen();
-    }
-
-    public void OnStateExited(GameplayState state)
-    {
-        UnloadScreen();
-    }
 
     public void UnloadScreen()
     {


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->

This fixes giving the menu bar buttons their on-click action twice.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

N/A
