### PR TITLE
Fix thruster postmapinit

### DIFF
--- a/Content.Server/Construction/Completions/BuildMachine.cs
+++ b/Content.Server/Construction/Completions/BuildMachine.cs
@@ -100,7 +100,7 @@ namespace Content.Server.Construction.Completions
 
             if (entityManager.TryGetComponent(machine, out MachineComponent? machineComp))
             {
-                constructionSystem.RefreshParts(machineComp);
+                constructionSystem.RefreshParts(machine, machineComp);
             }
 
             var entChangeEv = new ConstructionChangeEntityEvent(machine, uid);

--- a/Content.Server/Construction/ConstructionSystem.Machine.cs
+++ b/Content.Server/Construction/ConstructionSystem.Machine.cs
@@ -5,6 +5,7 @@ using Content.Shared.Construction.Components;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Construction;
@@ -28,8 +29,8 @@ public sealed partial class ConstructionSystem
 
     private void OnMachineMapInit(EntityUid uid, MachineComponent component, MapInitEvent args)
     {
-        CreateBoardAndStockParts(component);
-        RefreshParts(component);
+        CreateBoardAndStockParts(uid, component);
+        RefreshParts(uid, component);
     }
 
     private void OnMachineExaminableVerb(EntityUid uid, MachineComponent component, GetVerbsEvent<ExamineVerb> args)
@@ -99,21 +100,21 @@ public sealed partial class ConstructionSystem
         return output;
     }
 
-    public void RefreshParts(MachineComponent component)
+    public void RefreshParts(EntityUid uid, MachineComponent component)
     {
         var parts = GetAllParts(component);
-        EntityManager.EventBus.RaiseLocalEvent(component.Owner, new RefreshPartsEvent
+        EntityManager.EventBus.RaiseLocalEvent(uid, new RefreshPartsEvent
         {
             Parts = parts,
             PartRatings = GetPartsRatings(parts),
         }, true);
     }
 
-    public void CreateBoardAndStockParts(MachineComponent component)
+    private void CreateBoardAndStockParts(EntityUid uid, MachineComponent component)
     {
         // Entity might not be initialized yet.
-        var boardContainer = _container.EnsureContainer<Container>(component.Owner, MachineFrameComponent.BoardContainerName);
-        var partContainer = _container.EnsureContainer<Container>(component.Owner, MachineFrameComponent.PartContainerName);
+        var boardContainer = _container.EnsureContainer<Container>(uid, MachineFrameComponent.BoardContainerName);
+        var partContainer = _container.EnsureContainer<Container>(uid, MachineFrameComponent.PartContainerName);
 
         if (string.IsNullOrEmpty(component.BoardPrototype))
             return;
@@ -122,11 +123,11 @@ public sealed partial class ConstructionSystem
         if (boardContainer.ContainedEntities.Count > 0)
             return;
 
-        var board = EntityManager.SpawnEntity(component.BoardPrototype, Transform(component.Owner).Coordinates);
+        var board = EntityManager.SpawnEntity(component.BoardPrototype, Transform(uid).Coordinates);
 
         if (!component.BoardContainer.Insert(board))
         {
-            throw new Exception($"Couldn't insert board with prototype {component.BoardPrototype} to machine with prototype {MetaData(component.Owner).EntityPrototype?.ID ?? "N/A"}!");
+            throw new Exception($"Couldn't insert board with prototype {component.BoardPrototype} to machine with prototype {MetaData(uid).EntityPrototype?.ID ?? "N/A"}!");
         }
 
         if (!TryComp<MachineBoardComponent?>(board, out var machineBoard))
@@ -134,7 +135,7 @@ public sealed partial class ConstructionSystem
             throw new Exception($"Entity with prototype {component.BoardPrototype} doesn't have a {nameof(MachineBoardComponent)}!");
         }
 
-        var xform = Transform(component.Owner);
+        var xform = Transform(uid);
         foreach (var (part, amount) in machineBoard.Requirements)
         {
             var partProto = _prototypeManager.Index<MachinePartPrototype>(part);
@@ -149,20 +150,20 @@ public sealed partial class ConstructionSystem
 
         foreach (var (stackType, amount) in machineBoard.MaterialRequirements)
         {
-            var stack = _stackSystem.Spawn(amount, stackType, Transform(component.Owner).Coordinates);
+            var stack = _stackSystem.Spawn(amount, stackType, Transform(uid).Coordinates);
 
             if (!partContainer.Insert(stack))
-                throw new Exception($"Couldn't insert machine material of type {stackType} to machine with prototype {MetaData(component.Owner).EntityPrototype?.ID ?? "N/A"}");
+                throw new Exception($"Couldn't insert machine material of type {stackType} to machine with prototype {MetaData(uid).EntityPrototype?.ID ?? "N/A"}");
         }
 
         foreach (var (compName, info) in machineBoard.ComponentRequirements)
         {
             for (var i = 0; i < info.Amount; i++)
             {
-                var c = EntityManager.SpawnEntity(info.DefaultPrototype, Transform(component.Owner).Coordinates);
+                var c = EntityManager.SpawnEntity(info.DefaultPrototype, Transform(uid).Coordinates);
 
                 if(!partContainer.Insert(c))
-                    throw new Exception($"Couldn't insert machine component part with default prototype '{compName}' to machine with prototype {MetaData(component.Owner).EntityPrototype?.ID ?? "N/A"}");
+                    throw new Exception($"Couldn't insert machine component part with default prototype '{compName}' to machine with prototype {MetaData(uid).EntityPrototype?.ID ?? "N/A"}");
             }
         }
 
@@ -170,10 +171,10 @@ public sealed partial class ConstructionSystem
         {
             for (var i = 0; i < info.Amount; i++)
             {
-                var c = EntityManager.SpawnEntity(info.DefaultPrototype, Transform(component.Owner).Coordinates);
+                var c = EntityManager.SpawnEntity(info.DefaultPrototype, Transform(uid).Coordinates);
 
                 if(!partContainer.Insert(c))
-                    throw new Exception($"Couldn't insert machine component part with default prototype '{tagName}' to machine with prototype {MetaData(component.Owner).EntityPrototype?.ID ?? "N/A"}");
+                    throw new Exception($"Couldn't insert machine component part with default prototype '{tagName}' to machine with prototype {MetaData(uid).EntityPrototype?.ID ?? "N/A"}");
             }
         }
     }

--- a/Content.Server/Construction/PartExchangerSystem.cs
+++ b/Content.Server/Construction/PartExchangerSystem.cs
@@ -83,7 +83,7 @@ public sealed class PartExchangerSystem : EntitySystem
             storage.Storage.Insert(unused.Owner);
             _storage.Insert(uid, unused.Owner, null, false);
         }
-        _construction.RefreshParts(machine);
+        _construction.RefreshParts(args.Args.Target.Value, machine);
 
         args.Handled = true;
     }

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -15,12 +15,12 @@ namespace Content.Server.Shuttles.Components
         /// <summary>
         /// The thrusters contributing to each direction for impulse.
         /// </summary>
