### PR TITLE
Diona CO2 Respiration

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -116,8 +116,15 @@
   metabolisms:
     Gas:
       effects:
+      - !type:Oxygenate
+        conditions:
+        - !type:OrganType
+          type: Plant
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Plant
+          shouldHave: false
         # Don't want people to get toxin damage from the gas they just
         # exhaled, right?
         - !type:ReagentThreshold


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Made Diona immune to CO2 poisoning. Also made Diona able to breathe CO2.

When Diona were being added, them breathing CO2 was highly requested. This idea was thrown out because the atmos scrubbers meant CO2 in the station was always at 0. Thus, Diona breathe oxygen.

Now, I don't see why they can't breathe CO2 _and_ oxygen. CO2 can _literally_ instantly kill careless space persons, which makes little sense when the person in question is a Diona. This PR makes Diona immune to the dangers of CO2, making them hopefully more useful in CO2-based emergencies.

...Also, Diona, like all the other species, are very lacking in unique features. Letting Diona breathe CO2 will lead to interesting moments, and is unlikely to have any negative knock-on effects.

This change could be said to be one of those nasty "ignoring mechanics instead of interacting with them" species features. I think CO2 is so uncommon, and its effects so strong, that ignoring it is a unique interaction all on its own. If requested, I can add a bit more depth, for example making CO2 heal Diona in addition to not poisoning them, or have it give them more speed, or have it just be a resistance instead of a full-on immunity.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://user-images.githubusercontent.com/113810873/229618625-1836092b-cbb5-4394-87a3-37fd1b06134b.png)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Diona can now breathe CO2 and are not poisoned by it. They are still capable of breathing oxygen!