### PR TITLE
Fix weapon cooldown serialization while mapping

### DIFF
--- a/Content.Server/Abilities/Mime/MimePowersComponent.cs
+++ b/Content.Server/Abilities/Mime/MimePowersComponent.cs
@@ -53,7 +53,7 @@ namespace Content.Server.Abilities.Mime
         /// <summary>
         /// How long it takes the mime to get their powers back
         /// </summary>
-        [DataField("vowCooldown", customTypeSerializer: typeof(TimeOffsetSerializer))]
+        [DataField("vowCooldown")]
         public TimeSpan VowCooldown = TimeSpan.FromMinutes(5);
     }
 }

--- a/Content.Shared/Materials/MaterialStorageComponent.cs
+++ b/Content.Shared/Materials/MaterialStorageComponent.cs
@@ -55,7 +55,7 @@ public sealed class MaterialStorageComponent : Component
     /// <summary>
     /// How long the inserting animation will play
     /// </summary>
-    [DataField("insertionTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [DataField("insertionTime")]
     public TimeSpan InsertionTime = TimeSpan.FromSeconds(0.79f); // 0.01 off for animation timing
 }
 

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -70,6 +70,16 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         SubscribeAllEvent<HeavyAttackEvent>(OnHeavyAttack);
         SubscribeAllEvent<DisarmAttackEvent>(OnDisarmAttack);
         SubscribeAllEvent<StopAttackEvent>(OnStopAttack);
+
+#if DEBUG
+        SubscribeLocalEvent<MeleeWeaponComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, MeleeWeaponComponent component, MapInitEvent args)
+    {
+        if (component.NextAttack > TimeSpan.Zero)
+            Logger.Warning($"Initializing a map that contains an entity that is on cooldown. Entity: {ToPrettyString(uid)}");
+#endif
     }
 
     private void OnMeleeSelected(EntityUid uid, MeleeWeaponComponent component, HandSelectedEvent args)
@@ -78,6 +88,9 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return;
 
         if (!component.ResetOnHandSelected)
+            return;
+
+        if (Paused(uid))
             return;
 
         // If someone swaps to this weapon then reset its cd.

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -152,7 +152,8 @@ public abstract partial class SharedGunSystem
     {
         // Reset shotting for cycling
         if (Resolve(uid, ref gunComp, false) &&
-            gunComp is { FireRate: > 0f })
+            gunComp is { FireRate: > 0f } &&
+            !Paused(uid))
         {
             gunComp.NextFire = Timing.CurTime + TimeSpan.FromSeconds(1 / gunComp.FireRate);
         }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -64,13 +64,17 @@ public abstract partial class SharedGunSystem
 
         DebugTools.Assert((component.AvailableModes  & fire) != 0x0);
         component.SelectedMode = fire;
-        var curTime = Timing.CurTime;
-        var cooldown = TimeSpan.FromSeconds(InteractNextFire);
 
-        if (component.NextFire < curTime)
-            component.NextFire = curTime + cooldown;
-        else
-            component.NextFire += cooldown;
+        if (!Paused(uid))
+        {
+            var curTime = Timing.CurTime;
+            var cooldown = TimeSpan.FromSeconds(InteractNextFire);
+
+            if (component.NextFire < curTime)
+                component.NextFire = curTime + cooldown;
+            else
+                component.NextFire += cooldown;
+        }
 
         Audio.PlayPredicted(component.SoundModeToggle, uid, user);
         Popup(Loc.GetString("gun-selected-mode", ("mode", GetLocSelector(fire))), uid, user);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -88,6 +88,16 @@ public abstract partial class SharedGunSystem : EntitySystem
         SubscribeLocalEvent<GunComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<GunComponent, CycleModeEvent>(OnCycleMode);
         SubscribeLocalEvent<GunComponent, ComponentInit>(OnGunInit);
+
+#if DEBUG
+        SubscribeLocalEvent<GunComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, GunComponent component, MapInitEvent args)
+    {
+        if (component.NextFire > TimeSpan.Zero)
+            Logger.Warning($"Initializing a map that contains an entity that is on cooldown. Entity: {ToPrettyString(uid)}");
+#endif
     }
 
     private void OnGunInit(EntityUid uid, GunComponent component, ComponentInit args)

--- a/Resources/Maps/Test/dev_map.yml
+++ b/Resources/Maps/Test/dev_map.yml
@@ -1057,8 +1057,6 @@ entities:
   - pos: -2.172831,4.5306726
     parent: 179
     type: Transform
-  - nextAttack: 384.7724706
-    type: MeleeWeapon
 - uid: 148
   type: Ointment
   components:
@@ -1689,8 +1687,6 @@ entities:
   - pos: -3.4579864,-1.9811735
     parent: 179
     type: Transform
-  - nextAttack: 582.1216812
-    type: MeleeWeapon
 - uid: 186
   type: PowerCellMedium
   components:
@@ -2619,16 +2615,12 @@ entities:
   - pos: -0.11783123,4.753312
     parent: 179
     type: Transform
-  - nextAttack: 244.2972008
-    type: MeleeWeapon
 - uid: 328
   type: MopItem
   components:
   - pos: 7.6382103,16.08618
     parent: 179
     type: Transform
-  - nextAttack: 3088.5283222
-    type: MeleeWeapon
   - solutions:
       absorbed:
         temperature: 293.15
@@ -2730,8 +2722,6 @@ entities:
   - pos: 0.6895334,4.7183027
     parent: 179
     type: Transform
-  - nextAttack: 247.8805212
-    type: MeleeWeapon
 - uid: 344
   type: ClothingHeadHatWelding
   components:
@@ -2840,8 +2830,6 @@ entities:
   - pos: -1.6207478,4.3951616
     parent: 179
     type: Transform
-  - nextAttack: 232.4472496
-    type: MeleeWeapon
 - uid: 360
   type: PowerCellMedium
   components:
@@ -2975,8 +2963,6 @@ entities:
   - pos: -3.277628,-2.15838
     parent: 179
     type: Transform
-  - nextAttack: 578.7883598
-    type: MeleeWeapon
 - uid: 382
   type: SheetSteel
   components:
@@ -3359,8 +3345,6 @@ entities:
   - pos: -1.235331,4.739151
     parent: 179
     type: Transform
-  - nextAttack: 385.5557994
-    type: MeleeWeapon
 - uid: 432
   type: ChemicalPayload
   components:
@@ -3379,8 +3363,6 @@ entities:
   - pos: -3.1734612,-2.6066077
     parent: 179
     type: Transform
-  - nextAttack: 577.9550312
-    type: MeleeWeapon
 - uid: 435
   type: ModularGrenade
   components:
@@ -5107,8 +5089,6 @@ entities:
   - pos: 1.1246341,7.500063
     parent: 179
     type: Transform
-  - nextAttack: 669.0197422
-    type: MeleeWeapon
 - uid: 673
   type: Poweredlight
   components:
@@ -7199,13 +7179,11 @@ entities:
     parent: 179
     type: Transform
 - uid: 956
-  type: EmergencyOxygenTank
+  type: EmergencyOxygenTankFilled
   components:
   - pos: -10.505015,6.711994
     parent: 179
     type: Transform
-  - nextAttack: 396.1132382
-    type: MeleeWeapon
 - uid: 957
   type: AlwaysPoweredLightLED
   components:


### PR DESCRIPTION
- fixes #15113 by removing next-attack times from the dev map file
- Prevents next attack & next fire times from being set while the entity is paused.
- Adds warning logs to try prevent repeat incidents for guns & melee
- Removes some bad TimeOffsetSerializer uses.