### PR TITLE
prevent removing battery from ninja suit

### DIFF
--- a/Content.Shared/Ninja/Systems/NinjaSuitSystem.cs
+++ b/Content.Shared/Ninja/Systems/NinjaSuitSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Ninja.Components;
 using Content.Shared.Stealth;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Timing;
+using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -23,6 +24,7 @@ public abstract class SharedNinjaSuitSystem : EntitySystem
 
         SubscribeLocalEvent<NinjaSuitComponent, GotEquippedEvent>(OnEquipped);
         SubscribeLocalEvent<NinjaSuitComponent, GetItemActionsEvent>(OnGetItemActions);
+        SubscribeLocalEvent<NinjaSuitComponent, ContainerIsRemovingAttemptEvent>(OnSuitRemoveAttempt);
         SubscribeLocalEvent<NinjaSuitComponent, GotUnequippedEvent>(OnUnequipped);
 
         SubscribeNetworkEvent<SetCloakedMessage>(OnSetCloakedMessage);
@@ -46,6 +48,12 @@ public abstract class SharedNinjaSuitSystem : EntitySystem
         args.Actions.Add(comp.CreateSoapAction);
         args.Actions.Add(comp.KatanaDashAction);
         args.Actions.Add(comp.EmpAction);
+    }
+
+    private void OnSuitRemoveAttempt(EntityUid uid, NinjaSuitComponent comp, ContainerIsRemovingAttemptEvent args)
+    {
+        // no removing your battery idiot!!!
+        args.Cancel();
     }
 
     private void OnUnequipped(EntityUid uid, NinjaSuitComponent comp, GotUnequippedEvent args)


### PR DESCRIPTION
## About the PR
so originally i think i had code to handle this but due to ??? i removed it
i found out about it in liltens video where he takes out battery to charge it in a recharger
this is not intended, but is an interesting mechanic since you can sacrafice all suit abilities if you for whatever reason cant find any power storage devices to drain from???

dont merge without discussion ig

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed being able to remove powercells from ninja suits.
