### PR TITLE
Fix not being to take ghost role for rat king spawners

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -5,10 +5,11 @@
   parent: MarkerBase
   components:
   - type: GhostRole
-    prototype: MobRatKing
     name: Rat King
     description: You are the Rat King, scavenge food in order to produce rat minions to do your bidding.
     rules: You are an antagonist, scavenge, attack, and grow your hoard!
+  - type: GhostRoleMobSpawner
+    prototype: MobRatKing
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:


### PR DESCRIPTION
## About the PR
**Media**

https://user-images.githubusercontent.com/10968691/232400301-c8da7787-576b-48f7-85f3-2a2e534972bb.mp4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed not being able to take over the rat king ghost role.