### PR TITLE
[APRIL FOOLS] fix clothing sprites and names

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -105,7 +105,7 @@
 
 - type: entity
   noSpawn: true
-  parent: ClothingBackpackSecurity
+  parent: ClothingBackpackHOS
   id: ClothingBackpackHOSFilled
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
@@ -104,7 +104,7 @@
 
 - type: entity
   noSpawn: true
-  parent: ClothingBackpackDuffelSecurity
+  parent: ClothingBackpackDuffelHOS
   id: ClothingBackpackDuffelHOSFilled
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -30,11 +30,11 @@
 - type: entity
   parent: ClothingBackpack
   id: ClothingBackpackClown
-  name: giggles von honkerton
-  description: It's a backpack made by Honk! Co.
+  name: security backpack
+  description: It's a very robust backpack.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/clown.rsi
+    sprite: Clothing/Back/Backpacks/security.rsi
   - type: Storage
     storageOpenSound:
       collection: BikeHorn
@@ -42,11 +42,20 @@
 - type: entity
   parent: ClothingBackpack
   id: ClothingBackpackSecurity
-  name: security backpack
-  description: It's a very robust backpack.
+  name: giggles von honkerton
+  description: It's a backpack made by Honk! Co.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/security.rsi
+    sprite: Clothing/Back/Backpacks/clown.rsi
+
+- type: entity
+  parent: ClothingBackpack
+  id: ClothingBackpackHOS
+  name: mime backpack
+  description: A silent backpack made for those silent workers. Silence Co.
+  components:
+  - type: Sprite
+    sprite: Clothing/Back/Backpacks/clown.rsi
 
 - type: entity
   parent: ClothingBackpack
@@ -78,11 +87,11 @@
 - type: entity
   parent: ClothingBackpack
   id: ClothingBackpackMime
-  name: mime backpack
-  description: A silent backpack made for those silent workers. Silence Co.
+  name: security backpack
+  description: It's a very robust backpack.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/mime.rsi
+    sprite: Clothing/Back/Backpacks/security.rsi
 
 - type: entity
   parent: ClothingBackpack

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -57,11 +57,11 @@
 - type: entity
   parent: ClothingBackpackDuffel
   id: ClothingBackpackDuffelClown
-  name: clown duffel bag
-  description: A large duffel bag for holding extra honk goods.
+  name: security duffel bag
+  description: A large duffel bag for holding extra security related goods.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Duffels/clown.rsi
+    sprite: Clothing/Back/Duffels/security.rsi
   - type: Storage
     storageOpenSound:
       collection: BikeHorn
@@ -69,11 +69,20 @@
 - type: entity
   parent: ClothingBackpackDuffel
   id: ClothingBackpackDuffelSecurity
-  name: security duffel bag
-  description: A large duffel bag for holding extra security related goods.
+  name: clown duffel bag
+  description: A large duffel bag for holding extra honk goods.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Duffels/security.rsi
+    sprite: Clothing/Back/Duffels/clown.rsi
+
+- type: entity
+  parent: ClothingBackpackDuffel
+  id: ClothingBackpackDuffelHOS
+  name: mime duffel bag
+  description: A large duffel bag for holding... mime... stuff.
+  components:
+  - type: Sprite
+    sprite: Clothing/Back/Duffels/mime.rsi
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -96,11 +105,11 @@
 - type: entity
   parent: ClothingBackpackDuffel
   id: ClothingBackpackDuffelMime
-  name: mime duffel bag
-  description: A large duffel bag for holding... mime... stuff.
+  name: security duffel bag
+  description: A large duffel bag for holding extra security related goods.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Duffels/mime.rsi
+    sprite: Clothing/Back/Duffels/security.rsi
     storageOpenSound:
       collection: null
     storageInsertSound:

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -12,13 +12,13 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatBeret
-  name: beret
-  description: A beret, an artists favorite headwear.
+  name: head of security's beret
+  description: A black beret with a commander's rank emblem. For officers that are more inclined towards style than safety.
   components:
   - type: Sprite
