### PR TITLE
Makes how much water you need to clean into a constant set to one third

### DIFF
--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -203,7 +203,12 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
 
         absorberSoln.RemoveReagent(PuddleSystem.EvaporationReagent, split.Volume / PuddleSystem.EvaporationReagentRatio);
         puddleSolution.AddReagent(PuddleSystem.EvaporationReagent, split.Volume / PuddleSystem.EvaporationReagentRatio);
-        absorberSoln.AddSolution(split, _prototype);
+        absorberSoln.AddSolution(split.SplitSolution(absorberSoln.AvailableVolume), _prototype);
+        // puts back the excess if any, a hack to circumvent it being a differential equation and prevent the
+        // overflow of the absorber due to residual water not being checked for
+        if (split.Volume > 0){
+            puddleSolution.AddSolution(split, _prototype);
+        }
 
         _solutionSystem.UpdateChemicals(used, absorberSoln);
         _solutionSystem.UpdateChemicals(target, puddleSolution);

--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -117,13 +117,6 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
         if (!_solutionSystem.TryGetRefillableSolution(target, out var refillableSolution, refillable: refillable))
             return false;
 
-        if (refillableSolution.Volume < 0)
-        {
-            var msg = Loc.GetString("mopping-system-target-container-empty", ("target", target));
-            _popups.PopupEntity(msg, user, user);
-            return false;
-        }
-
         var transferAmount = component.PickupAmount / PuddleSystem.EvaporationReagentRatio -
             absorberSoln.GetReagentQuantity(PuddleSystem.EvaporationReagent);
 

--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -181,8 +181,8 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
             return true;
         }
 
-        // Check if we have any evaporative reagents on our absorber to transfer
-        absorberSoln.TryGetReagent(PuddleSystem.EvaporationReagent, out var available);
+        // Amount of evaporative reagents on our absorber to transfer
+        var available = absorberSoln.GetReagentQuantity(PuddleSystem.EvaporationReagent);
 
         // No material
         if (available == FixedPoint2.Zero)

--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -181,8 +181,8 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
             return true;
         }
 
-        // Amount of evaporative reagents on our absorber to transfer
-        var available = absorberSoln.GetReagentQuantity(PuddleSystem.EvaporationReagent);
+        // Check if we have any evaporative reagents on our absorber to transfer
+        absorberSoln.TryGetReagent(PuddleSystem.EvaporationReagent, out var available);
 
         // No material
         if (available == FixedPoint2.Zero)
@@ -199,32 +199,21 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
                 PuddleSystem.EvaporationReagentRatio % 5 != 0){
             available += FixedPoint2.Epsilon;
         }
+        available *= PuddleSystem.EvaporationReagentRatio;
 
-        var dirtVolumeAvailable = puddleSolution.Volume - puddleSolution.GetReagentQuantity(PuddleSystem.EvaporationReagent);
-
-        var transferAmount = FixedPoint2.Min(dirtVolumeAvailable,
-                                             available * PuddleSystem.EvaporationReagentRatio,
-                                             absorber.PickupAmount);
-
-        var prospectWaterTransfer = FixedPoint2.Min(transferAmount / PuddleSystem.EvaporationReagentRatio,
-                                                    absorberSoln.GetReagentQuantity(PuddleSystem.EvaporationReagent));
-
-        // This var exists for no other purpose than code readability
-        var prospectAvailableVolume = absorberSoln.AvailableVolume + prospectWaterTransfer;
-
-        // this one really depends on the first value of transferAmount, it's supposed to be separate
-        transferAmount = FixedPoint2.Min(prospectAvailableVolume, transferAmount);
+        var transferMax = absorber.PickupAmount;
+        var transferAmount = available > transferMax ? transferMax : available;
 
         var split = puddleSolution.SplitSolutionWithout(transferAmount, PuddleSystem.EvaporationReagent);
 
-        DebugTools.Assert(split.Volume == transferAmount);
-
-        var removed = absorberSoln.RemoveReagent(PuddleSystem.EvaporationReagent, split.Volume / PuddleSystem.EvaporationReagentRatio);
-        puddleSolution.AddReagent(PuddleSystem.EvaporationReagent, removed);
-
-        DebugTools.Assert(split.Volume <= absorberSoln.AvailableVolume);
-
-        absorberSoln.AddSolution(split, _prototype);
+        absorberSoln.RemoveReagent(PuddleSystem.EvaporationReagent, split.Volume / PuddleSystem.EvaporationReagentRatio);
+        puddleSolution.AddReagent(PuddleSystem.EvaporationReagent, split.Volume / PuddleSystem.EvaporationReagentRatio);
+        absorberSoln.AddSolution(split.SplitSolution(absorberSoln.AvailableVolume), _prototype);
+        // puts back the excess if any, a hack to circumvent it being a differential equation and prevent the
+        // overflow of the absorber due to residual water not being checked for
+        if (split.Volume > 0){
+            puddleSolution.AddSolution(split, _prototype);
+        }
 
         _solutionSystem.UpdateChemicals(used, absorberSoln);
         _solutionSystem.UpdateChemicals(target, puddleSolution);

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
@@ -11,6 +11,8 @@ public sealed partial class PuddleSystem
 
     public const string EvaporationReagent = "Water";
 
+    public const int EvaporationReagentRatio = 3;
+
     private void OnEvaporationMapInit(EntityUid uid, EvaporationComponent component, MapInitEvent args)
     {
         component.NextTick = _timing.CurTime + EvaporationCooldown;

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -124,7 +124,7 @@
   name: mop bucket
   id: MopBucketFull
   parent: MopBucket
-  suffix: full
+  suffix: filled
   components:
     - type: Sprite
       layers:
@@ -137,7 +137,7 @@
           maxVol: 600
           reagents:
             - ReagentId: Water
-              Quantity: 600
+              Quantity: 200
 
 - type: entity
   name: wet floor sign


### PR DESCRIPTION
So, I was finding it a bit hard for janitors and service workers to keep it clean so I made this patch. So here we are.
I made sure to make it as tweakable as possible and I think if you put the constant to 1 it will be almost as if nothing had changed.

I would love to make you people able to make commits into my branch if that's possible but I suck at github. If anyone can tell me how, I'll do it. Otherwise, I can make any requested changes soonish, as per usual

Instead of transferring to the mop just as much volume as there is water in it, it transfer up to 3 times that amount of water, 3 being the current value for the constant.

Refilling the absorber (mop) only fills up to 1 / 3 of it as well, otherwise it would be senseless.

:cl: rber
- tweak: Cleaning puddles no longer takes just as much water as the puddle volume

cheers