### PR TITLE
Vents leak slowly, limit their max pressure

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -44,6 +44,20 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField("underPressureLockoutThreshold")]
         public float UnderPressureLockoutThreshold = 1;
 
+        /// <summary>
+        ///     Pressure locked vents still leak a little (leading to eventual pressurization of sealed sections)
+        /// </summary>
+        /// <remarks>
+        ///     Ratio of pressure difference between pipes and atmosphere that will leak each second, in moles.
+        ///     If the pipes are 200 kPa and the room is spaced, at 0.01 UnderPressureLockoutLeaking, the room will fill
+        ///     at a rate of 2 moles / sec. It will then reach 1 kPa (UnderPressureLockoutThreshold) and begin normal
+        ///     filling after about 10 seconds (depending on room size).
+        /// </remarks>
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("underPressureLockoutLeaking")]
+        public float UnderPressureLockoutLeaking = 0.005f;
+
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("externalPressureBound")]
         public float ExternalPressureBound
@@ -88,6 +102,17 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("targetPressureChange")]
         public float TargetPressureChange = Atmospherics.OneAtmosphere;
+
+        /// <summary>
+        ///     Ratio of max output air pressure and pipe pressure, representing the vent's ability to increase pressure
+        /// </summary>
+        /// <remarks>
+        ///     Vents cannot suck a pipe completely empty, instead pressurizing a section to a max of
+        ///     pipe pressure * PumpPower (in kPa). So a 51 kPa pipe is required for 101 kPA sections at PumpPower 2.0
+        /// </remarks>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("PumpPower")]
+        public float PumpPower = 2.0f;
 
         #region Machine Linking
         /// <summary>

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("underPressureLockoutThreshold")]
-        public float UnderPressureLockoutThreshold = 1;
+        public float UnderPressureLockoutThreshold = 2;
 
         /// <summary>
         ///     Pressure locked vents still leak a little (leading to eventual pressurization of sealed sections)
@@ -50,13 +50,16 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// <remarks>
         ///     Ratio of pressure difference between pipes and atmosphere that will leak each second, in moles.
         ///     If the pipes are 200 kPa and the room is spaced, at 0.01 UnderPressureLockoutLeaking, the room will fill
-        ///     at a rate of 2 moles / sec. It will then reach 1 kPa (UnderPressureLockoutThreshold) and begin normal
-        ///     filling after about 10 seconds (depending on room size).
+        ///     at a rate of 2 moles / sec. It will then reach 2 kPa (UnderPressureLockoutThreshold) and begin normal
+        ///     filling after about 20 seconds (depending on room size).
+        ///
+        ///     Since we want to prevent automating the work of atmos, the leaking rate of 0.0001f is set to make auto
+        ///     repressurizing of the development map take about 30 minutes using an oxygen tank (high pressure)
         /// </remarks>
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("underPressureLockoutLeaking")]
-        public float UnderPressureLockoutLeaking = 0.005f;
+        public float UnderPressureLockoutLeaking = 0.0001f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("externalPressureBound")]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This change makes air vents slightly smarter and easier to manage, at the cost of a higher air drain overall. There are two main new features.

### 1. Air vents in spaced sections (called vent.UnderPressureLockout) will still leak slowly.

The leaking will result in spaced rooms that were later sealed slowly regaining ~~1kPa~~ 2kPa pressure (vent.UnderPressureLockoutThreshold). After that they will fill quickly. The leaking is proportional to the pipe pressure, so if the pipe pressure is 2000 kPa then sealed sections will repressurize within ~~10 seconds~~ 10-30 minutes. This is a rough guide and varies by room size.

**A decision was made (below) to reduce leak speed so as not to automate Atmos jobs too much**

If the section is still spaced, this leaking will be a parasitic drag on the air system, dragging down the station supply pressure gradually. It takes a couple of minutes to empty a single oxygen tank. The leaking slows as the air system pressure reduces.

The leaking rate is adjusted using Vent.UnderPressureLockoutLeaking

### 2. Air vents can only pressurize to supply pressure * Vent.PumpPower at most

So a supply pipe of at least 51 kPa is required to fill a room to 101 kPA with the PumpPower of 2.

This means the station will fill evenly, with the minimum air on the station readable by looking at the supply pipe. Prior to this PR vents would drain the supply to a vaccuum which is simply unrealistic. 

### What it impacts

It makes working as an atmos slightly easier, ~~since spaced sections will refill automatically.~~ When supply is correctly set up you'll see air in the supply pipe (whereas prior to this PR the supply would read 0 kPa as long as any section is below 101 kPa).

Prior to this change you needed an air source to test / repressurize rooms you think are now sealed after spacing. Or you'd use a crowbar to open an airlock and experimentally space the next section. Now you'll see immediate (but small) pressure building the instant you've sealed a spaced room containing a working air vent.

**Media**
If you space the test map and then connect an oxygen test tank, it will stabilize to this:
![image](https://user-images.githubusercontent.com/5285589/235329933-c2951627-14c4-4064-b401-459cb7d75173.png)
![image](https://user-images.githubusercontent.com/5285589/235329949-a1511fd4-4ae8-44ed-8170-20cf63761c9b.png)

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Air vents leak in vacuum, eventually (10-30 mins) re-pressurizing sealed, spaced sections
- add: Air vent pumps are limited to 2.0 * supply pressure at most