### PR TITLE
Fix UninitializedSaveTest prototypes

### DIFF
--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -43,15 +43,11 @@ public sealed class PrototypeSaveTest
         // These should NOT be added to.
         // 99% of these are going to be changing the physics bodytype (where the entity is anchored)
         // or some ambientsound change.
-        "PlasticFlapsOpaque",
-        "PlasticFlapsAirtightClear",
         "BoxingBell",
-        "PlasticFlapsClear",
         "ClothingBackpackChameleon",
         "ClothingBackpackChameleonFill",
         "AMEControllerUnanchored",
         "NuclearBomb",
-        "PlasticFlapsAirtightOpaque",
         "MachineFrameDestroyed",
         "VehicleJanicartDestroyed",
         "Gyroscope",

--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -38,23 +38,6 @@ public sealed class PrototypeSaveTest
     {
         "Singularity", // physics collision uses "AllMask" (-1). The flag serializer currently fails to save this because this features un-named bits.
         "constructionghost",
-
-        // These ones are from the serialization change to alwayswrite.
-        // These should NOT be added to.
-        // 99% of these are going to be changing the physics bodytype (where the entity is anchored)
-        // or some ambientsound change.
-        "BoxingBell",
-        "ClothingBackpackChameleon",
-        "ClothingBackpackChameleonFill",
-        "AMEControllerUnanchored",
-        "NuclearBomb",
-        "MachineFrameDestroyed",
-        "VehicleJanicartDestroyed",
-        "Gyroscope",
-        "Thruster",
-        "SurveillanceWirelessCameraAnchoredEntertainment",
-        "SurveillanceWirelessCameraAnchoredConstructed",
-
     };
 
     [Test]

--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -168,7 +168,7 @@ public sealed class PrototypeSaveTest
                 foreach (var prototype in prototypes)
                 {
                     uid = entityMan.SpawnEntity(prototype.ID, testLocation);
-                    context.Prototype = prototype.ID;
+                    context.Prototype = prototype;
 
                     // get default prototype data
                     Dictionary<string, MappingDataNode> protoData = new();
@@ -205,6 +205,7 @@ public sealed class PrototypeSaveTest
                         MappingDataNode compMapping;
                         try
                         {
+                            context.WritingComponent = compName;
                             compMapping = seriMan.WriteValueAs<MappingDataNode>(compType, component, alwaysWrite: true, context: context);
                         }
                         catch (Exception e)
@@ -250,7 +251,7 @@ public sealed class PrototypeSaveTest
         public bool WritingReadingPrototypes { get; set; }
 
         public string WritingComponent = string.Empty;
-        public string Prototype = string.Empty;
+        public EntityPrototype Prototype = default!;
 
         public TestEntityUidContext()
         {
@@ -268,11 +269,12 @@ public sealed class PrototypeSaveTest
             IDependencyCollection dependencies, bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
-            if (WritingComponent != "Transform")
+            if (WritingComponent != "Transform" && !Prototype.NoSpawn)
             {
                 // Maybe this will be necessary in the future, but at the moment it just indicates that there is some
-                // issue, like a non-nullable entityUid data-field.
-                Assert.Fail($"Uninitialized entities should not be saving entity Uids. Component: {WritingComponent}. Prototype: {Prototype}");
+                // issue, like a non-nullable entityUid data-field. If a component MUST have an entity uid to work with,
+                // then the prototype very likely has to be a no-spawn entity that is never meant to be directly spawned.
+                Assert.Fail($"Uninitialized entities should not be saving entity Uids. Component: {WritingComponent}. Prototype: {Prototype.ID}");
             }
 
             return new ValueDataNode(value.ToString());

--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -168,6 +168,7 @@ public sealed class PrototypeSaveTest
                 foreach (var prototype in prototypes)
                 {
                     uid = entityMan.SpawnEntity(prototype.ID, testLocation);
+                    context.Prototype = prototype.ID;
 
                     // get default prototype data
                     Dictionary<string, MappingDataNode> protoData = new();
@@ -177,9 +178,11 @@ public sealed class PrototypeSaveTest
 
                         foreach (var (compType, comp) in prototype.Components)
                         {
+                            context.WritingComponent = compType;
                             protoData.Add(compType, seriMan.WriteValueAs<MappingDataNode>(comp.Component.GetType(), comp.Component, alwaysWrite: true, context: context));
                         }
 
+                        context.WritingComponent = string.Empty;
                         context.WritingReadingPrototypes = false;
                     }
                     catch (Exception e)
@@ -246,6 +249,9 @@ public sealed class PrototypeSaveTest
         public SerializationManager.SerializerProvider SerializerProvider { get; }
         public bool WritingReadingPrototypes { get; set; }
 
+        public string WritingComponent = string.Empty;
+        public string Prototype = string.Empty;
+
         public TestEntityUidContext()
         {
             SerializerProvider = new();
@@ -262,6 +268,13 @@ public sealed class PrototypeSaveTest
             IDependencyCollection dependencies, bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
+            if (WritingComponent != "Transform")
+            {
+                // Maybe this will be necessary in the future, but at the moment it just indicates that there is some
+                // issue, like a non-nullable entityUid data-field.
+                Assert.Fail($"Uninitialized entities should not be saving entity Uids. Component: {WritingComponent}. Prototype: {Prototype}");
+            }
+
             return new ValueDataNode(value.ToString());
         }
 

--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -43,25 +43,20 @@ public sealed class PrototypeSaveTest
         // These should NOT be added to.
         // 99% of these are going to be changing the physics bodytype (where the entity is anchored)
         // or some ambientsound change.
-        "ComfyChair",
         "PlasticFlapsOpaque",
         "PlasticFlapsAirtightClear",
-        "SurveillanceWirelessCameraAnchoredEntertainment",
-        "Chair",
-        "Thruster",
         "BoxingBell",
         "PlasticFlapsClear",
         "ClothingBackpackChameleon",
+        "ClothingBackpackChameleonFill",
         "AMEControllerUnanchored",
         "NuclearBomb",
         "PlasticFlapsAirtightOpaque",
-        "ToiletDirtyWater",
         "MachineFrameDestroyed",
-        "ChairPilotSeat",
         "VehicleJanicartDestroyed",
         "Gyroscope",
-        "ToiletEmpty",
-        "ClothingBackpackChameleonFill",
+        "Thruster",
+        "SurveillanceWirelessCameraAnchoredEntertainment",
         "SurveillanceWirelessCameraAnchoredConstructed",
 
     };

--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -43,57 +43,25 @@ public sealed class PrototypeSaveTest
         // These should NOT be added to.
         // 99% of these are going to be changing the physics bodytype (where the entity is anchored)
         // or some ambientsound change.
-        "GasVentScrubber",
-        "GasPassiveVent",
-        "CableHV",
-        "ParticleAcceleratorFuelChamberUnfinished",
         "ComfyChair",
         "PlasticFlapsOpaque",
-        "ParticleAcceleratorEmitterRightUnfinished",
         "PlasticFlapsAirtightClear",
-        "SignalControlledValve",
-        "SignalControlledValve",
-        "GasPipeTJunction",
-        "GasFilter",
-        "GasOutletInjector",
-        "GasPressurePump",
         "SurveillanceWirelessCameraAnchoredEntertainment",
-        "GasPort",
         "Chair",
-        "GasMixer",
-        "ParticleAcceleratorPowerBoxUnfinished",
-        "GasValve",
         "Thruster",
         "BoxingBell",
-        "CableApcExtension",
         "PlasticFlapsClear",
         "ClothingBackpackChameleon",
         "AMEControllerUnanchored",
-        "GasPipeFourway",
         "NuclearBomb",
         "PlasticFlapsAirtightOpaque",
-        "ParticleAcceleratorControlBoxUnfinished",
-        "GasPipeHalf",
-        "GasVolumePump",
-        "ParticleAcceleratorEmitterLeftUnfinished",
-        "GasMixerFlipped",
         "ToiletDirtyWater",
-        "GasPipeBend",
-        "ParticleAcceleratorEndCapUnfinished",
-        "GasPipeStraight",
         "MachineFrameDestroyed",
         "ChairPilotSeat",
         "VehicleJanicartDestroyed",
         "Gyroscope",
-        "ParticleAcceleratorEmitterCenterUnfinished",
         "ToiletEmpty",
-        "GasPassiveGate",
-        "CableMV",
         "ClothingBackpackChameleonFill",
-        "GasDualPortVentPump",
-        "GasVentPump",
-        "PressureControlledValve",
-        "GasFilterFlipped",
         "SurveillanceWirelessCameraAnchoredConstructed",
 
     };
@@ -127,7 +95,7 @@ public sealed class PrototypeSaveTest
 
             grid = mapManager.CreateGrid(mapId);
 
-            var tileDefinition = tileDefinitionManager["UnderPlating"];
+            var tileDefinition = tileDefinitionManager["FloorSteel"]; // Wires n such disable ambiance while under the floor
             var tile = new Tile(tileDefinition.TileId);
             var coordinates = grid.ToCoordinates();
 

--- a/Content.Server/Dragon/Components/DragonRiftComponent.cs
+++ b/Content.Server/Dragon/Components/DragonRiftComponent.cs
@@ -10,7 +10,7 @@ public sealed class DragonRiftComponent : SharedDragonRiftComponent
     /// <summary>
     /// Dragon that spawned this rift.
     /// </summary>
-    [DataField("dragon")] public EntityUid Dragon;
+    [DataField("dragon")] public EntityUid? Dragon;
 
     /// <summary>
     /// How long the rift has been active.

--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -210,8 +210,8 @@ namespace Content.Server.Dragon
 
                 // We can't predict the rift being destroyed anyway so no point adding weakened to shared.
                 dragon.WeakenedAccumulator = dragon.WeakenedDuration;
-                _movement.RefreshMovementSpeedModifiers(component.Dragon);
-                _popupSystem.PopupEntity(Loc.GetString("carp-rift-destroyed"), component.Dragon, component.Dragon);
+                _movement.RefreshMovementSpeedModifiers(component.Dragon.Value);
+                _popupSystem.PopupEntity(Loc.GetString("carp-rift-destroyed"), component.Dragon.Value, component.Dragon.Value);
             }
         }
 

--- a/Content.Server/Lightning/LightningSystem.cs
+++ b/Content.Server/Lightning/LightningSystem.cs
@@ -37,28 +37,28 @@ public sealed class LightningSystem : SharedLightningSystem
 
     private void OnCollide(EntityUid uid, LightningComponent component, ref StartCollideEvent args)
     {
-        if (!TryComp<BeamComponent>(uid, out var lightningBeam) || !TryComp<BeamComponent>(lightningBeam.VirtualBeamController, out var beamController))
-        {
+        if (!TryComp<BeamComponent>(uid, out var lightningBeam)
+            || !TryComp<BeamComponent>(lightningBeam.VirtualBeamController, out var beamController))
             return;
-        }
 
-        if (component.CanArc)
-        {
-            while (beamController.CreatedBeams.Count < component.MaxTotalArcs)
-            {
-                Arc(component, args.OtherFixture.Body.Owner, lightningBeam.VirtualBeamController.Value);
+        if (!component.CanArc && beamController.CreatedBeams.Count < component.MaxTotalArcs)
+            return;
 
-                var spriteState = LightningRandomizer();
+        Arc(component, args.OtherEntity, lightningBeam.VirtualBeamController.Value);
 
-                component.ArcTargets.Add(args.OtherFixture.Body.Owner);
-                component.ArcTargets.Add(component.ArcTarget);
+        if (component.ArcTarget == null)
+            return;
 
-                _beam.TryCreateBeam(args.OtherFixture.Body.Owner, component.ArcTarget, component.LightningPrototype, spriteState, controller: lightningBeam.VirtualBeamController.Value);
+        var spriteState = LightningRandomizer();
+        component.ArcTargets.Add(args.OtherEntity);
+        component.ArcTargets.Add(component.ArcTarget.Value);
 
-                //Break from this loop so other created bolts can collide and arc
-                break;
-            }
-        }
+        _beam.TryCreateBeam(
+            args.OtherEntity,
+            component.ArcTarget.Value,
+            component.LightningPrototype,
+            spriteState,
+            controller: lightningBeam.VirtualBeamController.Value);
     }
 
     /// <summary>

--- a/Content.Shared/Lightning/Components/SharedLightningComponent.cs
+++ b/Content.Shared/Lightning/Components/SharedLightningComponent.cs
@@ -34,7 +34,7 @@ public abstract class SharedLightningComponent : Component
     /// The target that the lightning will Arc to.
     /// </summary>
     [DataField("arcTarget")]
-    public EntityUid ArcTarget;
+    public EntityUid? ArcTarget;
 
     /// <summary>
     /// How far should this lightning go?

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -9,9 +9,6 @@
       tags: [] # ignore "WhitelistChameleon" tag
     - type: Sprite
       sprite: Clothing/Back/Backpacks/backpack.rsi
-      netsync: false
-    - type: Clothing
-      sprite: Clothing/Back/Backpacks/backpack.rsi
     - type: ChameleonClothing
       slot: [back]
       default: ClothingBackpack

--- a/Resources/Prototypes/Entities/Effects/lightning.yml
+++ b/Resources/Prototypes/Entities/Effects/lightning.yml
@@ -34,6 +34,7 @@
   name: lightning
   id: Lightning
   parent: BaseLightning
+  noSpawn: true
   components:
     - type: Lightning
       canArc: true
@@ -42,6 +43,7 @@
   name: spooky lightning
   id: LightningRevenant
   parent: BaseLightning
+  noSpawn: true
   components:
     - type: Sprite
       sprite: /Textures/Effects/lightning.rsi
@@ -65,6 +67,7 @@
   name: charged lightning
   id: ChargedLightning
   parent: BaseLightning
+  noSpawn: true
   components:
     - type: Sprite
       sprite: /Textures/Effects/lightning.rsi
@@ -83,6 +86,7 @@
   name: supercharged lightning
   id: SuperchargedLightning
   parent: ChargedLightning
+  noSpawn: true
   components:
     - type: Sprite
       sprite: /Textures/Effects/lightning.rsi
@@ -108,6 +112,7 @@
   name: hypercharged lightning
   id: HyperchargedLightning
   parent: ChargedLightning
+  noSpawn: true
   components:
     - type: Sprite
       sprite: /Textures/Effects/lightning.rsi

--- a/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
@@ -12,7 +12,7 @@
     noRot: true
     state: nuclearbomb_base
   - type: Physics
-    bodyType: Dynamic
+    bodyType: Static
   - type: Fixtures
     fixtures:
     - shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -56,6 +56,8 @@
   components:
   - type: Transform
     anchored: true
+  - type: Physics
+    bodyType: Static
   - type: Anchorable
   - type: Rotatable
   - type: Sprite
@@ -127,6 +129,8 @@
   components:
   - type: Transform
     anchored: true
+  - type: Physics
+    bodyType: Static
   - type: Anchorable
   - type: Rotatable
   - type: Sprite
@@ -143,6 +147,8 @@
   components:
   - type: Transform
     anchored: true
+  - type: Physics
+    bodyType: Static
   - type: Anchorable
   - type: Rotatable
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -27,6 +27,8 @@
         maxVol: 250
   - type: Transform
     anchored: true
+  - type: Physics
+    bodyType: Static
   - type: Construction
     graph: Toilet
     node: toilet

--- a/Resources/Prototypes/Entities/Structures/Machines/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/frame.yml
@@ -122,6 +122,8 @@
     - type: Transform
       anchored: true
       noRot: true
+    - type: Physics
+      bodyType: Static
     - type: Construction
       graph: Machine
       node: destroyedMachineFrame

--- a/Resources/Prototypes/Entities/Structures/Machines/wireless_surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/wireless_surveillance_camera.yml
@@ -48,6 +48,8 @@
     - type: Anchorable
     - type: Transform
       anchored: true
+    - type: Physics
+      bodyType: Static
     - type: Sprite
       noRot: true
       sprite: Structures/monitors.rsi

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -175,7 +175,7 @@
       graph: GasBinary
       node: valve
     - type: AmbientSound
-      enabled: false
+      enabled: true
       volume: -9
       range: 5
       sound:
@@ -229,7 +229,7 @@
     graph: GasBinary
     node: signalvalve
   - type: AmbientSound
-    enabled: false
+    enabled: true
     volume: -9
     range: 5
     sound:
@@ -313,6 +313,8 @@
           !type:PipeNode
           nodeGroupID: Pipe
           pipeDirection: South
+    - type: AmbientSound
+      enabled: true
 
 - type: entity
   parent: [ BaseMachine, ConstructibleMachine ]
@@ -355,7 +357,7 @@
   - type: AtmosDevice
   - type: AtmosPipeColor
   - type: AmbientSound
-    enabled: false
+    enabled: true
     volume: -9
     range: 5
     sound:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -42,6 +42,7 @@
     - Pipe
   - type: Physics
     canCollide: false
+    bodyType: static
   - type: AmbientSound
     enabled: false
     volume: -15

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -79,7 +79,7 @@
       node: ventpump
     - type: VentCritterSpawnLocation
     - type: AmbientSound
