### PR TITLE
Fix sprite layer visibility for folded body bag

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -92,6 +92,18 @@
   components:
   - type: Foldable
     folded: true
+  - type: Sprite
+    layers:
+      - state: bag
+        map: [ "unfoldedLayer" ]
+        visible: false
+      - state: bag_folded
+        map: [ "foldedLayer" ]
+      - state: open_overlay
+        map: [ "enum.StorageVisualLayers.Door" ]
+      - state: label_overlay
+        map: [ "enum.BodyBagVisualLayers.Label" ]
+
 #  - type: BodyBagItem #TODO: we need some kind of generic placable, like thus:
 # - type: Placeable
 #   prototype: someId


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Alters the folded body bag prototype so that it initially has the folded layer visible instead of incorrectly displaying the unfolded sprite. This fixes #14660. 


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Small fix, no new sprites.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: robertGN
- fix: Folded body bags now start with the correct sprite
