### PR TITLE
Can open safe firelocks with a single click

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -65,7 +65,7 @@
       openTimeTwo: 0.6
       state: Open
       bumpOpen: false
-      clickOpen: false
+      clickOpen: true
       crushDamage:
         types:
           Blunt: 15


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
- Players no longer need crowbars to navigate through "safe" firelocks, i.e those which are not holding back pressure or temperature
- It means travelling through safe areas with recent alarms is far less painful for general crew
- Combined with https://github.com/space-wizards/space-station-14/pull/15892 it's clear which doors you can click on to open (those without lights)

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://user-images.githubusercontent.com/5285589/236365720-5b4c0548-722b-4fa4-a439-fa71e123eb95.mp4

(Note: I've combined https://github.com/space-wizards/space-station-14/pull/15892 for the lights here)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: You can open and close firelock doors like airlock doors if they are safe. You still need a crowbar for unsafe doors.
