### PR TITLE
Allow ghosts to hear radio message globally

### DIFF
--- a/Content.Server/Radio/Components/ActiveRadioComponent.cs
+++ b/Content.Server/Radio/Components/ActiveRadioComponent.cs
@@ -14,4 +14,10 @@ public sealed class ActiveRadioComponent : Component
     /// </summary>
     [DataField("channels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
     public HashSet<string> Channels = new();
+
+    /// <summary>
+    ///     If this radio can hear all messages on all maps
+    /// </summary>
+    [DataField("globalReceive")]
+    public bool GlobalReceive = false;
 }

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -90,14 +90,14 @@ public sealed class RadioSystem : EntitySystem
             if (!radio.Channels.Contains(channel.ID))
                 continue;
 
-            if (!channel.LongRange && transform.MapID != sourceMapId)
+            if (!channel.LongRange && transform.MapID != sourceMapId && !radio.GlobalReceive)
                 continue;
 
             // don't need telecom server for long range channels or handheld radios and intercoms
             var needServer = !channel.LongRange && (!hasMicro || !speakerQuery.HasComponent(receiver));
             if (needServer && !hasActiveServer)
                 continue;
-                
+
             // check if message can be sent to specific receiver
             var attemptEv = new RadioReceiveAttemptEvent(channel, radioSource, receiver);
             RaiseLocalEvent(ref attemptEv);

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -41,6 +41,7 @@
     - Service
     - Supply
     - Syndicate
+    globalReceive: true
   - type: Sprite
     overrideContainerOcclusion: true # Ghosts always show up regardless of where they're contained.
     netsync: false


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Observers can now hear radio messages regardless of map.
Fixes #14952 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/4607006/229382838-2062a446-88ad-499c-aea3-820a2256feb4.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed ghosts being unable to hear radio cross-map
