### PR TITLE
DoAfter fixes

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -233,6 +233,9 @@ namespace Content.Server.Construction
                 BreakOnTargetMove = false,
                 BreakOnUserMove = true,
                 NeedHand = false,
+                // allow simultaneously starting several construction jobs using the same stack of materials.
+                CancelDuplicate = false,
+                BlockDuplicate = false,
             };
 
             if (await _doAfterSystem.WaitDoAfter(doAfterArgs) == DoAfterStatus.Cancelled)
@@ -481,13 +484,13 @@ namespace Content.Server.Construction
 
             // We do this to be able to move the construction to its proper position in case it's anchored...
             // Oh wow transform anchoring is amazing wow I love it!!!!
-            var wasAnchored = EntityManager.GetComponent<TransformComponent>(structure).Anchored;
-            EntityManager.GetComponent<TransformComponent>(structure).Anchored = false;
-
-            EntityManager.GetComponent<TransformComponent>(structure).Coordinates = ev.Location;
-            EntityManager.GetComponent<TransformComponent>(structure).LocalRotation = constructionPrototype.CanRotate ? ev.Angle : Angle.Zero;
-
-            EntityManager.GetComponent<TransformComponent>(structure).Anchored = wasAnchored;
+            // ikr
+            var xform = Transform(structure);
+            var wasAnchored = xform.Anchored;
+            xform.Anchored = false;
+            xform.Coordinates = ev.Location;
+            xform.LocalRotation = constructionPrototype.CanRotate ? ev.Angle : Angle.Zero;
+            xform.Anchored = wasAnchored;
 
             RaiseNetworkEvent(new AckStructureConstructionMessage(ev.Ack));
             _adminLogger.Add(LogType.Construction, LogImpact.Low, $"{ToPrettyString(user):player} has turned a {ev.PrototypeName} construction ghost into {ToPrettyString(structure)} at {Transform(structure).Coordinates}");

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -229,7 +229,7 @@ namespace Content.Server.Power.EntitySystems
 
         private void OnToolFinished(EntityUid uid, ApcComponent component, ApcToolFinishedEvent args)
         {
-            if (!args.Cancelled)
+            if (args.Cancelled)
                 return;
 
             component.IsApcOpen = !component.IsApcOpen;

--- a/Content.Server/Repairable/RepairableSystem.cs
+++ b/Content.Server/Repairable/RepairableSystem.cs
@@ -65,7 +65,7 @@ namespace Content.Server.Repairable
                 delay *= component.SelfRepairPenalty;
 
             // Can the tool actually repair this, does it have enough fuel?
-            args.Handled = !_toolSystem.UseTool(args.Used, args.User, uid, delay, component.QualityNeeded, new RepairFinishedEvent(), component.FuelCost);
+            args.Handled = _toolSystem.UseTool(args.Used, args.User, uid, delay, component.QualityNeeded, new RepairFinishedEvent(), component.FuelCost);
         }
     }
 }

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -88,6 +88,7 @@ public sealed partial class RevenantSystem
         var searchDoAfter = new DoAfterArgs(uid, revenant.SoulSearchDuration, new SoulEvent(), uid, target: target)
         {
             BreakOnUserMove = true,
+            BreakOnDamage = true,
             DistanceThreshold = 2
         };
 
@@ -142,6 +143,7 @@ public sealed partial class RevenantSystem
         {
             DistanceThreshold = 2,
             BreakOnUserMove = true,
+            BreakOnDamage = true,
             RequireCanInteract = false, // stuns itself
         };
 


### PR DESCRIPTION
Fixes #15111
Fixes #15098
Fixes #15097
Fixes #14408

:cl:
- fix: You can once again build several structures simultaneously.
- fix: Fixed being unable to repair reinforced windows.
- fix: Fixed APC-screw driver interaction
- tweak: Revenant soul-leeching will now be interrupted if they receive damage
