### PR TITLE
experimental welder fuel regeneration

### DIFF
--- a/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
@@ -41,5 +41,5 @@ public sealed class SolutionRegenerationComponent : Component
     /// The time when the next regeneration will occur.
     /// </summary>
     [DataField("nextChargeTime", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan NextRegenTime = TimeSpan.MaxValue;
+    public TimeSpan NextRegenTime = TimeSpan.FromSeconds(0);
 }

--- a/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
@@ -1,5 +1,5 @@
 using Content.Server.Chemistry.EntitySystems;
-using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -14,22 +14,16 @@ namespace Content.Server.Chemistry.Components;
 public sealed class SolutionRegenerationComponent : Component
 {
     /// <summary>
-    /// The solution to have reagent added to.
+    /// The name of the solution to add to.
     /// </summary>
     [DataField("solution", required: true), ViewVariables(VVAccess.ReadWrite)]
     public string Solution = string.Empty;
 
     /// <summary>
-    /// The reagent to be regenerated in the solution.
+    /// The reagent(s) to be regenerated in the solution.
     /// </summary>
-    [DataField("reagent", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>)), ViewVariables(VVAccess.ReadWrite)]
-    public string Reagent = string.Empty;
-
-    /// <summary>
-    /// Quantity of the reagent regenerated every time.
-    /// </summary>
-    [DataField("quantity"), ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 Quantity = FixedPoint2.New(1f);
+    [DataField("added", required: true), ViewVariables(VVAccess.ReadWrite)]
+    public Solution Added = default!;
 
     /// <summary>
     /// How long it takes to regenerate once.

--- a/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
@@ -1,0 +1,45 @@
+using Content.Server.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Chemistry.Components;
+
+/// <summary>
+/// Passively increases a solution's quantity of a reagent.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(SolutionRegenerationSystem))]
+public sealed class SolutionRegenerationComponent : Component
+{
+    /// <summary>
+    /// The solution to have reagent added to.
+    /// </summary>
+    [DataField("solution", required: true), ViewVariables(VVAccess.ReadWrite)]
+    public string Solution = string.Empty;
+
+    /// <summary>
+    /// The reagent to be regenerated in the solution.
+    /// </summary>
+    [DataField("reagent", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>)), ViewVariables(VVAccess.ReadWrite)]
+    public string Reagent = string.Empty;
+
+    /// <summary>
+    /// Quantity of the reagent regenerated every time.
+    /// </summary>
+    [DataField("quantity"), ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 Quantity = FixedPoint2.New(1f);
+
+    /// <summary>
+    /// How long it takes to regenerate once.
+    /// </summary>
+    [DataField("duration"), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan Duration = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The time when the next regeneration will occur.
+    /// </summary>
+    [DataField("nextChargeTime", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan NextRegenTime = TimeSpan.MaxValue;
+}

--- a/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
@@ -22,8 +22,8 @@ public sealed class SolutionRegenerationComponent : Component
     /// <summary>
     /// The reagent(s) to be regenerated in the solution.
     /// </summary>
-    [DataField("added", required: true), ViewVariables(VVAccess.ReadWrite)]
-    public Solution Added = default!;
+    [DataField("generated", required: true), ViewVariables(VVAccess.ReadWrite)]
+    public Solution Generated = default!;
 
     /// <summary>
     /// How long it takes to regenerate once.

--- a/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
@@ -29,7 +29,7 @@ public sealed class SolutionRegenerationSystem : EntitySystem
             // timer ignores if its full, it's just a fixed cycle
             regen.NextRegenTime = _timing.CurTime + regen.Duration;
             if (_solutionContainer.TryGetSolution(uid, regen.Solution, out var solution, manager))
-                _solutionContainer.TryAddReagent(uid, solution, regen.Reagent, regen.Quantity, out var _);
+                _solutionContainer.TryAddSolution(uid, solution, regen.Added);
         }
     }
 

--- a/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
@@ -29,7 +29,7 @@ public sealed class SolutionRegenerationSystem : EntitySystem
             // timer ignores if its full, it's just a fixed cycle
             regen.NextRegenTime = _timing.CurTime + regen.Duration;
             if (_solutionContainer.TryGetSolution(uid, regen.Solution, out var solution, manager))
-                _solutionContainer.TryAddSolution(uid, solution, regen.Added);
+                _solutionContainer.TryAddSolution(uid, solution, regen.Generated);
         }
     }
 

--- a/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
@@ -1,0 +1,40 @@
+using Content.Server.Chemistry.Components;
+using Content.Server.Chemistry.Components.SolutionManager;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Chemistry.EntitySystems;
+
+public sealed class SolutionRegenerationSystem : EntitySystem
+{
+    [Dependency] private readonly SolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SolutionRegenerationComponent, EntityUnpausedEvent>(OnUnpaused);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<SolutionRegenerationComponent, SolutionContainerManagerComponent>();
+        while (query.MoveNext(out var uid, out var regen, out var manager))
+        {
+            if (_timing.CurTime < regen.NextRegenTime)
+                continue;
+
+            // timer ignores if its full, it's just a fixed cycle
+            regen.NextRegenTime = _timing.CurTime + regen.Duration;
+            if (_solutionContainer.TryGetSolution(uid, regen.Solution, out var solution, manager))
+                _solutionContainer.TryAddReagent(uid, solution, regen.Reagent, regen.Quantity, out var _);
+        }
+    }
+
+    private void OnUnpaused(EntityUid uid, SolutionRegenerationComponent comp, ref EntityUnpausedEvent args)
+    {
+        comp.NextRegenTime += args.PausedTime;
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -127,6 +127,9 @@
     enabled: false
     radius: 1.5
     color: lightblue
+  - type: SolutionRegeneration
+    solution: Welder
+    reagent: WeldingFuel
 
 - type: entity
   name: emergency welding tool

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -129,7 +129,7 @@
     color: lightblue
   - type: SolutionRegeneration
     solution: Welder
-    added:
+    generated:
       reagents:
       - ReagentId: WeldingFuel
         Quantity: 1

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -129,7 +129,10 @@
     color: lightblue
   - type: SolutionRegeneration
     solution: Welder
-    reagent: WeldingFuel
+    added:
+      reagents:
+      - ReagentId: WeldingFuel
+        Quantity: 1
 
 - type: entity
   name: emergency welding tool


### PR DESCRIPTION
## About the PR
- adds solution regeneration component/system
- fixes #15430 by regenerating 1u of fuel every second for the experimental welding tool

stats are arbitrary but seem fine from 1 minute of testing

**Media**


https://user-images.githubusercontent.com/39013340/232413104-e99ddef5-51ac-4bf9-868d-ac2ae9327ce5.mp4



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: NanoTrasen lost a lawsuit regarding the false claims of fuel regeneration, experimental welding tools now regenerate 1u of fuel every second.
