### PR TITLE
Use AllEntityQuery<> In power systems

### DIFF
--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -73,10 +73,10 @@ namespace Content.Server.Power.EntitySystems
             while (enumerator.MoveNext(out var uid, out var netBat, out var bat))
             {
                 var netCharge = netBat.NetworkBattery.CurrentStorage;
-                if (MathHelper.CloseToPercent(bat.CurrentCharge, netCharge))
+                if (MathHelper.CloseTo(bat.CurrentCharge, netCharge))
                     continue;
 
-                bat.CurrentCharge = netBat.NetworkBattery.CurrentStorage;
+                bat.CurrentCharge = netCharge;
             }
         }
 

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -57,7 +57,9 @@ namespace Content.Server.Power.EntitySystems
 
         private void PreSync(NetworkBatteryPreSync ev)
         {
-            foreach (var (netBat, bat) in EntityManager.EntityQuery<PowerNetworkBatteryComponent, BatteryComponent>())
+            // Ignoring entity pausing. If the entity was paused, neither component's data should have been changed.
+            var enumerator = AllEntityQuery<PowerNetworkBatteryComponent, BatteryComponent>();
+            while (enumerator.MoveNext(out var netBat, out var bat))
             {
                 netBat.NetworkBattery.Capacity = bat.MaxCharge;
                 netBat.NetworkBattery.CurrentStorage = bat.CurrentCharge;
@@ -66,8 +68,14 @@ namespace Content.Server.Power.EntitySystems
 
         private void PostSync(NetworkBatteryPostSync ev)
         {
-            foreach (var (netBat, bat) in EntityManager.EntityQuery<PowerNetworkBatteryComponent, BatteryComponent>())
+            // Ignoring entity pausing. If the entity was paused, neither component's data should have been changed.
+            var enumerator = AllEntityQuery<PowerNetworkBatteryComponent, BatteryComponent>();
+            while (enumerator.MoveNext(out var uid, out var netBat, out var bat))
             {
+                var netCharge = netBat.NetworkBattery.CurrentStorage;
+                if (MathHelper.CloseToPercent(bat.CurrentCharge, netCharge))
+                    continue;
+
                 bat.CurrentCharge = netBat.NetworkBattery.CurrentStorage;
             }
         }
@@ -93,7 +101,7 @@ namespace Content.Server.Power.EntitySystems
         private void OnEmpPulse(EntityUid uid, BatteryComponent component, ref EmpPulseEvent args)
         {
             args.Affected = true;
-            component.UseCharge(args.EnergyConsumption);   
+            component.UseCharge(args.EnergyConsumption);
         }
     }
 }

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -289,11 +289,15 @@ namespace Content.Server.Power.EntitySystems
         private void UpdateApcPowerReceiver()
         {
             var appearanceQuery = GetEntityQuery<AppearanceComponent>();
-            var enumerator = EntityQueryEnumerator<ApcPowerReceiverComponent>();
-            while (enumerator.MoveNext(out var apcReceiver))
+            var metaQuery = GetEntityQuery<MetaDataComponent>();
+            var enumerator = AllEntityQuery<ApcPowerReceiverComponent>();
+            while (enumerator.MoveNext(out var uid, out var apcReceiver))
             {
                 var powered = apcReceiver.Powered;
                 if (powered == apcReceiver.PoweredLastUpdate)
+                    continue;
+
+                if (metaQuery.GetComponent(uid).EntityPaused)
                     continue;
 
                 apcReceiver.PoweredLastUpdate = powered;
@@ -301,24 +305,28 @@ namespace Content.Server.Power.EntitySystems
 
                 RaiseLocalEvent(apcReceiver.Owner, ref ev);
 
-                if (appearanceQuery.TryGetComponent(apcReceiver.Owner, out var appearance))
-                    _appearance.SetData(appearance.Owner, PowerDeviceVisuals.Powered, powered, appearance);
+                if (appearanceQuery.TryGetComponent(uid, out var appearance))
+                    _appearance.SetData(uid, PowerDeviceVisuals.Powered, powered, appearance);
             }
         }
 
         private void UpdatePowerConsumer()
         {
-            var enumerator = EntityQueryEnumerator<PowerConsumerComponent>();
-            while (enumerator.MoveNext(out var consumer))
+            var metaQuery = GetEntityQuery<MetaDataComponent>();
+            var enumerator = AllEntityQuery<PowerConsumerComponent>();
+            while (enumerator.MoveNext(out var uid, out var consumer))
             {
                 var newRecv = consumer.NetworkLoad.ReceivingPower;
                 ref var lastRecv = ref consumer.LastReceived;
                 if (MathHelper.CloseToPercent(lastRecv, newRecv))
                     continue;
 
+                if (metaQuery.GetComponent(uid).EntityPaused)
+                    continue;
+
                 lastRecv = newRecv;
                 var msg = new PowerConsumerReceivedChanged(newRecv, consumer.DrawRate);
-                RaiseLocalEvent(consumer.Owner, ref msg);
+                RaiseLocalEvent(uid, ref msg);
             }
         }
 

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -33,7 +33,7 @@ namespace Content.Server.Power.Pow3r
             foreach (var group in state.GroupedNets)
             {
                 // Note that many net-layers only have a handful of networks.
-                // E.g., the number of nets from lowest to heights for box and saltern are:
+                // E.g., the number of nets from lowest to highest for box and saltern are:
                 // Saltern: 1477, 11, 2, 2, 3.
                 // Box:     3308, 20, 1, 5.
                 //
@@ -164,7 +164,7 @@ namespace Content.Server.Power.Pow3r
                     battery.AvailableSupply = Math.Min(scaledSpace, supplyAndPassthrough);
                     battery.LoadingNetworkDemand = unmet;
 
-                    battery.MaxEffectiveSupply = Math.Min(battery.CurrentStorage / frameTime, battery.MaxSupply + battery.CurrentReceiving * battery.Efficiency); 
+                    battery.MaxEffectiveSupply = Math.Min(battery.CurrentStorage / frameTime, battery.MaxSupply + battery.CurrentReceiving * battery.Efficiency);
                     totalBatterySupply += battery.AvailableSupply;
                     totalMaxBatterySupply += battery.MaxEffectiveSupply;
                 }
@@ -174,7 +174,7 @@ namespace Content.Server.Power.Pow3r
             network.LastCombinedMaxSupply = totalMaxSupply + totalMaxBatterySupply;
 
             var met = Math.Min(demand, network.LastCombinedSupply);
-            if (met == 0) 
+            if (met == 0)
                 return;
 
             var supplyRatio = met / demand;
@@ -228,7 +228,7 @@ namespace Content.Server.Power.Pow3r
                     supply.SupplyRampTarget = supply.MaxSupply * targetRelativeSupplyOutput;
                 }
             }
-            
+
             if (unmet <= 0 || totalBatterySupply <= 0)
                 return;
 


### PR DESCRIPTION
This replaces some power system entity queries with AllEntityQuery<> with separate pause checks.

The rationale is that the majority of entities on live servers will be unpaused, and these specific entity queries only occasionally have an effect (when an entity changes from powered to unpowered), so its better to defer fetching the meta data component until it we need to actually check if the entity is paused. This also makes the pre- and post- sync enumerators just ignore pausing, which **should** have no effect.

Also stops `ChargeChangedEvent` from being raised every tick for every battery, now it should only be raised when the charge actually changes.