### PR TITLE
Cached barotrauma resistance and immunity values instead of computing them each Update()

### DIFF
--- a/Content.Server/Atmos/Components/BarotraumaComponent.cs
+++ b/Content.Server/Atmos/Components/BarotraumaComponent.cs
@@ -40,8 +40,11 @@ namespace Content.Server.Atmos.Components
         [ViewVariables]
         public float LowPressureModifier = 0f;
 
+        /// <summary>
+        /// Whether the entity is immuned to pressure (i.e possess the PressureImmunity component)
+        /// </summary>
         [ViewVariables]
-        public bool Immuned = false;
+        public bool HasImmunity = false;
 
     }
 }

--- a/Content.Server/Atmos/Components/BarotraumaComponent.cs
+++ b/Content.Server/Atmos/Components/BarotraumaComponent.cs
@@ -29,7 +29,7 @@ namespace Content.Server.Atmos.Components
         public List<string> ProtectionSlots = new() { "head", "outerClothing" };
 
         /// <summary>
-        /// Cached protection values gained from the entity equipment
+        /// Cached pressure protection values
         /// </summary>
         [ViewVariables]
         public float HighPressureMultiplier = 1f;

--- a/Content.Server/Atmos/Components/BarotraumaComponent.cs
+++ b/Content.Server/Atmos/Components/BarotraumaComponent.cs
@@ -26,6 +26,22 @@ namespace Content.Server.Atmos.Components
         ///     These are the inventory slots that are checked for pressure protection. If a slot is missing protection, no protection is applied.
         /// </summary>
         [DataField("protectionSlots")]
-        public List<string> ProtectionSlots = new() { "head", "outerClothing" }; 
+        public List<string> ProtectionSlots = new() { "head", "outerClothing" };
+
+        /// <summary>
+        /// Cached protection values gained from the entity equipment
+        /// </summary>
+        [ViewVariables]
+        public float HighPressureMultiplier = 1f;
+        [ViewVariables]
+        public float HighPressureModifier = 0f;
+        [ViewVariables]
+        public float LowPressureMultiplier = 1f;
+        [ViewVariables]
+        public float LowPressureModifier = 0f;
+
+        [ViewVariables]
+        public bool Immuned = false;
+
     }
 }

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -47,7 +47,6 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 barotrauma.Immuned = false;
             }
-
         }
 
         private void OnPressureProtectionInit(EntityUid uid, PressureProtectionComponent pressureImmunity, ComponentInit args)
@@ -64,7 +63,6 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 UpdateCachedResistances(uid, barotrauma);
             }
-
         }
 
         private void OnPressureProtectionEquipped(EntityUid uid, PressureProtectionComponent pressureProtection, GotEquippedEvent args)
@@ -73,7 +71,6 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 UpdateCachedResistances(args.Equipee, barotrauma);
             }
-
         }
 
         private void OnPressureProtectionUnequipped(EntityUid uid, PressureProtectionComponent pressureProtection, GotUnequippedEvent args)
@@ -120,7 +117,6 @@ namespace Content.Server.Atmos.EntitySystems
                     hPMultiplier = Math.Max(hPMultiplier, protection.HighPressureMultiplier);
                     lPModifier = Math.Min(lPModifier, protection.LowPressureModifier);
                     lPMultiplier = Math.Min(lPMultiplier, protection.LowPressureMultiplier);
-
                 }
 
                 barotrauma.HighPressureModifier = hPModifier;
@@ -137,7 +133,6 @@ namespace Content.Server.Atmos.EntitySystems
                 barotrauma.LowPressureModifier += innatePressureProtection.LowPressureModifier;
                 barotrauma.LowPressureMultiplier *= innatePressureProtection.LowPressureMultiplier;
             }
-
         }
 
         /// <summary>

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -26,8 +26,8 @@ namespace Content.Server.Atmos.EntitySystems
         {
             SubscribeLocalEvent<PressureProtectionComponent, GotEquippedEvent>(OnPressureProtectionEquipped);
             SubscribeLocalEvent<PressureProtectionComponent, GotUnequippedEvent>(OnPressureProtectionUnequipped);
-            SubscribeLocalEvent<PressureProtectionComponent, ComponentInit>(OnPressureProtectionInit);
-            SubscribeLocalEvent<PressureProtectionComponent, ComponentRemove>(OnPressureProtectionRemove);
+            SubscribeLocalEvent<PressureProtectionComponent, ComponentInit>(OnUpdateResistance);
+            SubscribeLocalEvent<PressureProtectionComponent, ComponentRemove>(OnUpdateResistance);
 
             SubscribeLocalEvent<PressureImmunityComponent, ComponentInit>(OnPressureImmuneInit);
             SubscribeLocalEvent<PressureImmunityComponent, ComponentRemove>(OnPressureImmuneRemove);
@@ -37,7 +37,7 @@ namespace Content.Server.Atmos.EntitySystems
         {
             if (TryComp<BarotraumaComponent>(uid, out var barotrauma))
             {
-                barotrauma.Immuned = true;
+                barotrauma.HasImmunity = true;
             }
         }
 
@@ -45,19 +45,14 @@ namespace Content.Server.Atmos.EntitySystems
         {
             if (TryComp<BarotraumaComponent>(uid, out var barotrauma))
             {
-                barotrauma.Immuned = false;
+                barotrauma.HasImmunity = false;
             }
         }
 
-        private void OnPressureProtectionInit(EntityUid uid, PressureProtectionComponent pressureImmunity, ComponentInit args)
-        {
-            if (TryComp<BarotraumaComponent>(uid, out var barotrauma))
-            {
-                UpdateCachedResistances(uid, barotrauma);
-            }
-        }
-
-        private void OnPressureProtectionRemove(EntityUid uid, PressureProtectionComponent pressureImmunity, ComponentRemove args)
+        /// <summary>
+        /// Generic method for updating resistance on component Lifestage events
+        /// </summary>
+        private void OnUpdateResistance(EntityUid uid, PressureProtectionComponent pressureProtection, EntityEventArgs args)
         {
             if (TryComp<BarotraumaComponent>(uid, out var barotrauma))
             {
@@ -140,7 +135,7 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float GetFeltLowPressure(EntityUid uid, BarotraumaComponent barotrauma, float environmentPressure)
         {
-            if (barotrauma.Immuned)
+            if (barotrauma.HasImmunity)
             {
                 return Atmospherics.OneAtmosphere;
             }
@@ -153,7 +148,7 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float GetFeltHighPressure(EntityUid uid, BarotraumaComponent barotrauma, float environmentPressure)
         {
-            if (barotrauma.Immuned)
+            if (barotrauma.HasImmunity)
             {
                 return Atmospherics.OneAtmosphere;
             }


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Implement the TODO in the barotrauma system by caching resistance/immunity values instead of sending events and computing them each system `Update()`.

The whole thing feels still a little rough on the edges, don't hesitate to point any area that could be improved.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
no cl, but fun