-    sprite: Clothing/Head/Hats/beret.rsi
+    sprite: Clothing/Head/Hats/beret_hos.rsi
   - type: Clothing
-    sprite: Clothing/Head/Hats/beret.rsi
+    sprite: Clothing/Head/Hats/beret_hos.rsi
 
 - type: entity
   parent: ClothingHeadBase
@@ -34,13 +34,13 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatBeretHoS
-  name: head of security's beret
-  description: A black beret with a commander's rank emblem. For officers that are more inclined towards style than safety.
+  name: beret
+  description: A beret, an artists favorite headwear.
   components:
   - type: Sprite
-    sprite: Clothing/Head/Hats/beret_hos.rsi
+    sprite: Clothing/Head/Hats/beret.rsi
   - type: Clothing
-    sprite: Clothing/Head/Hats/beret_hos.rsi
+    sprite: Clothing/Head/Hats/beret.rsi
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -17,13 +17,13 @@
 - type: entity
   parent: ClothingMaskGas
   id: ClothingMaskGasSecurity
-  name: security gas mask
-  description: A standard issue Security gas mask.
+  name: clown wig and mask
+  description: A true prankster's facial attire. A clown is incomplete without his wig and mask.
   components:
   - type: Sprite
-    sprite: Clothing/Mask/gassecurity.rsi
+    sprite: Clothing/Mask/clown.rsi
   - type: Clothing
-    sprite: Clothing/Mask/gassecurity.rsi
+    sprite: Clothing/Mask/clown.rsi
 
 - type: entity
   parent: ClothingMaskGas
@@ -142,13 +142,13 @@
 - type: entity
   parent: ClothingMaskBase
   id: ClothingMaskClown
-  name: clown wig and mask
-  description: A true prankster's facial attire. A clown is incomplete without his wig and mask.
+  name: security gas mask
+  description: A standard issue Security gas mask.
   components:
   - type: Sprite
-    sprite: Clothing/Mask/clown.rsi
+    sprite: Clothing/Mask/gassecurity.rsi
   - type: Clothing
-    sprite: Clothing/Mask/clown.rsi
+    sprite: Clothing/Mask/gassecurity.rsi
   - type: BreathMask
   - type: IdentityBlocker
 
@@ -167,6 +167,19 @@
 - type: entity
   parent: ClothingMaskBase
   id: ClothingMaskMime
+  name: security gas mask
+  description: A standard issue Security gas mask.
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/gassecurity.rsi
+  - type: Clothing
+    sprite: Clothing/Mask/gassecurity.rsi
+  - type: BreathMask
+  - type: IdentityBlocker
+
+- type: entity
+  parent: ClothingMaskBase
+  id: ClothingMaskHoS
   name: mime mask
   description: The traditional mime's mask. It has an eerie facial posture.
   components:
@@ -174,8 +187,6 @@
     sprite: Clothing/Mask/mime.rsi
   - type: Clothing
     sprite: Clothing/Mask/mime.rsi
-  - type: BreathMask
-  - type: IdentityBlocker
 
 - type: entity
   parent: ClothingMaskPullableBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -44,13 +44,12 @@
 - type: entity
   parent: ClothingOuterStorageBase
   id: ClothingOuterCoatHoSTrench
-  name: head of security's trenchcoat
-  description: This trenchcoat was specifically designed for asserting superior authority.
+  name: mime winter coat
   components:
   - type: Sprite
-    sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi
+    sprite: Clothing/OuterClothing/WinterCoats/coatmime.rsi
   - type: Clothing
-    sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi
+    sprite: Clothing/OuterClothing/WinterCoats/coatmime.rsi
   - type: Armor
     modifiers:
       coefficients:
