### PR TITLE
prevent from prying blast doors

### DIFF
--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -185,7 +185,7 @@ public sealed class DoorSystem : SharedDoorSystem
             var canEv = new BeforeDoorPryEvent(user, tool);
             RaiseLocalEvent(target, canEv, false);
 
-            if (canEv.Cancelled)
+            if (!door.CanPry || canEv.Cancelled)
                 // mark handled, as airlock component will cancel after generating a pop-up & you don't want to pry a tile
                 // under a windoor.
                 return true;

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -262,13 +262,16 @@ public sealed class DoorComponent : Component
     }
     #endregion
 
+    [DataField("canPry"), ViewVariables(VVAccess.ReadWrite)]
+    public bool CanPry = true;
+
     [DataField("pryingQuality", customTypeSerializer: typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
     public string PryingQuality = "Prying";
 
     /// <summary>
     /// Default time that the door should take to pry open.
     /// </summary>
-    [DataField("pryTime")]
+    [DataField("pryTime"), ViewVariables(VVAccess.ReadWrite)]
     public float PryTime = 1.5f;
 
     [DataField("changeAirtight")]

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -17,7 +17,7 @@
     openTimeTwo: 0.4
     openingAnimationTime: 1.0
     closingAnimationTime: 1.0
-    pryTime: -1
+    pryTime: 60
     crushDamage:
       types:
         Blunt: 25 # yowch

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -17,7 +17,7 @@
     openTimeTwo: 0.4
     openingAnimationTime: 1.0
     closingAnimationTime: 1.0
-    pryTime: 60
+    canPry: false
     crushDamage:
       types:
         Blunt: 25 # yowch


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
closes #16075
DoAfter stuff broke blast door, making them open the second you pry them. Original PR - #6474

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: You can't pry blast doors anymore
