### PR TITLE
Factions for animals

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -744,7 +744,7 @@
   - type: CanHostGuardian
   - type: Faction
     factions:
-    - SimpleNeutral
+    - Victim
   - type: GhostRole
     makeSentient: true
     name: monkey

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -742,6 +742,9 @@
   - type: MonkeyAccent
   - type: Puller
   - type: CanHostGuardian
+  - type: Faction
+    factions:
+    - SimpleNeutral
   - type: GhostRole
     makeSentient: true
     name: monkey

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -199,7 +199,7 @@
     needsHands: true
   - type: Faction
     factions:
-    - Delicious
+    - Passive
 
 - type: entity
   name: mallard duck #Quack
@@ -253,7 +253,7 @@
     flavorKind: station-event-random-sentience-flavor-organic
   - type: Faction
     factions:
-    - Delicious
+    - Passive
 
 - type: entity
   name: white duck #Quack
@@ -415,7 +415,7 @@
     molsPerSecondPerUnitMass: 0.0015
   - type: Faction
     factions:
-    - Delicious
+    - Passive
 
 - type: entity
   name: crab
@@ -518,7 +518,7 @@
       path: /Audio/Animals/goat_bah.ogg
   - type: Faction
     factions:
-    - Delicious
+    - Passive
 
 # Note that we gotta make this bitch vomit someday when you feed it anthrax or sumthin. Needs to be a small item thief too and aggressive if attacked.
 - type: entity
@@ -567,7 +567,7 @@
   - type: Puller
   - type: Faction
     factions:
-    - Delicious
+    - Passive
 
 - type: entity
   name: gorilla
@@ -758,7 +758,7 @@
   - type: CanHostGuardian
   - type: Faction
     factions:
-    - Delicious
+    - Passive
   - type: GhostRole
     makeSentient: true
     name: monkey
@@ -1191,7 +1191,7 @@
       path: /Audio/Animals/penguin_squawk.ogg
   - type: Faction
     factions:
-    - Delicious
+    - Passive
 
 - type: entity
   name: grenade penguin
@@ -2148,4 +2148,4 @@
     flavorKind: station-event-random-sentience-flavor-organic
   - type: Faction
     factions:
-    - Delicious
+    - Passive

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -197,6 +197,9 @@
     flavorKind: station-event-random-sentience-flavor-organic
   - type: Puller
     needsHands: true
+  - type: Faction
+    factions:
+    - Delicious
 
 - type: entity
   name: mallard duck #Quack
@@ -248,6 +251,9 @@
     accent: duck
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-organic
+  - type: Faction
+    factions:
+    - Delicious
 
 - type: entity
   name: white duck #Quack
@@ -407,7 +413,9 @@
       path: /Audio/Animals/cow_moo.ogg
   - type: Perishable
     molsPerSecondPerUnitMass: 0.0015
-
+  - type: Faction
+    factions:
+    - Delicious
 
 - type: entity
   name: crab
@@ -508,6 +516,9 @@
     interactFailureString: petting-failure-goat
     interactSuccessSound:
       path: /Audio/Animals/goat_bah.ogg
+  - type: Faction
+    factions:
+    - Delicious
 
 # Note that we gotta make this bitch vomit someday when you feed it anthrax or sumthin. Needs to be a small item thief too and aggressive if attacked.
 - type: entity
@@ -554,6 +565,9 @@
   - type: Bloodstream
     bloodMaxVolume: 100
   - type: Puller
+  - type: Faction
+    factions:
+    - Delicious
 
 - type: entity
   name: gorilla
@@ -744,7 +758,7 @@
   - type: CanHostGuardian
   - type: Faction
     factions:
-    - Victim
+    - Delicious
   - type: GhostRole
     makeSentient: true
     name: monkey
@@ -1175,6 +1189,9 @@
     interactFailureString: petting-failure-generic
     interactSuccessSound:
       path: /Audio/Animals/penguin_squawk.ogg
+  - type: Faction
+    factions:
+    - Delicious
 
 - type: entity
   name: grenade penguin
@@ -2129,3 +2146,6 @@
     accent: pig
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-organic
+  - type: Faction
+    factions:
+    - Delicious

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -125,6 +125,9 @@
   parent: MobCatCalico
   description: Ask nicely, and maybe they'll give you one of their spare lives.
   components:
+  - type: Faction
+    factions:
+      - PetsNT
   - type: Grammar
     attributes:
       gender: male

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -26,7 +26,7 @@
     showExamineInfo: true
   - type: Faction
     factions:
-    - Victim
+    - PetsNT
   - type: Alerts
   - type: Familiar
 
@@ -56,7 +56,7 @@
   - type: MobMover
   - type: Faction
     factions:
-    - Victim
+    - PetsNT
   - type: InteractionPopup
     successChance: 0.5
     interactSuccessString: petting-success-corrupted-corgi

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -56,7 +56,7 @@
   - type: MobMover
   - type: Faction
     factions:
-    - PetsNT
+    - SimpleNeutral
   - type: InteractionPopup
     successChance: 0.5
     interactSuccessString: petting-success-corrupted-corgi

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -26,7 +26,7 @@
     showExamineInfo: true
   - type: Faction
     factions:
-    - SimpleNeutral
+    - Victim
   - type: Alerts
   - type: Familiar
 
@@ -56,7 +56,7 @@
   - type: MobMover
   - type: Faction
     factions:
-    - SimpleNeutral
+    - Victim
   - type: InteractionPopup
     successChance: 0.5
     interactSuccessString: petting-success-corrupted-corgi

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -24,6 +24,9 @@
     - Chapel
   - type: Mind
     showExamineInfo: true
+  - type: Faction
+    factions:
+    - SimpleNeutral
   - type: Alerts
   - type: Familiar
 

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -52,5 +52,5 @@
   hostile:
   - NanoTrasen
   - Syndicate
-  - PetsNT
   - Passive
+  - PetsNT

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -33,8 +33,8 @@
   hostile:
   - NanoTrasen
   - Syndicate
-  - PetsNT
   - Passive
+  - PetsNT
 
 - type: faction
   id: SimpleNeutral

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -7,9 +7,6 @@
     - PetsNT
 
 - type: faction
-  id: Delicious
-
-- type: faction
   id: NanoTrasen
   hostile:
   - SimpleHostile
@@ -20,6 +17,9 @@
   id: Mouse
   hostile:
     - PetsNT
+
+- type: faction
+  id: Passive
 
 - type: faction
   id: PetsNT
@@ -34,7 +34,7 @@
   - NanoTrasen
   - Syndicate
   - PetsNT
-  - Delicious
+  - Passive
 
 - type: faction
   id: SimpleNeutral
@@ -53,4 +53,4 @@
   - NanoTrasen
   - Syndicate
   - PetsNT
-  - Delicious
+  - Passive

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -4,6 +4,7 @@
     - NanoTrasen
     - Syndicate
     - Xeno
+    - PetsNT
 
 - type: faction
   id: NanoTrasen
@@ -29,9 +30,14 @@
   hostile:
   - NanoTrasen
   - Syndicate
+  - PetsNT
+  - Victim
 
 - type: faction
   id: SimpleNeutral
+
+- type: faction
+  id: Victim
 
 - type: faction
   id: Syndicate
@@ -39,9 +45,12 @@
   - NanoTrasen
   - SimpleHostile
   - Xeno
+  - PetsNT
 
 - type: faction
   id: Xeno
   hostile:
   - NanoTrasen
   - Syndicate
+  - PetsNT
+  - Victim

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -7,6 +7,9 @@
     - PetsNT
 
 - type: faction
+  id: Delicious
+
+- type: faction
   id: NanoTrasen
   hostile:
   - SimpleHostile
@@ -31,13 +34,10 @@
   - NanoTrasen
   - Syndicate
   - PetsNT
-  - Victim
+  - Delicious
 
 - type: faction
   id: SimpleNeutral
-
-- type: faction
-  id: Victim
 
 - type: faction
   id: Syndicate
@@ -53,4 +53,4 @@
   - NanoTrasen
   - Syndicate
   - PetsNT
-  - Victim
+  - Delicious


### PR DESCRIPTION
## About the PR

Added a faction to some animals so they too would be targeted and not use their neutral status to attack with impunity. Added a new faction to be the target of an attack, but not to attack anyone. 
Made some factions enemies to each other.

Solves the problem [#15988](https://github.com/space-wizards/space-station-14/issues/15988)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: Nimfar11

- add: Adds a neutral faction Delicious, to Monkeys. Now they are not untouchable. They are a delicacy for the antagas.
- add: Adds a faction PetsNT for the cat Exception, Remilia and Cerberus.