### PR TITLE
Remove lobby preload

### DIFF
--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -34,7 +34,6 @@ namespace Content.Client.GameTicking.Managers
         [ViewVariables] public bool DisallowedLateJoin { get; private set; }
         [ViewVariables] public string? ServerInfoBlob { get; private set; }
         [ViewVariables] public TimeSpan StartTime { get; private set; }
-        [ViewVariables] public TimeSpan PreloadTime { get; private set; }
         [ViewVariables] public TimeSpan RoundStartTimeSpan { get; private set; }
         [ViewVariables] public new bool Paused { get; private set; }
 
@@ -90,7 +89,6 @@ namespace Content.Client.GameTicking.Managers
         private void LobbyStatus(TickerLobbyStatusEvent message)
         {
             StartTime = message.StartTime;
-            PreloadTime = message.PreloadTime;
             RoundStartTimeSpan = message.RoundStartTimeSpan;
             IsGameStarted = message.IsRoundStarted;
             AreWeReady = message.YouAreReady;

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -136,15 +136,17 @@ namespace Content.Client.Lobby
                 return;
             }
 
+            _lobby!.StationTime.Text =  Loc.GetString("lobby-state-player-status-round-not-started");
             string text;
 
             if (_gameTicker.Paused)
             {
                 text = Loc.GetString("lobby-state-paused");
             }
-            else if ((_gameTicker.StartTime - _gameTicker.PreloadTime) < _gameTiming.CurTime)
+            else if (_gameTicker.StartTime < _gameTiming.CurTime)
             {
-                text = Loc.GetString("lobby-state-preloading");
+                _lobby!.StartTime.Text = Loc.GetString("lobby-state-soon");
+                return;
             }
             else
             {
@@ -160,7 +162,6 @@ namespace Content.Client.Lobby
                 }
             }
 
-            _lobby!.StationTime.Text =  Loc.GetString("lobby-state-player-status-round-not-started");
             _lobby!.StartTime.Text = Loc.GetString("lobby-state-round-start-countdown-text", ("timeLeft", text));
         }
 

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -45,7 +45,6 @@ namespace Content.Shared.GameTicking
         public bool YouAreReady { get; }
         // UTC.
         public TimeSpan StartTime { get; }
-        public TimeSpan PreloadTime { get; }
         public TimeSpan RoundStartTimeSpan { get; }
         public bool Paused { get; }
 
@@ -56,7 +55,6 @@ namespace Content.Shared.GameTicking
             LobbyBackground = lobbyBackground;
             YouAreReady = youAreReady;
             StartTime = startTime;
-            PreloadTime = preloadTime;
             RoundStartTimeSpan = roundStartTimeSpan;
             Paused = paused;
         }

--- a/Resources/Locale/en-US/lobby/lobby-state.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-state.ftl
@@ -1,8 +1,8 @@
 lobby-state-paused = Paused
-lobby-state-preloading = Soon
+lobby-state-soon = Round starting soon
 lobby-state-right-now-question = Right Now?
 lobby-state-right-now-confirmation = Right Now
-lobby-state-round-start-countdown-text = Round Starts In: {$timeLeft}
+lobby-state-round-start-countdown-text = Round starts In: {$timeLeft}
 lobby-state-ready-button-join-state = Join
 lobby-state-ready-button-ready-up-state = Ready Up
 lobby-state-player-status-not-ready = Not Ready


### PR DESCRIPTION
I forgot to delete this before merging arrivals. I kept the soon bit.

:cl:
- fix: Remove lobby starting soon showing up 20 seconds before roundstart.