### PR TITLE
Wardrobe restock box hotfix (Removes CentCom gear)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -84,7 +84,6 @@
     - AtmosDrobeInventory
     - BarDrobeInventory
     - CargoDrobeInventory
-    - CentDrobeInventory
     - ChefDrobeInventory
     - ChemDrobeInventory
     - DetDrobeInventory
@@ -104,6 +103,16 @@
     - state: green_bit
       shader: unshaded
     - state: refill_clothes
+
+- type: entity
+  parent: VendingMachineRestockClothes
+  id: VendingMachineRestockClothesCentCom
+  name: wardrobe restock box (CentCom)
+  description: Even Central Command needs to get their clothes from somewhere! Place inside a CentComn clothes vendor restock slot.
+  components:
+  - type: VendingMachineRestock
+    canrestock:
+    - CentDrobeInventory
 
 - type: entity
   parent: BaseVendingMachineRestock

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -105,16 +105,6 @@
     - state: refill_clothes
 
 - type: entity
-  parent: VendingMachineRestockClothes
-  id: VendingMachineRestockClothesCentCom
-  name: wardrobe restock box (CentCom)
-  description: Even Central Command needs to get their clothes from somewhere! Place inside a CentComn clothes vendor restock slot.
-  components:
-  - type: VendingMachineRestock
-    canrestock:
-    - CentDrobeInventory
-
-- type: entity
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockCostumes
   name: AutoDrobe restock box


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes wardrobe restock boxes from having a chance to drop centcom gear when destroyed.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: CentCom has changed clothing suppliers. CentCom clothing will no longer appear in wardrobe restock boxes from cargo.
