### PR TITLE
Update AnomGen UI

### DIFF
--- a/Content.Client/Anomaly/Ui/AnomalyGeneratorWindow.xaml
+++ b/Content.Client/Anomaly/Ui/AnomalyGeneratorWindow.xaml
@@ -1,13 +1,13 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
                 xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 Title="{Loc 'anomaly-generator-ui-title'}"
-                MinSize="270 180"
-                SetSize="360 180">
-    <BoxContainer Margin="10 0 10 0"
+
+                Resizable="False">
+    <BoxContainer Margin="0 0"
                   Orientation="Vertical"
                   HorizontalExpand="True"
                   VerticalExpand="True">
-        <BoxContainer Orientation="Horizontal">
+        <BoxContainer Margin="10 0 10 0" Orientation="Horizontal">
             <BoxContainer Orientation="Vertical" HorizontalExpand="True">
                 <BoxContainer Orientation="Horizontal"
                               HorizontalExpand="True"
@@ -30,6 +30,7 @@
                 <RichTextLabel Name="CooldownLabel" StyleClasses="StatusFieldTitle" />
                 <RichTextLabel Name="ReadyLabel" StyleClasses="StatusFieldTitle" />
             </BoxContainer>
+            <!--Sprite View-->
             <PanelContainer Margin="12 0 0 0"
                             StyleClasses="Inset"
                             VerticalAlignment="Center">
@@ -40,9 +41,22 @@
         </BoxContainer>
         <BoxContainer VerticalExpand="True"
                       HorizontalAlignment="Center"
-                      VerticalAlignment="Center">
+                      VerticalAlignment="Center"
+                      Margin="0 10">
             <Button Name="GenerateButton"
                     Text="{Loc 'anomaly-generator-generate'}"></Button>
+        </BoxContainer>
+
+         <!-- Footer -->
+        <BoxContainer Orientation="Vertical">
+            <PanelContainer StyleClasses="LowDivider" />
+            <BoxContainer Orientation="Horizontal" Margin="10 2 5 0" VerticalAlignment="Bottom">
+                <Label Text="{Loc 'anomaly-generator-flavor-left'}" StyleClasses="WindowFooterText" />
+                <Label Text="{Loc 'anomaly-generator-flavor-right'}" StyleClasses="WindowFooterText"
+                        HorizontalAlignment="Right" HorizontalExpand="True"  Margin="0 0 5 0" />
+                <TextureRect StyleClasses="NTLogoDark" Stretch="KeepAspectCentered"
+                        VerticalAlignment="Center" HorizontalAlignment="Right" SetSize="19 19"/>
+            </BoxContainer>
         </BoxContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Anomaly/Ui/AnomalyGeneratorWindow.xaml.cs
+++ b/Content.Client/Anomaly/Ui/AnomalyGeneratorWindow.xaml.cs
@@ -25,6 +25,7 @@ public sealed partial class AnomalyGeneratorWindow : FancyWindow
         IoCManager.InjectDependencies(this);
 
         EntityView.Sprite = _entityManager.GetComponent<SpriteComponent>(gen);
+        EntityView.SpriteOffset = false;
 
         GenerateButton.OnPressed += _ => OnGenerateButtonPressed?.Invoke();
     }

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -24,15 +24,19 @@ anomaly-scanner-particle-unstable = - [color=plum]Unstable type:[/color] {$type}
 anomaly-scanner-particle-containment = - [color=goldenrod]Containment type:[/color] {$type}
 anomaly-scanner-pulse-timer = Time until next pulse: [color=gray]{$time}[/color]
 
-anomaly-generator-ui-title = anomaly generator
+anomaly-generator-ui-title = Anomaly Generator
 anomaly-generator-fuel-display = Fuel:
 anomaly-generator-cooldown = Cooldown: [color=gray]{$time}[/color]
 anomaly-generator-no-cooldown = Cooldown: [color=gray]Complete[/color]
 anomaly-generator-yes-fire = Status: [color=forestgreen]Ready[/color]
 anomaly-generator-no-fire = Status: [color=crimson]Not ready[/color]
 anomaly-generator-generate = Generate Anomaly
-anomaly-generator-charges = {$charges -> 
+anomaly-generator-charges = {$charges ->
     [one] {$charges} charge
     *[other] {$charges} charges
 }
 anomaly-generator-announcement = An anomaly has been generated!
+
+# Flavor text on the footer
+anomaly-generator-flavor-left = Anomaly may spawn inside the operator.
+anomaly-generator-flavor-right = v1.1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This fixes issue #13559 and makes some minor UI improvements to the Anomaly Generator UI

This PR is in Draft state because it is blocked https://github.com/space-wizards/RobustToolbox/pull/3865 (engine PR) to fix the Sprite view issue. 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame
<img width="285" alt="Screenshot 2023-03-26 at 7 39 03 PM" src="https://user-images.githubusercontent.com/4888377/227773272-a0677ec3-a5ec-4ba9-965d-8bbfa846aa6e.png">


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Minor UI enhancements to the Anomaly Generator UI
- fix: Fixed broken sprite view in Anomaly Generator UI 
