### PR TITLE
Change sleep action icon to syndie pyjama

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -129,13 +129,13 @@
   name: action-name-sleep
   description: action-desc-sleep
   checkCanInteract: false
-  icon: { sprite: Objects/Consumable/Food/egg.rsi, state: icon }
+  icon: { sprite: Clothing/Head/Hats/pyjamasyndicatered.rsi, state: icon }
   event: !type:SleepActionEvent
 
 - type: instantAction
   id: Wake
   name: action-name-wake
   description: action-desc-wake
-  icon: { sprite: Objects/Consumable/Food/egg.rsi, state: icon }
+  icon: { sprite: Clothing/Head/Hats/pyjamasyndicatered.rsi, state: icon }
   checkCanInteract: false
   event: !type:WakeActionEvent


### PR DESCRIPTION
Change sleep and wake actions icons to syndie pyjamas hat (which is more logical than just an egg)

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<img width="167" alt="hat" src="https://user-images.githubusercontent.com/81412348/231523771-8bbb6e40-05e1-4a46-b08b-a58c8b886d77.png">

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: mhamster
- tweak: Changed sleep action icon from egg to syndie pyjama
