### PR TITLE
signaller can be used as a payload

### DIFF
--- a/Content.Server/MachineLinking/System/SignallerSystem.cs
+++ b/Content.Server/MachineLinking/System/SignallerSystem.cs
@@ -1,31 +1,55 @@
+using Content.Server.Explosion.EntitySystems;
 using Content.Server.MachineLinking.Components;
-using JetBrains.Annotations;
 using Content.Shared.Interaction.Events;
+using System.Linq;
 
-namespace Content.Server.MachineLinking.System
+namespace Content.Server.MachineLinking.System;
+
+public sealed class SignallerSystem : EntitySystem
 {
-    [UsedImplicitly]
-    public sealed class SignallerSystem : EntitySystem
+    [Dependency] private readonly SignalLinkerSystem _signal = default!;
+
+    private HashSet<(EntityUid, String)> _triggering = new();
+
+    public override void Initialize()
     {
-        [Dependency] private readonly SignalLinkerSystem _signalSystem = default!;
-        public override void Initialize()
-        {
-            base.Initialize();
-            SubscribeLocalEvent<SignallerComponent, ComponentInit>(OnInit);
-            SubscribeLocalEvent<SignallerComponent, UseInHandEvent>(OnUseInHand);
-        }
+        base.Initialize();
 
-        private void OnInit(EntityUid uid, SignallerComponent component, ComponentInit args)
-        {
-            _signalSystem.EnsureTransmitterPorts(uid, component.Port);
-        }
+        SubscribeLocalEvent<SignallerComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<SignallerComponent, UseInHandEvent>(OnUseInHand);
+        SubscribeLocalEvent<SignallerComponent, TriggerEvent>(OnTrigger);
+    }
 
-        private void OnUseInHand(EntityUid uid, SignallerComponent component, UseInHandEvent args)
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // do any deferred triggers for this tick
+        var list = _triggering.ToList();
+        _triggering.Clear();
+        foreach (var (uid, port) in list)
         {
-            if (args.Handled)
-                return;
-            _signalSystem.InvokePort(uid, component.Port);
-            args.Handled = true;
-        }   
+            _signal.InvokePort(uid, port);
+        }
+    }
+
+    private void OnInit(EntityUid uid, SignallerComponent component, ComponentInit args)
+    {
+        _signal.EnsureTransmitterPorts(uid, component.Port);
+    }
+
+    private void OnUseInHand(EntityUid uid, SignallerComponent component, UseInHandEvent args)
+    {
+        if (args.Handled)
+            return;
+        _signal.InvokePort(uid, component.Port);
+        args.Handled = true;
+    }
+
+    private void OnTrigger(EntityUid uid, SignallerComponent component, TriggerEvent args)
+    {
+        // defer it to the next tick to prevent stack overflow
+        _triggering.Add((uid, component.Port));
+        args.Handled = true;
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/signaller.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/signaller.yml
@@ -16,3 +16,6 @@
   - type: SignalTransmitter
     outputs:
       Pressed: []
+  - type: Tag
+    tags:
+    - Payload


### PR DESCRIPTION
## About the PR
lets you use signaller as a payload for more advanced chicanery like having a one-way door using landmine on one side to open it, or for using triggers to relay a signal to multiple grenades at once.
it has a cooldown so you cant do epic clocks that honk at 30Hz

**Media**
first: landmine that opens airlock
second: voice trigger that opens door when asked nicely
third: clock powering a honk grenade, started by voice (no longer works)

https://user-images.githubusercontent.com/39013340/227485420-017dac6d-1f3a-4edd-b15c-ffed84d4dd29.mp4

- [X] I have added a video to this PR showcasing its changes ingame

**Changelog**
:cl:
- tweak: Remote signaller can now be used as a payload in grenades and mines, have fun!