### PR TITLE
Energy Sword Buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -2,13 +2,14 @@
   name: energy sword
   parent: BaseItem
   id: EnergySword
-  description: A very dangerous energy sword. Can be stored in pockets when turned off. Makes a lot of noise when used or turned on.
+  description: Very loud and very dangerous. Can be stored in pockets when turned off.
   components:
   - type: EnergySword
     litDamageBonus:
         types:
-            Slash: 9.5
-            Heat: 9.5
+            Slash: 15
+            Heat: 15
+            Structural: 4
             Blunt: -4.5
     litDisarmMalus: 0.6
   - type: Sprite
@@ -21,9 +22,9 @@
         shader: unshaded
         map: [ "blade" ]
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 1
     soundHit:
-      path: /Audio/Weapons/genhit1.ogg
+      path: /Audio/Weapons/eblade1.ogg
     damage:
       types:
         Blunt: 4.5


### PR DESCRIPTION
## About the PR
Buffs the e-sword to do 30 damage (split across slash and heat) plus 4 structural damage (probably about 1.5x - 3x slower than a crowbar for breaking windows.) To compensate, the energy sword now only has a speed of 1.0 and has received its iconic EEEENNNNNGG hitsound back.

In combination with #14029 this shouldn't be too much. There, the 25% chance to reflect only really serves as a side-feature and probably won't end up substanstially changing how effective the energy sword is.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: The energy sword now does 30 damage per hit and swings slower.
- tweak: The energy sword can now break structures.
- tweak: The energy sword has received its iconic hitsound back, making it much more obvious and threatening.
