### PR TITLE
Adding the station alert level in PDAs

### DIFF
--- a/Content.Client/PDA/PDAMenu.xaml
+++ b/Content.Client/PDA/PDAMenu.xaml
@@ -27,17 +27,20 @@
                       HorizontalExpand="True"
                       MinSize="50 50"
                       Margin="8">
+            <PanelContainer Margin="0 0 0 5">
+                <BoxContainer Orientation="Vertical">
+                    <RichTextLabel Name="StationNameLabel"
+                                   Access="Public"
+                                   HorizontalExpand="True" />
+                    <RichTextLabel Name="StationAlertLevelLabel"
+                                    Access="Public"
+                                    HorizontalExpand="True" />
+                </BoxContainer>
+            </PanelContainer>
             <RichTextLabel Name="PdaOwnerLabel" Access="Public" />
             <RichTextLabel Name="IdInfoLabel"
                            Access="Public"
                            HorizontalExpand="True" />
-            <PanelContainer>
-                <BoxContainer Orientation="Horizontal">
-                    <RichTextLabel Name="StationNameLabel"
-                                   Access="Public"
-                                   HorizontalExpand="True" />
-                </BoxContainer>
-            </PanelContainer>
         </BoxContainer>
         <ScrollContainer HorizontalExpand="True" VerticalExpand="True" HScrollEnabled="True">
             <BoxContainer Orientation="Vertical"

--- a/Content.Client/PDA/PDAMenu.xaml
+++ b/Content.Client/PDA/PDAMenu.xaml
@@ -27,7 +27,7 @@
                       HorizontalExpand="True"
                       MinSize="50 50"
                       Margin="8">
-            <PanelContainer Margin="0 0 0 5">
+            <PanelContainer Margin="0 0 0 5" Name="StationNameContainer">
                 <BoxContainer Orientation="Vertical">
                     <RichTextLabel Name="StationNameLabel"
                                    Access="Public"

--- a/Content.Client/PDA/PDAMenu.xaml.cs
+++ b/Content.Client/PDA/PDAMenu.xaml.cs
@@ -104,6 +104,14 @@ namespace Content.Client.PDA
             StationNameLabel.SetMarkup(Loc.GetString("comp-pda-ui-station", ("Station",state.StationName ?? Loc.GetString("comp-pda-ui-unknown"))));
             AddressLabel.Text = state.Address?.ToUpper() ?? " - ";
 
+            if (state.StationAlertLevel != null) {
+                StationAlertLevelLabel.SetMarkup($"Current alert level: {state.StationAlertLevel}");
+            }
+            else
+            {
+                StationAlertLevelLabel.SetMarkup("none!");
+            }
+
             EjectIdButton.IsActive = state.PDAOwnerInfo.IdOwner != null || state.PDAOwnerInfo.JobTitle != null;
             EjectPenButton.IsActive = state.HasPen;
             ActivateUplinkButton.Visible = state.HasUplink;

--- a/Content.Client/PDA/PDAMenu.xaml.cs
+++ b/Content.Client/PDA/PDAMenu.xaml.cs
@@ -93,23 +93,29 @@ namespace Content.Client.PDA
             if (state.PDAOwnerInfo.IdOwner != null || state.PDAOwnerInfo.JobTitle != null)
             {
                 IdInfoLabel.SetMarkup(Loc.GetString("comp-pda-ui",
-                    ("Owner",state.PDAOwnerInfo.IdOwner ?? Loc.GetString("comp-pda-ui-unknown")),
-                    ("JobTitle",state.PDAOwnerInfo.JobTitle ?? Loc.GetString("comp-pda-ui-unassigned"))));
+                    ("Owner", state.PDAOwnerInfo.IdOwner ?? Loc.GetString("comp-pda-ui-unknown")),
+                    ("JobTitle", state.PDAOwnerInfo.JobTitle ?? Loc.GetString("comp-pda-ui-unassigned"))));
             }
             else
             {
                 IdInfoLabel.SetMarkup(Loc.GetString("comp-pda-ui-blank"));
             }
 
-            StationNameLabel.SetMarkup(Loc.GetString("comp-pda-ui-station", ("Station",state.StationName ?? Loc.GetString("comp-pda-ui-unknown"))));
-            AddressLabel.Text = state.Address?.ToUpper() ?? " - ";
+            StationNameContainer.Visible = false;
+            StationAlertLevelLabel.Visible = false;
 
-            if (state.StationAlertLevel != null) {
-                StationAlertLevelLabel.SetMarkup($"Current alert level: {state.StationAlertLevel}");
-            }
-            else
+            if (state.StationName != null)
             {
-                StationAlertLevelLabel.SetMarkup("none!");
+                StationNameContainer.Visible = true;
+                StationNameLabel.SetMarkup(Loc.GetString("comp-pda-ui-station",
+                    ("Station", state.StationName ?? Loc.GetString("comp-pda-ui-unknown"))));
+                AddressLabel.Text = state.Address?.ToUpper() ?? " - ";
+
+                if (state.StationAlertLevel != null)
+                {
+                    StationAlertLevelLabel.Visible = true;
+                    StationAlertLevelLabel.SetMarkup(GetLocalStingForLevelAlert(state.StationAlertLevel));
+                }
             }
 
             EjectIdButton.IsActive = state.PDAOwnerInfo.IdOwner != null || state.PDAOwnerInfo.JobTitle != null;
