### PR TITLE
dylo has 30u overdose

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -21,13 +21,42 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: -1
-    # TODO overdose: vomit, dizzy effect (drunkenness?)
+            Poison: -2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          types:
+            Brute: 0.5
+      - !type:Jitter
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+      - !type:PopupMessage
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        type: Local
+        visualType: Medium
+        messages: [ "generic-reagent-effect-nauseous" ]
+        probability: 0.2
+      - !type:ChemVomit
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        probability: 0.02
+    Alcohol:
+      effects:
+      - !type:Drunk
+        conditions:
+        - !type:ReagentThreshold
+          min: 15
   plantMetabolism:
-    - !type:PlantAdjustToxins
-      amount: -10
-    - !type:PlantAdjustHealth
-      amount: 1
+  - !type:PlantAdjustToxins
+    amount: -10
+  - !type:PlantAdjustHealth
+    amount: 1
 
 - type: reagent
   id: Diphenhydramine

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -21,7 +21,7 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: -2
+            Poison: -1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
## About the PR
1. drunk effect if you take over 15u
2. if you take over 30u:
   - does 1 brute damage
   - jitters
   - vomiting

**Media**
no

**Changelog**
:cl:
- tweak: The rumors of dylovene's overdose turned out to be true! Anything above 30u will now have unwanted side effects.