### PR TITLE
Fix collision for entity with LargeMobLayer.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -225,7 +225,7 @@
       mask:
       - LargeMobMask
       layer:
-      - MobLayer # Must be LargeMobLayer, but now LargeMobLayerWork incorrectly
+      - MobLayer
   - type: Appearance
     rotate: true
     states:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -225,7 +225,7 @@
       mask:
       - LargeMobMask
       layer:
-      - LargeMobLayer
+      - MobLayer # Must be LargeMobLayer, but now LargeMobLayerWork incorrectly
   - type: Appearance
     rotate: true
     states:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -212,6 +212,9 @@
     - state: onestar_boss_screen
       sprite: Mobs/Silicon/onestar.rsi
       shader: unshaded
+  - type: FootstepModifier
+    footstepSoundCollection:
+      path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
   - type: MovementIgnoreGravity
   - type: Fixtures
     fixtures:
@@ -231,3 +234,7 @@
       Dead:
         Base: onestar_boss_wrecked
   - type: CombatMode
+  - type: Tag
+    tags:
+      - FootstepSound
+


### PR DESCRIPTION
## About the PR
Added sound for playable silicon pawn "Onestar mecha" he exist in game but have some issue like he hasnt footstep sound, atleast before this PR. Used sound alredy existing if u want u can hear it in /Audio/Mecha/sound_mecha_powerloader_step.ogg
Also fixed collision layer.

**Media**
Reason of update collisions
![image](https://user-images.githubusercontent.com/33431126/225834752-15398cee-a674-4177-8ec3-861de24d77e0.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: 778b
- fix: Collision and sound for onestar mecha!
