### PR TITLE
Cargo Ripley Variant (Hauler APLU)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -117,3 +117,47 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 3.6
+
+- type: entity
+  id: MechHauler
+  parent: MechRipley
+  name: Hauler APLU
+  description: A stripped down version of the Ripley, designed to cut costs & further aid in cargo transfer. It is not as bulky as the standard Ripley.
+  components:
+  - type: Mech
+    baseState: hauler
+    openState: hauler-open
+    brokenState: hauler-broken
+    mechToPilotDamageMultiplier: 0.85
+    maxEquipmentAmount: 2
+    maxIntegrity: 150
+  - type: MeleeWeapon
+    hidden: true
+    attackRate: 1
+    damage:
+      types:
+        Blunt: 10
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 2.40
+    baseSprintSpeed: 3.80
+
+- type: entity
+  id: MechHaulerBattery
+  parent: MechHauler
+  name: Hauler APLU
+  suffix: Battery
+  components:
+  - type: Mech
+    startingBattery: PowerCellHigh
+
+#this doesn't show up in the spawnmenu for some reason (which is why it's commented out.)
+#- type: entity
+#  id: MechHaulerRoundstart
+#  parent: MechHauler
+#  name: Hauler APLU
+#  suffix: Battery, Hydraulic Clamp
+#  components:
+#  - type: Mech
+#    startingBattery: PowerCellHigh
+#    startingEquipment: MechEquipmentGrabber
+#


### PR DESCRIPTION
## About the PR
Adds a weakened variant of the Ripley with .20 additional movespeed, but generally worse stats overall (less heath, damage resistance, equipment slots, etc.) for the salvage shuttle. Could also be mapped in cargo roundstart but that's the mapper's decision.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![Content Client_HoQhoHcmTZ](https://user-images.githubusercontent.com/78941145/234225801-6a6645e7-bd4c-424d-8c9d-9a41dec09296.png)

**Changelog**
:cl:
- add: Added a cheapo Ripley variant for cargo. It has marginally faster movement speed, but is overall weaker.
