### PR TITLE
Fix auto-emote bug

### DIFF
--- a/Content.Server/Chat/Systems/AutoEmoteSystem.cs
+++ b/Content.Server/Chat/Systems/AutoEmoteSystem.cs
@@ -83,6 +83,8 @@ public sealed class AutoEmoteSystem : EntitySystem
         if (!Resolve(uid, ref autoEmote, logMissing: false))
             return false;
 
+        DebugTools.Assert(autoEmote.LifeStage <= ComponentLifeStage.Running);
+
         if (autoEmote.Emotes.Contains(autoEmotePrototypeId))
             return false;
 
@@ -93,9 +95,9 @@ public sealed class AutoEmoteSystem : EntitySystem
     }
 
     /// <summary>
-    /// Stop preforming an emote.
+    /// Stop preforming an emote. Note that by default this will queue empty components for removal.
     /// </summary>
-    public bool RemoveEmote(EntityUid uid, string autoEmotePrototypeId, AutoEmoteComponent? autoEmote = null)
+    public bool RemoveEmote(EntityUid uid, string autoEmotePrototypeId, AutoEmoteComponent? autoEmote = null, bool removeEmpty = true)
     {
         if (!Resolve(uid, ref autoEmote, logMissing: false))
             return false;
@@ -105,7 +107,13 @@ public sealed class AutoEmoteSystem : EntitySystem
         if (!autoEmote.EmoteTimers.Remove(autoEmotePrototypeId))
             return false;
 
-        autoEmote.NextEmoteTime = autoEmote.EmoteTimers.Values.Min();
+        if (autoEmote.EmoteTimers.Count > 0)
+            autoEmote.NextEmoteTime = autoEmote.EmoteTimers.Values.Min();
+        else if (removeEmpty)
+            RemCompDeferred(uid, autoEmote);
+        else
+            autoEmote.NextEmoteTime = TimeSpan.MaxValue;
+
         return true;
     }
 

--- a/Content.Server/Chat/Systems/EmoteOnDamageSystem.cs
+++ b/Content.Server/Chat/Systems/EmoteOnDamageSystem.cs
@@ -62,21 +62,28 @@ public sealed class EmoteOnDamageSystem : EntitySystem
         if (!Resolve(uid, ref emoteOnDamage, logMissing: false))
             return false;
 
+        DebugTools.Assert(emoteOnDamage.LifeStage <= ComponentLifeStage.Running);
         DebugTools.Assert(_prototypeManager.HasIndex<EmotePrototype>(emotePrototypeId), "Prototype not found. Did you make a typo?");
 
         return emoteOnDamage.Emotes.Add(emotePrototypeId);
     }
 
     /// <summary>
-    /// Stop preforming an emote.
+    /// Stop preforming an emote. Note that by default this will queue empty components for removal.
     /// </summary>
-    public bool RemoveEmote(EntityUid uid, string emotePrototypeId, EmoteOnDamageComponent? emoteOnDamage = null)
+    public bool RemoveEmote(EntityUid uid, string emotePrototypeId, EmoteOnDamageComponent? emoteOnDamage = null, bool removeEmpty = true)
     {
         if (!Resolve(uid, ref emoteOnDamage, logMissing: false))
             return false;
 
         DebugTools.Assert(_prototypeManager.HasIndex<EmotePrototype>(emotePrototypeId), "Prototype not found. Did you make a typo?");
 
-        return emoteOnDamage.Emotes.Remove(emotePrototypeId);
+        if (!emoteOnDamage.Emotes.Remove(emotePrototypeId))
+            return false;
+
+        if (removeEmpty && emoteOnDamage.Emotes.Count == 0)
+            RemCompDeferred(uid, emoteOnDamage);
+
+        return true;
     }
 }


### PR DESCRIPTION
Fixes an error that happens when trying to calculate `NextEmoteTime` after removing all emotes. Also makes it so that empty components will default to removing themselves.

- [X] This PR does not require an ingame showcase
