### PR TITLE
Fix map renderer erroring on tiles with an empty sprite string

### DIFF
--- a/Content.MapRenderer/Painters/TilePainter.cs
+++ b/Content.MapRenderer/Painters/TilePainter.cs
@@ -43,7 +43,7 @@ namespace Content.MapRenderer.Painters
             {
                 var path = _sTileDefinitionManager[tile.Tile.TypeId].Sprite.ToString();
 
-                if (path == null)
+                if (string.IsNullOrWhiteSpace(path))
                     return;
 
                 var x = (int) (tile.X + xOffset);
@@ -72,7 +72,7 @@ namespace Content.MapRenderer.Painters
             {
                 var path = definition.Sprite.ToString();
 
-                if (path == null)
+                if (string.IsNullOrWhiteSpace(path))
                     continue;
 
                 images[path] = new List<Image>(definition.Variants);


### PR DESCRIPTION
## About the PR
**Media**
![Cluster-0](https://user-images.githubusercontent.com/10968691/234961885-e64fcbd8-eebf-4c4a-97ac-db4b937b740f.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase