### PR TITLE
Fix handcuff raising assert on applying/removing

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -486,7 +486,7 @@ namespace Content.Shared.Cuffs
                 }
             }
 
-            _audio.PlayPvs(handcuffComponent.StartCuffSound, handcuff);
+            _audio.PlayPredicted(handcuffComponent.StartCuffSound, handcuff, user);
         }
 
         /// <summary>
@@ -567,7 +567,7 @@ namespace Content.Shared.Cuffs
             if (attempt.Cancelled)
                 return;
 
-            _audio.PlayPvs(cuff.EndUncuffSound, target);
+            _audio.PlayPredicted(cuff.EndUncuffSound, target, user);
 
             cuffable.Container.Remove(cuffsToRemove);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

The handcuff user client was raising an assert because it was failing a `IsFirstTimePredicted` check on audio source creation.
Fixes #15169.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] No screens required.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
no cl, somewhat fun
