### PR TITLE
Make broken cuffs trash, fix color for broken makeshift cuffs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -84,28 +84,34 @@
     state: cuff
 
 - type: entity
+  id: BaseHandcuffsBroken
+  parent: BaseItem
+  abstract: true
+  components:
+  - type: Item
+    size: 2
+  - type: Recyclable
+  - type: Tag
+    tags:
+    - Trash
+
+- type: entity
   name: broken zipties
   description: These zipties look like they tried to manage the wrong cables.
   id: ZiptiesBroken
-  parent: BaseItem
+  parent: BaseHandcuffsBroken
   components:
   - type: Sprite
     sprite: Objects/Misc/zipties.rsi
     state: cuff-broken
-  - type: Item
-    size: 2
-  - type: Recyclable
 
 - type: entity
   name: broken cables
   description: These cables are broken in several places and don't seem very useful.
   id: CablecuffsBroken
-  parent: BaseItem
+  parent: BaseHandcuffsBroken
   components:
   - type: Sprite
     sprite: Objects/Misc/cablecuffs.rsi
     state: cuff-broken
-    color: red
-  - type: Item
-    size: 2
-  - type: Recyclable
+    color: forestgreen


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Closes #15200 

Marks the broken cuffs as trash
also makes the broken makeshift one green; i must've missed it the first time around.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Broken cuffs are now marked as trash.
- fix: Broken makeshift handcuffs are now the correct color.
