### PR TITLE
Adds reaction for creating water

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -1,4 +1,14 @@
 - type: reaction
+  id: Water
+  reactants:
+    Hydrogen:
+      amount: 2
+    Oxygen:
+      amount: 1
+  products:
+    Water: 3
+
+- type: reaction
   id: Ammonia
   reactants:
     Hydrogen:


### PR DESCRIPTION
## About the PR
There are not that many recipes which require water, and it is not really hard to obtain,
but it is a bit annoying for a chemist to leave the room just to get some water.
This PR adds the ability to create water directly in the chemical dispenser,
which will make six recipes (which involve water) easier and two others
(which involve hydrogen and oxygen) harder as order now matters.

**Media**
The attached video shows that sulfuric acid and norepinephric acid are still possibly to make and how to create water in the chemical dispenser:
![making water in chemical dispenser](https://user-images.githubusercontent.com/309583/232295965-9eb1d5c5-fe7c-44bb-8d87-c86bd5e89eb4.mp4)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
add: added a reaction for creating water in the chemical dispenser