### PR TITLE
fix ban_exemption_get only listing Datacenter flag

### DIFF
--- a/Content.Server/Administration/Commands/BanExemptionCommands.cs
+++ b/Content.Server/Administration/Commands/BanExemptionCommands.cs
@@ -98,7 +98,7 @@ public sealed class BanExemptionGetCommand : LocalizedCommands
         {
             var mask = (ServerBanExemptFlags) (1 << i);
             if ((mask & flags) == 0)
-                break;
+                continue;
 
             if (!first)
                 joined.Append(", ");


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes an issue where the command will not list all exemption flags because it breaks out of the loop instead of continuing.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase