### PR TITLE
Changed damage of advanced circular saw from 10 to 15

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -218,7 +218,7 @@
     attackRate: 1.5
     damage:
       groups:
-        Brute: 10
+        Brute: 15
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: Tool


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Base circular saw have 15 damage and attack rate of 1. The "advanced" circular saw have 10 damage and attack rate of 1.5; Its feels not like improvement but rather the opposite.


**Media**

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Changed damage of advanced circular saw from 10 to 15.