### PR TITLE
Bring back brigmedic 💙

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -30,6 +30,16 @@
 
 - type: entity
   noSpawn: true
+  parent: ClothingBackpackBrigmedic
+  id: ClothingBackpackBrigmedicFilled
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxSurvivalBrigmedic
+      - id: Flash
+
+- type: entity
+  noSpawn: true
   parent: ClothingBackpackMedical
   id: ClothingBackpackMedicalFilled
   components:

--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -460,6 +460,8 @@
   parent: SpawnPointJobBase
   name: brigmedic
   components:
+  - type: SpawnPoint
+    job_id: Brigmedic
   - type: Sprite
     layers:
       - state: green

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -159,7 +159,7 @@
     - state: idmedicaldoctor
   - type: PresetIdCard
     job: MedicalDoctor
-
+ 
 - type: entity
   parent: IDCardStandard
   id: ParamedicIDCard
@@ -419,6 +419,8 @@
     layers:
     - state: default
     - state: idbrigmedic
+  - type: PresetIdCard
+    job: Brigmedic
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -48,4 +48,5 @@
         Reporter: [ 2, 2 ]
         Detective: [ 1, 1 ]
         ResearchAssistant: [ 2, 2 ]
+        Brigmedic: [ 1, 1 ]
         Paramedic: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -6,7 +6,7 @@
   stations:
     Boxstation:
       mapNameTemplate: '{0} Box Station {1}'
-      emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
+      emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml      
       nameGenerator:
         !type:NanotrasenNameGenerator
         prefixCreator: 'TG'
@@ -46,4 +46,5 @@
         SecurityCadet: [ 4, 4 ]
         Detective: [ 1, 1 ]
         ResearchAssistant: [ 4, 4 ]
+        Brigmedic: [ 1, 1 ]
         Paramedic: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -46,3 +46,4 @@
         SecurityCadet: [ 1, 1 ]
         SalvageSpecialist: [ 2, 2 ]
         Quartermaster: [ 1, 1 ]
+        Brigmedic: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -46,4 +46,5 @@
         SecurityCadet: [ 2, 2 ]
         Detective: [ 1, 1 ]
         ResearchAssistant: [ 3, 3 ]
+        Brigmedic: [ 1, 1 ]
         Paramedic: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/kettle.yml
+++ b/Resources/Prototypes/Maps/kettle.yml
@@ -46,4 +46,5 @@
         ServiceWorker: [ 4, 4 ]
         SecurityCadet: [ 4, 4 ]
         Detective: [ 1, 1 ]
+        Brigmedic: [ 1, 1 ]
         Zookeeper: [1, 1]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -46,4 +46,5 @@
         SecurityCadet: [ 4, 4 ]
         Detective: [ 1, 1 ]
         ResearchAssistant: [ 4, 4 ]
+        Brigmedic: [ 1, 1 ]
         Paramedic: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/origin.yml
+++ b/Resources/Prototypes/Maps/origin.yml
@@ -46,5 +46,6 @@
         SecurityCadet: [ 3, 3 ]
         Detective: [ 1, 1 ]
         ResearchAssistant: [ 2, 2]
+        Brigmedic: [ 1, 1]
         Boxer: [ 1, 1]
         Paramedic: [ 1, 1]

--- a/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
@@ -1,0 +1,40 @@
+- type: job
+  id: Brigmedic
+  name: job-name-brigmedic
+  description: job-description-brigmedic
+  playTimeTracker: JobBrigmedic
+  requirements:
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 18000
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 7200
+  startingGear: BrigmedicGear
+  icon: "Brigmedic"
+  supervisors: job-supervisors-hos
+  canBeAntag: false
+  access:
+  - Medical
+  - Security
+  - Brig
+  - Maintenance
+  - External
+
+- type: startingGear
+  id: BrigmedicGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitBrigmedic
+    outerClothing: ClothingOuterCoatAMG
+    back: ClothingBackpackBrigmedicFilled
+    shoes: ClothingShoesColorRed
+    gloves: ClothingHandsGlovesNitrile
+    eyes: ClothingEyesHudMedical
+    head: ClothingHeadHatBeretBrigmedic
+    id: BrigmedicPDA
+    ears: ClothingHeadsetBrigmedic
+    mask: ClothingMaskBreathMedicalSecurity
+    belt: ClothingBeltMedicalFilled
+  innerclothingskirt: ClothingUniformJumpskirtBrigmedic
+  satchel: ClothingBackpackSatchelBrigmedicFilled
+  duffelbag: ClothingBackpackDuffelBrigmedicFilled

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -79,6 +79,7 @@
   - SecurityOfficer
   - Detective
   - Warden
+  - Brigmedic
 
 - type: department
   id: Science

--- a/Resources/Prototypes/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/Roles/play_time_trackers.yml
@@ -65,6 +65,9 @@
   id: JobHeadOfSecurity
 
 - type: playTimeTracker
+  id: JobBrigmedic
+
+- type: playTimeTracker
   id: JobJanitor
 
 - type: playTimeTracker

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -12,26 +12,6 @@ KvassTankFull: null
 DrinkKvassGlass: null
 KvassTank: null
 
-# 2023-05-03
-SpawnPointBrigmedic: null
-ClothingHeadsetBrigmedic: null
-ClothingHeadHatBeretBrigmedic: null
-ClothingHeadHelmetHardsuitBrigmedic: null
-ClothingOuterHardsuitBrigmedic: null
-ClothingOuterCoatAMG: null
-ClothingBackpackBrigmedic: null
-ClothingBackpackBrigmedicFilled: null
-ClothingBackpackSatchelBrigmedic: null
-ClothingBackpackSatchelBrigmedicFilled: null
-ClothingBackpackDuffelBrigmedic: null
-ClothingBackpackDuffelBrigmedicFilled: null
-BrigmedicIDCard: null
-BrigmedicPDA: null
-BoxSurvivalBrigmedic: null
-LockerBrigmedic: null
-LockerBrigmedicFilled: null
-BedsheetBrigmedic: null
-
 # 2023-05-04
 BoxMagazineMagnumSubMachineGun: BoxMagazinePistolSubMachineGun
 BoxMagazineMagnumSubMachineGunPractice: BoxMagazinePistolSubMachineGunPractice


### PR DESCRIPTION
Recently, a well intentioned but unpopular [PR](https://github.com/space-wizards/space-station-14/pull/16069) removed brigmedic.  This PR seeks to revert it given the majority of reacts in both github and discord thread seem to be in favor of brigmedic.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
(PR revert, no original code)
<!-- What does it change? What other things could this impact? -->


**Media**
![image](https://user-images.githubusercontent.com/22365940/236656838-37069ecc-8b9e-444c-a83f-2481dbfd276f.png)

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Brings back brigmedic, my beloved.