### PR TITLE
DoAfter & misc interaction fixes

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -7,6 +7,7 @@ using Content.Shared.Construction;
 using Content.Shared.Construction.Steps;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
+using Content.Shared.Radio.EntitySystems;
 using Content.Shared.Tools.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
@@ -33,7 +34,7 @@ namespace Content.Server.Construction
             SubscribeLocalEvent<ConstructionComponent, ConstructionInteractDoAfterEvent>(OnDoAfterComplete);
 
             // Event handling. Add your subscriptions here! Just make sure they're all handled by EnqueueEvent.
-            SubscribeLocalEvent<ConstructionComponent, InteractUsingEvent>(EnqueueEvent, new []{typeof(AnchorableSystem)});
+            SubscribeLocalEvent<ConstructionComponent, InteractUsingEvent>(EnqueueEvent, new []{typeof(AnchorableSystem), typeof(EncryptionKeySystem)});
             SubscribeLocalEvent<ConstructionComponent, OnTemperatureChangeEvent>(EnqueueEvent);
         }
 

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -463,12 +463,16 @@ public sealed class WiresSystem : SharedWiresSystem
             _toolSystem.HasQuality(args.Used, "Pulsing", tool)))
         {
             if (TryComp(args.User, out ActorComponent? actor))
+            {
                 _uiSystem.TryOpen(uid, WiresUiKey.Key, actor.PlayerSession);
+                args.Handled = true;
+            }
         }
         else if (_toolSystem.UseTool(args.Used, args.User, uid, ScrewTime, "Screwing", new WirePanelDoAfterEvent(), toolComponent: tool))
         {
             _adminLogger.Add(LogType.Action, LogImpact.Low,
                 $"{ToPrettyString(args.User):user} is screwing {ToPrettyString(uid):target}'s {(panel.Open ? "open" : "closed")} maintenance panel at {Transform(uid).Coordinates:targetlocation}");
+            args.Handled = true;
         }
     }
 

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -245,14 +245,14 @@ public sealed class ToggleableClothingSystem : EntitySystem
 
         var parent = Transform(target).ParentUid;
         if (component.Container.ContainedEntity == null)
-            _inventorySystem.TryUnequip(parent, component.Slot);
+            _inventorySystem.TryUnequip(user, parent, component.Slot);
         else if (_inventorySystem.TryGetSlotEntity(parent, component.Slot, out var existing))
         {
             _popupSystem.PopupEntity(Loc.GetString("toggleable-clothing-remove-first", ("entity", existing)),
                 user, user);
         }
         else
-            _inventorySystem.TryEquip(parent, component.ClothingUid.Value, component.Slot);
+            _inventorySystem.TryEquip(user, parent, component.ClothingUid.Value, component.Slot);
     }
 
     private void OnGetActions(EntityUid uid, ToggleableClothingComponent component, GetItemActionsEvent args)


### PR DESCRIPTION
Fixes https://discord.com/channels/310555209753690112/1092759367750791168 , caused by interactions being improperly marked as handled
Fixes https://discord.com/channels/310555209753690112/1092186458732908544 , caused by not passing the user into the (un)equip methods.
Fixes #15139, caused by construction system not clearing cancelled do afters.

:cl:
- fix: Fixed being unable to toggle hardsuit helmets on incapacitated players
- fix: Fixed being unable to open some wiring panels with a screw driver
- fix: Fixed various construction interactions getting stuck in an incomplete state.
