### PR TITLE
Reparent crafted items

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -325,6 +325,7 @@ namespace Content.Server.Construction
 
             // Transform transferring.
             var newTransform = Transform(newUid);
+            newTransform.AttachToGridOrMap(); // in case in hands or a container
             newTransform.LocalRotation = transform.LocalRotation;
             newTransform.Anchored = transform.Anchored;
 


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->
This makes items that are crafted in hands or a container drop to the floor instead of getting stuck.

This fixes the "crafted item gets stuck to your character or your bag" bug. Steps to reproduce:

1. Find a crafting recipe involving a prototype change.
2. Craft that item while holding that item in your hand. After the doafter completes, the item ends up attached to your player character.
3. Craft that item when the item is in the bag. The item looks like it's disappeared, but really it's parented to the bag but not inside it. You can recover the item by dropping your bag and picking up the crafted item.

Of course, it would be better if the crafted item would end up in your hand, or back in the bag. But this fix is still better than the item "disappearing".

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
N/A