### PR TITLE
Folded objects are spawned with the folded sprite

### DIFF
--- a/Content.Shared/Foldable/SharedFoldableSystem.cs
+++ b/Content.Shared/Foldable/SharedFoldableSystem.cs
@@ -45,9 +45,6 @@ public abstract class SharedFoldableSystem : EntitySystem
     /// </summary>
     public virtual void SetFolded(EntityUid uid, FoldableComponent component, bool folded)
     {
-        if (component.IsFolded == folded)
-            return;
-
         component.IsFolded = folded;
         Dirty(component);
         Appearance.SetData(uid, FoldedVisuals.State, folded);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Removes the early return of SetFolded(), as when called by OnFoldableInit() it would fail to update the sprites of folded prototypes. SetFolded() appears to be intended to allow setting to both folded and unfolded states, which the early return prevented. This impacts all prototypes that use FoldableComponent. Fixes #14660 and other similar undocumented sprite issues with objects spawned as folded.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:
https://user-images.githubusercontent.com/16929123/225450152-f3039899-8e00-44f1-b090-d1e1c07e58b1.mp4
After:
https://user-images.githubusercontent.com/16929123/225450161-fa109aed-86b5-40c3-b25e-07280de18c7d.mp4
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: robertGN
- fix: Foldable objects spawned folded now use the correct sprites
