### PR TITLE
display item charge on examine

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.cs
@@ -41,6 +41,7 @@ public sealed class PowerCellSystem : SharedPowerCellSystem
         SubscribeLocalEvent<PowerCellComponent, RejuvenateEvent>(OnRejuvenate);
 
         SubscribeLocalEvent<PowerCellComponent, ExaminedEvent>(OnCellExamined);
+        SubscribeLocalEvent<PowerCellSlotComponent, ExaminedEvent>(OnCellSlotExamined);
 
         SubscribeLocalEvent<PowerCellDrawComponent, EntityUnpausedEvent>(OnUnpaused);
 
@@ -287,10 +288,19 @@ public sealed class PowerCellSystem : SharedPowerCellSystem
 
     private void OnCellExamined(EntityUid uid, PowerCellComponent component, ExaminedEvent args)
     {
-        if (!TryComp(uid, out BatteryComponent? battery))
-            return;
+        if (TryComp<BatteryComponent>(uid, out var battery))
+            OnBatteryExamined(uid, battery, args);
+    }
 
-        var charge = battery.CurrentCharge / battery.MaxCharge * 100;
+    private void OnCellSlotExamined(EntityUid uid, PowerCellSlotComponent component, ExaminedEvent args)
+    {
+        if (TryGetBatteryFromSlot(uid, out var battery))
+            OnBatteryExamined(uid, battery, args);
+    }
+
+    private void OnBatteryExamined(EntityUid uid, BatteryComponent component, ExaminedEvent args)
+    {
+        var charge = component.CurrentCharge / component.MaxCharge * 100;
         args.PushMarkup(Loc.GetString("power-cell-component-examine-details", ("currentCharge", $"{charge:F0}")));
     }
 }

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -69,9 +69,6 @@ public sealed class JammerSystem : EntitySystem
                 ? Loc.GetString("radio-jammer-component-examine-on-state")
                 : Loc.GetString("radio-jammer-component-examine-off-state");
             args.PushMarkup(msg);
-            if (_powerCell.TryGetBatteryFromSlot(uid, out var battery))
-                args.PushMarkup(Loc.GetString("radio-jammer-component-charge",
-                    ("charge", (int) ((battery.CurrentCharge / battery.MaxCharge) * 100))));
         }
     }
 

--- a/Resources/Locale/en-US/radio/components/radio-jammer-component.ftl
+++ b/Resources/Locale/en-US/radio/components/radio-jammer-component.ftl
@@ -4,4 +4,3 @@ radio-jammer-component-off-state = off
 
 radio-jammer-component-examine-on-state = The light is currently [color=darkgreen]on[/color].
 radio-jammer-component-examine-off-state = The light is currently [color=darkred]off[/color].
-radio-jammer-component-charge = The battery is [color=yellow]{$charge}%[/color] full.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Items with power cell slots now show charge (e.g. flashlights, handheld monitors and etc.)

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![Peek 2023-05-05 15-19](https://user-images.githubusercontent.com/40753025/236456399-c8c41b59-43f6-478a-9df7-fffaeaf925ad.gif)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: items with powercell slots now display charge (e.g. flashlights, handheld monitors and etc.)
