### PR TITLE
Lag compensation for wide attacks

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Client.Gameplay;
 using Content.Shared.CombatMode;
 using Content.Shared.Hands.Components;
@@ -142,7 +143,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
                     coordinates = EntityCoordinates.FromMap(MapManager.GetMapEntityId(mousePos.MapId), mousePos, _transform, EntityManager);
                 }
 
-                EntityManager.RaisePredictiveEvent(new HeavyAttackEvent(weaponUid, coordinates));
+                ClientHeavyAttack(entity, coordinates, weaponUid, weapon);
             }
 
             return;
@@ -242,6 +243,31 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Raises a heavy attack event with the relevant attacked entities.
+    /// This is to avoid lag effecting the client's perspective too much.
+    /// </summary>
+    private void ClientHeavyAttack(EntityUid user, EntityCoordinates coordinates, EntityUid meleeUid, MeleeWeaponComponent component)
+    {
+        // Only run on first prediction to avoid the potential raycast entities changing.
+        if (!TryComp<TransformComponent>(user, out var userXform) || !Timing.IsFirstTimePredicted)
+            return;
+
+        var targetMap = coordinates.ToMap(EntityManager, _transform);
+
+        if (targetMap.MapId != userXform.MapID)
+            return;
+
+        var userPos = _transform.GetWorldPosition(userXform);
+        var direction = targetMap.Position - userPos;
+        var distance = Math.Min(component.Range, direction.Length);
+
+        // This should really be improved. GetEntitiesInArc uses pos instead of bounding boxes.
+        // Server will validate it with InRangeUnobstructed.
+        var entities = ArcRayCast(userPos, direction.ToWorldAngle(), component.Angle, distance, userXform.MapID, user);
+        RaisePredictiveEvent(new HeavyAttackEvent(meleeUid, entities.ToList(), coordinates));
     }
 
     protected override void Popup(string message, EntityUid? uid, EntityUid? user)

--- a/Content.Server/Movement/Systems/LagCompensationSystem.cs
+++ b/Content.Server/Movement/Systems/LagCompensationSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Movement.Components;
 using Robust.Server.Player;
 using Robust.Shared.Map;
+using Robust.Shared.Players;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Movement.Systems;
@@ -64,13 +65,13 @@ public sealed class LagCompensationSystem : EntitySystem
         component.Positions.Enqueue((_timing.CurTime, args.NewPosition, args.NewRotation));
     }
 
