### PR TITLE
storage open sound has cooldown now

### DIFF
--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Hands.Components;
 using Content.Server.Storage.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Storage;
+using Content.Shared.Timing;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
@@ -59,6 +60,7 @@ namespace Content.Server.Storage.EntitySystems
         [Dependency] private readonly SharedCombatModeSystem _combatMode = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly UseDelaySystem _useDelay = default!;
 
         /// <inheritdoc />
         public override void Initialize()
@@ -601,8 +603,13 @@ namespace Content.Server.Storage.EntitySystems
             if (!Resolve(uid, ref storageComp) || !TryComp(entity, out ActorComponent? player))
                 return;
 
+            // prevent spamming bag open / honkerton honk sound
+            silent |= _useDelay.ActiveDelay(uid);
             if (!silent)
+            {
                 _audio.PlayPvs(storageComp.StorageOpenSound, uid);
+                _useDelay.BeginDelay(uid);
+            }
 
             Logger.DebugS(storageComp.LoggerName, $"Storage (UID {uid}) \"used\" by player session (UID {player.PlayerSession.AttachedEntity}).");
 

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -604,12 +604,12 @@ namespace Content.Server.Storage.EntitySystems
                 return;
 
             // prevent spamming bag open / honkerton honk sound
-            TryComp<UseDelayComponent>(uid, out var useDelay);
-            silent |= _useDelay.ActiveDelay(uid, useDelay);
+            silent |= TryComp<UseDelayComponent>(uid, out var useDelay) && _useDelay.ActiveDelay(uid, useDelay);
             if (!silent)
             {
                 _audio.PlayPvs(storageComp.StorageOpenSound, uid);
-                _useDelay.BeginDelay(uid, useDelay);
+                if (useDelay != null)
+                    _useDelay.BeginDelay(uid, useDelay);
             }
 
             Logger.DebugS(storageComp.LoggerName, $"Storage (UID {uid}) \"used\" by player session (UID {player.PlayerSession.AttachedEntity}).");

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -604,11 +604,12 @@ namespace Content.Server.Storage.EntitySystems
                 return;
 
             // prevent spamming bag open / honkerton honk sound
-            silent |= _useDelay.ActiveDelay(uid);
+            TryComp<UseDelayComponent>(uid, out var useDelay);
+            silent |= _useDelay.ActiveDelay(uid, useDelay);
             if (!silent)
             {
                 _audio.PlayPvs(storageComp.StorageOpenSound, uid);
-                _useDelay.BeginDelay(uid);
+                _useDelay.BeginDelay(uid, useDelay);
             }
 
             Logger.DebugS(storageComp.LoggerName, $"Storage (UID {uid}) \"used\" by player session (UID {player.PlayerSession.AttachedEntity}).");

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -23,6 +23,9 @@
     interfaces:
     - key: enum.StorageUiKey.Key
       type: StorageBoundUserInterface
+  # to prevent bag open/honk spam
+  - type: UseDelay
+    delay: 0.5
 
 - type: entity
   parent: ClothingBackpack


### PR DESCRIPTION
## About the PR
#14146 except better

adds 0.5s delay to bag open sound, same as bike horn

**Media**

https://user-images.githubusercontent.com/39013340/227253989-a386805d-4595-473d-981b-9ee0b01ca80f.mp4

- [X] I have added a videos to this PR showcasing its changes ingame

**Changelog**
:cl: G. Orwell
- tweak: Giggles Von Honkerton's honk can no longer be spammed at the speed of light.
