### PR TITLE
[Access] Fire axe cabinet

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: FireAxeCabinet
   name: fire axe cabinet
   description: There is a small label that reads "For Emergency use only" along with details for safe use of the axe. As if.
@@ -34,7 +34,7 @@
   - type: Appearance
   - type: Lock
   - type: AccessReader
-    access: [["Atmospherics"]]
+    access: [["Atmospherics"]], [["Command"]]
   - type: ItemSlots
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -34,7 +34,7 @@
   - type: Appearance
   - type: Lock
   - type: AccessReader
-    access: [["Atmospherics"]], [["Command"]]
+    access: [["Atmospherics"], ["Command"]]
   - type: ItemSlots
   - type: ContainerContainer
     containers:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
There is often a problem that there is an axe on the bridge or in the brig of the stations, but a paradox arises, an atmospheric technician cannot get into these places freely, and this axe may be the last hope of the department, for example, when attacking nuclear operatives, the head of the department can get it without the help of the captain for protection.


<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: PuroSlavKing
- tweak: Changed access to fire axe cabinet, now not only an atmospheric technician can get a fire axe.
