### PR TITLE
Don't draw handitem offscreen

### DIFF
--- a/Content.Client/Hands/ShowHandItemOverlay.cs
+++ b/Content.Client/Hands/ShowHandItemOverlay.cs
@@ -6,6 +6,7 @@ using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
+using Robust.Shared.Map;
 
 namespace Content.Client.Hands
 {
@@ -44,18 +45,28 @@ namespace Content.Client.Hands
             _renderBackbuffer.Dispose();
         }
 
-        protected override void Draw(in OverlayDrawArgs args)
+        protected override bool BeforeDraw(in OverlayDrawArgs args)
         {
             if (!_cfg.GetCVar(CCVars.HudHeldItemShow))
+                return false;
+
+            return base.BeforeDraw(in args);
+        }
+
+        protected override void Draw(in OverlayDrawArgs args)
+        {
+            var mousePos = _inputManager.MouseScreenPosition;
+
+            // Offscreen
+            if (mousePos.Window == WindowId.Invalid)
                 return;
 
             var screen = args.ScreenHandle;
             var offset = _cfg.GetCVar(CCVars.HudHeldItemOffset);
-            var mousePos = _inputManager.MouseScreenPosition.Position;
 
             if (IconOverride != null)
             {
-                screen.DrawTexture(IconOverride, mousePos - IconOverride.Size / 2 + offset, Color.White.WithAlpha(0.75f));
+                screen.DrawTexture(IconOverride, mousePos.Position - IconOverride.Size / 2 + offset, Color.White.WithAlpha(0.75f));
                 return;
             }
 
@@ -73,7 +84,7 @@ namespace Content.Client.Hands
                 screen.DrawEntity(handEntity.Value, halfSize, new Vector2(1f, 1f) * uiScale, Angle.Zero, Angle.Zero, Direction.South, sprite);
             }, Color.Transparent);
 
-            screen.DrawTexture(_renderBackbuffer.Texture, mousePos - halfSize + offset, Color.White.WithAlpha(0.75f));
+            screen.DrawTexture(_renderBackbuffer.Texture, mousePos.Position - halfSize + offset, Color.White.WithAlpha(0.75f));
         }
     }
 }


### PR DESCRIPTION
:cl:
- fix: Cursor item overlay no longer draws in the top-left when cursor offscreen.