@@ -185,13 +184,13 @@
 - type: entity
   parent: ClothingOuterStorageBase
   id: ClothingOuterClownPriest
-  name: robes of the honkmother
-  description: Meant for a clown of the cloth.
+  name: kevlar vest
+  description: An armor vest made of synthetic fibers.
   components:
   - type: Sprite
-    sprite: Clothing/OuterClothing/Coats/clownpriest.rsi
+    sprite: Clothing/OuterClothing/Vests/kevlar.rsi
   - type: Clothing
-    sprite: Clothing/OuterClothing/Coats/clownpriest.rsi
+    sprite: Clothing/OuterClothing/Vests/kevlar.rsi
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -41,13 +41,13 @@
 - type: entity
   parent: ClothingOuterBase
   id: ClothingOuterVestKevlar
-  name: kevlar vest
-  description: An armor vest made of synthetic fibers.
+  name: robes of the honkmother
+  description: Meant for a clown of the cloth.
   components:
   - type: Sprite
-    sprite: Clothing/OuterClothing/Vests/kevlar.rsi
+    sprite: Clothing/OuterClothing/Coats/clownpriest.rsi
   - type: Clothing
-    sprite: Clothing/OuterClothing/Vests/kevlar.rsi
+    sprite: Clothing/OuterClothing/Coats/clownpriest.rsi
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -212,12 +212,13 @@
 - type: entity
   parent: ClothingOuterWinterCoat
   id: ClothingOuterWinterMime
-  name: mime winter coat
+  name: head of security's trenchcoat
+  description: This trenchcoat was specifically designed for asserting superior authority.
   components:
   - type: Sprite
-    sprite: Clothing/OuterClothing/WinterCoats/coatmime.rsi
+    sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi
   - type: Clothing
-    sprite: Clothing/OuterClothing/WinterCoats/coatmime.rsi
+    sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi
 
 - type: entity
   parent: ClothingOuterWinterCoat

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -12,13 +12,13 @@
 - type: entity
   parent: ClothingShoesBaseButcherable
   id: ClothingShoesBootsJack
-  name: jackboots
-  description: Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time.
+  name: clown shoes
+  description: "The prankster's standard-issue clowning shoes. Damn they're huge!"
   components:
   - type: Sprite
-    sprite: Clothing/Shoes/Boots/jackboots.rsi
+    sprite: Clothing/Shoes/Specific/clown.rsi
   - type: Clothing
-    sprite: Clothing/Shoes/Boots/jackboots.rsi
+    sprite: Clothing/Shoes/Specific/clown.rsi
 
 - type: entity
   parent: ClothingShoesBaseButcherable
@@ -45,13 +45,13 @@
 - type: entity
   parent: ClothingShoesStorageBase
   id: ClothingShoesBootsCombat
-  name: combat boots
-  description: Robust combat boots for combat scenarios or combat situations. All combat, all the time.
+  name: white shoes
+  description: Don't take them off at your office Christmas party.
   components:
   - type: Sprite
-    sprite: Clothing/Shoes/Boots/combatboots.rsi
+    sprite: Clothing/Shoes/Color/white.rsi
   - type: Clothing
-    sprite: Clothing/Shoes/Boots/combatboots.rsi
+    sprite: Clothing/Shoes/Color/white.rsi
   - type: Storage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Clothing/Shoes/color.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/color.yml
@@ -88,6 +88,10 @@
 
 - type: entity
   parent: ClothingShoesBaseButcherable
+  id: ClothingShoesBootsJackHoS
+
+- type: entity
+  parent: ClothingShoesBaseButcherable
   id: ClothingShoesColorYellow
   name: yellow shoes
   description: Stylish yellow shoes.

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -12,16 +12,27 @@
 - type: entity
   parent: ClothingShoesBaseButcherable
   id: ClothingShoesClown
