### PR TITLE
Refactor: Chat transmission ranges (+ a little preparation for downstream fork functionality)

### DIFF
--- a/Content.Server/Chat/Commands/MeCommand.cs
+++ b/Content.Server/Chat/Commands/MeCommand.cs
@@ -38,7 +38,7 @@ namespace Content.Server.Chat.Commands
                 return;
 
             IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
-                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Emote, false, false, shell, player);
+                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Emote, ChatTransmitRange.Normal, shell, player);
         }
     }
 }

--- a/Content.Server/Chat/Commands/SayCommand.cs
+++ b/Content.Server/Chat/Commands/SayCommand.cs
@@ -38,7 +38,7 @@ namespace Content.Server.Chat.Commands
                 return;
 
             IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
-                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Speak, false, false, shell, player);
+                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Speak, ChatTransmitRange.Normal, shell, player);
         }
     }
 }

--- a/Content.Server/Chat/Commands/WhisperCommand.cs
+++ b/Content.Server/Chat/Commands/WhisperCommand.cs
@@ -38,7 +38,7 @@ namespace Content.Server.Chat.Commands
                 return;
 
             IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
-                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Whisper, false, false, shell, player);
+                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Whisper, ChatTransmitRange.Normal, shell, player);
         }
     }
 }

--- a/Content.Server/Chat/Systems/AutoEmoteSystem.cs
+++ b/Content.Server/Chat/Systems/AutoEmoteSystem.cs
@@ -47,7 +47,7 @@ public sealed class AutoEmoteSystem : EntitySystem
 
                 if (autoEmotePrototype.WithChat)
                 {
-                    _chatSystem.TryEmoteWithChat(uid, autoEmotePrototype.EmoteId, autoEmotePrototype.HiddenFromChatWindow);
+                    _chatSystem.TryEmoteWithChat(uid, autoEmotePrototype.EmoteId, autoEmotePrototype.HiddenFromChatWindow ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal);
                 }
                 else
                 {

--- a/Content.Server/Chat/Systems/ChatSystem.Emote.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Emote.cs
@@ -52,15 +52,13 @@ public partial class ChatSystem
     /// </summary>
     /// <param name="source">The entity that is speaking</param>
     /// <param name="emoteId">The id of emote prototype. Should has valid <see cref="EmotePrototype.ChatMessages"/></param>
-    /// <param name="hideChat">Whether or not this message should appear in the chat window</param>
-    /// <param name="hideGlobalGhostChat">Whether or not this message should appear in the chat window for out-of-range ghosts (which otherwise ignore range restrictions)</param>
+    /// <param name="range">Conceptual range of transmission, if it shows in the chat window, if it shows to far-away ghosts or ghosts at all...</param>
     /// <param name="nameOverride">The name to use for the speaking entity. Usually this should just be modified via <see cref="TransformSpeakerNameEvent"/>. If this is set, the event will not get raised.</param>
-    public void TryEmoteWithChat(EntityUid source, string emoteId, bool hideChat = false,
-        bool hideGlobalGhostChat = false, string? nameOverride = null)
+    public void TryEmoteWithChat(EntityUid source, string emoteId, ChatTransmitRange range = ChatTransmitRange.Normal, string? nameOverride = null)
     {
         if (!_prototypeManager.TryIndex<EmotePrototype>(emoteId, out var proto))
             return;
-        TryEmoteWithChat(source, proto, hideChat, hideGlobalGhostChat, nameOverride);
+        TryEmoteWithChat(source, proto, range, nameOverride);
     }
 
     /// <summary>
@@ -68,17 +66,15 @@ public partial class ChatSystem
     /// </summary>
     /// <param name="source">The entity that is speaking</param>
     /// <param name="emote">The emote prototype. Should has valid <see cref="EmotePrototype.ChatMessages"/></param>
-    /// <param name="hideChat">Whether or not this message should appear in the chat window</param>
-    /// <param name="hideGlobalGhostChat">Whether or not this message should appear in the chat window for out-of-range ghosts (which otherwise ignore range restrictions)</param>
+    /// <param name="range">Conceptual range of transmission, if it shows in the chat window, if it shows to far-away ghosts or ghosts at all...</param>
     /// <param name="nameOverride">The name to use for the speaking entity. Usually this should just be modified via <see cref="TransformSpeakerNameEvent"/>. If this is set, the event will not get raised.</param>
-    public void TryEmoteWithChat(EntityUid source, EmotePrototype emote, bool hideChat = false,
-        bool hideGlobalGhostChat = false, string? nameOverride = null)
+    public void TryEmoteWithChat(EntityUid source, EmotePrototype emote, ChatTransmitRange range = ChatTransmitRange.Normal, string? nameOverride = null)
     {
         // check if proto has valid message for chat
         if (emote.ChatMessages.Count != 0)
         {
             var action = _random.Pick(emote.ChatMessages);
-            SendEntityEmote(source, action, MTRFromLegacyFlags(hideChat, hideGlobalGhostChat), nameOverride, false);
+            SendEntityEmote(source, action, range, nameOverride, false);
         }
 
         // do the rest of emote event logic here

--- a/Content.Server/Chat/Systems/ChatSystem.Emote.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Emote.cs
@@ -78,7 +78,7 @@ public partial class ChatSystem
         if (emote.ChatMessages.Count != 0)
         {
             var action = _random.Pick(emote.ChatMessages);
-            SendEntityEmote(source, action, hideChat, hideGlobalGhostChat, nameOverride, false);
+            SendEntityEmote(source, action, MTRFromLegacyFlags(hideChat, hideGlobalGhostChat), nameOverride, false);
         }
 
         // do the rest of emote event logic here

--- a/Content.Server/Chat/Systems/EmoteOnDamageSystem.cs
+++ b/Content.Server/Chat/Systems/EmoteOnDamageSystem.cs
@@ -44,7 +44,7 @@ public sealed class EmoteOnDamageSystem : EntitySystem
         var emote = _random.Pick(emoteOnDamage.Emotes);
         if (emoteOnDamage.WithChat)
         {
-            _chatSystem.TryEmoteWithChat(uid, emote, emoteOnDamage.HiddenFromChatWindow);
+            _chatSystem.TryEmoteWithChat(uid, emote, emoteOnDamage.HiddenFromChatWindow ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal);
         }
         else
         {

--- a/Content.Server/Chemistry/ReagentEffects/Emote.cs
+++ b/Content.Server/Chemistry/ReagentEffects/Emote.cs
@@ -25,7 +25,7 @@ public sealed class Emote : ReagentEffect
 
         var chatSys = args.EntityManager.System<ChatSystem>();
         if (ShowInChat)
-            chatSys.TryEmoteWithChat(args.SolutionEntity, EmoteId, hideGlobalGhostChat: true);
+            chatSys.TryEmoteWithChat(args.SolutionEntity, EmoteId, ChatTransmitRange.GhostRangeLimit);
         else
             chatSys.TryEmoteWithoutChat(args.SolutionEntity, EmoteId);
 

--- a/Content.Server/Cluwne/CluwneSystem.cs
+++ b/Content.Server/Cluwne/CluwneSystem.cs
@@ -91,14 +91,14 @@ public sealed class CluwneSystem : EntitySystem
         if (_robustRandom.Prob(component.GiggleRandomChance))
         {
             _audio.PlayPvs(component.SpawnSound, uid);
-            _chat.TrySendInGameICMessage(uid, "honks", InGameICChatType.Emote, false, false);
+            _chat.TrySendInGameICMessage(uid, "honks", InGameICChatType.Emote, ChatTransmitRange.Normal);
         }
 
         else if (_robustRandom.Prob(component.KnockChance))
         {
             _audio.PlayPvs(component.KnockSound, uid);
             _stunSystem.TryParalyze(uid, TimeSpan.FromSeconds(component.ParalyzeTime), true);
-            _chat.TrySendInGameICMessage(uid, "spasms", InGameICChatType.Emote, false, false);
+            _chat.TrySendInGameICMessage(uid, "spasms", InGameICChatType.Emote, ChatTransmitRange.Normal);
         }
     }
 }

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/MedibotInjectOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/MedibotInjectOperator.cs
@@ -80,7 +80,7 @@ public sealed class MedibotInjectOperator : HTNOperator
             _solution.TryAddReagent(target, injectable, botComp.EmergencyMed, botComp.EmergencyMedAmount, out var accepted);
             _popup.PopupEntity(Loc.GetString("hypospray-component-feel-prick-message"), target, target);
             _audio.PlayPvs(botComp.InjectSound, target);
-            _chat.TrySendInGameICMessage(owner, Loc.GetString("medibot-finish-inject"), InGameICChatType.Speak, hideChat: false, hideGlobalGhostChat: true);
+            _chat.TrySendInGameICMessage(owner, Loc.GetString("medibot-finish-inject"), InGameICChatType.Speak, ChatTransmitRange.GhostRangeLimit);
             return HTNOperatorStatus.Finished;
         }
 
