### PR TITLE
Make guidebook start with some entries collapsed

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
@@ -9,7 +9,7 @@
     <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Split">
         <!-- Guide select -->
         <BoxContainer Orientation="Horizontal" Name="TreeBox">
-            <fancyTree:FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True"/>
+            <fancyTree:FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>
             <cc:VSeparator StyleClasses="LowDivider" Margin="0 -2"/>
         </BoxContainer>
         <ScrollContainer Name="Scroll" HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True">

--- a/Content.Client/UserInterface/Controls/FancyTree/FancyTree.xaml.cs
+++ b/Content.Client/UserInterface/Controls/FancyTree/FancyTree.xaml.cs
@@ -176,20 +176,30 @@ public sealed partial class FancyTree : Control
         OnSelectedItemChanged?.Invoke(newSelection);
     }
 
-    public void SetAllExpanded(bool value)
+    /// <summary>
+    ///     Recursively expands or collapse all entries, optionally up to some depth.
+    /// </summary>
+    /// <param name="value">Whether to expand or collapse the entries</param>
+    /// <param name="depth">The recursion depth. If negative, implies no limit. Zero will expand only the top-level entries.</param>
+    public void SetAllExpanded(bool value, int depth = -1)
     {
         foreach (var item in Body.Children)
         {
-            RecursiveSetExpanded((TreeItem) item, value);
+            RecursiveSetExpanded((TreeItem) item, value, depth);
         }
     }
 
-    public void RecursiveSetExpanded(TreeItem item, bool value)
+    public void RecursiveSetExpanded(TreeItem item, bool value, int depth)
     {
         item.SetExpanded(value);
+
+        if (depth == 0)
+            return;
+        depth--;
+        
         foreach (var child in item.Body.Children)
         {
-            RecursiveSetExpanded((TreeItem) child, value);
+            RecursiveSetExpanded((TreeItem) child, value, depth);
         }
     }
 

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -116,7 +116,7 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
     }
 
     /// <summary>
-    ///     Opens the guidebook.
+    ///     Opens or closes the guidebook.
     /// </summary>
     /// <param name="guides">What guides should be shown. If not specified, this will instead list all the entries</param>
     /// <param name="rootEntries">A list of guides that should form the base of the table of contents. If not specified,
@@ -162,6 +162,11 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         }
 
         _guideWindow.UpdateGuides(guides, rootEntries, forceRoot, selected);
+
+        // Expand up to depth-2.
+        _guideWindow.Tree.SetAllExpanded(false);
+        _guideWindow.Tree.SetAllExpanded(true, 1);
+
         _guideWindow.OpenCenteredRight();
     }
 


### PR DESCRIPTION
Now it only expands doubly nested entries. IMO, this makes the guidebook slightly less cluttered/busy and probably less overwhelming for new players.

Before:
![Content Client_vcbJdNJfK0](https://user-images.githubusercontent.com/60421075/236640754-9913cb18-c50d-410e-9c89-ba59a340e5dd.png)

After:
![Content Client_s11yQW4Hi2](https://user-images.githubusercontent.com/60421075/236640757-6cc18078-2bd5-4b89-b9c6-84f70ca6a69d.png)
