### PR TITLE
Fix not showing ahelp relay label to players

### DIFF
--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -39,7 +39,7 @@ public sealed class AHelpUIController: UIController, IOnStateChanged<GameplaySta
     {
         base.Initialize();
 
-        SubscribeNetworkEvent<SharedBwoinkSystem.BwoinkDiscordRelayUpdated>(DiscordRelayUpdated);
+        SubscribeNetworkEvent<BwoinkDiscordRelayUpdated>(DiscordRelayUpdated);
     }
 
     public void OnStateEntered(GameplayState state)
@@ -137,7 +137,7 @@ public sealed class AHelpUIController: UIController, IOnStateChanged<GameplaySta
         UIHelper!.Receive(message);
     }
 
-    private void DiscordRelayUpdated(SharedBwoinkSystem.BwoinkDiscordRelayUpdated args, EntitySessionEventArgs session)
+    private void DiscordRelayUpdated(BwoinkDiscordRelayUpdated args, EntitySessionEventArgs session)
     {
         _discordRelayActive = args.DiscordRelayEnabled;
         UIHelper?.DiscordRelayChanged(_discordRelayActive);

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -15,6 +15,7 @@ using JetBrains.Annotations;
 using Robust.Server.Player;
 using Robust.Shared;
 using Robust.Shared.Configuration;
+using Robust.Shared.Enums;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
 
@@ -63,8 +64,17 @@ namespace Content.Server.Administration.Systems
             _config.OnValueChanged(CVars.GameHostName, OnServerNameChanged, true);
             _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("AHELP");
             _maxAdditionalChars = GenerateAHelpMessage("", "", true).Length;
+            _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
 
             SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameRunLevelChanged);
+        }
+
+        private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
+        {
+            if (e.NewStatus != SessionStatus.InGame)
+                return;
+
+            RaiseNetworkEvent(new BwoinkDiscordRelayUpdated(!string.IsNullOrWhiteSpace(_webhookUrl)), e.Session);
         }
 
         private void OnGameRunLevelChanged(GameRunLevelChangedEvent args)

--- a/Content.Shared/Administration/SharedBwoinkSystem.cs
+++ b/Content.Shared/Administration/SharedBwoinkSystem.cs
@@ -46,20 +46,20 @@ namespace Content.Shared.Administration
                 Text = text;
             }
         }
+    }
 
-        /// <summary>
-        ///     Sent by the server to notify all clients when the webhook url is sent.
-        ///     The webhook url itself is not and should not be sent.
-        /// </summary>
-        [Serializable, NetSerializable]
-        public sealed class BwoinkDiscordRelayUpdated : EntityEventArgs
+    /// <summary>
+    ///     Sent by the server to notify all clients when the webhook url is sent.
+    ///     The webhook url itself is not and should not be sent.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed class BwoinkDiscordRelayUpdated : EntityEventArgs
+    {
+        public bool DiscordRelayEnabled { get; }
+
+        public BwoinkDiscordRelayUpdated(bool enabled)
         {
-            public bool DiscordRelayEnabled { get; }
-
-            public BwoinkDiscordRelayUpdated(bool enabled)
-            {
-                DiscordRelayEnabled = enabled;
-            }
+            DiscordRelayEnabled = enabled;
         }
     }
 }


### PR DESCRIPTION
## About the PR
**Media**

https://user-images.githubusercontent.com/10968691/231297246-2b5c36aa-0d4d-4e8e-9f7a-c19ffbdad0a0.mp4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed not showing the ahelp relay label unless the relay was changed while connected.