### PR TITLE
Toxin damage and name tweaks

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -1,5 +1,5 @@
-reagent-name-toxin = toxin
-reagent-desc-toxin = A toxic chemical.
+reagent-name-toxin = cyanide
+reagent-desc-toxin = A toxic and potentially deadly chemical.
 
 reagent-name-carpotoxin = carpotoxin
 reagent-desc-carpotoxin = Toxic secretions of a space carp. Causes a painful burning sensation.

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -17,7 +17,7 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: 2
+            Poison: 4
 
 - type: reagent
   id: CarpoToxin


### PR DESCRIPTION
Tweak: Increased toxin poison damage from 2 to 4.
Tweak: Changed name of toxin to "cyanide" and updated description.

Toxin is mostly useless at it currently stands and the mostly useless emag is even more useless in chemistry as several chemicals are equally effective without the use of an emag. This should make toxin slightly more appealing while not being overpowered. At 4 poison per unit, a 20u pill should crit whoever consumes it while still providing ample time to be rescued before death. The name has been changed to more closely match the styling of other chemicals found in the chem dispenser.