### PR TITLE
Reagent interactivity (pt. 1)

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/SpillBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpillBehavior.cs
@@ -31,12 +31,12 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                 solutionContainerSystem.TryGetSolution(owner, spillableComponent.SolutionName,
                     out var compSolution))
             {
-                spillableSystem.SpillAt(compSolution, coordinates, "PuddleSmear", false);
+                spillableSystem.SplashSpillAt(owner, compSolution, coordinates, "PuddleSmear", false, user: cause);
             }
             else if (Solution != null &&
                      solutionContainerSystem.TryGetSolution(owner, Solution, out var behaviorSolution))
             {
-                spillableSystem.SpillAt(behaviorSolution, coordinates, "PuddleSmear");
+                spillableSystem.SplashSpillAt(owner, behaviorSolution, coordinates, "PuddleSmear", user: cause);
             }
         }
     }

--- a/Content.Server/Fluids/Components/SpillableComponent.cs
+++ b/Content.Server/Fluids/Components/SpillableComponent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.FixedPoint;
+
 namespace Content.Server.Fluids.Components;
 
 [RegisterComponent]
@@ -15,4 +17,10 @@ public sealed class SpillableComponent : Component
 
     [DataField("spillDelay")]
     public float? SpillDelay;
+
+    /// <summary>
+    ///     At most how much reagent can be splashed on someone at once?
+    /// </summary>
+    [DataField("maxMeleeSpillAmount")]
+    public FixedPoint2 MaxMeleeSpillAmount = FixedPoint2.New(20);
 }

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -85,7 +85,7 @@ namespace Content.Server.Fluids.EntitySystems
 
             // Take 15% of the puddle solution
             var splitSol = _solutionContainerSystem.SplitSolution(uid, solution, solution.Volume * 0.15f);
-            _reactive.ReactionEntity(args.Slipped, ReactionMethod.Touch, splitSol);
+            _reactive.DoEntityReaction(args.Slipped, splitSol, ReactionMethod.Touch);
         }
 
         private void OnSolutionUpdate(EntityUid uid, PuddleComponent component, SolutionChangedEvent args)

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -1,8 +1,13 @@
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Fluids.Components;
+using Content.Shared.Chemistry;
+using Content.Shared.Chemistry.Reaction;
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids;
+using Content.Shared.Popups;
+using Content.Shared.Slippery;
 using Content.Shared.StepTrigger.Components;
 using Content.Shared.StepTrigger.Systems;
 using JetBrains.Annotations;
@@ -11,6 +16,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Solution = Content.Shared.Chemistry.Components.Solution;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Server.Fluids.EntitySystems
 {
@@ -21,7 +27,10 @@ namespace Content.Server.Fluids.EntitySystems
         [Dependency] private readonly FluidSpreaderSystem _fluidSpreaderSystem = default!;
         [Dependency] private readonly StepTriggerSystem _stepTrigger = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly ReactiveSystem _reactive = default!;
+        [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly IPrototypeManager _protoMan = default!;
+        [Dependency] private readonly IRobustRandom _random = default!;
 
         public static float PuddleVolume = 1000;
 
@@ -38,6 +47,7 @@ namespace Content.Server.Fluids.EntitySystems
             SubscribeLocalEvent<PuddleComponent, ExaminedEvent>(HandlePuddleExamined);
             SubscribeLocalEvent<PuddleComponent, SolutionChangedEvent>(OnSolutionUpdate);
             SubscribeLocalEvent<PuddleComponent, ComponentInit>(OnPuddleInit);
+            SubscribeLocalEvent<PuddleComponent, SlipEvent>(OnPuddleSlip);
         }
 
         public override void Update(float frameTime)
@@ -53,6 +63,29 @@ namespace Content.Server.Fluids.EntitySystems
         private void OnPuddleInit(EntityUid uid, PuddleComponent component, ComponentInit args)
         {
             _solutionContainerSystem.EnsureSolution(uid, component.SolutionName, FixedPoint2.New(PuddleVolume), out _);
+        }
+
+        private void OnPuddleSlip(EntityUid uid, PuddleComponent component, ref SlipEvent args)
+        {
+            // Reactive entities have a chance to get a touch reaction from slipping on a puddle
+            // (i.e. it is implied they fell face first onto it or something)
+            if (!HasComp<ReactiveComponent>(args.Slipped))
+                return;
+
+            // Eventually probably have some system of 'body coverage' to tweak the probability but for now just 0.5
+            // (implying that spacemen have a 50% chance to either land on their ass or their face)
+            if (!_random.Prob(0.5f))
+                return;
+
+            if (!_solutionContainerSystem.TryGetSolution(uid, component.SolutionName, out var solution))
+                return;
+
+            _popup.PopupEntity(Loc.GetString("puddle-component-slipped-touch-reaction", ("puddle", uid)),
+                args.Slipped, args.Slipped, PopupType.SmallCaution);
+
+            // Take 15% of the puddle solution
+            var splitSol = _solutionContainerSystem.SplitSolution(uid, solution, solution.Volume * 0.15f);
+            _reactive.ReactionEntity(args.Slipped, ReactionMethod.Touch, splitSol);
         }
 
         private void OnSolutionUpdate(EntityUid uid, PuddleComponent component, SolutionChangedEvent args)

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -218,7 +218,7 @@ public sealed class SpillableSystem : EntitySystem
 
     /// <summary>
     ///     First splashes reagent on reactive entities near the spilling entity, then spills the rest regularly to a
-    ///     puddle.
+    ///     puddle. This is intended for 'destructive' spills, like when entities are destroyed or thrown.
     /// </summary>
     public PuddleComponent? SplashSpillAt(EntityUid uid, Solution solution, EntityCoordinates coordinates, string prototype,
         bool overflow = true, bool sound = true, bool combine = true, EntityUid? user=null)
@@ -246,8 +246,7 @@ public sealed class SpillableSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("spill-land-spilled-on-other", ("spillable", uid), ("target", owner)), owner, PopupType.SmallCaution);
         }
 
-        return SpillAt(solution, coordinates, prototype, overflow, sound,
-            combine: combine);
+        return SpillAt(solution, coordinates, prototype, overflow, sound, combine: combine);
     }
 
     /// <summary>
@@ -263,8 +262,7 @@ public sealed class SpillableSystem : EntitySystem
     public PuddleComponent? SpillAt(Solution solution, EntityCoordinates coordinates, string prototype,
         bool overflow = true, bool sound = true, bool combine = true)
     {
-        if (solution.Volume == 0)
-            return null;
+        if (solution.Volume == 0) return null;
 
         if (!_mapManager.TryGetGrid(coordinates.GetGridUid(EntityManager), out var mapGrid))
             return null; // Let's not spill to space.

--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
@@ -136,7 +136,7 @@ namespace Content.Server.Nutrition.EntitySystems
                     continue;
                 }
 
-                _reactiveSystem.ReactionEntity(containerManager.Owner, ReactionMethod.Ingestion, inhaledSolution);
+                _reactiveSystem.DoEntityReaction(containerManager.Owner, inhaledSolution, ReactionMethod.Ingestion);
                 _bloodstreamSystem.TryAddToChemicals(containerManager.Owner, inhaledSolution, bloodstream);
             }
 

--- a/Content.Shared/Chemistry/ReactiveSystem.cs
+++ b/Content.Shared/Chemistry/ReactiveSystem.cs
@@ -17,14 +17,6 @@ namespace Content.Shared.Chemistry
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
-        public void ReactionEntity(EntityUid uid, ReactionMethod method, Solution solution)
-        {
-            foreach (var (id, quantity) in solution)
-            {
-                ReactionEntity(uid, method, id, quantity, solution);
-            }
-        }
-
         public void DoEntityReaction(EntityUid uid, Solution solution, ReactionMethod method)
         {
             foreach (var (reagentId, quantity) in solution.Contents.ToArray())

--- a/Resources/Locale/en-US/fluids/components/puddle-component.ftl
+++ b/Resources/Locale/en-US/fluids/components/puddle-component.ftl
@@ -1,1 +1,2 @@
 puddle-component-examine-is-slipper-text = It looks slippery.
+puddle-component-slipped-touch-reaction = The chemicals in {THE($puddle)} get on your skin!

--- a/Resources/Locale/en-US/fluids/components/spillable-component.ftl
+++ b/Resources/Locale/en-US/fluids/components/spillable-component.ftl
@@ -7,5 +7,7 @@ spill-target-verb-activate-is-empty-message = {$owner} is empty!
 spill-melee-hit-attacker = You spill {$amount}u of {THE($spillable)} onto {THE($target)}!
 spill-melee-hit-others = {CAPITALIZE(THE($attacker))} spills some of {THE($spillable)} onto {THE($target)}!
 
+spill-land-spilled-on-other = {CAPITALIZE(THE($spillable))} spills some of its solution onto {THE($target)}!
+
 spill-examine-is-spillable = This container looks spillable.
 spill-examine-spillable-weapon = You could splash this onto someone with a melee attack.

--- a/Resources/Locale/en-US/fluids/components/spillable-component.ftl
+++ b/Resources/Locale/en-US/fluids/components/spillable-component.ftl
@@ -3,3 +3,9 @@
 spill-target-verb-get-data-text = Spill liquid
 spill-target-verb-activate-cannot-drain-message = You can't pour anything from {$owner}!
 spill-target-verb-activate-is-empty-message = {$owner} is empty!
+
+spill-melee-hit-attacker = You spill {$amount}u of {THE($spillable)} onto {THE($target)}!
+spill-melee-hit-others = {CAPITALIZE(THE($attacker))} spills some of {THE($spillable)} onto {THE($target)}!
+
+spill-examine-is-spillable = This container looks spillable.
+spill-examine-spillable-weapon = You could splash this onto someone with a melee attack.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -15,6 +15,8 @@
   - type: Sprite
     state: icon
   - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -14,6 +14,10 @@
   - type: Drink
   - type: Sprite
     state: icon
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
   - type: Spillable
     solution: drink
   - type: FitsInDispenser

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -45,6 +45,8 @@
   - type: Spillable
     solution: drink
   - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -44,6 +44,10 @@
           False: {state: "icon"}
   - type: Spillable
     solution: drink
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
   - type: ItemCooldown
   - type: Recyclable
   - type: SpaceGarbage
@@ -386,7 +390,7 @@
     sprite: Objects/Consumable/Drinks/shamblersjuice.rsi
   - type: Item
     sprite: Objects/Consumable/Drinks/shamblersjuice.rsi
-    
+
 - type: entity
   parent: DrinkCanBaseFull
   id: DrinkPwrGameCan

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -32,6 +32,8 @@
   - type: Spillable
     solution: drink
   - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -31,6 +31,10 @@
     state: icon
   - type: Spillable
     solution: drink
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
   - type: ItemCooldown
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -17,6 +17,10 @@
     maxTransferAmount: 5
   - type: Drink
     isOpen: true
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
   - type: Spillable
     solution: drink
   - type: FitsInDispenser

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -18,6 +18,8 @@
   - type: Drink
     isOpen: true
   - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -54,6 +54,8 @@
   - type: Spillable
     solution: food
   - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -53,6 +53,10 @@
       path: /Audio/Items/eating_1.ogg
   - type: Spillable
     solution: food
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
   - type: TrashOnEmpty
     solution: food
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -28,6 +28,8 @@
     solution: food
   # soup weapon!
   - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -26,6 +26,11 @@
         Blunt: 5
   - type: Spillable
     solution: food
+  # soup weapon!
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -43,6 +43,8 @@
   - type: Spillable
     solution: drink
   - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -42,6 +42,10 @@
     sprite: Objects/Specific/Chemistry/beaker.rsi
   - type: Spillable
     solution: drink
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
   - type: TrashOnEmpty
     solution: drink
   - type: StaticPrice

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -17,6 +17,8 @@
   - type: Item
     sprite: Objects/Specific/Chemistry/beaker.rsi
   - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
     damage:
       types:
         Blunt: 0

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -16,6 +16,10 @@
         visible: false
   - type: Item
     sprite: Objects/Specific/Chemistry/beaker.rsi
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
   - type: SolutionContainerManager
     solutions:
       beaker:

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -35,6 +35,10 @@
     interfaces:
     - key: enum.TransferAmountUiKey.Key
       type: TransferAmountBoundUserInterface
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 0
   - type: Spillable
     solution: bucket
   - type: DrawableSolution

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -36,6 +36,8 @@
     - key: enum.TransferAmountUiKey.Key
       type: TransferAmountBoundUserInterface
   - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
     damage:
       types:
         Blunt: 0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

see changelog/videos for details, but the basic idea is to just integrate the reagent system with more things and have a bigger surface of possible interactions with them

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

(slimes are hurt by water)

https://user-images.githubusercontent.com/19853115/229726844-84bd1d39-1660-4fda-97b8-0a1077fe15c0.mp4

polytrinic acid then phlogiston

https://user-images.githubusercontent.com/19853115/229726788-51420392-7b7f-40f4-97b9-c0e6c99ff0b8.mp4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Melee attacking people with spillable containers will now splash some of the solution onto them.
- add: Slipping on puddles now has a chance for some of its solution to interact with you.
- add: Destructively spilling (throwing, breaking) spillable objects will now splash some of its solution onto nearby reactive entities (like players)