### PR TITLE
Add support for true randomized characters

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1300,6 +1300,18 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ICNameCase =
             CVarDef.Create("ic.name_case", true, CVar.SERVER | CVar.REPLICATED);
 
+        /// <summary>
+        /// Whether or not players' characters are randomly generated rather than using their selected characters in the creator.
+        /// </summary>
+        public static readonly CVarDef<bool> ICRandomCharacters =
+            CVarDef.Create("ic.random_characters", false, CVar.SERVER);
+
+        /// <summary>
+        /// A weighted random prototype used to determine the species selected for random characters.
+        /// </summary>
+        public static readonly CVarDef<string> ICRandomSpeciesWeights =
+            CVarDef.Create("ic.random_species_weights", "SpeciesWeights", CVar.SERVER);
+
         /*
          * Salvage
          */

--- a/Resources/Prototypes/Species/species_weights.yml
+++ b/Resources/Prototypes/Species/species_weights.yml
@@ -1,0 +1,8 @@
+#default species weights used for randomly selected species
+- type: weightedRandom
+  id: SpeciesWeights
+  weights:
+    Human: 5
+    Reptilian: 4
+    SlimePerson: 4
+    Diona: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adds two cvars:
- IC.random_characters: if enabled, the character the player spawns at will be fully randomized each time.
- IC.random_species_weights: this is a weighted random prototype used to select which species will chosen for the random characters.

This essentially just allows servers to prevent metagaming with people playing their "regulars."
Not for upstream, but it's something that could be useful for downstreams.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
i did 5 spawns and got 5 people
![image](https://user-images.githubusercontent.com/98561806/228132305-0b4956fa-6a4e-41d4-9075-d7eca7a83ff8.png)
![image](https://user-images.githubusercontent.com/98561806/228132313-494b0e3b-7d68-41eb-9034-c787046fcf6d.png)
![image](https://user-images.githubusercontent.com/98561806/228132321-eaab36d4-af95-4cbb-9bd1-dc61e63328a5.png)
![image](https://user-images.githubusercontent.com/98561806/228132331-9c3f4619-066a-4283-aeb5-aa10882bea9e.png)
![image](https://user-images.githubusercontent.com/98561806/228132343-57857f84-df8f-4c48-af78-16198f1d88fa.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun
