### PR TITLE
prevent rcd destroying planets

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -74,6 +74,11 @@ namespace Content.Shared.Maps
         /// </summary>
         [DataField("weather")] public bool Weather = false;
 
+        /// <summary>
+        /// Is this tile immune to RCD deconstruct.
+        /// </summary>
+        [DataField("indestructible")] public bool Indestructible = false;
+
         public void AssignTileId(ushort id)
         {
             TileId = id;

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -237,14 +237,25 @@ public sealed class RCDSystem : EntitySystem
                 if (tile.Tile.IsEmpty)
                     return false;
 
-                //They tried to decon a turf but the turf is blocked
-                if (target == null && IsTileBlocked(tile))
+                //They tried to decon a turf but...
+                if (target == null)
                 {
-                    _popup.PopupClient(Loc.GetString("rcd-component-tile-obstructed-message"), uid, user);
-                    return false;
+                    // the turf is blocked
+                    if (IsTileBlocked(tile))
+                    {
+                        _popup.PopupClient(Loc.GetString("rcd-component-tile-obstructed-message"), uid, user);
+                        return false;
+                    }
+                    // the turf can't be destroyed (planet probably)
+                    var tileDef = (ContentTileDefinition) _tileDefMan[tile.Tile.TypeId];
+                    if (tileDef.Indestructible)
+                    {
+                        _popup.PopupClient(Loc.GetString("rcd-component-tile-indestructible-message"), uid, user);
+                        return false;
+                    }
                 }
                 //They tried to decon a non-turf but it's not in the whitelist
-                if (target != null && !_tag.HasTag(target.Value, "RCDDeconstructWhitelist"))
+                else if (!_tag.HasTag(target.Value, "RCDDeconstructWhitelist"))
                 {
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);
                     return false;

--- a/Resources/Locale/en-US/rcd/components/rcd-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-component.ftl
@@ -11,6 +11,7 @@ rcd-component-change-mode = The RCD is now set to {$mode} mode.
 
 rcd-component-no-ammo-message = The RCD is out of ammo!
 rcd-component-tile-obstructed-message = That tile is obstructed!
+rcd-component-tile-indestructible-message = That tile can't be destroyed!
 rcd-component-deconstruct-target-not-on-whitelist-message = You can't deconstruct that!
 rcd-component-cannot-build-floor-tile-not-empty-message = You can only build a floor on space!
 rcd-component-cannot-build-wall-tile-not-empty-message = You cannot build a wall on space!

--- a/Resources/Prototypes/Tiles/planet.yml
+++ b/Resources/Prototypes/Tiles/planet.yml
@@ -8,6 +8,7 @@
     collection: FootstepAsteroid
   heatCapacity: 10000
   weather: true
+  indestructible: true
 
 # Desert
 - type: tile
@@ -22,6 +23,7 @@
     collection: FootstepAsteroid
   heatCapacity: 10000
   weather: true
+  indestructible: true
 
 - type: tile
   id: FloorLowDesert
@@ -35,6 +37,7 @@
     collection: FootstepAsteroid
   heatCapacity: 10000
   weather: true
+  indestructible: true
 
 # Grass
 - type: tile
@@ -61,6 +64,7 @@
   itemDrop: FloorTileItemGrass
   heatCapacity: 10000
   weather: true
+  indestructible: true
 
 # Lava
 - type: tile
@@ -73,6 +77,7 @@
     collection: FootstepAsteroid
   heatCapacity: 10000
   weather: true
+  indestructible: true
 
 # Snow
 - type: tile
@@ -92,5 +97,6 @@
   friction: 0.20
   heatCapacity: 10000
   weather: true
+  indestructible: true
 
 # Wasteland


### PR DESCRIPTION
## About the PR
- adds Indestructible field to tile prototype
- gives all the planet tiles this (but not station grass)
- rcd refuses to deconstruct indestructible tiles (fixes #16112)

**Media**
![14:50:54](https://user-images.githubusercontent.com/39013340/236476758-f961f1eb-0820-480b-954b-48927a17b37d.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun