### PR TITLE
biomass + tank sprite tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/biomass_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/biomass_reclaimer.yml
@@ -10,6 +10,7 @@
     sprite: Structures/Machines/Medical/biomass_reclaimer.rsi
     state: icon
     netsync: false
+    snapCardinals: true
   - type: BiomassReclaimer
   - type: Climbable
     delay: 7

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
@@ -7,7 +7,7 @@
   components:
   - type: Sprite
     netsync: false
-    snapCardinals: true
+    noRot: true
   - type: InteractionOutline
   - type: Physics
   - type: Fixtures


### PR DESCRIPTION
- Tanks are noRot because the snapping looks weird.
- snapcardinals for biomass reclaimer.