### PR TITLE
"Blocked by" string is fluent now

### DIFF
--- a/Content.Client/Hands/UI/HandVirtualItemStatus.xaml
+++ b/Content.Client/Hands/UI/HandVirtualItemStatus.xaml
@@ -1,3 +1,3 @@
 ﻿<Control xmlns="https://spacestation14.io">
-    <Label StyleClasses="ItemStatus" Text="Blocked by" />
+    <Label StyleClasses="ItemStatus" Text="{Loc 'hands-system-blocked-by'}" />
 </Control>

--- a/Resources/Locale/en-US/hands/hands-system.ftl
+++ b/Resources/Locale/en-US/hands/hands-system.ftl
@@ -4,5 +4,6 @@ hands-system-empty-equipment-slot = There's nothing in your {$slotName} to take 
 
 
 # Examine text after when they're holding something (in-hand)
-comp-hands-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } holding a { $item }.    
+comp-hands-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } holding a { $item }.
 
+hands-system-blocked-by = Blocked by


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
"Blocked by" string is fluent now

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
