### PR TITLE
Ban message improvements

### DIFF
--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -28,6 +28,7 @@ namespace Content.Server.Connection
         [Dependency] private readonly IServerNetManager _netMgr = default!;
         [Dependency] private readonly IServerDbManager _db = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
+        [Dependency] private readonly ILocalizationManager _loc = default!;
 
         public void Initialize()
         {
@@ -147,7 +148,8 @@ namespace Content.Server.Connection
             if (bans.Count > 0)
             {
                 var firstBan = bans[0];
-                return (ConnectionDenyReason.Ban, firstBan.DisconnectMessage, bans);
+                var message = firstBan.FormatBanMessage(_cfg, _loc);
+                return (ConnectionDenyReason.Ban, message, bans);
             }
 
             if (_cfg.GetCVar(CCVars.WhitelistEnabled))

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1475,6 +1475,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> InfoLinksBugReport =
             CVarDef.Create("infolinks.bug_report", "", CVar.SERVER | CVar.REPLICATED);
 
+        /// <summary>
+        /// Link to site handling ban appeals. Shown in ban disconnect messages.
+        /// </summary>
+        public static readonly CVarDef<string> InfoLinksAppeal =
+            CVarDef.Create("infolinks.appeal", "", CVar.SERVER | CVar.REPLICATED);
+
         /*
          * CONFIG
          */

--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -14,6 +14,7 @@ github     = "https://github.com/space-wizards/space-station-14"
 patreon    = "https://www.patreon.com/spacestation14"
 website    = "https://spacestation14.io"
 wiki       = "https://wiki.spacestation14.io"
+appeal     = "https://appeal.ss14.io"
 
 [net]
 max_connections = 1024

--- a/Resources/Locale/en-US/connection-messages.ftl
+++ b/Resources/Locale/en-US/connection-messages.ftl
@@ -25,10 +25,12 @@ command-whitelistremove-not-found = Unable to find '{$username}'
 command-kicknonwhitelisted-description = Kicks all non-whitelisted players from the server.
 command-kicknonwhitelisted-help = kicknonwhitelisted
 
-ban-banned-permanent = This ban is appeal only.
+ban-banned-permanent = This ban will only be removed via appeal.
+ban-banned-permanent-appeal = This ban will only be removed via appeal. You can appeal at {$link}
 ban-expires = This ban is for {$duration} minutes and will expire at {$time} UTC.
 ban-banned-1 = You, or another user of this computer or connection, are banned from playing here.
 ban-banned-2 = The ban reason is: "{$reason}"
+ban-banned-3 = Attempts to circumvent this ban such as creating a new account will be logged.
 
 soft-player-cap-full = The server is full!
 panic-bunker-account-denied = This server is in panic bunker mode. New connections are not being accepted at this time. Try again later


### PR DESCRIPTION
Server config now provide appeals forum link, game admins won't need to type it out manually anymore. Add warning about trying to ban evade.
Cleaned up code a bit.

`appeal.ss14.io` is gonna redirect to the appeals forum but I think it's broken right now due to DNS caching. I'll check it again tomorrow.