### PR TITLE
Cargo 1984

### DIFF
--- a/Content.Server/UserInterface/StatValuesCommand.cs
+++ b/Content.Server/UserInterface/StatValuesCommand.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using Content.Server.Administration;
 using Content.Server.Cargo.Systems;
 using Content.Server.EUI;
@@ -16,6 +17,11 @@ namespace Content.Server.UserInterface;
 [AdminCommand(AdminFlags.Debug)]
 public sealed class StatValuesCommand : IConsoleCommand
 {
+    [Dependency] private readonly EuiManager _eui = default!;
+    [Dependency] private readonly IComponentFactory _factory = default!;
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
     public string Command => "showvalues";
     public string Description => Loc.GetString("stat-values-desc");
     public string Help => $"{Command} <cargosell / lathsell / melee>";
@@ -51,10 +57,19 @@ public sealed class StatValuesCommand : IConsoleCommand
                 return;
         }
 
-        var euiManager = IoCManager.Resolve<EuiManager>();
         var eui = new StatValuesEui();
-        euiManager.OpenEui(eui, pSession);
+        _eui.OpenEui(eui, pSession);
         eui.SendMessage(message);
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromOptions(new[] { "cargosell", "lathesell", "melee" });
+        }
+
+        return CompletionResult.Empty;
     }
 
     private StatValuesEuiMessage GetCargo()
@@ -63,12 +78,12 @@ public sealed class StatValuesCommand : IConsoleCommand
         // So we'll just get the first value for each prototype ID which is probably good enough for the majority.
 
         var values = new List<string[]>();
-        var entManager = IoCManager.Resolve<IEntityManager>();
-        var priceSystem = entManager.System<PricingSystem>();
-        var metaQuery = entManager.GetEntityQuery<MetaDataComponent>();
+        var priceSystem = _entManager.System<PricingSystem>();
+        var metaQuery = _entManager.GetEntityQuery<MetaDataComponent>();
         var prices = new HashSet<string>(256);
+        var ents = _entManager.GetEntities().ToArray();
 
-        foreach (var entity in entManager.GetEntities())
+        foreach (var entity in ents)
         {
             if (!metaQuery.TryGetComponent(entity, out var meta))
                 continue;
@@ -107,15 +122,13 @@ public sealed class StatValuesCommand : IConsoleCommand
 
     private StatValuesEuiMessage GetMelee()
     {
-        var compFactory = IoCManager.Resolve<IComponentFactory>();
-        var protoManager = IoCManager.Resolve<IPrototypeManager>();
-
         var values = new List<string[]>();
+        var meleeName = _factory.GetComponentName(typeof(MeleeWeaponComponent));
 
-        foreach (var proto in protoManager.EnumeratePrototypes<EntityPrototype>())
+        foreach (var proto in _proto.EnumeratePrototypes<EntityPrototype>())
         {
             if (proto.Abstract ||
-                !proto.Components.TryGetValue(compFactory.GetComponentName(typeof(MeleeWeaponComponent)),
+                !proto.Components.TryGetValue(meleeName,
                     out var meleeComp))
             {
                 continue;
@@ -153,20 +166,19 @@ public sealed class StatValuesCommand : IConsoleCommand
     private StatValuesEuiMessage GetLatheMessage()
     {
         var values = new List<string[]>();
-        var protoManager = IoCManager.Resolve<IPrototypeManager>();
-        var priceSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<PricingSystem>();
+        var priceSystem = _entManager.System<PricingSystem>();
 
-        foreach (var proto in protoManager.EnumeratePrototypes<LatheRecipePrototype>())
+        foreach (var proto in _proto.EnumeratePrototypes<LatheRecipePrototype>())
         {
             var cost = 0.0;
 
             foreach (var (material, count) in proto.RequiredMaterials)
             {
-                var materialPrice = protoManager.Index<MaterialPrototype>(material).Price;
+                var materialPrice = _proto.Index<MaterialPrototype>(material).Price;
                 cost += materialPrice * count;
             }
 
-            var sell = priceSystem.GetEstimatedPrice(protoManager.Index<EntityPrototype>(proto.Result));
+            var sell = priceSystem.GetEstimatedPrice(_proto.Index<EntityPrototype>(proto.Result));
 
             values.Add(new[]
             {

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
@@ -56,5 +56,3 @@
     containers:
       board: !type:Container
         ents: []
-  - type: StaticPrice
-    price: 400

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -72,7 +72,7 @@
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-mechanical
   - type: StaticPrice
-    price: 200
+    price: 100
   - type: Appearance
   - type: WiresVisuals
 

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -16,8 +16,6 @@
           nodeGroupID: Pipe
           pipeDirection: South
     - type: CollideOnAnchor
-    - type: StaticPrice
-      price: 200
 
 - type: entity
   parent: GasUnaryBase
@@ -253,8 +251,6 @@
           !type:PipeNode
           nodeGroupID: Pipe
           pipeDirection: South
-    - type: StaticPrice
-      price: 500
     - type: Transform
       noRot: false
 

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -38,7 +38,7 @@
           - !type:DoActsBehavior
             acts: ["Destruction"]
     - type: StaticPrice
-      price: 1000
+      price: 300
   placement:
     mode: SnapgridCenter
 

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -65,6 +65,8 @@
       entity_storage: !type:Container
       paper_label: !type:ContainerSlot
   - type: ItemSlots
+  - type: StaticPrice
+    price: 50
   - type: Construction
     graph: CrateGenericSteel
     node: crategenericsteel

--- a/Resources/Prototypes/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/Entities/Structures/base_structure.yml
@@ -53,8 +53,6 @@
       - MidImpassable
       - LowImpassable
   - type: Anchorable
-  - type: StaticPrice
-    price: 50
 
 - type: Tag
   id: Structure


### PR DESCRIPTION
- Remove some of the default sell prices giving easy exploits.
- Nerf some common overpriced items.

Gonna make some stuff sell for 0 but we can just address it on a case-by-case basis as the defaults are too easily manipulated atm.

:cl:
- tweak: Nerf or remove some standard sell prices.