### PR TITLE
Crew monitoring server board

### DIFF
--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -186,6 +186,7 @@
   - ChemMasterMachineCircuitboard
   - ChemDispenserMachineCircuitboard
   - CrewMonitoringComputerCircuitboard
+  - CrewMonitoringServerMachineCircuitboard
   - HandheldCrewMonitor
   - BiomassReclaimerMachineCircuitboard
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -341,6 +341,7 @@
       - BoozeDispenserMachineCircuitboard
       - SodaDispenserMachineCircuitboard
       - TelecomServerCircuitboard
+      - CrewMonitoringServerMachineCircuitboard
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -586,3 +586,11 @@
   materials:
      Steel: 100
      Glass: 900
+
+- type: latheRecipe
+  id: CrewMonitoringServerMachineCircuitboard
+  result: CrewMonitoringServerMachineCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 900


### PR DESCRIPTION
## About the PR

Now if the crew monitoring server is destroyed or unavailable, the RND will be able to build it.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: Nimfar11

- add: Adds the ability to research and print the crew monitoring server board.