-  name: clown shoes
-  description: "The prankster's standard-issue clowning shoes. Damn they're huge!"
+  name: jackboots
+  description: Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time.
   components:
   - type: Sprite
-    sprite: Clothing/Shoes/Specific/clown.rsi
+    sprite: Clothing/Shoes/Boots/jackboots.rsi
   - type: Clothing
-    sprite: Clothing/Shoes/Specific/clown.rsi
+    sprite: Clothing/Shoes/Boots/jackboots.rsi
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepClown
+
+- type: entity
+  parent: ClothingShoesBaseButcherable
+  id: ClothingShoesMime
+  name: combat boots
+  description: Robust combat boots for combat scenarios or combat situations. All combat, all the time.
+  components:
+  - type: Sprite
+    sprite: Clothing/Shoes/Boots/combatboots.rsi
+  - type: Clothing
+    sprite: Clothing/Shoes/Boots/combatboots.rsi
 
 - type: entity
   parent: ClothingShoesBaseButcherable

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -139,35 +139,35 @@
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtHoS
-  name: head of security's jumpskirt
-  description: It's bright red and rather crisp, much like security's victims tend to be.
+  name: mime jumpskirt
+  description: ...
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpskirt/hos.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/mime.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpskirt/hos.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/mime.rsi
 
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtHoSAlt
-  name: head of security's turtleneck
-  description: It's a turtleneck worn by those strong and disciplined enough to achieve the position of Head of Security. Its sturdy fabric provides minor protection from mechanical damage.
+  name: mime jumpskirt
+  description: ...
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpskirt/hos_alt.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/mime.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpskirt/hos_alt.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/mime.rsi
 
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtHoSParadeMale
-  name: head of security's parade uniform
-  description: A head of security's luxury-wear, for special occasions.
+  name: mime jumpskirt
+  description: ...
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpskirt/hos_parade.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/mime.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpskirt/hos_parade.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/mime.rsi
 
 - type: entity
   parent: ClothingUniformSkirtBase
@@ -207,13 +207,13 @@
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtMime
-  name: mime jumpskirt
-  description: ...
+  name: head of security's jumpskirt
+  description: It's bright red and rather crisp, much like security's victims tend to be.
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpskirt/mime.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/hos.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpskirt/mime.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/hos.rsi
 
 - type: entity
   parent: ClothingUniformSkirtBase
@@ -279,13 +279,14 @@
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtSec
-  name: security jumpskirt
-  description: A jumpskirt made of strong material, providing robust protection.
+  name: clown suit
+  description: HONK!
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpskirt/security.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/clown.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpskirt/security.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/clown.rsi
+    femaleMask: UniformTop
 
 - type: entity
   parent: ClothingUniformSkirtBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -142,14 +142,13 @@
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitClown
-  name: clown suit
-  description: HONK!
+  name: security jumpsuit
+  description: A jumpsuit made of strong material, providing robust protection.
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpsuit/clown.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/security.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpsuit/clown.rsi
-    femaleMask: UniformTop
+    sprite: Clothing/Uniforms/Jumpsuit/security.rsi
 
 - type: entity
   parent: ClothingUniformBase
@@ -242,57 +241,57 @@
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoS
-  name: head of security's jumpsuit
-  description: It's bright red and rather crisp, much like security's victims tend to be.
+  name: mime suit
+  description: ...
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpsuit/hos.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpsuit/hos.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
 
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoSAlt
-  name: head of security's turtleneck
-  description: It's a turtleneck worn by those strong and disciplined enough to achieve the position of Head of Security. Its sturdy fabric provides minor protection from mechanical damage.
+  name: mime suit
+  description: ...
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpsuit/hos_alt.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpsuit/hos_alt.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
 
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoSBlue
-  name: head of security's blue jumpsuit
-  description: A blue jumpsuit of Head of Security.
+  name: mime suit
+  description: ...
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpsuit/hos_blue.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpsuit/hos_blue.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
 
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoSGrey
-  name: head of security's grey jumpsuit
-  description: A grey jumpsuit of Head of Security, which make him look somewhat like a passenger.
+  name: mime suit
+  description: ...
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpsuit/hos_grey.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpsuit/hos_grey.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
 
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoSParadeMale
-  name: head of security's parade uniform
-  description: A male head of security's luxury-wear, for special occasions.
+  name: mime suit
+  description: ...
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpsuit/hos_parade.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpsuit/hos_parade.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
 
 - type: entity
   parent: ClothingUniformBase
