### PR TITLE
[BUG] fixing lizard's stomach sizes

### DIFF
--- a/Resources/Prototypes/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/Body/Organs/reptilian.yml
@@ -4,4 +4,4 @@
   noSpawn: true
   components:
   - type: Stomach
-    maxVolume: 50
+    maxVol: 50


### PR DESCRIPTION
My first ever PR and it's a webeddit, yay. Can't see this going wrong or just straight out denied. 

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
fixes #15108 = lizards having twice the stomach volumes they should


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- Lizards have found digestion easier as they no longer suffer from x2 size stomachs.
