### PR TITLE
Ghost roles of slimes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -110,10 +110,11 @@
     interactFailureString: petting-failure-generic
   - type: ReplacementAccent
     accent: slimes
-  - type: GhostTakeoverAvailable
+  - type: GhostRole
     makeSentient: true
     name: ghost-role-information-slimes-name
     description: ghost-role-information-slimes-description
+  - type: GhostTakeoverAvailable
 
 - type: entity
   name: blue slime


### PR DESCRIPTION
## About the PR

Small mistake, now slimes can be a ghost role.

**Media**

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: Nimfar11

- fix: Now slimes can be a ghost role
