### PR TITLE
fix sprite exceptions for cuffs

### DIFF
--- a/Content.Client/Cuffs/CuffableSystem.cs
+++ b/Content.Client/Cuffs/CuffableSystem.cs
@@ -27,15 +27,6 @@ public sealed class CuffableSystem : SharedCuffableSystem
 
         component.Cuffing = state.Cuffing;
         component.OverlayIconState = state.IconState;
-        /*
-        if (state.IconState == string.Empty)
-            return;
-
-        if (TryComp<SpriteComponent>(uid, out var sprite))
-        {
-            // If you think this should be an explicit layer look at the YML and see https://github.com/space-wizards/space-station-14/issues/14771
-            sprite.LayerSetState(0, state.IconState);
-        }*/
     }
 
     private void OnCuffableShutdown(EntityUid uid, CuffableComponent component, ComponentShutdown args)

--- a/Content.Client/Cuffs/CuffableSystem.cs
+++ b/Content.Client/Cuffs/CuffableSystem.cs
@@ -26,7 +26,8 @@ public sealed class CuffableSystem : SharedCuffableSystem
             return;
 
         component.Cuffing = state.Cuffing;
-
+        component.OverlayIconState = state.IconState;
+        /*
         if (state.IconState == string.Empty)
             return;
 
@@ -34,7 +35,7 @@ public sealed class CuffableSystem : SharedCuffableSystem
         {
             // If you think this should be an explicit layer look at the YML and see https://github.com/space-wizards/space-station-14/issues/14771
             sprite.LayerSetState(0, state.IconState);
-        }
+        }*/
     }
 
     private void OnCuffableShutdown(EntityUid uid, CuffableComponent component, ComponentShutdown args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Closes #14910 
Closes #14898
TL;DR:
the sprite of the cuff itself was for some reason being updated, which shouldn't be needed at all. Additionally, it was using the state that was meant to be combined with cuffable in order to display the cuff overlay on cuffable entities.

the solution is just removing it outright.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun