### PR TITLE
Raise hand (un)equipped events on container insert/remove

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -43,9 +43,6 @@ namespace Content.Client.Hands.Systems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<HandsComponent, EntRemovedFromContainerMessage>(HandleItemRemoved);
-            SubscribeLocalEvent<HandsComponent, EntInsertedIntoContainerMessage>(HandleItemAdded);
-
             SubscribeLocalEvent<HandsComponent, PlayerAttachedEvent>(HandlePlayerAttached);
             SubscribeLocalEvent<HandsComponent, PlayerDetachedEvent>(HandlePlayerDetached);
             SubscribeLocalEvent<HandsComponent, ComponentAdd>(HandleCompAdd);
@@ -253,9 +250,11 @@ namespace Content.Client.Hands.Systems
 
         #region visuals
 
-        private void HandleItemAdded(EntityUid uid, HandsComponent handComp, ContainerModifiedMessage args)
+        protected override void HandleEntityInserted(EntityUid uid, HandsComponent hands, EntInsertedIntoContainerMessage args)
         {
-            if (!handComp.Hands.TryGetValue(args.Container.ID, out var hand))
+            base.HandleEntityInserted(uid, hands, args);
+
+            if (!hands.Hands.TryGetValue(args.Container.ID, out var hand))
                 return;
             UpdateHandVisuals(uid, args.Entity, hand);
             _stripSys.UpdateUi(uid);
@@ -269,9 +268,11 @@ namespace Content.Client.Hands.Systems
                 OnPlayerHandBlocked?.Invoke(hand.Name);
         }
 
-        private void HandleItemRemoved(EntityUid uid, HandsComponent handComp, ContainerModifiedMessage args)
+        protected override void HandleEntityRemoved(EntityUid uid, HandsComponent hands, EntRemovedFromContainerMessage args)
         {
-            if (!handComp.Hands.TryGetValue(args.Container.ID, out var hand))
+            base.HandleEntityRemoved(uid, hands, args);
+
+            if (!hands.Hands.TryGetValue(args.Container.ID, out var hand))
                 return;
             UpdateHandVisuals(uid, args.Entity, hand);
             _stripSys.UpdateUi(uid);

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -54,8 +54,6 @@ namespace Content.Server.Hands.Systems
             SubscribeLocalEvent<HandsComponent, PullStartedMessage>(HandlePullStarted);
             SubscribeLocalEvent<HandsComponent, PullStoppedMessage>(HandlePullStopped);
 
-            SubscribeLocalEvent<HandsComponent, EntRemovedFromContainerMessage>(HandleEntityRemoved);
-
             SubscribeLocalEvent<HandsComponent, BodyPartAddedEvent>(HandleBodyPartAdded);
             SubscribeLocalEvent<HandsComponent, BodyPartRemovedEvent>(HandleBodyPartRemoved);
 
@@ -109,8 +107,10 @@ namespace Content.Server.Hands.Systems
             RaiseNetworkEvent(new PickupAnimationEvent(item, initialPosition, finalPosition), filter);
         }
 
-        private void HandleEntityRemoved(EntityUid uid, HandsComponent component, EntRemovedFromContainerMessage args)
+        protected override void HandleEntityRemoved(EntityUid uid, HandsComponent hands, EntRemovedFromContainerMessage args)
         {
+            base.HandleEntityRemoved(uid, hands, args);
+
             if (!Deleted(args.Entity) && TryComp(args.Entity, out HandVirtualItemComponent? @virtual))
                 _virtualSystem.Delete(@virtual, uid);
         }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -361,7 +361,7 @@ public abstract class SharedActionsSystem : EntitySystem
 
         // for client-exclusive actions, the client shouldn't mark the comp as dirty. Otherwise that just leads to
         // unnecessary prediction resetting and state handling.
-        if (dirty)
+        if (dirty && !action.ClientExclusive)
             Dirty(comp);
     }
 
@@ -380,12 +380,15 @@ public abstract class SharedActionsSystem : EntitySystem
     {
         comp ??= EnsureComp<ActionsComponent>(uid);
 
+        bool allClientExclusive = true;
+
         foreach (var action in actions)
         {
             AddAction(uid, action, provider, comp, false);
+            allClientExclusive = allClientExclusive && action.ClientExclusive;
         }
 
-        if (dirty)
+        if (dirty && !allClientExclusive)
             Dirty(comp);
     }
 

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -7,6 +7,25 @@ namespace Content.Shared.Hands.EntitySystems;
 
 public abstract partial class SharedHandsSystem : EntitySystem
 {
+    private void InitializeDrop()
+    {
+        SubscribeLocalEvent<HandsComponent, EntRemovedFromContainerMessage>(HandleEntityRemoved);
+    }
+
+    protected virtual void HandleEntityRemoved(EntityUid uid, HandsComponent hands, EntRemovedFromContainerMessage args)
+    {
+        if (!TryGetHand(uid, args.Container.ID, out var hand))
+        {
+            return;
+        }
+
+        var gotUnequipped = new GotUnequippedHandEvent(uid, args.Entity, hand);
+        RaiseLocalEvent(args.Entity, gotUnequipped, false);
+
+        var didUnequip = new DidUnequipHandEvent(uid, args.Entity, hand);
+        RaiseLocalEvent(uid, didUnequip, true);
+    }
+
     /// <summary>
     ///     Checks if the contents of a hand is able to be removed from its container.
     /// </summary>
@@ -153,12 +172,6 @@ public abstract partial class SharedHandsSystem : EntitySystem
 
         if (doDropInteraction)
             _interactionSystem.DroppedInteraction(uid, entity);
-
-        var gotUnequipped = new GotUnequippedHandEvent(uid, entity, hand);
-        RaiseLocalEvent(entity, gotUnequipped, false);
-
-        var didUnequip = new DidUnequipHandEvent(uid, entity, hand);
-        RaiseLocalEvent(uid, didUnequip, true);
 
         if (hand == handsComp.ActiveHand)
             RaiseLocalEvent(entity, new HandDeselectedEvent(uid), false);

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -23,7 +23,7 @@ public abstract partial class SharedHandsSystem : EntitySystem
         RaiseLocalEvent(args.Entity, gotUnequipped, false);
 
         var didUnequip = new DidUnequipHandEvent(uid, args.Entity, hand);
-        RaiseLocalEvent(uid, didUnequip, true);
+        RaiseLocalEvent(uid, didUnequip, false);
     }
 
     /// <summary>

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
@@ -14,6 +14,7 @@ public abstract partial class SharedHandsSystem : EntitySystem
     {
         SubscribeLocalEvent<HandsComponent, EntInsertedIntoContainerMessage>(HandleEntityInserted);
     }
