### PR TITLE
Server-side light level system

### DIFF
--- a/Content.Shared/Light/LightLevelSystem.cs
+++ b/Content.Shared/Light/LightLevelSystem.cs
@@ -9,8 +9,11 @@ namespace Content.Shared.Light;
 
 public sealed class LightLevelSystem : EntitySystem
 {
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public const float MaxLightRange = 15f;
 
     private bool Ignored(EntityUid ignored)
     {
@@ -32,8 +35,11 @@ public sealed class LightLevelSystem : EntitySystem
         // todo: in the future, this should support light on planet maps.
         var lightLevel = 0f;
 
-        foreach (var (light, xform) in EntityQuery<SharedPointLightComponent, TransformComponent>(true))
+        foreach (var light in _entityLookup.GetComponentsInRange<SharedPointLightComponent>(map, pos, MaxLightRange))
         {
+            // todo mercy until entityLookup supports multiple components
+            var xform = Transform(light.Owner);
+
             if (!light.Enabled)
                 continue;
 

--- a/Content.Shared/Light/LightLevelSystem.cs
+++ b/Content.Shared/Light/LightLevelSystem.cs
@@ -1,0 +1,74 @@
+﻿using System.Linq;
+using Content.Shared.Physics;
+using JetBrains.Annotations;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Shared.Light;
+
+public sealed class LightLevelSystem : EntitySystem
+{
+    [Dependency] private readonly IMapManager _map = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private bool Ignored(EntityUid ignored)
+    {
+        return !Transform(ignored).Anchored;
+    }
+
+    [PublicAPI]
+    public float GetLightLevel(EntityUid uid, TransformComponent? xform = null)
+    {
+        if (!Resolve(uid, ref xform))
+            return 0f;
+        var pos = _transform.GetWorldPosition(xform);
+        return GetLightLevel(pos, xform.MapID);
+    }
+
+    [PublicAPI]
+    public float GetLightLevel(Vector2 pos, MapId map)
+    {
+        // todo: in the future, this should support light on planet maps.
+        var lightLevel = 0f;
+
+        var validLights = new HashSet<(SharedPointLightComponent, TransformComponent)>();
+        foreach (var (light, xform) in EntityQuery<SharedPointLightComponent, TransformComponent>(true))
+        {
+            if (!light.Enabled)
+                continue;
+
+            if (xform.MapID != map)
+                continue;
+            validLights.Add((light, xform));
+        }
+
+        // quit while we're ahead.
+        if (validLights.Count == 0)
+            return lightLevel;
+
+        foreach (var (light, xform) in validLights)
+        {
+            var lightRot = _transform.GetWorldRotation(xform);
+            var lightPos = _transform.GetWorldPosition(xform) + lightRot.RotateVec(light.Offset);
+            var direction = pos - lightPos;
+            var length = direction.Length;
+            if (length > light.Radius)
+                continue;
+
+            if (light.CastShadows && !direction.LengthSquared.Equals(0f))
+            {
+                var ray = new CollisionRay(lightPos, direction.Normalized, (int) CollisionGroup.Opaque);
+                var rayResults = _physics.IntersectRayWithPredicate(map, ray, length, Ignored, false).ToList();
+                if (rayResults.Count != 0)
+                    continue;
+            }
+
+            var strength = light.Energy * (1f - length / light.Radius);
+            lightLevel += strength;
+        }
+
+        return lightLevel;
+    }
+}

--- a/Content.Shared/Light/LightLevelSystem.cs
+++ b/Content.Shared/Light/LightLevelSystem.cs
@@ -9,7 +9,6 @@ namespace Content.Shared.Light;
 
 public sealed class LightLevelSystem : EntitySystem
 {
-    [Dependency] private readonly IMapManager _map = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 

--- a/Content.Shared/Light/LightLevelSystem.cs
+++ b/Content.Shared/Light/LightLevelSystem.cs
@@ -32,7 +32,6 @@ public sealed class LightLevelSystem : EntitySystem
         // todo: in the future, this should support light on planet maps.
         var lightLevel = 0f;
 
-        var validLights = new HashSet<(SharedPointLightComponent, TransformComponent)>();
         foreach (var (light, xform) in EntityQuery<SharedPointLightComponent, TransformComponent>(true))
         {
             if (!light.Enabled)
@@ -40,15 +39,7 @@ public sealed class LightLevelSystem : EntitySystem
 
             if (xform.MapID != map)
                 continue;
-            validLights.Add((light, xform));
-        }
 
-        // quit while we're ahead.
-        if (validLights.Count == 0)
-            return lightLevel;
-
-        foreach (var (light, xform) in validLights)
-        {
             var lightRot = _transform.GetWorldRotation(xform);
             var lightPos = _transform.GetWorldPosition(xform) + lightRot.RotateVec(light.Offset);
             var direction = pos - lightPos;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adds a system for calculating how much "light" is in a certain position on the map.
is based on a pretty rudimentary estimation using pointlightcomponents
Perhaps not all that efficient; i really don't know.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
no cl no fun
