### PR TITLE
Reduce power of anomaly vessel upgrades

### DIFF
--- a/Content.Server/Anomaly/Components/AnomalyVesselComponent.cs
+++ b/Content.Server/Anomaly/Components/AnomalyVesselComponent.cs
@@ -39,7 +39,7 @@ public sealed class AnomalyVesselComponent : Component
     /// with the corresponding part rating.
     /// </summary>
     [DataField("partRatingPointModifier")]
-    public float PartRatingPointModifier = 1.5f;
+    public float PartRatingPointModifier = 1.25f;
 
     /// <summary>
     /// The maximum time between each beep


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Yes I webeditted it.
Yes i know that's wrong.
i was too lazy to change 3 characters

so, basically, with the old value you could boost a single vessel up to 3.3x the production rate. Even just T3 parts already was double output. Getting 250 points a second with a single anomaly vessel is busted as hell so i'm just gonna nerf it a bit.

this is entirely fey's fault. 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Reduced the power of anomaly vessel upgrades.