### PR TITLE
refactor rehydration

### DIFF
--- a/Content.Server/Chemistry/Components/RehydratableComponent.cs
+++ b/Content.Server/Chemistry/Components/RehydratableComponent.cs
@@ -22,7 +22,7 @@ public sealed class RehydratableComponent : Component
     /// <summary>
     /// The minimum amount of catalyst that must be present to be hydrated.
     /// </summary>
-    [DataField("catalystAmount"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField("catalystMinimum"), ViewVariables(VVAccess.ReadWrite)]
     public FixedPoint2 CatalystMinimum = FixedPoint2.Zero;
 
     /// <summary>

--- a/Content.Server/Chemistry/Components/RehydratableComponent.cs
+++ b/Content.Server/Chemistry/Components/RehydratableComponent.cs
@@ -20,10 +20,10 @@ public sealed class RehydratableComponent : Component
     public string CatalystPrototype = "Water";
 
     /// <summary>
-    /// The amount of catalyst that must be present to be hydrated.
+    /// The minimum amount of catalyst that must be present to be hydrated.
     /// </summary>
     [DataField("catalystAmount"), ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 CatalystAmount = FixedPoint2.Zero;
+    public FixedPoint2 CatalystMinimum = FixedPoint2.Zero;
 
     /// <summary>
     /// The entity to create when hydrated.

--- a/Content.Server/Chemistry/Components/RehydratableComponent.cs
+++ b/Content.Server/Chemistry/Components/RehydratableComponent.cs
@@ -1,18 +1,39 @@
-namespace Content.Server.Chemistry.Components
+using Content.Server.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Chemistry.Components;
+
+/// <summary>
+/// Basically, monkey cubes.
+/// But specifically, this component deletes the entity and spawns in a new entity when the entity is exposed to a certain amount of a given reagent.
+/// </summary>
+[RegisterComponent, Access(typeof(RehydratableSystem))]
+public sealed class RehydratableComponent : Component
 {
     /// <summary>
-    /// Basically, monkey cubes.
-    /// But specifically, this component deletes the entity and spawns in a new entity when the entity is exposed to a given reagent.
+    /// The reagent that must be present to count as hydrated.
     /// </summary>
-    [RegisterComponent]
-    public sealed class RehydratableComponent : Component
-    {
-        [DataField("catalyst")]
-        internal string CatalystPrototype = "Water";
+    [DataField("catalyst", customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>)), ViewVariables(VVAccess.ReadWrite)]
+    public string CatalystPrototype = "Water";
 
-        [DataField("target")]
-        internal string? TargetPrototype = default!;
+    /// <summary>
+    /// The amount of catalyst that must be present to be hydrated.
+    /// </summary>
+    [DataField("catalystAmount"), ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 CatalystAmount = FixedPoint2.Zero;
 
-        internal bool Expanding;
-    }
+    /// <summary>
+    /// The entity to create when hydrated.
+    /// </summary>
+    [DataField("target", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>)), ViewVariables(VVAccess.ReadWrite)]
+    public string? TargetPrototype = default!;
 }
+
+/// <summary>
+/// Raised on the rehydrated entity with target being the new entity it became.
+/// </summary>
+[ByRefEvent]
+public readonly record struct GotRehydratedEvent(EntityUid Target);

--- a/Content.Server/Chemistry/EntitySystems/RehydratableSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/RehydratableSystem.cs
@@ -17,7 +17,8 @@ public sealed class RehydratableSystem : EntitySystem
 
     private void OnSolutionChange(EntityUid uid, RehydratableComponent comp, SolutionChangedEvent args)
     {
-        if (_solutions.GetReagentQuantity(uid, comp.CatalystPrototype) > comp.CatalystMinimum)
+        var quantity = _solutions.GetReagentQuantity(uid, comp.CatalystPrototype);
+        if (quantity != FixedPoint.Zero && quantity >= comp.CatalystMinimum)
         {
             Expand(uid, comp);
         }

--- a/Content.Server/Chemistry/EntitySystems/RehydratableSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/RehydratableSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Chemistry.Components;
+using Content.Shared.FixedPoint;
 using Content.Shared.Popups;
 
 namespace Content.Server.Chemistry.EntitySystems;
@@ -18,7 +19,7 @@ public sealed class RehydratableSystem : EntitySystem
     private void OnSolutionChange(EntityUid uid, RehydratableComponent comp, SolutionChangedEvent args)
     {
         var quantity = _solutions.GetReagentQuantity(uid, comp.CatalystPrototype);
-        if (quantity != FixedPoint.Zero && quantity >= comp.CatalystMinimum)
+        if (quantity != FixedPoint2.Zero && quantity >= comp.CatalystMinimum)
         {
             Expand(uid, comp);
         }

--- a/Content.Server/Chemistry/EntitySystems/RehydratableSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/RehydratableSystem.cs
@@ -17,7 +17,7 @@ public sealed class RehydratableSystem : EntitySystem
 
     private void OnSolutionChange(EntityUid uid, RehydratableComponent comp, SolutionChangedEvent args)
     {
-        if (_solutions.GetReagentQuantity(uid, comp.CatalystPrototype) > comp.CatalystAmount)
+        if (_solutions.GetReagentQuantity(uid, comp.CatalystPrototype) > comp.CatalystMinimum)
         {
             Expand(uid, comp);
         }

--- a/Content.Server/Chemistry/EntitySystems/RehydratableSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/RehydratableSystem.cs
@@ -1,47 +1,40 @@
-﻿using Content.Server.Chemistry.Components;
-using Content.Server.Popups;
-using Content.Shared.FixedPoint;
-using JetBrains.Annotations;
+using Content.Server.Chemistry.Components;
+using Content.Shared.Popups;
 
-namespace Content.Server.Chemistry.EntitySystems
+namespace Content.Server.Chemistry.EntitySystems;
+
+public sealed class RehydratableSystem : EntitySystem
 {
-    [UsedImplicitly]
-    public sealed class RehydratableSystem : EntitySystem
+    [Dependency] private readonly SharedPopupSystem _popups = default!;
+    [Dependency] private readonly SolutionContainerSystem _solutions = default!;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly SolutionContainerSystem _solutionsSystem = default!;
-        public override void Initialize()
+        base.Initialize();
+
+        SubscribeLocalEvent<RehydratableComponent, SolutionChangedEvent>(OnSolutionChange);
+    }
+
+    private void OnSolutionChange(EntityUid uid, RehydratableComponent comp, SolutionChangedEvent args)
+    {
+        if (_solutions.GetReagentQuantity(uid, comp.CatalystPrototype) > comp.CatalystAmount)
         {
-            base.Initialize();
-
-            SubscribeLocalEvent<RehydratableComponent, SolutionChangedEvent>(OnSolutionChange);
+            Expand(uid, comp);
         }
+    }
 
-        private void OnSolutionChange(EntityUid uid, RehydratableComponent component, SolutionChangedEvent args)
-        {
-            if (_solutionsSystem.GetReagentQuantity(uid, component.CatalystPrototype) > FixedPoint2.Zero)
-            {
-                Expand(component, component.Owner);
-            }
-        }
+    // Try not to make this public if you can help it.
+    private void Expand(EntityUid uid, RehydratableComponent comp)
+    {
+        _popups.PopupEntity(Loc.GetString("rehydratable-component-expands-message", ("owner", uid)), uid);
 
-        // Try not to make this public if you can help it.
-        private void Expand(RehydratableComponent component, EntityUid owner)
-        {
-            if (component.Expanding)
-            {
-                return;
-            }
+        var target = Spawn(comp.TargetPrototype, Transform(uid).Coordinates);
+        Transform(target).AttachToGridOrMap();
+        var ev = new GotRehydratedEvent(target);
+        RaiseLocalEvent(uid, ref ev);
 
-            component.Expanding = true;
-            owner.PopupMessageEveryone(Loc.GetString("rehydratable-component-expands-message", ("owner", owner)));
-            if (!string.IsNullOrEmpty(component.TargetPrototype))
-            {
-                var ent = EntityManager.SpawnEntity(component.TargetPrototype,
-                    EntityManager.GetComponent<TransformComponent>(owner).Coordinates);
-                EntityManager.GetComponent<TransformComponent>(ent).AttachToGridOrMap();
-            }
-
-            EntityManager.QueueDeleteEntity((EntityUid) owner);
-        }
+        // prevent double hydration while queued
+        RemComp<RehydratableComponent>(uid);
+        QueueDel(uid);
     }
 }


### PR DESCRIPTION
## About the PR
makes it nicer and adds 2 things:
- `catalystMinimum`: minimum amount of the catalyst reagent before hydrating, say to require at least 1u injected into bread to "hydrate" it into moldy slice
- `GotRehydratedEvent`: i need for #14709

i tested in game everything seems to work but i haven't verified if the queuedel remcomp stuff works since no idea how to rehydrate twice in same tick
also havent tested catalyst amount > 0 but it probably works

**Media**
- [X] This PR does not require an ingame showcase

**Changelog**
no cl no fun