### PR TITLE
Drain buffs

### DIFF
--- a/Content.Shared/Fluids/Components/DrainComponent.cs
+++ b/Content.Shared/Fluids/Components/DrainComponent.cs
@@ -22,7 +22,7 @@ public sealed class DrainComponent : Component
     /// How many units are ejected from the buffer per second.
     /// </summary>
     [DataField("unitsDestroyedPerSecond")]
-    public float UnitsDestroyedPerSecond = 1f;
+    public float UnitsDestroyedPerSecond = 3f;
 
     /// <summary>
     /// How many (unobstructed) tiles away the drain will

--- a/Content.Shared/Fluids/Components/DrainComponent.cs
+++ b/Content.Shared/Fluids/Components/DrainComponent.cs
@@ -22,7 +22,7 @@ public sealed class DrainComponent : Component
     /// How many units are ejected from the buffer per second.
     /// </summary>
     [DataField("unitsDestroyedPerSecond")]
-    public float UnitsDestroyedPerSecond = 3f;
+    public float UnitsDestroyedPerSecond = 1f;
 
     /// <summary>
     /// How many (unobstructed) tiles away the drain will

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -327,7 +327,7 @@
     - type: SolutionContainerManager
       solutions:
         drainBuffer:
-          maxVol: 500
+          maxVol: 1000
     - type: DrainableSolution
       solution: drainBuffer
     - type: Damageable

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -327,7 +327,7 @@
     - type: SolutionContainerManager
       solutions:
         drainBuffer:
-          maxVol: 1000
+          maxVol: 500
     - type: DrainableSolution
       solution: drainBuffer
     - type: Damageable


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Mid/Late round janitor has felt like a slog because there's a lot more draining the cart, but it got full incredibly quickly and drained slowly.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: EnDecc
- tweak: Doubled drain buffer size from 500u > 1000u, Tripled units deleted per tick from 1 > 3
