### PR TITLE
Fix static pricing for stacks

### DIFF
--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -149,8 +149,14 @@ public sealed class PricingSystem : EntitySystem
         var price = ev.Price;
         price += GetMaterialsPrice(prototype);
         price += GetSolutionsPrice(prototype);
+        // Can't use static price with stackprice
+        var oldPrice = price;
         price += GetStackPrice(prototype);
-        price += GetStaticPrice(prototype);
+
+        if (oldPrice.Equals(price))
+        {
+            price += GetStaticPrice(prototype);
+        }
 
         // TODO: Proper container support.
 
@@ -179,8 +185,15 @@ public sealed class PricingSystem : EntitySystem
         // DO NOT FORGET TO UPDATE ESTIMATED PRICING
         price += GetMaterialsPrice(uid);
         price += GetSolutionsPrice(uid);
+
+        // Can't use static price with stackprice
+        var oldPrice = price;
         price += GetStackPrice(uid);
-        price += GetStaticPrice(uid);
+
+        if (oldPrice.Equals(price))
+        {
+            price += GetStaticPrice(uid);
+        }
 
         if (TryComp<ContainerManagerComponent>(uid, out var containers))
         {

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -5,8 +5,6 @@
   components:
   - type: Item
     size: 5
-  - type: StaticPrice
-    price: 20
   - type: Clickable
   - type: InteractionOutline
   - type: MovedByPressure


### PR DESCRIPTION
Removed BaseItem price as it was always a placeholder and easier to just change without it. Ensure staticprice is never used if stackprice is present. Added StackComponent to the test so the behavior matches expectation.

Fixes https://github.com/space-wizards/space-station-14/issues/14863

:cl:
- fix: Fixed static pricing being used on some stackable entities.
- tweak: Removed the base $20 price for items.