### PR TITLE
Makes emergency EVA and firesuits always spawn in their respective lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -19,22 +19,20 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingOuterSuitEmergency
+      - id: ClothingMaskBreath
+      - id: EmergencyOxygenTankFilled
+        prob: 0.80
+        orGroup: EmergencyTankOrRegularTank
+      - id: OxygenTankFilled
+        prob: 0.20
+        orGroup: EmergencyTankOrRegularTank
       - id: ToolboxEmergencyFilled
         prob: 0.4
-      - id: ClothingMaskBreath
-        prob: 0.4
-      - id: ClothingMaskBreath
-        prob: 0.25
-      - id: EmergencyOxygenTankFilled
-        prob: 0.4
-      - id: OxygenTankFilled
-        prob: 0.2
       - id: MedkitOxygenFilled
         prob: 0.2
       - id: WeaponFlareGun
         prob: 0.05
-      - id: ClothingOuterSuitEmergency
-        prob: 0.5
       - id: BoxMRE
         prob: 0.1
 
@@ -45,25 +43,23 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingOuterSuitEmergency
+      - id: ClothingMaskBreath
+      - id: EmergencyOxygenTankFilled
+        prob: 0.80
+        orGroup: EmergencyTankOrRegularTank
+      - id: OxygenTankFilled
+        prob: 0.20
+        orGroup: EmergencyTankOrRegularTank
       - id: ToolboxEmergencyFilled
         prob: 0.4
-      - id: ClothingMaskBreath
-        prob: 0.4
-      - id: ClothingMaskBreath
-        prob: 0.25
-      - id: EmergencyOxygenTankFilled
-        prob: 0.4
-      - id: OxygenTankFilled
-        prob: 0.2
       - id: MedkitOxygenFilled
         prob: 0.2
       - id: WeaponFlareGun
         prob: 0.05
-      - id: ClothingOuterSuitEmergency
-        prob: 0.5
       - id: BoxMRE
         prob: 0.1
-        
+
 - type: entity
   id: ClosetFireFilled
   parent: ClosetFire
@@ -71,15 +67,12 @@
   components:
     - type: StorageFill
       contents:
-        - id: YellowOxygenTankFilled
-          prob: 0.6
         - id: ClothingOuterSuitFire
-          prob: 0.75
-        - id: ClothingMaskGas
-          prob: 0.75
         - id: ClothingHeadHelmetFire
-          prob: 0.75
-
+        - id: ClothingMaskGas
+        - id: YellowOxygenTankFilled
+        - id: FireExtinguisher
+          prob: 0.25
 - type: entity
   id: ClosetWallFireFilledRandom
   parent: ClosetWallFire
@@ -87,15 +80,12 @@
   components:
     - type: StorageFill
       contents:
-        - id: YellowOxygenTankFilled
-          prob: 0.6
         - id: ClothingOuterSuitFire
-          prob: 0.75
-        - id: ClothingMaskGas
-          prob: 0.75
         - id: ClothingHeadHelmetFire
-          prob: 0.75
-
+        - id: ClothingMaskGas
+        - id: YellowOxygenTankFilled
+        - id: FireExtinguisher
+          prob: 0.25
 - type: entity
   id: ClosetMaintenanceFilledRandom
   suffix: Filled, Random
@@ -143,21 +133,35 @@
   components:
   - type: StorageFill
     contents:
-      - id: ToolboxEmergencyFilled
-        prob: 0.4
-      - id: ClothingMaskBreath
-        prob: 0.4
-      - id: ClothingMaskBreath
-        prob: 0.25
-      - id: EmergencyOxygenTankFilled
-        prob: 0.4
-      - id: OxygenTankFilled
-        prob: 0.2
-      - id: MedkitOxygenFilled
-        prob: 0.2
-      - id: WeaponFlareGun
-        prob: 0.05
-      - id: ClothingOuterSuitEmergency
-        prob: 0.5
-      - id: BoxMRE
-        prob: 0.1
+        - id: lantern
+          prob: 0.50
+        - id: Wirecutter
+          prob: 0.33
+        - id: Screwdriver
+          prob: 0.33
+        - id: Wrench
+          prob: 0.33
+        - id: Crowbar
+          prob: 0.50
+        - id: Welder
+          prob: 0.33
+        - id: Multitool
+          prob: 0.10
+        - id: Soap
+          prob: 0.44
+        - id: PlushieCarp
+          prob: 0.2
+        - id: PlushieSlime
+          prob: 0.2
+        - id: PlushieSnake
+          prob: 0.2
+        - id: ClothingHandsGlovesColorYellow
+          prob: 0.05
+        - id: ClothingBeltUtility
+          prob: 0.10
+        - id: ClothingHeadHatCone
+          prob: 0.2
+        - id: WeaponFlareGun
+          prob: 0.1
+        - id: ClothingHandsGlovesColorYellowBudget
+          prob: 0.25


### PR DESCRIPTION
## About the PR
Does what it says on the tin - makes both the emergency and fire lockers always spawn the required gear for survival. "Additional" spawns like the MRE and flaregun have been untouched.
...also makes maint wall locker gear not the same as the emergency gear while I'm at it. Someone clearly fucked up the spawns, and it was in the same file.

Should hopefully breed more fun survival scenarios. It's just not fun to randomly get fucked and get bad RNG on the locker spawns and then die because half of evac was spaced and there was nothing you could do.

If needed I could nerf either the firesuit or emergency spacesuit to accomodate for this change, but I can't be sure if they need it because I've never actually really had much of a chance to use them myself.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Emergency space suits, emergency fire suits, and O2 will now always spawn in their respective lockers.
- fix: Maintenance wall lockers no longer contain emergency locker gear.
