### PR TITLE
Fix network configurator verbs and misc fixes

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -293,22 +293,22 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
             Impact = LogImpact.Low
         };
 
-        if (configurator.LinkModeActive)
+        if (configurator.LinkModeActive && (HasComp<DeviceLinkSinkComponent>(args.Target) || HasComp<DeviceLinkSourceComponent>(args.Target)))
         {
             var linkStarted = configurator.ActiveDeviceLink.HasValue;
             verb.Text = Loc.GetString(linkStarted ? "network-configurator-link" : "network-configurator-start-link");
             verb.Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/in.svg.192dpi.png"));
+            args.Verbs.Add(verb);
         }
-        else if (!HasComp<DeviceNetworkComponent>(args.Target))
+        else if (HasComp<DeviceNetworkComponent>(args.Target))
         {
             var isDeviceList = HasComp<DeviceListComponent>(args.Target);
             verb.Text = Loc.GetString(isDeviceList ? "network-configurator-configure" : "network-configurator-save-device");
             verb.Icon = isDeviceList
                 ? new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/settings.svg.192dpi.png"))
                 : new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/in.svg.192dpi.png"));
+            args.Verbs.Add(verb);
         }
-
-        args.Verbs.Add(verb);
     }
 
     /// <summary>
@@ -356,9 +356,9 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
 
         AlternativeVerb verb = new()
         {
-            Text = Loc.GetString("network-configurator-save-device"),
-            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/in.svg.192dpi.png")),
-            Act = () => TryAddNetworkDevice(args.Target, args.Using.Value, args.User),
+            Text = Loc.GetString("network-configurator-switch-mode"),
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/settings.svg.192dpi.png")),
+            Act = () => SwitchMode(args.User, args.Target, configurator),
             Impact = LogImpact.Low
         };
         args.Verbs.Add(verb);

--- a/Content.Shared/DeviceNetwork/Components/NetworkConfiguratorComponent.cs
+++ b/Content.Shared/DeviceNetwork/Components/NetworkConfiguratorComponent.cs
@@ -17,7 +17,7 @@ public sealed class NetworkConfiguratorComponent : Component
     /// </summary>
     [DataField("linkModeActive")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public bool LinkModeActive = false;
+    public bool LinkModeActive = true;
 
     /// <summary>
     /// The entity containing a <see cref="DeviceListComponent"/> this configurator is currently interacting with

--- a/Resources/Prototypes/DeviceLinking/sink_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/sink_ports.yml
@@ -1,7 +1,7 @@
 - type: sinkPort
   id: AutoClose
-  name: signal-port-name-autoclose
-  description: signal-port-description-autoclose
+  name: signal-port-name-hold-open
+  description: signal-port-description-hold-open
 
 - type: sinkPort
   id: Toggle


### PR DESCRIPTION
This PR fixes https://github.com/space-wizards/space-station-14/issues/16204 and a wrong translation key for the airlock hold open port.
It also changes the default mode for the configurator to link as talked about in https://github.com/space-wizards/space-station-14/pull/13645 with @AJCM-git