@@ -89,7 +89,7 @@ public sealed class MedibotInjectOperator : HTNOperator
             _solution.TryAddReagent(target, injectable, botComp.StandardMed, botComp.StandardMedAmount, out var accepted);
             _popup.PopupEntity(Loc.GetString("hypospray-component-feel-prick-message"), target, target);
             _audio.PlayPvs(botComp.InjectSound, target);
-            _chat.TrySendInGameICMessage(owner, Loc.GetString("medibot-finish-inject"), InGameICChatType.Speak, hideChat: false, hideGlobalGhostChat: true);
+            _chat.TrySendInGameICMessage(owner, Loc.GetString("medibot-finish-inject"), InGameICChatType.Speak, ChatTransmitRange.GhostRangeLimit);
             return HTNOperatorStatus.Finished;
         }
 

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -214,7 +214,7 @@ public sealed class RadioDeviceSystem : EntitySystem
         var name = Loc.GetString("speech-name-relay", ("speaker", Name(uid)),
             ("originalName", nameEv.Name));
 
-        var hideGlobalGhostChat = true; // log to chat so people can identity the speaker/source, but avoid clogging ghost chat if there are many radios
-        _chat.TrySendInGameICMessage(uid, args.Message, InGameICChatType.Speak, false, nameOverride: name, hideGlobalGhostChat:hideGlobalGhostChat, checkRadioPrefix: false);
+        // log to chat so people can identity the speaker/source, but avoid clogging ghost chat if there are many radios
+        _chat.TrySendInGameICMessage(uid, args.Message, InGameICChatType.Speak, ChatTransmitRange.GhostRangeLimit, nameOverride: name, checkRadioPrefix: false);
     }
 }

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSpeakerSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSpeakerSystem.cs
@@ -74,7 +74,7 @@ public sealed class SurveillanceCameraSpeakerSystem : EntitySystem
         var name = Loc.GetString("speech-name-relay", ("speaker", Name(uid)),
             ("originalName", nameEv.Name));
 