+
     protected virtual void HandleEntityInserted(EntityUid uid, HandsComponent hands, EntInsertedIntoContainerMessage args)
     {
         if (!TryGetHand(uid, args.Container.ID, out var hand))
@@ -25,7 +26,7 @@ public abstract partial class SharedHandsSystem : EntitySystem
         RaiseLocalEvent(uid, didEquip, false);
 
         var gotEquipped = new GotEquippedHandEvent(uid, args.Entity, hand);
-        RaiseLocalEvent(args.Entity, gotEquipped, true);
+        RaiseLocalEvent(args.Entity, gotEquipped, false);
     }
 
     /// <summary>

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
@@ -10,6 +10,24 @@ namespace Content.Shared.Hands.EntitySystems;
 
 public abstract partial class SharedHandsSystem : EntitySystem
 {
+    private void InitializePickup()
+    {
+        SubscribeLocalEvent<HandsComponent, EntInsertedIntoContainerMessage>(HandleEntityInserted);
+    }
+    protected virtual void HandleEntityInserted(EntityUid uid, HandsComponent hands, EntInsertedIntoContainerMessage args)
+    {
+        if (!TryGetHand(uid, args.Container.ID, out var hand))
+        {
+            return;
+        }
+
+        var didEquip = new DidEquipHandEvent(uid, args.Entity, hand);
+        RaiseLocalEvent(uid, didEquip, false);
+
+        var gotEquipped = new GotEquippedHandEvent(uid, args.Entity, hand);
+        RaiseLocalEvent(args.Entity, gotEquipped, true);
+    }
+
     /// <summary>
     ///     Maximum pickup distance for which the pickup animation plays.
     /// </summary>
@@ -207,17 +225,6 @@ public abstract partial class SharedHandsSystem : EntitySystem
         _adminLogger.Add(LogType.Pickup, LogImpact.Low, $"{ToPrettyString(uid):user} picked up {ToPrettyString(entity):entity}");
 
         Dirty(hands);
-
-        var didEquip = new DidEquipHandEvent(uid, entity, hand);
-        RaiseLocalEvent(uid, didEquip, false);
-
-        var gotEquipped = new GotEquippedHandEvent(uid, entity, hand);
-        RaiseLocalEvent(entity, gotEquipped, true);
-
-        // TODO this should REALLY be a cancellable thing, not a handled event.
-        // If one of the interactions resulted in the item being dropped, return early.
-        if (gotEquipped.Handled)
-            return;
 
         if (hand == hands.ActiveHand)
             RaiseLocalEvent(entity, new HandSelectedEvent(uid), false);

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -23,6 +23,8 @@ public abstract partial class SharedHandsSystem : EntitySystem
         base.Initialize();
 
         InitializeInteractions();
+        InitializeDrop();
+        InitializePickup();
     }
 
     public override void Shutdown()

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -146,10 +146,6 @@ public abstract partial class InventorySystem
         if (!_handsSystem.CanDropHeld(actor, hands.ActiveHand!, checkActionBlocker: false))
             return;
 
-        var gotUnequipped = new GotUnequippedHandEvent(actor, held.Value, hands.ActiveHand!);
-        var didUnequip = new DidUnequipHandEvent(actor, held.Value, hands.ActiveHand!);
-        RaiseLocalEvent(held.Value, gotUnequipped, false);
-        RaiseLocalEvent(actor, didUnequip, true);
         RaiseLocalEvent(held.Value, new HandDeselectedEvent(actor), false);
 
         TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory, force: true);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Applying an *ElectroJr/Sr* design suggestion : `drop/unequip handshould work more like inventory does, where it just raises unequip events automatically whenever anything is removed from the container` so actions list prediction on client can be accurate.
That fixes sidebar icons duplication, notably for magboots (fixes # 13408).

There's still multiple client reconciliation on a single pickup/drop, but it's now working as intended (as far as i can tell from my local testing).

Alongside the usual maintainers, requesting @ElectroJr review if/when they have some spare time to make sure it was what they had in mind.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

