### PR TITLE
dehydrated carp can fit in locker again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -33,13 +33,13 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.4,-0.3,0.4,0.3"
+        bounds: "-0.3,-0.3,0.3,0.3"
       density: 5
       mask:
       - ItemMask
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.4,-0.3,0.4,0.3"
+        bounds: "-0.3,-0.3,0.3,0.3"
       id: "rehydrate"
       hard: false
       layer:
@@ -77,13 +77,13 @@
     fixtures: # TODO: Make a second fixture.
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.4,-0.4,0.4,0.4"
+        bounds: "-0.3,-0.3,0.3,0.3"
       density: 15
       mask:
       - ItemMask
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.4,-0.4,0.4,0.4"
+        bounds: "-0.3,-0.3,0.3,0.3"
       id: "rehydrate"
       hard: false
       layer:

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -74,7 +74,7 @@
   - type: Physics
     bodyType: KinematicController
   - type: Fixtures
-    fixtures: # TODO: Make a second fixture.
+    fixtures:
     - shape:
         !type:PhysShapeAabb
         bounds: "-0.3,-0.3,0.3,0.3"


### PR DESCRIPTION
## About the PR
backstory:
- monkey cube had a non-aabb size of 0.8x0.6 which let it usually fit in crates and lockers
- dehydrated carp had one of 0.8x0.8 which, when grid was rotated even a little, made its aabb size exceed 1
- this almost always stopped you from putting fishe in locker

so this pr makes both of them 0.6x0.6, shouldn't really affect hydrating them its such a small difference

tl;dr fishops is back baby!!!!

**Media**
left: old
right: new


https://user-images.githubusercontent.com/39013340/225388491-7610a3b8-f509-4a6e-8cf4-4c20b9433d5b.mp4


- [X] I have added a video to this PR showcasing its changes ingame

**Changelog**

:cl:
- fix: Dehydrated carp will fit in lockers now.