### PR TITLE
Fix welder interaction

### DIFF
--- a/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
+++ b/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
@@ -23,7 +23,6 @@ public sealed class IgnitionSourceSystem : EntitySystem
 
     private void OnIsHot(EntityUid uid, IgnitionSourceComponent component, IsHotEvent args)
     {
-        Logger.Debug(args.IsHot.ToString());
         SetIgnited(uid,component,args.IsHot);
     }
 

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -301,6 +301,7 @@ namespace Content.Server.Tools
 
             if (neededFuel > fuel)
             {
+                _popupSystem.PopupEntity(Loc.GetString("welder-component-cannot-weld-message"), uid, args.User);
                 args.Cancel();
             }
 

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -15,7 +15,6 @@ using Content.Shared.Weapons.Melee.Events;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
-using Robust.Shared.Player;
 
 namespace Content.Server.Tools
 {

--- a/Content.Shared/Tools/Components/ToolComponent.cs
+++ b/Content.Shared/Tools/Components/ToolComponent.cs
@@ -65,6 +65,7 @@ namespace Content.Shared.Tools.Components
 
         public ToolUseFinishAttemptEvent(float fuel, EntityUid user)
         {
+            User = user;
             Fuel = fuel;
         }
     }

--- a/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
@@ -35,7 +35,7 @@ public abstract class SharedToolSystem : EntitySystem
         if (args.Handled || args.AdditionalData.Ev == null)
             return;
 
-        if (args.Cancelled)
+        if (args.Cancelled || !ToolFinishUse(uid, args.Args.User, args.AdditionalData.Fuel))
         {
             if (args.AdditionalData.CancelledEv != null)
             {
@@ -50,15 +50,12 @@ public abstract class SharedToolSystem : EntitySystem
             return;
         }
 
-        if (ToolFinishUse(uid, args.Args.User, args.AdditionalData.Fuel))
-        {
-            if (args.AdditionalData.TargetEntity != null)
-                RaiseLocalEvent(args.AdditionalData.TargetEntity.Value, args.AdditionalData.Ev);
-            else
-                RaiseLocalEvent(args.AdditionalData.Ev);
+        if (args.AdditionalData.TargetEntity != null)
+            RaiseLocalEvent(args.AdditionalData.TargetEntity.Value, args.AdditionalData.Ev);
+        else
+            RaiseLocalEvent(args.AdditionalData.Ev);
 
-            args.Handled = true;
-        }
+        args.Handled = true;
     }
 
     public bool UseTool(EntityUid tool, EntityUid user, EntityUid? target, float doAfterDelay, IEnumerable<string> toolQualitiesNeeded, ToolEventData toolEventData, float fuel = 0f, ToolComponent? toolComponent = null, Func<bool>? doAfterCheck = null, CancellationTokenSource? cancelToken = null)


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->

There is 2 fix in this PR:

* the construction step isn't cancelled if the welder doesn't have enough fuel (So we are stuck with a paused step)
* `ToolUseFinishAttemptEvent` didn't save the user `EntityUid`

**Media**
Before:

https://user-images.githubusercontent.com/32521367/225621599-2d8319e9-66d3-4bbf-96d1-0bc66841f9d4.mp4

After:

https://user-images.githubusercontent.com/32521367/225621607-e0880a36-e77c-464e-b4d0-3bf362a65edd.mp4



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed welder interaction when it has a fuel shortage problem