### PR TITLE
door electronics can be programmed by hop

### DIFF
--- a/Content.Client/Access/AccessReaderSystem.cs
+++ b/Content.Client/Access/AccessReaderSystem.cs
@@ -2,4 +2,4 @@ using Content.Shared.Access.Systems;
 
 namespace Content.Client.Access;
 
-public sealed class AccessSystem : SharedAccessSystem {}
+public sealed class AccessReaderSystem : SharedAccessReaderSystem {}

--- a/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
+++ b/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
@@ -20,7 +20,7 @@ namespace Content.IntegrationTests.Tests.Access
 
             await server.WaitAssertion(() =>
             {
-                var system = EntitySystem.Get<AccessReaderSystem>();
+                var system = EntitySystem.Get<SharedAccessReaderSystem>();
 
                 // test empty
                 var reader = new AccessReaderComponent();

--- a/Content.Server/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Server/Access/Systems/AccessReaderSystem.cs
@@ -1,0 +1,108 @@
+using Content.Server.Doors.Components;
+using Content.Server.Examine;
+using Content.Server.Popups;
+using Content.Server.Tools;
+using Content.Shared.Access;
+using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems;
+using Content.Shared.Interaction;
+using Content.Shared.Tag;
+using Content.Shared.Verbs;
+using Robust.Shared.Containers;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+using Robust.Shared.ViewVariables;
+
+namespace Content.Server.Access.Systems;
+
+public sealed class AccessReaderSystem : SharedAccessReaderSystem
+{
+    [Dependency] private readonly ExamineSystem _examine = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly ToolSystem _tool = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AccessReaderComponent, GetVerbsEvent<ExamineVerb>>(OnGetExamineVerbsEvent);
+    }
+
+    private FormattedMessage CreateMessage(List<HashSet<string>> stringLists)
+    {
+        var message = new FormattedMessage();
+        var hashSet = new HashSet<string>();
+
+        foreach (var entry in stringLists)
+        {
+            foreach (var value in entry)
+            {
+                hashSet.Add(value);
+            }
+        }
+
+        var first = true;
+
+        if (hashSet.Count == 0)
+        {
+            message.AddMarkup(Loc.GetString("generic-not-available-shorthand"));
+        }
+
+        foreach (var value in hashSet)
+        {
+            if (!_proto.TryIndex<AccessLevelPrototype>(value, out var accessPrototype))
+            {
+                Logger.ErrorS(SharedIdCardConsoleSystem.Sawmill, $"Unable to find accesslevel for {value}");
+                continue;
+            }
+
+            var accessName = Loc.GetString(accessPrototype.Name ?? "");
+
+            if (!first)
+            {
+                message.AddMarkup(", " + accessName);
+                continue;
+            }
+
+            first = false;
+            message.AddMarkup(accessName);
+        }
+
+        return message;
+    }
+
+    private void OnGetExamineVerbsEvent(EntityUid uid, AccessReaderComponent component, GetVerbsEvent<ExamineVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || args.Using == null)
+            return;
+
+        if (!_tool.HasQuality(args.Using.Value, "Pulsing"))
+            return;
+
+        // Should we be able to check the access levels of other things with an AccessReaderComponent?
+         if (!_tag.HasTag(uid, "DoorElectronics"))
+            return;
+
+        var message = new FormattedMessage();
+        message.AddMarkup("Programmed access levels: ");
+        message.AddMessage(CreateMessage(component.AccessLists));
+
+        ExamineVerb verb = new()
+        {
+            Act = () =>
+            {
+                _examine.SendExamineTooltip(args.User, uid, message, false, false);
+            },
+            Text = Loc.GetString("verb-examine-access-text"),
+            Message = Loc.GetString("verb-examine-access-message"),
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("/Textures/Interface/VerbIcons/vv.svg.192dpi.png")),
+            Category = VerbCategory.Examine
+        };
+
+        args.Verbs.Add(verb);
+    }
+}

--- a/Content.Server/Access/Systems/AccessSystem.cs
+++ b/Content.Server/Access/Systems/AccessSystem.cs
@@ -1,8 +1,0 @@
-using Content.Shared.Access.Systems;
-
-namespace Content.Server.Access.Systems;
-
-public sealed class AccessSystem : SharedAccessSystem
-{
-
-}

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -36,7 +36,7 @@ public sealed class AirAlarmSystem : EntitySystem
     [Dependency] private readonly AtmosDeviceNetworkSystem _atmosDevNetSystem = default!;
     [Dependency] private readonly AtmosAlarmableSystem _atmosAlarmable = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
