### PR TITLE
Syndicate encryption key now gives two keys for the price of one

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -81,7 +81,7 @@ uplink-stealth-box-desc = A box outfitted with stealth technology, sneak around 
 uplink-headset-name = Syndicate Over-ear Headset
 uplink-headset-desc = A headset that allows you to communicate with other syndicate operatives. Has 4 slots for encryption keys.
 
-uplink-encryption-key-name = Syndicate Encryption Key
+uplink-encryption-key-name = Syndicate Encryption Keys
 uplink-encryption-key-desc = Two encryption keys for access to the secret frequency of our special agents. Give the spare to a friend, but make sure it doesn't fall into enemy hands.
 
 uplink-hypopen-name = Hypopen

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -82,7 +82,7 @@ uplink-headset-name = Syndicate Over-ear Headset
 uplink-headset-desc = A headset that allows you to communicate with other syndicate operatives. Has 4 slots for encryption keys.
 
 uplink-encryption-key-name = Syndicate Encryption Key
-uplink-encryption-key-desc = An encryption key for access to the secret frequency of our special agents. No one will know about your special channel with friends... or rivals.
+uplink-encryption-key-desc = Two encryption keys for access to the secret frequency of our special agents. Give the spare to a friend, but make sure it doesn't fall into enemy hands.
 
 uplink-hypopen-name = Hypopen
 uplink-hypopen-desc = A chemical hypospray disguised as a pen, capable of instantly injecting up to 15u of reagents. Starts empty.

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -381,9 +381,13 @@
   name: syndicate encryption key box
   parent: BoxEncryptionKeyPassenger
   id: BoxEncryptionKeySyndie
-  description: Two syndicate encryption keys for the price of one.
+  description: Two syndicate encryption keys for the price of one. Miniaturized for ease of use.
   components:
+  - type: Item
+    size: 15
   - type: StorageFill
     contents:
       - id: EncryptionKeySyndie
         amount: 2
+  - type: Storage
+    capacity: 15

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -376,3 +376,14 @@
     contents:
       - id: EncryptionKeyService
         amount: 6
+
+- type: entity
+  name: syndicate encryption key box
+  parent: BoxEncryptionKeyPassenger
+  id: BoxEncryptionKeySyndie
+  description: Two syndicate encryption keys for the price of one.
+  components:
+  - type: StorageFill
+    contents:
+      - id: EncryptionKeySyndie
+        amount: 2

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -294,7 +294,7 @@
   id: UplinkHeadsetEncryptionKey
   name: uplink-encryption-key-name
   description: uplink-encryption-key-desc
-  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: syn_cypherkey }
+  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: synd_label }
   productEntity: BoxEncryptionKeySyndie # Two for the price of one
   cost:
     Telecrystal: 2

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -294,7 +294,8 @@
   id: UplinkHeadsetEncryptionKey
   name: uplink-encryption-key-name
   description: uplink-encryption-key-desc
-  productEntity: EncryptionKeySyndie
+  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: syn_cypherkey }
+  productEntity: BoxEncryptionKeySyndie # Two for the price of one
   cost:
     Telecrystal: 2
   categories:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Purchasing the Syndicate Encryption Key now gives two keys in a box instead of one. This solves the same problem as #13849 (people don't want to risk buying the key), but without the rather unbalanced solution.

This PR ultimately reduces the risk of buying the syndicate encryption key, as you can give the spare key to a fellow traitor.

This PR also introduces a new risk to buying the key. If you buy the box and throw out the spare key, no matter how hard you hide it, there's always the risk for security to find it at some point, letting them eavesdrop on your conversations. Plus, the key is contraband, so you can't keep it on you in a bag.

Due to this risk, syndies may be less inclined to buy the box if they do not know any other traitors to help keep the key, which solves the issue of encryption keys skipping the whole codeword thing.

There's also the issue of me not actually changing the price. I can change the price if needed, but I think the added risk is enough to offset the price change. Also, 2tc does feel like a reasonable amount anyway.

(I am aware that syndicate keys are bought more than they seem making the "problem" irrelevant, but I think this is still addressed by the added risk that having a key floating around entails. Ultimately this might be more a side-grade than anything.)

Edit: another way of looking at this PR is to consider it a way of moving the encryption key's usage away from a traitor identifier, and moving it towards a traitor communicator.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/113810873/225194833-26390db6-fe11-4d65-9a20-9d4041405ad9.png)
![image](https://user-images.githubusercontent.com/113810873/225194900-3c6091ba-2b86-433a-aba1-5cd8897a515a.png)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: The Syndicate has elected to introduce a permanent two-for-the-price-of-one deal on Syndicate Encryption Keys. Give the spare to a friend (or enemy)!
