### PR TITLE
Fix NPC awake assert

### DIFF
--- a/Content.Server/NPC/Systems/NPCSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSystem.cs
@@ -53,7 +53,7 @@ namespace Content.Server.NPC.Systems
 
         private void OnPlayerNPCDetach(EntityUid uid, NPCComponent component, PlayerDetachedEvent args)
         {
-            if (_mobState.IsIncapacitated(uid))
+            if (_mobState.IsIncapacitated(uid) || Deleted(uid))
                 return;
 
             WakeNPC(uid, component);
@@ -83,9 +83,9 @@ namespace Content.Server.NPC.Systems
         /// <summary>
         /// Is the NPC awake and updating?
         /// </summary>
-        public bool IsAwake(NPCComponent component, ActiveNPCComponent? active = null)
+        public bool IsAwake(EntityUid uid, NPCComponent component, ActiveNPCComponent? active = null)
         {
-            return Resolve(component.Owner, ref active, false);
+            return Resolve(uid, ref active, false);
         }
 
         /// <summary>
@@ -98,8 +98,8 @@ namespace Content.Server.NPC.Systems
                 return;
             }
 
-            _sawmill.Debug($"Waking {ToPrettyString(component.Owner)}");
-            EnsureComp<ActiveNPCComponent>(component.Owner);
+            _sawmill.Debug($"Waking {ToPrettyString(uid)}");
+            EnsureComp<ActiveNPCComponent>(uid);
         }
 
         public void SleepNPC(EntityUid uid, NPCComponent? component = null)
@@ -109,8 +109,8 @@ namespace Content.Server.NPC.Systems
                 return;
             }
 
-            _sawmill.Debug($"Sleeping {ToPrettyString(component.Owner)}");
-            RemComp<ActiveNPCComponent>(component.Owner);
+            _sawmill.Debug($"Sleeping {ToPrettyString(uid)}");
+            RemComp<ActiveNPCComponent>(uid);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
If you delete an NPCable entity while someone is attached this assert would trip.