@@ -332,13 +331,13 @@
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitMime
-  name: mime suit
-  description: ...
+  name: head of security's jumpsuit
+  description: It's bright red and rather crisp, much like security's victims tend to be.
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/hos.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/hos.rsi
 
 - type: entity
   parent: ClothingUniformBase
@@ -415,13 +414,14 @@
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitSec
-  name: security jumpsuit
-  description: A jumpsuit made of strong material, providing robust protection.
+  name: clown suit
+  description: HONK!
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpsuit/security.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/clown.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpsuit/security.rsi
+    sprite: Clothing/Uniforms/Jumpsuit/clown.rsi
+    femaleMask: UniformTop
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -28,9 +28,10 @@
     jumpsuit: ClothingUniformJumpsuitClown
     back: ClothingBackpackClownFilled
     shoes: ClothingShoesClown
+    outerClothing: ClothingOuterClownPriest
     mask: ClothingMaskClown
     pocket1: BikeHorn
     id: ClownPDA
     ears: ClothingHeadsetService
-  satchel: ClothingBackpackSatchelFilled
+  satchel: ClothingBackpackSatchelSecurityFilled
   duffelbag: ClothingBackpackDuffelClownFilled

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -22,7 +22,8 @@
     head: ClothingHeadHatBeret
     belt: ClothingBeltSuspenders
     gloves: ClothingHandsGlovesLatex
-    shoes: ClothingShoesColorWhite
+    shoes: ClothingShoesMime
+    outerClothing: ClothingOuterWinterMime
     pocket1: CrayonMime
     pocket2: Paper
     mask: ClothingMaskMime

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -37,6 +37,7 @@
     outerClothing: ClothingOuterCoatHoSTrench
     eyes: ClothingEyesGlassesSecurity
     head: ClothingHeadHatBeretHoS
+    mask: ClothingMaskHoS
     id: HoSPDA
     gloves: ClothingHandsGlovesCombat
     ears: ClothingHeadsetAltSecurity

--- a/Resources/Server Info/Guidebook/Science/Xenoarchaeology.xml
+++ b/Resources/Server Info/Guidebook/Science/Xenoarchaeology.xml
@@ -24,6 +24,6 @@ The main equipment that you'll be using for Xenoarchaeology is the [color=#a4885
 
 To set them up, simply link them with a multitool, set an artifact on top of the analyzer, and press the [color=#a4885c]Scan[/color] button.
 
-Using the console, you can permanently destroy and artifact in exchange for points. This is irreversible, so be sure to confirm with your department that all research on it has concluded.
+Using the console, you can permanently destroy an artifact in exchange for points. This is irreversible, so be sure to confirm with your department that all research on it has concluded.
 
 </Document>


### PR DESCRIPTION
## About the PR
1 pr not enough

(mostly) swaps clown/mime and sec/hos clothes with some caveats:
- cadet is not affected
- seccie helmet stays the same since no clown hat
- gloves not affected since cant be bothered
- glasses/belt/etc not important 

**Media**
from left to right: clown, secoff, mime, hos

![155117](https://user-images.githubusercontent.com/39013340/228877682-f938de76-6549-4d0c-82df-1bb5a6f7c026.png)


- [X] I have added a screenshot to this PR showcasing its changes ingame

**Changelog**
:cl:
- fix: CentCom has recalled incorrect uniforms for some your crew.