### PR TITLE
Resolving issue: "Armor isn't predicted #15273"

### DIFF
--- a/Content.Server/Armor/ArmorSystem.cs
+++ b/Content.Server/Armor/ArmorSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Cargo.Systems;
 using Robust.Shared.Prototypes;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Inventory;
+using Content.Shared.Armor;
 
 namespace Content.Server.Armor
 {
@@ -21,7 +22,6 @@ namespace Content.Server.Armor
         {
             base.Initialize();
 
-            SubscribeLocalEvent<ArmorComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnDamageModify);
             SubscribeLocalEvent<ArmorComponent, GetVerbsEvent<ExamineVerb>>(OnArmorVerbExamine);
             SubscribeLocalEvent<ArmorComponent, PriceCalculationEvent>(GetArmorPrice);
         }
@@ -62,10 +62,6 @@ namespace Content.Server.Armor
             args.Price += price;
         }
 
-        private void OnDamageModify(EntityUid uid, ArmorComponent component, InventoryRelayedEvent<DamageModifyEvent> args)
-        {
-            args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, component.Modifiers);
-        }
 
         private void OnArmorVerbExamine(EntityUid uid, ArmorComponent component, GetVerbsEvent<ExamineVerb> args)
         {

--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -1,11 +1,13 @@
-﻿using Content.Shared.Damage;
+using Content.Shared.Damage;
 
-namespace Content.Server.Armor
+namespace Content.Shared.Armor
 {
     [RegisterComponent]
     public sealed class ArmorComponent : Component
     {
         [DataField("modifiers", required: true)]
         public DamageModifierSet Modifiers = default!;
+
     }
+    
 }

--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -7,7 +7,5 @@ namespace Content.Shared.Armor
     {
         [DataField("modifiers", required: true)]
         public DamageModifierSet Modifiers = default!;
-
     }
-    
 }

--- a/Content.Shared/Armor/ArmorDamageSystem.cs
+++ b/Content.Shared/Armor/ArmorDamageSystem.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Damage;
+using Content.Shared.Inventory;
+using Content.Shared.Armor;
+
+namespace Content.Shared.ArmorDamage
+{
+    public sealed class ArmorSystem : EntitySystem
+    {
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<ArmorComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnDamageModify);
+        }
+        private void OnDamageModify(EntityUid uid, ArmorComponent component, InventoryRelayedEvent<DamageModifyEvent> args)
+        {
+            args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, component.Modifiers);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Armor mitigation should be properly when attacking self. Changes made via moving ArmorComponent.cs to a new folder in Shared and adding a new file called ArmorDamageSystem in that same folder.

Tested via process in "Armor isn't predicted #15273"
1. attacked self without armor: dead in 9 hits
2. attacked self with armor: dead in 14 hits
3. attacked a non-self identical entity wearing the same armor: dead in 14 hits

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Changed self inflicted damage to account for armor mitigation
