### PR TITLE
made security's deployable barriers easier to move

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
@@ -19,7 +19,7 @@
     - shape:
         !type:PhysShapeCircle
         radius: 0.45
-      density: 235
+      density: 75
       mask:
       - MachineMask
       layer:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Changes density from 235 to 75.

Security's deployable barriers are very underutilized, and I feel like this is mostly due to their weight. These things are heavier than a nuke or an engi-vend, making them very painful to move. With this PR, these barriers are now slightly ligher than a fuel tank or a crate. This should hopefully make security use them more for whatever situation it entails.

Also, due to the recent addition of security holoprojectors, these barriers are used less than ever. This will help them not fall into total oblivion.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->


https://user-images.githubusercontent.com/113810873/230162232-0379f467-c653-4deb-89a6-5b2b66a36464.mp4



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Nanotrasen has installed wheels on Security's Deployable Barriers. They are now far easier to move.