### PR TITLE
Zombie disease is easier to spread and deadly in minutes. Zombies heal over time.

### DIFF
--- a/Content.Server/Zombies/PendingZombieComponent.cs
+++ b/Content.Server/Zombies/PendingZombieComponent.cs
@@ -12,12 +12,18 @@ public sealed class PendingZombieComponent : Component
 {
     [DataField("damage")] public DamageSpecifier Damage = new()
     {
-        DamageDict = new Dictionary<string, FixedPoint2>()
+        DamageDict = new ()
         {
-            { "Blunt", FixedPoint2.New(1) }
+            { "Blunt", 0.5 },
+            { "Cellular", 0.2 },
+            { "Toxin", 0.2 },
         }
     };
 
     [DataField("nextTick", customTypeSerializer:typeof(TimeOffsetSerializer))]
     public TimeSpan NextTick;
+
+    // Scales damage over time.
+    [DataField("infectedSecs")]
+    public int InfectedSecs;
 }

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -71,7 +71,8 @@ namespace Content.Server.Zombies
 
                 comp.InfectedSecs += 1;
                 // Pain of becoming a zombie grows over time
-                var pain_multiple = 0.1 + 0.02 * comp.InfectedSecs + 0.01 * comp.InfectedSecs * comp.InfectedSecs;
+                // 1x at 30s, 3x at 60s, 6x at 90s, 10x at 120s.
+                var pain_multiple = 0.1 + 0.02 * comp.InfectedSecs + 0.0005 * comp.InfectedSecs * comp.InfectedSecs;
                 comp.NextTick = curTime;
                 _damageable.TryChangeDamage(uid, comp.Damage * pain_multiple, true, false);
             }

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -181,14 +181,18 @@ namespace Content.Server.Zombies
                 if (!TryComp<MobStateComponent>(entity, out var mobState) || HasComp<DroneComponent>(entity))
                     continue;
 
-                if (_random.Prob(GetZombieInfectionChance(entity, component)))
-                {
-                    EnsureComp<PendingZombieComponent>(entity);
-                    EnsureComp<ZombifyOnDeathComponent>(entity);
-                }
-
                 if (HasComp<ZombieComponent>(entity))
+                {
                     args.BonusDamage = -args.BaseDamage * zombieComp.OtherZombieDamageCoefficient;
+                }
+                else
+                {
+                    if (_random.Prob(GetZombieInfectionChance(entity, component)))
+                    {
+                        EnsureComp<PendingZombieComponent>(entity);
+                        EnsureComp<ZombifyOnDeathComponent>(entity);
+                    }
+                }
 
                 if ((mobState.CurrentState == MobState.Dead || mobState.CurrentState == MobState.Critical)
                     && !HasComp<ZombieComponent>(entity))

--- a/Content.Server/Zombies/ZombifyOnDeathSystem.cs
+++ b/Content.Server/Zombies/ZombifyOnDeathSystem.cs
@@ -107,7 +107,7 @@ namespace Content.Server.Zombies
             //we need to basically remove all of these because zombies shouldn't
             //get diseases, breath, be thirst, be hungry, or die in space
             RemComp<RespiratorComponent>(target);
-            // RemComp<BarotraumaComponent>(target); Actually yes, they should die in space (to prevent zombie spacing)
+            RemComp<BarotraumaComponent>(target); 
             RemComp<HungerComponent>(target);
             RemComp<ThirstComponent>(target);
 
@@ -175,9 +175,6 @@ namespace Content.Server.Zombies
             _serverInventory.TryUnequip(target, "gloves", true, true);
             //Should prevent instances of zombies using comms for information they shouldnt be able to have.
             _serverInventory.TryUnequip(target, "ears", true, true);
-            //Shouldn't be wearing a helmet. How are you going to bite things?
-            _serverInventory.TryUnequip(target, "head", true, true);
-            _serverInventory.TryUnequip(target, "mask", true, true);
 
             //popup
             _popupSystem.PopupEntity(Loc.GetString("zombie-transform", ("target", target)), target, PopupType.LargeCaution);

--- a/Content.Server/Zombies/ZombifyOnDeathSystem.cs
+++ b/Content.Server/Zombies/ZombifyOnDeathSystem.cs
@@ -227,12 +227,14 @@ namespace Content.Server.Zombies
                 _sharedHands.RemoveHand(target, hand.Name);
             }
             RemComp<HandsComponent>(target);
+            // No longer waiting to become a zombie:
+            RemComp<PendingZombieComponent>(target);
 
-            // Zombiefication takes 5 seconds. Groan on the floor for a bit.
+            // Zombiefication takes a second. Groan on the floor for a bit.
             if (EntityManager.TryGetComponent<StatusEffectsComponent>(target, out var status))
             {
-                _stunSystem.TryStun(target, TimeSpan.FromSeconds(5.0), true, status);
-                _stunSystem.TryKnockdown(target, TimeSpan.FromSeconds(4.5), true,
+                _stunSystem.TryStun(target, TimeSpan.FromSeconds(2.0), true, status);
+                _stunSystem.TryKnockdown(target, TimeSpan.FromSeconds(1.8), true,
                     status);
             }
 

--- a/Content.Server/Zombies/ZombifyOnDeathSystem.cs
+++ b/Content.Server/Zombies/ZombifyOnDeathSystem.cs
@@ -14,7 +14,6 @@ using Content.Server.Mind.Components;
 using Content.Server.Nutrition.Components;
 using Content.Server.Popups;
 using Content.Server.Speech.Components;
-using Content.Server.Stunnable;
 using Content.Server.Temperature.Components;
 using Content.Server.Traitor;
 using Content.Shared.CombatMode;
@@ -30,7 +29,6 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
-using Content.Shared.StatusEffect;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
@@ -58,7 +56,6 @@ namespace Content.Server.Zombies
         [Dependency] private readonly SharedCombatModeSystem _combat = default!;
         [Dependency] private readonly IChatManager _chatMan = default!;
         [Dependency] private readonly IPrototypeManager _proto = default!;
-        [Dependency] private readonly StunSystem _stunSystem = default!;
         [Dependency] private readonly MobStateSystem _mobState = default!;
         [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
 
@@ -107,7 +104,7 @@ namespace Content.Server.Zombies
             //we need to basically remove all of these because zombies shouldn't
             //get diseases, breath, be thirst, be hungry, or die in space
             RemComp<RespiratorComponent>(target);
-            RemComp<BarotraumaComponent>(target); 
+            RemComp<BarotraumaComponent>(target);
             RemComp<HungerComponent>(target);
             RemComp<ThirstComponent>(target);
 
@@ -236,14 +233,6 @@ namespace Content.Server.Zombies
             RemComp<HandsComponent>(target);
             // No longer waiting to become a zombie:
             RemComp<PendingZombieComponent>(target);
-
-            // Zombiefication takes a second. Groan on the floor for a bit.
-            if (EntityManager.TryGetComponent<StatusEffectsComponent>(target, out var status))
-            {
-                _stunSystem.TryStun(target, TimeSpan.FromSeconds(1.0), true, status);
-                _stunSystem.TryKnockdown(target, TimeSpan.FromSeconds(0.8), true,
-                    status);
-            }
 
             //zombie gamemode stuff
             RaiseLocalEvent(new EntityZombifiedEvent(target));

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -1,8 +1,10 @@
 using Content.Shared.Chat.Prototypes;
+using Content.Shared.Damage;
 using Content.Shared.Roles;
 using Content.Shared.Humanoid;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using static Content.Shared.Humanoid.HumanoidAppearanceState;
 
@@ -22,14 +24,14 @@ namespace Content.Shared.Zombies
         /// The baseline infection chance you have if you are completely nude
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MaxZombieInfectionChance = 0.50f;
+        public float MaxZombieInfectionChance = 0.90f;
 
         /// <summary>
         /// The minimum infection chance possible. This is simply to prevent
         /// being invincible by bundling up.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MinZombieInfectionChance = 0.05f;
+        public float MinZombieInfectionChance = 0.20f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public float ZombieMovementSpeedDebuff = 0.75f;
@@ -86,5 +88,20 @@ namespace Content.Shared.Zombies
         public string? EmoteSoundsId = "Zombie";
 
         public EmoteSoundsPrototype? EmoteSounds;
+
+        // Heal on tick
+        [DataField("nextTick", customTypeSerializer:typeof(TimeOffsetSerializer))]
+        public TimeSpan NextTick;
+
+        [DataField("damage")] public DamageSpecifier Damage = new()
+        {
+            DamageDict = new ()
+            {
+                { "Blunt", -0.3 },
+                { "Slash", -0.5 },
+                { "Heat", -0.2 },
+                { "Cold", -0.2 },
+            }
+        };
     }
 }

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -98,9 +98,10 @@ namespace Content.Shared.Zombies
             DamageDict = new ()
             {
                 { "Blunt", -0.3 },
-                { "Slash", -0.5 },
+                { "Slash", -0.2 },
                 { "Heat", -0.2 },
                 { "Cold", -0.2 },
+                { "Shock", -0.2 },
             }
         };
     }

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -24,14 +24,14 @@ namespace Content.Shared.Zombies
         /// The baseline infection chance you have if you are completely nude
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MaxZombieInfectionChance = 0.90f;
+        public float MaxZombieInfectionChance = 0.40f;
 
         /// <summary>
         /// The minimum infection chance possible. This is simply to prevent
         /// being invincible by bundling up.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MinZombieInfectionChance = 0.20f;
+        public float MinZombieInfectionChance = 0.10f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public float ZombieMovementSpeedDebuff = 0.75f;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
After some discussion, this PR is a become a buff to the zombie virus. The infection is far more virulent now.
- The zombie disease is easier to spread, being from 20% (fully clothed) to 80% (nude) per bite. Up from 5 and 50% respectively.
- The zombie disease does quite a lot of DoT and that damage increases over time. You will only survive for about 1 minute before you die.
- Actual death (not just crit) turns you into a zombie. Given time, you will come back to life as zombie after death or critting.

NB: This PR initially hurt zombies in space, which the comments reflect. That has been removed now.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Please see the video in the comments below

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Zombification happens post death, rather than just crit. So you lie on the floor a bit before beginning your new life.
- tweak: Zombies are more likely (10-40% depending on clothes) to inflict a zombifying Damage over Time.  This was 5% - 50% before. A typical outfit without outer suit, mask or helmet has a 17.5% chance of being infected each hit.
- tweak: Zombies have some heal over time. This might also bring them back from the dead (again).