### PR TITLE
Species-blocking system for specific jobs

### DIFF
--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -85,6 +85,9 @@ namespace Content.Shared.Roles
         [DataField("special", serverOnly:true)]
         public JobSpecial[] Special { get; private set; } = Array.Empty<JobSpecial>();
 
+        [DataField("allowedSpecies", serverOnly:true)]
+        public string[] allowedSpecies { get; private set; } = Array.Empty<string>();
+
         [DataField("access", customTypeSerializer: typeof(PrototypeIdListSerializer<AccessLevelPrototype>))]
         public IReadOnlyCollection<string> Access { get; } = Array.Empty<string>();
 

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -24,6 +24,9 @@ game-ticker-get-info-preround-text = Hi and welcome to [color=white]Space Statio
                             >[color=yellow]{$desc}[/color]
 game-ticker-no-map-selected = [color=yellow]Map not yet selected![/color]
 game-ticker-player-no-jobs-available-when-joining = When attempting to join to the game, no jobs were available.
+game-ticker-player-cant-join-as-not-allowed-species = You cannot join as not allowed species on that job. Allowed species:
+game-ticker-player-trying-find-suitable-char-in-preferences = Trying to find a suitable character in preferences...
+game-ticker-player-cant-find-suitable-char-in-preferences = Can't find a suitable character in Preferences. Generating a new character...
 
 # Displayed in chat to admins when a player joins
 player-join-message = Player {$name} joined.

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -8,8 +8,6 @@
   supervisors: job-supervisors-everyone
   access:
   - Maintenance
-  allowedSpecies:
-  - Human
 
 - type: startingGear
   id: PassengerGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -8,6 +8,8 @@
   supervisors: job-supervisors-everyone
   access:
   - Maintenance
+  allowedSpecies:
+  - Human
 
 - type: startingGear
   id: PassengerGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
In this PR, I added a species-blocking system for specific jobs. This can be useful for blocking aliens from the positions of captain or head. To do this, a new field called "allowSpecies" has been added to the Job prototype. It takes a list of allowed strings. If a player tries to enter a task with a prohibited species, the system will try to find a character in the preferences with a suitable Species. If it doesn't find one, it will create a new character with the allowed species.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Species-blocking system for specific jobs 
