### PR TITLE
modify base sec job playtime requirements

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -6,7 +6,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 3600
+    time: 7200 #2 hrs
   startingGear: DetectiveGear
   icon: "Detective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -4,9 +4,11 @@
   description: job-description-cadet
   playTimeTracker: JobSecurityCadet
   requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 18000 #5 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 28800
+      time: 28800 #8 hrs
       inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "SecurityCadet"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 1800
+      time: 3600 #1 hr
   startingGear: SecurityOfficerGear
   icon: "SecurityOfficer"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adjusts the following job playtimes in the security department:

- Security Cadet now requires five hours (300 minutes) of overall playtime to play (from none).
- Security Officer now requires one hour (60 minutes) of security playtime to play (from 30 minutes).
- Detective now requires two hours (120 minutes) of security playtime to play (from 60 minutes).

Cadets: Security is not only a mechanically complex job (involving less-lethal combat and control of other crewmembers) but is also a socially complex job requiring a good deal of general knowledge about the game in general and how security should operate, as well as adherence to specific rules regarding lethal force and identifying antagonists. Players should have somewhat significant playtime before being able to throw themselves at security to ensure they at least have a basic grasp upon the controls and game's flow in general to help alleviate the problem of Cadets going missing/disconnecting/being completely lost. This also somewhat alleviates the problem of ban evaders grabbing a baton and cuffs, but that's an aside.

Officer & Detective: Previously, officer only required 30 minutes, which was usually a single shift as a Cadet, with no guarantee anything had been learned. A slight increase here should hopefully squeeze an extra round or two of Cadet gameplay being needed so the player at least has some general sense of being IN security instead of a single round. Detective is an Officer with a gun and more responsibilities relating to evidence, which should also need just a tad more experience.

As a note, Warden and Head of Security's playtimes remain unchanged.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Five hours minimum overall playtime needed for Security Cadet to become available.
- tweak: One hour minimum security playtime needed for Security Officer to become available.
- tweak: Two hours minimum security playtime needed for Detective to become available.
