### PR TITLE
emag disposal units to disable pressure requirement

### DIFF
--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -18,7 +18,6 @@ using Content.Shared.Disposal;
 using Content.Shared.Disposal.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
-using Content.Shared.Emag.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -550,7 +549,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
             component.AutomaticEngageToken?.Cancel();
             component.AutomaticEngageToken = null;
 
-            if (!HasComp<EmaggedComponent>(uid))
+            if (!component.AutoFlush)
             {
                 component.Pressure = 0;
                 component.State = SharedDisposalUnitComponent.PressureState.Pressurizing;
@@ -713,8 +712,8 @@ namespace Content.Server.Disposal.Unit.EntitySystems
                 return;
             }
 
-            // if emagged, ignore the timer and instantly flush
-            if (HasComp<EmaggedComponent>(uid))
+            // if autoflushing, ignore the timer and instantly flush
+            if (component.AutoFlush)
             {
                 if (!TryFlush(uid, component))
                     TryQueueEngage(uid, component);

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -549,7 +549,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
             component.AutomaticEngageToken?.Cancel();
             component.AutomaticEngageToken = null;
 
-            if (!component.AutoFlush)
+            if (!component.DisablePressure)
             {
                 component.Pressure = 0;
                 component.State = SharedDisposalUnitComponent.PressureState.Pressurizing;
@@ -709,14 +709,6 @@ namespace Content.Server.Disposal.Unit.EntitySystems
         {
             if (component.Deleted || !component.AutomaticEngage || !component.Powered && component.Container.ContainedEntities.Count == 0)
             {
-                return;
-            }
-
-            // if autoflushing, ignore the timer and instantly flush
-            if (component.AutoFlush)
-            {
-                if (!TryFlush(uid, component))
-                    TryQueueEngage(uid, component);
                 return;
             }
 

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Disposal;
 using Content.Shared.Disposal.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
+using Content.Shared.Emag.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -549,8 +550,11 @@ namespace Content.Server.Disposal.Unit.EntitySystems
             component.AutomaticEngageToken?.Cancel();
             component.AutomaticEngageToken = null;
 
-            component.Pressure = 0;
-            component.State = SharedDisposalUnitComponent.PressureState.Pressurizing;
+            if (!HasComp<EmaggedComponent>(uid))
+            {
+                component.Pressure = 0;
+                component.State = SharedDisposalUnitComponent.PressureState.Pressurizing;
+            }
 
             component.Engaged = false;
 
@@ -706,6 +710,14 @@ namespace Content.Server.Disposal.Unit.EntitySystems
         {
             if (component.Deleted || !component.AutomaticEngage || !component.Powered && component.Container.ContainedEntities.Count == 0)
             {
+                return;
+            }
+
+            // if emagged, ignore the timer and instantly flush
+            if (HasComp<EmaggedComponent>(uid))
+            {
+                if (!TryFlush(uid, component))
+                    TryQueueEngage(uid, component);
                 return;
             }
 

--- a/Content.Shared/Disposal/Components/SharedDisposalUnitComponent.cs
+++ b/Content.Shared/Disposal/Components/SharedDisposalUnitComponent.cs
@@ -22,10 +22,10 @@ namespace Content.Shared.Disposal.Components
         public bool MobsCanEnter = true;
 
         /// <summary>
-        /// Automatically flushes items and has no pressure requirement
+        /// Removes the pressure requirement for flushing.
         /// </summary>
-        [DataField("autoFlush"), ViewVariables(VVAccess.ReadWrite)]
-        public bool AutoFlush = false;
+        [DataField("disablePressure"), ViewVariables(VVAccess.ReadWrite)]
+        public bool DisablePressure = false;
 
         [Serializable, NetSerializable]
         public enum Visuals : byte

--- a/Content.Shared/Disposal/Components/SharedDisposalUnitComponent.cs
+++ b/Content.Shared/Disposal/Components/SharedDisposalUnitComponent.cs
@@ -21,6 +21,12 @@ namespace Content.Shared.Disposal.Components
         [DataField("mobsCanEnter")]
         public bool MobsCanEnter = true;
 
+        /// <summary>
+        /// Automatically flushes items and has no pressure requirement
+        /// </summary>
+        [DataField("autoFlush"), ViewVariables(VVAccess.ReadWrite)]
+        public bool AutoFlush = false;
+
         [Serializable, NetSerializable]
         public enum Visuals : byte
         {

--- a/Content.Shared/Disposal/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/SharedDisposalUnitSystem.cs
@@ -61,7 +61,7 @@ namespace Content.Shared.Disposal
 
         private void OnEmagged(EntityUid uid, SharedDisposalUnitComponent component, ref GotEmaggedEvent args)
         {
-            component.AutoFlush = true;
+            component.DisablePressure = true;
             args.Handled = true;
         }
 

--- a/Content.Shared/Disposal/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/SharedDisposalUnitSystem.cs
@@ -61,6 +61,7 @@ namespace Content.Shared.Disposal
 
         private void OnEmagged(EntityUid uid, SharedDisposalUnitComponent component, ref GotEmaggedEvent args)
         {
+            component.AutoFlush = true;
             args.Handled = true;
         }
 

--- a/Content.Shared/Disposal/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/SharedDisposalUnitSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared.Body.Components;
 using Content.Shared.Disposal.Components;
 using Content.Shared.DragDrop;
+using Content.Shared.Emag.Systems;
 using Content.Shared.Item;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -28,6 +29,7 @@ namespace Content.Shared.Disposal
             base.Initialize();
             SubscribeLocalEvent<SharedDisposalUnitComponent, PreventCollideEvent>(OnPreventCollide);
             SubscribeLocalEvent<SharedDisposalUnitComponent, CanDropTargetEvent>(OnCanDragDropOn);
+            SubscribeLocalEvent<SharedDisposalUnitComponent, GotEmaggedEvent>(OnEmagged);
         }
 
         private void OnPreventCollide(EntityUid uid, SharedDisposalUnitComponent component, ref PreventCollideEvent args)
@@ -54,6 +56,11 @@ namespace Content.Shared.Disposal
                 return;
 
             args.CanDrop = CanInsert(component, args.Dragged);
+            args.Handled = true;
+        }
+
+        private void OnEmagged(EntityUid uid, SharedDisposalUnitComponent component, ref GotEmaggedEvent args)
+        {
             args.Handled = true;
         }
 


### PR DESCRIPTION
## About the PR
you can now emag disposals units to autoflush items
pressure is no longer reset when flushing
must still be toggled to flush manually

main purpose is for an easy getaway and to rapidly flush other people/evidence without getting caught

of course a simple crowbar will fix it, so for a permanent installation (say for a taxi using mail pipes) it will require the crews cooperation

**Media**


https://user-images.githubusercontent.com/39013340/227220530-fda00b66-ce78-4ce6-b011-c164ec71e6aa.mp4




- [X] I have added a video to this PR showcasing its changes ingame

**Changelog**
:cl:
- tweak: The Emag has received an update for disabling safety overrides on disposal units.