### PR TITLE
list codewords on traitor round end

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -322,6 +322,8 @@ public sealed class TraitorRuleSystem : GameRuleSystem
 
         var result = Loc.GetString("traitor-round-end-result", ("traitorCount", Traitors.Count));
 
+        result += "\n" + Loc.GetString("traitor-round-end-codewords", ("codewords", string.Join(", ", Codewords))) + "\n";
+
         foreach (var traitor in Traitors)
         {
             var name = traitor.Mind.CharacterName;

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -7,6 +7,10 @@ traitor-round-end-result = {$traitorCount ->
     *[other] There were {$traitorCount} traitors.
 }
 
+traitor-round-end-codewords =
+    The codewords were:
+    {$codewords}.
+
 # Shown at the end of a round of Traitor
 traitor-user-was-a-traitor = [color=gray]{$user}[/color] was a traitor.
 traitor-user-was-a-traitor-named = [color=White]{$name}[/color] ([color=gray]{$user}[/color]) was a traitor.

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -9,7 +9,7 @@ traitor-round-end-result = {$traitorCount ->
 
 traitor-round-end-codewords =
     The codewords were:
-    {$codewords}.
+    [color=White]{$codewords}[/color].
 
 # Shown at the end of a round of Traitor
 traitor-user-was-a-traitor = [color=gray]{$user}[/color] was a traitor.


### PR DESCRIPTION
## About the PR
whiskey echo whiskey lima alpha delta

**Media**

![151015](https://user-images.githubusercontent.com/39013340/227247773-ed95c273-1da8-4b5c-8ee0-793d9117ff68.png)

- [X] I have added a screenshot to this PR showcasing its changes ingame

**Changelog**
:cl:
- tweak: Round end screen now lists traitor codewords.