### PR TITLE
printed health analyzers and crew monitors no longer have batteries

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -29,3 +29,13 @@
   - type: StationLimitedNetwork
   - type: StaticPrice
     price: 500
+
+- type: entity
+  id: HandheldCrewMonitorNoBattery
+  parent: HandheldCrewMonitor
+  suffix: No Battery
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -31,9 +31,9 @@
     price: 500
 
 - type: entity
-  id: HandheldCrewMonitorNoBattery
+  id: HandheldCrewMonitorEmpty
   parent: HandheldCrewMonitor
-  suffix: No Battery
+  suffix: Empty
   components:
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -29,6 +29,16 @@
     - DiscreteHealthAnalyzer
 
 - type: entity
+  id: HandheldHealthAnalyzerNoBattery
+  parent: HandheldHealthAnalyzer
+  suffix: No Battery
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default 
+
+- type: entity
   parent: HandheldHealthAnalyzer
   id: HandheldHealthAnalyzerGigacancer
   suffix: gigacancer

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -29,9 +29,9 @@
     - DiscreteHealthAnalyzer
 
 - type: entity
-  id: HandheldHealthAnalyzerNoBattery
+  id: HandheldHealthAnalyzerEmpty
   parent: HandheldHealthAnalyzer
-  suffix: No Battery
+  suffix: Empty
   components:
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -55,9 +55,9 @@
         volume: -8
 
 - type: entity
-  id: AnomalyLocatorNoBattery
+  id: AnomalyLocatorEmpty
   parent: AnomalyLocator
-  suffix: No Battery
+  suffix: Empty
   components:
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -59,7 +59,6 @@
 
 # PowerCellSlot parents
 - type: entity
-  name: a
   id: PowerCellSlotSmallItem
   abstract: true
   components:
@@ -75,7 +74,6 @@
           startingItem: PowerCellSmall
 
 - type: entity
-  name: a
   id: PowerCellSlotMediumItem
   abstract: true
   components:

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -51,7 +51,7 @@
 
 - type: latheRecipe
   id: AnomalyLocator
-  result: AnomalyLocatorNoBattery
+  result: AnomalyLocatorEmpty
   completetime: 3
   materials:
     Steel: 400

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -50,7 +50,7 @@
 
 - type: latheRecipe
   id: HandheldCrewMonitor
-  result: HandheldCrewMonitorNoBattery
+  result: HandheldCrewMonitorEmpty
   completetime: 2
   materials:
     Glass: 1200
@@ -59,7 +59,7 @@
 
 - type: latheRecipe
   id: HandheldHealthAnalyzer
-  result: HandheldHealthAnalyzerNoBattery
+  result: HandheldHealthAnalyzerEmpty
   completetime: 4
   materials:
     Glass: 500

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -50,7 +50,7 @@
 
 - type: latheRecipe
   id: HandheldCrewMonitor
-  result: HandheldCrewMonitor
+  result: HandheldCrewMonitorNoBattery
   completetime: 2
   materials:
     Glass: 1200
@@ -59,7 +59,7 @@
 
 - type: latheRecipe
   id: HandheldHealthAnalyzer
-  result: HandheldHealthAnalyzer
+  result: HandheldHealthAnalyzerNoBattery
   completetime: 4
   materials:
     Glass: 500


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixed #15671 
just print the batteries separately lol

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Printed health analyzers and crew monitors no longer come pre-loaded with batteries.
