### PR TITLE
Allow eating and drinking to be cancelled.

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -282,7 +282,6 @@ namespace Content.Server.Nutrition.EntitySystems
                 // Mice and the like can eat without hands.
                 // TODO maybe set this based on some CanEatWithoutHands event or component?
                 NeedHand = forceDrink,
-                CancelDuplicate = false,
             };
 
             _doAfterSystem.TryStartDoAfter(doAfterEventArgs);

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -146,8 +146,6 @@ namespace Content.Server.Nutrition.EntitySystems
                 // Mice and the like can eat without hands.
                 // TODO maybe set this based on some CanEatWithoutHands event or component?
                 NeedHand = forceFeed,
-                //Works better with cancel duplicate on because you can just use again to stop
-                CancelDuplicate = false,
             };
 
             _doAfterSystem.TryStartDoAfter(doAfterArgs);


### PR DESCRIPTION
Added a "Needs Discussion" label because apparently some people dislike this behaviour, though AFAIK that was partly because the DoAfters didn't have an auto-repeat feature.

:cl:
- tweak: Eating and drinking interactions can once again be cancelled by using the item a second time.
