### PR TITLE
Fix docking config in some instances

### DIFF
--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -75,7 +75,7 @@ public sealed partial class DockingSystem
        if (!ValidSpawn(grid, shuttleDockedAABB.Value))
            return false;
 
-       gridRotation = targetGridRotation + gridDockAngle - shuttleDockAngle;
+       gridRotation = (targetGridRotation + gridDockAngle - shuttleDockAngle).Reduced();
        return true;
    }
 
@@ -162,7 +162,7 @@ public sealed partial class DockingSystem
                    var spawnPosition = new EntityCoordinates(targetGrid, matty.Transform(Vector2.Zero));
                    spawnPosition = new EntityCoordinates(targetGridXform.MapUid!.Value, spawnPosition.ToMapPos(EntityManager, _transform));
 
-                   var dockedBounds = new Box2Rotated(shuttleAABB.Translated(spawnPosition.Position), targetGridAngle, spawnPosition.Position);
+                   var dockedBounds = new Box2Rotated(shuttleAABB.Translated(spawnPosition.Position), targetAngle, spawnPosition.Position);
 
                    // Check if there's no intersecting grids (AKA oh god it's docking at cargo).
                    if (_mapManager.FindGridsIntersecting(targetGridXform.MapID,
@@ -179,8 +179,6 @@ public sealed partial class DockingSystem
                    {
                        (dockUid, gridDockUid, shuttleDock, gridDock),
                    };
-
-                   // TODO: Check shuttle orientation as the tiebreaker.
 
                    foreach (var (otherUid, other) in shuttleDocks)
                    {


### PR DESCRIPTION
It was using the existing rotation and not the target rotation so might lead to some configs being labelled as incorrect. I only noticed as the Aspid shuttle is just barely close enough to occasionally block the 4-docking config.

:cl:
- fix: Fix docking config in some instances. This mainly affected Aspid with the shuttle blocking the 4-port docking configuration for the emergency shuttle.