### PR TITLE
Fixes air sensors not accessing gas mixture on construction + visual fixes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -62,22 +62,23 @@
         - AirSensor
     - type: AccessReader
       access: [ [ "Atmospherics" ] ]
-    - type: GenericVisualizer
-      visuals:
-        enum.PowerDeviceVisuals.Powered:
-          sensor:
-            True: { state: gsensor1 }
-            False: { state: gsensor0 }
     - type: Construction
       graph: AirSensor
       node: sensor
+    - type: Appearance
     - type: Sprite
       netsync: false
       drawdepth: FloorObjects
       sprite: Structures/Specific/Atmospherics/sensor.rsi
       layers:
         - state: gsensor1
-          map: [ "sensor" ]
+          map: [ "enum.PowerDeviceVisualLayers.Powered" ]
+    - type: GenericVisualizer
+      visuals:
+        enum.PowerDeviceVisuals.Powered:
+          enum.PowerDeviceVisualLayers.Powered:
+            True: { state: gsensor1 }
+            False: { state: gsensor0 }
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
Fixed air sensors not accessing their tile gas mixture without power cycling (now they update their tilegas on enter/exit atmosphere, like they should).
That fixes #14681.

Also added an appearance component to the sensors so their sprite actually updates on power changes.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Air and scrubbers sensors will now be properly detected by air alarms when manually linking them.
- fix: Air sensors appearance will now update on power changes.
