### PR TITLE
Remove stun and knockdown status effects before applying sleep

### DIFF
--- a/Content.Server/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Server/Bed/Sleep/SleepingSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
+using Content.Shared.StatusEffect;
 using Content.Shared.Slippery;
 using Content.Shared.Stunnable;
 using Content.Shared.Verbs;
@@ -29,6 +30,7 @@ namespace Content.Server.Bed.Sleep
         [Dependency] private readonly ActionsSystem _actionsSystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
+        [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
 
         public override void Initialize()
         {
@@ -53,6 +55,10 @@ namespace Content.Server.Bed.Sleep
             _prototypeManager.TryIndex<InstantActionPrototype>("Wake", out var wakeAction);
             if (args.FellAsleep)
             {
+                // Expiring status effects would remove the components needed for sleeping
+                _statusEffectsSystem.TryRemoveStatusEffect(uid, "Stun");
+                _statusEffectsSystem.TryRemoveStatusEffect(uid, "KnockedDown");
+
                 EnsureComp<StunnedComponent>(uid);
                 EnsureComp<KnockedDownComponent>(uid);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Sleeping applies the same components. If the effects are not removed before applying those components, the expiring status effects remove the components before the sleep ends.

This probably isn't the optimal way to fix the bug, but I tried these alternatives:
1. Converting the Stun status effect to ForcedSleeping
2. Blocking removal of the Stun and KnockedDown components while Sleep component is active

Issues with the above:
1. Chloral Hydrate adds more duration to the ForcedSleep -> would buff sleep reagents
2. Couldn't find a way to do it. Lifestage events aren't cancellable, and StatusEffectsSystem doesn't have a way to prevent it from removing a component used by another status effect.

A more involved fix could be to make StatusEffectsSystem check that there are no effects using the same component before removing, and then make a status effect for Sleeping.

### Bug
Reported by Shironas on the Nyanotrasen Discord: https://discord.com/channels/968983104247185448/1094754338418737232
> when ya sleept  a pushed down target witgh the hypospray ther sleept person can just walk and radio 
-push down a catperson as a oni and inject her with the hypospray with cloralhyrdate

#### Reproduction
1. Stun a mob with stun baton
4. Inject them with 20u of Chloral Hydrate using a hypospray
5. Take control of the mob

Result: You're able to walk around while sleeping

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: jick
- fix: Fixed sleepwalking after being stunned