### PR TITLE
Fix 0.25sec doafters

### DIFF
--- a/Content.Server/Power/Components/CableComponent.cs
+++ b/Content.Server/Power/Components/CableComponent.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Power.Components
         public CableType CableType = CableType.HighVoltage;
 
         [DataField("cuttingDelay")]
-        public float CuttingDelay = 0.25f;
+        public float CuttingDelay = 1f;
     }
 
     public enum CableType

--- a/Content.Server/Tools/Components/LatticeCuttingComponent.cs
+++ b/Content.Server/Tools/Components/LatticeCuttingComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Tools;
+using Content.Shared.Tools;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Tools.Components;
@@ -10,7 +10,7 @@ public sealed class LatticeCuttingComponent : Component
     public string QualityNeeded = "Cutting";
 
     [DataField("delay")]
-    public float Delay = 0.25f;
+    public float Delay = 1f;
 
     [DataField("vacuumDelay")]
     public float VacuumDelay = 1.75f;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Changes the 0.25sec doafters to 1sec.
Resolves #15506

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Nanotrasen now supplies the station with off-brand wirecutters. Cutting cables and lattices takes slightly longer.
