### PR TITLE
Kelotane Overdose Effect

### DIFF
--- a/Resources/Locale/en-US/reagents/generic.ftl
+++ b/Resources/Locale/en-US/reagents/generic.ftl
@@ -5,3 +5,5 @@ generic-reagent-effect-burning-eyes = Your eyes begin to slightly burn.
 generic-reagent-effect-burning-eyes-a-bit = Your eyes burn a bit.
 generic-reagent-effect-tearing-up = Your eyes start to tear up.
 generic-reagent-effect-nauseous = You feel nauseous.
+generic-reagent-effect-parched = You feel parched.
+generic-reagent-effect-thirsty = You feel thirsty.

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -38,7 +38,7 @@ reagent-name-inaprovaline = inaprovaline
 reagent-desc-inaprovaline = Inaprovaline is a synaptic stimulant and cardiostimulant. Commonly used to stabilize patients- it stops oxygen loss when the patient is in critical health. It'll also slow down bleeding by a good amount. Acts as a decent painkiller.
 
 reagent-name-kelotane = kelotane
-reagent-desc-kelotane = Treats burn damage and prevents infection.
+reagent-desc-kelotane = Treats burn damage. Overdosing greatly reduces the body's ability to retain water.
 
 reagent-name-leporazine = leporazine
 reagent-desc-leporazine = This keeps a patient's body temperature stable. High doses can allow short periods of unprotected EVA, but prevents use of the cryogenics tubes.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -439,7 +439,9 @@
         type: Local
         messages:
         - generic-reagent-effect-nauseous
-        probability: 0.08
+        - generic-reagent-effect-thirsty
+        - generic-reagent-effect-parched
+        probability: 0.1
         conditions:
         - !type:ReagentThreshold
           min: 25

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -430,6 +430,19 @@
             Heat: -0.33
             Shock: -0.33
             Cold: -0.33
+      - !type:SatiateThirst
+        factor: -10
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+      - !type:PopupMessage
+        type: Local
+        messages:
+        - generic-reagent-effect-nauseous
+        probability: 0.08
+        conditions:
+        - !type:ReagentThreshold
+          min: 25
 
 - type: reagent
   id: Leporazine


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Added an Overdose Effect to Kelotane. This makes Ointment slightly more mandatory. 

![image](https://user-images.githubusercontent.com/113810873/236694355-5ab3a352-f42b-470b-b810-daef58ce23b0.png) _"look, a PM approves, merge when??"_

Unlike every other overdose effect, this one causes thirst. For each unit of Kelotane that goes over 30 units, you will need 5 units of soda to offset the lost water.

This means that accidently overdosing on Kelotane isn't incredibly lethal, and just requires some time next to a sink.

Full list of changes:

- When kelotane exeeds 30u, deplete 10 thirsts per half unit, or 5 soda-units of thirst per unit.
- When Kelotane exeeds 25u, give a bunch of messages telling the player they're thirsty.
- Removed the random "prevents infection" quip in the Kelotane description
- Added a "Kelotane OD maeks thirsty" quip to the Kelotane description

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/113810873/236694158-45ce2ff3-cb59-4e9e-8547-eee03ee6b918.png)
![image](https://user-images.githubusercontent.com/113810873/236694272-b7d49828-2a43-4f9f-a503-dcc0ad96db34.png)



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

please ignore the word "third" in the first commit i have no idea how it got there

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Kelotane can now cause an overdose above 30u, greatly decreasing the body's ability to retain water.
