### PR TITLE
only add emag component if the event was handled

### DIFF
--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -164,7 +164,7 @@ namespace Content.Shared.Emag.Systems
             var emaggedEvent = new GotEmaggedEvent(user);
             RaiseLocalEvent(target, ref emaggedEvent);
 
-            if (!emaggedEvent.Repeatable)
+            if (emaggedEvent.Handled && !emaggedEvent.Repeatable)
                 EnsureComp<EmaggedComponent>(target);
             return emaggedEvent.Handled;
         }


### PR DESCRIPTION
## About the PR
using an emag on anything would add emagged component, even if it didn't handle the event

only gameplay consequence of this bug i noticed is being able to silently emag a door by first bolting it then emagging and unbolting, access is now ignored with no loud spark

this pr fixes and only adds the component if the event got handled

**Changelog**
no cl no fun