### PR TITLE
Don't delete virtual hand items on client

### DIFF
--- a/Content.Shared/Hands/SharedHandVirtualItemSystem.cs
+++ b/Content.Shared/Hands/SharedHandVirtualItemSystem.cs
@@ -48,6 +48,9 @@ public abstract class SharedHandVirtualItemSystem : EntitySystem
     /// </summary>
     public void DeleteInHandsMatching(EntityUid user, EntityUid matching)
     {
+        if (_net.IsClient)
+            return;
+
         foreach (var hand in _hands.EnumerateHands(user))
         {
             if (TryComp(hand.HeldEntity, out HandVirtualItemComponent? virt) && virt.BlockingEntity == matching)


### PR DESCRIPTION
ECS cuffs PR moved this to shared which is good, though client shouldn't be deleting networked entities (at least atm) as this will throw exceptions.

In this case when the hands move outside of PVS they get removed from their containers and get deleted.

Fixes https://github.com/space-wizards/space-station-14/issues/14771
Fixes https://github.com/space-wizards/space-station-14/issues/14888


:cl:
- fix: Fix HandVirtualItem exceptions.
