### PR TITLE
Fix computer deconstruction

### DIFF
--- a/Content.Server/Construction/Components/ConstructionComponent.cs
+++ b/Content.Server/Construction/Components/ConstructionComponent.cs
@@ -34,9 +34,6 @@ namespace Content.Server.Construction.Components
         [DataField("deconstructionTarget")]
         public string? DeconstructionNode { get; set; } = "start";
 
-        [DataField("doAfter")]
-        public DoAfterId? DoAfter;
-
         [ViewVariables]
         // TODO Force flush interaction queue before serializing to YAML.
         // Otherwise you can end up with entities stuck in invalid states (e.g., waiting for DoAfters).


### PR DESCRIPTION
Fixes another construction-doafter bug, again caused by 0-second DoAfters which caused construction recursion issues.

:cl:
- fix: Fixed computer deconstruction not working.
