### PR TITLE
Fixed respawn in game bug *Critical*

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -173,6 +173,11 @@ namespace Content.Server.GameTicking
             if (!_userDb.IsLoadComplete(player))
                 return;
 
+            if (RunLevel != GameRunLevel.PreRoundLobby)
+            {
+                return;
+            }
+
             var status = ready ? PlayerGameStatus.ReadyToPlay : PlayerGameStatus.NotReadyToPlay;
             _playerGameStatuses[player.UserId] = ready ? PlayerGameStatus.ReadyToPlay : PlayerGameStatus.NotReadyToPlay;
             RaiseNetworkEvent(GetStatusMsg(player), player.ConnectedClient);


### PR DESCRIPTION
## About the PR
There is a bug for endless respawn on most part of servers. Tested on official Wizard's Den and Corvax servers.
So if you type in game commands:
toggleready true
joingame Passenger *station_id*

You will latejoin the game as passenger, even if you was in round.
It was caused because toggleready was changing session's status without checking round's state.

P.S when you latejoining the game, the full command appears in client console.

**Media**

https://youtu.be/G2wFixFfjoE

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: freeze2222#7452

- fix: Fixed respawn bug
