### PR TITLE
Adjusted cake sizes to make cake size = 25, slice = 5

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Item;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
@@ -79,7 +80,15 @@ namespace Content.Server.Nutrition.EntitySystems
             SoundSystem.Play(component.Sound.GetSound(), Filter.Pvs(uid),
                 transform.Coordinates, AudioParams.Default.WithVolume(-2));
 
+            // Decrease size of item based on count - Could implement in the future
+            // Bug with this currently is the size in a container is not updated
+            // if (TryComp(uid, out ItemComponent? itemComp) && TryComp(sliceUid, out ItemComponent? sliceComp))
+            // {
+            //     itemComp.Size -= sliceComp.Size;
+            // }
+
             component.Count--;
+
             // If someone makes food proto with 1 slice...
             if (component.Count < 1)
             {

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -22,6 +22,8 @@
           Quantity: 20
         - ReagentId: Vitamin
           Quantity: 5
+  - type: Item
+    size: 25
 
 - type: entity
   parent: FoodCakeBase
@@ -43,6 +45,8 @@
           Quantity: 4
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Item
+    size: 5
 
 # Custom Cake Example
 
@@ -89,6 +93,8 @@
     - state: plain
   - type: SliceableFood
     slice: FoodCakePlainSlice
+
+# Added in type lines above
 
 - type: entity
   name: slice of cake


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

The image below shows a cake, resized to have size 25, and its slice with size 5.

![image](https://user-images.githubusercontent.com/61713849/231809784-5c9a6c67-0b55-4500-8a2e-7a50daa45403.png)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed Cake and Cake Slices from having sizes that do not add to the same value.
