### PR TITLE
make solar flare only open autoclose airlocks

### DIFF
--- a/Content.Server/StationEvents/Events/SolarFlare.cs
+++ b/Content.Server/StationEvents/Events/SolarFlare.cs
@@ -48,16 +48,17 @@ public sealed class SolarFlare : StationEventSystem
         if (_effectTimer < 0)
         {
             _effectTimer += 1;
-            foreach (var comp in EntityQuery<PoweredLightComponent>())
+            var lightQuery = EntityQueryEnumerator<PoweredLightComponent>();
+            while (lightQuery.MoveNext(out var uid, out var light))
             {
                 if (RobustRandom.Prob(_event.LightBreakChancePerSecond))
-                    _poweredLight.TryDestroyBulb(comp.Owner, comp);
+                    _poweredLight.TryDestroyBulb(uid, light);
             }
-
-            foreach (var (airlock, door) in EntityQuery<AirlockComponent, DoorComponent>())
+            var airlockQuery = EntityQueryEnumerator<AirlockComponent, DoorComponent>();
+            while (airlockQuery.MoveNext(out var uid, out var airlock, out var door))
             {
                 if (airlock.AutoClose && RobustRandom.Prob(_event.DoorToggleChancePerSecond))
-                    _door.TryToggleDoor(door.Owner, door);
+                    _door.TryToggleDoor(uid, door);
             }
         }
 

--- a/Content.Server/StationEvents/Events/SolarFlare.cs
+++ b/Content.Server/StationEvents/Events/SolarFlare.cs
@@ -54,10 +54,10 @@ public sealed class SolarFlare : StationEventSystem
                     _poweredLight.TryDestroyBulb(comp.Owner, comp);
             }
 
-            foreach (var comp in EntityQuery<DoorComponent>())
+            foreach (var (airlock, door) in EntityQuery<AirlockComponent, DoorComponent>())
             {
-                if (RobustRandom.Prob(_event.DoorToggleChancePerSecond))
-                    _door.TryToggleDoor(comp.Owner, comp);
+                if (airlock.AutoClose && RobustRandom.Prob(_event.DoorToggleChancePerSecond))
+                    _door.TryToggleDoor(door.Owner, door);
             }
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
![image](https://user-images.githubusercontent.com/40753025/224700085-cb5c446a-0b85-46b3-8153-5e02d72d5762.png)
Solar flares opening curtains and mechanical doors wasn't intended. Now it only affects airlocks that can be automatically closed (still affects high security doors - just bolt them). 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Solar flare lost it's ability to manipulate mechanical doors, curtains and firelocks. Now it only affects autoclosing airlocks.
