### PR TITLE
[Access] Detective personal access

### DIFF
--- a/Content.Shared/Access/Components/SharedIdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/SharedIdCardConsoleComponent.cs
@@ -46,7 +46,7 @@ namespace Content.Shared.Access.Components
             "Atmospherics",
             "Bar",
             "Brig",
-            // "Detective",
+            "Detective",
             "Captain",
             "Cargo",
             "Chapel",

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -1,4 +1,4 @@
-﻿- type: accessGroup
+- type: accessGroup
   id: AllAccess
   tags:
   - EmergencyShuttleRepealAll
@@ -10,6 +10,7 @@
   - ResearchDirector
   - Command
   - Security
+  - Detective
   - Armory
   - Brig
   - Engineering

--- a/Resources/Prototypes/Access/security.yml
+++ b/Resources/Prototypes/Access/security.yml
@@ -14,8 +14,9 @@
   id: Brig
   name: id-card-access-level-brig
 
-#- type: accessLevel
-#  id: Detective
+- type: accessLevel
+  id: Detective
+  name: id-card-access-level-detective
 
 - type: accessGroup
   id: Security
@@ -24,7 +25,7 @@
   - Security
   - Armory
   - Brig
-  # - Detective
+  - Detective
 
 - type: accessGroup
   id: Armory

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -261,6 +261,16 @@
 
 - type: entity
   parent: AirlockSecurity
+  id: AirlockDetectiveLocked
+  suffix: Detective, Locked
+  components:
+  - type: AccessReader
+    access: [["Detective"]]
+  - type: Wires
+    LayoutId: AirlockSecurity
+
+- type: entity
+  parent: AirlockSecurity
   id: AirlockBrigLocked
   suffix: Brig, Locked
   components:
@@ -503,6 +513,14 @@
   components:
   - type: AccessReader
     access: [["Security"]]
+
+- type: entity
+  parent: AirlockSecurityGlass
+  id: AirlockDetectiveGlassLocked
+  suffix: Detective, Locked
+  components:
+  - type: AccessReader
+    access: [["Detective"]]
 
 - type: entity
   parent: AirlockSecurityGlass

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -709,6 +709,14 @@
 
 - type: entity
   parent: AirlockMaint
+  id: AirlockMaintDetectiveLocked
+  suffix: Detective, Locked
+  components:
+  - type: AccessReader
+    access: [["Detective"]]
+
+- type: entity
+  parent: AirlockMaint
   id: AirlockMaintHOPLocked
   suffix: HeadOfPersonnel, Locked
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1573,7 +1573,7 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
-    access: [["Security"]]
+    access: [["Detective"]]
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -329,7 +329,7 @@
   description: Usually cold and empty... like your heart.
   components:
   - type: AccessReader
-    access: [["Security"]] # TODO access [["Detective"]]
+    access: [["Detective"]]
 
 - type: entity
   id: LockerEvidence

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -16,6 +16,7 @@
   - Brig
   - Maintenance
   - Service
+  - Detective
 
 - type: startingGear
   id: DetectiveGear

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -27,6 +27,7 @@
   - Maintenance
   - Service
   - External
+  - Detective
 
 - type: startingGear
   id: HoSGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -18,6 +18,7 @@
   - Service
   - Brig
   - External
+  - Detective
 
 - type: startingGear
   id: WardenGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adds personal access for the detective, and airlocks with his access. This will help to escape from officers who like to break into the detective's office, confiscate already confiscated contraband, and simply smash all the evidence.


<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: PuroSlavKing
- add: Added personal access for detective, and detective airlocks.