### PR TITLE
Update title of "Esc Menu" window to "Game Menu"

### DIFF
--- a/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
@@ -1,6 +1,6 @@
 ### EscapeMenu.xaml
 
-ui-escape-title = Esc Menu
+ui-escape-title = Game Menu
 ui-escape-options = Options
 ui-escape-rules = Rules
 ui-escape-guidebook = Guidebook


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
In the other PR https://github.com/space-wizards/space-station-14/pull/15287#pullrequestreview-1378282211, @vulppine noticed that the game menu was referred to as 'Esc Menu' in some places.   (Esc menu naming doesn't make much sense now that the menu is key-independent, so @ShadowCommander suggested a better name, Game Menu.)  

@ShadowCommander already got it updated in the key bindings window, which is great, but I realized it was also still shown that way on the game menu window itself.  This updates the title of the menu window itself it so it has the updated name.



<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://user-images.githubusercontent.com/22365940/231060910-0fc01f7c-1e02-4572-a175-c37b031f1050.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: 'Esc Menu' title renamed to 'Game Menu'