### PR TITLE
Fix cloth not going into lathes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -65,6 +65,8 @@
   components:
   - type: Tag
     tags:
+    - RawMaterial
+    - DroneUsable
     - Gauze
   - type: Healing
     damageContainer: Biological


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Cloths goes it lathe. Fixes bug caused by #16194.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://user-images.githubusercontent.com/44417085/236703911-a63830c6-6ab2-4a93-b001-a3593d58dcf0.mp4


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- fix: Cloth can go into the autolathe and uniform printer again.