-    [Dependency] private readonly AccessReaderSystem _accessSystem = default!;
+    [Dependency] private readonly SharedAccessReaderSystem _accessSystem = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
 

--- a/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
@@ -21,7 +21,7 @@ public sealed class FireAlarmSystem : EntitySystem
     [Dependency] private readonly AtmosDeviceNetworkSystem _atmosDevNet = default!;
     [Dependency] private readonly AtmosAlarmableSystem _atmosAlarmable = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
-    [Dependency] private readonly AccessReaderSystem _access = default!;
+    [Dependency] private readonly SharedAccessReaderSystem _access = default!;
     [Dependency] private readonly IConfigurationManager _configManager = default!;
 
     public override void Initialize()

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -33,7 +33,7 @@ namespace Content.Server.Cargo.Systems
         private float _timer;
 
         [Dependency] private readonly IdCardSystem _idCardSystem = default!;
-        [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
+        [Dependency] private readonly SharedAccessReaderSystem _accessReader = default!;
         [Dependency] private readonly SignalLinkerSystem _linker = default!;
         [Dependency] private readonly PopupSystem _popup = default!;
         [Dependency] private readonly StationSystem _station = default!;
@@ -97,7 +97,7 @@ namespace Content.Server.Cargo.Systems
             if (args.Session.AttachedEntity is not {Valid: true} player)
                 return;
 
-            if (!_accessReaderSystem.IsAllowed(player, uid))
+            if (!_accessReader.IsAllowed(player, uid))
             {
                 ConsolePopup(args.Session, Loc.GetString("cargo-console-order-not-allowed"));
                 PlayDenySound(uid, component);

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Communications
 {
     public sealed class CommunicationsConsoleSystem : EntitySystem
     {
-        [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
+        [Dependency] private readonly SharedAccessReaderSystem _accessReader = default!;
         [Dependency] private readonly InteractionSystem _interaction = default!;
         [Dependency] private readonly AlertLevelSystem _alertLevelSystem = default!;
         [Dependency] private readonly ChatSystem _chatSystem = default!;
@@ -178,7 +178,7 @@ namespace Content.Server.Communications
 
             if (TryComp<AccessReaderComponent>(console, out var accessReaderComponent) && !HasComp<EmaggedComponent>(console))
             {
-                return _accessReaderSystem.IsAllowed(user, accessReaderComponent);
+                return _accessReader.IsAllowed(user, accessReaderComponent);
             }
             return true;
         }

--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -21,7 +21,7 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     [Dependency] private readonly DeviceListSystem _deviceListSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
-    [Dependency] private readonly AccessReaderSystem _accessSystem = default!;
+    [Dependency] private readonly SharedAccessReaderSystem _accessSystem = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
 
 

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Server.Doors.Systems;
 
 public sealed class DoorSystem : SharedDoorSystem
 {
-    [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
+    [Dependency] private readonly SharedAccessReaderSystem _accessReader = default!;
     [Dependency] private readonly AirlockSystem _airlock = default!;
     [Dependency] private readonly AirtightSystem _airtightSystem = default!;
     [Dependency] private readonly ConstructionSystem _constructionSystem = default!;
@@ -239,9 +239,9 @@ public sealed class DoorSystem : SharedDoorSystem
         return AccessType switch
         {
             // Some game modes modify access rules.
-            AccessTypes.AllowAllIdExternal => !isExternal || _accessReaderSystem.IsAllowed(user.Value, access),
+            AccessTypes.AllowAllIdExternal => !isExternal || _accessReader.IsAllowed(user.Value, access),
             AccessTypes.AllowAllNoExternal => !isExternal,
-            _ => _accessReaderSystem.IsAllowed(user.Value, access)
+            _ => _accessReader.IsAllowed(user.Value, access)
         };
     }
 

--- a/Content.Server/NPC/NPCBlackboard.cs
+++ b/Content.Server/NPC/NPCBlackboard.cs
@@ -149,7 +149,7 @@ public sealed class NPCBlackboard : IEnumerable<KeyValuePair<string, object>>
                     return false;
                 }
 
-                var access = entManager.EntitySysManager.GetEntitySystem<AccessReaderSystem>();
+                var access = entManager.EntitySysManager.GetEntitySystem<SharedAccessReaderSystem>();
                 value = access.FindAccessTags(owner);
                 return true;
             case CanMove:

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -22,7 +22,7 @@ namespace Content.Server.Power.EntitySystems
     [UsedImplicitly]
     internal sealed class ApcSystem : EntitySystem
     {
-        [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+        [Dependency] private readonly SharedAccessReaderSystem _accessReader = default!;
         [Dependency] private readonly UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.EmergencyConsole.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.EmergencyConsole.cs
@@ -29,7 +29,7 @@ public sealed partial class ShuttleSystem
 
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IdCardSystem _idSystem = default!;
-    [Dependency] private readonly AccessReaderSystem _reader = default!;
+    [Dependency] private readonly SharedAccessReaderSystem _reader = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly RoundEndSystem _roundEnd = default!;
 

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -28,7 +28,7 @@ namespace Content.Server.VendingMachines
         [Dependency] private readonly IComponentFactory _factory = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-        [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+        [Dependency] private readonly SharedAccessReaderSystem _accessReader = default!;
         [Dependency] private readonly AppearanceSystem _appearanceSystem = default!;
         [Dependency] private readonly AudioSystem _audioSystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;

--- a/Content.Shared/Access/Systems/SharedAccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/SharedAccessReaderSystem.cs
@@ -13,7 +13,7 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.Access.Systems
 {
-    public sealed class AccessReaderSystem : EntitySystem
+    public abstract class SharedAccessReaderSystem : EntitySystem
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly InventorySystem _inventorySystem = default!;
@@ -291,6 +291,30 @@ namespace Content.Shared.Access.Systems
 
             key = null;
             return false;
+        }
+
+        /// <summary>
+        /// Replaces the access lists of this reader with a single list accepting any of the access tags.
+        /// </summary>
+        public void UpdateAccess(AccessReaderComponent comp, HashSet<string> accessTags)
+        {
+            comp.AccessLists.Clear();
+            comp.AccessLists.Add(accessTags);
+        }
+
+        /// <summary>
+        /// Returns all of this readers' accepted accesses, ignoring conditions
+        /// </summary>
+        public HashSet<string> GetAccessList(AccessReaderComponent comp)
+        {
+            var list = new HashSet<string>();
+
+            foreach (var accessList in comp.AccessLists)
+            {
+                list.UnionWith(accessList);
+            }
+
+            return list;
         }
     }
 }

--- a/Content.Shared/Access/Systems/SharedAccessSystem.cs
+++ b/Content.Shared/Access/Systems/SharedAccessSystem.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Access.Systems
 {
-    public abstract class SharedAccessSystem : EntitySystem
+    public sealed class SharedAccessSystem : EntitySystem
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -26,7 +26,7 @@ public sealed class LockSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+    [Dependency] private readonly SharedAccessReaderSystem _accessReader = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPopupSystem _sharedPopupSystem = default!;

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -31,7 +31,7 @@ public abstract class SharedMechSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
-    [Dependency] private readonly AccessReaderSystem _access = default!;
+    [Dependency] private readonly SharedAccessReaderSystem _access = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;

--- a/Content.Shared/Vehicle/SharedVehicleSystem.cs
+++ b/Content.Shared/Vehicle/SharedVehicleSystem.cs
@@ -26,7 +26,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
-    [Dependency] private readonly AccessReaderSystem _access = default!;
+    [Dependency] private readonly SharedAccessReaderSystem _access = default!;
 
     private const string KeySlot = "key_slot";
 

--- a/Resources/Locale/en-US/access/components/access-reader-component.ftl
+++ b/Resources/Locale/en-US/access/components/access-reader-component.ftl
@@ -1,0 +1,4 @@
+access-update-popup = Access updated
+verb-update-access = Update access
+verb-examine-access-text = Examine access
+verb-examine-access-message = Examine access

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -426,6 +426,8 @@
       whitelist:
         components:
         - IdCard
+        tags:
+        - DoorElectronics
   - type: ActivatableUI
     key: enum.IdCardConsoleUiKey.Key
   - type: UserInterface


### PR DESCRIPTION
## About the PR
door electronics working like in cheackraze's suggestion in #12424
multitool to inspect accesses like in the base pr

to change access instead of using your id, you go to hop and ~~break in~~ ask them nicely to set the accesses

jobs require *any* of the listed accesses, not all. so sammy salvage / gary graytide example still applies. HoPs should be aware of this before setting job to captain expecting only cap to be able to open, but in reality anyone will be able to.

also only programmed electronics will have accesses, ripping out the bridge doors' electronics and putting them back will make them AA since currently it doesnt make mapped doors copy their accessreaders to their electronics. could be done in the future but it's pretty minor, you can just bolt it open if you want to fuck with the bridge

**Media**

https://user-images.githubusercontent.com/39013340/225238655-35ebbaad-cec4-433a-b16f-451001bafc61.mp4


- [X] I have added a video to this PR showcasing its changes ingame

**Changelog**
:cl:
- add: You can now change door electronics' access requirements in id card consoles.