### PR TITLE
Update SpawnPointSystem.cs

### DIFF
--- a/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
@@ -51,6 +51,22 @@ public sealed class SpawnPointSystem : EntitySystem
             }
         }
 
+        // First, let's try to spawn the player at the late join points..
+        foreach (var spawnPoint in points)
+        {
+            var xform = Transform(spawnPoint.Owner);
+            if (spawnPoint.SpawnType == SpawnPointType.LateJoin)
+            {
+                args.SpawnResult = _stationSpawning.SpawnPlayerMob(
+                    xform.Coordinates,
+                    args.Job,
+                    args.HumanoidCharacterProfile,
+                    args.Station);
+
+                return;
+            }
+        }
+
         // Ok we've still not returned, but we need to put them /somewhere/.
         // TODO: Refactor gameticker spawning code so we don't have to do this!
         foreach (var spawnPoint in points)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
It would be more logical to start by trying to throw the player at a late join point and not throw him anywhere. For the most part, this is necessary in case of adding new professions, but not having the desire to add a marker for a new profession to each card.
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed spawn when no find spawner!
