### PR TITLE
Medkit inventory change

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -57,7 +57,7 @@
         amount: 2
       - id: AntiPoisonMedipen
       - id: PillDylovene
-        amount: 5
+        amount: 7
 
 - type: entity
   id: MedkitOxygenFilled
@@ -71,7 +71,7 @@
       - id: EmergencyMedipen
       - id: SyringeInaprovaline
       - id: PillDexalin
-        amount: 5
+        amount: 7
 
 - type: entity
   id: MedkitRadiationFilled
@@ -81,11 +81,11 @@
   - type: StorageFill
     contents:
       - id: Ointment
-        amount: 2
+        amount: 3
       - id: EmergencyMedipen
         amount: 2
       - id: PillHyronalin
-        amount: 10
+        amount: 9
 
 - type: entity
   id: MedkitAdvancedFilled
@@ -96,8 +96,8 @@
     contents:
       - id: Brutepack
         amount: 2 # TO DO: Advanced fills
-      - id: Gauze
       - id: Ointment
+      - id: Gauze
       - id: Bloodpack
         amount: 2
 
@@ -113,6 +113,8 @@
       - id: SyringeTranexamicAcid
       - id: AntiPoisonMedipen
       - id: Bloodpack
+        amount: 2
+      - id: PillTricordrazine
         amount: 2
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -11,8 +11,9 @@
         amount: 2
       - id: Ointment
         amount: 2
+      - id: Gauze
       - id: PillTricordrazine
-        amount: 3
+        amount: 5
       # see https://github.com/tgstation/blob/master/code/game/objects/items/storage/firstaid.dm for example contents
 
 - type: entity
@@ -22,10 +23,11 @@
   components:
   - type: StorageFill
     contents:
+      - id: SyringeInaprovaline
       - id: Ointment
         amount: 4
       - id: PillKelotane
-        amount: 3
+        amount: 5
 
 - type: entity
   id: MedkitBruteFilled
@@ -36,11 +38,11 @@
     contents:
       - id: Brutepack
         amount: 2 # TO DO: Advanced brute pack
-      - id: PillIron
-        amount: 2
       - id: Gauze
       - id: Bloodpack
       - id: SyringeTranexamicAcid
+      - id: PillIron
+        amount: 5
 
 - type: entity
   id: MedkitToxinFilled
@@ -50,10 +52,12 @@
   - type: StorageFill
     contents:
       - id: SyringeSpaceacillin
+        amount: 2
       - id: SyringeIpecac
-      - id: PillDylovene
-        amount: 3
+        amount: 2
       - id: AntiPoisonMedipen
+      - id: PillDylovene
+        amount: 5
 
 - type: entity
   id: MedkitOxygenFilled
@@ -62,11 +66,12 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingMaskBreathMedical
+      - id: EmergencyOxygenTank
       - id: EmergencyMedipen
-      - id: PillDexalin
-        amount: 3
       - id: SyringeInaprovaline
-        amount: 2
+      - id: PillDexalin
+        amount: 5
 
 - type: entity
   id: MedkitRadiationFilled
@@ -77,9 +82,10 @@
     contents:
       - id: Ointment
         amount: 2
-      - id: PillHyronalin
-        amount: 3
       - id: EmergencyMedipen
+        amount: 2
+      - id: PillHyronalin
+        amount: 10
 
 - type: entity
   id: MedkitAdvancedFilled

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -160,7 +160,7 @@
         maxVol: 20
         reagents:
         - ReagentId: Dexalin
-          Quantity: 15
+          Quantity: 10
 
 - type: entity
   name: dylovene pill
@@ -173,7 +173,7 @@
         maxVol: 20
         reagents:
         - ReagentId: Dylovene
-          Quantity: 15
+          Quantity: 10
 
 - type: entity
   name: hyronalin pill
@@ -186,7 +186,7 @@
         maxVol: 20
         reagents:
         - ReagentId: Hyronalin
-          Quantity: 15
+          Quantity: 10
 
 - type: entity
   name: iron pill
@@ -199,7 +199,7 @@
         maxVol: 20
         reagents:
         - ReagentId: Iron
-          Quantity: 15
+          Quantity: 10
 
 - type: entity
   name: kelotane pill
@@ -212,7 +212,7 @@
         maxVol: 20
         reagents:
         - ReagentId: Kelotane
-          Quantity: 15
+          Quantity: 10
 
 - type: entity
   name: space drugs
@@ -238,7 +238,7 @@
         maxVol: 20
         reagents:
         - ReagentId: Tricordrazine
-          Quantity: 15
+          Quantity: 10
 
 - type: entity
   name: romerol pill


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Pads out first aid kits to their role and ensures they start filled to the brim. Pills that start in first aid kits had their medication reduced to 10u from 15u per pill, but the overall number of pills was increased so they aren't so scarce after the kit has been used twice. This should hopefully make the individual first aid kit easier to divide up between multiple people (especially in medbay storage) and increase the individual kit's value beyond just treating two or three people.

Specific changes:
Standard first aid kit: +1 Gauze stack, +2 tricordazine pills (five total pills, total dosage 45u -> 50u)
Burn aid kit: +1 inaprovaline syringe, +2 kelotane pills (five total pills, total dosage 45u -> 50u)
Blunt trauma kit: +3 iron pills (five total pills, total dosage 30u -> 50u)
Toxin aid kit: +1 spaceacillin syringe, +1 ipecac syringe, +4 dylovene pills (seven total pills, total dosage 45u -> 70u)
Oxygen deprivation kit: -1 inaprovaline syringe, +1 medical breath mask, +1 emergency O2 tank, +4 dexalin pills (seven pills total, total dosage 45u -> 70u)
Radiation kit: +1 emergency medipen, +6 hyroalin pills (nine total pills, total dosage 45u -> 90u)
Advanced medkit: no changes
Combat medkit: padded the remaining two space with +2 tricordazine pills (20u total)

<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://user-images.githubusercontent.com/104049107/233752516-b2ab3265-39f1-4d4a-bcec-2ac5b0db8b6d.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: First aid kits are now more thoroughly stocked
