### PR TITLE
make maxcaps sqrt-scaling

### DIFF
--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -83,7 +83,7 @@ namespace Content.Server.Atmos.Components
         ///     Increases explosion for each scale kPa above threshold.
         /// </summary>
         [DataField("tankFragmentScale")]
-        public float TankFragmentScale { get; set; }    = 10 * Atmospherics.OneAtmosphere;
+        public float TankFragmentScale { get; set; }    = 2 * Atmospherics.OneAtmosphere;
 
         [DataField("toggleAction", required: true)]
         public InstantAction ToggleAction = new();

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -263,7 +263,7 @@ namespace Content.Server.Atmos.EntitySystems
                 }
 
                 pressure = component.Air.Pressure;
-                var range = (pressure - component.TankFragmentPressure) / component.TankFragmentScale;
+                var range = MathF.Sqrt((pressure - component.TankFragmentPressure) / component.TankFragmentScale);
 
                 // Let's cap the explosion, yeah?
                 // !1984


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
an alternative to https://github.com/space-wizards/space-station-14/pull/16014 that i think better fixes the issue (discussed in comments of mentioned PR)
changes atmos tank bomb scaling to `radius = sqrt(overpressure * 5)` as opposed to `radius = overpressure`, this results in good atmos bombs requiring a lot of knowledge and time (including having to make frezon) to make
nerfs "weak" atmos bombs in use (i've seen many atmos techs use those) to around 14 range and the strongest ones in use (only seen myself make those) to around 25 range
has been tested, change works properly

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Nanotrasen changed the supplier of gas tanks to atmos, making them harder to use as bombs.
