### PR TITLE
Hide ugly float to string conversion results from players in the mixer UI

### DIFF
--- a/Content.Client/Atmos/UI/GasMixerBoundUserInteface.cs
+++ b/Content.Client/Atmos/UI/GasMixerBoundUserInteface.cs
@@ -60,7 +60,7 @@ namespace Content.Client.Atmos.UI
             // We don't need to send both nodes because it's just 100.0f - node
             float node = float.TryParse(value, out var parsed) ? parsed : 1.0f;
 
-            node = Math.Clamp(node, 0, 100);
+            node = Math.Clamp(node, 0f, 100.0f);
 
             if (_window is not null) node = _window.NodeOneLastEdited ? node : 100.0f - node;
 

--- a/Content.Client/Atmos/UI/GasMixerWindow.xaml.cs
+++ b/Content.Client/Atmos/UI/GasMixerWindow.xaml.cs
@@ -74,10 +74,10 @@ namespace Content.Client.Atmos.UI
 
         public void SetNodePercentages(float nodeOne)
         {
-            nodeOne *= 100.0f;
+            nodeOne = (float) Math.Round(nodeOne * 100.0f, 2);
             MixerNodeOneInput.Text = nodeOne.ToString(CultureInfo.InvariantCulture);
 
-            float nodeTwo = 100.0f - nodeOne;
+            float nodeTwo = (float) Math.Round(100.0f - nodeOne, 2);
             MixerNodeTwoInput.Text = nodeTwo.ToString(CultureInfo.InvariantCulture);
         }
 

--- a/Content.Client/Atmos/UI/GasMixerWindow.xaml.cs
+++ b/Content.Client/Atmos/UI/GasMixerWindow.xaml.cs
@@ -75,10 +75,10 @@ namespace Content.Client.Atmos.UI
         public void SetNodePercentages(float nodeOne)
         {
             nodeOne *= 100.0f;
-            MixerNodeOneInput.Text = nodeOne.ToString("F0", CultureInfo.InvariantCulture);
+            MixerNodeOneInput.Text = nodeOne.ToString("0.##", CultureInfo.InvariantCulture);
 
             float nodeTwo = 100.0f - nodeOne;
-            MixerNodeTwoInput.Text = nodeTwo.ToString("F0", CultureInfo.InvariantCulture);
+            MixerNodeTwoInput.Text = nodeTwo.ToString("0.##", CultureInfo.InvariantCulture);
         }
 
         public void SetMixerStatus(bool enabled)

--- a/Content.Client/Atmos/UI/GasMixerWindow.xaml.cs
+++ b/Content.Client/Atmos/UI/GasMixerWindow.xaml.cs
@@ -74,11 +74,11 @@ namespace Content.Client.Atmos.UI
 
         public void SetNodePercentages(float nodeOne)
         {
-            nodeOne = (float) Math.Round(nodeOne * 100.0f, 2);
-            MixerNodeOneInput.Text = nodeOne.ToString(CultureInfo.InvariantCulture);
+            nodeOne *= 100.0f;
+            MixerNodeOneInput.Text = nodeOne.ToString("F0", CultureInfo.InvariantCulture);
 
-            float nodeTwo = (float) Math.Round(100.0f - nodeOne, 2);
-            MixerNodeTwoInput.Text = nodeTwo.ToString(CultureInfo.InvariantCulture);
+            float nodeTwo = 100.0f - nodeOne;
+            MixerNodeTwoInput.Text = nodeTwo.ToString("F0", CultureInfo.InvariantCulture);
         }
 
         public void SetMixerStatus(bool enabled)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
It rounds the numbers shown to players in the gas mixer UI to 2 decimal places so conversion to string won't show them ugly 60.00004% when they input 60%.
They shouldn't have to know how floating point numbers really work.

Issue from discord: https://discord.com/channels/310555209753690112/1093453658336796703/1093453658336796703
**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Mumohan
- fix: Gas mixers no longer show weird ratio numbers