### PR TITLE
emp on electro supercritical

### DIFF
--- a/Content.Server/Anomaly/Effects/ElectricityAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/ElectricityAnomalySystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.Electrocution;
+﻿using Content.Server.Emp;
 using Content.Server.Lightning;
 using Content.Server.Power.Components;
 using Content.Shared.Anomaly.Components;
@@ -16,6 +17,7 @@ public sealed class ElectricityAnomalySystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly LightningSystem _lightning = default!;
     [Dependency] private readonly ElectrocutionSystem _electrocution = default!;
+    [Dependency] private readonly EmpSystem _emp = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
     /// <inheritdoc/>
@@ -55,6 +57,9 @@ public sealed class ElectricityAnomalySystem : EntitySystem
         {
             _lightning.ShootLightning(uid, ent);
         }
+
+        var empRange = component.MaxElectrocuteRange * 3;
+        _emp.EmpPulse(Transform(uid).MapPosition, empRange, component.EmpEnergyConsumption);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/Anomaly/Effects/Components/ElectricityAnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Effects/Components/ElectricityAnomalyComponent.cs
@@ -38,4 +38,10 @@ public sealed class ElectricityAnomalyComponent : Component
     /// </summary>
     [DataField("nextSecond", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan NextSecond = TimeSpan.Zero;
+
+    /// <summary>
+    /// Energy consumed from devices by the emp pulse upon going supercritical.
+    /// <summary>
+    [DataField("empEnergyConsumption"), ViewVariables(VVAccess.ReadWrite)]
+    public float EmpEnergyConsumption = 100000f;
 }


### PR DESCRIPTION
## About the PR
partial solution for #15231

adds an emp effect when electricity anomaly goes supercritical

emp energy consumption is double an emp grenade
emp range is triple the standard shock range (1.5x the supercritical lightning range)

values are abitrary, feedback welcome

**Media**


https://user-images.githubusercontent.com/39013340/230758544-8bc758ad-6e86-49c0-b5b1-cf6ea8ff9fde.mp4



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Electricity anomalies will now create an EMP when going supercritical.
