### PR TITLE
Removes clown abuse

### DIFF
--- a/Content.Server/Climbing/ClimbSystem.cs
+++ b/Content.Server/Climbing/ClimbSystem.cs
@@ -41,7 +41,6 @@ public sealed class ClimbSystem : SharedClimbSystem
     [Dependency] private readonly InteractionSystem _interactionSystem = default!;
     [Dependency] private readonly StunSystem _stunSystem = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
-    [Dependency] private readonly BonkSystem _bonkSystem = default!;
 
     private const string ClimbingFixtureName = "climb";
     private const int ClimbingCollisionGroup = (int) (CollisionGroup.TableLayer | CollisionGroup.LowImpassable);
@@ -108,9 +107,6 @@ public sealed class ClimbSystem : SharedClimbSystem
         EntityUid climbable)
     {
         if (!TryComp(entityToMove, out ClimbingComponent? climbingComponent) || climbingComponent.IsClimbing)
-            return;
-
-        if (_bonkSystem.TryBonk(entityToMove, climbable))
             return;
 
         var args = new DoAfterArgs(user, component.ClimbDelay, new ClimbDoAfterEvent(), entityToMove, target: climbable, used: entityToMove)

--- a/Content.Shared/Climbing/BonkSystem.cs
+++ b/Content.Shared/Climbing/BonkSystem.cs
@@ -2,11 +2,13 @@ using Content.Shared.Interaction;
 using Content.Shared.Stunnable;
 using Content.Shared.CCVar;
 using Content.Shared.Damage;
+using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Robust.Shared.Configuration;
 using Content.Shared.Popups;
 using Content.Shared.IdentityManagement;
 using Robust.Shared.Player;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Climbing;
 
@@ -18,12 +20,25 @@ public sealed class BonkSystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stunSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
 
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<BonkableComponent, DragDropTargetEvent>(OnDragDrop);
+        SubscribeLocalEvent<BonkableComponent, BonkDoAfterEvent>(OnBonkDoAfter);
     }
+
+    private void OnBonkDoAfter(EntityUid uid, BonkableComponent component, BonkDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled || args.Args.Target == null)
+            return;
+
+        TryBonk(args.Args.User, uid, component);
+
+        args.Handled = true;
+    }
+
 
     public bool TryBonk(EntityUid user, EntityUid bonkableUid, BonkableComponent? bonkableComponent = null)
     {
@@ -55,8 +70,25 @@ public sealed class BonkSystem : EntitySystem
 
     }
 
-    private void OnDragDrop(EntityUid uid, BonkableComponent bonkableComponent, ref DragDropTargetEvent args)
+    private void OnDragDrop(EntityUid uid, BonkableComponent component, ref DragDropTargetEvent args)
     {
-        TryBonk(args.Dragged, uid);
+        if (args.Handled)
+            return;
+
+        var doAfterArgs = new DoAfterArgs(args.Dragged, component.BonkDelay, new BonkDoAfterEvent(), uid, target: uid)
+        {
+            BreakOnTargetMove = true,
+            BreakOnUserMove = true,
+            BreakOnDamage = true
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs);
+
+        args.Handled = true;
+    }
+
+    [Serializable, NetSerializable]
+    private sealed class BonkDoAfterEvent : SimpleDoAfterEvent
+    {
     }
 }

--- a/Content.Shared/Climbing/BonkableComponent.cs
+++ b/Content.Shared/Climbing/BonkableComponent.cs
@@ -37,4 +37,10 @@ public sealed class BonkableComponent : Component
     /// <seealso cref="Bonk"/>
     [DataField("bonkDamage")]
     public DamageSpecifier? BonkDamage;
+
+    /// <summary>
+    /// How long it takes to bonk.
+    /// </summary>
+    [DataField("bonkDelay")]
+    public float BonkDelay = 0.8f;
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Bonks were hitting twice, once in climbing and once in their own system, and neither had a delay. So you could turbo beat a clown to death with a few drag drops. Now there's no more double dipping and there's a delay on the bonk.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Bonks hit once and have a delay