### PR TITLE
Fix gibbing related test warnings

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Body.Systems;
 
@@ -138,9 +139,15 @@ public sealed class BodySystem : SharedBodySystem
         if (bodyId == null || !Resolve(bodyId.Value, ref body, false))
             return new HashSet<EntityUid>();
 
-        var gibs = base.GibBody(bodyId, gibOrgans, body, deleteItems);
+        if (LifeStage(bodyId.Value) >= EntityLifeStage.Terminating || EntityManager.IsQueuedForDeletion(bodyId.Value))
+            return new HashSet<EntityUid>();
 
         var xform = Transform(bodyId.Value);
+        if (xform.MapUid == null)
+            return new HashSet<EntityUid>();
+
+        var gibs = base.GibBody(bodyId, gibOrgans, body, deleteItems);
+
         var coordinates = xform.Coordinates;
         var filter = Filter.Pvs(bodyId.Value, entityManager: EntityManager);
         var audio = AudioParams.Default.WithVariation(0.025f);


### PR DESCRIPTION
Prevents gibbing of entities that are terminating, queued for deletion, or in null-space.

There is a remote chance this might also be the cause of #15142, but that might be wishful thinking.