### PR TITLE
Gun safe, not a shotgun safe

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -100,9 +100,10 @@
       - id: ClothingMaskGas
 
 - type: entity
-  id: ShotgunSafeDisabler
+  id: GunSafeDisabler
   suffix: Disabler
-  parent: ShotgunSafe
+  parent: GunSafe
+  name: gun safe disabler
   components:
   - type: StorageFill
     contents:
@@ -110,9 +111,10 @@
         amount: 5
 
 - type: entity
-  id: ShotgunSafePistolMK58
+  id: GunSafePistolMk58
   suffix: MK58
-  parent: ShotgunSafe
+  parent: GunSafe
+  name: gun safe Mk58
   components:
   - type: StorageFill
     contents:
@@ -122,9 +124,10 @@
         amount: 8
 
 - type: entity
-  id: ShotgunSafeRifleLecter
+  id: GunSafeRifleLecter
   suffix: Lecter
-  parent: ShotgunSafe
+  parent: GunSafe
+  name: gun safe lecter
   components:
   - type: StorageFill
     contents:
@@ -134,9 +137,10 @@
         amount: 4
 
 - type: entity
-  id: ShotgunSafeSubMachineGunVector
+  id: GunSafeSubMachineGunVector
   suffix: Vector
-  parent: ShotgunSafe
+  parent: GunSafe
+  name: gun safe vector
   components:
   - type: StorageFill
     contents:
@@ -146,9 +150,10 @@
         amount: 4
 
 - type: entity
-  id: ShotgunSafeShotgunEnforcer
+  id: GunSafeShotgunEnforcer
   suffix: Enforcer
-  parent: ShotgunSafe
+  parent: GunSafe
+  name: gun safe enforcer
   components:
   - type: StorageFill
     contents:
@@ -158,9 +163,10 @@
         amount: 4
 
 - type: entity
-  id: ShotgunSafeShotgunKammerer
+  id: GunSafeShotgunKammerer
   suffix: Kammerer
-  parent: ShotgunSafe
+  parent: GunSafe
+  name: gun safe kammerer
   components:
   - type: StorageFill
     contents:
@@ -170,9 +176,10 @@
         amount: 4
 
 - type: entity
-  id: ShotgunSafeSubMachineGunWt550
+  id: GunSafeSubMachineGunWt550
   suffix: Wt550
-  parent: ShotgunSafe
+  parent: GunSafe
+  name: gun safe Wt550
   components:
   - type: StorageFill
     contents:
@@ -182,9 +189,10 @@
         amount: 4
 
 - type: entity
-  id: ShotgunSafeLaserCarbine
+  id: GunSafeLaserCarbine
   suffix: Laser Carbine
-  parent: ShotgunSafe
+  parent: GunSafe
+  name: gun safe laser carbine
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -322,9 +322,9 @@
     access: [["Security"]]
 
 - type: entity
-  id: ShotgunSafe
+  id: GunSafe
   parent: LockerBaseSecure
-  name: shotgun safe
+  name: gun safe
   components:
   - type: Appearance
     visuals:


### PR DESCRIPTION
## About the PR

Renamed `id:` and `parent:` to correct, also added names to safes with weapons inside

**Media**

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: Nimfar

- tweak: Renamed Gun Safes as well as their prototypes. On each safe of the spawn, it is now written what weapons are inside
