### PR TITLE
Adds despawn timer to brokenposter.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -37,6 +37,8 @@
     drawdepth: WallTops
     sprite: Structures/Wallmounts/posters.rsi
     state: poster_broken
+  - type: TimedDespawn
+    lifetime: 20
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
Adds a 20second despawn timer to the broken poster. This means after 20 seconds the broken poster entity dissapears. 