### PR TITLE
More Musical Cargo

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/fun-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/fun-crates.ftl
@@ -13,7 +13,7 @@ ent-CrateFunInstrumentsString = String instrument ensemble crate
 ent-CrateFunInstrumentsWoodwind = Woodwind instrument ensemble crate
     .desc = If atmos is good at their job, use air to play music with these woodwind instruments! Real wood not guaranteed with every item.
 
-ent-CrateFunInstrumentsKeyedPercussion = Keyed and Percussion instrument ensemble crate
+ent-CrateFunInstrumentsKeyedPercussion = Keyed/Percussion instrument ensemble crate
     .desc = Hit some keys with some sticks or your hands, with this Keyed and Percussion instrument ensemble crate.
 
 ent-CrateFunInstrumentsSpecial = Special instrument collector's crate

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/fun-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/fun-crates.ftl
@@ -1,11 +1,23 @@
 ent-CrateFunPlushie = Plushie crate
     .desc = A buncha soft plushies. Throw them around and then wonder how you're gonna explain this purchase to NT.
 
-ent-CrateFunInstruments = Big band instrument collection
-    .desc = Get your sad station movin' and groovin' with this fine collection! Contains thirteen different instruments.
+ent-CrateFunInstrumentsVariety = Variety instrument collection
+    .desc = Get your sad station movin' and groovin' with this catch-all variety pack! Contains seven different instruments.
 
-ent-CrateFunBrass = Brass instrument ensemble crate
+ent-CrateFunInstrumentsBrass = Brass instrument ensemble crate
     .desc = Bring some jazz to the station with the brass ensemble. Contains a variety of brass instruments for the whole station to play.
+
+ent-CrateFunInstrumentsString = String instrument ensemble crate
+    .desc = Pluck or pick, slap or shred! Play a smooth melody or melt peoples' faces with this package of stringed instruments.
+
+ent-CrateFunInstrumentsWoodwind = Woodwind instrument ensemble crate
+    .desc = If atmos is good at their job, use air to play music with these woodwind instruments! Real wood not guaranteed with every item.
+
+ent-CrateFunInstrumentsKeyedPercussion = Keyed and Percussion instrument ensemble crate
+    .desc = Hit some keys with some sticks or your hands, with this Keyed and Percussion instrument ensemble crate.
+
+ent-CrateFunInstrumentsSpecial = Special instrument collector's crate
+    .desc = Create some noise with this special collection of arguably-instruments! Centcomm is not responsible for any trauma caused by the contents.
 
 ent-CrateFunArtSupplies = Art supplies
     .desc = Make some happy little accidents with lots of crayons!

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -51,7 +51,7 @@
 - type: cargoProduct
   id: FunInstrumentsSpecial
   icon:
-    sprite: Objects\Fun\Instruments\gunpet.rsi
+    sprite: Objects/Fun/nstruments/gunpet.rsi
     state: icon
   product: CrateFunInstrumentsSpecial
   cost: 10000

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -31,7 +31,7 @@
 - type: cargoProduct
   id: FunInstrumentsWoodwind
   icon:
-    sprite: Objects\Fun\Instruments\harmonica.rsi
+    sprite: Objects/Fun/Instruments/harmonica.rsi
     state: icon
   product: CrateFunInstrumentsWoodwind
   cost: 2500

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -41,7 +41,7 @@
 - type: cargoProduct
   id: FunInstrumentsKeyedPercussion
   icon:
-    sprite: Objects\Fun\Instruments\h_synthesizer.rsi
+    sprite: Objects/Fun/Instruments/h_synthesizer.rsi
     state: icon
   product: CrateFunInstrumentsKeyedPercussion
   cost: 2500

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -21,7 +21,7 @@
 - type: cargoProduct
   id: FunInstrumentsString
   icon:
-    sprite: Objects\Fun\Instruments\bassguitar.rsi
+    sprite: Objects/Fun/Instruments/bassguitar.rsi
     state: icon
   product: CrateFunInstrumentsString
   cost: 2500

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -51,7 +51,7 @@
 - type: cargoProduct
   id: FunInstrumentsSpecial
   icon:
-    sprite: Objects/Fun/nstruments/gunpet.rsi
+    sprite: Objects/Fun/Instruments/gunpet.rsi
     state: icon
   product: CrateFunInstrumentsSpecial
   cost: 10000

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -1,20 +1,60 @@
 - type: cargoProduct
-  id: FunInstruments
+  id: FunInstrumentsVariety
   icon:
     sprite: Objects/Fun/Instruments/accordion.rsi
     state: icon
-  product: CrateFunInstruments
-  cost: 3000
+  product: CrateFunInstrumentsVariety
+  cost: 2000
   category: Fun
   group: market
 
 - type: cargoProduct
-  id: FunBrass
+  id: FunInstrumentsBrass
   icon:
     sprite: Objects/Fun/Instruments/structureinstruments.rsi
     state: tuba
-  product: CrateFunBrass
+  product: CrateFunInstrumentsBrass
   cost: 2500
