### PR TITLE
voice mask no longer works in pockets !1984

### DIFF
--- a/Content.Server/VoiceMask/VoiceMaskSystem.Equip.cs
+++ b/Content.Server/VoiceMask/VoiceMaskSystem.Equip.cs
@@ -18,7 +18,12 @@ public sealed partial class VoiceMaskSystem
 
     private void OnEquip(EntityUid uid, VoiceMaskerComponent component, GotEquippedEvent args)
     {
-        var comp = EnsureComp<VoiceMaskComponent>(args.Equipee);
+        var user = args.Equipee;
+        // have to be wearing the mask to use it, duh.
+        if (!_inventory.TryGetSlotEntity(user, MaskSlot, out var maskEntity) || maskEntity != uid)
+            return;
+
+        var comp = EnsureComp<VoiceMaskComponent>(user);
         comp.VoiceName = component.LastSetName;
 
         if (!_prototypeManager.TryIndex<InstantActionPrototype>(component.Action, out var action))
@@ -26,7 +31,7 @@ public sealed partial class VoiceMaskSystem
             throw new ArgumentException("Could not get voice masking prototype.");
         }
 
-        _actions.AddAction(args.Equipee, (InstantAction) action.Clone(), uid);
+        _actions.AddAction(user, (InstantAction) action.Clone(), uid);
     }
 
     private void OnUnequip(EntityUid uid, VoiceMaskerComponent compnent, GotUnequippedEvent args)


### PR DESCRIPTION
## About the PR
fixes #14739 and fixes #14738 by only adding the action and masker if it's equipped to mask slot.

**Media**


https://user-images.githubusercontent.com/39013340/226213046-930085d7-0cad-4142-b513-1f0bcc0d94d1.mp4



- [X] I have added a video to this PR showcasing its changes ingame

**Changelog**
:cl:
- fix: Voice mask can no longer be used from your pockets.
