### PR TITLE
Space sections substantially slower (5-15 sec, exponential) with cooling

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -635,7 +635,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (!MonstermosRipTiles)
                 return;
 
-            var chance = MathHelper.Clamp(0.02f + (sum / Atmospherics.SpacingMaxWind) * 0.3f, 0.005f, 0.3f);
+            var chance = MathHelper.Clamp(0.01f + (sum / Atmospherics.SpacingMaxWind) * 0.3f, 0.003f, 0.3f);
 
             if (sum > 20 && _robustRandom.Prob(chance))
                 PryTile(mapGrid, tile.GridIndices);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -499,13 +499,12 @@ namespace Content.Server.Atmos.EntitySystems
                     // And then some magically into space
                     ReleaseGasTo(otherTile2.Air!, null, sum * 0.3f);
 
-                    // Temperature reduces as air drains. But nerf the real temperature reduction a bit
-                    float realtemploss = (otherTile.Air.TotalMoles - sum) / otherTile.Air.TotalMoles;
-                    otherTile.Air.Temperature *= 0.9f + 0.1f * realtemploss;
-                    if (otherTile.Air.Temperature < 310.0f && otherTile.Air.Temperature > 270.0f)
+                    if (otherTile.Air.Temperature > 280.0f)
                     {
-                        // Make some water vapor between 0 and 30 deg. c
-                        otherTile.Air.AdjustMoles(Gas.WaterVapor, sum * 0.01f);
+                        // Temperature reduces as air drains. But nerf the real temperature reduction a bit
+                        //   Also, limit the temperature loss to remain > 10 Deg.C for convenience
+                        float realtemploss = (otherTile.Air.TotalMoles - sum) / otherTile.Air.TotalMoles;
+                        otherTile.Air.Temperature *= 0.9f + 0.1f * realtemploss;
                     }
                 }
                 else

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -454,7 +454,7 @@ namespace Content.Server.Atmos.EntitySystems
                 AddActiveTile(gridAtmosphere, otherTile);
                 var otherTile2 = otherTile.AdjacentTiles[otherTile.MonstermosInfo.CurrentTransferDirection.ToIndex()];
                 if (otherTile2?.Air == null) continue;
-                var sum = otherTile2.Air.TotalMoles * 0.2f;
+                var sum = otherTile2.Air.TotalMoles * Atmospherics.SpacingEscapeRatio;
                 totalMolesRemoved += sum;
                 otherTile.MonstermosInfo.CurrentTransferAmount += sum;
                 otherTile2.MonstermosInfo.CurrentTransferAmount += otherTile.MonstermosInfo.CurrentTransferAmount;
@@ -467,7 +467,7 @@ namespace Content.Server.Atmos.EntitySystems
                     otherTile2.PressureDirection = otherTile.MonstermosInfo.CurrentTransferDirection;
                 }
 
-                if (tile.Air != null && tile.Air.Pressure > 20.0)
+                if (tile.Air != null && tile.Air.Pressure > Atmospherics.SpacingMinGas)
                 {
                     // Transfer the air into the other tile (space wind :)
                     ReleaseGasTo(otherTile.Air!, otherTile2.Air!, sum);

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -300,6 +300,19 @@ namespace Content.Shared.Atmos
         /// </summary>
         public const float MaxTransferRate = 200;
 
+        /// <summary>
+        ///     What fraction of air from a spaced tile escapes every tick.
+        ///     1.0 for instant spacing, 0.2 means 20% of remaining air lost each time
+        /// </summary>
+        public const float SpacingEscapeRatio = 0.2f;
+
+        /// <summary>
+        ///     Minimum amount of air allowed on a spaced tile before it is reset to 0 immediately in kPa
+        ///     Since the decay due to SpacingEscapeRatio follows a curve, it would never reach 0.0 exactly
+        ///     unless we truncate it somewhere.
+        /// </summary>
+        public const float SpacingMinGas = 5.0f;
+
         #endregion
     }
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -313,6 +313,12 @@ namespace Content.Shared.Atmos
         /// </summary>
         public const float SpacingMinGas = 5.0f;
 
+        /// <summary>
+        ///     How much wind can go through a single tile before that tile doesn't depressurize itself
+        ///     (I.e spacing is limited in large rooms heading into smaller spaces)
+        /// </summary>
+        public const float SpacingMaxWind = 1000.0f;
+
         #endregion
     }
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -304,20 +304,20 @@ namespace Content.Shared.Atmos
         ///     What fraction of air from a spaced tile escapes every tick.
         ///     1.0 for instant spacing, 0.2 means 20% of remaining air lost each time
         /// </summary>
-        public const float SpacingEscapeRatio = 0.15f;
+        public const float SpacingEscapeRatio = 0.05f;
 
         /// <summary>
         ///     Minimum amount of air allowed on a spaced tile before it is reset to 0 immediately in kPa
         ///     Since the decay due to SpacingEscapeRatio follows a curve, it would never reach 0.0 exactly
         ///     unless we truncate it somewhere.
         /// </summary>
-        public const float SpacingMinGas = 5.0f;
+        public const float SpacingMinGas = 2.0f;
 
         /// <summary>
         ///     How much wind can go through a single tile before that tile doesn't depressurize itself
         ///     (I.e spacing is limited in large rooms heading into smaller spaces)
         /// </summary>
-        public const float SpacingMaxWind = 250.0f;
+        public const float SpacingMaxWind = 500.0f;
 
         #endregion
     }

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -317,7 +317,7 @@ namespace Content.Shared.Atmos
         ///     How much wind can go through a single tile before that tile doesn't depressurize itself
         ///     (I.e spacing is limited in large rooms heading into smaller spaces)
         /// </summary>
-        public const float SpacingMaxWind = 500.0f;
+        public const float SpacingMaxWind = 250.0f;
 
         #endregion
     }

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -304,7 +304,7 @@ namespace Content.Shared.Atmos
         ///     What fraction of air from a spaced tile escapes every tick.
         ///     1.0 for instant spacing, 0.2 means 20% of remaining air lost each time
         /// </summary>
-        public const float SpacingEscapeRatio = 0.2f;
+        public const float SpacingEscapeRatio = 0.15f;
 
         /// <summary>
         ///     Minimum amount of air allowed on a spaced tile before it is reset to 0 immediately in kPa
@@ -317,7 +317,7 @@ namespace Content.Shared.Atmos
         ///     How much wind can go through a single tile before that tile doesn't depressurize itself
         ///     (I.e spacing is limited in large rooms heading into smaller spaces)
         /// </summary>
-        public const float SpacingMaxWind = 1000.0f;
+        public const float SpacingMaxWind = 500.0f;
 
         #endregion
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- You have just a moment when you start spacing a section to close the airlock before the air is all gone.
- Typical spacing time is about 10 seconds.
- ExplosivelyDepressurize reduces air pressure by about 10% each pass, sets to vacuum below 2 kPa
- Cools the area about 1/3 of what would be realistic.
- Initially it caused some issues with AdjacentBits on airlock close, I've added some checks due to failed asserts. I think that is because the hard vacuum before created less edge cases. Seen no more bugs in a lot of testing after that was fixed.
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/5285589/dd36adbb-8560-4d2b-8934-e5120ab8421c

Older video (before wind limitations and effects on tiles):
https://user-images.githubusercontent.com/5285589/236445196-69e79500-5b52-44c1-8ccd-40250db669b8.mp4

- [ X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Spacing takes a short time to occur, rather than being totally instant. The decompression will make you cold.
- tweak: Ripped tiles during spacing reflect the wind that passed through that area, ripped tiles tend to be concentrated around the breach.