### PR TITLE
Revert "Wrenchable Chairs and Plants"

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -9,7 +9,7 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
-  - type: Anchorable
+    bodyType: Dynamic
   - type: Fixtures
     fixtures:
     - shape:
@@ -56,6 +56,7 @@
   components:
   - type: Transform
     anchored: true
+  - type: Anchorable
   - type: Rotatable
   - type: Sprite
     state: chair
@@ -69,6 +70,7 @@
   parent: SeatBase
   description: Apply butt.
   components:
+  - type: Anchorable
   - type: Sprite
     state: stool
   - type: Construction
@@ -84,6 +86,7 @@
     anchored: true
   - type: Rotatable
     rotateWhileAnchored: true
+  - type: Anchorable
   - type: Sprite
     state: bar
   - type: Construction
@@ -122,6 +125,7 @@
   components:
   - type: Transform
     anchored: true
+  - type: Anchorable
   - type: Rotatable
   - type: Sprite
     state: comfy
@@ -137,6 +141,7 @@
   components:
   - type: Transform
     anchored: true
+  - type: Anchorable
   - type: Rotatable
   - type: Sprite
     state: shuttle
@@ -185,6 +190,7 @@
   parent: SeatBase
   description: Looks uncomfortable.
   components:
+  - type: Anchorable
   - type: Rotatable
   - type: Sprite
     state: ritual
@@ -198,6 +204,7 @@
   parent: SeatBase
   description: It's staring back.
   components:
+  - type: Anchorable
   - type: Rotatable
   - type: Sprite
     state: cursed


### PR DESCRIPTION
few grievances:
- you shouldn't be able to arbitrarily wrench every single chair
- plants shouldn't be wrenchable imo. it doesn't make sense.
- the way wrenching plants is implemented is super weird.

Reverts space-wizards/space-station-14#14489

closes #15720 
closes #15229 