### PR TITLE
Fix ghost lighting being disabled when any ghost is removed

### DIFF
--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -116,10 +116,11 @@ namespace Content.Client.Ghost
             _actions.RemoveAction(uid, component.ToggleLightingAction);
             _actions.RemoveAction(uid, component.ToggleFoVAction);
             _actions.RemoveAction(uid, component.ToggleGhostsAction);
-            _lightManager.Enabled = true;
 
             if (uid != _playerManager.LocalPlayer?.ControlledEntity)
                 return;
+
+            _lightManager.Enabled = true;
 
             if (component.IsAttached)
             {


### PR DESCRIPTION
## About the PR
**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed ghost lighting being disabled when any ghost is removed.
