### PR TITLE
Changes the SingularitySystem to use generic visualizers

### DIFF
--- a/Content.Client/Singularity/Systems/SingularitySystem.cs
+++ b/Content.Client/Singularity/Systems/SingularitySystem.cs
@@ -45,7 +45,7 @@ public sealed class SingularitySystem : SharedSingularitySystem
         base.OnSingularityStartup(uid, comp, args);
         if (TryComp<SpriteComponent>(uid, out var sprite))
         {
-            sprite.LayerMapReserveBlank(comp.Layer);
+            sprite.LayerMapReserveBlank(comp.SpriteLayerKey);
         }
     }
 
@@ -57,10 +57,9 @@ public sealed class SingularitySystem : SharedSingularitySystem
         if (args.Sprite == null)
             return;
 
-        if(!_appearanceSystem.TryGetData<byte>(uid, SingularityVisuals.Level, out var level, args.Component))
+        if(!_appearanceSystem.TryGetData<byte>(uid, SingularityAppearanceKeys.Singularity, out var level, args.Component))
             return;
 
-        args.Sprite.LayerSetSprite(comp.Layer,
-            new SpriteSpecifier.Rsi(new ResourcePath($"{comp.BaseSprite.RsiPath}_{level}.rsi"), $"{comp.BaseSprite.RsiState}_{level}"));
+        args.Sprite.LayerSetState("VisualLevel", comp.SpriteBaseRsi + "_" + level ) ;
     }
 }

--- a/Content.Client/Singularity/Systems/SingularitySystem.cs
+++ b/Content.Client/Singularity/Systems/SingularitySystem.cs
@@ -20,7 +20,6 @@ public sealed class SingularitySystem : SharedSingularitySystem
         base.Initialize();
 
         SubscribeLocalEvent<SingularityComponent, ComponentHandleState>(HandleSingularityState);
-        SubscribeLocalEvent<SingularityComponent, AppearanceChangeEvent>(OnAppearanceChange);
     }
 
     /// <summary>
@@ -35,31 +34,5 @@ public sealed class SingularitySystem : SharedSingularitySystem
             return;
 
         SetLevel(uid, state.Level, comp);
-    }
-
-    /// <summary>
-    /// Handles ensuring that the singularity has a sprite to see.
-    /// </summary>
-    protected override void OnSingularityStartup(EntityUid uid, SingularityComponent comp, ComponentStartup args)
-    {
-        base.OnSingularityStartup(uid, comp, args);
-        if (TryComp<SpriteComponent>(uid, out var sprite))
-        {
-            sprite.LayerMapReserveBlank(comp.SpriteLayerKey);
-        }
-    }
-
-    /// <summary>
-    /// Handles updating the visible state of the singularity to reflect its current level.
-    /// </summary>
-    private void OnAppearanceChange(EntityUid uid, SingularityComponent comp, ref AppearanceChangeEvent args)
-    {
-        if (args.Sprite == null)
-            return;
-
-        if(!_appearanceSystem.TryGetData<byte>(uid, SingularityAppearanceKeys.Singularity, out var level, args.Component))
-            return;
-
-        args.Sprite.LayerSetState("VisualLevel", comp.SpriteBaseRsi + "_" + level ) ;
     }
 }

--- a/Content.Shared/Singularity/Components/SingularityComponent.cs
+++ b/Content.Shared/Singularity/Components/SingularityComponent.cs
@@ -82,24 +82,6 @@ public sealed class SingularityComponent : Component
 
     #endregion Audio
 
-    #region Appearance
-
-    /// <summary>
-    /// The sprite layer the singularity appearance is attached to.
-    /// </summary>
-    [DataField("spriteLayerKey")]
-    public string SpriteLayerKey { get; } = "VisualLevel";
-
-    /// <summary>
-    /// The base rsi key to use for updating the sprite layer.
-    /// 'singularity' if singularity_level or 'brodylarity' if using a custom singulo rsi like 'brodylarity_level.
-    /// </summary>
-    ///
-    [DataField("spriteBaseRsi")]
-    public string SpriteBaseRsi = "singularity";
-
-    #endregion Appearance
-
     #region Update Timing
 
     /// <summary>

