### PR TITLE
Set SpriteView sizes in various controls.

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
@@ -8,7 +8,7 @@
         <BoxContainer Orientation="Horizontal" Margin="0 0 0 2">
             <!-- Left column (view of entity) -->
             <PanelContainer Margin="2 0 6 0" StyleClasses="Inset" VerticalAlignment="Center" VerticalExpand="True">
-                <SpriteView Name="EntityView" OverrideDirection="South" Scale="2 2" />
+                <SpriteView Name="EntityView" OverrideDirection="South" Scale="2 2" SetSize="64 64"/>
             </PanelContainer>
             <!-- Center column (pressure, temperature, alarm state) -->
             <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="0 0 6 0">

--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -207,6 +207,7 @@ namespace Content.Client.Examine
                 hBox.AddChild(new SpriteView
                 {
                     Sprite = sprite, OverrideDirection = Direction.South,
+                    SetSize = (32, 32),
                     Margin = new Thickness(2, 0, 2, 0),
                 });
             }

--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -129,6 +129,7 @@ namespace Content.Client.RoundEnd
                         Sprite = sprite,
                         OverrideDirection = Direction.South,
                         VerticalAlignment = VAlignment.Center,
+                        SetSize = (32, 32),
                         VerticalExpand = true,
                     });
                 }

--- a/Content.Client/Storage/UI/StorageWindow.cs
+++ b/Content.Client/Storage/UI/StorageWindow.cs
@@ -123,7 +123,7 @@ namespace Content.Client.Storage.UI
                         {
                             HorizontalAlignment = HAlignment.Left,
                             VerticalAlignment = VAlignment.Center,
-                            MinSize = new Vector2(32.0f, 32.0f),
+                            SetSize = new Vector2(32.0f, 32.0f),
                             OverrideDirection = Direction.South,
                             Sprite = sprite
                         },

--- a/Content.Client/UserInterface/Controls/SlotControl.cs
+++ b/Content.Client/UserInterface/Controls/SlotControl.cs
@@ -132,12 +132,14 @@ namespace Content.Client.UserInterface.Controls
             AddChild(SpriteView = new SpriteView
             {
                 Scale = (2, 2),
+                SetSize = (DefaultButtonSize, DefaultButtonSize),
                 OverrideDirection = Direction.South
             });
 
             AddChild(HoverSpriteView = new SpriteView
             {
                 Scale = (2, 2),
+                SetSize = (DefaultButtonSize, DefaultButtonSize),
                 OverrideDirection = Direction.South
             });
 

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -95,6 +95,7 @@ public sealed class ActionButton : Control
             HorizontalExpand = true,
             VerticalExpand = true,
             Scale = (2, 2),
+            SetSize = (64, 64),
             Visible = false,
             OverrideDirection = Direction.South,
         };

--- a/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
@@ -8,7 +8,7 @@
     <ScrollContainer>
         <BoxContainer Orientation="Vertical">
             <BoxContainer Orientation="Horizontal">
-                <SpriteView OverrideDirection="South" Scale="2 2" Name="SpriteView" Access="Public"/>
+                <SpriteView OverrideDirection="South" Scale="2 2" Name="SpriteView" Access="Public" SetSize="64 64"/>
                 <BoxContainer Orientation="Vertical" VerticalAlignment="Top">
                     <Label Name="NameLabel" Access="Public"/>
                     <Label Name="SubText" VerticalAlignment="Top" StyleClasses="LabelSubText" Access="Public"/>

--- a/Content.Client/Verbs/UI/VerbMenuElement.cs
+++ b/Content.Client/Verbs/UI/VerbMenuElement.cs
@@ -48,6 +48,7 @@ namespace Content.Client.Verbs.UI
                 var spriteView = new SpriteView()
                 {
                     OverrideDirection = Direction.South,
+                    SetSize = (ElementHeight, ElementHeight),
                     Sprite = entManager.GetComponentOrNull<SpriteComponent>(verb.IconEntity.Value)
                 };
 


### PR DESCRIPTION
Now that sprite view sizes auto scale various controls behave weirdly with large entities. This PR should just fix them to their original size.