### PR TITLE
Add space dungeon support

### DIFF
--- a/Content.Server/Procedural/DungeonJob.cs
+++ b/Content.Server/Procedural/DungeonJob.cs
@@ -6,6 +6,7 @@ using Content.Server.Decals;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.DungeonGenerators;
 using Content.Shared.Procedural.PostGeneration;
+using Robust.Server.Physics;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
@@ -76,6 +77,7 @@ public sealed partial class DungeonJob : Job<Dungeon>
     {
         Dungeon dungeon;
         _sawmill.Info($"Generating dungeon {_gen.ID} with seed {_seed} on {_entManager.ToPrettyString(_gridUid)}");
+        _grid.CanSplit = false;
 
         switch (_gen.Generator)
         {
@@ -126,6 +128,8 @@ public sealed partial class DungeonJob : Job<Dungeon>
             ValidateResume();
         }
 
+        _grid.CanSplit = true;
+        _entManager.System<GridFixtureSystem>().CheckSplits(_gridUid);
         return dungeon;
     }
 

--- a/Content.Server/Procedural/DungeonSystem.Commands.cs
+++ b/Content.Server/Procedural/DungeonSystem.Commands.cs
@@ -30,13 +30,6 @@ public sealed partial class DungeonSystem
         }
 
         var mapId = new MapId(mapInt);
-        var mapUid = _mapManager.GetMapEntityId(mapId);
-
-        if (!TryComp<MapGridComponent>(mapUid, out var mapGrid))
-        {
-            shell.WriteError(Loc.GetString("cmd-dungen-mapgrid"));
-            return;
-        }
 
         if (!_prototype.TryIndex<DungeonConfigPrototype>(args[1], out var dungeon))
         {
@@ -51,6 +44,15 @@ public sealed partial class DungeonSystem
         }
 
         var position = new Vector2(posX, posY);
+        var dungeonUid = _mapManager.GetMapEntityId(mapId);
+
+        if (!TryComp<MapGridComponent>(dungeonUid, out var dungeonGrid))
+        {
+            dungeonUid = EntityManager.CreateEntityUninitialized(null, new EntityCoordinates(dungeonUid, position));
+            dungeonGrid = EntityManager.AddComponent<MapGridComponent>(dungeonUid);
+            EntityManager.InitializeAndStartEntity(dungeonUid, mapId);
+        }
+
         int seed;
 
         if (args.Length >= 5)
@@ -67,7 +69,7 @@ public sealed partial class DungeonSystem
         }
 
         shell.WriteLine(Loc.GetString("cmd-dungen-start", ("seed", seed)));
-        GenerateDungeon(dungeon, mapUid, mapGrid, position, seed);
+        GenerateDungeon(dungeon, dungeonUid, dungeonGrid, position, seed);
     }
 
     private CompletionResult CompletionCallback(IConsoleShell shell, string[] args)

--- a/Resources/Locale/en-US/procedural/command.ftl
+++ b/Resources/Locale/en-US/procedural/command.ftl
@@ -1,4 +1,4 @@
-cmd-dungen-desc = Generates a procedural dungeon with the specified preset, position, and seed.
+cmd-dungen-desc = Generates a procedural dungeon with the specified preset, position, and seed. Will spawn in space if the MapId doesn't have MapGridComponent.
 cmd-dungen-help = dungen <MapId> <DungeonPreset> <PosX> <PosY> [seed]
 cmd-dungen-arg-count = Require 4 args.
 cmd-dungen-map-parse = Unable to parse MapId.


### PR DESCRIPTION
Just spawn a new grid if the map doesn't have grid component. Just in case I made an engine PR to prevent splitting but it's not a hard requirement (outside of API) as I think the gen currently can't cause splits due to bulk placement.

![image](https://user-images.githubusercontent.com/31366439/224596339-b2eba319-aa81-4314-9365-5f939666e1eb.png)

Requires https://github.com/space-wizards/RobustToolbox/pull/3848