### PR TITLE
Adds formatting issue analyzing in Omnisharp (VSCode)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -196,73 +196,73 @@ csharp_preserve_single_line_blocks = true
 #dotnet_naming_style.begins_with_i.word_separator =
 #dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
+dotnet_diagnostic.IDE0055.severity = warning
 
-
-dotnet_naming_rule.constants_rule.severity = warning
+dotnet_naming_rule.constants_rule.severity = error
 dotnet_naming_rule.constants_rule.style = upper_camel_case_style
 dotnet_naming_rule.constants_rule.symbols = constants_symbols
 
-dotnet_naming_rule.event_rule.severity = warning
+dotnet_naming_rule.event_rule.severity = error
 dotnet_naming_rule.event_rule.style = upper_camel_case_style
 dotnet_naming_rule.event_rule.symbols = event_symbols
 
-dotnet_naming_rule.interfaces_rule.severity = warning
+dotnet_naming_rule.interfaces_rule.severity = error
 dotnet_naming_rule.interfaces_rule.style = i_upper_camel_case_style
 dotnet_naming_rule.interfaces_rule.symbols = interfaces_symbols
 
-dotnet_naming_rule.locals_rule.severity = warning
+dotnet_naming_rule.locals_rule.severity = error
 dotnet_naming_rule.locals_rule.style = lower_camel_case_style_1
 dotnet_naming_rule.locals_rule.symbols = locals_symbols
 
-dotnet_naming_rule.local_constants_rule.severity = warning
+dotnet_naming_rule.local_constants_rule.severity = error
 dotnet_naming_rule.local_constants_rule.style = lower_camel_case_style_1
 dotnet_naming_rule.local_constants_rule.symbols = local_constants_symbols
 
-dotnet_naming_rule.local_functions_rule.severity = warning
+dotnet_naming_rule.local_functions_rule.severity = error
 dotnet_naming_rule.local_functions_rule.style = upper_camel_case_style
 dotnet_naming_rule.local_functions_rule.symbols = local_functions_symbols
 
-dotnet_naming_rule.method_rule.severity = warning
+dotnet_naming_rule.method_rule.severity = error
 dotnet_naming_rule.method_rule.style = upper_camel_case_style
 dotnet_naming_rule.method_rule.symbols = method_symbols
 
-dotnet_naming_rule.parameters_rule.severity = warning
+dotnet_naming_rule.parameters_rule.severity = error
 dotnet_naming_rule.parameters_rule.style = lower_camel_case_style_1
 dotnet_naming_rule.parameters_rule.symbols = parameters_symbols
 
-dotnet_naming_rule.private_constants_rule.severity = warning
+dotnet_naming_rule.private_constants_rule.severity = error
 dotnet_naming_rule.private_constants_rule.style = upper_camel_case_style
 dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
 
-dotnet_naming_rule.private_instance_fields_rule.severity = warning
+dotnet_naming_rule.private_instance_fields_rule.severity = error
 dotnet_naming_rule.private_instance_fields_rule.style = lower_camel_case_style
 dotnet_naming_rule.private_instance_fields_rule.symbols = private_instance_fields_symbols
 
-dotnet_naming_rule.private_static_fields_rule.severity = warning
+dotnet_naming_rule.private_static_fields_rule.severity = error
 dotnet_naming_rule.private_static_fields_rule.style = lower_camel_case_style
 dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
 
-dotnet_naming_rule.private_static_readonly_rule.severity = warning
+dotnet_naming_rule.private_static_readonly_rule.severity = error
 dotnet_naming_rule.private_static_readonly_rule.style = upper_camel_case_style
 dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
 
-dotnet_naming_rule.property_rule.severity = warning
+dotnet_naming_rule.property_rule.severity = error
 dotnet_naming_rule.property_rule.style = upper_camel_case_style
 dotnet_naming_rule.property_rule.symbols = property_symbols
 
-dotnet_naming_rule.public_fields_rule.severity = warning
+dotnet_naming_rule.public_fields_rule.severity = error
 dotnet_naming_rule.public_fields_rule.style = upper_camel_case_style
 dotnet_naming_rule.public_fields_rule.symbols = public_fields_symbols
 
-dotnet_naming_rule.static_readonly_rule.severity = warning
+dotnet_naming_rule.static_readonly_rule.severity = error
 dotnet_naming_rule.static_readonly_rule.style = upper_camel_case_style
 dotnet_naming_rule.static_readonly_rule.symbols = static_readonly_symbols
 
-dotnet_naming_rule.types_and_namespaces_rule.severity = warning
+dotnet_naming_rule.types_and_namespaces_rule.severity = error
 dotnet_naming_rule.types_and_namespaces_rule.style = upper_camel_case_style
 dotnet_naming_rule.types_and_namespaces_rule.symbols = types_and_namespaces_symbols
 
-dotnet_naming_rule.type_parameters_rule.severity = warning
+dotnet_naming_rule.type_parameters_rule.severity = error
 dotnet_naming_rule.type_parameters_rule.style = t_upper_camel_case_style
 dotnet_naming_rule.type_parameters_rule.symbols = type_parameters_symbols
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -198,71 +198,71 @@ csharp_preserve_single_line_blocks = true
 
 dotnet_diagnostic.IDE0055.severity = warning
 
