### PR TITLE
[Sprite] Admin Observer unique color

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -18,6 +18,17 @@
   - type: CombatMode
   - type: Actions
   - type: InputMover
+  - type: Sprite
+    overrideContainerOcclusion: true
+    netsync: false
+    noRot: true
+    drawdepth: Ghosts
+    sprite: Mobs/Ghosts/ghost_human.rsi
+    state: animated
+    color: "#FF8C00"
+    layers:
+      - state: animated
+        shader: unshaded
   - type: MovementSpeedModifier
     baseSprintSpeed: 12
     baseWalkSpeed: 8


### PR DESCRIPTION
highlights Admin Observer, against the background of ordinary ghosts.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
it will help to visually distinguish an ordinary ghost from the server staff.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/103608145/228913301-afcd9045-89a2-4cd6-8182-19322c3f51da.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: PuroSlavKing
- add: Added unique color for Admin Observer.