-        public readonly List<ThrusterComponent>[] LinearThrusters = new List<ThrusterComponent>[4];
+        public readonly List<EntityUid>[] LinearThrusters = new List<EntityUid>[4];
 
         /// <summary>
         /// The thrusters contributing to the angular impulse of the shuttle.
         /// </summary>
-        public readonly List<ThrusterComponent> AngularThrusters = new();
+        public readonly List<EntityUid> AngularThrusters = new();
 
         [ViewVariables]
         public float AngularThrust = 0f;

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.Shuttles.Systems;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Damage;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Shuttles.Components
@@ -42,7 +43,8 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         public bool IsOn;
 
-        [ViewVariables(VVAccess.ReadWrite)]
+        // Need to serialize this because RefreshParts isn't called on Init and this will break post-mapinit maps!
+        [ViewVariables(VVAccess.ReadWrite), DataField("thrust")]
         public float Thrust;
 
         [DataField("baseThrust"), ViewVariables(VVAccess.ReadWrite)]
@@ -72,6 +74,12 @@ namespace Content.Server.Shuttles.Components
         public List<EntityUid> Colliding = new();
 
         public bool Firing = false;
+
+        /// <summary>
+        /// Next time we tick damage for anyone colliding.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite), DataField("nextFire", customTypeSerializer:typeof(TimeOffsetSerializer))]
+        public TimeSpan NextFire;
 
         [DataField("machinePartThrust", customTypeSerializer: typeof(PrototypeIdSerializer<MachinePartPrototype>))]
         public string MachinePartThrust = "Laser";

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -12,165 +12,165 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
 
-namespace Content.Server.Shuttles.Systems
+namespace Content.Server.Shuttles.Systems;
+
+[UsedImplicitly]
+public sealed partial class ShuttleSystem : SharedShuttleSystem
 {
-    [UsedImplicitly]
-    public sealed partial class ShuttleSystem : SharedShuttleSystem
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly AirlockSystem _airlock = default!;
+    [Dependency] private readonly DockingSystem _dockSystem = default!;
+    [Dependency] private readonly DoorSystem _doors = default!;
+    [Dependency] private readonly FixtureSystem _fixtures = default!;
+    [Dependency] private readonly MapLoaderSystem _loader = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly ShuttleConsoleSystem _console = default!;
+    [Dependency] private readonly StunSystem _stuns = default!;
+    [Dependency] private readonly ThrusterSystem _thruster = default!;
+    [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+
+    private ISawmill _sawmill = default!;
+
+    public const float TileMassMultiplier = 0.5f;
+
+    public const float ShuttleLinearDamping = 0.05f;
+    public const float ShuttleAngularDamping = 0.05f;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly IMapManager _mapManager = default!;
-        [Dependency] private readonly IRobustRandom _random = default!;
-        [Dependency] private readonly AirlockSystem _airlock = default!;
-        [Dependency] private readonly DockingSystem _dockSystem = default!;
-        [Dependency] private readonly DoorSystem _doors = default!;
-        [Dependency] private readonly FixtureSystem _fixtures = default!;
-        [Dependency] private readonly MapLoaderSystem _loader = default!;
-        [Dependency] private readonly SharedAudioSystem _audio = default!;
-        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
-        [Dependency] private readonly SharedTransformSystem _transform = default!;
-        [Dependency] private readonly ShuttleConsoleSystem _console = default!;
-        [Dependency] private readonly StunSystem _stuns = default!;
-        [Dependency] private readonly ThrusterSystem _thruster = default!;
-        [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+        base.Initialize();
+        _sawmill = Logger.GetSawmill("shuttles");
 
-        private ISawmill _sawmill = default!;
+        InitializeFTL();
+        InitializeGridFills();
+        InitializeIFF();
+        InitializeImpact();
 
-        public const float TileMassMultiplier = 0.5f;
+        SubscribeLocalEvent<ShuttleComponent, ComponentAdd>(OnShuttleAdd);
+        SubscribeLocalEvent<ShuttleComponent, ComponentStartup>(OnShuttleStartup);
+        SubscribeLocalEvent<ShuttleComponent, ComponentShutdown>(OnShuttleShutdown);
 
-        public const float ShuttleLinearDamping = 0.05f;
-        public const float ShuttleAngularDamping = 0.05f;
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
 
-        public override void Initialize()
+        SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
+        SubscribeLocalEvent<GridFixtureChangeEvent>(OnGridFixtureChange);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        UpdateHyperspace(frameTime);
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        CleanupHyperspace();
+    }
+
+    private void OnShuttleAdd(EntityUid uid, ShuttleComponent component, ComponentAdd args)
+    {
+        // Easier than doing it in the comp and they don't have constructors.
+        for (var i = 0; i < component.LinearThrusters.Length; i++)
         {
-            base.Initialize();
-            _sawmill = Logger.GetSawmill("shuttles");
+            component.LinearThrusters[i] = new List<EntityUid>();
+        }
+    }
 
-            InitializeFTL();
-            InitializeGridFills();
-            InitializeIFF();
-            InitializeImpact();
+    private void OnGridFixtureChange(GridFixtureChangeEvent args)
+    {
+        // Look this is jank but it's a placeholder until we design it.
+        if (args.NewFixtures.Count == 0)
+            return;
 
-            SubscribeLocalEvent<ShuttleComponent, ComponentAdd>(OnShuttleAdd);
-            SubscribeLocalEvent<ShuttleComponent, ComponentStartup>(OnShuttleStartup);
-            SubscribeLocalEvent<ShuttleComponent, ComponentShutdown>(OnShuttleShutdown);
+        var uid = args.NewFixtures[0].Body.Owner;
+        var manager = Comp<FixturesComponent>(uid);
 
-            SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
-
-            SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
-            SubscribeLocalEvent<GridFixtureChangeEvent>(OnGridFixtureChange);
+        foreach (var fixture in args.NewFixtures)
+        {
+            _physics.SetDensity(uid, fixture, TileMassMultiplier, false, manager);
+            _fixtures.SetRestitution(uid, fixture, 0.1f, false, manager);
         }
 
-        public override void Update(float frameTime)
+        _fixtures.FixtureUpdate(uid, manager: manager);
+    }
+
+    private void OnGridInit(GridInitializeEvent ev)
+    {
+        if (HasComp<MapComponent>(ev.EntityUid))
+            return;
+
+        EntityManager.EnsureComponent<ShuttleComponent>(ev.EntityUid);
+    }
+
+    private void OnShuttleStartup(EntityUid uid, ShuttleComponent component, ComponentStartup args)
+    {
+        if (!EntityManager.HasComponent<MapGridComponent>(uid))
         {
-            base.Update(frameTime);
-            UpdateHyperspace(frameTime);
+            return;
         }
 
-        private void OnRoundRestart(RoundRestartCleanupEvent ev)
+        if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
         {
-            CleanupHyperspace();
+            return;
         }
 
-        private void OnShuttleAdd(EntityUid uid, ShuttleComponent component, ComponentAdd args)
+        if (component.Enabled)
         {
-            // Easier than doing it in the comp and they don't have constructors.
-            for (var i = 0; i < component.LinearThrusters.Length; i++)
-            {
-                component.LinearThrusters[i] = new List<ThrusterComponent>();
-            }
+            Enable(uid, physicsComponent);
         }
+    }
 
-        private void OnGridFixtureChange(GridFixtureChangeEvent args)
+    public void Toggle(EntityUid uid, ShuttleComponent component)
+    {
+        if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
+            return;
+
+        component.Enabled = !component.Enabled;
+
+        if (component.Enabled)
         {
-            // Look this is jank but it's a placeholder until we design it.
-            if (args.NewFixtures.Count == 0)
-                return;
-
-            var uid = args.NewFixtures[0].Body.Owner;
-            var manager = Comp<FixturesComponent>(uid);
-
-            foreach (var fixture in args.NewFixtures)
-            {
-                _physics.SetDensity(uid, fixture, TileMassMultiplier, false, manager);
-                _fixtures.SetRestitution(uid, fixture, 0.1f, false, manager);
-            }
-
-            _fixtures.FixtureUpdate(uid, manager: manager);
+            Enable(uid, physicsComponent);
         }
-
-        private void OnGridInit(GridInitializeEvent ev)
+        else
         {
-            if (HasComp<MapComponent>(ev.EntityUid))
-                return;
-
-            EntityManager.EnsureComponent<ShuttleComponent>(ev.EntityUid);
-        }
-
-        private void OnShuttleStartup(EntityUid uid, ShuttleComponent component, ComponentStartup args)
-        {
-            if (!EntityManager.HasComponent<MapGridComponent>(uid))
-            {
-                return;
-            }
-
-            if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
-            {
-                return;
-            }
-
-            if (component.Enabled)
-            {
-                Enable(uid, physicsComponent);
-            }
-        }
-
-        public void Toggle(EntityUid uid, ShuttleComponent component)
-        {
-            if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
-                return;
-
-            component.Enabled = !component.Enabled;
-
-            if (component.Enabled)
-            {
-                Enable(uid, physicsComponent);
-            }
-            else
-            {
-                Disable(uid, physicsComponent);
-            }
-        }
-
-        private void Enable(EntityUid uid, PhysicsComponent component)
-        {
-            FixturesComponent? manager = null;
-
-            _physics.SetBodyType(uid, BodyType.Dynamic, manager: manager, body: component);
-            _physics.SetBodyStatus(component, BodyStatus.InAir);
-            _physics.SetFixedRotation(uid, false, manager: manager, body: component);
-            _physics.SetLinearDamping(component, ShuttleLinearDamping);
-            _physics.SetAngularDamping(component, ShuttleAngularDamping);
-        }
-
-        private void Disable(EntityUid uid, PhysicsComponent component)
-        {
-            FixturesComponent? manager = null;
-
-            _physics.SetBodyType(uid, BodyType.Static, manager: manager, body: component);
-            _physics.SetBodyStatus(component, BodyStatus.OnGround);
-            _physics.SetFixedRotation(uid, true, manager: manager, body: component);
-        }
-
-        private void OnShuttleShutdown(EntityUid uid, ShuttleComponent component, ComponentShutdown args)
-        {
-            // None of the below is necessary for any cleanup if we're just deleting.
-            if (EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage >= EntityLifeStage.Terminating) return;
-
-            if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
-            {
-                return;
-            }
-
             Disable(uid, physicsComponent);
         }
+    }
+
+    private void Enable(EntityUid uid, PhysicsComponent component)
+    {
+        FixturesComponent? manager = null;
+
+        _physics.SetBodyType(uid, BodyType.Dynamic, manager: manager, body: component);
+        _physics.SetBodyStatus(component, BodyStatus.InAir);
+        _physics.SetFixedRotation(uid, false, manager: manager, body: component);
+        _physics.SetLinearDamping(component, ShuttleLinearDamping);
+        _physics.SetAngularDamping(component, ShuttleAngularDamping);
+    }
+
+    private void Disable(EntityUid uid, PhysicsComponent component)
+    {
+        FixturesComponent? manager = null;
+
+        _physics.SetBodyType(uid, BodyType.Static, manager: manager, body: component);
+        _physics.SetBodyStatus(component, BodyStatus.OnGround);
+        _physics.SetFixedRotation(uid, true, manager: manager, body: component);
+    }
+
+    private void OnShuttleShutdown(EntityUid uid, ShuttleComponent component, ComponentShutdown args)
+    {
+        // None of the below is necessary for any cleanup if we're just deleting.
+        if (EntityManager.GetComponent<MetaDataComponent>(uid).EntityLifeStage >= EntityLifeStage.Terminating)
+            return;
+
+        if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
+        {
+            return;
+        }
+
+        Disable(uid, physicsComponent);
     }
 }

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -43,6 +43,7 @@ public sealed class ThrusterSystem : EntitySystem
         SubscribeLocalEvent<ThrusterComponent, ActivateInWorldEvent>(OnActivateThruster);
         SubscribeLocalEvent<ThrusterComponent, ComponentInit>(OnThrusterInit);
         SubscribeLocalEvent<ThrusterComponent, ComponentShutdown>(OnThrusterShutdown);
+        SubscribeLocalEvent<ThrusterComponent, MapInitEvent>(OnThrusterMapInit);
         SubscribeLocalEvent<ThrusterComponent, PowerChangedEvent>(OnPowerChange);
         SubscribeLocalEvent<ThrusterComponent, AnchorStateChangedEvent>(OnAnchorChange);
         SubscribeLocalEvent<ThrusterComponent, ReAnchorEvent>(OnThrusterReAnchor);
@@ -199,11 +200,14 @@ public sealed class ThrusterSystem : EntitySystem
             EnableThruster(uid, component);
     }
 
