### PR TITLE
Fix Bureaucratic Error event affecting fewer jobs than intended

### DIFF
--- a/Content.Server/StationEvents/Events/BureaucraticError.cs
+++ b/Content.Server/StationEvents/Events/BureaucraticError.cs
@@ -41,13 +41,14 @@ public sealed class BureaucraticError : StationEventSystem
             var lower = (int) (jobList.Count * Math.Min(1.0f, 0.20 * mod));
             var upper = (int) (jobList.Count * Math.Min(1.0f, 0.30 * mod));
             // Changing every role is maybe a bit too chaotic so instead change 20-30% of them.
-            for (var i = 0; i < RobustRandom.Next(lower, upper); i++)
+            var num = RobustRandom.Next(lower, upper);
+            for (var i = 0; i < num; i++)
             {
                 var chosenJob = RobustRandom.PickAndTake(jobList);
                 if (_stationJobs.IsJobUnlimited(chosenStation, chosenJob))
                     continue;
 
-                _stationJobs.TryAdjustJobSlot(chosenStation, chosenJob, RobustRandom.Next(-3, 6));
+                _stationJobs.TryAdjustJobSlot(chosenStation, chosenJob, RobustRandom.Next(-3, 6), clamp: true);
             }
         }
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
When the "normal" bureaucratic error event happens, it was intended that it adjusted the job count of 20%-30% of jobs by -3 to +6. However, a couple small bugs made it so that affecting more than 20% of jobs was very rare and some jobs would resist having their slots reduced to zero.

This PR fixes the event so that the 20%-30% random range is evaluated only once (instead of every loop of the for loop) and adds the "clamp" flag to the `TryAdjustJobSlot` call so that passing a -3 to a two-slot job (or a -2 to a one-slot job and similar) properly reduces the job slots to zero instead of not affecting the job at all.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed the bureaucratic error event affecting fewer jobs than intended
