### PR TITLE
Light replacer cleanup + examine

### DIFF
--- a/Content.Server/Light/Components/LightReplacerComponent.cs
+++ b/Content.Server/Light/Components/LightReplacerComponent.cs
@@ -1,45 +1,35 @@
-using Content.Shared.Light.Component;
+using Content.Server.Light.EntitySystems;
+using Content.Shared.Storage;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Server.Light.Components
+namespace Content.Server.Light.Components;
+
+/// <summary>
+///     Device that allows user to quikly change bulbs in <see cref="PoweredLightComponent"/>
+///     Can be reloaded by new light tubes or light bulbs
+/// </summary>
+[RegisterComponent, Access(typeof(LightReplacerSystem))]
+public sealed class LightReplacerComponent : Component
 {
-    /// <summary>
-    ///     Device that allows user to quikly change bulbs in <see cref="PoweredLightComponent"/>
-    ///     Can be reloaded by new light tubes or light bulbs
-    /// </summary>
-    [RegisterComponent]
-    public sealed class LightReplacerComponent : Component
+    [DataField("sound")]
+    public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/Weapons/click.ogg")
     {
-        [DataField("sound")]
-        public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/Weapons/click.ogg");
-
-        /// <summary>
-        /// Bulbs that were inside light replacer when it spawned
-        /// </summary>
-        [DataField("contents")]
-        public List<LightReplacerEntity> Contents = new();
-
-        /// <summary>
-        /// Bulbs that were inserted inside light replacer
-        /// </summary>
-        [ViewVariables]
-        public IContainer InsertedBulbs = default!;
-
-        [Serializable]
-        [DataDefinition]
-        public sealed class LightReplacerEntity
+        Params = new()
         {
-            [DataField("name", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-            public string PrototypeName = default!;
-
-            [DataField("amount")]
-            public int Amount;
-
-            [DataField("type")]
-            public LightBulbType Type;
+            Volume = -4f
         }
-    }
+    };
+
+    /// <summary>
+    /// Bulbs that were inserted inside light replacer
+    /// </summary>
+    [ViewVariables]
+    public Container InsertedBulbs = default!;
+
+    /// <summary>
+    /// The default starting bulbs
+    /// </summary>
+    [DataField("contents")]
+    public List<EntitySpawnEntry> Contents = new();
 }

--- a/Content.Server/Light/EntitySystems/LightReplacerSystem.cs
+++ b/Content.Server/Light/EntitySystems/LightReplacerSystem.cs
@@ -1,217 +1,236 @@
 using System.Linq;
 using Content.Server.Light.Components;
 using Content.Server.Storage.Components;
+using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Light.Component;
 using Content.Shared.Popups;
+using Content.Shared.Storage;
 using JetBrains.Annotations;
-using Robust.Shared.Audio;
 using Robust.Shared.Containers;
-using Robust.Shared.Player;
 
-namespace Content.Server.Light.EntitySystems
+namespace Content.Server.Light.EntitySystems;
+
+[UsedImplicitly]
+public sealed class LightReplacerSystem : EntitySystem
 {
-    [UsedImplicitly]
-    public sealed class LightReplacerSystem : EntitySystem
+    [Dependency] private readonly PoweredLightSystem _poweredLight = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly PoweredLightSystem _poweredLight = default!;
-        [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+        base.Initialize();
 
-        public override void Initialize()
+        SubscribeLocalEvent<LightReplacerComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<LightReplacerComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<LightReplacerComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<LightReplacerComponent, InteractUsingEvent>(HandleInteract);
+        SubscribeLocalEvent<LightReplacerComponent, AfterInteractEvent>(HandleAfterInteract);
+    }
+
+    private void OnExamined(EntityUid uid, LightReplacerComponent component, ExaminedEvent args)
+    {
+        if (!component.InsertedBulbs.ContainedEntities.Any())
         {
-            base.Initialize();
-
-            SubscribeLocalEvent<LightReplacerComponent, ComponentInit>(OnInit);
-            SubscribeLocalEvent<LightReplacerComponent, InteractUsingEvent>(HandleInteract);
-            SubscribeLocalEvent<LightReplacerComponent, AfterInteractEvent>(HandleAfterInteract);
+            args.PushMarkup(Loc.GetString("comp-light-replacer-no-lights"));
+            return;
+        }
+        args.PushMarkup(Loc.GetString("comp-light-replacer-has-lights"));
+        var groups = new Dictionary<string, int>();
+        var metaQuery = GetEntityQuery<MetaDataComponent>();
+        foreach (var bulb in component.InsertedBulbs.ContainedEntities)
+        {
+            var metaData = metaQuery.GetComponent(bulb);
+            groups[metaData.EntityName] = groups.GetValueOrDefault(metaData.EntityName) + 1;
         }
 
-        private void OnInit(EntityUid uid, LightReplacerComponent replacer, ComponentInit args)
+        foreach (var (name, amount) in groups)
         {
-            replacer.InsertedBulbs = ContainerHelpers.EnsureContainer<Container>(replacer.Owner, "light_replacer_storage");
+            args.PushMarkup(Loc.GetString("comp-light-replacer-light-listing", ("amount", amount), ("name", name)));
+        }
+    }
+
+    private void OnMapInit(EntityUid uid, LightReplacerComponent component, MapInitEvent args)
+    {
+        var xform = Transform(uid);
+        foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Contents))
+        {
+            var ent = Spawn(spawn, xform.Coordinates);
+            TryInsertBulb(uid, ent, replacer: component);
+        }
+    }
+
+    private void OnInit(EntityUid uid, LightReplacerComponent replacer, ComponentInit args)
+    {
+        replacer.InsertedBulbs = _container.EnsureContainer<Container>(uid, "light_replacer_storage");
+    }
+
+    private void HandleAfterInteract(EntityUid uid, LightReplacerComponent component, AfterInteractEvent eventArgs)
+    {
+        if (eventArgs.Handled)
+            return;
+
+        // standard interaction checks
+        if (!eventArgs.CanReach)
+            return;
+
+        // behaviour will depends on target type
+        if (eventArgs.Target != null)
+        {
+            var targetUid = (EntityUid) eventArgs.Target;
+
+            // replace broken light in fixture?
+            if (TryComp<PoweredLightComponent>(targetUid, out var fixture))
+                eventArgs.Handled = TryReplaceBulb(uid, targetUid, eventArgs.User, component, fixture);
+            // add new bulb to light replacer container?
+            else if (TryComp<LightBulbComponent>(targetUid, out var bulb))
+                eventArgs.Handled = TryInsertBulb(uid, targetUid, eventArgs.User, true, component, bulb);
+        }
+    }
+
+    private void HandleInteract(EntityUid uid, LightReplacerComponent component, InteractUsingEvent eventArgs)
+    {
+        if (eventArgs.Handled)
+            return;
+
+        var usedUid = eventArgs.Used;
+
+        // want to insert a new light bulb?
+        if (TryComp<LightBulbComponent>(usedUid, out var bulb))
+            eventArgs.Handled = TryInsertBulb(uid, usedUid, eventArgs.User, true, component, bulb);
+        // add bulbs from storage?
+        else if (TryComp<ServerStorageComponent>(usedUid, out var storage))
+            eventArgs.Handled = TryInsertBulbsFromStorage(uid, usedUid, eventArgs.User, component, storage);
+    }
+
+    /// <summary>
+    ///     Try to replace a light bulb in <paramref name="fixtureUid"/>
+    ///     using light replacer. Light fixture should have <see cref="PoweredLightComponent"/>.
+    /// </summary>
+    /// <returns>True if successfully replaced light, false otherwise</returns>
+    public bool TryReplaceBulb(EntityUid replacerUid, EntityUid fixtureUid, EntityUid? userUid = null,
+        LightReplacerComponent? replacer = null, PoweredLightComponent? fixture = null)
+    {
+        if (!Resolve(replacerUid, ref replacer))
+            return false;
+        if (!Resolve(fixtureUid, ref fixture))
+            return false;
+
+        // check if light bulb is broken or missing
+        var fixtureBulbUid = _poweredLight.GetBulb(fixtureUid, fixture);
+        if (fixtureBulbUid != null)
+        {
+            if (!TryComp<LightBulbComponent>(fixtureBulbUid.Value, out var fixtureBulb))
+                return false;
+            if (fixtureBulb.State == LightBulbState.Normal)
+                return false;
         }
 
-        private void HandleAfterInteract(EntityUid uid, LightReplacerComponent component, AfterInteractEvent eventArgs)
+        // try get first inserted bulb of the same type as targeted light fixtutre
+        var bulb = replacer.InsertedBulbs.ContainedEntities.FirstOrDefault(
+            e => CompOrNull<LightBulbComponent>(e)?.Type == fixture.BulbType);
+
+        // found bulb in inserted storage
+        if (bulb.Valid) // FirstOrDefault can return default/invalid uid.
         {
-            if (eventArgs.Handled)
-                return;
-
-            // standard interaction checks
-            if (!eventArgs.CanReach) return;
-
-            // behaviour will depends on target type
-            if (eventArgs.Target != null)
+            // try to remove it
+            var hasRemoved = replacer.InsertedBulbs.Remove(bulb);
+            if (!hasRemoved)
+                return false;
+        }
+        else
+        {
+            if (userUid != null)
             {
-                var targetUid = (EntityUid) eventArgs.Target;
-
-                // replace broken light in fixture?
-                if (EntityManager.TryGetComponent(targetUid, out PoweredLightComponent? fixture))
-                    eventArgs.Handled = TryReplaceBulb(uid, targetUid, eventArgs.User, component, fixture);
-                // add new bulb to light replacer container?
-                else if (EntityManager.TryGetComponent(targetUid, out LightBulbComponent? bulb))
-                    eventArgs.Handled = TryInsertBulb(uid, targetUid, eventArgs.User, true, component, bulb);
+                var msg = Loc.GetString("comp-light-replacer-missing-light",
+                    ("light-replacer", replacerUid));
+                _popupSystem.PopupEntity(msg, replacerUid, userUid.Value);
             }
+            return false;
         }
 
-        private void HandleInteract(EntityUid uid, LightReplacerComponent component, InteractUsingEvent eventArgs)
+        // insert it into fixture
+        var wasReplaced = _poweredLight.ReplaceBulb(fixtureUid, bulb, fixture);
+        if (wasReplaced)
         {
-            if (eventArgs.Handled)
-                return;
-
-            var usedUid = eventArgs.Used;
-
-            // want to insert a new light bulb?
-            if (EntityManager.TryGetComponent(usedUid, out LightBulbComponent? bulb))
-                eventArgs.Handled = TryInsertBulb(uid, usedUid, eventArgs.User, true, component, bulb);
-            // add bulbs from storage?
-            else if (EntityManager.TryGetComponent(usedUid, out ServerStorageComponent? storage))
-                eventArgs.Handled = TryInsertBulbsFromStorage(uid, usedUid, eventArgs.User, component, storage);
+            _audio.PlayPvs(replacer.Sound, replacerUid);
         }
 
-        /// <summary>
-        ///     Try to replace a light bulb in <paramref name="fixtureUid"/>
-        ///     using light replacer. Light fixture should have <see cref="PoweredLightComponent"/>.
-        /// </summary>
-        /// <returns>True if successfully replaced light, false otherwise</returns>
-        public bool TryReplaceBulb(EntityUid replacerUid, EntityUid fixtureUid, EntityUid? userUid = null,
-            LightReplacerComponent? replacer = null, PoweredLightComponent? fixture = null)
+        return wasReplaced;
+    }
+
+    /// <summary>
+    ///     Try to insert a new bulb inside light replacer
+    /// </summary>
+    /// <returns>True if successfully inserted light, false otherwise</returns>
+    public bool TryInsertBulb(EntityUid replacerUid, EntityUid bulbUid, EntityUid? userUid = null, bool showTooltip = false,
+        LightReplacerComponent? replacer = null, LightBulbComponent? bulb = null)
+    {
+        if (!Resolve(replacerUid, ref replacer))
+            return false;
+        if (!Resolve(bulbUid, ref bulb))
+            return false;
+
+        // only normal (non-broken) bulbs can be inserted inside light replacer
+        if (bulb.State != LightBulbState.Normal)
         {
-            if (!Resolve(replacerUid, ref replacer))
-                return false;
-            if (!Resolve(fixtureUid, ref fixture))
-                return false;
-
-            // check if light bulb is broken or missing
-            var fixtureBulbUid = _poweredLight.GetBulb(fixture.Owner, fixture);
-            if (fixtureBulbUid != null)
+            if (showTooltip && userUid != null)
             {
-                if (!EntityManager.TryGetComponent(fixtureBulbUid.Value, out LightBulbComponent? fixtureBulb))
-                    return false;
-                if (fixtureBulb.State == LightBulbState.Normal)
-                    return false;
+                var msg = Loc.GetString("comp-light-replacer-insert-broken-light");
+                _popupSystem.PopupEntity(msg, replacerUid, userUid.Value);
             }
 
-            // try get first inserted bulb of the same type as targeted light fixtutre
-            var bulb = replacer.InsertedBulbs.ContainedEntities.FirstOrDefault(
-                (e) => EntityManager.GetComponentOrNull<LightBulbComponent>(e)?.Type == fixture.BulbType);
-
-            // found bulb in inserted storage
-            if (bulb.Valid) // FirstOrDefault can return default/invalid uid.
-            {
-                // try to remove it
-                var hasRemoved = replacer.InsertedBulbs.Remove(bulb);
-                if (!hasRemoved)
-                    return false;
-            }
-            // try to create new instance of bulb from LightReplacerEntity
-            else
-            {
-                var bulbEnt = replacer.Contents.FirstOrDefault((e) => e.Type == fixture.BulbType && e.Amount > 0);
-
-                // found right bulb, let's spawn it
-                if (bulbEnt != null)
-                {
-                    bulb = EntityManager.SpawnEntity(bulbEnt.PrototypeName, EntityManager.GetComponent<TransformComponent>(replacer.Owner).Coordinates);
-                    bulbEnt.Amount--;
-                }
-                // not found any light bulbs
-                else
-                {
-                    if (userUid != null)
-                    {
-                        var msg = Loc.GetString("comp-light-replacer-missing-light",
-                            ("light-replacer", replacer.Owner));
-                        _popupSystem.PopupEntity(msg, replacerUid, userUid.Value);
-                    }
-                    return false;
-                }
-            }
-
-            // insert it into fixture
-            var wasReplaced = _poweredLight.ReplaceBulb(fixtureUid, bulb, fixture);
-            if (wasReplaced)
-            {
-                SoundSystem.Play(replacer.Sound.GetSound(),
-                    Filter.Pvs(replacerUid), replacerUid, AudioParams.Default.WithVolume(-4f));
-            }
-
-
-            return wasReplaced;
+            return false;
         }
 
-        /// <summary>
-        ///     Try to insert a new bulb inside light replacer
-        /// </summary>
-        /// <returns>True if successfully inserted light, false otherwise</returns>
-        public bool TryInsertBulb(EntityUid replacerUid, EntityUid bulbUid, EntityUid? userUid = null, bool showTooltip = false,
-            LightReplacerComponent? replacer = null, LightBulbComponent? bulb = null)
+        // try insert light and show message
+        var hasInsert = replacer.InsertedBulbs.Insert(bulbUid);
+        if (hasInsert && showTooltip && userUid != null)
         {
-            if (!Resolve(replacerUid, ref replacer))
-                return false;
-            if (!Resolve(bulbUid, ref bulb))
-                return false;
-
-            // only normal (non-broken) bulbs can be inserted inside light replacer
-            if (bulb.State != LightBulbState.Normal)
-            {
-                if (showTooltip && userUid != null)
-                {
-                    var msg = Loc.GetString("comp-light-replacer-insert-broken-light");
-                    _popupSystem.PopupEntity(msg, replacerUid, userUid.Value);
-                }
-
-                return false;
-            }
-
-            // try insert light and show message
-            var hasInsert = replacer.InsertedBulbs.Insert(bulb.Owner);
-            if (hasInsert && showTooltip && userUid != null)
-            {
-                var msg = Loc.GetString("comp-light-replacer-insert-light",
-                    ("light-replacer", replacer.Owner), ("bulb", bulb.Owner));
-                _popupSystem.PopupEntity(msg, replacerUid, userUid.Value, PopupType.Medium);
-            }
-
-            return hasInsert;
+            var msg = Loc.GetString("comp-light-replacer-insert-light",
+                ("light-replacer", replacerUid), ("bulb", bulbUid));
+            _popupSystem.PopupEntity(msg, replacerUid, userUid.Value, PopupType.Medium);
         }
 
-        /// <summary>
-        ///     Try to insert all light bulbs from storage (for example light tubes box)
-        /// </summary>
-        /// <returns>
-        ///     Returns true if storage contained at least one light bulb
-        ///     which was successfully inserted inside light replacer
-        /// </returns>
-        public bool TryInsertBulbsFromStorage(EntityUid replacerUid, EntityUid storageUid, EntityUid? userUid = null,
-            LightReplacerComponent? replacer = null, ServerStorageComponent? storage = null)
+        return hasInsert;
+    }
+
+    /// <summary>
+    ///     Try to insert all light bulbs from storage (for example light tubes box)
+    /// </summary>
+    /// <returns>
+    ///     Returns true if storage contained at least one light bulb
+    ///     which was successfully inserted inside light replacer
+    /// </returns>
+    public bool TryInsertBulbsFromStorage(EntityUid replacerUid, EntityUid storageUid, EntityUid? userUid = null,
+        LightReplacerComponent? replacer = null, ServerStorageComponent? storage = null)
+    {
+        if (!Resolve(replacerUid, ref replacer))
+            return false;
+        if (!Resolve(storageUid, ref storage))
+            return false;
+
+        if (storage.StoredEntities == null)
+            return false;
+
+        var insertedBulbs = 0;
+        var storagedEnts = storage.StoredEntities.ToArray();
+        foreach (var ent in storagedEnts)
         {
-            if (!Resolve(replacerUid, ref replacer))
-                return false;
-            if (!Resolve(storageUid, ref storage))
-                return false;
-
-            if (storage.StoredEntities == null)
-                return false;
-
-            var insertedBulbs = 0;
-            var storagedEnts = storage.StoredEntities.ToArray();
-            foreach (var ent in storagedEnts)
-            {
-                if (EntityManager.TryGetComponent(ent, out LightBulbComponent? bulb))
-                {
-                    if (TryInsertBulb(replacerUid, ent, userUid, false, replacer, bulb))
-                        insertedBulbs++;
-                }
-            }
-
-            // show some message if success
-            if (insertedBulbs > 0 && userUid != null)
-            {
-                var msg = Loc.GetString("comp-light-replacer-refill-from-storage", ("light-replacer", storage.Owner));
-                _popupSystem.PopupEntity(msg, replacerUid, userUid.Value, PopupType.Medium);
-            }
-
-            return insertedBulbs > 0;
+            if (TryComp<LightBulbComponent>(ent, out var bulb) &&
+                TryInsertBulb(replacerUid, ent, userUid, false, replacer, bulb))
+                insertedBulbs++;
         }
+
+        // show some message if success
+        if (insertedBulbs > 0 && userUid != null)
+        {
+            var msg = Loc.GetString("comp-light-replacer-refill-from-storage", ("light-replacer", storageUid));
+            _popupSystem.PopupEntity(msg, replacerUid, userUid.Value, PopupType.Medium);
+        }
+
+        return insertedBulbs > 0;
     }
 }

