### PR TITLE
Adds uploadfolder command 

### DIFF
--- a/Content.Client/Administration/Commands/UploadFolder.cs
+++ b/Content.Client/Administration/Commands/UploadFolder.cs
@@ -1,0 +1,70 @@
+using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Robust.Client.UserInterface;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+using Robust.Shared.Network;
+using Robust.Shared.Utility;
+
+namespace Content.Client.Administration.Commands;
+
+public sealed class UploadFolder : IConsoleCommand
+{
+    public string Command => "uploadfolder";
+    public string Description => "Uploads a folder recursively to the server.";
+    public string Help => $"{Command} [relative path for the resources] ";
+
+    public async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var cfgMan = IoCManager.Resolve<IConfigurationManager>();
+
+        if (!cfgMan.GetCVar(CCVars.ResourceUploadingEnabled))
+        {
+            shell.WriteError("Network Resource Uploading is currently disabled by the server.");
+            return;
+        }
+
+        if (args.Length != 1)
+        {
+            shell.WriteError("Wrong number of arguments!");
+            return;
+        }
+
+        var uploadPath = new ResourcePath(args[0]).ToRelativePath();
+
+        var dialog = IoCManager.Resolve<IFileDialogManager>();
+
+        var filters = new FileDialogFilters(new FileDialogFilters.Group(uploadPath.Extension));
+        var streams = await dialog.OpenFolder();
+
+
+
+        var uploadPath1 = new ResourcePath(args[0]).ToRelativePath();
+
+
+
+        // if (streams == null)
+        // {
+        //     shell.WriteError("Error picking file!");
+        //     return;
+        // }
+        //
+        // var sizeLimit = cfgMan.GetCVar(CCVars.ResourceUploadingLimitMb);
+        //
+        // if (sizeLimit > 0f && streams.Length * SharedNetworkResourceManager.BytesToMegabytes > sizeLimit)
+        // {
+        //     shell.WriteError($"File above the current size limit! It must be smaller than {sizeLimit} MB.");
+        //     return;
+        // }
+        //
+        // var data = streams.CopyToArray();
+        //
+        // var netManager = IoCManager.Resolve<INetManager>();
+        // var msg = netManager.CreateNetMessage<NetworkResourceUploadMessage>();
+        //
+        // msg.RelativePath = uploadPath;
+        // msg.Data = data;
+        //
+        // netManager.ClientSendMessage(msg);
+    }
+}

--- a/Content.Client/Administration/Commands/UploadFolder.cs
+++ b/Content.Client/Administration/Commands/UploadFolder.cs
@@ -39,14 +39,12 @@ public sealed class UploadFolder : IConsoleCommand
         {
             if (file.Stream == null)
             {
+                shell.WriteError($"One of the files was un accessable or missing! command exited.");
                 break;
             }
 
             var filepath = new ResourcePath(uploadPath +"/"+ file.filename);
-
-
             var sizeLimit = cfgMan.GetCVar(CCVars.ResourceUploadingLimitMb);
-
             if (sizeLimit > 0f && file.Stream.Length * SharedNetworkResourceManager.BytesToMegabytes > sizeLimit)
             {
                 shell.WriteError($"File above the current size limit! It must be smaller than {sizeLimit} MB.");
@@ -62,8 +60,6 @@ public sealed class UploadFolder : IConsoleCommand
             msg.Data = data;
 
             netManager.ClientSendMessage(msg);
-
         }
-
     }
 }