@@ -255,6 +261,37 @@ namespace Content.Client.PDA
             {
                 view.Visible = false;
             }
+        }
+
+        private string GetLocalStingForLevelAlert(string alertlevel)
+        {
+            string color;
+
+            switch (alertlevel)
+            {
+                case "epsilon":
+                    color = "darkviolet";
+                    break;
+                case "gamma":
+                    color = "darkviolet";
+                    break;
+                case "delta":
+                    color = "darkred";
+                    break;
+                case "blue":
+                    color = "dodgerblue";
+                    break;
+                default:
+                    color = alertlevel;
+                    break;
+            }
+
+            if (Loc.TryGetString($"alert-level-{alertlevel}", out var locName))
+            {
+                alertlevel = locName;
+            }
+
+            return Loc.GetString("comp-pda-ui-station-alert-level", ("ColorLevel", color), ("AlertLevel", alertlevel));
         }
     }
 }

--- a/Content.Server/PDA/PDASystem.cs
+++ b/Content.Server/PDA/PDASystem.cs
@@ -28,9 +28,6 @@ namespace Content.Server.PDA
         [Dependency] private readonly StationSystem _stationSystem = default!;
         [Dependency] private readonly CartridgeLoaderSystem _cartridgeLoaderSystem = default!;
         [Dependency] private readonly StoreSystem _storeSystem = default!;
-
-        private PDAComponent? _pda;
-
         public override void Initialize()
         {
             base.Initialize();
@@ -48,8 +45,6 @@ namespace Content.Server.PDA
 
             if (!TryComp(uid, out ServerUserInterfaceComponent? uiComponent))
                 return;
-
-            _pda = pda;
 
             UpdateStationName(pda);
             UpdatePdaStationAlertLevel(pda);

--- a/Content.Shared/PDA/PDAComponent.cs
+++ b/Content.Shared/PDA/PDAComponent.cs
@@ -35,5 +35,6 @@ namespace Content.Shared.PDA
 
         [ViewVariables] public string? OwnerName;
         [ViewVariables] public string? StationName;
+        [ViewVariables] public string? StationAlertLevel;
     }
 }

--- a/Content.Shared/PDA/PDAUpdateState.cs
+++ b/Content.Shared/PDA/PDAUpdateState.cs
@@ -11,11 +11,15 @@ namespace Content.Shared.PDA
         public bool HasPen;
         public PDAIdInfoText PDAOwnerInfo;
         public string? StationName;
+        public string? StationAlertLevel;
         public bool HasUplink;
         public bool CanPlayMusic;
         public string? Address;
 
-        public PDAUpdateState(bool flashlightEnabled, bool hasPen, PDAIdInfoText pdaOwnerInfo, string? stationName, bool hasUplink = false, bool canPlayMusic = false, string? address = null)
+
+        public PDAUpdateState(bool flashlightEnabled, bool hasPen, PDAIdInfoText pdaOwnerInfo,
+            string? stationName, bool hasUplink = false, bool canPlayMusic = false, string? address = null,
+                string? stationAlertLevel = null)
         {
             FlashlightEnabled = flashlightEnabled;
             HasPen = hasPen;
@@ -23,6 +27,7 @@ namespace Content.Shared.PDA
             HasUplink = hasUplink;
             CanPlayMusic = canPlayMusic;
             StationName = stationName;
+            StationAlertLevel = stationAlertLevel;
             Address = address;
         }
     }

--- a/Resources/Locale/en-US/pda/pda-component.ftl
+++ b/Resources/Locale/en-US/pda/pda-component.ftl
@@ -41,3 +41,5 @@ pda-bound-user-interface-music-button-description = Play music on your PDA
 comp-pda-ui-unknown = Unknown
 
 comp-pda-ui-unassigned = Unassigned
+
+comp-pda-ui-station-alert-level = The current station alert level is: [color={ $ColorLevel }]{ $AlertLevel }[/color]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

In this pull request, I slightly modify the elements in the PDA and add alert level display for the station. If there is no code for such stations, the code string is not displayed. If there is no station, then the strings with the station name and code not displayed. It is important that the data is updated only when the PDA is opening, the event for changing the alert level is not processed.

I moved the station name and alert level to the top because I plan to add information about access levels below. And in order to prevent the station information from cutting off the employee information, I moved it.

I have used code from https://github.com/VigersRay user.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Alert level is red
![image](https://user-images.githubusercontent.com/2144635/230737873-519ab7ad-8018-4d1a-8e0c-dbc52d0b4a1b.png)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Added the station alert level in the PDA
- tweak: Changed the position of the some PDA elements
