### PR TITLE
Shotgun Safe

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -98,3 +98,95 @@
       - id: ClothingHeadHelmetBombSuit
       - id: ClothingOuterSuitBomb
       - id: ClothingMaskGas
+
+- type: entity
+  id: ShotgunCaseDisabler
+  suffix: Disabler
+  parent: ShotgunCase
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponDisabler
+        amount: 5
+
+- type: entity
+  id: ShotgunCasePistolMK58
+  suffix: MK58
+  parent: ShotgunCase
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponPistolMk58
+        amount: 4
+      - id: MagazinePistol
+        amount: 8
+
+- type: entity
+  id: ShotgunCaseRifleLecter
+  suffix: Lecter
+  parent: ShotgunCase
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponRifleLecter
+        amount: 2
+      - id: MagazineRifle
+        amount: 4
+
+- type: entity
+  id: ShotgunCaseSubMachineGunVector
+  suffix: Vector
+  parent: ShotgunCase
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponSubMachineGunVector
+        amount: 2
+      - id: MagazineMagnumSubMachineGun
+        amount: 4
+
+- type: entity
+  id: ShotgunCaseShotgunEnforcer
+  suffix: Enforcer
+  parent: ShotgunCase
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponShotgunEnforcer
+        amount: 2
+      - id: MagazineShotgun
+        amount: 4
+
+- type: entity
+  id: ShotgunCaseShotgunKammerer
+  suffix: Kammerer
+  parent: ShotgunCase
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponShotgunKammerer
+        amount: 2
+      - id: MagazineShotgun
+        amount: 4
+
+- type: entity
+  id: ShotgunCaseSubMachineGunWt550
+  suffix: Wt550
+  parent: ShotgunCase
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponSubMachineGunWt550
+        amount: 2
+      - id: MagazineMagnumSubMachineGun
+        amount: 4
+
+- type: entity
+  id: ShotgunCaseLaserCarbine
+  suffix: Laser Carbine
+  parent: ShotgunCase
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponLaserCarbine
+        amount: 3

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -100,9 +100,9 @@
       - id: ClothingMaskGas
 
 - type: entity
-  id: ShotgunCaseDisabler
+  id: ShotgunSafeDisabler
   suffix: Disabler
-  parent: ShotgunCase
+  parent: ShotgunSafe
   components:
   - type: StorageFill
     contents:
@@ -110,9 +110,9 @@
         amount: 5
 
 - type: entity
-  id: ShotgunCasePistolMK58
+  id: ShotgunSafePistolMK58
   suffix: MK58
-  parent: ShotgunCase
+  parent: ShotgunSafe
   components:
   - type: StorageFill
     contents:
@@ -122,9 +122,9 @@
         amount: 8
 
 - type: entity
-  id: ShotgunCaseRifleLecter
+  id: ShotgunSafeRifleLecter
   suffix: Lecter
-  parent: ShotgunCase
+  parent: ShotgunSafe
   components:
   - type: StorageFill
     contents:
@@ -134,9 +134,9 @@
         amount: 4
 
 - type: entity
-  id: ShotgunCaseSubMachineGunVector
+  id: ShotgunSafeSubMachineGunVector
   suffix: Vector
-  parent: ShotgunCase
+  parent: ShotgunSafe
   components:
   - type: StorageFill
     contents:
@@ -146,9 +146,9 @@
         amount: 4
 
 - type: entity
-  id: ShotgunCaseShotgunEnforcer
+  id: ShotgunSafeShotgunEnforcer
   suffix: Enforcer
-  parent: ShotgunCase
+  parent: ShotgunSafe
   components:
   - type: StorageFill
     contents:
@@ -158,9 +158,9 @@
         amount: 4
 
 - type: entity
-  id: ShotgunCaseShotgunKammerer
+  id: ShotgunSafeShotgunKammerer
   suffix: Kammerer
-  parent: ShotgunCase
+  parent: ShotgunSafe
   components:
   - type: StorageFill
     contents:
@@ -170,9 +170,9 @@
         amount: 4
 
 - type: entity
-  id: ShotgunCaseSubMachineGunWt550
+  id: ShotgunSafeSubMachineGunWt550
   suffix: Wt550
-  parent: ShotgunCase
+  parent: ShotgunSafe
   components:
   - type: StorageFill
     contents:
@@ -182,9 +182,9 @@
         amount: 4
 
 - type: entity
-  id: ShotgunCaseLaserCarbine
+  id: ShotgunSafeLaserCarbine
   suffix: Laser Carbine
-  parent: ShotgunCase
+  parent: ShotgunSafe
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -321,6 +321,20 @@
   - type: AccessReader
     access: [["Security"]]
 
+- type: entity
+  id: ShotgunCase
+  parent: LockerBaseSecure
+  name: shotgun case
+  components:
+  - type: Appearance
+    visuals:
+    - type: StorageVisualizer
+      state: shotguncase
+      state_open: shotguncase_open
+      state_closed: shotguncase_door
+  - type: AccessReader
+    access: [["Security"]]
+
 # Detective
 - type: entity
   id: LockerDetective

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -322,9 +322,9 @@
     access: [["Security"]]
 
 - type: entity
-  id: ShotgunCase
+  id: ShotgunSafe
   parent: LockerBaseSecure
-  name: shotgun case
+  name: shotgun safe
   components:
   - type: Appearance
     visuals:


### PR DESCRIPTION
## About the PR

I noticed that in the game there were sprite gun safes, but they were not used in any way. I fixed this, made kits with weapons for the Security Office, which can now be put in the Armory.

I think I put all the weapons I have in the Armory. Speak up if you need to add more Gun safes.
**Media**
![ShotgunCase](https://user-images.githubusercontent.com/128169402/232253847-34c75aba-2877-4bd0-92c4-a36abf1901c6.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: Nimfar

- add: Gun safe for SO, now weapons can be stored in even more security

