### PR TITLE
Add Rotation attribute to GuideEntityEmbed.

### DIFF
--- a/Content.Client/Guidebook/Controls/GuideEntityEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideEntityEmbed.xaml.cs
@@ -164,6 +164,11 @@ public sealed partial class GuideEntityEmbed : BoxContainer, IDocumentTag
         if (args.TryGetValue("Interactive", out var interactive))
             Interactive = bool.Parse(interactive);
 
+        if (args.TryGetValue("Rotation", out var rotation))
+        {
+            Sprite.Rotation = Angle.FromDegrees(double.Parse(rotation));
+        }
+
         Margin = new Thickness(4, 8);
 
         control = this;


### PR DESCRIPTION
Simply adds a Rotation attribute which accepts a value in degrees to rotate the sprite of a GuideEntityEmbed.