### PR TITLE
Fixes zipties spawning multiple entities on removal

### DIFF
--- a/Resources/Locale/en-US/cuffs/components/cuffable-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/cuffable-component.ftl
@@ -1,6 +1,11 @@
 cuffable-component-cannot-interact-message = You can't do that!
 cuffable-component-cannot-remove-cuffs-too-far-message = You are too far away to remove the cuffs.
-cuffable-component-start-removing-cuffs-message = You start removing the cuffs.
+
+cuffable-component-start-uncuffing-self = You start uncuffing yourself.
+cuffable-component-start-uncuffing-observer = {$user} starts uncuffing {$target}!
+cuffable-component-start-uncuffing-target-message = You start uncuffing {$targetName}.
+cuffable-component-start-uncuffing-by-other-message = {$otherName} starts uncuffing you!
+
 cuffable-component-remove-cuffs-success-message = You successfully remove the cuffs.
 cuffable-component-remove-cuffs-by-other-success-message = {$otherName} uncuffs your hands.
 cuffable-component-remove-cuffs-to-other-partial-success-message = You successfully remove the cuffs. {$cuffedHandCount} of {$otherName}'s hands remain cuffed.


### PR DESCRIPTION
The handcuff system is now handling the broken cuffs spawning server-side, fixes #15730 .

Also fixed the popups misprediction when beginning to uncuff someone and added PVS wide popup feedback as it was already the case for cuffing.

(forced pushed to retrigger the tests now they're fixed)

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Despite clowns complains, Nanotrasen have recalled all magic zipties that spawned myriads of themselves on removal and replaced them with plain ones.
- tweak: Starting to uncuff someone (or self) now gives a popup feedback to observers around.