-      enabled: false
+      enabled: true
       volume: -12
       range: 5
       sound:
@@ -171,7 +171,7 @@
       graph: GasUnary
       node: ventscrubber
     - type: AmbientSound
-      enabled: false
+      enabled: true
       volume: -12
       range: 5
       sound:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -45,8 +45,6 @@
   suffix: Unfinished
   description: This controls the density of the particles. It looks unfinished.
   components:
-    - type: Physics
-      bodyType: Dynamic
     - type: Sprite
       sprite: Structures/Power/Generation/PA/control_box.rsi
     - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/emitter.yml
@@ -46,8 +46,6 @@
   suffix: Unfinished, Left
   description: This launchs the Alpha particles, might not want to stand near this end. It looks unfinished.
   components:
-    - type: Physics
-      bodyType: Dynamic
     - type: Sprite
       sprite: Structures/Power/Generation/PA/emitter_left.rsi
     - type: Construction
@@ -60,8 +58,6 @@
   suffix: Unfinished
   description: This launchs the Alpha particles, might not want to stand near this end. It looks unfinished.
   components:
-    - type: Physics
-      bodyType: Dynamic
     - type: Sprite
       sprite: Structures/Power/Generation/PA/emitter_center.rsi
     - type: Construction
@@ -74,8 +70,6 @@
   suffix: Unfinished
   description: This launchs the Alpha particles, might not want to stand near this end. It looks unfinished.
   components:
-    - type: Physics
-      bodyType: Dynamic
     - type: Sprite
       sprite: Structures/Power/Generation/PA/emitter_right.rsi
     - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/end_cap.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/end_cap.yml
@@ -22,8 +22,6 @@
   suffix: Unfinished
   description: Formally known as the Alpha Particle Generation Array. This is where Alpha particles are generated from [REDACTED]. It looks unfinished.
   components:
-    - type: Physics
-      bodyType: Dynamic
     - type: Sprite
       sprite: Structures/Power/Generation/PA/end_cap.rsi
     - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/fuel_chamber.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/fuel_chamber.yml
@@ -19,8 +19,6 @@
   suffix: Unfinished
   description: Formally known as the EM Acceleration Chamber. This is where the Alpha particles are accelerated to radical speeds. It looks unfinished.
   components:
-    - type: Physics
-      bodyType: Dynamic
     - type: Sprite
       sprite: Structures/Power/Generation/PA/fuel_chamber.rsi
     - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/power_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/power_box.yml
@@ -25,8 +25,6 @@
   suffix: Unfinished
   description: Formally known as the Particle Focusing EM Lens. This uses electromagnetic waves to focus the Alpha-Particles. It looks unfinished.
   components:
-    - type: Physics
-      bodyType: Dynamic
     - type: Sprite
       sprite: Structures/Power/Generation/PA/power_box.rsi
     - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
@@ -82,6 +82,8 @@
   id: AMEControllerUnanchored
   suffix: Unanchored
   components:
+  - type: Transform
+    anchored: false
   - type: Physics
     bodyType: Dynamic
 

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -11,6 +11,9 @@
   - type: Transform
     anchored: true
     noRot: true
+  - type: Physics
+    bodyType: Static
+    canCollide: false
   - type: Sprite
     netsync: false
     drawdepth: ThinWire

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -11,6 +11,8 @@
         path: /Audio/Effects/shuttle_thruster.ogg
     - type: Transform
       anchored: true
+    - type: Physics
+      bodyType: Static
     - type: Rotatable
       rotateWhileAnchored: true
     - type: Thruster

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/bell.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/bell.yml
@@ -30,7 +30,7 @@
     enabled: false
   - type: Physics
     canCollide: false
-    bodyType: Dynamic
+    bodyType: Static
   - type: Fixtures
   - type: Damageable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -13,6 +13,7 @@
     state: plasticflaps
     drawdepth: Mobs
   - type: Physics
+    bodyType: Static
   - type: Transform
     anchored: true
   - type: Fixtures


### PR DESCRIPTION
Fixes #15940 and re-adds a check for whether uninitialized entities are writing references to other entities while serializing. 

Note that I haven't actually tested most of these changes in game, I just changed the prototypes until the test was happy, but AFAIK this shouldn't cause any issues seeing as the entities were being modified on spawn anyways.