### PR TITLE
Chat Filter (April Fools)

### DIFF
--- a/Content.Server/Speech/Components/ChatFilterAccentComponent.cs
+++ b/Content.Server/Speech/Components/ChatFilterAccentComponent.cs
@@ -1,0 +1,9 @@
+﻿namespace Content.Server.Speech.Components;
+
+// #####. ##### ### ###. #####? ### #####!
+
+[RegisterComponent]
+public sealed class ChatFilterAccentComponent : Component
+{
+
+}

--- a/Content.Server/Speech/EntitySystems/ChatFilterAccentComponent.cs
+++ b/Content.Server/Speech/EntitySystems/ChatFilterAccentComponent.cs
@@ -1,0 +1,79 @@
+﻿using System.Text.RegularExpressions;
+using Content.Server.Speech.Components;
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class ChatFilterAccentSystem : EntitySystem
+{
+    private static readonly Dictionary<string, string> DirectReplacements = new()
+    {
+        { "fuck", "####" },
+        { "shit", "####" },
+        { "ass", "###" },
+        { "dick", "####" },
+        { "bitch", "#####" },
+        { "piss", "####" },
+        { "damn", "####" },
+        { "kill", "####" },
+        { "hurt", "####" },
+        { "god", "###" },
+        { "hell", "####" },
+        { "nuke", "####" },
+        { "dang", "####" },
+        { "lol", "###" },
+        { "nukies", "#####" },
+        { "nukie", "#####" },
+        { "gun", "###" },
+        { "ammo", "####" },
+        { "bridge", "#####" },
+        { "med", "###" },
+        { "clown", "#####" },
+        { "admin", "#####" },
+        { "badmin", "######" },
+        { "admeme", "######" },
+        { "badmeme", "######" },
+        { "centcom", "#######" },
+        { "singulo", "#######" },
+        { "singuloose", "##########" },
+        { "sword", "#####" },
+        { "dead", "####" },
+        { "died", "####" },
+        { "sus", "###" },
+        { "aos", "###" },
+        { "kos", "###" },
+        { "anomaly", "#######" },
+        { "shuttle", "#######" },
+        { "hos", "###" },
+        { "drunk", "#####" },
+        { "bar", "###" },
+        { "arrest", "#####" },
+        { "bomb", "####" },
+        { "I", "#" },
+        { "traitor", "#######" },
+        { "tator", "#####" },
+        { "bad", "###" },
+    };
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ChatFilterAccentComponent, AccentGetEvent>(OnAccentGet);
+    }
+
+    public string Accentuate(string message)
+    {
+        var msg = message;
+
+        foreach (var (first, replace) in DirectReplacements)
+        {
+            msg = Regex.Replace(msg, $@"{first}", replace, RegexOptions.IgnoreCase);
+        }
+
+        return msg;
+    }
+
+    private void OnAccentGet(EntityUid uid, ChatFilterAccentComponent component, AccentGetEvent args)
+    {
+        args.Message = Accentuate(args.Message);
+    }
+}

--- a/Content.Server/Speech/EntitySystems/ChatFilterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ChatFilterAccentSystem.cs
@@ -1,9 +1,14 @@
 ﻿using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+
 namespace Content.Server.Speech.EntitySystems;
 
 public sealed class ChatFilterAccentSystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
     private static readonly Dictionary<string, string> DirectReplacements = new()
     {
         { "fuck", "####" },
@@ -64,9 +69,15 @@ public sealed class ChatFilterAccentSystem : EntitySystem
     {
         var msg = message;
 
-        foreach (var (first, replace) in DirectReplacements)
+        if (_cfg.GetCVar(CCVars.GameChatFilter) == true)
         {
-            msg = Regex.Replace(msg, $@"{first}", replace, RegexOptions.IgnoreCase);
+
+            foreach (var (first, replace) in DirectReplacements)
+            {
+                msg = Regex.Replace(msg, $@"{first}", replace, RegexOptions.IgnoreCase);
+            }
+
+            return msg;
         }
 
         return msg;

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -276,6 +276,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> GameTableBonk =
             CVarDef.Create("game.table_bonk", false, CVar.SERVERONLY);
 
+        /// <summary>
+        /// Enables the Roblox chat filter. True by default.
+        /// </summary>
+        public static readonly CVarDef<bool> GameChatFilter =
+            CVarDef.Create("game.chat_filter", true, CVar.SERVERONLY);
+
 #if EXCEPTION_TOLERANCE
         /// <summary>
         ///     Amount of times round start must fail before the server is shut down.

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -395,3 +395,4 @@
       interfaces:
         - key: enum.HumanoidMarkingModifierKey.Key # sure, this can go here too
           type: HumanoidMarkingModifierBoundUserInterface
+    - type: ChatFilterAccent


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

2010s Roblox chat vibes incoming


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: SS14 Development Team
- add: Hey there spacemen! We want SS14 to be a game that's fun for everyone, but we've been observing an alarming rise in profanity lately. In response, we've implemented a basic chat filter to make sure the game stays family-friendly for everyone. Have a great shift!
