### PR TITLE
Removed duplicated line from chat sanitizer replacements

### DIFF
--- a/Resources/Locale/en-US/chat/sanitizer-replacements.ftl
+++ b/Resources/Locale/en-US/chat/sanitizer-replacements.ftl
@@ -13,7 +13,6 @@ chatsan-annoyed = looks annoyed
 chatsan-sighs = sighs
 chatsan-stick-out-tongue = sticks { POSS-ADJ($ent) } tongue out
 chatsan-wide-eyed = looks shocked
-chatsan-surprised = looks surpised
 chatsan-confused = looks confused
 chatsan-unimpressed = seems unimpressed
 chatsan-waves = waves


### PR DESCRIPTION
Just removed second `chatsan-surprised = looks surprised`.