### PR TITLE
Fix loneops

### DIFF
--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -4,7 +4,7 @@ namespace Content.Server.GameTicking.Rules;
 
 public abstract class GameRuleSystem<T> : EntitySystem where T : Component
 {
-    [Dependency] protected GameTicker GameTicker = default!;
+    [Dependency] protected readonly GameTicker GameTicker = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/StationEvents/Events/LoneOpsSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/LoneOpsSpawnRule.cs
@@ -20,7 +20,10 @@ public sealed class LoneOpsSpawnRule : StationEventSystem<LoneOpsSpawnRuleCompon
         base.Started(uid, component, gameRule, args);
 
         if (!_nukeopsRuleSystem.CheckLoneOpsSpawn())
+        {
+            ForceEndSelf(uid, gameRule);
             return;
+        }
 
         var shuttleMap = _mapManager.CreateMap();
         var options = new MapLoadOptions

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -279,4 +279,3 @@
     reoccurrenceDelay: 25
     duration: 1
   - type: LoneOpsSpawnRule
-  - type: NukeopsRule


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
someone needs to combine these two fuckin' things at some point.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/98561806/235273407-2870378b-3cb3-4467-9bd1-7f3096d8b728.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Nuke ops will no longer start in the middle of rounds instead of lone ops.
