### PR TITLE
Add margins to chat

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml
@@ -13,7 +13,7 @@
         </PanelContainer.PanelOverride>
 
         <BoxContainer Orientation="Vertical" SeparationOverride="4" HorizontalExpand="True" VerticalExpand="True">
-            <OutputPanel Name="Contents" HorizontalExpand="True" VerticalExpand="True" />
+            <OutputPanel Name="Contents" HorizontalExpand="True" VerticalExpand="True" Margin="8 8" />
             <controls:ChatInputBox HorizontalExpand="True" Name="ChatInput" Access="Public" Margin="2"/>
         </BoxContainer>
     </PanelContainer>

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml
@@ -13,7 +13,7 @@
         </PanelContainer.PanelOverride>
 
         <BoxContainer Orientation="Vertical" SeparationOverride="4" HorizontalExpand="True" VerticalExpand="True">
-            <OutputPanel Name="Contents" HorizontalExpand="True" VerticalExpand="True" Margin="8 8" />
+            <OutputPanel Name="Contents" HorizontalExpand="True" VerticalExpand="True" Margin="8 8 8 4" />
             <controls:ChatInputBox HorizontalExpand="True" Name="ChatInput" Access="Public" Margin="2"/>
         </BoxContainer>
     </PanelContainer>


### PR DESCRIPTION
Old:
<img width="380" alt="old_chat" src="https://user-images.githubusercontent.com/31366439/227779773-98e17c44-9e72-4ec1-9288-459bc94bbce2.PNG">

New:
<img width="367" alt="new_chat" src="https://user-images.githubusercontent.com/31366439/227779779-e14772ee-528f-4515-b560-6625054cbf7b.PNG">

Needs an engine PR to avoid drawing over the VScrollBar though this PR doesn't depend upon it.

:cl:
- tweak: Added margins to the chatbox.