### PR TITLE
Fix 15710, can now admin ctrl | traitor

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -210,7 +210,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         if (traitorRule == null)
         {
             //todo fuck me this shit is awful
-            GameTicker.StartGameRule("traitor", out var ruleEntity);
+            GameTicker.StartGameRule("Traitor", out var ruleEntity);
             traitorRule = EntityManager.GetComponent<TraitorRuleComponent>(ruleEntity);
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
When you right click on an entity as an admin, then choose Admin Ctrl | Traitor (an icon) it works correctly.

Resolves https://github.com/space-wizards/space-station-14/issues/15710

The issue was caused by the wrong prototype "traitor" being mentioned, which caused an exception.

**Media**
None

**Changelog**
Too minor, but "fix: let admins create traitors" perhaps.
