### PR TITLE
Cleanbot tweaks

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/InteractWithOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/InteractWithOperator.cs
@@ -1,0 +1,31 @@
+using Content.Server.Interaction;
+using Content.Shared.Timing;
+
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators;
+
+public sealed class InteractWithOperator : HTNOperator
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    /// <summary>
+    /// Key that contains the target entity.
+    /// </summary>
+    [DataField("targetKey", required: true)]
+    public string TargetKey = default!;
+
+    public override HTNOperatorStatus Update(NPCBlackboard blackboard, float frameTime)
+    {
+        var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
+
+        if (_entManager.System<UseDelaySystem>().ActiveDelay(owner) ||
+            !blackboard.TryGetValue<EntityUid>(TargetKey, out var moveTarget, _entManager) ||
+            !_entManager.TryGetComponent<TransformComponent>(moveTarget, out var targetXform))
+        {
+            return HTNOperatorStatus.Continuing;
+        }
+
+        _entManager.System<InteractionSystem>().UserInteraction(owner, targetXform.Coordinates, moveTarget);
+
+        return HTNOperatorStatus.Finished;
+    }
+}

--- a/Content.Server/NPC/NPCBlackboard.cs
+++ b/Content.Server/NPC/NPCBlackboard.cs
@@ -1,7 +1,9 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using Content.Server.Interaction;
 using Content.Shared.Access.Systems;
 using Content.Shared.ActionBlocker;
+using Content.Shared.Interaction;
 using Robust.Shared.Utility;
 
 namespace Content.Server.NPC;
@@ -18,6 +20,7 @@ public sealed class NPCBlackboard : IEnumerable<KeyValuePair<string, object>>
         {"FollowCloseRange", 3f},
         {"FollowRange", 7f},
         {"IdleRange", 7f},
+        {"InteractRange", SharedInteractionSystem.InteractionRange},
         {"MaximumIdleTime", 7f},
         {MedibotInjectRange, 4f},
         {MeleeMissChance, 0.3f},

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -194,18 +194,30 @@
     drawdepth: Mobs
     sprite: Mobs/Silicon/Bots/cleanbot.rsi
     state: cleanbot
-  - type: Drain
-    range: 1
-    unitsDestroyedPerSecond: 6
   - type: Construction
     graph: CleanBot
     node: bot
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-mechanical
+  - type: Absorbent
+    pickupAmount: 10
+  - type: UseDelay
+    delay: 2
+  - type: SolutionRegeneration
+    solution: absorbed
+    generated:
+      reagents:
+        - ReagentId: Water
+          Quantity: 10
+  - type: SolutionPurge
+    solution: absorbed
+    preserve:
+      - Water
+    quantity: 10
   - type: SolutionContainerManager
     solutions:
-      drainBuffer:
-        maxVol: 30
+      absorbed:
+        maxVol: 50
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3

--- a/Resources/Prototypes/NPCs/cleanbot.yml
+++ b/Resources/Prototypes/NPCs/cleanbot.yml
@@ -13,13 +13,11 @@
     - tasks:
         - id: PickPuddlePrimitive
         - id: MoveToAccessiblePrimitive
-        - id: SetIdleTimePrimitive
-        - id: WaitIdleTimePrimitive
-
+        - id: InteractWithPrimitive
 
 - type: htnPrimitive
   id: PickPuddlePrimitive
-  operator: !type:PickAccessibleComponentOperator
+  operator: !type:PickPuddleOperator
     rangeKey: BufferRange
     targetKey: MovementTarget
     component: Puddle

--- a/Resources/Prototypes/NPCs/idle.yml
+++ b/Resources/Prototypes/NPCs/idle.yml
@@ -32,14 +32,18 @@
 
 # Primitives
 - type: htnPrimitive
-  id: PickRandomRotationPrimitive
-  operator: !type:PickRandomRotationOperator
-    targetKey: RotateTarget
+  id: InteractWithPrimitive
+  preconditions:
+    - !type:TargetInRangePrecondition
+      targetKey: Target
+      rangeKey: InteractRange
+  operator: !type:InteractWithOperator
+    targetKey: Target
 
 - type: htnPrimitive
-  id: RotateToTargetPrimitive
-  operator: !type:RotateToTargetOperator
-    targetKey: RotateTarget
+  id: MoveToAccessiblePrimitive
+  operator: !type:MoveToOperator
+    pathfindInPlanning: false
 
 - type: htnPrimitive
   id: PickAccessiblePrimitive
@@ -48,9 +52,14 @@
     targetKey: MovementTarget
 
 - type: htnPrimitive
-  id: MoveToAccessiblePrimitive
-  operator: !type:MoveToOperator
-    pathfindInPlanning: false
+  id: PickRandomRotationPrimitive
+  operator: !type:PickRandomRotationOperator
+    targetKey: RotateTarget
+
+- type: htnPrimitive
+  id: RotateToTargetPrimitive
+  operator: !type:RotateToTargetOperator
+    targetKey: RotateTarget
 
 - type: htnPrimitive
   id: RandomIdleTimePrimitive


### PR DESCRIPTION
Now they actually mop floors.

I had an idea on how to make NPC queries less shit so the pick operators are gonna be similar for a bit until I flesh that out.

I buffed it to 10 absorbent per interaction with a delay of 2s (5 / 1.5s before) after recording the video.

https://user-images.githubusercontent.com/31366439/234558844-869ab61c-869d-425a-9e84-d2835351116d.mp4

The target selection is also bad due to the aforementioned query implementation.

:cl:
- tweak: Cleanbots now mop floors rather than drain near them.
