### PR TITLE
Added small text to Guidebook Security tab.

### DIFF
--- a/Resources/Server Info/Guidebook/Security/Security.xml
+++ b/Resources/Server Info/Guidebook/Security/Security.xml
@@ -1,3 +1,30 @@
 ﻿<Document>
+  # Security
+  Ensuring the safety of both station and crew is number one for Security. Be it Syndicate Agents, Nuclear Operatives, Infestations or just unruly staff. Security are on hand to maintain order and control crowds.
 
+  ## Gear
+  First we have non-lethals a step above simply telling someone to cooperate with instructions. Both the stunbaton and disabler are capable of limiting the movement of an assailant, whereas handcuffs can be applied to deny a criminal free movement and access to their hands.
+  <Box>
+    <GuideEntityEmbed Entity="Stunbaton"/>
+    <GuideEntityEmbed Entity="Handcuffs"/>
+    <GuideEntityEmbed Entity="WeaponDisabler"/>
+  </Box>
+
+  ## Flashes
+  Flashes are an effective tool for dispersing crowds and apprehending particularly evasive targets, with a large area of effect blinding all those without protection.
+  Security and [color=#a4885c]some[/color] other members of staff have eye protection from flashbangs and flashes.
+  <Box>
+    <GuideEntityEmbed Entity="Flash"/>
+    <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity"/>
+    <GuideEntityEmbed Entity="GrenadeFlashBang"/>
+
+  </Box>
+  ## Lethals
+  Should the situation dictate, Security have access to laser rifles, shotguns, handguns and automatic rifles able to put down substancial fire against any who would stand against the station.
+  <Box>
+  <GuideEntityEmbed Entity="WeaponLaserCarbine"/>
+  <GuideEntityEmbed Entity="WeaponShotgunKammerer"/>
+  <GuideEntityEmbed Entity="WeaponPistolMk58"/>
+  <GuideEntityEmbed Entity="WeaponRifleLecter"/>
+  </Box>
 </Document>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This file has existed for a good while with zero content as is the only dropdown in the guidebook without text. Why not for a first commit eh?
Slightly large amount of text for a guidebook pag, possibly could be thinned out?

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/130304754/230799752-7c188cc7-493f-43f7-9b21-f217db6df955.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame,

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
