### PR TITLE
[Spawner] New pirates icon

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Conditional/pirates.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Conditional/pirates.yml
@@ -7,5 +7,5 @@
   - type: Sprite
     layers:
     - state: green
-    - sprite: Objects/Fun/toys.rsi
-      state: synb
+    - sprite: Mobs/Species/Skeleton/parts.rsi
+      state: skull_icon


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
1) The pirate spawner and the nuclear operatives have the same icon. 
2) The pirate spawner have a syndicate icon.

> Better call PuroSlavKing, i fix that.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/103608145/230781206-4a3cf6e5-72a1-47bf-bd10-7376f283fc30.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: PuroSlavKing
- tweak: Changed to scull icon for Pirates spawner.
