### PR TITLE
Fix MovespeedModifierMetabolism state handling

### DIFF
--- a/Content.Shared/Chemistry/Components/MovespeedModifierMetabolismComponent.cs
+++ b/Content.Shared/Chemistry/Components/MovespeedModifierMetabolismComponent.cs
@@ -20,11 +20,6 @@ namespace Content.Shared.Chemistry.Components
         [ViewVariables]
         public TimeSpan ModifierTimer { get; set; } = TimeSpan.Zero;
 
-        public override ComponentState GetComponentState()
-        {
-            return new MovespeedModifierMetabolismComponentState(WalkSpeedModifier, SprintSpeedModifier, ModifierTimer);
-        }
-
         [Serializable, NetSerializable]
         public sealed class MovespeedModifierMetabolismComponentState : ComponentState
         {

--- a/Content.Shared/Chemistry/MetabolismMovespeedModifierSystem.cs
+++ b/Content.Shared/Chemistry/MetabolismMovespeedModifierSystem.cs
@@ -22,8 +22,17 @@ namespace Content.Shared.Chemistry
             UpdatesOutsidePrediction = true;
 
             SubscribeLocalEvent<MovespeedModifierMetabolismComponent, ComponentHandleState>(OnMovespeedHandleState);
+            SubscribeLocalEvent<MovespeedModifierMetabolismComponent, ComponentGetState>(OnGetState);
             SubscribeLocalEvent<MovespeedModifierMetabolismComponent, ComponentStartup>(AddComponent);
             SubscribeLocalEvent<MovespeedModifierMetabolismComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
+        }
+
+        private void OnGetState(EntityUid uid, MovespeedModifierMetabolismComponent component, ref ComponentGetState args)
+        {
+            args.State = new MovespeedModifierMetabolismComponentState(
+                component.WalkSpeedModifier,
+                component.SprintSpeedModifier,
+                component.ModifierTimer);
         }
 
         private void OnMovespeedHandleState(EntityUid uid, MovespeedModifierMetabolismComponent component, ref ComponentHandleState args)
@@ -31,17 +40,9 @@ namespace Content.Shared.Chemistry
             if (args.Current is not MovespeedModifierMetabolismComponentState cast)
                 return;
 
-            if (EntityManager.TryGetComponent<MovementSpeedModifierComponent>(uid, out var modifier) &&
-                (!component.WalkSpeedModifier.Equals(cast.WalkSpeedModifier) ||
-                 !component.SprintSpeedModifier.Equals(cast.SprintSpeedModifier)))
-            {
-                _movespeed.RefreshMovementSpeedModifiers(uid);
-            }
-
             component.WalkSpeedModifier = cast.WalkSpeedModifier;
             component.SprintSpeedModifier = cast.SprintSpeedModifier;
             component.ModifierTimer = cast.ModifierTimer;
-
         }
 
         private void OnRefreshMovespeed(EntityUid uid, MovespeedModifierMetabolismComponent component, RefreshMovementSpeedModifiersEvent args)

--- a/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
@@ -2,11 +2,15 @@ using Content.Shared.Inventory;
 using Content.Shared.Movement.Components;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Movement.Systems
 {
     public sealed class MovementSpeedModifierSystem : EntitySystem
     {
+        [Dependency] private readonly IGameTiming _timing = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -37,6 +41,9 @@ namespace Content.Shared.Movement.Systems
         public void RefreshMovementSpeedModifiers(EntityUid uid, MovementSpeedModifierComponent? move = null)
         {
             if (!Resolve(uid, ref move, false))
+                return;
+
+            if (_timing.ApplyingState)
                 return;
 
             var ev = new RefreshMovementSpeedModifiersEvent();


### PR DESCRIPTION
Should hopefully fix the constant hunger/thirst mispredict issues, though those systems still need to be moved to shared code as it will still cause temporary mispredicts whenever move speed changes.