### PR TITLE
Fix redundant null check

### DIFF
--- a/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
+++ b/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
@@ -67,8 +67,7 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
 
         foreach (var pair in consoleRecords)
         {
-            if (console != null && console.Filter != null
-                && IsSkippedRecord(console.Filter, pair.Item2))
+            if (console.Filter != null && IsSkippedRecord(console.Filter, pair.Item2))
             {
                 continue;
             }


### PR DESCRIPTION
I think on .NET 8 this actually causes the analysis to show nullability errors down below.
