### PR TITLE
Stretch top bar for separated hud

### DIFF
--- a/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
+++ b/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
@@ -9,7 +9,7 @@
            Name = "MenuButtons"
            VerticalExpand="False"
            Orientation="Horizontal"
-           HorizontalAlignment="Left"
+           HorizontalAlignment="Stretch"
            VerticalAlignment="Top"
            SeparationOverride="5"
 >


### PR DESCRIPTION
Current:
![image](https://user-images.githubusercontent.com/31366439/227776832-b95d116b-506b-43a8-a51b-b9b881b9d1c9.png)

Proposed:
![image](https://user-images.githubusercontent.com/31366439/227776894-9941ea0e-6ba0-4680-adba-4ce0909c4696.png)

Most people I imagine play with chat less wide.

:cl:
- tweak: The top menu in separated hud will now stretch with chat size.
