### PR TITLE
Reducing the size of new combat mode indicators

### DIFF
--- a/Content.Client/CombatMode/CombatModeIndicatorsOverlay.cs
+++ b/Content.Client/CombatMode/CombatModeIndicatorsOverlay.cs
@@ -30,7 +30,7 @@ public sealed class CombatModeIndicatorsOverlay : Overlay
 
     public Color MainColor = Color.White.WithAlpha(0.3f);
     public Color StrokeColor = Color.Black.WithAlpha(0.5f);
-    public float Scale = 0.8f;  // 1 is a little big
+    public float Scale = 0.6f;  // 1 is a little big
 
     public CombatModeIndicatorsOverlay(IInputManager input, IEntityManager entMan,
             IEyeManager eye, CombatModeSystem combatSys, HandsSystem hands)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
The reviews asked me to make it smaller. I changed the parameter of scale for it from 0.8 to 0.6. It is a very simple pull request.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

The indicators with new size
![image](https://user-images.githubusercontent.com/2144635/236632991-044ea210-6b81-4e34-a9d4-5f7ed3024644.png)
The melee indicator

![image](https://user-images.githubusercontent.com/2144635/236633029-97dcde43-caf0-417e-a405-754d2100eb6c.png)
The gun indicator

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Changed size for additional combat mode indicators.