### PR TITLE
Revert "Syndicate Encryption Key buff"

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -82,7 +82,7 @@ uplink-headset-name = Syndicate Over-ear Headset
 uplink-headset-desc = A headset that allows you to communicate with other syndicate operatives. Has 4 slots for encryption keys.
 
 uplink-encryption-key-name = Syndicate Encryption Key
-uplink-encryption-key-desc = An encryption key that not only allows you to access all station-side radio channels, but also allows you to use a secure Syndicate channel to contact other agents.
+uplink-encryption-key-desc = An encryption key for access to the secret frequency of our special agents. No one will know about your special channel with friends... or rivals.
 
 uplink-hypopen-name = Hypopen
 uplink-hypopen-desc = A chemical hypospray disguised as a pen, capable of instantly injecting up to 15u of reagents. Starts empty.
@@ -208,7 +208,7 @@ uplink-syndicate-segway-crate-desc = Be an enemy of the corporation, in style!
 uplink-revolver-cap-gun-name = Cap Gun
 uplink-revolver-cap-gun-desc = Looks almost like the real thing! Ages 8 and up.
 
-uplink-syndicate-stamp-name = Syndicate Rubber Stamp # In loving memory, Btamp, ???-2/1/23
+uplink-syndicate-stamp-name = Syndicate Rubber Btamp
 uplink-syndicate-stamp-desc = A rubber stamp for stamping important documents.
 
 uplink-cat-ears-name = Cat Ears

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -279,6 +279,17 @@
   categories:
     - UplinkUtility
 
+#TODO: Remove this from the uplink
+- type: listing
+  id: UplinkHeadset
+  name: uplink-headset-name
+  description: uplink-headset-desc
+  productEntity: ClothingHeadsetAltSyndicate
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkUtility
+
 - type: listing
   id: UplinkHeadsetEncryptionKey
   name: uplink-encryption-key-name
@@ -288,11 +299,6 @@
     Telecrystal: 2
   categories:
   - UplinkUtility
-  conditions:
-    - !type:StoreWhitelistCondition
-      blacklist:
-        tags:
-          - NukeOpsUplink
 
 - type: listing
   id: UplinkHypopen

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -70,7 +70,7 @@
     sprite: Clothing/Ears/Headsets/engineering.rsi
   - type: Clothing
     sprite: Clothing/Ears/Headsets/engineering.rsi
-
+ 
 - type: entity
   parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltMedical
@@ -123,7 +123,7 @@
   parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltSyndicate
   name: blood-red over-ear headset
-  description: An updated, modular syndicate headset that accepts up to 5 encryption keys.
+  description: An updated, modular syndicate intercom that fits over the head and takes encryption keys (there are 5 key slots.).
   components:
   - type: Headset
   - type: EncryptionKeyHolder
@@ -131,7 +131,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyNukie
+      - EncryptionKeySyndie
   - type: Sprite
     sprite: Clothing/Ears/Headsets/syndicate.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -192,30 +192,8 @@
 - type: entity
   parent: EncryptionKey
   id: EncryptionKeySyndie
-  name: syndicate encryption key
-  description: An encryption key used by Syndicate agents to not only access the station's radio channels, but also securely contact other agents in the field.
-  components:
-  - type: EncryptionKey
-    channels:
-    - Common
-    - Command
-    - Engineering
-    - Medical
-    - Science
-    - Security
-    - Service
-    - Supply
-    - Syndicate
-    defaultChannel: Syndicate
-  - type: Sprite
-    sprite: Objects/Devices/encryption_keys.rsi
-    state: syn_cypherkey
-
-- type: entity
-  parent: EncryptionKey
-  id: EncryptionKeyNukie
-  name: nuclear operative encryption key
-  description: An encryption key used by nuclear operatives to securely contact each other during operations.
+  name: blood-red encryption key
+  description: An encryption key used by... wait... Who is owner of this chip?
   components:
   - type: EncryptionKey
     channels:


### PR DESCRIPTION
Reverts space-wizards/space-station-14#13849

this is really silly it just makes an entire game mechanic pointless for no reason

:cl:
- remove: The syndicate encryption key no longer allows you to access every radio channel.