### PR TITLE
Moose HoP doors fix, attempt 2

### DIFF
--- a/Resources/Maps/moose.yml
+++ b/Resources/Maps/moose.yml
@@ -5556,10 +5556,12 @@ entities:
     - id: Moose
       type: BecomesStation
     - type: RadiationGridResistance
-    - shakeTimes: 10
+    - nextShake: 0
+      shakeTimes: 10
       type: GravityShake
     - type: GasTileOverlay
-    - type: SpreaderGrid
+    - nextUpdate: 0
+      type: SpreaderGrid
   - uid: 10465
     components:
     - type: MetaData
@@ -5658,7 +5660,8 @@ entities:
       type: GridAtmosphere
     - type: RadiationGridResistance
     - type: GasTileOverlay
-    - type: SpreaderGrid
+    - nextUpdate: 0
+      type: SpreaderGrid
   - uid: 13645
     components:
     - type: MetaData
@@ -5745,7 +5748,8 @@ entities:
       type: GridAtmosphere
     - type: RadiationGridResistance
     - type: GasTileOverlay
-    - type: SpreaderGrid
+    - nextUpdate: 0
+      type: SpreaderGrid
 - proto: AcousticGuitarInstrument
   entities:
   - uid: 4891
@@ -6631,11 +6635,6 @@ entities:
       type: Transform
 - proto: AirlockCommandGlassLocked
   entities:
-  - uid: 5114
-    components:
-    - pos: 0.5,-6.5
-      parent: 6
-      type: Transform
   - uid: 5119
     components:
     - pos: 1.5,4.5
@@ -7862,9 +7861,16 @@ entities:
     - pos: -43.5,-42.5
       parent: 6
       type: Transform
-- proto: AirlockHeadOfPersonnelLocked
+- proto: AirlockHeadOfPersonnelGlassLocked
   entities:
   - uid: 17
+    components:
+    - pos: 0.5,-6.5
+      parent: 6
+      type: Transform
+- proto: AirlockHeadOfPersonnelLocked
+  entities:
+  - uid: 708
     components:
     - pos: -1.5,-4.5
       parent: 6
@@ -7949,16 +7955,18 @@ entities:
     - pos: -4.5,-2.5
       parent: 6
       type: Transform
-  - uid: 5115
-    components:
-    - pos: -4.5,-5.5
-      parent: 6
-      type: Transform
 - proto: AirlockMaintEngiLocked
   entities:
   - uid: 8333
     components:
     - pos: -39.5,-1.5
+      parent: 6
+      type: Transform
+- proto: AirlockMaintHOPLocked
+  entities:
+  - uid: 705
+    components:
+    - pos: -4.5,-5.5
       parent: 6
       type: Transform
 - proto: AirlockMaintJanitorLocked
@@ -73779,8 +73787,6 @@ entities:
       pos: 3.5,-3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 2575
@@ -73789,8 +73795,6 @@ entities:
       pos: -64.5,-7.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 2576
@@ -73799,8 +73803,6 @@ entities:
       pos: -58.5,-7.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 2893
@@ -73809,8 +73811,6 @@ entities:
       pos: -56.5,-7.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 2894
@@ -73819,8 +73819,6 @@ entities:
       pos: -66.5,-7.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 3014
@@ -73829,8 +73827,6 @@ entities:
       pos: -0.5,-3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 3612
@@ -73839,8 +73835,6 @@ entities:
       pos: 4.5,-25.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 3642
@@ -73849,8 +73843,6 @@ entities:
       pos: -9.5,-76.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 4941
@@ -73858,8 +73850,6 @@ entities:
     - pos: -16.5,-10.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 5535
@@ -73868,8 +73858,6 @@ entities:
       pos: -35.5,-22.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 5559
@@ -73878,8 +73866,6 @@ entities:
       pos: -16.5,-16.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 6412
@@ -73888,8 +73874,6 @@ entities:
       pos: -13.5,-26.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 6423
