### PR TITLE
Keep brigmed jumpsuits available to HOP

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -264,7 +264,7 @@
   parent: ClothingUniformBase
   id: ClothingUniformJumpskirtBrigmedic
   name: brigmedic jumpskirt
-  description: The uniform is issued to qualified persons who have been trained, but no one cares that the training took place half a day.
+  description: This uniform is issued to qualified personnel who have been trained. No one cares that the training took half a day.
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpskirt/brigmedic.rsi

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -389,7 +389,7 @@
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitBrigmedic
   name: brigmedic jumpsuit
-  description: The uniform is issued to qualified persons who have been trained, but no one cares that the training took place half a day.
+  description: This uniform is issued to qualified personnel who have been trained. No one cares that the training took half a day.
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpsuit/brigmedic.rsi

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -576,6 +576,8 @@
       - ClothingUniformJumpskirtScientist
       - ClothingUniformJumpsuitSec
       - ClothingUniformJumpskirtSec
+      - ClothingUniformJumpsuitBrigmedic
+      - ClothingUniformJumpskirtBrigmedic
       - ClothingUniformJumpsuitWarden
       - ClothingUniformJumpskirtWarden
       - ClothingOuterWinterCap

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -393,6 +393,20 @@
     Cloth: 300
 
 - type: latheRecipe
+  id: ClothingUniformJumpsuitBrigmedic
+  result: ClothingUniformJumpsuitBrigmedic
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtBrigmedic
+  result: ClothingUniformJumpskirtBrigmedic
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
   id: ClothingUniformJumpsuitWarden
   result: ClothingUniformJumpsuitWarden
   completetime: 4

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -16,9 +16,6 @@ ClothingHeadHatBeretBrigmedic: null
 ClothingHeadHelmetHardsuitBrigmedic: null
 ClothingOuterHardsuitBrigmedic: null
 ClothingOuterCoatAMG: null
-ClothingUniformJumpsuitBrigmedic: null
-ClothingUniformJumpskirtBrigmedic: null
-ClothingUniformJumpskirtOfLife: null
 ClothingBackpackBrigmedic: null
 ClothingBackpackBrigmedicFilled: null
 ClothingBackpackSatchelBrigmedic: null

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -6,7 +6,7 @@
 # Window: WallSolid
 # WallSolid: Window
 # Table: null
-
+#
 chem_dispenser: ChemDispenser
 
 # 2023-05-03


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Brigmedic jumpsuits will still be available in game through HOP. Security players can choose at their discretion to ask HOS to make them a brigmedic, and can ask CMO if they truly want medical access as well. If/when loadouts exist, those departments will probably have brigmedic clothing as an option.

Partial revert of #16069

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Whisper
- tweak: Brigmedic jumpsuit blueprints have been returned to the HOP. Ask your local HOS if you wish to be security's in house doctor.
