### PR TITLE
Flash now flashes black instead of white.

### DIFF
--- a/Resources/Textures/Shaders/flashed_effect.swsl
+++ b/Resources/Textures/Shaders/flashed_effect.swsl
@@ -12,7 +12,7 @@ void fragment() {
     highp vec4 textureMix = mix(tex1, tex2, 0.5);
 
     // Gradually mixes between the texture mix and a full-white texture, causing the "blinding" effect
-    highp vec4 mixed = mix(vec4(1.0, 1.0, 1.0, 1.0), textureMix, percentComplete);
+    highp vec4 mixed = mix(vec4(0.0, 0.0, 0.0, 1.0), textureMix, percentComplete);
 
     COLOR = vec4(mixed.rgb, remaining);
 }


### PR DESCRIPTION
Much easier on the eyes.

**Changelog**
:cl: moony
- tweak: The flashbang now darkens the screen instead of brightening it.
