### PR TITLE
[Spawn] Plush Dion now spawns

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -30,7 +30,8 @@
         amount: 1
       - id: PlushieAtmosian
         amount: 1
-
+      - id: PlushieDiona
+        amount: 1
 
 - type: entity
   id: CrateFunInstruments

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
@@ -31,6 +31,7 @@
         - PlushieSharkGrey
         - ToyAmongPequeno
         - ToyMouse
+        - PlushieDiona
       chance: 0.5
       offset: 0.2
 

--- a/Resources/Prototypes/Entities/Objects/Decoration/present.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/present.yml
@@ -87,6 +87,8 @@
         orGroup: GiftPool
       - id: ToyAmongPequeno
         orGroup: GiftPool
+      - id: PlushieDiona
+        orGroup: GiftPool
       - id: ToyMouse
         orGroup: GiftPool
       - id: ToyAi


### PR DESCRIPTION
shkibididopdop

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
The plush Dione now appears on the map like the rest of the toys, drops out of the gifts.


<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Added Plush Dion to spawn pools
