### PR TITLE
add IP ban exemption flag

### DIFF
--- a/Content.Server.Database/Model.cs
+++ b/Content.Server.Database/Model.cs
@@ -459,6 +459,14 @@ namespace Content.Server.Database
         /// Ban is a datacenter range, connections usually imply usage of a VPN service.
         /// </summary>
         Datacenter = 1 << 0,
+
+        /// <summary>
+        /// Ban only matches the IP.
+        /// </summary>
+        /// <remarks>
+        /// Intended use is for users with shared connections. This should not be used as an alternative to <see cref="Datacenter"/>.
+        /// </remarks>
+        IP = 1 << 1,
         // @formatter:on
     }
 

--- a/Content.Server/Database/ServerDbPostgres.cs
+++ b/Content.Server/Database/ServerDbPostgres.cs
@@ -119,7 +119,7 @@ namespace Content.Server.Database
                 query = query == null ? newQ : query.Union(newQ);
             }
 
-            if (address != null)
+            if (address != null && !exemptFlags.GetValueOrDefault(ServerBanExemptFlags.None).HasFlag(ServerBanExemptFlags.IP))
             {
                 var newQ = db.PgDbContext.Ban
                     .Include(p => p.Unban)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adds an IP ban exemption flag. Allows users to bypass bans that only match by IP. This should not be used as an alternative to the datacenter exemption to allow people to bypass datacenter bans.

I tested this with SQLite. I expect it to work with PostgreSQL, but someone should double check the code.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase