### PR TITLE
Stop mimes from screaming or laughing

### DIFF
--- a/Content.Server/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Server/Abilities/Mime/MimePowersSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Timing;
 using Content.Server.Chat.Systems;
 using Content.Server.Speech.Components;
 using Content.Shared.Chat.Prototypes;
+using Content.Server.Speech.EntitySystems;
 
 namespace Content.Server.Abilities.Mime
 {
@@ -31,8 +32,8 @@ namespace Content.Server.Abilities.Mime
             SubscribeLocalEvent<MimePowersComponent, ComponentInit>(OnComponentInit);
             SubscribeLocalEvent<MimePowersComponent, SpeakAttemptEvent>(OnSpeakAttempt);
             SubscribeLocalEvent<MimePowersComponent, InvisibleWallActionEvent>(OnInvisibleWall);
-            SubscribeLocalEvent<MimePowersComponent, EmoteEvent>(OnEmote);
-            SubscribeLocalEvent<MimePowersComponent, ScreamActionEvent>(OnScreamAction);
+            SubscribeLocalEvent<MimePowersComponent, EmoteEvent>(OnEmote, before: new[] { typeof(VocalSystem) });
+            SubscribeLocalEvent<MimePowersComponent, ScreamActionEvent>(OnScreamAction, before: new[] { typeof(VocalSystem) });
         }
         public override void Update(float frameTime)
         {

--- a/Content.Server/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Server/Abilities/Mime/MimePowersSystem.cs
@@ -11,6 +11,9 @@ using Robust.Shared.Player;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
+using Content.Server.Chat.Systems;
+using Content.Server.Speech.Components;
+using Content.Shared.Chat.Prototypes;
 
 namespace Content.Server.Abilities.Mime
 {
@@ -28,6 +31,8 @@ namespace Content.Server.Abilities.Mime
             SubscribeLocalEvent<MimePowersComponent, ComponentInit>(OnComponentInit);
             SubscribeLocalEvent<MimePowersComponent, SpeakAttemptEvent>(OnSpeakAttempt);
             SubscribeLocalEvent<MimePowersComponent, InvisibleWallActionEvent>(OnInvisibleWall);
+            SubscribeLocalEvent<MimePowersComponent, EmoteEvent>(OnEmote);
+            SubscribeLocalEvent<MimePowersComponent, ScreamActionEvent>(OnScreamAction);
         }
         public override void Update(float frameTime)
         {
@@ -58,6 +63,25 @@ namespace Content.Server.Abilities.Mime
 
             _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), uid, uid);
             args.Cancel();
+        }
+
+        private void OnEmote(EntityUid uid, MimePowersComponent component, ref EmoteEvent args)
+        {
+            if (!component.Enabled || args.Handled)
+                return;
+
+            //still leaves the text so it looks like they are pantomiming a laugh
+            if (args.Emote.Category.HasFlag(EmoteCategory.Vocal))
+                args.Handled = true;
+        }
+
+        private void OnScreamAction(EntityUid uid, MimePowersComponent component, ScreamActionEvent args)
+        {
+            if (!component.Enabled || args.Handled)
+                return;
+
+            _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), uid, uid);
+            args.Handled = true;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

- Mime system checks for vow and stops screams/laughs
- Leaves text for laughs to allow for pantomiming
- Fixes #16048 
- (MutingSystem may need to be updated as well.)

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Mimes with unbroken vows can no longer scream or laugh
