### PR TITLE
add colorful reagent buttons

### DIFF
--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -67,6 +67,10 @@ namespace Content.Client.Chemistry.UI
                 button.OnMouseEntered += args => OnDispenseReagentButtonMouseEntered?.Invoke(args, button);
                 button.OnMouseExited += args => OnDispenseReagentButtonMouseExited?.Invoke(args, button);
                 ChemicalList.AddChild(button);
+                if (p != null)
+                {
+                    button.SetColor(p.SubstanceColor);
+                }
             }
         }
 
@@ -187,6 +191,21 @@ namespace Content.Client.Chemistry.UI
         {
             ReagentId = reagentId;
             Text = text;
+        }
+
+        public void SetColor(Color color)
+        {
+            this.ModulateSelfOverride = Color.LightGray;
+            this.ModulateSelfOverride = color;
+            // if background (button) is light then make text dark and vice versa
+            if (Color.ToHsl(color).Z > 0.4)
+            {
+                Label.ModulateSelfOverride = Color.Black;
+            }
+            else
+            {
+                Label.ModulateSelfOverride = Color.White;
+            }
         }
     }
 }

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -195,15 +195,16 @@ namespace Content.Client.Chemistry.UI
 
         public void SetColor(Color color)
         {
-            this.ModulateSelfOverride = color;
+            var background = Color.InterpolateBetween(color, Color.Black, 0.25f);
+            this.ModulateSelfOverride = background;
             // if background (button) is light then make text dark and vice versa
-            if (Color.ToHsl(color).Z > 0.4)
+            if (Color.ToHsl(background).Z > 0.5f)
             {
-                Label.ModulateSelfOverride = Color.Black;
+                Label.FontColorOverride = Color.Black;
             }
             else
             {
-                Label.ModulateSelfOverride = Color.White;
+                Label.FontColorOverride = Color.White;
             }
         }
     }

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -195,7 +195,6 @@ namespace Content.Client.Chemistry.UI
 
         public void SetColor(Color color)
         {
-            this.ModulateSelfOverride = Color.LightGray;
             this.ModulateSelfOverride = color;
             // if background (button) is light then make text dark and vice versa
             if (Color.ToHsl(color).Z > 0.4)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
second attempt of coloring reagent buttons, see also #13985

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://user-images.githubusercontent.com/40753025/225028463-5c838354-ec08-488a-b610-bdf1355f5b53.png)
![image](https://user-images.githubusercontent.com/40753025/225028496-346523a7-ab98-4f5e-b1d5-c88a13775d66.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Reagent dispensers buttons are now colored according to the reagent color!