@@ -73898,8 +73882,6 @@ entities:
       pos: -15.5,-34.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 6424
@@ -73908,8 +73890,6 @@ entities:
       pos: -13.5,-40.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 6425
@@ -73918,8 +73898,6 @@ entities:
       pos: -8.5,-48.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 6559
@@ -73928,8 +73906,6 @@ entities:
       pos: -18.5,-45.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 6561
@@ -73938,8 +73914,6 @@ entities:
       pos: -1.5,-46.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8189
@@ -73948,8 +73922,6 @@ entities:
       pos: 16.5,-4.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8425
@@ -73957,8 +73929,6 @@ entities:
     - pos: -36.5,4.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8426
@@ -73967,8 +73937,6 @@ entities:
       pos: -31.5,-3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8427
@@ -73976,8 +73944,6 @@ entities:
     - pos: -25.5,-0.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8428
@@ -73985,8 +73951,6 @@ entities:
     - pos: -25.5,4.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8429
@@ -73995,8 +73959,6 @@ entities:
       pos: -18.5,3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8430
@@ -74005,8 +73967,6 @@ entities:
       pos: -22.5,3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8431
@@ -74015,8 +73975,6 @@ entities:
       pos: -19.5,-1.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8432
@@ -74024,8 +73982,6 @@ entities:
     - pos: -22.5,-3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8433
@@ -74034,8 +73990,6 @@ entities:
       pos: -24.5,-6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8434
@@ -74043,8 +73997,6 @@ entities:
     - pos: -33.5,-6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8435
@@ -74053,8 +74005,6 @@ entities:
       pos: -36.5,-6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8438
@@ -74063,8 +74013,6 @@ entities:
       pos: -26.5,-16.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8439
@@ -74072,8 +74020,6 @@ entities:
     - pos: -20.5,-19.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8440
@@ -74082,8 +74028,6 @@ entities:
       pos: -7.5,-76.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8442
@@ -74091,8 +74035,6 @@ entities:
     - pos: -38.5,-17.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8443
@@ -74101,8 +74043,6 @@ entities:
       pos: -9.5,-73.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8444
@@ -74111,8 +74051,6 @@ entities:
       pos: -18.5,-32.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8457
@@ -74121,8 +74059,6 @@ entities:
       pos: -47.5,-40.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8458
@@ -74130,8 +74066,6 @@ entities:
     - pos: -39.5,-29.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8459
@@ -74140,8 +74074,6 @@ entities:
       pos: -47.5,-35.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8460
@@ -74149,8 +74081,6 @@ entities:
     - pos: -46.5,-29.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8461
@@ -74159,8 +74089,6 @@ entities:
       pos: -42.5,-32.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8462
@@ -74169,8 +74097,6 @@ entities:
       pos: -43.5,-38.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8471
@@ -74179,8 +74105,6 @@ entities:
       pos: -52.5,-44.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8472
@@ -74189,8 +74113,6 @@ entities:
       pos: -51.5,-33.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8473
@@ -74199,8 +74121,6 @@ entities:
       pos: -47.5,-25.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8474
@@ -74209,8 +74129,6 @@ entities:
       pos: -51.5,-19.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8475
@@ -74218,8 +74136,6 @@ entities:
     - pos: -59.5,-10.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8476
@@ -74228,8 +74144,6 @@ entities:
       pos: -61.5,-14.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8477
@@ -74238,8 +74152,6 @@ entities:
       pos: -45.5,-17.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8478
@@ -74248,8 +74160,6 @@ entities:
       pos: -37.5,-15.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8479
@@ -74258,8 +74168,6 @@ entities:
       pos: -30.5,-26.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8480
@@ -74268,8 +74176,6 @@ entities:
       pos: -19.5,-27.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8491
@@ -74277,8 +74183,6 @@ entities:
     - pos: -8.5,-24.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8492
@@ -74287,8 +74191,6 @@ entities:
       pos: -9.5,-20.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8493
