### PR TITLE
Fix heater and freezer temperature range and wrong unit

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         public float MaxTemperature;
 
         /// <summary>
-        ///     Minimum temperature the device can reach with a 0 total laser quality. Usually the quality will be at
+        ///     Minimum temperature the device can reach with a 0 total capacitor quality. Usually the quality will be at
         ///     least 1.
         /// </summary>
         [DataField("baseMinTemperature")]
@@ -60,7 +60,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         public float BaseMinTemperature = 96.625f; // Selected so that tier-1 parts can reach 73.15k
 
         /// <summary>
-        ///     Maximum temperature the device can reach with a 0 total laser quality. Usually the quality will be at
+        ///     Maximum temperature the device can reach with a 0 total capacitor quality. Usually the quality will be at
         ///     least 1.
         /// </summary>
         [DataField("baseMaxTemperature")]

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -57,22 +57,22 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnGasThermoRefreshParts(EntityUid uid, GasThermoMachineComponent thermoMachine, RefreshPartsEvent args)
         {
-            var matterBinRating = args.PartRatings[thermoMachine.MachinePartHeatCapacity];
-            var laserRating = args.PartRatings[thermoMachine.MachinePartTemperature];
+            var heatCapacityPartRating = args.PartRatings[thermoMachine.MachinePartHeatCapacity];
+            var temperatureRangePartRating = args.PartRatings[thermoMachine.MachinePartTemperature];
 
-            thermoMachine.HeatCapacity = thermoMachine.BaseHeatCapacity * MathF.Pow(matterBinRating, 2);
+            thermoMachine.HeatCapacity = thermoMachine.BaseHeatCapacity * MathF.Pow(heatCapacityPartRating, 2);
 
             switch (thermoMachine.Mode)
             {
                 // 593.15K with stock parts.
                 case ThermoMachineMode.Heater:
-                    thermoMachine.MaxTemperature = thermoMachine.BaseMaxTemperature + thermoMachine.MaxTemperatureDelta * laserRating;
+                    thermoMachine.MaxTemperature = thermoMachine.BaseMaxTemperature + thermoMachine.MaxTemperatureDelta * temperatureRangePartRating;
                     thermoMachine.MinTemperature = Atmospherics.T20C;
                     break;
                 // 73.15K with stock parts.
                 case ThermoMachineMode.Freezer:
                     thermoMachine.MinTemperature = MathF.Max(
-                        thermoMachine.BaseMinTemperature - thermoMachine.MinTemperatureDelta * laserRating, Atmospherics.TCMB);
+                        thermoMachine.BaseMinTemperature - thermoMachine.MinTemperatureDelta * temperatureRangePartRating, Atmospherics.TCMB);
                     thermoMachine.MaxTemperature = Atmospherics.T20C;
                     break;
             }

--- a/Resources/Locale/en-US/atmos/gas-thermomachine-system.ftl
+++ b/Resources/Locale/en-US/atmos/gas-thermomachine-system.ftl
@@ -1,2 +1,2 @@
 # Examine Text
-gas-thermomachine-system-examined = The {$machineName} thermostat is set to [color={$tempColor}]{$temp} °C[/color].
+gas-thermomachine-system-examined = The {$machineName} thermostat is set to [color={$tempColor}]{$temp} °K[/color].

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: AutolatheMachineCircuitboard
   parent: BaseMachineCircuitboard
   name: autolathe machine board
@@ -230,7 +230,7 @@
     prototype: GasThermoMachineFreezer
     requirements:
       MatterBin: 2
-      Manipulator: 2
+      Capacitor: 2
     materialRequirements:
       Cable: 5
   - type: Construction
@@ -250,7 +250,7 @@
     prototype: GasThermoMachineHeater
     requirements:
       MatterBin: 2
-      Manipulator: 2
+      Capacitor: 2
     materialRequirements:
       Cable: 5
   - type: Construction


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
In #15802 Emo changed temperature range conmponent from Lasers to Capacitors, but both heater and freezer didn't use any of them in the construction, this fixes it. Also on the examination both machines display their temperature in Kelvin but say it's Celsius, fixes that too.
Also changed the variable names so they aren't bound to specific component.
Bug from Discord: https://discord.com/channels/310555209753690112/1101814074959994881/1101814074959994881

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
 No need for CL I guess
