### PR TITLE
Rebindable menu + move menu to default F10

### DIFF
--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -147,6 +147,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.OpenAdminMenu);
             AddButton(EngineKeyFunctions.WindowCloseAll);
             AddButton(EngineKeyFunctions.WindowCloseRecent);
+            AddButton(EngineKeyFunctions.EscapeMenu);
 
             AddHeader("ui-options-header-misc");
             AddButton(ContentKeyFunctions.TakeScreenshot);

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -137,7 +137,7 @@ ui-options-function-open-admin-menu = Open admin menu
 ui-options-function-open-guidebook = Open guidebook
 ui-options-function-window-close-all = Close all windows
 ui-options-function-window-close-recent = Close recent window
-ui-options-function-show-escape-menu = Toggle menu
+ui-options-function-show-escape-menu = Toggle game menu
 
 ui-options-function-take-screenshot = Take screenshot
 ui-options-function-take-screenshot-no-ui = Take screenshot (without UI)

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -137,6 +137,7 @@ ui-options-function-open-admin-menu = Open admin menu
 ui-options-function-open-guidebook = Open guidebook
 ui-options-function-window-close-all = Close all windows
 ui-options-function-window-close-recent = Close recent window
+ui-options-function-show-escape-menu = Toggle menu
 
 ui-options-function-take-screenshot = Take screenshot
 ui-options-function-take-screenshot-no-ui = Take screenshot (without UI)

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -79,7 +79,7 @@ binds:
 # Misc
 - function: ShowEscapeMenu
   type: State
-  key: F11
+  key: F10
 - function: CycleChatChannelForward
   type: State
   key: Tab

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -79,7 +79,7 @@ binds:
 # Misc
 - function: ShowEscapeMenu
   type: State
-  key: F12
+  key: F11
 - function: CycleChatChannelForward
   type: State
   key: Tab


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- Steam users have F12 bound to screenshot, so they would prefer F12 not be bound to anything
- It's now possible to bind the menu key yourself via the UI (allows users to put it back on ESC if they want to)

<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://user-images.githubusercontent.com/22365940/230997367-e5e69ec3-37eb-429e-b3f6-8ae451aab549.mp4
(In the middle of the test video I forgot F6/F7 are already bound to things :P )


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Ability to bind the menu toggle key directly in the UI
- tweak: Default menu toggle moved from F12 to F10