+  category: Fun
+  group: market
+
+- type: cargoProduct
+  id: FunInstrumentsString
+  icon:
+    sprite: Objects\Fun\Instruments\bassguitar.rsi
+    state: icon
+  product: CrateFunInstrumentsString
+  cost: 2500
+  category: Fun
+  group: market
+
+- type: cargoProduct
+  id: FunInstrumentsWoodwind
+  icon:
+    sprite: Objects\Fun\Instruments\harmonica.rsi
+    state: icon
+  product: CrateFunInstrumentsWoodwind
+  cost: 2500
+  category: Fun
+  group: market
+
+- type: cargoProduct
+  id: FunInstrumentsKeyedPercussion
+  icon:
+    sprite: Objects\Fun\Instruments\h_synthesizer.rsi
+    state: icon
+  product: CrateFunInstrumentsKeyedPercussion
+  cost: 2500
+  category: Fun
+  group: market
+
+- type: cargoProduct
+  id: FunInstrumentsSpecial
+  icon:
+    sprite: Objects\Fun\Instruments\gunpet.rsi
+    state: icon
+  product: CrateFunInstrumentsSpecial
+  cost: 10000
   category: Fun
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -92,7 +92,7 @@
         amount: 2
       - id: AccordionInstrument
         amount: 2
-      - id: Kalimba
+      - id: KalimbaInstrument
         amount: 2
       - id: WoodblockInstrument
       - id: GlockenspielInstrument

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -20,39 +20,101 @@
       - id: PlushieDiona
 
 - type: entity
-  id: CrateFunInstruments
+  id: CrateFunInstrumentsVariety
   parent: CrateGenericSteel
   components:
   - type: StorageFill
     contents:
       - id: SynthesizerInstrument
       - id: AcousticGuitarInstrument
-      - id: ViolinInstrument
       - id: TrumpetInstrument
-      - id: ElectricGuitarInstrument
       - id: AccordionInstrument
       - id: HarmonicaInstrument
       - id: RecorderInstrument
-      - id: TromboneInstrument
-      - id: SaxophoneInstrument
       - id: GlockenspielInstrument
-      - id: BanjoInstrument
-      - id: BikeHornInstrument
 
 - type: entity
-  id: CrateFunBrass
+  id: CrateFunInstrumentsBrass
   parent: CrateGenericSteel
   components:
   - type: StorageFill
     contents:
       - id: TrumpetInstrument
-        amount: 3
+        amount: 2
       - id: TromboneInstrument
-        amount: 3
+        amount: 2
       - id: FrenchHornInstrument
+        amount: 2
+      - id: SaxophoneInstrument
         amount: 2
       - id: EuphoniumInstrument
       - id: TubaInstrument
+
+- type: entity
+  id: CrateFunInstrumentsString
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: AcousticGuitarInstrument
+      - id: ElectricGuitarInstrument
+      - id: BassGuitarInstrument
+      - id: RockGuitarInstrument
+      - id: BanjoInstrument
+      - id: ViolinInstrument
+      - id: CelloInstrument
+      - id: ViolaInstrument
+      - id: HarpInstrument
+
+- type: entity
+  id: CrateFunInstrumentsWoodwind
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: RecorderInstrument
+        amount: 2
+      - id: BagpipeInstrument
+      - id: ClarinetInstrument
+      - id: FluteInstrument
+      - id: HarmonicaInstrument
+        amount: 2
+      - id: OcarinaInstrument
+      - id: PanFluteInstrument
+
+- type: entity
+  id: CrateFunInstrumentsKeyedPercussion
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: SynthesizerInstrument
+        amount: 2
+      - id: AccordionInstrument
+        amount: 2
+      - id: Kalimba
+        amount: 2
+      - id: WoodblockInstrument
+      - id: GlockenspielInstrument
+        amount: 2
+      - id: VibraphoneInstrument
+
+- type: entity
+  id: CrateFunInstrumentsSpecial
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: BikeHornInstrument
+      - id: MusicBoxInstrument
+      - id: SeashellInstrument
+      - id: XylophoneInstrument
+      - id: GunpetInstrument
+      - id: MicrophoneInstrument
+      - id: HelicopterInstrument
+      - id: BirdToyInstrument
+      - id: MusicalLungInstrument
+      - id: ReverseCymbalsInstrument
 
 - type: entity
   id: CrateFunArtSupplies


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adds a whole bunch of Instruments to the Cargo manifest, via bundles organized (roughly) by Type


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

[Options within the Cargo UI](https://i.imgur.com/H8oQ1oP.png)
[Contents of each box (Variety, Brass, String, Woodwind, Keyed/Percussion, Specialty](https://i.imgur.com/5HLLU0A.png)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: EnDecc
- add: Added String, Woodwind, Keyed and Percussion, and Specialty Music crates to Cargo's Manifest
- tweak: Renamed 'Big Band' crate to Variety Instrument collection, tweaked ID of Brass crate to easily identify with other Instrument Crate IDs, and its contents.
