### PR TITLE
Syndicate Pill of Death

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -199,7 +199,7 @@ uplink-nocturine-chemistry-bottle-name = Nocturine Bottle
 uplink-nocturine-chemistry-bottle-desc = A chemical that makes it very hard for your target to stand up.
 
 uplink-poison-pill-name = Poison Pill
-uplink-poison-pill-desc = An lethal, unlabeled pill containing lexorin and nocturine which lulls victims into a sleep while the lexorin works away. The victim has around 4 seconds to react before death.
+uplink-poison-pill-desc = A lethal, unlabeled pill containing lexorin and nocturine which lulls victims into a sleep while the lexorin works away. The victim has around 4 seconds to react before death.
 
 uplink-stimpack-name = Stimpack
 uplink-stimpack-desc = The legendary chemical produced by Donk Co. for the Syndicate. Injecting yourself with this will increase your run speed and let you recover from stuns faster for 5 minutes.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -199,7 +199,7 @@ uplink-nocturine-chemistry-bottle-name = Nocturine Bottle
 uplink-nocturine-chemistry-bottle-desc = A chemical that makes it very hard for your target to stand up.
 
 uplink-poison-pill-name = Poison Pill
-uplink-poison-pill-desc = A lethal, unlabeled pill containing lexorin and nocturine which lulls victims into a sleep while the lexorin works away. The victim has around 4 seconds to react before death.
+uplink-poison-pill-desc = A lethal, unlabeled pill containing lexorin and nocturine which lulls victims into a slumber while the lexorin works away. The victim has around 4 seconds to react before death.
 
 uplink-stimpack-name = Stimpack
 uplink-stimpack-desc = The legendary chemical produced by Donk Co. for the Syndicate. Injecting yourself with this will increase your run speed and let you recover from stuns faster for 5 minutes.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -198,6 +198,9 @@ uplink-ultrabright-lantern-desc = Blinding.
 uplink-nocturine-chemistry-bottle-name = Nocturine Bottle
 uplink-nocturine-chemistry-bottle-desc = A chemical that makes it very hard for your target to stand up.
 
+uplink-poison-pill-name = Poison Pill
+uplink-poison-pill-desc = An lethal, unlabeled pill containing lexorin and nocturine which lulls victims into a sleep while the lexorin works away. The victim has around 4 seconds to react before death.
+
 uplink-stimpack-name = Stimpack
 uplink-stimpack-desc = The legendary chemical produced by Donk Co. for the Syndicate. Injecting yourself with this will increase your run speed and let you recover from stuns faster for 5 minutes.
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -766,6 +766,16 @@
   - UplinkMisc
 
 - type: listing
+  id: UplinkPoisonPill
+  name: uplink-poison-pill-name
+  description: uplink-poison-pill-desc
+  productEntity: PillPoison
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkMisc
+
+- type: listing
   id: UplinkStimpack
   name: uplink-stimpack-name
   description: uplink-stimpack-desc

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -227,6 +227,22 @@
         - ReagentId: Romerol
           Quantity: 10
 
+- type: entity
+  name: pill
+  parent: Pill
+  id: PillPoison
+  suffix: Poison
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 50
+        reagents:
+        - ReagentId: Lexorin
+          Quantity: 10
+        - ReagentId: Nocturine
+          Quantity: 10
+
 # Syringes
 - type: entity
   name: ephedrine syringe


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
"A lethal, unlabeled pill containing lexorin and nocturine which lulls victims into a slumber while the lexorin works away. The victim has around 4 seconds to react before death."

Adds a pill to the uplink containing 10u lexorin and 10u nocturine. This puts the victim to sleep, then deals some damage. The victim wakes up 4 seconds before the lexorin puts them into crit.

This pill is a way for syndies to assassinate victims without using those boring pens or those crappy guns that seem to shoot foam darts instead of lead. Nobody wants to eat an unlabeled pill, so the idea is to gain the trust of the victim, wait for them to be damaged, then feed them this pill, resulting in their swift death.

Costs 4 telecrystals, a price which I decided in half a second, please help me hone this down to a more perfect cost.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
(the movement glitch near the start is not part of the PR)

https://user-images.githubusercontent.com/113810873/227804491-ff221f82-6785-4982-aa79-b8d62d665996.mp4


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: The Syndicate has begun mass-producing unlabeled pills filled with nocturine and lexorin. Watch out!