### PR TITLE
holster + sus box tweaks

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -127,7 +127,7 @@ uplink-super-surplus-bundle-desc = Contains 125 telecrystals worth of completely
 
 # Tools
 uplink-toolbox-name = Toolbox
-uplink-toolbox-desc = A full compliment of tools for the mechanically inclined traitor. Includes a pair of insulated combat gloves, syndicate gas mask and a shoulder holster.
+uplink-toolbox-desc = A full compliment of tools for the mechanically inclined traitor. Includes a pair of insulated combat gloves, syndicate gas mask and a utility belt.
 
 uplink-syndicate-jaws-of-life-name = Jaws Of Life
 uplink-syndicate-jaws-of-life-desc = A combined prying and cutting tool. Useful for entering the station or its departments.

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -69,14 +69,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Screwdriver
-      - id: Wrench
-      - id: Welder
-      - id: Crowbar
-      - id: Multitool
-      - id: Wirecutter
+      - id: ClothingBeltUtilityFilled
       - id: ClothingHandsGlovesCombat
-      - id: ClothingBeltSyndieHolster
       - id: ClothingMaskGasSyndicate
 
 - type: entity

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -496,7 +496,7 @@
   description: uplink-toolbox-desc
   productEntity: ToolboxSyndicateFilled
   cost:
-    Telecrystal: 2
+    Telecrystal: 4
   categories:
   - UplinkTools
 

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -450,7 +450,6 @@
     whitelist:
       components:
         - Gun
-        - MeleeWeapon
         - BallisticAmmoProvider
         - CartridgeAmmo
 


### PR DESCRIPTION
# About the PR
- holster can no longer hold melee weapons (its for guns)
- sus box comes with a utility belt instead of holster + individual tools

**Media**
![095429](https://user-images.githubusercontent.com/39013340/227167457-3c94c992-e3ae-40ad-b0e5-fda4c4b30c98.png)
![095442](https://user-images.githubusercontent.com/39013340/227167512-b236d6c7-7e62-4e6d-bd96-9d63e0bf6dff.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Syndicate shoulder holsters can no longer hold melee weapons.
- tweak: Suspicious toolbox now comes with a utility belt in place of a holster.
