### PR TITLE
Fix invalid followers being saved in maps

### DIFF
--- a/Content.Server/Maps/MapMigrationSystem.cs
+++ b/Content.Server/Maps/MapMigrationSystem.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Robust.Server.GameObjects;
 using Robust.Server.Maps;
 using Robust.Shared.ContentPack;
+using Robust.Shared.Map.Events;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Verbs;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Events;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Follower;
@@ -20,6 +21,25 @@ public sealed class FollowerSystem : EntitySystem
         SubscribeLocalEvent<GetVerbsEvent<AlternativeVerb>>(OnGetAlternativeVerbs);
         SubscribeLocalEvent<FollowerComponent, MoveInputEvent>(OnFollowerMove);
         SubscribeLocalEvent<FollowedComponent, EntityTerminatingEvent>(OnFollowedTerminating);
+        SubscribeLocalEvent<BeforeSaveEvent>(OnBeforeSave);
+    }
+
+    private void OnBeforeSave(BeforeSaveEvent ev)
+    {
+        // Some followers will not be map savable. This ensures that maps don't get saved with empty/invalid
+        // followers, but just stopping any following on the map being saved.
+
+        var query = AllEntityQuery<FollowerComponent, TransformComponent, MetaDataComponent>();
+        while (query.MoveNext(out var uid, out var follower, out var xform, out var meta))
+        {
+            if (meta.EntityPrototype == null || meta.EntityPrototype.MapSavable)
+                continue;
+
+            if (xform.MapUid != ev.Map)
+                continue;
+
+            StopFollowingEntity(uid, follower.Following);
+        }
     }
 
     private void OnGetAlternativeVerbs(GetVerbsEvent<AlternativeVerb> ev)


### PR DESCRIPTION
Currently a ghost following something while a map gets saved will lead to the `FollowedComponent` being saved with an invalid entity uid, as ghosts don't get saved. This just makes it so that all non-saveable entities stop following on a map before an entity on that map gets saved.

Requires space-wizards/RobustToolbox/pull/4005