--- a/Content.Client/Administration/Commands/UploadFolder.cs
+++ b/Content.Client/Administration/Commands/UploadFolder.cs
@@ -1,24 +1,31 @@
-using Content.Client.Popups;
+using System.IO;
+using System.Resources;
+using System.Threading.Tasks;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
-using Content.Shared.Popups;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
+using Robust.Client.Utility;
+using Robust.Shared.ContentPack;
 
 namespace Content.Client.Administration.Commands;
 
 public sealed class UploadFolder : IConsoleCommand
 {
     public string Command => "uploadfolder";
-    public string Description => "Uploads a folder recursively to the server.";
-    public string Help => $"{Command} [relative path for the resources] [level of recursion] ";
+    public string Description => "Uploads a folder recursively to the server contentDB.";
+    public string Help => $"{Command} [folder in userdata/UploadFolder] ";
+
+    private static readonly ResourcePath BaseUploadFolderPath = new("/UploadFolder");
 
     public async void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         var cfgMan = IoCManager.Resolve<IConfigurationManager>();
+        var resourceMan = IoCManager.Resolve<IResourceManager>();
+
 
         if (!cfgMan.GetCVar(CCVars.ResourceUploadingEnabled))
         {
@@ -26,45 +33,61 @@ public sealed class UploadFolder : IConsoleCommand
             return;
         }
 
-        if (args.Length != 2)
+        if (args.Length != 1)
         {
-            shell.WriteError("Wrong number of arguments!");
+            shell.WriteError($"Wrong number of arguments! \n usage: {Command} [folder in userdata/UploadFolder] ");
             return;
         }
 
-        if (shell.Player == null)
-            return;
+        if (args[0].Contains(".."))
+            return; // silent bomb out if the user is trying to escape the UploadFolder dir
 
-        var dialog = IoCManager.Resolve<IFileDialogManager>();
-        var uploadPath = new ResourcePath(args[0]).ToRelativePath();
+        var folderPath = new ResourcePath(BaseUploadFolderPath + $"/{args[0]}");
 
-        await foreach (var file in dialog.OpenFolder())
+        if (!resourceMan.UserData.Exists(folderPath.ToRootedPath()))
         {
-            if (file.Stream == null)
-            {
-                shell.WriteError($"One of the files was un accessable or missing! command exited.");
+            shell.WriteError($"Folder not found in /UploadFolder");
+            return; // bomb out if the folder doesnt exist in /UploadFolder
+        }
+
+        //Run the top level directory first
+        foreach (var filename in resourceMan.UserData.Find($"{folderPath.ToRelativePath()}/*").files )
+        {
+            //dont upload yaml files
+            if (filename.ToString().Contains(".yaml"))
                 break;
-            }
 
-            var filepath = new ResourcePath(uploadPath +"/"+ file.filename);
-
-
-            var sizeLimit = cfgMan.GetCVar(CCVars.ResourceUploadingLimitMb);
-            if (sizeLimit > 0f && file.Stream.Length * SharedNetworkResourceManager.BytesToMegabytes > sizeLimit)
+            await using var filestream = resourceMan.UserData.Open(filename,FileMode.Open);
             {
-                shell.WriteError($"File above the current size limit! It must be smaller than {sizeLimit} MB.");
-                return;
+
             }
+        }
 
-            var data = file.Stream.CopyToArray();
+        //Get all sub directories from top and loop over files in each directory.
+        foreach (var directory in resourceMan.UserData.Find($"{folderPath.ToRelativePath()}/*").directories)
+        {
+            foreach (var filename in resourceMan.UserData.Find($"{directory.ToRelativePath()}/*").files )
+            {
+                await using var filestream = resourceMan.UserData.Open(filename,FileMode.Open);
+                {
+                    var sizeLimit = cfgMan.GetCVar(CCVars.ResourceUploadingLimitMb);
+                    if (sizeLimit > 0f && filestream.Length * SharedNetworkResourceManager.BytesToMegabytes > sizeLimit)
+                    {
+                        shell.WriteError($"File {filename} above the current size limit! It must be smaller than {sizeLimit} MB. skipping.");
+                        return;
+                    }
 
-            var netManager = IoCManager.Resolve<INetManager>();
-            var msg = netManager.CreateNetMessage<NetworkResourceUploadMessage>();
+                    var data = filestream.CopyToArray();
 
-            msg.RelativePath = filepath ;
-            msg.Data = data;
+                    var netManager = IoCManager.Resolve<INetManager>();
+                    var msg = netManager.CreateNetMessage<NetworkResourceUploadMessage>();
 
-            netManager.ClientSendMessage(msg);
+                    msg.RelativePath = new ResourcePath($"{filename.ToString().Remove(0,14)}");
+                    msg.Data = data;
+
+                    netManager.ClientSendMessage(msg);
+                }
+            }
         }
     }
 }

--- a/Content.Client/Administration/Commands/UploadFolder.cs
+++ b/Content.Client/Administration/Commands/UploadFolder.cs
@@ -1,5 +1,7 @@
+using Content.Client.Popups;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
+using Content.Shared.Popups;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
@@ -12,7 +14,7 @@ public sealed class UploadFolder : IConsoleCommand
 {
     public string Command => "uploadfolder";
     public string Description => "Uploads a folder recursively to the server.";
-    public string Help => $"{Command} [relative path for the resources] ";
+    public string Help => $"{Command} [relative path for the resources] [level of recursion] ";
 
     public async void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -24,13 +26,14 @@ public sealed class UploadFolder : IConsoleCommand
             return;
         }
 
-        if (args.Length != 1)
+        if (args.Length != 2)
         {
             shell.WriteError("Wrong number of arguments!");
             return;
         }
 
-
+        if (shell.Player == null)
+            return;
 
         var dialog = IoCManager.Resolve<IFileDialogManager>();
         var uploadPath = new ResourcePath(args[0]).ToRelativePath();
@@ -44,6 +47,8 @@ public sealed class UploadFolder : IConsoleCommand
             }
 
             var filepath = new ResourcePath(uploadPath +"/"+ file.filename);