@@ -74296,8 +74198,6 @@ entities:
     - pos: -8.5,-14.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8500
@@ -74306,8 +74206,6 @@ entities:
       pos: 17.5,-17.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8501
@@ -74316,8 +74214,6 @@ entities:
       pos: 12.5,-17.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8502
@@ -74325,8 +74221,6 @@ entities:
     - pos: 8.5,-18.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8504
@@ -74335,8 +74229,6 @@ entities:
       pos: 8.5,-32.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8505
@@ -74344,8 +74236,6 @@ entities:
     - pos: 15.5,-34.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8506
@@ -74354,8 +74244,6 @@ entities:
       pos: 9.5,-38.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8507
@@ -74364,8 +74252,6 @@ entities:
       pos: 4.5,-32.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8508
@@ -74373,8 +74259,6 @@ entities:
     - pos: 3.5,-43.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8509
@@ -74383,8 +74267,6 @@ entities:
       pos: 14.5,-40.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8510
@@ -74393,8 +74275,6 @@ entities:
       pos: 19.5,-42.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8513
@@ -74403,8 +74283,6 @@ entities:
       pos: 17.5,-27.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8514
@@ -74413,8 +74291,6 @@ entities:
       pos: 25.5,4.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8515
@@ -74423,8 +74299,6 @@ entities:
       pos: 19.5,6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8516
@@ -74432,8 +74306,6 @@ entities:
     - pos: 11.5,9.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8519
@@ -74442,8 +74314,6 @@ entities:
       pos: 14.5,-1.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8520
@@ -74451,8 +74321,6 @@ entities:
     - pos: 9.5,-3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8521
@@ -74460,8 +74328,6 @@ entities:
     - pos: 18.5,-6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8522
@@ -74469,8 +74335,6 @@ entities:
     - pos: 2.5,-9.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8523
@@ -74478,8 +74342,6 @@ entities:
     - pos: -2.5,-5.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8524
@@ -74488,8 +74350,6 @@ entities:
       pos: -3.5,-0.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8527
@@ -74498,8 +74358,6 @@ entities:
       pos: -9.5,-3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8529
@@ -74508,8 +74366,6 @@ entities:
       pos: -2.5,3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8530
@@ -74518,8 +74374,6 @@ entities:
       pos: -6.5,3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8531
@@ -74528,8 +74382,6 @@ entities:
       pos: 1.5,7.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8532
@@ -74538,8 +74390,6 @@ entities:
       pos: -10.5,7.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8533
@@ -74548,8 +74398,6 @@ entities:
       pos: 8.5,7.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8534
@@ -74558,8 +74406,6 @@ entities:
       pos: 6.5,-49.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8535
@@ -74568,8 +74414,6 @@ entities:
       pos: -1.5,-51.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8536
@@ -74578,8 +74422,6 @@ entities:
       pos: -4.5,-56.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8537
@@ -74588,8 +74430,6 @@ entities:
       pos: -6.5,-51.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8538
@@ -74598,8 +74438,6 @@ entities:
       pos: -9.5,-52.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8539
@@ -74608,8 +74446,6 @@ entities:
       pos: -14.5,-50.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8540
@@ -74617,8 +74453,6 @@ entities:
     - pos: -4.5,-58.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8542
@@ -74626,8 +74460,6 @@ entities:
     - pos: -7.5,-61.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8543
@@ -74636,8 +74468,6 @@ entities:
       pos: -4.5,-70.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8545
@@ -74645,8 +74475,6 @@ entities:
     - pos: 0.5,-75.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8546
@@ -74655,8 +74483,6 @@ entities:
       pos: -2.5,-70.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8547
@@ -74665,8 +74491,6 @@ entities:
       pos: 1.5,-73.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8548
@@ -74675,8 +74499,6 @@ entities:
       pos: -1.5,-78.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8549
@@ -74684,8 +74506,6 @@ entities:
     - pos: -4.5,-83.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8642
