### PR TITLE
Fixes Typo In Station Event Documentation.

### DIFF
--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -82,7 +82,7 @@ public sealed class StationEventComponent : Component
     public TimeSpan StartTime;
 
     /// <summary>
-    /// When the station event starts.
+    /// When the station event ends.
     /// </summary>
     [DataField("endTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? EndTime;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

Fixes a typo.

This change is brought to you by [ThetaGang](https://github.com/ThetaStation/ThetaStation)