--- a/Content.Shared/Singularity/Components/SingularityComponent.cs
+++ b/Content.Shared/Singularity/Components/SingularityComponent.cs
@@ -92,7 +92,7 @@ public sealed class SingularityComponent : Component
 
     /// <summary>
     /// The base rsi key to use for updating the sprite layer.
-    /// 'singularity' if singularity_level or 'brodylarity' if using a custom singulo rsi.
+    /// 'singularity' if singularity_level or 'brodylarity' if using a custom singulo rsi like 'brodylarity_level.
     /// </summary>
     ///
     [DataField("spriteBaseRsi")]

--- a/Content.Shared/Singularity/Components/SingularityComponent.cs
+++ b/Content.Shared/Singularity/Components/SingularityComponent.cs
@@ -87,14 +87,16 @@ public sealed class SingularityComponent : Component
     /// <summary>
     /// The sprite layer the singularity appearance is attached to.
     /// </summary>
-    [DataField("layer")]
-    public int Layer { get; } = 0;
+    [DataField("spriteLayerKey")]
+    public string SpriteLayerKey { get; } = "VisualLevel";
 
     /// <summary>
-    /// The base sprite file and state of the singularity.
+    /// The base rsi key to use for updating the sprite layer.
+    /// 'singularity' if singularity_level or 'brodylarity' if using a custom singulo rsi.
     /// </summary>
-    [DataField("baseSprite")]
-    public SpriteSpecifier.Rsi BaseSprite = new SpriteSpecifier.Rsi(new ResourcePath("Structures/Power/Generation/Singularity/singularity"), "singularity");
+    ///
+    [DataField("spriteBaseRsi")]
+    public string SpriteBaseRsi = "singularity";
 
     #endregion Appearance
 

--- a/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
@@ -366,7 +366,7 @@ public abstract class SharedSingularitySystem : EntitySystem
     /// <param name="args">The event arguments.</param>
     private void UpdateAppearance(EntityUid uid, AppearanceComponent comp, SingularityLevelChangedEvent args)
     {
-        _visualizer.SetData(uid, SingularityVisuals.Level, args.NewValue, comp);
+        _visualizer.SetData(uid, SingularityAppearanceKeys.Singularity, args.NewValue, comp);
     }
 
     /// <summary>

--- a/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
@@ -126,7 +126,7 @@ public abstract class SharedSingularitySystem : EntitySystem
 
         RaiseLocalEvent(uid, new SingularityLevelChangedEvent(singularity.Level, oldValue, singularity));
         if (singularity.Level <= 0)
-            EntityManager.DeleteEntity(singularity.Owner);
+            QueueDel(uid);
     }
 
     /// <summary>

