### PR TITLE
artifacts no longer rigged

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -18,9 +18,13 @@ public sealed partial class ArtifactSystem : EntitySystem
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
+    private ISawmill _sawmill = default!;
+
     public override void Initialize()
     {
         base.Initialize();
+
+        _sawmill = Logger.GetSawmill("artifact");
 
         SubscribeLocalEvent<ArtifactComponent, MapInitEvent>(OnInit);
         SubscribeLocalEvent<ArtifactComponent, PriceCalculationEvent>(GetPrice);
@@ -197,8 +201,8 @@ public sealed partial class ArtifactSystem : EntitySystem
         var currentNode = GetNodeFromId(component.CurrentNodeId.Value, component);
 
         var allNodes = currentNode.Edges;
-        Logger.DebugS("artifact", $"our node: {currentNode.Id}");
-        Logger.DebugS("artifact", $"other nodes: {string.Join(", ", allNodes)}");
+        _sawmill.Debug("artifact", $"our node: {currentNode.Id}");
+        _sawmill.Debug("artifact", $"other nodes: {string.Join(", ", allNodes)}");
 
         if (TryComp<BiasedArtifactComponent>(uid, out var bias) &&
             TryComp<TraversalDistorterComponent>(bias.Provider, out var trav) &&
@@ -221,14 +225,14 @@ public sealed partial class ArtifactSystem : EntitySystem
         }
 
         var undiscoveredNodes = allNodes.Where(x => !GetNodeFromId(x, component).Discovered).ToList();
-        Logger.DebugS("artifact", $"Undiscovered nodes: {string.Join(", ", undiscoveredNodes)}");
+        _sawmill.Debug("artifact", $"Undiscovered nodes: {string.Join(", ", undiscoveredNodes)}");
         var newNode = _random.Pick(allNodes);
         if (undiscoveredNodes.Any() && _random.Prob(0.75f))
         {
             newNode = _random.Pick(undiscoveredNodes);
         }
 
-        Logger.DebugS("artifact", $"Going to node {newNode}");
+        _sawmill.Debug("artifact", $"Going to node {newNode}");
         return GetNodeFromId(newNode, component);
     }
 

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -73,7 +73,7 @@ public sealed partial class ArtifactSystem : EntitySystem
     }
 
     /// <summary>
-    /// Calculates how many research points the artifact is worht
+    /// Calculates how many research points the artifact is worth
     /// </summary>
     /// <remarks>
     /// General balancing (for fully unlocked artifacts):
@@ -197,12 +197,8 @@ public sealed partial class ArtifactSystem : EntitySystem
         var currentNode = GetNodeFromId(component.CurrentNodeId.Value, component);
 
         var allNodes = currentNode.Edges;
-        Logger.Debug($"our node: {currentNode.Id}");
-        Logger.Debug("other nodes:");
-        foreach (var other in allNodes)
-        {
-            Logger.Debug($"{other}");
-        }
+        Logger.DebugS("artifact", $"our node: {currentNode.Id}");
+        Logger.DebugS("artifact", $"other nodes: {string.Join(", ", allNodes)}");
 
         if (TryComp<BiasedArtifactComponent>(uid, out var bias) &&
             TryComp<TraversalDistorterComponent>(bias.Provider, out var trav) &&
@@ -224,13 +220,15 @@ public sealed partial class ArtifactSystem : EntitySystem
             }
         }
 
-        var undiscoveredNodes = allNodes.Where(x => GetNodeFromId(x, component).Discovered).ToList();
+        var undiscoveredNodes = allNodes.Where(x => !GetNodeFromId(x, component).Discovered).ToList();
+        Logger.DebugS("artifact", $"Undiscovered nodes: {string.Join(", ", undiscoveredNodes)}");
         var newNode = _random.Pick(allNodes);
         if (undiscoveredNodes.Any() && _random.Prob(0.75f))
         {
             newNode = _random.Pick(undiscoveredNodes);
         }
 
+        Logger.DebugS("artifact", $"Going to node {newNode}");
         return GetNodeFromId(newNode, component);
     }
 


### PR DESCRIPTION
## About the PR
- fixes #15268 by inverting the condition so that its actually biased towards undiscovered nodes
- fix typo in doc
- add debug prints to `artifact` it was weird that they were just in root

**Media**
no

**Changelog**
:cl:
- fix: Fixed artifacts being biased towards nodes that were already discovered.