### PR TITLE
traitors can see types of pens when examined

### DIFF
--- a/Content.Server/Traitor/TraitorExamineComponent.cs
+++ b/Content.Server/Traitor/TraitorExamineComponent.cs
@@ -1,0 +1,15 @@
+namespace Content.Server.Traitor;
+
+/// <summary>
+/// Shows a message only when examined by a traitor.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(TraitorExamineSystem))]
+public sealed class TraitorExamineComponent : Component
+{
+    /// <summary>
+    /// Message to be shown when examined.
+    /// </summary>
+    [DataField("message", required: true), ViewVariables(VVAccess.ReadWrite)]
+    public string Message = string.Empty;
+}

--- a/Content.Server/Traitor/TraitorExamineSystem.cs
+++ b/Content.Server/Traitor/TraitorExamineSystem.cs
@@ -1,0 +1,28 @@
+using Content.Server.Mind.Components;
+using Content.Shared.Examine;
+using Content.Shared.Ghost;
+
+namespace Content.Server.Traitor;
+
+public sealed class TraitorExamineSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TraitorExamineComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(EntityUid uid, TraitorExamineComponent comp, ExaminedEvent args)
+    {
+        // observers and other traitors can see examine messages
+        if (HasComp<SharedGhostComponent>(args.Examiner) || (args.IsInDetailsRange && IsTraitor(args.Examiner)))
+            args.PushMarkup(Loc.GetString(comp.Message));
+    }
+
+    private bool IsTraitor(EntityUid user)
+    {
+        // TODO: if/when mind is refactored, change to use role id + put id in the component
+        return TryComp<MindComponent>(user, out var mind) && (mind.Mind?.HasRole<TraitorRole>() ?? false);
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -130,6 +130,8 @@
   description: Stylish black shoes.
   components:
   - type: NoSlip
+  - type: TraitorExamine
+    message: These are no-slip shoes.
 
 - type: entity
   parent: ClothingShoesClown

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -243,3 +243,6 @@
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta
     price: 75
+  # if you need this to identify a hypopen you're a bit slow...
+  - type: TraitorExamine
+    message: There is a small needle inside.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
@@ -16,3 +16,5 @@
     canCreateVacuum: false
   - type: ActivateOnPaperOpened
   - type: ExplodeOnTrigger
+  - type: TraitorExamine
+    message: There is an explosive contained inside.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -121,3 +121,5 @@
     - Write
   - type: DisarmMalus
     malus: 0
+  - type: TraitorExamine
+    message: There is a laser emitter contained inside.


### PR DESCRIPTION
## About the PR
adds TraitorExamine component/system and puts it on the 3 sus pens

only traitors (in detail range) and observers can see the type of pen.

fixes #15179 

**Media**
nothing sus
![23:23:49](https://user-images.githubusercontent.com/39013340/230505013-f807b088-725e-4b26-a43b-5c88ded509a0.png)

john syndicate sees all
![23:24:25](https://user-images.githubusercontent.com/39013340/230504980-f181285a-d3d0-474c-8123-49a15e950d39.png)

- [X] I have added screenshots to this PR showcasing its changes ingame

**Changelog**
:cl:
- tweak: The Syndicate has given its operatives retina implants to see what kind of gadgets are hidden inside of pens.