### PR TITLE
Fix door remote not updating airlock lights

### DIFF
--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -91,12 +91,12 @@ namespace Content.Server.Remotes
                 case OperatingMode.ToggleBolts:
                     if (!airlockComp.BoltWireCut)
                     {
-                        _airlock.SetBoltsWithAudio(uid, airlockComp, !airlockComp.BoltsDown);
+                        _airlock.SetBoltsWithAudio(args.Target.Value, airlockComp, !airlockComp.BoltsDown);
                         _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(airlockComp.BoltsDown ? "" : "un")}bolt it");
                     }
                     break;
                 case OperatingMode.ToggleEmergencyAccess:
-                    _airlock.ToggleEmergencyAccess(uid, airlockComp);
+                    _airlock.ToggleEmergencyAccess(args.Target.Value, airlockComp);
                     _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to set emergency access {(airlockComp.EmergencyAccess ? "on" : "off")}");
                     break;
                 default:


### PR DESCRIPTION
Fixes a bug introduced in 2873a830bd86bd6a2859e3b4f419e50a9a0a9a02 causing airlock lights to not update when toggling bolts or emergency access. It was passing the uid of the door remote instead of the door to AirlockSystem.

The AirlockSystem public methods should probably use Resolve and optional comp arguments, which would trigger a debug assert when uid doesn't match the comp. But that is out of scope for this pr.

:cl:
- fix: Fixed a bug where airlock lights would not update when using a door remote.