### PR TITLE
Prevent brains from walking

### DIFF
--- a/Content.Server/Body/Systems/BrainSystem.cs
+++ b/Content.Server/Body/Systems/BrainSystem.cs
@@ -4,12 +4,16 @@ using Content.Server.Mind.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Events;
 using Content.Shared.Body.Organ;
+using Content.Shared.Body.Part;
 using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Systems;
 
 namespace Content.Server.Body.Systems
 {
     public sealed class BrainSystem : EntitySystem
     {
+        [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -42,7 +46,14 @@ namespace Content.Server.Body.Systems
                 Comp<GhostOnMoveComponent>(newEntity).MustBeDead = true;
 
             // TODO: This is an awful solution.
-            EnsureComp<InputMoverComponent>(newEntity);
+            // Our greatest minds still can't figure out how to allow brains/heads to ghost without giving them the
+            // ability to move first. I hate this with a passion.
+            if (!HasComp<InputMoverComponent>(newEntity))
+            {
+                AddComp<InputMoverComponent>(newEntity);
+                var move = EnsureComp<MovementSpeedModifierComponent>(newEntity);
+                _movementSpeed.ChangeBaseSpeed(newEntity, 0, 0 , 0, move);
+            }
 
             oldMind.Mind?.TransferTo(newEntity);
         }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -311,11 +311,11 @@ public partial class SharedBodySystem
         var acceleration = 0f;
         foreach (var leg in allLegs)
         {
-            if (!TryComp<MovementSpeedModifierComponent>(leg, out var legModifier))
+            if (!TryComp<MovementBodyPartComponent>(leg, out var legModifier))
                 continue;
 
-            walkSpeed += legModifier.BaseWalkSpeed;
-            sprintSpeed += legModifier.BaseSprintSpeed;
+            walkSpeed += legModifier.WalkSpeed;
+            sprintSpeed += legModifier.SprintSpeed;
             acceleration += legModifier.Acceleration;
         }
 

--- a/Content.Shared/Movement/Components/MovementBodyPartComponent.cs
+++ b/Content.Shared/Movement/Components/MovementBodyPartComponent.cs
@@ -1,6 +1,6 @@
 namespace Content.Shared.Movement.Components;
 
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 public sealed class MovementBodyPartComponent : Component
 {
     [DataField("walkSpeed")]

--- a/Content.Shared/Movement/Components/MovementBodyPartComponent.cs
+++ b/Content.Shared/Movement/Components/MovementBodyPartComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Shared.Movement.Components;
+
+[RegisterComponent]
+public sealed class MovementBodyPartComponent : Component
+{
+    [DataField("walkSpeed")]
+    public readonly float WalkSpeed = MovementSpeedModifierComponent.DefaultBaseWalkSpeed;
+
+    [DataField("sprintSpeed")]
+    public readonly float SprintSpeed = MovementSpeedModifierComponent.DefaultBaseSprintSpeed;
+
+    [DataField("acceleration")]
+    public float Acceleration = MovementSpeedModifierComponent.DefaultAcceleration;
+}

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -40,10 +40,6 @@
       Lung:
         maxVol: 100
         canReact: False
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 0
-    baseSprintSpeed: 0
-  - type: GhostOnMove
   - type: Brain
   - type: Lung #lungs in they head. why they there tho?
   - type: Metabolizer

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -29,10 +29,6 @@
   - type: Input
     context: "ghost"
   - type: InputMover
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 0
-    baseSprintSpeed: 0
-  - type: GhostOnMove
   - type: Brain
 
 - type: entity

--- a/Resources/Prototypes/Body/Parts/animal.yml
+++ b/Resources/Prototypes/Body/Parts/animal.yml
@@ -40,7 +40,7 @@
   components:
   - type: BodyPart
     partType: Leg
-  - type: MovementSpeedModifier
+  - type: MovementBodyPart
 
 - type: entity
   id: FeetAnimal

--- a/Resources/Prototypes/Body/Parts/diona.yml
+++ b/Resources/Prototypes/Body/Parts/diona.yml
@@ -48,11 +48,6 @@
     vital: true
   - type: Input
     context: "ghost"
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 0
-    baseSprintSpeed: 0
-  - type: InputMover
-  - type: GhostOnMove
   - type: Tag
     tags:
       - Head
@@ -121,9 +116,9 @@
   - type: BodyPart
     partType: Leg
     symmetry: Left
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 1.5
-    baseSprintSpeed : 3.5
+  - type: MovementBodyPart
+    walkSpeed : 1.5
+    sprintSpeed : 3.5
 
 - type: entity
   id: RightLegDiona
@@ -137,9 +132,9 @@
   - type: BodyPart
     partType: Leg
     symmetry: Right
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 1.5
-    baseSprintSpeed : 3.5
+  - type: MovementBodyPart
+    walkSpeed : 1.5
+    sprintSpeed : 3.5
 
 - type: entity
   id: LeftFootDiona

--- a/Resources/Prototypes/Body/Parts/human.yml
+++ b/Resources/Prototypes/Body/Parts/human.yml
@@ -51,11 +51,6 @@
     vital: true
   - type: Input
     context: "ghost"
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 0
-    baseSprintSpeed: 0
-  - type: InputMover
-  - type: GhostOnMove
   - type: Tag
     tags:
       - Head
@@ -139,7 +134,7 @@
   - type: BodyPart
     partType: Leg
     symmetry: Left
-  - type: MovementSpeedModifier
+  - type: MovementBodyPart
 
 - type: entity
   id: RightLegHuman
@@ -156,7 +151,7 @@
   - type: BodyPart
     partType: Leg
     symmetry: Right
-  - type: MovementSpeedModifier
+  - type: MovementBodyPart
 
 - type: entity
   id: LeftFootHuman

--- a/Resources/Prototypes/Body/Parts/reptilian.yml
+++ b/Resources/Prototypes/Body/Parts/reptilian.yml
@@ -49,11 +49,6 @@
     vital: true
   - type: Input
     context: "ghost"
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 0
-    baseSprintSpeed: 0
-  - type: InputMover
-  - type: GhostOnMove
   - type: Tag
     tags:
       - Head
@@ -137,9 +132,9 @@
   - type: BodyPart
     partType: Leg
     symmetry: Left
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.7
-    baseSprintSpeed : 4.5
+  - type: MovementBodyPart
+    walkSpeed : 2.7
+    sprintSpeed : 4.5
 
 - type: entity
   id: RightLegReptilian
@@ -156,9 +151,9 @@
   - type: BodyPart
     partType: Leg
     symmetry: Right
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.7
-    baseSprintSpeed : 4.5
+  - type: MovementBodyPart
+    walkSpeed : 2.7
+    sprintSpeed : 4.5
 
 - type: entity
   id: LeftFootReptilian

--- a/Resources/Prototypes/Body/Parts/skeleton.yml
+++ b/Resources/Prototypes/Body/Parts/skeleton.yml
@@ -50,9 +50,6 @@
       partType: Head
     - type: Input
       context: "human"
-    - type: MovementSpeedModifier
-      baseWalkSpeed: 0
-      baseSprintSpeed: 0
     - type: Speech
     - type: SkeletonAccent
     - type: Actions
@@ -154,7 +151,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Left
-    - type: MovementSpeedModifier
+    - type: MovementBodyPart
 
 - type: entity
   id: RightLegSkeleton
@@ -171,7 +168,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Right
-    - type: MovementSpeedModifier
+    - type: MovementBodyPart
 
 - type: entity
   id: LeftFootSkeleton

--- a/Resources/Prototypes/Body/Parts/slime.yml
+++ b/Resources/Prototypes/Body/Parts/slime.yml
@@ -50,11 +50,6 @@
       vital: true
     - type: Input
       context: "ghost"
-    - type: MovementSpeedModifier
-      baseWalkSpeed: 0
-      baseSprintSpeed: 0
-    - type: InputMover
-    - type: GhostOnMove
     - type: Tag
       tags:
         - Head
@@ -138,7 +133,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Left
-    - type: MovementSpeedModifier
+    - type: MovementBodyPart
 
 - type: entity
   id: RightLegSlime
@@ -155,7 +150,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Right
-    - type: MovementSpeedModifier
+    - type: MovementBodyPart
 
 - type: entity
   id: LeftFootSlime

--- a/Resources/Prototypes/Body/Parts/vox.yml
+++ b/Resources/Prototypes/Body/Parts/vox.yml
@@ -51,11 +51,6 @@
       vital: true
     - type: Input
       context: "ghost"
-    - type: MovementSpeedModifier
-      baseWalkSpeed: 0
-      baseSprintSpeed: 0
-    - type: InputMover
-    - type: GhostOnMove
     - type: Tag
       tags:
         - Head
@@ -139,7 +134,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Left
-    - type: MovementSpeedModifier
+    - type: MovementBodyPart
 
 - type: entity
   id: RightLegVox
@@ -156,7 +151,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Right
-    - type: MovementSpeedModifier
+    - type: MovementBodyPart
 
 - type: entity
   id: LeftFootVox


### PR DESCRIPTION
Fixes #14014 and moves the body part movement modifier into its own component.

:cl:
- fix: Fixed a bug that allowed slime corpses/brains to move around after death.