### PR TITLE
Fixes codewords in the roundend summary

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -7,9 +7,7 @@ traitor-round-end-result = {$traitorCount ->
     *[other] There were {$traitorCount} traitors.
 }
 
-traitor-round-end-codewords =
-    The codewords were:
-    [color=White]{$codewords}[/color].
+traitor-round-end-codewords = The codewords were: [color=White]{$codewords}[/color]
 
 # Shown at the end of a round of Traitor
 traitor-user-was-a-traitor = [color=gray]{$user}[/color] was a traitor.


### PR DESCRIPTION
**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ x I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Traitor codewords now get properly displayed in the round end summary
