### PR TITLE
add the ability to override the equipped state sprite clothing system uses for custom prototypes.

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -142,9 +142,15 @@ public sealed class ClientClothingSystem : ClothingSystem
         var correctedSlot = slot;
         TemporarySlotMap.TryGetValue(correctedSlot, out correctedSlot);
 
-        var state = (clothing.EquippedPrefix == null)
-            ? $"equipped-{correctedSlot}"
-            : $"{clothing.EquippedPrefix}-equipped-{correctedSlot}";
+
+
+        var state = $"equipped-{correctedSlot}";
+
+        if (clothing.EquippedPrefix != null)
+            state = $"{clothing.EquippedPrefix}-equipped-{correctedSlot}";
+
+        if (clothing.EquippedState != null)
+            state = $"{clothing.EquippedState}";
 
         // species specific
         if (speciesId != null && rsi.TryGetState($"{state}-{speciesId}", out _))

--- a/Content.Shared/Clothing/Components/ClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ClothingComponent.cs
@@ -40,6 +40,15 @@ public sealed class ClothingComponent : Component
     [DataField("equippedPrefix")]
     public string? EquippedPrefix;
 
+    /// <summary>
+    /// Allows the equipped state to be directly overwritten.
+    /// useful when prototyping INNERCLOTHING items into OUTERCLOTHING items without duplicating/modifying RSIs etc.
+    /// </summary>
+    [Access(typeof(ClothingSystem))]
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("equippedState")]
+    public string? EquippedState;
+
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("sprite")]
     public string? RsiPath;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This pr adds in the ability to override what equipped state clothing system uses in the given sprite.

The clothing system by default is hardcoded to look for a "equipped-SLOT" state.

this is a problem when you want to take a jumpsuit for example, and make it into a hardsuit. 

you would have had to download the rsi, rename the equipped-INNERCLOTHING state to equipped-OUTERCLOTHING, and then use/reupload this modified RSI in the prototype.

This is wasteful and duplicates sprites that could easily be handled by an override/remapping. 

Now all you need to do is to specify what sprite layer you want to use and clothing system will use that layer for the slot like so to override the defaults!

``` 
 #instead of clothing system using equipped-OUTER, we override 
 #and tell it to use equipped-INNER on this hardsuit prototype like so!
  - type: Clothing
    sprite: Clothing/Mask/clown.rsi
    equippedState: equipped-INNERCLOTHING
```

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

[discord message with media](https://discord.com/channels/310555209753690112/310555209753690112/1095118409534013541)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

