### PR TITLE
fix mug names

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -46,7 +46,7 @@
   parent: DrinkBaseCup
   id: DrinkBaseMug
   abstract: true
-  name: base mug
+  name: mug
   description: A mug.
   components:
   - type: Sprite
@@ -55,6 +55,7 @@
       - state: icon-0
       - map: ["enum.SolutionContainerLayers.Fill"]
         state: icon-3
+        visible: false
   - type: Appearance
   - type: SolutionContainerVisuals
     maxFillLevels: 3
@@ -72,7 +73,7 @@
 - type: entity
   parent: DrinkBaseMug
   id: DrinkMugBlack
-  name: mug black
+  name: black mug
   description: A sleek black mug.
   components:
   - type: Sprite
@@ -81,7 +82,7 @@
 - type: entity
   parent: DrinkBaseMug
   id: DrinkMugBlue
-  name: mug blue
+  name: blue mug
   description: A blue and black mug.
   components:
   - type: Sprite
@@ -90,7 +91,7 @@
 - type: entity
   parent: DrinkBaseMug
   id: DrinkMugGreen
-  name: mug green
+  name: green mug
   description: A pale green and pink mug.
   components:
   - type: Sprite
@@ -109,7 +110,7 @@
 - type: entity
   parent: DrinkBaseMug
   id: DrinkMugHeart
-  name: mug heart
+  name: heart mug
   description: A white mug, it prominently features a red heart.
   components:
   - type: Sprite
@@ -118,7 +119,7 @@
 - type: entity
   parent: DrinkBaseMug
   id: DrinkMugMetal
-  name: mug metal
+  name: metal mug
   description: A metal mug. You're not sure which metal.
   components:
   - type: Sprite
@@ -127,7 +128,7 @@
 - type: entity
   parent: DrinkBaseMug
   id: DrinkMugMoebius
-  name: mug moebius
+  name: moebius mug
   description: A mug with a Moebius Laboratories logo on it. Not even your morning coffee is safe from corporate advertising.
   components:
   - type: Sprite
@@ -145,7 +146,7 @@
 - type: entity
   parent: DrinkBaseMug
   id: DrinkMugRainbow
-  name: mug rainbow
+  name: rainbow mug
   description: A rainbow mug. The colors are almost as blinding as a welder.
   components:
   - type: Sprite
@@ -154,7 +155,7 @@
 - type: entity
   parent: DrinkBaseMug
   id: DrinkMugRed
-  name: mug red
+  name: red mug
   description: A red and black mug.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
the names were all "mug ___" which is weird

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Mugs are now named correctly.