### PR TITLE
restructure cognizine effect so creatures that have minds can talk

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -13,17 +13,17 @@ public sealed class MakeSentient : ReagentEffect
         var entityManager = args.EntityManager;
         var uid = args.SolutionEntity;
 
-        // This makes it so it doesn't affect things that are already sentient
+        // This piece of code makes things able to speak "normally". One thing of note is that monkeys have a unique accent and won't be affected by this.
+        entityManager.RemoveComponent<ReplacementAccentComponent>(uid);
+
+        // Monke talk. This makes cognizine a cure to AMIV's long term damage funnily enough, do with this information what you will.
+        entityManager.RemoveComponent<MonkeyAccentComponent>(uid);
+
+        // This makes it so it doesn't add a ghost role to things that are already sentient
         if (entityManager.HasComponent<MindComponent>(uid))
         {
             return;
         }
-
-        // This piece of code makes things able to speak "normally". One thing of note is that monkeys have a unique accent and won't be affected by this.
-        entityManager.RemoveComponent<ReplacementAccentComponent>(uid);
-
-        // Monke talk
-        entityManager.RemoveComponent<MonkeyAccentComponent>(uid);
 
         // No idea what anything past this point does
         if (entityManager.TryGetComponent(uid, out GhostTakeoverAvailableComponent? takeOver))


### PR DESCRIPTION
## About the PR
does what it says on the tin

fixes #14692 by always removing replacement accent even if there is already a mind

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Cognizine works on animals that are already being controlled.