@@ -74694,8 +74514,6 @@ entities:
       pos: -30.5,15.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8643
@@ -74704,8 +74522,6 @@ entities:
       pos: -32.5,20.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8644
@@ -74714,8 +74530,6 @@ entities:
       pos: -33.5,9.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
     - type: Timer
@@ -74725,8 +74539,6 @@ entities:
       pos: -40.5,10.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8646
@@ -74735,8 +74547,6 @@ entities:
       pos: -40.5,18.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8647
@@ -74744,8 +74554,6 @@ entities:
     - pos: -32.5,24.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8648
@@ -74753,8 +74561,6 @@ entities:
     - pos: -36.5,24.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8649
@@ -74763,8 +74569,6 @@ entities:
       pos: -36.5,28.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8650
@@ -74773,8 +74577,6 @@ entities:
       pos: -32.5,28.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 9681
@@ -74782,8 +74584,6 @@ entities:
     - pos: -8.5,-83.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 9682
@@ -74791,8 +74591,6 @@ entities:
     - pos: -4.5,-83.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 9683
@@ -74800,8 +74598,6 @@ entities:
     - pos: -0.5,-83.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 9685
@@ -74810,8 +74606,6 @@ entities:
       pos: 1.5,-79.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10756
@@ -74819,8 +74613,6 @@ entities:
     - pos: -37.5,-10.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10757
@@ -74829,8 +74621,6 @@ entities:
       pos: -16.5,6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10758
@@ -74839,8 +74629,6 @@ entities:
       pos: -15.5,0.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10759
@@ -74849,8 +74637,6 @@ entities:
       pos: -14.5,-7.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10760
@@ -74858,8 +74644,6 @@ entities:
     - pos: -18.5,-3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10762
@@ -74868,8 +74652,6 @@ entities:
       pos: 13.5,12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10768
@@ -74878,8 +74660,6 @@ entities:
       pos: 22.5,-12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10769
@@ -74888,8 +74668,6 @@ entities:
       pos: 34.5,-12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10775
@@ -74898,8 +74676,6 @@ entities:
       pos: 43.5,6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10776
@@ -74908,8 +74684,6 @@ entities:
       pos: 45.5,1.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10777
@@ -74917,8 +74691,6 @@ entities:
     - pos: 45.5,-4.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10778
@@ -74927,8 +74699,6 @@ entities:
       pos: 43.5,-3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10779
@@ -74937,8 +74707,6 @@ entities:
       pos: 42.5,-12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10780
@@ -74947,8 +74715,6 @@ entities:
       pos: 30.5,-3.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10781
@@ -74957,8 +74723,6 @@ entities:
       pos: 30.5,6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10782
@@ -74966,8 +74730,6 @@ entities:
     - pos: 13.5,-10.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10784
@@ -74976,8 +74738,6 @@ entities:
       pos: -8.5,-12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10785
@@ -74986,8 +74746,6 @@ entities:
       pos: -25.5,-12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10829
@@ -74995,8 +74753,6 @@ entities:
     - pos: -10.5,-43.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10830
@@ -75004,8 +74760,6 @@ entities:
     - pos: -22.5,-43.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10831
@@ -75013,8 +74767,6 @@ entities:
     - pos: -32.5,-43.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10832
@@ -75023,8 +74775,6 @@ entities:
       pos: -50.5,-44.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10846
@@ -75033,8 +74783,6 @@ entities:
       pos: -48.5,-12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10847
@@ -75043,8 +74791,6 @@ entities:
       pos: -1.5,-12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13760
@@ -75053,8 +74799,6 @@ entities:
       pos: -30.5,-6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13767
@@ -75062,8 +74806,6 @@ entities:
     - pos: 7.5,-6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13768
@@ -75072,8 +74814,6 @@ entities:
       pos: 7.5,-12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13799
@@ -75082,8 +74822,6 @@ entities:
       pos: -40.5,-12.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13800
@@ -75092,8 +74830,6 @@ entities:
       pos: -2.5,6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13801