-    public (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(EntityUid uid, IPlayerSession pSession,
+    public (EntityCoordinates Coordinates, Angle Angle) GetCoordinatesAngle(EntityUid uid, ICommonSession? pSession,
         TransformComponent? xform = null)
     {
         if (!Resolve(uid, ref xform))
             return (EntityCoordinates.Invalid, Angle.Zero);
 
-        if (!TryComp<LagCompensationComponent>(uid, out var lag) || lag.Positions.Count == 0)
+        if (pSession == null || !TryComp<LagCompensationComponent>(uid, out var lag) || lag.Positions.Count == 0)
             return (xform.Coordinates, xform.LocalRotation);
 
         var angle = Angle.Zero;
@@ -102,15 +103,15 @@ public sealed class LagCompensationSystem : EntitySystem
         return (coordinates, angle);
     }
 
-    public Angle GetAngle(EntityUid uid, IPlayerSession pSession, TransformComponent? xform = null)
+    public Angle GetAngle(EntityUid uid, ICommonSession? session, TransformComponent? xform = null)
     {
-        var (_, angle) = GetCoordinatesAngle(uid, pSession, xform);
+        var (_, angle) = GetCoordinatesAngle(uid, session, xform);
         return angle;
     }
 
-    public EntityCoordinates GetCoordinates(EntityUid uid, IPlayerSession pSession, TransformComponent? xform = null)
+    public EntityCoordinates GetCoordinates(EntityUid uid, ICommonSession? session, TransformComponent? xform = null)
     {
-        var (coordinates, _) = GetCoordinatesAngle(uid, pSession, xform);
+        var (coordinates, _) = GetCoordinatesAngle(uid, session, xform);
         return coordinates;
     }
 }

--- a/Content.Shared/Weapons/Melee/Events/HeavyAttackEvent.cs
+++ b/Content.Shared/Weapons/Melee/Events/HeavyAttackEvent.cs
@@ -11,8 +11,14 @@ public sealed class HeavyAttackEvent : AttackEvent
 {
     public readonly EntityUid Weapon;
 
-    public HeavyAttackEvent(EntityUid weapon, EntityCoordinates coordinates) : base(coordinates)
+    /// <summary>
+    /// As what the client swung at will not match server we'll have them tell us what they hit so we can verify.
+    /// </summary>
+    public List<EntityUid> Entities;
+
+    public HeavyAttackEvent(EntityUid weapon, List<EntityUid> entities, EntityCoordinates coordinates) : base(coordinates)
     {
         Weapon = weapon;
+        Entities = entities;
     }
 }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -524,7 +524,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         var damage = component.Damage * GetModifier(component, false);
         var entities = ev.Entities;
-        Sawmill.Debug($"Heavy attacking {entities.Count} entities");
 
         if (entities.Count == 0)
         {

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -41,7 +41,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] protected readonly SharedInteractionSystem Interaction = default!;
     [Dependency] private   readonly SharedPhysicsSystem _physics = default!;
     [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
-    [Dependency] protected   readonly SharedTransformSystem _transform = default!;
+    [Dependency] protected readonly SharedTransformSystem _transform = default!;
     [Dependency] private   readonly StaminaSystem _stamina = default!;
 
     protected ISawmill Sawmill = default!;
@@ -64,10 +64,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         SubscribeLocalEvent<MeleeWeaponComponent, HandDeselectedEvent>(OnMeleeDropped);
         SubscribeLocalEvent<MeleeWeaponComponent, HandSelectedEvent>(OnMeleeSelected);
 
+        SubscribeAllEvent<HeavyAttackEvent>(OnHeavyAttack);
         SubscribeAllEvent<LightAttackEvent>(OnLightAttack);
         SubscribeAllEvent<StartHeavyAttackEvent>(OnStartHeavyAttack);
         SubscribeAllEvent<StopHeavyAttackEvent>(OnStopHeavyAttack);
-        SubscribeAllEvent<HeavyAttackEvent>(OnHeavyAttack);
         SubscribeAllEvent<DisarmAttackEvent>(OnDisarmAttack);
         SubscribeAllEvent<StopAttackEvent>(OnStopAttack);
 
@@ -507,29 +507,24 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
     protected abstract void DoDamageEffect(List<EntityUid> targets, EntityUid? user,  TransformComponent targetXform);
 
-    protected virtual void DoHeavyAttack(EntityUid user, HeavyAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session)
+    private void DoHeavyAttack(EntityUid user, HeavyAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session)
     {
         // TODO: This is copy-paste as fuck with DoPreciseAttack
         if (!TryComp<TransformComponent>(user, out var userXform))
-        {
             return;
-        }
 
         var targetMap = ev.Coordinates.ToMap(EntityManager, _transform);
 
         if (targetMap.MapId != userXform.MapID)
-        {
             return;
-        }
 
         var userPos = _transform.GetWorldPosition(userXform);
         var direction = targetMap.Position - userPos;
         var distance = Math.Min(component.Range, direction.Length);
 
         var damage = component.Damage * GetModifier(component, false);
-
-        // This should really be improved. GetEntitiesInArc uses pos instead of bounding boxes.
-        var entities = ArcRayCast(userPos, direction.ToWorldAngle(), component.Angle, distance, userXform.MapID, user);
+        var entities = ev.Entities;
+        Sawmill.Debug($"Heavy attacking {entities.Count} entities");
 
         if (entities.Count == 0)
         {
@@ -538,6 +533,19 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
             Audio.PlayPredicted(component.SwingSound, meleeUid, user);
             return;
+        }
+
+        // Validate client
+        for (var i = entities.Count - 1; i >= 0; i--)
+        {
+            if (ArcRaySuccessful(entities[i], userPos, direction.ToWorldAngle(), component.Angle, distance,
+                    userXform.MapID, user, session))
+            {
+                continue;
+            }
+
+            // Bad input
+            entities.RemoveAt(i);
         }
 
         var targets = new List<EntityUid>();
@@ -627,7 +635,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         }
     }
 
-    private HashSet<EntityUid> ArcRayCast(Vector2 position, Angle angle, Angle arcWidth, float range, MapId mapId, EntityUid ignore)
+    protected HashSet<EntityUid> ArcRayCast(Vector2 position, Angle angle, Angle arcWidth, float range, MapId mapId, EntityUid ignore)
     {
         // TODO: This is pretty sucky.
         var widthRad = arcWidth;
@@ -651,6 +659,13 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         }
 
         return resSet;
+    }
+
+    protected virtual bool ArcRaySuccessful(EntityUid targetUid, Vector2 position, Angle angle, Angle arcWidth, float range,
+        MapId mapId, EntityUid ignore, ICommonSession? session)
+    {
+        // Only matters for server.
+        return true;
     }
 
     private void PlayHitSound(EntityUid target, EntityUid? user, string? type, SoundSpecifier? hitSoundOverride, SoundSpecifier? hitSound)


### PR DESCRIPTION
I watched tstalker fight for a bit as a kangaroo and I was malding over the server not registering hits that the client was showing effects for.

Slightly more prone to cheating (there's no arc-width validation atm, just the raycast + range) though if they're aimbotting it won't make a difference (unless they're hitting 1 target on 1 side of them and another on the other side). Making melee combat not awful is the bigger prio atm.

:cl:
- add: Wide melee attacks are now also lag compensated.
