### PR TITLE
rmobjective fix

### DIFF
--- a/Content.Server/Mind/Mind.cs
+++ b/Content.Server/Mind/Mind.cs
@@ -289,12 +289,12 @@ namespace Content.Server.Mind
         }
 
         /// <summary>
-        /// Removes an objective to this mind.
+        /// Removes an objective from this mind.
         /// </summary>
         /// <returns>Returns true if the removal succeeded.</returns>
         public bool TryRemoveObjective(int index)
         {
-            if (_objectives.Count >= index) return false;
+            if (index < 0 || index >= _objectives.Count) return false;
 
             var objective = _objectives[index];
 

--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Objectives.Commands
             }
             for (var i = 0; i < objectives.Count; i++)
             {
-                shell.WriteLine($"- [{i + 1}] {objectives[i].Conditions[0].Title}");
+                shell.WriteLine($"- [{i}] {objectives[i].Conditions[0].Title}");
             }
 
         }


### PR DESCRIPTION
Signed-off-by: vanx <vanx#5477>

fixed TryRemoveObjective in mind not working
made lsobjectives list objectives with actual indexes as they are only used in rmobjective and are more intuitive that way

no cl no fun