### PR TITLE
[Fix] Fixed base showcase robot

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Decoration/showcase.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/showcase.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BaseShowcaseRobot
-  noSpawn: true
+  abstract: true
   parent: BaseStructure
   name: security robot showcase
   description: A non-functional replica of an old security robot.

--- a/Resources/Prototypes/Entities/Structures/Decoration/showcase.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/showcase.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: BaseShowcaseRobot
+  noSpawn: true
   parent: BaseStructure
   name: security robot showcase
   description: A non-functional replica of an old security robot.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
The search query "ShowcaseRobot" in F5, gives out 5 robot layouts, and one of them is BaseShowcaseRobot, it is impossible to spawn it, and it has no texture, so I decided to remove it from F5.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/103608145/229301480-f81eacda-3247-4bb6-b0de-ca91d050029d.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: PuroSlavKing
- fix: Fixed base showcase robot in F5 (just remove it)
