### PR TITLE
set miros player cap to 50

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/miros.toml
+++ b/Resources/ConfigPresets/WizardsDen/miros.toml
@@ -2,3 +2,4 @@
 
 [game]
 hostname = "[EN] Wizard's Den Miros [EU West 2]"
+soft_max_players = 40

--- a/Resources/ConfigPresets/WizardsDen/miros.toml
+++ b/Resources/ConfigPresets/WizardsDen/miros.toml
@@ -2,4 +2,7 @@
 
 [game]
 hostname = "[EN] Wizard's Den Miros [EU West 2]"
-soft_max_players = 40
+soft_max_players = 50
+
+[net]
+tickrate = 20


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Miros is having performance issues at high player counts. I'm not sure where the issues start so it might need to be lowered more or might be able to be a bit higher.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase