### PR TITLE
Reduce expedition time

### DIFF
--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTimeMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTimeMod.cs
@@ -16,8 +16,8 @@ public sealed class SalvageTimeMod : IPrototype, ISalvageMod
     public float Cost { get; } = 0f;
 
     [DataField("minDuration")]
-    public int MinDuration = 1080;
+    public int MinDuration = 900;
 
     [DataField("maxDuration")]
-    public int MaxDuration = 1200;
+    public int MaxDuration = 900;
 }

--- a/Resources/Prototypes/Procedural/salvage_mods.yml
+++ b/Resources/Prototypes/Procedural/salvage_mods.yml
@@ -75,8 +75,8 @@
 - type: salvageTimeMod
   id: RushTime
   desc: Rush
-  minDuration: 900
-  maxDuration: 1020
+  minDuration: 720
+  maxDuration: 780
   cost: 1
 
 # Misc mods


### PR DESCRIPTION
Originally it was 8-10 minutes which felt too short as they had maybe 2 minutes to loot, but 18 was giving them almost 10 minutes to loot and salvagers often left very early anyway. This seems like a better fit and we can tweak over time.

:cl:
- tweak: Reduce the standard salvage expedition time from 18-20 minutes to 15 minutes.