-dotnet_naming_rule.constants_rule.severity = error
+dotnet_naming_rule.constants_rule.severity = warning
 dotnet_naming_rule.constants_rule.style = upper_camel_case_style
 dotnet_naming_rule.constants_rule.symbols = constants_symbols
 
-dotnet_naming_rule.event_rule.severity = error
+dotnet_naming_rule.event_rule.severity = warning
 dotnet_naming_rule.event_rule.style = upper_camel_case_style
 dotnet_naming_rule.event_rule.symbols = event_symbols
 
-dotnet_naming_rule.interfaces_rule.severity = error
+dotnet_naming_rule.interfaces_rule.severity = warning
 dotnet_naming_rule.interfaces_rule.style = i_upper_camel_case_style
 dotnet_naming_rule.interfaces_rule.symbols = interfaces_symbols
 
-dotnet_naming_rule.locals_rule.severity = error
+dotnet_naming_rule.locals_rule.severity = warning
 dotnet_naming_rule.locals_rule.style = lower_camel_case_style_1
 dotnet_naming_rule.locals_rule.symbols = locals_symbols
 
-dotnet_naming_rule.local_constants_rule.severity = error
+dotnet_naming_rule.local_constants_rule.severity = warning
 dotnet_naming_rule.local_constants_rule.style = lower_camel_case_style_1
 dotnet_naming_rule.local_constants_rule.symbols = local_constants_symbols
 
-dotnet_naming_rule.local_functions_rule.severity = error
+dotnet_naming_rule.local_functions_rule.severity = warning
 dotnet_naming_rule.local_functions_rule.style = upper_camel_case_style
 dotnet_naming_rule.local_functions_rule.symbols = local_functions_symbols
 
-dotnet_naming_rule.method_rule.severity = error
+dotnet_naming_rule.method_rule.severity = warning
 dotnet_naming_rule.method_rule.style = upper_camel_case_style
 dotnet_naming_rule.method_rule.symbols = method_symbols
 
-dotnet_naming_rule.parameters_rule.severity = error
+dotnet_naming_rule.parameters_rule.severity = warning
 dotnet_naming_rule.parameters_rule.style = lower_camel_case_style_1
 dotnet_naming_rule.parameters_rule.symbols = parameters_symbols
 
-dotnet_naming_rule.private_constants_rule.severity = error
+dotnet_naming_rule.private_constants_rule.severity = warning
 dotnet_naming_rule.private_constants_rule.style = upper_camel_case_style
 dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
 
-dotnet_naming_rule.private_instance_fields_rule.severity = error
+dotnet_naming_rule.private_instance_fields_rule.severity = warning
 dotnet_naming_rule.private_instance_fields_rule.style = lower_camel_case_style
 dotnet_naming_rule.private_instance_fields_rule.symbols = private_instance_fields_symbols
 
-dotnet_naming_rule.private_static_fields_rule.severity = error
+dotnet_naming_rule.private_static_fields_rule.severity = warning
 dotnet_naming_rule.private_static_fields_rule.style = lower_camel_case_style
 dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
 
-dotnet_naming_rule.private_static_readonly_rule.severity = error
+dotnet_naming_rule.private_static_readonly_rule.severity = warning
 dotnet_naming_rule.private_static_readonly_rule.style = upper_camel_case_style
 dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
 
-dotnet_naming_rule.property_rule.severity = error
+dotnet_naming_rule.property_rule.severity = warning
 dotnet_naming_rule.property_rule.style = upper_camel_case_style
 dotnet_naming_rule.property_rule.symbols = property_symbols
 
-dotnet_naming_rule.public_fields_rule.severity = error
+dotnet_naming_rule.public_fields_rule.severity = warning
 dotnet_naming_rule.public_fields_rule.style = upper_camel_case_style
 dotnet_naming_rule.public_fields_rule.symbols = public_fields_symbols
 
-dotnet_naming_rule.static_readonly_rule.severity = error
+dotnet_naming_rule.static_readonly_rule.severity = warning
 dotnet_naming_rule.static_readonly_rule.style = upper_camel_case_style
 dotnet_naming_rule.static_readonly_rule.symbols = static_readonly_symbols
 
-dotnet_naming_rule.types_and_namespaces_rule.severity = error
+dotnet_naming_rule.types_and_namespaces_rule.severity = warning
 dotnet_naming_rule.types_and_namespaces_rule.style = upper_camel_case_style
 dotnet_naming_rule.types_and_namespaces_rule.symbols = types_and_namespaces_symbols
 
-dotnet_naming_rule.type_parameters_rule.severity = error
+dotnet_naming_rule.type_parameters_rule.severity = warning
 dotnet_naming_rule.type_parameters_rule.style = t_upper_camel_case_style
 dotnet_naming_rule.type_parameters_rule.symbols = type_parameters_symbols
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "omnisharp.analyzeOpenDocumentsOnly": true
+}

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -2,6 +2,5 @@
     "RoslynExtensionsOptions": {
         "DocumentAnalysisTimeoutMs": 600000,
         "EnableAnalyzersSupport": true
-
     }
 }

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,0 +1,7 @@
+{
+    "RoslynExtensionsOptions": {
+        "DocumentAnalysisTimeoutMs": 600000,
+        "EnableAnalyzersSupport": true
+
+    }
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

This now makes formatting issues according to .editorconfig show a warning in VSCode. This uses code IDE0055, included with .NET for the formatting issue check.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

N/A