-    private void OnThrusterInit(EntityUid uid, ThrusterComponent component, ComponentInit args)
+    private void OnThrusterMapInit(EntityUid uid, ThrusterComponent component, MapInitEvent args)
     {
         if (component.NextFire < _timing.CurTime)
             component.NextFire = _timing.CurTime;
+    }
 
+    private void OnThrusterInit(EntityUid uid, ThrusterComponent component, ComponentInit args)
+    {
         _ambient.SetAmbience(uid, false);
 
         if (!component.Enabled)

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -17,496 +17,523 @@ using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
-namespace Content.Server.Shuttles.Systems
+namespace Content.Server.Shuttles.Systems;
+
+public sealed class ThrusterSystem : EntitySystem
 {
-    public sealed class ThrusterSystem : EntitySystem
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly ITileDefinitionManager _tileDefManager = default!;
+    [Dependency] private readonly AmbientSoundSystem _ambient = default!;
+    [Dependency] private readonly FixtureSystem _fixtureSystem = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    // Essentially whenever thruster enables we update the shuttle's available impulses which are used for movement.
+    // This is done for each direction available.
+
+    public const string BurnFixture = "thruster-burn";
+
+    public override void Initialize()
     {
-        [Dependency] private readonly IMapManager _mapManager = default!;
-        [Dependency] private readonly ITileDefinitionManager _tileDefManager = default!;
-        [Dependency] private readonly AmbientSoundSystem _ambient = default!;
-        [Dependency] private readonly FixtureSystem _fixtureSystem = default!;
-        [Dependency] private readonly DamageableSystem _damageable = default!;
-        [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        base.Initialize();
+        SubscribeLocalEvent<ThrusterComponent, ActivateInWorldEvent>(OnActivateThruster);
+        SubscribeLocalEvent<ThrusterComponent, ComponentInit>(OnThrusterInit);
+        SubscribeLocalEvent<ThrusterComponent, ComponentShutdown>(OnThrusterShutdown);
+        SubscribeLocalEvent<ThrusterComponent, PowerChangedEvent>(OnPowerChange);
+        SubscribeLocalEvent<ThrusterComponent, AnchorStateChangedEvent>(OnAnchorChange);
+        SubscribeLocalEvent<ThrusterComponent, ReAnchorEvent>(OnThrusterReAnchor);
+        SubscribeLocalEvent<ThrusterComponent, MoveEvent>(OnRotate);
+        SubscribeLocalEvent<ThrusterComponent, IsHotEvent>(OnIsHotEvent);
+        SubscribeLocalEvent<ThrusterComponent, StartCollideEvent>(OnStartCollide);
+        SubscribeLocalEvent<ThrusterComponent, EndCollideEvent>(OnEndCollide);
 
-        // Essentially whenever thruster enables we update the shuttle's available impulses which are used for movement.
-        // This is done for each direction available.
+        SubscribeLocalEvent<ThrusterComponent, ExaminedEvent>(OnThrusterExamine);
 
-        public const string BurnFixture = "thruster-burn";
+        SubscribeLocalEvent<ThrusterComponent, RefreshPartsEvent>(OnRefreshParts);
+        SubscribeLocalEvent<ThrusterComponent, UpgradeExamineEvent>(OnUpgradeExamine);
 
-        private readonly HashSet<ThrusterComponent> _activeThrusters = new();
+        SubscribeLocalEvent<ShuttleComponent, TileChangedEvent>(OnShuttleTileChange);
+    }
 
-        // Used for accumulating burn if someone touches a firing thruster.
+    private void OnThrusterExamine(EntityUid uid, ThrusterComponent component, ExaminedEvent args)
+    {
+        // Powered is already handled by other power components
+        var enabled = Loc.GetString(component.Enabled ? "thruster-comp-enabled" : "thruster-comp-disabled");
 
-        private float _accumulator;
+        args.PushMarkup(enabled);
 
-        public override void Initialize()
+        if (component.Type == ThrusterType.Linear &&
+            EntityManager.TryGetComponent(uid, out TransformComponent? xform) &&
+            xform.Anchored)
         {
-            base.Initialize();
-            SubscribeLocalEvent<ThrusterComponent, ActivateInWorldEvent>(OnActivateThruster);
-            SubscribeLocalEvent<ThrusterComponent, ComponentInit>(OnThrusterInit);
-            SubscribeLocalEvent<ThrusterComponent, ComponentShutdown>(OnThrusterShutdown);
-            SubscribeLocalEvent<ThrusterComponent, PowerChangedEvent>(OnPowerChange);
-            SubscribeLocalEvent<ThrusterComponent, AnchorStateChangedEvent>(OnAnchorChange);
-            SubscribeLocalEvent<ThrusterComponent, ReAnchorEvent>(OnThrusterReAnchor);
-            SubscribeLocalEvent<ThrusterComponent, MoveEvent>(OnRotate);
-            SubscribeLocalEvent<ThrusterComponent, IsHotEvent>(OnIsHotEvent);
-            SubscribeLocalEvent<ThrusterComponent, StartCollideEvent>(OnStartCollide);
-            SubscribeLocalEvent<ThrusterComponent, EndCollideEvent>(OnEndCollide);
+            var nozzleDir = Loc.GetString("thruster-comp-nozzle-direction",
+                ("direction", xform.LocalRotation.Opposite().ToWorldVec().GetDir().ToString().ToLowerInvariant()));
 
-            SubscribeLocalEvent<ThrusterComponent, ExaminedEvent>(OnThrusterExamine);
+            args.PushMarkup(nozzleDir);
 
-            SubscribeLocalEvent<ThrusterComponent, RefreshPartsEvent>(OnRefreshParts);
-            SubscribeLocalEvent<ThrusterComponent, UpgradeExamineEvent>(OnUpgradeExamine);
+            var exposed = NozzleExposed(xform);
 
-            SubscribeLocalEvent<ShuttleComponent, TileChangedEvent>(OnShuttleTileChange);
+            var nozzleText = Loc.GetString(exposed ? "thruster-comp-nozzle-exposed" : "thruster-comp-nozzle-not-exposed");
+
+            args.PushMarkup(nozzleText);
         }
+    }
 
-        private void OnThrusterExamine(EntityUid uid, ThrusterComponent component, ExaminedEvent args)
+    private void OnIsHotEvent(EntityUid uid, ThrusterComponent component, IsHotEvent args)
+    {
+        args.IsHot = component.Type != ThrusterType.Angular && component.IsOn;
+    }
+
+    private void OnShuttleTileChange(EntityUid uid, ShuttleComponent component, ref TileChangedEvent args)
+    {
+        // If the old tile was space but the new one isn't then disable all adjacent thrusters
+        if (args.NewTile.IsSpace(_tileDefManager) || !args.OldTile.IsSpace(_tileDefManager))
+            return;
+
+        var tilePos = args.NewTile.GridIndices;
+        var grid = _mapManager.GetGrid(uid);
+        var xformQuery = GetEntityQuery<TransformComponent>();
+        var thrusterQuery = GetEntityQuery<ThrusterComponent>();
+
+        for (var x = -1; x <= 1; x++)
         {
-            // Powered is already handled by other power components
-            var enabled = Loc.GetString(component.Enabled ? "thruster-comp-enabled" : "thruster-comp-disabled");
-
-            args.PushMarkup(enabled);
-
-            if (component.Type == ThrusterType.Linear &&
-                EntityManager.TryGetComponent(uid, out TransformComponent? xform) &&
-                xform.Anchored)
+            for (var y = -1; y <= 1; y++)
             {
-                var nozzleDir = Loc.GetString("thruster-comp-nozzle-direction",
-                    ("direction", xform.LocalRotation.Opposite().ToWorldVec().GetDir().ToString().ToLowerInvariant()));
+                if (x != 0 && y != 0)
+                    continue;
 
-                args.PushMarkup(nozzleDir);
+                var checkPos = tilePos + new Vector2i(x, y);
+                var enumerator = grid.GetAnchoredEntitiesEnumerator(checkPos);
 
-                var exposed = NozzleExposed(xform);
-
-                var nozzleText = Loc.GetString(exposed ? "thruster-comp-nozzle-exposed" : "thruster-comp-nozzle-not-exposed");
-
-                args.PushMarkup(nozzleText);
-            }
-        }
-
-        private void OnIsHotEvent(EntityUid uid, ThrusterComponent component, IsHotEvent args)
-        {
-            args.IsHot = component.Type != ThrusterType.Angular && component.IsOn;
-        }
-
-        private void OnShuttleTileChange(EntityUid uid, ShuttleComponent component, ref TileChangedEvent args)
-        {
-            // If the old tile was space but the new one isn't then disable all adjacent thrusters
-            if (args.NewTile.IsSpace(_tileDefManager) || !args.OldTile.IsSpace(_tileDefManager)) return;
-
-            var tilePos = args.NewTile.GridIndices;
-            var grid = _mapManager.GetGrid(uid);
-            var xformQuery = GetEntityQuery<TransformComponent>();
-            var thrusterQuery = GetEntityQuery<ThrusterComponent>();
-
-            for (var x = -1; x <= 1; x++)
-            {
-                for (var y = -1; y <= 1; y++)
+                while (enumerator.MoveNext(out var ent))
                 {
-                    if (x != 0 && y != 0) continue;
+                    if (!thrusterQuery.TryGetComponent(ent.Value, out var thruster) || !thruster.RequireSpace)
+                        continue;
 
-                    var checkPos = tilePos + new Vector2i(x, y);
-                    var enumerator = grid.GetAnchoredEntitiesEnumerator(checkPos);
+                    // Work out if the thruster is facing this direction
+                    var xform = xformQuery.GetComponent(ent.Value);
+                    var direction = xform.LocalRotation.ToWorldVec();
 
-                    while (enumerator.MoveNext(out var ent))
-                    {
-                        if (!thrusterQuery.TryGetComponent(ent.Value, out var thruster) || !thruster.RequireSpace) continue;
+                    if (new Vector2i((int) direction.X, (int) direction.Y) != new Vector2i(x, y))
+                        continue;
 
-                        // Work out if the thruster is facing this direction
-                        var xform = xformQuery.GetComponent(ent.Value);
-                        var direction = xform.LocalRotation.ToWorldVec();
-
-                        if (new Vector2i((int) direction.X, (int) direction.Y) != new Vector2i(x, y)) continue;
-
-                        DisableThruster(ent.Value, thruster, xform.GridUid);
-                    }
+                    DisableThruster(ent.Value, thruster, xform.GridUid);
                 }
             }
         }
+    }
 
-        private void OnActivateThruster(EntityUid uid, ThrusterComponent component, ActivateInWorldEvent args)
+    private void OnActivateThruster(EntityUid uid, ThrusterComponent component, ActivateInWorldEvent args)
+    {
+        component.Enabled ^= true;
+    }
+
+    /// <summary>
+    /// If the thruster rotates change the direction where the linear thrust is applied
+    /// </summary>
+    private void OnRotate(EntityUid uid, ThrusterComponent component, ref MoveEvent args)
+    {
+        // TODO: Disable visualizer for old direction
+
+        if (!component.Enabled ||
+            component.Type != ThrusterType.Linear ||
+            !EntityManager.TryGetComponent(uid, out TransformComponent? xform) ||
+            !EntityManager.TryGetComponent(xform.GridUid, out ShuttleComponent? shuttleComponent))
         {
-            component.Enabled ^= true;
+            return;
         }
 
-        /// <summary>
-        /// If the thruster rotates change the direction where the linear thrust is applied
-        /// </summary>
-        private void OnRotate(EntityUid uid, ThrusterComponent component, ref MoveEvent args)
+        var canEnable = CanEnable(uid, component);
+
+        // If it's not on then don't enable it inadvertantly (given we don't have an old rotation)
+        if (!canEnable && !component.IsOn)
+            return;
+
+        // Enable it if it was turned off but new tile is valid
+        if (!component.IsOn && canEnable)
         {
-            // TODO: Disable visualizer for old direction
-
-            if (!component.Enabled ||
-                component.Type != ThrusterType.Linear ||
-                !EntityManager.TryGetComponent(uid, out TransformComponent? xform) ||
-                !_mapManager.TryGetGrid(xform.GridUid, out var grid) ||
-                !EntityManager.TryGetComponent(grid.Owner, out ShuttleComponent? shuttleComponent))
-            {
-                return;
-            }
-
-            var canEnable = CanEnable(uid, component);
-
-            // If it's not on then don't enable it inadvertantly (given we don't have an old rotation)
-            if (!canEnable && !component.IsOn) return;
-
-            // Enable it if it was turned off but new tile is valid
-            if (!component.IsOn && canEnable)
-            {
-                EnableThruster(uid, component);
-                return;
-            }
-
-            // Disable if new tile invalid
-            if (component.IsOn && !canEnable)
-            {
-                DisableThruster(uid, component, xform, args.OldRotation);
-                return;
-            }
-
-            var oldDirection = (int) args.OldRotation.GetCardinalDir() / 2;
-            var direction = (int) args.NewRotation.GetCardinalDir() / 2;
-
-            shuttleComponent.LinearThrust[oldDirection] -= component.Thrust;
-            DebugTools.Assert(shuttleComponent.LinearThrusters[oldDirection].Contains(component));
-            shuttleComponent.LinearThrusters[oldDirection].Remove(component);
-
-            shuttleComponent.LinearThrust[direction] += component.Thrust;
-            DebugTools.Assert(!shuttleComponent.LinearThrusters[direction].Contains(component));
-            shuttleComponent.LinearThrusters[direction].Add(component);
+            EnableThruster(uid, component);
+            return;
         }
 
-        private void OnAnchorChange(EntityUid uid, ThrusterComponent component, ref AnchorStateChangedEvent args)
+        // Disable if new tile invalid
+        if (component.IsOn && !canEnable)
         {
-            if (args.Anchored && CanEnable(uid, component))
-            {
-                EnableThruster(uid, component);
-            }
-            else
-            {
-                DisableThruster(uid, component);
-            }
+            DisableThruster(uid, component, xform, args.OldRotation);
+            return;
         }
 
-        private void OnThrusterReAnchor(EntityUid uid, ThrusterComponent component, ref ReAnchorEvent args)
+        var oldDirection = (int) args.OldRotation.GetCardinalDir() / 2;
+        var direction = (int) args.NewRotation.GetCardinalDir() / 2;
+
+        shuttleComponent.LinearThrust[oldDirection] -= component.Thrust;
+        DebugTools.Assert(shuttleComponent.LinearThrusters[oldDirection].Contains(uid));
+        shuttleComponent.LinearThrusters[oldDirection].Remove(uid);
+
+        shuttleComponent.LinearThrust[direction] += component.Thrust;
+        DebugTools.Assert(!shuttleComponent.LinearThrusters[direction].Contains(uid));
+        shuttleComponent.LinearThrusters[direction].Add(uid);
+    }
+
+    private void OnAnchorChange(EntityUid uid, ThrusterComponent component, ref AnchorStateChangedEvent args)
+    {
+        if (args.Anchored && CanEnable(uid, component))
         {
-            DisableThruster(uid, component, args.OldGrid);
-
-            if (CanEnable(uid, component))
-                EnableThruster(uid, component);
+            EnableThruster(uid, component);
         }
-
-        private void OnThrusterInit(EntityUid uid, ThrusterComponent component, ComponentInit args)
-        {
-            _ambient.SetAmbience(uid, false);
-
-            if (!component.Enabled)
-            {
-                return;
-            }
-
-            if (CanEnable(uid, component))
-            {
-                EnableThruster(uid, component);
-            }
-        }
-
-        private void OnThrusterShutdown(EntityUid uid, ThrusterComponent component, ComponentShutdown args)
+        else
         {
             DisableThruster(uid, component);
         }
+    }
 
-        private void OnPowerChange(EntityUid uid, ThrusterComponent component, ref PowerChangedEvent args)
+    private void OnThrusterReAnchor(EntityUid uid, ThrusterComponent component, ref ReAnchorEvent args)
+    {
+        DisableThruster(uid, component, args.OldGrid);
+
+        if (CanEnable(uid, component))
+            EnableThruster(uid, component);
+    }
+
+    private void OnThrusterInit(EntityUid uid, ThrusterComponent component, ComponentInit args)
+    {
+        if (component.NextFire < _timing.CurTime)
+            component.NextFire = _timing.CurTime;
+
+        _ambient.SetAmbience(uid, false);
+
+        if (!component.Enabled)
         {
-            if (args.Powered && CanEnable(uid, component))
-            {
-                EnableThruster(uid, component);
-            }
-            else
-            {
-                DisableThruster(uid, component);
-            }
+            return;
         }
 
-        /// <summary>
-        /// Tries to enable the thruster and turn it on. If it's already enabled it does nothing.
-        /// </summary>
-        public void EnableThruster(EntityUid uid, ThrusterComponent component, TransformComponent? xform = null)
+        if (CanEnable(uid, component))
         {
-            if (component.IsOn ||
-                !Resolve(uid, ref xform) ||
-                !_mapManager.TryGetGrid(xform.GridUid, out var grid)) return;
+            EnableThruster(uid, component);
+        }
+    }
 
-            component.IsOn = true;
+    private void OnThrusterShutdown(EntityUid uid, ThrusterComponent component, ComponentShutdown args)
+    {
+        DisableThruster(uid, component);
+    }
 
-            if (!EntityManager.TryGetComponent(grid.Owner, out ShuttleComponent? shuttleComponent)) return;
+    private void OnPowerChange(EntityUid uid, ThrusterComponent component, ref PowerChangedEvent args)
+    {
+        if (args.Powered && CanEnable(uid, component))
+        {
+            EnableThruster(uid, component);
+        }
+        else
+        {
+            DisableThruster(uid, component);
+        }
+    }
 
-            // Logger.DebugS("thruster", $"Enabled thruster {uid}");
-
-            switch (component.Type)
-            {
-                case ThrusterType.Linear:
-                    var direction = (int) xform.LocalRotation.GetCardinalDir() / 2;
-
-                    shuttleComponent.LinearThrust[direction] += component.Thrust;
-                    DebugTools.Assert(!shuttleComponent.LinearThrusters[direction].Contains(component));
-                    shuttleComponent.LinearThrusters[direction].Add(component);
-
-                    // Don't just add / remove the fixture whenever the thruster fires because perf
-                    if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent) &&
-                        component.BurnPoly.Count > 0)
-                    {
-                        var shape = new PolygonShape();
-                        shape.SetVertices(component.BurnPoly);
-                        _fixtureSystem.TryCreateFixture(uid, shape, BurnFixture, hard: false, collisionLayer: (int) CollisionGroup.FullTileMask);
-                    }
-
-                    break;
-                case ThrusterType.Angular:
-                    shuttleComponent.AngularThrust += component.Thrust;
-                    DebugTools.Assert(!shuttleComponent.AngularThrusters.Contains(component));
-                    shuttleComponent.AngularThrusters.Add(component);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-
-            if (EntityManager.TryGetComponent(uid, out AppearanceComponent? appearance))
-            {
-                _appearance.SetData(uid, ThrusterVisualState.State, true, appearance);
-            }
-
-            if (EntityManager.TryGetComponent(uid, out PointLightComponent? pointLightComponent))
-            {
-                pointLightComponent.Enabled = true;
-            }
-
-            _ambient.SetAmbience(uid, true);
+    /// <summary>
+    /// Tries to enable the thruster and turn it on. If it's already enabled it does nothing.
+    /// </summary>
+    public void EnableThruster(EntityUid uid, ThrusterComponent component, TransformComponent? xform = null)
+    {
+        if (component.IsOn ||
+            !Resolve(uid, ref xform))
+        {
+            return;
         }
 
-        public void DisableThruster(EntityUid uid, ThrusterComponent component, TransformComponent? xform = null, Angle? angle = null)
+        component.IsOn = true;
+
+        if (!EntityManager.TryGetComponent(xform.GridUid, out ShuttleComponent? shuttleComponent))
+            return;
+
+        // Logger.DebugS("thruster", $"Enabled thruster {uid}");
+
+        switch (component.Type)
         {
-            if (!Resolve(uid, ref xform)) return;
-            DisableThruster(uid, component, xform.GridUid, xform);
-        }
+            case ThrusterType.Linear:
+                var direction = (int) xform.LocalRotation.GetCardinalDir() / 2;
 
-        /// <summary>
-        /// Tries to disable the thruster.
-        /// </summary>
-        public void DisableThruster(EntityUid uid, ThrusterComponent component, EntityUid? gridId, TransformComponent? xform = null, Angle? angle = null)
-        {
-            if (!component.IsOn ||
-                !Resolve(uid, ref xform) ||
-                !_mapManager.TryGetGrid(gridId, out var grid)) return;
+                shuttleComponent.LinearThrust[direction] += component.Thrust;
+                DebugTools.Assert(!shuttleComponent.LinearThrusters[direction].Contains(uid));
+                shuttleComponent.LinearThrusters[direction].Add(uid);
 
-            component.IsOn = false;
-
-            if (!EntityManager.TryGetComponent(grid.Owner, out ShuttleComponent? shuttleComponent)) return;
-
-            // Logger.DebugS("thruster", $"Disabled thruster {uid}");
-
-            switch (component.Type)
-            {
-                case ThrusterType.Linear:
-                    angle ??= xform.LocalRotation;
-                    var direction = (int) angle.Value.GetCardinalDir() / 2;
-
-                    shuttleComponent.LinearThrust[direction] -= component.Thrust;
-                    DebugTools.Assert(shuttleComponent.LinearThrusters[direction].Contains(component));
-                    shuttleComponent.LinearThrusters[direction].Remove(component);
-                    break;
-                case ThrusterType.Angular:
-                    shuttleComponent.AngularThrust -= component.Thrust;
-                    DebugTools.Assert(shuttleComponent.AngularThrusters.Contains(component));
-                    shuttleComponent.AngularThrusters.Remove(component);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-
-            if (EntityManager.TryGetComponent(uid, out AppearanceComponent? appearance))
-            {
-                _appearance.SetData(uid, ThrusterVisualState.State, false, appearance);
-            }
-
-            if (EntityManager.TryGetComponent(uid, out PointLightComponent? pointLightComponent))
-            {
-                pointLightComponent.Enabled = false;
-            }
-
-            _ambient.SetAmbience(uid, false);
-
-            if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
-            {
-                _fixtureSystem.DestroyFixture(uid, BurnFixture, body: physicsComponent);
-            }
-
-            _activeThrusters.Remove(component);
-            component.Colliding.Clear();
-        }
-
-        public bool CanEnable(EntityUid uid, ThrusterComponent component)
-        {
-            if (!component.Enabled) return false;
-            if (component.LifeStage > ComponentLifeStage.Running) return false;
-
-            var xform = Transform(uid);
-
-            if (!xform.Anchored ||!this.IsPowered(uid, EntityManager))
-            {
-                return false;
-            }
-
-            if (!component.RequireSpace)
-                return true;
-
-            return NozzleExposed(xform);
-        }
-
-        private bool NozzleExposed(TransformComponent xform)
-        {
-            if (xform.GridUid == null)
-                return true;
-
-            var (x, y) = xform.LocalPosition + xform.LocalRotation.Opposite().ToWorldVec();
-            var tile = _mapManager.GetGrid(xform.GridUid.Value).GetTileRef(new Vector2i((int) Math.Floor(x), (int) Math.Floor(y)));
-
-            return tile.Tile.IsSpace();
-        }
-
-        #region Burning
-
-        public override void Update(float frameTime)
-        {
-            base.Update(frameTime);
-
-            _accumulator += frameTime;
-
-            if (_accumulator < 1) return;
-
-            _accumulator -= 1;
-
-            foreach (var comp in _activeThrusters.ToArray())
-            {
-                MetaDataComponent? metaData = null;
-
-                if (!comp.Firing || comp.Damage == null || Paused(comp.Owner, metaData) || Deleted(comp.Owner, metaData)) continue;
-
-                DebugTools.Assert(comp.Colliding.Count > 0);
-
-                foreach (var uid in comp.Colliding.ToArray())
+                // Don't just add / remove the fixture whenever the thruster fires because perf
+                if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent) &&
+                    component.BurnPoly.Count > 0)
                 {
-                    _damageable.TryChangeDamage(uid, comp.Damage);
+                    var shape = new PolygonShape();
+                    shape.SetVertices(component.BurnPoly);
+                    _fixtureSystem.TryCreateFixture(uid, shape, BurnFixture, hard: false, collisionLayer: (int) CollisionGroup.FullTileMask, body: physicsComponent);
                 }
+
+                break;
+            case ThrusterType.Angular:
+                shuttleComponent.AngularThrust += component.Thrust;
+                DebugTools.Assert(!shuttleComponent.AngularThrusters.Contains(uid));
+                shuttleComponent.AngularThrusters.Add(uid);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        if (EntityManager.TryGetComponent(uid, out AppearanceComponent? appearance))
+        {
+            _appearance.SetData(uid, ThrusterVisualState.State, true, appearance);
+        }
+
+        if (EntityManager.TryGetComponent(uid, out PointLightComponent? pointLightComponent))
+        {
+            pointLightComponent.Enabled = true;
+        }
+
+        _ambient.SetAmbience(uid, true);
+    }
+
+    public void DisableThruster(EntityUid uid, ThrusterComponent component, TransformComponent? xform = null, Angle? angle = null)
+    {
+        if (!Resolve(uid, ref xform)) return;
+        DisableThruster(uid, component, xform.GridUid, xform);
+    }
+
+    /// <summary>
+    /// Tries to disable the thruster.
+    /// </summary>
+    public void DisableThruster(EntityUid uid, ThrusterComponent component, EntityUid? gridId, TransformComponent? xform = null, Angle? angle = null)
+    {
+        if (!component.IsOn ||
+            !Resolve(uid, ref xform))
+        {
+            return;
+        }
+
+        component.IsOn = false;
+
+        if (!EntityManager.TryGetComponent(gridId, out ShuttleComponent? shuttleComponent))
+            return;
+
+        // Logger.DebugS("thruster", $"Disabled thruster {uid}");
+
+        switch (component.Type)
+        {
+            case ThrusterType.Linear:
+                angle ??= xform.LocalRotation;
+                var direction = (int) angle.Value.GetCardinalDir() / 2;
+
+                shuttleComponent.LinearThrust[direction] -= component.Thrust;
+                DebugTools.Assert(shuttleComponent.LinearThrusters[direction].Contains(uid));
+                shuttleComponent.LinearThrusters[direction].Remove(uid);
+                break;
+            case ThrusterType.Angular:
+                shuttleComponent.AngularThrust -= component.Thrust;
+                DebugTools.Assert(shuttleComponent.AngularThrusters.Contains(uid));
+                shuttleComponent.AngularThrusters.Remove(uid);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        if (EntityManager.TryGetComponent(uid, out AppearanceComponent? appearance))
+        {
+            _appearance.SetData(uid, ThrusterVisualState.State, false, appearance);
+        }
+
+        if (EntityManager.TryGetComponent(uid, out PointLightComponent? pointLightComponent))
+        {
+            pointLightComponent.Enabled = false;
+        }
+
+        _ambient.SetAmbience(uid, false);
+
+        if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
+        {
+            _fixtureSystem.DestroyFixture(uid, BurnFixture, body: physicsComponent);
+        }
+
+        component.Colliding.Clear();
+    }
+
+    public bool CanEnable(EntityUid uid, ThrusterComponent component)
+    {
+        if (!component.Enabled)
+            return false;
+
+        if (component.LifeStage > ComponentLifeStage.Running)
+            return false;
+
+        var xform = Transform(uid);
+
+        if (!xform.Anchored ||!this.IsPowered(uid, EntityManager))
+        {
+            return false;
+        }
+
+        if (!component.RequireSpace)
+            return true;
+
+        return NozzleExposed(xform);
+    }
+
+    private bool NozzleExposed(TransformComponent xform)
+    {
+        if (xform.GridUid == null)
+            return true;
+
+        var (x, y) = xform.LocalPosition + xform.LocalRotation.Opposite().ToWorldVec();
+        var tile = _mapManager.GetGrid(xform.GridUid.Value).GetTileRef(new Vector2i((int) Math.Floor(x), (int) Math.Floor(y)));
+
+        return tile.Tile.IsSpace();
+    }
+
+    #region Burning
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<ThrusterComponent>();
+        var curTime = _timing.CurTime;
+
+        while (query.MoveNext(out var comp))
+        {
+            if (!comp.Firing || comp.Colliding.Count == 0 || comp.Damage == null || comp.NextFire < curTime)
+                continue;
+
+            comp.NextFire += TimeSpan.FromSeconds(1);
+
+            foreach (var uid in comp.Colliding.ToArray())
+            {
+                _damageable.TryChangeDamage(uid, comp.Damage);
             }
         }
+    }
 
-        private void OnStartCollide(EntityUid uid, ThrusterComponent component, ref StartCollideEvent args)
+    private void OnStartCollide(EntityUid uid, ThrusterComponent component, ref StartCollideEvent args)
+    {
+        if (args.OurFixture.ID != BurnFixture)
+            return;
+
+        component.Colliding.Add(args.OtherEntity);
+    }
+
+    private void OnEndCollide(EntityUid uid, ThrusterComponent component, ref EndCollideEvent args)
+    {
+        if (args.OurFixture.ID != BurnFixture)
+            return;
+
+        component.Colliding.Remove(args.OtherEntity);
+    }
+
+    /// <summary>
+    /// Considers a thrust direction as being active.
+    /// </summary>
+    public void EnableLinearThrustDirection(ShuttleComponent component, DirectionFlag direction)
+    {
+        if ((component.ThrustDirections & direction) != 0x0)
+            return;
+
+        component.ThrustDirections |= direction;
+
+        var index = GetFlagIndex(direction);
+        var appearanceQuery = GetEntityQuery<AppearanceComponent>();
+        var thrusterQuery = GetEntityQuery<ThrusterComponent>();
+
+        foreach (var uid in component.LinearThrusters[index])
         {
-            if (args.OurFixture.ID != BurnFixture) return;
+            if (!thrusterQuery.TryGetComponent(uid, out var comp))
+                continue;
 
-            _activeThrusters.Add(component);
-            component.Colliding.Add((args.OtherFixture.Body).Owner);
+            comp.Firing = true;
+            appearanceQuery.TryGetComponent(uid, out var appearance);
+            _appearance.SetData(uid, ThrusterVisualState.Thrusting, true, appearance);
+        }
+    }
+
+    /// <summary>
+    /// Disables a thrust direction.
+    /// </summary>
+    public void DisableLinearThrustDirection(ShuttleComponent component, DirectionFlag direction)
+    {
+        if ((component.ThrustDirections & direction) == 0x0)
+            return;
+
+        component.ThrustDirections &= ~direction;
+
+        var index = GetFlagIndex(direction);
+        var appearanceQuery = GetEntityQuery<AppearanceComponent>();
+        var thrusterQuery = GetEntityQuery<ThrusterComponent>();
+
+        foreach (var uid in component.LinearThrusters[index])
+        {
+            if (!thrusterQuery.TryGetComponent(uid, out var comp))
+                continue;
+
+            appearanceQuery.TryGetComponent(uid, out var appearance);
+            comp.Firing = false;
+            _appearance.SetData(uid, ThrusterVisualState.Thrusting, false, appearance);
+        }
+    }
+
+    public void DisableLinearThrusters(ShuttleComponent component)
+    {
+        foreach (DirectionFlag dir in Enum.GetValues(typeof(DirectionFlag)))
+        {
+            DisableLinearThrustDirection(component, dir);
         }
 
-        private void OnEndCollide(EntityUid uid, ThrusterComponent component, ref EndCollideEvent args)
+        DebugTools.Assert(component.ThrustDirections == DirectionFlag.None);
+    }
+
+    public void SetAngularThrust(ShuttleComponent component, bool on)
+    {
+        var appearanceQuery = GetEntityQuery<AppearanceComponent>();
+        var thrusterQuery = GetEntityQuery<ThrusterComponent>();
+
+        if (on)
         {
-            if (args.OurFixture.ID != BurnFixture) return;
-
-            component.Colliding.Remove((args.OtherFixture.Body).Owner);
-
-            if (component.Colliding.Count == 0)
+            foreach (var uid in component.AngularThrusters)
             {
-                _activeThrusters.Remove(component);
-            }
-        }
+                if (!thrusterQuery.TryGetComponent(uid, out var comp))
+                    continue;
 
-        /// <summary>
-        /// Considers a thrust direction as being active.
-        /// </summary>
-        public void EnableLinearThrustDirection(ShuttleComponent component, DirectionFlag direction)
-        {
-            if ((component.ThrustDirections & direction) != 0x0) return;
-
-            component.ThrustDirections |= direction;
-
-            var index = GetFlagIndex(direction);
-
-            foreach (var comp in component.LinearThrusters[index])
-            {
+                appearanceQuery.TryGetComponent(uid, out var appearance);
                 comp.Firing = true;
-                _appearance.SetData(comp.Owner, ThrusterVisualState.Thrusting, true);
+                _appearance.SetData(uid, ThrusterVisualState.Thrusting, true, appearance);
             }
         }
-
-        /// <summary>
-        /// Disables a thrust direction.
-        /// </summary>
-        public void DisableLinearThrustDirection(ShuttleComponent component, DirectionFlag direction)
+        else
         {
-            if ((component.ThrustDirections & direction) == 0x0) return;
-
-            component.ThrustDirections &= ~direction;
-
-            var index = GetFlagIndex(direction);
-
-            foreach (var comp in component.LinearThrusters[index])
+            foreach (var uid in component.AngularThrusters)
             {
+                if (!thrusterQuery.TryGetComponent(uid, out var comp))
+                    continue;
+
+                appearanceQuery.TryGetComponent(uid, out var appearance);
                 comp.Firing = false;
-                _appearance.SetData(comp.Owner, ThrusterVisualState.Thrusting, false);
+                _appearance.SetData(uid, ThrusterVisualState.Thrusting, false, appearance);
             }
         }
+    }
 
-        public void DisableLinearThrusters(ShuttleComponent component)
-        {
-            foreach (DirectionFlag dir in Enum.GetValues(typeof(DirectionFlag)))
-            {
-                DisableLinearThrustDirection(component, dir);
-            }
+    private void OnRefreshParts(EntityUid uid, ThrusterComponent component, RefreshPartsEvent args)
+    {
+        var thrustRating = args.PartRatings[component.MachinePartThrust];
 
-            DebugTools.Assert(component.ThrustDirections == DirectionFlag.None);
-        }
+        component.Thrust = component.BaseThrust * MathF.Pow(component.PartRatingThrustMultiplier, thrustRating - 1);
+    }
 
-        public void SetAngularThrust(ShuttleComponent component, bool on)
-        {
-            if (on)
-            {
-                foreach (var comp in component.AngularThrusters)
-                {
-                    comp.Firing = true;
-                    _appearance.SetData(comp.Owner, ThrusterVisualState.Thrusting, true);
-                }
-            }
-            else
-            {
-                foreach (var comp in component.AngularThrusters)
-                {
-                    comp.Firing = false;
-                    _appearance.SetData(comp.Owner, ThrusterVisualState.Thrusting, false);
-                }
-            }
-        }
+    private void OnUpgradeExamine(EntityUid uid, ThrusterComponent component, UpgradeExamineEvent args)
+    {
+        args.AddPercentageUpgrade("thruster-comp-upgrade-thrust", component.Thrust / component.BaseThrust);
+    }
 
-        private void OnRefreshParts(EntityUid uid, ThrusterComponent component, RefreshPartsEvent args)
-        {
-            var thrustRating = args.PartRatings[component.MachinePartThrust];
+    #endregion
 
-            component.Thrust = component.BaseThrust * MathF.Pow(component.PartRatingThrustMultiplier, thrustRating - 1);
-        }
-
-        private void OnUpgradeExamine(EntityUid uid, ThrusterComponent component, UpgradeExamineEvent args)
-        {
-            args.AddPercentageUpgrade("thruster-comp-upgrade-thrust", component.Thrust / component.BaseThrust);
-        }
-
-        #endregion
-
-        private int GetFlagIndex(DirectionFlag flag)
-        {
-            return (int) Math.Log2((int) flag);
-        }
+    private int GetFlagIndex(DirectionFlag flag)
+    {
+        return (int) Math.Log2((int) flag);
     }
 }


### PR DESCRIPTION
RefreshParts is only called on MapInit for startup so we'll just serialize the thrust value and call it a day.

Did some other cleanup (entityuid, file-scoped namespaces) elsewhere.