+
+
             var sizeLimit = cfgMan.GetCVar(CCVars.ResourceUploadingLimitMb);
             if (sizeLimit > 0f && file.Stream.Length * SharedNetworkResourceManager.BytesToMegabytes > sizeLimit)
             {

--- a/Content.Client/Administration/Commands/UploadFolder.cs
+++ b/Content.Client/Administration/Commands/UploadFolder.cs
@@ -25,6 +25,7 @@ public sealed class UploadFolder : IConsoleCommand
     {
         var cfgMan = IoCManager.Resolve<IConfigurationManager>();
         var resourceMan = IoCManager.Resolve<IResourceManager>();
+        var fileCount = 0;
 
 
         if (!cfgMan.GetCVar(CCVars.ResourceUploadingEnabled))
@@ -40,7 +41,10 @@ public sealed class UploadFolder : IConsoleCommand
         }
 
         if (args[0].Contains(".."))
+        {
+            shell.WriteError($"Illegal characters found in folder path. Remove '..' from your folder path! ");
             return; // silent bomb out if the user is trying to escape the UploadFolder dir
+        }
 
         var folderPath = new ResourcePath(BaseUploadFolderPath + $"/{args[0]}");
 
@@ -67,12 +71,13 @@ public sealed class UploadFolder : IConsoleCommand
                 var netManager = IoCManager.Resolve<INetManager>();
                 var msg = netManager.CreateNetMessage<NetworkResourceUploadMessage>();
 
-                msg.RelativePath = new ResourcePath($"{filename.ToString().Remove(0,14)}");
+                msg.RelativePath = new ResourcePath($"{filename.ToString().Remove(0,14)}"); //removes /UploadFolder/ from path
                 msg.Data = data;
 
                 netManager.ClientSendMessage(msg);
+                fileCount++;
             }
         }
-
+        shell.WriteLine($"Uploaded {fileCount} files");
     }
 }

--- a/Content.Client/Administration/Commands/UploadFolder.cs
+++ b/Content.Client/Administration/Commands/UploadFolder.cs
@@ -39,13 +39,6 @@ public sealed class UploadFolder : IConsoleCommand
             shell.WriteError($"Wrong number of arguments! \n usage: {Command} [folder in userdata/UploadFolder] ");
             return;
         }
-
-        if (args[0].Contains(".."))
-        {
-            shell.WriteError($"Illegal characters found in folder path. Remove '..' from your folder path! ");
-            return; // silent bomb out if the user is trying to escape the UploadFolder dir
-        }
-
         var folderPath = new ResourcePath(BaseUploadFolderPath + $"/{args[0]}");
 
         if (!resourceMan.UserData.Exists(folderPath.ToRootedPath()))

--- a/Resources/Locale/en-US/administration/commands/uploadfolder.ftl
+++ b/Resources/Locale/en-US/administration/commands/uploadfolder.ftl
@@ -1,0 +1,7 @@
+uploadfolder-command-description = Uploads a folder from your UserData folder recursively to the server contentDB.
+uploadfolder-command-help = uploadfolder [folder you want to upload in userdata/UploadFolder]
+uploadfolder-command-wrong-args = Wrong number of arguments!
+uploadfolder-command-folder-not-found = Folder {$folder} not found!
+uploadfolder-command-resource-upload-disabled = Network Resource Uploading is currently disabled. check Server CVars.
+uploadfolder-command-file-too-big = File {$filename} above the current size limit! It must be smaller than {$sizeLimit} MB. skipping.
+uploadfolder-command-success = Uploaded {$fileCount} files

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -71,3 +71,4 @@
   Commands:
     - uploadfile
     - loadprototype
+    - uploadfolder


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Game Admins Rejoice! uploadfolder is here

This PR adds the uploadfolder command, which allows you to upload a folders worth of RSIs, sounds, adminbus stuff faster and easier! 

There is a new folder in your UserData directory  which is:
```
.local/share/Space Station 14/data/UploadFolder for linux

%APPDATA%/Space Station 14/data/UploadFolder  for windows

~/Library/Application Support/Space Station 14/data/UploadFolder for macos
```

Whatever you put in this specific folder can be referenced in this command, and it will automagically upload all the files to the server saving you valuable adminbus time.

example: 

```uploadfolder zoldorf/prototypes/someprototype```
 would upload everything in this directory to the server
```Space Station 14/data/UploadFolder/someprototype```
and can be referenced in your prototype files with
```/Uploaded/zoldorf/protoypes/someprototype/somesprite.rsi```

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ x] I have added screenshots/videos to this PR showcasing its changes ingame
https://streamable.com/97wudw#

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: added uploadfolder command for game admins to speed up adminbus event setup time.