-        var hideGlobalGhostChat = true; // log to chat so people can identity the speaker/source, but avoid clogging ghost chat if there are many radios
-        _chatSystem.TrySendInGameICMessage(uid, args.Message, InGameICChatType.Speak, false, hideGlobalGhostChat, nameOverride: name);
+        // log to chat so people can identity the speaker/source, but avoid clogging ghost chat if there are many radios
+        _chatSystem.TrySendInGameICMessage(uid, args.Message, InGameICChatType.Speak, ChatTransmitRange.GhostRangeLimit, nameOverride: name);
     }
 }


### PR DESCRIPTION
## About the PR
This is an attempt to clean up chat transmission ranges somewhat for future expansion. In particular, it adds the necessary backend functionality for downstreams to implement chat that is simply not visible to non-admin ghosts.

Beware that:

1. The API might need further discussion.
2. I am not *completely sure* that this works perfectly for every single call site touched by this changeset. I've confirmed the basics work, but I ought to perform further tests (tomorrow perhaps).

**Media**

*The following video is taken with a specific added command, `subtlesay`, that is __not included in this PR__ because it may be unwanted by upstream but may be wanted by forks, and I wasn't able to figure out the UI for it. The command is a copy/paste of SayCommand.cs but with `ChatTransmitRange.NoGhosts`.*

https://user-images.githubusercontent.com/22304167/235802778-1a80cf2f-5f43-44e0-9501-9ec18a7cb41d.mp4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

*No user-visible changes.*