### PR TITLE
Add empty contents check for vape

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.Vape.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.Vape.cs
@@ -50,6 +50,14 @@ namespace Content.Server.Nutrition.EntitySystems
             || _foodSystem.IsMouthBlocked(args.Target.Value, args.User))
                 return;
 
+            if (solution.Contents.Count == 0)
+            {
+                _popupSystem.PopupEntity(
+                    Loc.GetString("vape-component-vape-empty"), args.Target.Value,
+                    args.User);
+                return;
+            }
+
             if (args.Target == args.User)
             {
                 delay = comp.UserDelay;

--- a/Resources/Locale/en-US/nutrition/components/vape-component.ftl
+++ b/Resources/Locale/en-US/nutrition/components/vape-component.ftl
@@ -4,3 +4,4 @@ vape-component-vape-success-user-forced = You successfully forced to puff {THE($
 vape-component-try-use-vape-forced = {CAPITALIZE(THE($user))} is trying to make you puff on the vape.
 vape-component-try-use-vape-forced-user = You are forcing {THE($target)} to puff on the vape.
 vape-component-try-use-vape = You are trying to puff on the vape.
+vape-component-vape-empty = The vape is empty!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

- Vape checks for if the contents are empty before continuing with doafter
- Fixes #16096 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: You can no longer puff empty vapes
