### PR TITLE
More Salamander CVar Changes

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/salamander.toml
+++ b/Resources/ConfigPresets/WizardsDen/salamander.toml
@@ -13,6 +13,12 @@ enabled = true
 reason = "whitelist-not-whitelisted-rp"
 min_players = 20
 
+[shuttle]
+emergency_early_launch_allowed = true
+
+[biomass]
+easy_mode = true
+
 [ooc]
 enable_during_round = true
 

--- a/Resources/ConfigPresets/WizardsDen/salamander.toml
+++ b/Resources/ConfigPresets/WizardsDen/salamander.toml
@@ -17,7 +17,7 @@ min_players = 20
 emergency_early_launch_allowed = true
 
 [biomass]
-easy_mode = true
+easy_mode = false
 
 [ooc]
 enable_during_round = true


### PR DESCRIPTION
Allows command staff to early launch the shuttle, and also enables biomass hard mode.

This should be 75% less controversial than the last PR, hopefully