### PR TITLE
PriceGun component added to Cargo PDA

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -295,6 +295,7 @@
     state: pda-qm
   - type: Icon
     state: pda-qm
+  - type: PriceGun
 
 - type: entity
   parent: BasePDA
@@ -307,6 +308,7 @@
     state: pda-cargo
   - type: Icon
     state: pda-cargo
+  - type: PriceGun
 
 - type: entity
   parent: BasePDA
@@ -319,6 +321,7 @@
     state: pda-miner
   - type: Icon
     state: pda-miner
+  - type: PriceGun
 
 - type: entity
   parent: BasePDA


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The Price Gun component has been added to PDAs (QuartermasterPDA, CargoPDA, SalvagePDA).
Cargo workers must always know the price of the goods, even when Price Gun is not with them.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame.

:cl: Lomcastar
- add: NanoTrasen Corporation has equipped all Cargo PDAs with an evaluation module!

https://user-images.githubusercontent.com/129697969/234325569-8d0f451d-2ba0-4bc7-87a7-cf3a6ff1175e.mp4