### PR TITLE
Stop toys from electrocuting on attack

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -130,6 +130,13 @@ namespace Content.Server.Electrocution
             if (!electrified.OnAttacked)
                 return;
 
+            //Dont shock if the attacker used a toy
+            if (EntityManager.TryGetComponent<MeleeWeaponComponent>(args.Used, out var meleeWeaponComponent))
+            {
+                if (meleeWeaponComponent.Damage.Total == 0)
+                    return;
+            }
+
             TryDoElectrifiedAct(uid, args.User, 1, electrified);
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Hitting electrified objects with a toy (melee weapon with 0 damage) will no longer electrocute you
Resolves #15173 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->


https://user-images.githubusercontent.com/46636558/231256351-5a90a0e6-3cb1-44df-ab71-0bfe94c89d61.mp4



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Mumohan
- fix: Plushies and other toys no longer conduct electricity