### PR TITLE
Make PowerCellDraw not tick dependent, buff anomaly locator power drain

### DIFF
--- a/Content.Server/PowerCell/PowerCellDrawComponent.cs
+++ b/Content.Server/PowerCell/PowerCellDrawComponent.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
 namespace Content.Server.PowerCell;
 
 /// <summary>
@@ -22,4 +24,10 @@ public sealed class PowerCellDrawComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("useRate")]
     public float UseRate = 0f;
+
+    /// <summary>
+    /// When the next automatic power draw will occur
+    /// </summary>
+    [DataField("nextUpdate", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan NextUpdateTime;
 }

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -44,7 +44,7 @@
           True: { visible: true }
           False: { visible: false }
   - type: PowerCellDraw
-    drawRate: 10
+    drawRate: 5
     useRate: 0
   - type: ProximityBeeper
     component: Anomaly


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Just makes it update per second rather than tickrate dependent ( * frameTime)
also buffs anomaly locator because the low battery made me shit myself.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Entities that draw battery power should now draw at a consistent rate.
- tweak: Anomaly locators now consume less power while active.