### PR TITLE
Makes unpowered flashlights emmagables.

### DIFF
--- a/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
+++ b/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
@@ -30,7 +30,7 @@ namespace Content.Server.Light.EntitySystems
             SubscribeLocalEvent<UnpoweredFlashlightComponent, GetItemActionsEvent>(OnGetActions);
             SubscribeLocalEvent<UnpoweredFlashlightComponent, ToggleActionEvent>(OnToggleAction);
             SubscribeLocalEvent<UnpoweredFlashlightComponent, MindAddedMessage>(OnMindAdded);
-            SubscribeLocalEvent<UnpoweredFlashlightComponent, GotEmaggedEvent>(OnGotEmmaged);
+            SubscribeLocalEvent<UnpoweredFlashlightComponent, GotEmaggedEvent>(OnGotEmagged);
         }
 
         private void OnToggleAction(EntityUid uid, UnpoweredFlashlightComponent component, ToggleActionEvent args)
@@ -69,12 +69,12 @@ namespace Content.Server.Light.EntitySystems
             _actionsSystem.AddAction(uid, component.ToggleAction, null);
         }
 
-        private void OnGotEmmaged(EntityUid uid, UnpoweredFlashlightComponent component, ref GotEmaggedEvent args)
+        private void OnGotEmagged(EntityUid uid, UnpoweredFlashlightComponent component, ref GotEmaggedEvent args)
         {
             if (!TryComp<PointLightComponent>(uid, out var light))
                 return;
 
-            if (_prototypeManager.TryIndex<ColorPalettePrototype>(component.EmmagedColorsPrototype, out var possibleColors))
+            if (_prototypeManager.TryIndex<ColorPalettePrototype>(component.EmaggedColorsPrototype, out var possibleColors))
             {
                 var pick = _random.Pick(possibleColors.Colors.Values);
                 light.Color = pick;

--- a/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
+++ b/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
@@ -1,22 +1,26 @@
-using Content.Server.Light.Components;
 using Content.Server.Light.Events;
 using Content.Server.Mind.Components;
 using Content.Shared.Actions;
+using Content.Shared.Decals;
+using Content.Shared.Emag.Systems;
 using Content.Shared.Light;
 using Content.Shared.Light.Component;
 using Content.Shared.Toggleable;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
-using Robust.Shared.Audio;
-using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Light.EntitySystems
 {
     public sealed class UnpoweredFlashlightSystem : EntitySystem
     {
+        [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
 
         public override void Initialize()
         {
@@ -26,6 +30,7 @@ namespace Content.Server.Light.EntitySystems
             SubscribeLocalEvent<UnpoweredFlashlightComponent, GetItemActionsEvent>(OnGetActions);
             SubscribeLocalEvent<UnpoweredFlashlightComponent, ToggleActionEvent>(OnToggleAction);
             SubscribeLocalEvent<UnpoweredFlashlightComponent, MindAddedMessage>(OnMindAdded);
+            SubscribeLocalEvent<UnpoweredFlashlightComponent, GotEmaggedEvent>(OnGotEmmaged);
         }
 
         private void OnToggleAction(EntityUid uid, UnpoweredFlashlightComponent component, ToggleActionEvent args)
@@ -48,11 +53,13 @@ namespace Content.Server.Light.EntitySystems
             if (!args.CanAccess || !args.CanInteract)
                 return;
 
-            ActivationVerb verb = new();
-            verb.Text = Loc.GetString("toggle-flashlight-verb-get-data-text");
-            verb.Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/light.svg.192dpi.png"));
-            verb.Act = () => ToggleLight(uid, component);
-            verb.Priority = -1; // For things like PDA's, Open-UI and other verbs that should be higher priority.
+            ActivationVerb verb = new()
+            {
+                Text = Loc.GetString("toggle-flashlight-verb-get-data-text"),
+                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/light.svg.192dpi.png")),
+                Act = () => ToggleLight(uid, component),
+                Priority = -1 // For things like PDA's, Open-UI and other verbs that should be higher priority.
+            };
 
             args.Verbs.Add(verb);
         }
@@ -61,20 +68,35 @@ namespace Content.Server.Light.EntitySystems
         {
             _actionsSystem.AddAction(uid, component.ToggleAction, null);
         }
+
+        private void OnGotEmmaged(EntityUid uid, UnpoweredFlashlightComponent component, ref GotEmaggedEvent args)
+        {
+            if (!TryComp<PointLightComponent>(uid, out var light))
+                return;
+
+            if (_prototypeManager.TryIndex<ColorPalettePrototype>(component.EmmagedColorsPrototype, out var possibleColors))
+            {
+                var pick = _random.Pick(possibleColors.Colors.Values);
+                light.Color = pick;
+            }
+
+            args.Repeatable = true;
+            args.Handled = true;
+        }
+
         public void ToggleLight(EntityUid uid, UnpoweredFlashlightComponent flashlight)
         {
-            if (!EntityManager.TryGetComponent(flashlight.Owner, out PointLightComponent? light))
+            if (!TryComp<PointLightComponent>(uid, out var light))
                 return;
 
             flashlight.LightOn = !flashlight.LightOn;
             light.Enabled = flashlight.LightOn;
 
-            if (EntityManager.TryGetComponent(flashlight.Owner, out AppearanceComponent? appearance))
-                _appearance.SetData(uid, UnpoweredFlashlightVisuals.LightOn, flashlight.LightOn, appearance);
+            _appearance.SetData(uid, UnpoweredFlashlightVisuals.LightOn, flashlight.LightOn);
 
-            SoundSystem.Play(flashlight.ToggleSound.GetSound(), Filter.Pvs(light.Owner), flashlight.Owner);
+            _audioSystem.PlayPvs(flashlight.ToggleSound, uid);
 
-            RaiseLocalEvent(flashlight.Owner, new LightToggleEvent(flashlight.LightOn), true);
+            RaiseLocalEvent(uid, new LightToggleEvent(flashlight.LightOn), true);
             _actionsSystem.SetToggled(flashlight.ToggleAction, flashlight.LightOn);
         }
     }

--- a/Content.Shared/Light/Component/UnpoweredFlashlightComponent.cs
+++ b/Content.Shared/Light/Component/UnpoweredFlashlightComponent.cs
@@ -21,9 +21,9 @@ public sealed class UnpoweredFlashlightComponent : Robust.Shared.GameObjects.Com
 
     /// <summary>
     ///  <see cref="ColorPalettePrototype"/> ID that determines the list
-    /// of colors to select from when we get emmaged
+    /// of colors to select from when we get emagged
     /// </summary>
-    [DataField("emmagedColorsPrototype")]
+    [DataField("emaggedColorsPrototype")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public string EmmagedColorsPrototype = "Emmaged";
+    public string EmaggedColorsPrototype = "Emagged";
 }

--- a/Content.Shared/Light/Component/UnpoweredFlashlightComponent.cs
+++ b/Content.Shared/Light/Component/UnpoweredFlashlightComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Actions.ActionTypes;
+using Content.Shared.Decals;
 using Robust.Shared.Audio;
 
 namespace Content.Shared.Light.Component;
@@ -17,4 +18,12 @@ public sealed class UnpoweredFlashlightComponent : Robust.Shared.GameObjects.Com
 
     [DataField("toggleAction", required: true)]
     public InstantAction ToggleAction = new();
+
+    /// <summary>
+    ///  <see cref="ColorPalettePrototype"/> ID that determines the list
+    /// of colors to select from when we get emmaged
+    /// </summary>
+    [DataField("emmagedColorsPrototype")]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public string EmmagedColorsPrototype = "Emmaged";
 }

--- a/Resources/Prototypes/Palettes/emagged.yml
+++ b/Resources/Prototypes/Palettes/emagged.yml
@@ -1,0 +1,11 @@
+﻿- type: palette
+  id: Emagged
+  name: Emagged
+  colors:
+    red: "#FF0000"
+    orange: "#FFA500"
+    yellow: "#FFFF00"
+    lime: "#32CD32"
+    bright_blue: "#0096FF"
+    cyan: "#00FFFF"
+    purple: "#A020F0"

--- a/Resources/Prototypes/Palettes/emmaged.yml
+++ b/Resources/Prototypes/Palettes/emmaged.yml
@@ -1,0 +1,5 @@
+﻿- type: palette
+  id: Emmaged
+  name: Emmaged
+  colors:
+    red: "#FF0000FF"

--- a/Resources/Prototypes/Palettes/emmaged.yml
+++ b/Resources/Prototypes/Palettes/emmaged.yml
@@ -1,5 +1,0 @@
-﻿- type: palette
-  id: Emmaged
-  name: Emmaged
-  colors:
-    red: "#FF0000FF"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Right now it only changes the color to a list of em

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


https://user-images.githubusercontent.com/60196617/236655911-e42eacda-9ec6-49ba-b7a4-32c8434e6242.mp4

**Changelog**

:cl:
- tweak: You can now emag PDA and vehicles to change the color of the light 
