### PR TITLE
Cardboard Boxes will play effect & sound again

### DIFF
--- a/Content.Server/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Server/CardboardBox/CardboardBoxSystem.cs
@@ -54,7 +54,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         {
             if (_timing.CurTime > component.EffectCooldown)
             {
-                RaiseNetworkEvent(new PlayBoxEffectMessage(uid, component.Mover.Value), Filter.PvsExcept(uid));
+                RaiseNetworkEvent(new PlayBoxEffectMessage(uid, component.Mover.Value));
                 _audio.PlayPvs(component.EffectSound, uid);
                 component.EffectCooldown = _timing.CurTime + CardboardBoxComponent.MaxEffectCooldown;
             }

--- a/Content.Server/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Server/CardboardBox/CardboardBoxSystem.cs
@@ -29,6 +29,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
     {
         base.Initialize();
         SubscribeLocalEvent<CardboardBoxComponent, StorageAfterOpenEvent>(AfterStorageOpen);
+        SubscribeLocalEvent<CardboardBoxComponent, StorageBeforeOpenEvent>(BeforeStorageOpen);
         SubscribeLocalEvent<CardboardBoxComponent, StorageAfterCloseEvent>(AfterStorageClosed);
         SubscribeLocalEvent<CardboardBoxComponent, InteractedNoHandEvent>(OnNoHandInteracted);
         SubscribeLocalEvent<CardboardBoxComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
@@ -46,19 +47,22 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         _storage.OpenStorage(uid);
     }
 
-    private void AfterStorageOpen(EntityUid uid, CardboardBoxComponent component, ref StorageAfterOpenEvent args)
+    private void BeforeStorageOpen(EntityUid uid, CardboardBoxComponent component, ref StorageBeforeOpenEvent args)
     {
-        //Remove the mover after the box is opened and play the effect if it hasn't been played yet.
+        //Play effect & sound
         if (component.Mover != null)
         {
             if (_timing.CurTime > component.EffectCooldown)
             {
-                RaiseNetworkEvent(new PlayBoxEffectMessage(component.Owner, component.Mover.Value), Filter.PvsExcept(component.Owner));
-                _audio.PlayPvs(component.EffectSound, component.Owner);
+                RaiseNetworkEvent(new PlayBoxEffectMessage(uid, component.Mover.Value), Filter.PvsExcept(uid));
+                _audio.PlayPvs(component.EffectSound, uid);
                 component.EffectCooldown = _timing.CurTime + CardboardBoxComponent.MaxEffectCooldown;
             }
         }
+    }
 
+    private void AfterStorageOpen(EntityUid uid, CardboardBoxComponent component, ref StorageAfterOpenEvent args)
+    {
         // If this box has a stealth/chameleon effect, disable the stealth effect while the box is open.
         _stealth.SetEnabled(uid, false);
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

A previous PR prevented the effect from playing when opened, this fixes that. Also removes references to .owner.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Cardboard Boxes will now play their effect again
