### PR TITLE
Add Alt-click insertion to ItemSlots

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -138,12 +138,10 @@ namespace Content.Shared.Containers.ItemSlots
         public bool EjectOnInteract = false;
 
         /// <summary>
-        ///     Whether the item slots system will attempt to eject this item to the user's hands when interacted with.
+        ///     Whether the item slots system will attempt to eject this item to the user's hands when alt interacted with.
         /// </summary>
         /// <remarks>
-        ///     For most item slots, this is probably not the case (eject is usually an alt-click interaction). But
-        ///     there are some exceptions. For example item cabinets and charging stations should probably eject their
-        ///     contents when clicked on normally.
+        ///     This is an override so that alt-interact will eject even if ejectOnInteract is set.
         /// </remarks>
         [DataField("ejectOnAltInteract")]
         public bool EjectOnAltInteract = false;

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -138,15 +138,6 @@ namespace Content.Shared.Containers.ItemSlots
         public bool EjectOnInteract = false;
 
         /// <summary>
-        ///     Whether the item slots system will attempt to eject this item to the user's hands when alt interacted with.
-        /// </summary>
-        /// <remarks>
-        ///     This is an override so that alt-interact will eject even if ejectOnInteract is set.
-        /// </remarks>
-        [DataField("ejectOnAltInteract")]
-        public bool EjectOnAltInteract = false;
-
-        /// <summary>
         ///     If true, and if this slot is attached to an item, then it will attempt to eject slot when to the slot is
         ///     used in the user's hands.
         /// </summary>

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -138,6 +138,17 @@ namespace Content.Shared.Containers.ItemSlots
         public bool EjectOnInteract = false;
 
         /// <summary>
+        ///     Whether the item slots system will attempt to eject this item to the user's hands when interacted with.
+        /// </summary>
+        /// <remarks>
+        ///     For most item slots, this is probably not the case (eject is usually an alt-click interaction). But
+        ///     there are some exceptions. For example item cabinets and charging stations should probably eject their
+        ///     contents when clicked on normally.
+        /// </remarks>
+        [DataField("ejectOnAltInteract")]
+        public bool EjectOnAltInteract = false;
+
+        /// <summary>
         ///     If true, and if this slot is attached to an item, then it will attempt to eject slot when to the slot is
         ///     used in the user's hands.
         /// </summary>

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -412,6 +412,54 @@ namespace Content.Shared.Containers.ItemSlots
                 return;
             }
 
