### PR TITLE
Some fixes to magboots

### DIFF
--- a/Content.Client/Clothing/MagbootsSystem.cs
+++ b/Content.Client/Clothing/MagbootsSystem.cs
@@ -1,27 +1,8 @@
 using Content.Shared.Clothing;
-using Robust.Shared.GameStates;
-using static Content.Shared.Clothing.MagbootsComponent;
 
 namespace Content.Client.Clothing;
 
 public sealed class MagbootsSystem : SharedMagbootsSystem
 {
-    public override void Initialize()
-    {
-        base.Initialize();
 
-        SubscribeLocalEvent<MagbootsComponent, ComponentHandleState>(OnHandleState);
-    }
-
-    private void OnHandleState(EntityUid uid, MagbootsComponent component, ref ComponentHandleState args)
-    {
-        if (args.Current is not MagbootsComponentState componentState)
-            return;
-
-        if (component.On == componentState.On) return;
-        
-        component.On = componentState.On;
-        OnChanged(component);
-    }
 }
-

--- a/Content.Server/Clothing/MagbootsSystem.cs
+++ b/Content.Server/Clothing/MagbootsSystem.cs
@@ -1,19 +1,13 @@
 using Content.Server.Atmos.Components;
-using Content.Server.Clothing.Components;
 using Content.Shared.Alert;
 using Content.Shared.Clothing;
-using Content.Shared.Clothing.EntitySystems;
-using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
-using Robust.Shared.Containers;
-using Robust.Shared.GameStates;
-using static Content.Shared.Clothing.MagbootsComponent;
 
 namespace Content.Server.Clothing;
 
 public sealed class MagbootsSystem : SharedMagbootsSystem
 {
-    [Dependency] private readonly AlertsSystem _alertsSystem = default!;
+    [Dependency] private readonly AlertsSystem _alerts = default!;
 
     public override void Initialize()
     {
@@ -21,7 +15,6 @@ public sealed class MagbootsSystem : SharedMagbootsSystem
 
         SubscribeLocalEvent<MagbootsComponent, GotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<MagbootsComponent, GotUnequippedEvent>(OnGotUnequipped);
-        SubscribeLocalEvent<MagbootsComponent, ComponentGetState>(OnGetState);
     }
 
     protected override void UpdateMagbootEffects(EntityUid parent, EntityUid uid, bool state, MagbootsComponent? component)
@@ -37,11 +30,11 @@ public sealed class MagbootsSystem : SharedMagbootsSystem
 
         if (state)
         {
-            _alertsSystem.ShowAlert(parent, AlertType.Magboots);
+            _alerts.ShowAlert(parent, AlertType.Magboots);
         }
         else
         {
-            _alertsSystem.ClearAlert(parent, AlertType.Magboots);
+            _alerts.ClearAlert(parent, AlertType.Magboots);
         }
     }
 
@@ -59,10 +52,5 @@ public sealed class MagbootsSystem : SharedMagbootsSystem
         {
             UpdateMagbootEffects(args.Equipee, uid, true, component);
         }
-    }
-
-    private void OnGetState(EntityUid uid, MagbootsComponent component, ref ComponentGetState args)
-    {
-        args.State = new MagbootsComponentState(component.On);
     }
 }

--- a/Content.Shared/Clothing/MagbootsComponent.cs
+++ b/Content.Shared/Clothing/MagbootsComponent.cs
@@ -1,26 +1,15 @@
 using Content.Shared.Actions.ActionTypes;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Clothing;
 
-[RegisterComponent, NetworkedComponent()]
-public sealed class MagbootsComponent : Component
+[RegisterComponent, NetworkedComponent(), AutoGenerateComponentState]
+[Access(typeof(SharedMagbootsSystem))]
+public sealed partial class MagbootsComponent : Component
 {
     [DataField("toggleAction", required: true)]
     public InstantAction ToggleAction = new();
 
-    [ViewVariables]
+    [DataField("on"), AutoNetworkedField]
     public bool On;
-
-    [Serializable, NetSerializable]
-    public sealed class MagbootsComponentState : ComponentState
-    {
-        public bool On { get; }
-
-        public MagbootsComponentState(bool @on)
-        {
-            On = on;
-        }
-    }
 }

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -15,7 +15,7 @@
     - type: Magboots
       toggleAction:
         icon: { sprite: Clothing/Shoes/Boots/magboots.rsi, state: icon }
-        iconOn: Clothing/Shoes/Boots/magboots.rsi/icon-on.png
+        iconOn: { sprite : Clothing/Shoes/Boots/magboots.rsi, state: icon-on }
         name: action-name-magboot-toggle
         description: action-decription-magboot-toggle
         itemIconStyle: NoItem


### PR DESCRIPTION
* Fixed the magboots sprite not updating on toggling
* Fixed the broken Toggling verb
* Various code cleaning (owner removal, raw texture reference replaced by state ref)
* Autogenerates states, courtesy of @deltanedas 

Fixing the icon duplication bug is out of scope from this PR (as it doesn't only touch magboots and would requires rewriting a part of the Equip system).

I've not added the poweronoff switch icon to the toggling verb since it's bigger than the other verbs icons and breaks the visual coherence of the menu.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Magboots sprite now updates on toggling. The toggling verb works properly too.