--- a/Content.Shared/Singularity/SingularityVisualKeys.cs
+++ b/Content.Shared/Singularity/SingularityVisualKeys.cs
@@ -3,8 +3,8 @@
 namespace Content.Shared.Singularity
 {
     [Serializable, NetSerializable]
-    public enum SingularityVisuals
+    public enum SingularityAppearanceKeys
     {
-        Level
+        Singularity
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -32,8 +32,6 @@
     energy: 180
     level: 1
     radsPerLevel: 2
-    spriteLayerKey: VisualLevel
-    spriteBaseRsi: singularity
   - type: RandomWalk # To make the singularity move around.
   - type: SingularityDistortion
     intensity: 20

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -11,13 +11,18 @@
       path: /Audio/Effects/singularity.ogg
   - type: Physics
     bodyType: Dynamic
+  - type: EventHorizon # To make the singularity consume things.
+    radius: 0.5
+  - type: GravityWell # To make the singularity attract things.
+    canBreachContainment: false
+    horizonFixtureId: EventHorizon
   - type: Fixtures
     fixtures:
     - id: EventHorizon
       shape:
         !type:PhysShapeCircle
-          radius: 0.5
-      restitution: 0.9
+          radius: 0.35
+      restitution: 0.8
       density: 99999
       mask:
       - AllMask
@@ -27,13 +32,11 @@
     energy: 180
     level: 1
     radsPerLevel: 2
-  - type: GravityWell # To make the singularity attract things.
-  - type: EventHorizon # To make the singularity consume things.
-    radius: 0.5
-    canBreachContainment: false
-    horizonFixtureId: EventHorizon
+    spriteLayerKey: VisualLevel
+    spriteBaseRsi: singularity
   - type: RandomWalk # To make the singularity move around.
   - type: SingularityDistortion
+    intensity: 20
   - type: RadiationSource
     slope: 0.2 # its emit really far away
   - type: Sprite
@@ -50,3 +53,33 @@
   - type: WarpPoint
     follow: true
     location: singularity
+  - type: Sprite
+    sprite: Structures/Power/Generation/Singularity/singularity_1.rsi
+    layers:
+    - map: [ "VisualLevel" ]
+      state: singularity_1
+  - type: GenericVisualizer
+    visuals:
+      enum.SingularityAppearanceKeys.Singularity:
+       VisualLevel:
+          1:
+            sprite: Structures/Power/Generation/Singularity/singularity_1.rsi
+            state: singularity_1
+          2:
+            sprite: Structures/Power/Generation/Singularity/singularity_2.rsi
+            state: singularity_2
+          3:
+            sprite: Structures/Power/Generation/Singularity/singularity_3.rsi
+            state: singularity_3
+          4:
+            sprite: Structures/Power/Generation/Singularity/singularity_4.rsi
+            state: singularity_4
+          5:
+            sprite: Structures/Power/Generation/Singularity/singularity_5.rsi
+            state: singularity_5
+            scale: 1.5,1.5
+          6:
+            sprite: Structures/Power/Generation/Singularity/singularity_6.rsi
+            state: singularity_6
+            scale: .9,.9
+

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -39,11 +39,6 @@
     intensity: 20
   - type: RadiationSource
     slope: 0.2 # its emit really far away
-  - type: Sprite
-    sprite: Structures/Power/Generation/Singularity/singularity_1.rsi
-    state: singularity_1
-    shader: unshaded
-    netsync: false
   - type: PointLight
     enabled: true
     radius: 10

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -13,9 +13,9 @@
     bodyType: Dynamic
   - type: EventHorizon # To make the singularity consume things.
     radius: 0.5
-  - type: GravityWell # To make the singularity attract things.
     canBreachContainment: false
     horizonFixtureId: EventHorizon
+  - type: GravityWell # To make the singularity attract things.
   - type: Fixtures
     fixtures:
     - id: EventHorizon
@@ -42,12 +42,14 @@
     radius: 10
   - type: Appearance
   - type: GuideHelp
-    guides: [ Singularity, Power ]
+    guides: [ Singularity, Power ] # uhhh.. I would hoped they'd  have read the manual before ever getting in viewing distance...
   - type: WarpPoint
     follow: true
     location: singularity
   - type: Sprite
     sprite: Structures/Power/Generation/Singularity/singularity_1.rsi
+    shader: unshaded
+    netsync: false
     layers:
     - map: [ "VisualLevel" ]
       state: singularity_1
@@ -58,15 +60,19 @@
           1:
             sprite: Structures/Power/Generation/Singularity/singularity_1.rsi
             state: singularity_1
+            scale: 1.0,1.0
           2:
             sprite: Structures/Power/Generation/Singularity/singularity_2.rsi
             state: singularity_2
+            scale: 1.0,1.0
           3:
             sprite: Structures/Power/Generation/Singularity/singularity_3.rsi
             state: singularity_3
+            scale: 1.0,1.0
           4:
             sprite: Structures/Power/Generation/Singularity/singularity_4.rsi
             state: singularity_4
+            scale: 1.0,1.0
           5:
             sprite: Structures/Power/Generation/Singularity/singularity_5.rsi
             state: singularity_5


### PR DESCRIPTION
## About the PR

The singularity had a lot of hardcoded rsi and old appearance stuff. this PR moves singularity to use a generic visualizer and updates some fields for better readability. also allows custom singularity adminbus stuff via prototypes :o)

**Media**

this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
