### PR TITLE
dont play sound if using tool was interrupted

### DIFF
--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -22,7 +22,9 @@ public abstract partial class SharedToolSystem : EntitySystem
 
     private void OnDoAfter(EntityUid uid, ToolComponent tool, ToolDoAfterEvent args)
     {
-        PlayToolSound(uid, tool, args.User);
+        if (!args.Cancelled)
+            PlayToolSound(uid, tool, args.User);
+
         var ev = args.WrappedEvent;
         ev.DoAfter = args.DoAfter;
 


### PR DESCRIPTION
## About the PR
this fucked me up so much since i would assume if sound played it worked and this combining with doafter predicting properly (i was used to taking ping in account for doafters) would make speedbuilding things very hard aaaaaaaa thanks for reading ted talk :trollface:

**Media**
no

**Changelog**
:cl:
- fix: Tools no longer make sounds if using them fails.