### PR TITLE
Chat sanitation improvement

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -1,12 +1,8 @@
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Xml.Linq;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
-using static System.Net.Mime.MediaTypeNames;
+using System.Text.RegularExpressions;
 
 namespace Content.Server.Chat.Managers;
 

--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -17,6 +17,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
     private static readonly Dictionary<string, string> SmileyToEmote = new()
     {
         // I could've done this with regex, but felt it wasn't the right idea.
+        // Added wtf, haha and kek, removed :v, :u, :s as these are conflicting with the radio channels and do more harm than good
         { ":)", "chatsan-smiles" },
         { ":]", "chatsan-smiles" },
         { "=)", "chatsan-smiles" },
@@ -38,16 +39,13 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { ":D", "chatsan-smiles-widely" },
         { "D:", "chatsan-frowns-deeply" },
         { ":O", "chatsan-surprised" },
-        { ":3", "chatsan-smiles" }, //nope
-        { ":S", "chatsan-uncertain" },
+        { ":3", "chatsan-smiles-smugly" }, //nope
         { ":>", "chatsan-grins" },
         { ":<", "chatsan-pouts" },
         { "xD", "chatsan-laughs" },
         { ";-;", "chatsan-cries" },
         { ";_;", "chatsan-cries" },
         { "qwq", "chatsan-cries" },
-        { ":u", "chatsan-smiles-smugly" },
-        { ":v", "chatsan-smiles-smugly" },
         { ">:i", "chatsan-annoyed" },
         { ":i", "chatsan-sighs" },
         { ":|", "chatsan-sighs" },


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
The current version of chat sanitation module only catches smileys at the end of a sentence, removes only one of them and is case sensitive.
This PR makes it so smileys and acronyms are catched throughout the message, is case insensitive and doesn't leave double spaces, spaces in front of punctuation marks and removes multiple smileys in the message.

Resolves #14748

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
https://user-images.githubusercontent.com/46636558/228322183-9b153896-87b1-4ddd-8045-ad1561ee1309.mp4

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB




-->

:cl: Mumohan
- fix: Fixed chat sanitation to be more robust.
