### PR TITLE
fix several bottle prototypes not having solution visuals

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -154,7 +154,7 @@
 - type: entity
   id: EpinephrineChemistryBottle
   name: epinephrine bottle
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -171,7 +171,7 @@
   id: RobustHarvestChemistryBottle
   name: robust harvest bottle
   description: This will increase the potency of your plants.
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -188,7 +188,7 @@
   id: UnstableMutagenChemistryBottle
   name: unstable mutagen bottle
   description: This will cause rapid mutations in your plants.
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -205,7 +205,7 @@
   id: NocturineChemistryBottle
   name: nocturine bottle
   description: This will make someone fall down almost immediately. Hard to overdose on.
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -221,7 +221,7 @@
 - type: entity
   id: EphedrineChemistryBottle
   name: ephedrine bottle
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -237,7 +237,7 @@
 - type: entity
   id: OmnizineChemistryBottle
   name: omnizine bottle
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Several bottle prototypes inherited from 'BaseChemistryEmptyBottle' which did not have 'SolutionContainerVisuals' component, this results in them not displaying contained solutions.

They now inherit from 'ChemistryEmptyBottle01'.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:
![before](https://user-images.githubusercontent.com/62370007/235632072-235797fa-b74c-422a-804c-513d18d97a84.PNG)

After:
![after](https://user-images.githubusercontent.com/62370007/235632089-7f125f29-a450-411c-af72-375f5b19b4e8.PNG)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed several bottles not correctly displaying contained solutions.
