### PR TITLE
Fix TC inserting into uplinks and PDAs

### DIFF
--- a/Content.Server/PDA/Ringer/RingerSystem.cs
+++ b/Content.Server/PDA/Ringer/RingerSystem.cs
@@ -55,12 +55,17 @@ namespace Content.Server.PDA.Ringer
 
         private void OnSetUplinkRingtone(EntityUid uid, RingerUplinkComponent uplink, RingerSetRingtoneMessage args)
         {
-            if (uplink.Code.SequenceEqual(args.Ringtone) &&
-                args.Session.AttachedEntity != null &&
+            if (args.Session.AttachedEntity != null &&
                 TryComp<StoreComponent>(uid, out var store))
             {
-                var user = args.Session.AttachedEntity.Value;
-                _store.ToggleUi(args.Session.AttachedEntity.Value, uid, store);
+                if (uplink.Code.SequenceEqual(args.Ringtone))
+                {
+                    var user = args.Session.AttachedEntity.Value;
+                    store.Unlocked = true;
+                    _store.ToggleUi(args.Session.AttachedEntity.Value, uid, store);
+                }
+                else
+                    store.Unlocked = false;
             }
         }
 

--- a/Content.Server/Store/Components/StoreComponent.cs
+++ b/Content.Server/Store/Components/StoreComponent.cs
@@ -48,6 +48,13 @@ public sealed class StoreComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     public EntityUid? AccountOwner = null;
 
+
+    /// <summary>
+    /// Locks and unlocks the store
+    /// </summary>
+    [DataField("unlocked")]
+    public bool Unlocked = false;
+
     /// <summary>
     /// All listings, including those that aren't available to the buyer
     /// </summary>

--- a/Content.Server/Store/Systems/StoreSystem.cs
+++ b/Content.Server/Store/Systems/StoreSystem.cs
@@ -72,9 +72,8 @@ public sealed partial class StoreSystem : EntitySystem
         if (args.Target == null || !TryComp<StoreComponent>(args.Target, out var store))
             return;
 
-        // require the store to be open before inserting currency
-        var user = args.User;
-        if (!TryComp<ActorComponent>(user, out var actor) || !_ui.SessionHasOpenUi(uid, StoreUiKey.Key, actor.PlayerSession))
+        // require the store to be unlocked before inserting currency
+        if (!store.Unlocked)
             return;
 
         args.Handled = TryAddCurrency(GetCurrencyValue(uid, component), args.Target.Value, store);

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -126,6 +126,7 @@
     preset: StorePresetUplink
     balance:
       Telecrystal: 0
+    unlocked: true
   - type: UserInterface
     interfaces:
     - key: enum.StoreUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -72,6 +72,7 @@
     preset: StorePresetUplink
     balance:
       Telecrystal: 0
+    unlocked: true
 
 - type: entity
   parent: BaseUplinkRadio


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR fixes the TC inserting issue after the recent uplink changes. Instead of checking if the player has uplink window open, which stopped working, it unlocks the uplink when the user inputs the correct ringtone and lets them insert the TC. The nukie radio uplink and uplink implant are always unlocked. 
Resolves #15920

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://user-images.githubusercontent.com/46636558/235329597-ad197e39-eef2-4c8e-8024-cf8564054051.mp4

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Mumohan
- fix: Syndicate agents can once again deposit telecrystals into their uplinks
