### PR TITLE
Revert "Allow RD, CMO, and QM to be traitors"

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -16,6 +16,7 @@
   startingGear: QuartermasterGear
   icon: "QuarterMaster"
   supervisors: job-supervisors-hop
+  canBeAntag: false
   access:
   - Cargo
   - Salvage

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -16,6 +16,7 @@
   icon: "ChiefMedicalOfficer"
   requireAdminNotify: true
   supervisors: job-supervisors-captain
+  canBeAntag: false
   access:
   - Medical
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -14,6 +14,7 @@
   icon: "ResearchDirector"
   requireAdminNotify: true
   supervisors: job-supervisors-captain
+  canBeAntag: false
   access:
   - Research
   - Command


### PR DESCRIPTION
Reverts space-wizards/space-station-14#13343

I'm ultimately of the opinion that this wasnt a good idea. Having Heads of staff always be reliable provides a more solid network of trust and department communication that I think is important. Additionally, heads being nonpresent due to traitorous activities ends up being annoying for everyone involved.

I also think this important with the anticipated changes to access coming up.

:cl:
- remove: RD, CMO, and QM can no longer be traitors.