+            // Add the insert-item verbs
+            if (args.Using != null && _actionBlockerSystem.CanDrop(args.User))
+            {
+                var canInsertAny = false;
+                foreach (var slot in itemSlots.Slots.Values)
+                {
+                    if (!CanInsert(uid, args.Using.Value, slot))
+                        continue;
+
+                    var verbSubject = slot.Name != string.Empty
+                        ? Loc.GetString(slot.Name)
+                        : Name(args.Using.Value) ?? string.Empty;
+
+                    AlternativeVerb verb = new();
+                    verb.IconEntity = args.Using;
+                    verb.Act = () => Insert(uid, slot, args.Using.Value, args.User, excludeUserAudio: true);
+
+                    if (slot.InsertVerbText != null)
+                    {
+                        verb.Text = Loc.GetString(slot.InsertVerbText);
+                        verb.Icon = new SpriteSpecifier.Texture(
+                            new ResourcePath("/Textures/Interface/VerbIcons/insert.svg.192dpi.png"));
+                    }
+                    else if (slot.EjectOnInteract)
+                    {
+                        // Inserting/ejecting is a primary interaction for this entity. Instead of using the insert
+                        // category, we will use a single "Place <item>" verb.
+                        verb.Text = Loc.GetString("place-item-verb-text", ("subject", verbSubject));
+                        verb.Icon = new SpriteSpecifier.Texture(
+                            new ResourcePath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png"));
+                    }
+                    else
+                    {
+                        verb.Category = VerbCategory.Insert;
+                        verb.Text = verbSubject;
+                    }
+
+                    verb.Priority = slot.Priority;
+                    args.Verbs.Add(verb);
+                    canInsertAny = true;
+                }
+
+                // If can insert then insert. Don't run eject verbs.
+                if (canInsertAny)
+                    return;
+            }
+
+            // Add the eject-item verbs
             foreach (var slot in itemSlots.Slots.Values)
             {
                 if (!slot.EjectOnAltInteract && slot.EjectOnInteract)
@@ -441,49 +489,6 @@ namespace Content.Shared.Containers.ItemSlots
                 else
                 {
                     verb.Text = Loc.GetString(slot.EjectVerbText);
-                }
-
-                verb.Priority = slot.Priority;
-                args.Verbs.Add(verb);
-            }
-
-            // Next, add the insert-item verbs
-            if (args.Using == null || !_actionBlockerSystem.CanDrop(args.User))
-                return;
-
-            foreach (var slot in itemSlots.Slots.Values)
-            {
-                if (!CanInsert(uid, args.Using.Value, slot))
-                    continue;
-
-                var verbSubject = slot.Name != string.Empty
-                    ? Loc.GetString(slot.Name)
-                    : Name(args.Using.Value) ?? string.Empty;
-
-                AlternativeVerb verb = new();
-                verb.IconEntity = args.Using;
-                verb.Act = () => Insert(uid, slot, args.Using.Value, args.User, excludeUserAudio: true);
-
-                if (slot.InsertVerbText != null)
-                {
-                    verb.Text = Loc.GetString(slot.InsertVerbText);
-                    verb.Icon =
-                        new SpriteSpecifier.Texture(
-                            new ResourcePath("/Textures/Interface/VerbIcons/insert.svg.192dpi.png"));
-                }
-                else if(slot.EjectOnInteract)
-                {
-                    // Inserting/ejecting is a primary interaction for this entity. Instead of using the insert
-                    // category, we will use a single "Place <item>" verb.
-                    verb.Text = Loc.GetString("place-item-verb-text", ("subject", verbSubject));
-                    verb.Icon =
-                        new SpriteSpecifier.Texture(
-                            new ResourcePath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png"));
-                }
-                else
-                {
-                    verb.Category = VerbCategory.Insert;
-                    verb.Text = verbSubject;
                 }
 
                 verb.Priority = slot.Priority;

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -463,7 +463,7 @@ namespace Content.Shared.Containers.ItemSlots
             // Add the eject-item verbs
             foreach (var slot in itemSlots.Slots.Values)
             {
-                if (!slot.EjectOnAltInteract && slot.EjectOnInteract)
+                if (slot.EjectOnInteract)
                     // For this item slot, ejecting/inserting is a primary interaction. Instead of an eject category
                     // alt-click verb, there will be a "Take item" primary interaction verb.
                     continue;

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Shared.Containers.ItemSlots
             SubscribeLocalEvent<ItemSlotsComponent, InteractHandEvent>(OnInteractHand);
             SubscribeLocalEvent<ItemSlotsComponent, UseInHandEvent>(OnUseInHand);
 
-            SubscribeLocalEvent<ItemSlotsComponent, GetVerbsEvent<AlternativeVerb>>(AddEjectVerbs);
+            SubscribeLocalEvent<ItemSlotsComponent, GetVerbsEvent<AlternativeVerb>>(AddAlternativeVerbs);
             SubscribeLocalEvent<ItemSlotsComponent, GetVerbsEvent<InteractionVerb>>(AddInteractionVerbsVerbs);
 
             SubscribeLocalEvent<ItemSlotsComponent, BreakageEventArgs>(OnBreak);
@@ -405,7 +405,7 @@ namespace Content.Shared.Containers.ItemSlots
         #endregion
 
         #region Verbs
-        private void AddEjectVerbs(EntityUid uid, ItemSlotsComponent itemSlots, GetVerbsEvent<AlternativeVerb> args)
+        private void AddAlternativeVerbs(EntityUid uid, ItemSlotsComponent itemSlots, GetVerbsEvent<AlternativeVerb> args)
         {
             if (args.Hands == null || !args.CanAccess ||!args.CanInteract)
             {
@@ -414,7 +414,7 @@ namespace Content.Shared.Containers.ItemSlots
 
             foreach (var slot in itemSlots.Slots.Values)
             {
-                if (slot.EjectOnInteract)
+                if (!slot.EjectOnAltInteract && slot.EjectOnInteract)
                     // For this item slot, ejecting/inserting is a primary interaction. Instead of an eject category
                     // alt-click verb, there will be a "Take item" primary interaction verb.
                     continue;
@@ -441,6 +441,49 @@ namespace Content.Shared.Containers.ItemSlots
                 else
                 {
                     verb.Text = Loc.GetString(slot.EjectVerbText);
+                }
+
+                verb.Priority = slot.Priority;
+                args.Verbs.Add(verb);
+            }
+
+            // Next, add the insert-item verbs
+            if (args.Using == null || !_actionBlockerSystem.CanDrop(args.User))
+                return;
+
+            foreach (var slot in itemSlots.Slots.Values)
+            {
+                if (!CanInsert(uid, args.Using.Value, slot))
+                    continue;
+
+                var verbSubject = slot.Name != string.Empty
+                    ? Loc.GetString(slot.Name)
+                    : Name(args.Using.Value) ?? string.Empty;
+
+                AlternativeVerb verb = new();
+                verb.IconEntity = args.Using;
+                verb.Act = () => Insert(uid, slot, args.Using.Value, args.User, excludeUserAudio: true);
+
+                if (slot.InsertVerbText != null)
+                {
+                    verb.Text = Loc.GetString(slot.InsertVerbText);
+                    verb.Icon =
+                        new SpriteSpecifier.Texture(
+                            new ResourcePath("/Textures/Interface/VerbIcons/insert.svg.192dpi.png"));
+                }
+                else if(slot.EjectOnInteract)
+                {
+                    // Inserting/ejecting is a primary interaction for this entity. Instead of using the insert
+                    // category, we will use a single "Place <item>" verb.
+                    verb.Text = Loc.GetString("place-item-verb-text", ("subject", verbSubject));
+                    verb.Icon =
+                        new SpriteSpecifier.Texture(
+                            new ResourcePath("/Textures/Interface/VerbIcons/drop.svg.192dpi.png"));
+                }
+                else
+                {
+                    verb.Category = VerbCategory.Insert;
+                    verb.Text = verbSubject;
                 }
 
                 verb.Priority = slot.Priority;

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -418,7 +418,8 @@ namespace Content.Shared.Containers.ItemSlots
                 var canInsertAny = false;
                 foreach (var slot in itemSlots.Slots.Values)
                 {
-                    if (!CanInsert(uid, args.Using.Value, slot))
+                    // Disable slot insert if InsertOnInteract is true
+                    if (slot.InsertOnInteract || !CanInsert(uid, args.Using.Value, slot))
                         continue;
 
                     var verbSubject = slot.Name != string.Empty

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -165,11 +165,14 @@
             tags:
               - Mop
           insertOnInteract: false # or it conflicts with bucket logic
+          priority: 3 # Higher than trash bag slot
         trashbag_slot:
           name: Bag
           whitelist:
             tags:
               - TrashBag
+          ejectOnAltInteract: true
+          priority: 3 # Higher than drinking priority
     - type: Fixtures
       fixtures:
       - shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -171,7 +171,6 @@
           whitelist:
             tags:
               - TrashBag
-          ejectOnAltInteract: true
           priority: 3 # Higher than drinking priority
     - type: Fixtures
       fixtures:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -165,7 +165,7 @@
             tags:
               - Mop
           insertOnInteract: false # or it conflicts with bucket logic
-          priority: 3 # Higher than trash bag slot
+          priority: 4 # Higher than trash bag slot
         trashbag_slot:
           name: Bag
           whitelist:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Made changes to ItemSlots so that the mop and trash bag can be inserted and removed from the janitorial trolley using alt-click.

Added alt-click insertion to ItemSlots.
Changed ItemSlot verb priority to be higher than the drinking verb priority.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://user-images.githubusercontent.com/10494922/229427730-5d3ff8c2-9d3c-4618-82fe-52288dcee0b0.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: The mop and trash bag can now be inserted and removed from the janitorial trolley by alt-clicking.