--- a/Resources/Locale/en-US/light/components/light-replacer-component.ftl
+++ b/Resources/Locale/en-US/light/components/light-replacer-component.ftl
@@ -1,14 +1,23 @@
 
 ### Interaction Messages
 
-# Shown when player tries to replace light, but there is no lighs left
-comp-light-replacer-missing-light = No lights left in {$light-replacer}.
+# Shown when player tries to replace light, but there is no lights left
+comp-light-replacer-missing-light = No lights left in {THE($light-replacer)}.
 
 # Shown when player inserts light bulb inside light replacer
-comp-light-replacer-insert-light = You insert {$bulb} into {$light-replacer}.
+comp-light-replacer-insert-light = You insert {$bulb} into {THE($light-replacer)}.
 
 # Shown when player tries to insert in light replacer brolen light bulb
 comp-light-replacer-insert-broken-light = You can't insert broken lights!
 
 # Shown when player refill light from light box
-comp-light-replacer-refill-from-storage = You refill {$light-replacer}.
+comp-light-replacer-refill-from-storage = You refill {THE($light-replacer)}.
+
+### Examine 
+
+comp-light-replacer-no-lights = It's empty.
+comp-light-replacer-has-lights = It contains the following:
+comp-light-replacer-light-listing = {$amount ->
+    [one] [color=yellow]{$amount}[/color] [color=gray]{$name}[/color]
+    *[other] [color=yellow]{$amount}[/color] [color=gray]{$name}s[/color]
+}

