### PR TITLE
reduced max solar power to 750 from 1500

### DIFF
--- a/Content.Server/Solar/Components/SolarPanelComponent.cs
+++ b/Content.Server/Solar/Components/SolarPanelComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Solar.Components
         /// Maximum supply output by this panel (coverage = 1)
         /// </summary>
         [DataField("maxSupply")]
-        public int MaxSupply = 1500;
+        public int MaxSupply = 750;
 
         /// <summary>
         /// Current coverage of this panel (from 0 to 1).


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes #15155

Potential fix to the above issue, some calculations in that issue too but generally this halves the maximum output of solars so they're a baseline power source for things like lights and life support only and not designed to fully power a station.

Also means you need a reasonable amount of solar panels on a shuttle to provide power, so they're not suitable for tiny shuttles, only mid sized ones.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

- tweak: Halved the power output of solar panels.
