### PR TITLE
Crowbar for ERT

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -229,7 +229,7 @@
         - id: MagazinePistolHighCapacityRubber
         - id: MagazinePistol
         - id: Handcuffs
-
+        - id: CrowbarRed
 
 - type: entity
   noSpawn: true
@@ -244,6 +244,7 @@
         - id: WeaponPulseCarbine
         - id: BoxHandcuff
         - id: Handcuffs
+        - id: CrowbarRed
 
 - type: entity
   noSpawn: true
@@ -256,7 +257,7 @@
         - id: WeaponPulseCarbine
         - id: Hypospray
         - id: MedkitAdvancedFilled
-
+        - id: CrowbarRed
 
 - type: entity
   noSpawn: true
@@ -286,6 +287,7 @@
         - id: BoxLightMixed
         - id: BoxLightMixed
         - id: Soap
+        - id: CrowbarRed
 
 - type: entity
   noSpawn: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Mostly, ERT coming to unpowered station and airlocks are closed...
So it would be nice to have crowbar

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl