### PR TITLE
Fix fake lag not being applied to clients

### DIFF
--- a/Content.Shared/Entry/EntryPoint.cs
+++ b/Content.Shared/Entry/EntryPoint.cs
@@ -40,6 +40,13 @@ namespace Content.Shared.Entry
 
             InitTileDefinitions();
             IoCManager.Resolve<MarkingManager>().Initialize();
+
+#if DEBUG
+            var configMan = IoCManager.Resolve<IConfigurationManager>();
+            configMan.OverrideDefault(CVars.NetFakeLagMin, 0.075f);
+            configMan.OverrideDefault(CVars.NetFakeLoss, 0.005f);
+            configMan.OverrideDefault(CVars.NetFakeDuplicates, 0.005f);
+#endif
         }
 
         private void InitTileDefinitions()

--- a/Resources/ConfigPresets/Build/debug.toml
+++ b/Resources/ConfigPresets/Build/debug.toml
@@ -8,9 +8,3 @@ enabled = false
 
 [shuttle]
 auto_call_time = 0
-
-[net]
-fakelagmin = 0.075
-fakeloss = 0.005
-fakeduplicates = 0.005
-fakelagrand = 0.0 # Net code is not robust.


### PR DESCRIPTION
Reverts some of the changes in #14614. Turns out the config presets only get loaded by the server