### PR TITLE
Captain's sabre sheath uses item slots

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -83,9 +83,13 @@
   parent: ClothingBeltSheath
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: CaptainSabre
+  - type: ItemSlots
+    slots:
+      sabreSlot:
+        startingItem: CaptainSabre
+        whitelist:
+          tags:
+            - CaptainSabre
 
 - type: entity
   id: ClothingBeltMilitaryWebbingMedFilled

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -371,7 +371,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: ClothingBeltBase
   id: ClothingBeltSheath
   name: sabre sheath
   description: An ornate sheath designed to hold an officer's blade.
@@ -381,11 +381,12 @@
     state: sheath
   - type: Clothing
     sprite: Clothing/Belt/sheath.rsi
-  - type: Storage
-    capacity: 15
-    whitelist:
-      tags:
-        - CaptainSabre
+  - type: ItemSlots
+    slots:
+      sabreSlot:
+        whitelist:
+          tags:
+            - CaptainSabre
   - type: ItemMapper
     mapLayers:
       sheath-sabre:

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -381,6 +381,9 @@
     state: sheath
   - type: Clothing
     sprite: Clothing/Belt/sheath.rsi
+  - type: ContainerContainer
+    containers:
+      sabreSlot: !type:ContainerSlot
   - type: ItemSlots
     slots:
       sabreSlot:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
The Captain's sabre sheath used to be a container that held the sabre. This PR makes it uses an item slot that allows quick access to draw the sabre. I did this as it is how I expected the sheath would work when I first saw it.

Prerequisites:
- [ ] support for quick draw from ItemSlots in belt slot.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
https://user-images.githubusercontent.com/44417085/231779993-c8cc28a9-9a0b-49c1-893f-4b16d3264a62.mp4
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- tweak: The Captain's sabre sheath is easier to use.