@@ -75102,8 +74838,6 @@ entities:
       pos: -6.5,6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13802
@@ -75111,8 +74845,6 @@ entities:
     - pos: 12.5,20.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13803
@@ -75121,8 +74853,6 @@ entities:
       pos: 12.5,22.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13804
@@ -75131,8 +74861,6 @@ entities:
       pos: 15.5,4.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13805
@@ -75141,8 +74869,6 @@ entities:
       pos: 6.5,-17.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13807
@@ -75150,8 +74876,6 @@ entities:
     - pos: -40.5,-43.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13809
@@ -75160,8 +74884,6 @@ entities:
       pos: 3.5,7.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13810
@@ -75170,8 +74892,6 @@ entities:
       pos: -13.5,6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13827
@@ -75179,8 +74899,6 @@ entities:
     - pos: -68.5,-10.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13832
@@ -75189,8 +74907,6 @@ entities:
       pos: 17.5,-0.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13833
@@ -75198,8 +74914,6 @@ entities:
     - pos: 12.5,-6.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13835
@@ -75208,8 +74922,6 @@ entities:
       pos: 16.5,18.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 13836
@@ -75218,8 +74930,6 @@ entities:
       pos: 15.5,23.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
 - proto: PoweredlightExterior
@@ -75230,8 +74940,6 @@ entities:
       pos: -56.5,-36.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 5205
@@ -75240,8 +74948,6 @@ entities:
       pos: -56.5,-30.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
 - proto: PoweredlightLED
@@ -75252,8 +74958,6 @@ entities:
       pos: -32.5,-16.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 4945
@@ -75262,8 +74966,6 @@ entities:
       pos: -23.5,-28.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 5520
@@ -75272,8 +74974,6 @@ entities:
       pos: -23.5,-22.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 6405
@@ -75282,8 +74982,6 @@ entities:
       pos: -30.5,-16.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
 - proto: PoweredLightPostSmall
@@ -75293,8 +74991,6 @@ entities:
     - pos: -62.5,-22.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10248
@@ -75302,8 +74998,6 @@ entities:
     - pos: -24.5,-66.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10798
@@ -75311,8 +75005,6 @@ entities:
     - pos: 27.5,-22.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 10804
@@ -75320,8 +75012,6 @@ entities:
     - pos: 6.5,-61.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
 - proto: PoweredlightSodium
@@ -75331,8 +75021,6 @@ entities:
     - pos: -4.5,-30.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 8424
@@ -75341,8 +75029,6 @@ entities:
       pos: -22.5,15.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
   - uid: 14043
@@ -75351,8 +75037,6 @@ entities:
       pos: -5.5,-39.5
       parent: 6
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - powerLoad: 0
       type: ApcPowerReceiver
 - proto: PoweredSmallLight
@@ -80536,7 +80220,7 @@ entities:
     - pos: 18.5,-39.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -114416.125
+    - SecondsUntilStateChange: -114478.85
       state: Opening
       type: Door
     - inputs:
@@ -80551,7 +80235,7 @@ entities:
     - pos: 17.5,-39.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -114416.125
+    - SecondsUntilStateChange: -114478.85
       state: Opening
       type: Door
     - inputs:
@@ -80567,7 +80251,7 @@ entities:
       pos: -20.5,-5.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116153.22
+    - SecondsUntilStateChange: -116215.945
       state: Opening
       type: Door
     - inputs:
@@ -80583,7 +80267,7 @@ entities:
       pos: -20.5,-4.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116153.22
+    - SecondsUntilStateChange: -116215.945
       state: Opening
       type: Door
     - inputs:
@@ -80599,7 +80283,7 @@ entities:
       pos: -11.5,4.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80615,7 +80299,7 @@ entities:
       pos: -11.5,3.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80631,7 +80315,7 @@ entities:
       pos: 2.5,4.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80647,7 +80331,7 @@ entities:
       pos: 2.5,3.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80662,7 +80346,7 @@ entities:
     - pos: -8.5,11.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80677,7 +80361,7 @@ entities:
     - pos: -6.5,11.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80692,7 +80376,7 @@ entities:
     - pos: -7.5,11.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80707,7 +80391,7 @@ entities:
     - pos: -5.5,11.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80722,7 +80406,7 @@ entities:
     - pos: -3.5,11.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80737,7 +80421,7 @@ entities:
     - pos: -2.5,11.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80752,7 +80436,7 @@ entities:
     - pos: -1.5,11.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80767,7 +80451,7 @@ entities:
     - pos: -0.5,11.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116670.13
+    - SecondsUntilStateChange: -116732.86
       state: Opening
       type: Door
     - inputs:
@@ -80782,7 +80466,7 @@ entities:
     - pos: -3.5,-8.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116665.63
+    - SecondsUntilStateChange: -116728.36
       state: Opening
       type: Door
     - inputs:
@@ -80797,7 +80481,7 @@ entities:
     - pos: -2.5,-8.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116665.63
+    - SecondsUntilStateChange: -116728.36
       state: Opening
       type: Door
     - inputs:
@@ -80812,7 +80496,7 @@ entities:
     - pos: -1.5,-8.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116665.63
+    - SecondsUntilStateChange: -116728.36
       state: Opening
       type: Door
     - inputs:
@@ -80827,7 +80511,7 @@ entities:
     - pos: 13.5,9.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116484.32
+    - SecondsUntilStateChange: -116547.05
       state: Opening
       type: Door
     - inputs:
@@ -80842,7 +80526,7 @@ entities:
     - pos: 13.5,8.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116484.32
+    - SecondsUntilStateChange: -116547.05
       state: Opening
       type: Door
     - inputs:
@@ -80857,7 +80541,7 @@ entities:
     - pos: 13.5,7.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116484.32
+    - SecondsUntilStateChange: -116547.05
       state: Opening
       type: Door
     - inputs:
@@ -80872,7 +80556,7 @@ entities:
     - pos: 8.5,-34.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116306.5
+    - SecondsUntilStateChange: -116369.23
       state: Opening
       type: Door
     - inputs:
@@ -80887,7 +80571,7 @@ entities:
     - pos: 9.5,-34.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116306.5
+    - SecondsUntilStateChange: -116369.23
       state: Opening
       type: Door
     - inputs:
@@ -80902,7 +80586,7 @@ entities:
     - pos: 11.5,-33.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116306.5
+    - SecondsUntilStateChange: -116369.23
       state: Opening
       type: Door
     - inputs:
@@ -81011,7 +80695,7 @@ entities:
     - pos: -0.5,-8.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -116665.63
+    - SecondsUntilStateChange: -116728.36
       state: Opening
       type: Door
     - inputs:
@@ -98144,12 +97828,6 @@ entities:
     - pos: -54.5,-45.5
       parent: 6
       type: Transform
-  - uid: 5104
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -0.5,-8.5
-      parent: 6
-      type: Transform
   - uid: 13264
     components:
     - rot: 3.141592653589793 rad
@@ -98180,6 +97858,14 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: -37.5,-5.5
+      parent: 6
+      type: Transform
+- proto: WindoorHeadOfPersonnelLocked
+  entities:
+  - uid: 707
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-8.5
       parent: 6
       type: Transform
 - proto: WindoorHydroponicsLocked
@@ -98916,7 +98602,7 @@ entities:
     - pos: -29.5,-52.5
       parent: 6
       type: Transform
-    - SecondsUntilStateChange: -241494.92
+    - SecondsUntilStateChange: -241557.64
       state: Opening
       type: Door
   - uid: 13315


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
You can bolt the doors in the HoP office on Moose. I had to close #15899 because I broke it.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://user-images.githubusercontent.com/44417085/235302104-3fd404e2-da43-4b20-b1d9-7d389bc66ac6.mp4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- fix: HoP's airlocks on Moose now work with their door remote.
