### PR TITLE
Add autocomplete to setgamepreset command

### DIFF
--- a/Content.Server/GameTicking/Commands/SetGamePresetCommand.cs
+++ b/Content.Server/GameTicking/Commands/SetGamePresetCommand.cs
@@ -1,12 +1,17 @@
 ﻿using Content.Server.Administration;
+using Content.Server.GameTicking.Presets;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.GameTicking.Commands
 {
     [AdminCommand(AdminFlags.Round)]
-    sealed class SetGamePresetCommand : IConsoleCommand
+    public sealed class SetGamePresetCommand : IConsoleCommand
     {
+        [Dependency] private readonly IEntityManager _entity = default!;
+        [Dependency] private readonly IPrototypeManager _prototype = default!;
+
         public string Command => "setgamepreset";
         public string Description => Loc.GetString("set-game-preset-command-description", ("command", Command));
         public string Help => Loc.GetString("set-game-preset-command-help-text", ("command", Command));
@@ -19,7 +24,7 @@ namespace Content.Server.GameTicking.Commands
                 return;
             }
 
-            var ticker = EntitySystem.Get<GameTicker>();
+            var ticker = _entity.System<GameTicker>();
 
             if (!ticker.TryFindGamePreset(args[0], out var preset))
             {
@@ -29,6 +34,23 @@ namespace Content.Server.GameTicking.Commands
 
             ticker.SetGamePreset(preset);
             shell.WriteLine(Loc.GetString("set-game-preset-preset-set", ("preset", preset.ID)));
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 1)
+            {
+                var gamePresets = _prototype.EnumeratePrototypes<GamePresetPrototype>();
+                var options = new List<string>();
+                foreach (var preset in gamePresets)
+                {
+                    options.Add(preset.ID);
+                    options.AddRange(preset.Alias);
+                }
+
+                return CompletionResult.FromHintOptions(options, "<id>");
+            }
+            return CompletionResult.Empty;
         }
     }
 }

--- a/Content.Server/GameTicking/Commands/SetGamePresetCommand.cs
+++ b/Content.Server/GameTicking/Commands/SetGamePresetCommand.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.Administration;
+﻿using System.Linq;
+using Content.Server.Administration;
 using Content.Server.GameTicking.Presets;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
@@ -40,7 +41,8 @@ namespace Content.Server.GameTicking.Commands
         {
             if (args.Length == 1)
             {
-                var gamePresets = _prototype.EnumeratePrototypes<GamePresetPrototype>();
+                var gamePresets = _prototype.EnumeratePrototypes<GamePresetPrototype>()
+                    .OrderBy(p => p.ID);
                 var options = new List<string>();
                 foreach (var preset in gamePresets)
                 {

--- a/Resources/Locale/en-US/game-ticking/set-game-preset-command.ftl
+++ b/Resources/Locale/en-US/game-ticking/set-game-preset-command.ftl
@@ -1,2 +1,5 @@
+set-game-preset-command-description = Sets the game preset for the current round.
+set-game-preset-command-help-text = setgamepreset <id>
+
 set-game-preset-preset-error = Unable to find game preset "{$preset}"
 set-game-preset-preset-set = Set game preset to "{$preset}"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
bro i can't remember that shit gimme autocomplete

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/98561806/231914169-f0f8b4a5-fc84-413c-b077-796d205ada43.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
no cl no fun
