### PR TITLE
Vending machines use the robot typing indicator

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -52,6 +52,8 @@
     BoardName: "Vending Machine"
     LayoutId: Vending
   - type: Anchorable
+  - type: TypingIndicator
+    proto: robot
   - type: Speech
     speechSounds: Vending
   - type: DoAfter
@@ -849,7 +851,7 @@
     radius: 1.5
     energy: 1.6
     color: "#c73434"
-    
+
 - type: entity
   parent: VendingMachineSnack
   id: VendingMachineSustenance
@@ -1734,7 +1736,7 @@
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
     access: [["Medical"]]
-   
+
 - type: entity
   parent: VendingMachine
   id: VendingMachineCentDrobe
@@ -1760,7 +1762,7 @@
     radius: 1.5
     energy: 1.6
     color: "#48CF48"
-    
+
 - type: entity
   parent: VendingMachine
   id: VendingMachineHappyHonk


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Vending machines use the robot typing indicator, like pAIs.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/44417085/231569888-b6dbcca6-7402-4f67-9db3-c8c4be26c058.png)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- tweak: Vending machines now use the robot typing indicator.