### PR TITLE
Alert display lights now properly react to power changes.

### DIFF
--- a/Content.Client/AlertLevel/AlertLevelDisplaySystem.cs
+++ b/Content.Client/AlertLevel/AlertLevelDisplaySystem.cs
@@ -15,32 +15,32 @@ public sealed class AlertLevelDisplaySystem : EntitySystem
         SubscribeLocalEvent<AlertLevelDisplayComponent, AppearanceChangeEvent>(OnAppearanceChange);
     }
 
-    private void OnAppearanceChange(EntityUid uid, AlertLevelDisplayComponent component, ref AppearanceChangeEvent args)
+    private void OnAppearanceChange(EntityUid uid, AlertLevelDisplayComponent alertLevelDisplay, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
         {
             return;
         }
+        var layer = args.Sprite.LayerMapReserveBlank(AlertLevelDisplay.Layer);
 
-        if (!args.Sprite.LayerMapTryGet(AlertLevelDisplay.Layer, out _))
+        if (args.AppearanceData.TryGetValue(AlertLevelDisplay.Powered, out var poweredObject))
         {
-            var layer = args.Sprite.AddLayer(new RSI.StateId(component.AlertVisuals.Values.First()));
-            args.Sprite.LayerMapSet(AlertLevelDisplay.Layer, layer);
+            args.Sprite.LayerSetVisible(layer, poweredObject is true);
         }
 
         if (!args.AppearanceData.TryGetValue(AlertLevelDisplay.CurrentLevel, out var level))
         {
-            args.Sprite.LayerSetState(AlertLevelDisplay.Layer, new RSI.StateId(component.AlertVisuals.Values.First()));
+            args.Sprite.LayerSetState(layer, alertLevelDisplay.AlertVisuals.Values.First());
             return;
         }
 
-        if (component.AlertVisuals.TryGetValue((string) level, out var visual))
+        if (alertLevelDisplay.AlertVisuals.TryGetValue((string) level, out var visual))
         {
-            args.Sprite.LayerSetState(AlertLevelDisplay.Layer, new RSI.StateId(visual));
+            args.Sprite.LayerSetState(layer, visual);
         }
         else
         {
-            args.Sprite.LayerSetState(AlertLevelDisplay.Layer, new RSI.StateId(component.AlertVisuals.Values.First()));
+            args.Sprite.LayerSetState(layer, alertLevelDisplay.AlertVisuals.Values.First());
         }
     }
 }

--- a/Content.Server/AlertLevel/AlertLevelDisplaySystem.cs
+++ b/Content.Server/AlertLevel/AlertLevelDisplaySystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Power.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.AlertLevel;
 using Robust.Server.GameObjects;
@@ -13,6 +14,7 @@ public sealed class AlertLevelDisplaySystem : EntitySystem
     {
         SubscribeLocalEvent<AlertLevelChangedEvent>(OnAlertChanged);
         SubscribeLocalEvent<AlertLevelDisplayComponent, ComponentInit>(OnDisplayInit);
+        SubscribeLocalEvent<AlertLevelDisplayComponent, PowerChangedEvent>(OnPowerChanged);
     }
 
     private void OnAlertChanged(AlertLevelChangedEvent args)
@@ -23,7 +25,7 @@ public sealed class AlertLevelDisplaySystem : EntitySystem
         }
     }
 
-    private void OnDisplayInit(EntityUid uid, AlertLevelDisplayComponent component, ComponentInit args)
+    private void OnDisplayInit(EntityUid uid, AlertLevelDisplayComponent alertLevelDisplay, ComponentInit args)
     {
         if (TryComp(uid, out AppearanceComponent? appearance))
         {
@@ -33,5 +35,12 @@ public sealed class AlertLevelDisplaySystem : EntitySystem
                 _appearance.SetData(uid, AlertLevelDisplay.CurrentLevel, alert.CurrentLevel, appearance);
             }
         }
+    }
+    private void OnPowerChanged(EntityUid uid, AlertLevelDisplayComponent alertLevelDisplay, ref PowerChangedEvent args)
+    {
+        if (!TryComp(uid, out AppearanceComponent? appearance))
+            return;
+
+        _appearance.SetData(uid, AlertLevelDisplay.Powered, args.Powered, appearance);
     }
 }

--- a/Content.Shared/AlertLevel/SharedAlertLevelDisplay.cs
+++ b/Content.Shared/AlertLevel/SharedAlertLevelDisplay.cs
@@ -6,5 +6,6 @@ namespace Content.Shared.AlertLevel;
 public enum AlertLevelDisplay
 {
     CurrentLevel,
-    Layer
+    Layer,
+    Powered
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Made the alert display component aware of power changes.
The alert display lights of the fire alarm panel should now properly shut down/light up on power changes.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Alert display lights on fire alarms properly reacts to power changes.