--- a/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
@@ -11,12 +11,10 @@
     sprite: Objects/Specific/Janitorial/light_replacer.rsi
   - type: LightReplacer
     contents:
-    - name: LightTube
+    - id: LightTube
       amount: 8
-      type: Tube
-    - name: LightBulb
+    - id: LightBulb
       amount: 5
-      type: Bulb
   - type: Tag
     tags:
       - DroneUsable
@@ -25,3 +23,13 @@
   - type: ContainerContainer
     containers:
       light_replacer_storage: !type:Container
+
+- type: entity
+  parent: LightReplacer
+  id: LightReplacerEmpty
+  suffix: Empty
+  components:
+  - type: LightReplacer
+    contents:
+    - id: LightTube
+      amount: 0

--- a/Resources/Prototypes/Recipes/Lathes/janitorial.yml
+++ b/Resources/Prototypes/Recipes/Lathes/janitorial.yml
@@ -50,11 +50,11 @@
 
 - type: latheRecipe
   id: LightReplacer
-  result: LightReplacer
+  result: LightReplacerEmpty
   completetime: 2.4
   materials:
     Steel: 100
-    Glass: 1000
+    Glass: 500
 
 - type: latheRecipe
   id: AdvMopItem


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
uses le modern methods
remove .Owner
remove the weird shit used for contents: move all of it to contains.
add examine text
make the lathe recipe print an empty one

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/98561806/236093912-a182e860-81f9-4049-9732-088da3800bbf.png)
![image](https://user-images.githubusercontent.com/98561806/236093990-1827898f-4ae2-4d1b-a7da-681f31c9c7ec.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: You can now examine light replacers to see how many lights are inside.
- fix: Light replacers printed by lathes are no longer full of lights.
