### PR TITLE
Spreaders travels across connected grids and SpreaderIgnore tag

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -86,14 +86,6 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
             return;
         }
 
-        var xform = Transform(uid);
-
-        if (!TryComp<MapGridComponent>(xform.GridUid, out var grid))
-        {
-            RemCompDeferred<EdgeSpreaderComponent>(uid);
-            return;
-        }
-
         var puddleQuery = GetEntityQuery<PuddleComponent>();
 
         // First we overflow to neighbors with overflow capacity
@@ -141,10 +133,10 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
             _random.Shuffle(args.NeighborFreeTiles);
             var spillAmount = overflow.Volume / args.NeighborFreeTiles.Count;
 
-            foreach (var tile in args.NeighborFreeTiles)
+            foreach (var neighbor in args.NeighborFreeTiles)
             {
                 var split = overflow.SplitSolution(spillAmount);
-                TrySpillAt(grid.GridTileToLocal(tile), split, out _, false);
+                TrySpillAt(neighbor.Grid.GridTileToLocal(neighbor.Tile), split, out _, false);
                 args.Updates--;
 
                 if (args.Updates <= 0)

--- a/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
@@ -73,7 +73,6 @@ public sealed class SmokeSystem : EntitySystem
     private void OnSmokeSpread(EntityUid uid, SmokeComponent component, ref SpreadNeighborsEvent args)
     {
         if (component.SpreadAmount == 0 ||
-            args.Grid == null ||
             !_solutionSystem.TryGetSolution(uid, SmokeComponent.SolutionName, out var solution) ||
             args.NeighborFreeTiles.Count == 0)
         {
@@ -94,9 +93,9 @@ public sealed class SmokeSystem : EntitySystem
         var smokePerSpread = component.SpreadAmount / args.NeighborFreeTiles.Count;
         component.SpreadAmount -= smokePerSpread;
 
-        foreach (var tile in args.NeighborFreeTiles)
+        foreach (var neighbor in args.NeighborFreeTiles)
         {
-            var coords = args.Grid.GridTileToLocal(tile);
+            var coords = neighbor.Grid.GridTileToLocal(neighbor.Tile);
             var ent = Spawn(prototype.ID, coords.SnapToGrid());
             var neighborSmoke = EnsureComp<SmokeComponent>(ent);
             neighborSmoke.SpreadAmount = Math.Max(0, smokePerSpread - 1);

--- a/Content.Server/Spreader/KudzuSystem.cs
+++ b/Content.Server/Spreader/KudzuSystem.cs
@@ -28,7 +28,7 @@ public sealed class KudzuSystem : EntitySystem
             return;
         }
 
-        if (args.NeighborFreeTiles.Count == 0 || args.Grid == null)
+        if (args.NeighborFreeTiles.Count == 0)
         {
             RemCompDeferred<EdgeSpreaderComponent>(uid);
             return;
@@ -47,7 +47,7 @@ public sealed class KudzuSystem : EntitySystem
 
         foreach (var neighbor in args.NeighborFreeTiles)
         {
-            var neighborUid = Spawn(prototype, args.Grid.GridTileToLocal(neighbor));
+            var neighborUid = Spawn(prototype, neighbor.Grid.GridTileToLocal(neighbor.Tile));
             EnsureComp<EdgeSpreaderComponent>(neighborUid);
             args.Updates--;
 

--- a/Content.Server/Spreader/SpreadNeighborsEvent.cs
+++ b/Content.Server/Spreader/SpreadNeighborsEvent.cs
@@ -10,9 +10,7 @@ namespace Content.Server.Spreader;
 [ByRefEvent]
 public record struct SpreadNeighborsEvent
 {
-    public MapGridComponent? Grid;
-    public ValueList<Vector2i> NeighborFreeTiles;
-    public ValueList<Vector2i> NeighborOccupiedTiles;
+    public ValueList<(MapGridComponent Grid, Vector2i Tile)> NeighborFreeTiles;
     public ValueList<EntityUid> Neighbors;
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -43,10 +43,7 @@
       path: /Audio/Machines/airlock_deny.ogg
   - type: Airtight
     fixVacuum: true
-    airBlockedDirection:
-      - East
-      - West
-      - South
+    noAirWhenFullyAirBlocked: false
   - type: Tag
     tags:
       - ForceNoFixRotations

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -22,3 +22,6 @@
   - type: Airtight
     noAirWhenFullyAirBlocked: false
   - type: Clickable
+  - type: Tag
+    tags:
+      - SpreaderIgnore

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -594,6 +594,9 @@
   id: SpeedLoaderRifle
 
 - type: Tag
+  id: SpreaderIgnore
+
+- type: Tag
   id: StringInstrument
 
 - type: Tag


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31366439/232177618-b7f288cc-0a3f-4be5-bc1e-55db1c63a841.png)

I also checked thindows and they still seemed okay. Think I also fixed a bug with thindows on the same tile as the puddle.

:cl:
- add: Spreaders (kudzu, puddles, smoke) can now travel across docks.