### PR TITLE
[Fix] Boxes of shotgun cartriges

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -349,13 +349,14 @@
 # Shotgun Shells
 - type: entity
   name: box of shotgun beanbag cartridges
-  parent: BoxAmmoProvider
+  parent: BoxMagazine
   id: BoxBeanbag
   description: A box full of beanbag shots, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunBeanbag
-      capacity: 12
+    - type: StorageFill
+    contents:
+      - id: ShellShotgunBeanbag
+        amount: 12
     - type: Sprite
       layers:
         - state: boxwide
@@ -363,13 +364,14 @@
 
 - type: entity
   name: box of shotgun lethal cartridges
-  parent: BoxAmmoProvider
+  parent: BoxMagazine
   id: BoxLethalshot
   description: A box full of lethal pellet shots, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgun
-      capacity: 12
+    - type: StorageFill
+    contents:
+      - id: ShellShotgun
+        amount: 12
     - type: Sprite
       layers:
         - state: boxwide
@@ -377,13 +379,14 @@
 
 - type: entity
   name: box of shotgun slug cartridges
-  parent: BoxAmmoProvider
+  parent: BoxMagazine
   id: BoxShotgunSlug
   description: A box full of shotgun slugs, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunSlug
-      capacity: 12
+    - type: StorageFill
+    contents:
+      - id: ShellShotgunSlug
+        amount: 12
     - type: Sprite
       layers:
         - state: boxwide
@@ -391,13 +394,14 @@
 
 - type: entity
   name: box of shotgun flare cartridges
-  parent: BoxAmmoProvider
+  parent: BoxMagazine
   id: BoxShotgunFlare
   description: A box full of shotgun flare cartridges, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunFlare
-      capacity: 12
+    - type: StorageFill
+    contents:
+      - id: ShellShotgunFlare
+        amount: 12
     - type: Sprite
       layers:
         - state: boxwide
@@ -405,13 +409,14 @@
 
 - type: entity
   name: box of shotgun incendiary cartridges
-  parent: BoxAmmoProvider
+  parent: BoxMagazine
   id: BoxShotgunIncendiary
   description: A box full of shotgun incendiary cartridges, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunIncendiary
-      capacity: 12
+    - type: StorageFill
+    contents:
+      - id: ShellShotgunIncendiary
+        amount: 12
     - type: Sprite
       layers:
         - state: boxwide
@@ -419,13 +424,14 @@
 
 - type: entity
   name: box of shotgun practice cartridges
-  parent: BoxAmmoProvider
+  parent: BoxMagazine
   id: BoxShotgunPractice
   description: A box full of shotgun practice cartridges, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunPractice
-      capacity: 12
+    - type: StorageFill
+    contents:
+      - id: ShellShotgunPractice
+        amount: 12
     - type: Sprite
       layers:
         - state: boxwide
@@ -433,13 +439,14 @@
 
 - type: entity
   name: box of tranquilizer cartridges
-  parent: BoxAmmoProvider
+  parent: BoxMagazine
   id: BoxShellTranquilizer
   description: A box full of tranquilizer cartridges, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellTranquilizer
-      capacity: 12
+    - type: StorageFill
+    contents:
+      - id: ShellTranquilizer
+        amount: 12
     - type: Sprite
       layers:
         - state: boxwide


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Removes the delivery function of 12 BlueSpace cartridges from shotgun cartridge boxes. Now the cartridges will lie inside the box, it will no longer look like a bug, and beginners will not be confused by the fact that the box is empty, and the cartridges when you press "Z" fall from it.

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: PuroSlavKing
- fix: Fixed now the box of shotgun cartridges does not have bluespace cartridges, they lie inside it as it should.
