### PR TITLE
Moves crew monitoring boards to cargo

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-circuitboards.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-circuitboards.ftl
@@ -1,0 +1,2 @@
+﻿ent-CircuitboardCrewMonitoring = { ent-CrateCrewMonitoringBoards }
+    .desc = { ent-CrateCrewMonitoringBoards.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/circuitboard-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/circuitboard-crates.ftl
@@ -1,0 +1,2 @@
+﻿ent-CrateCrewMonitoringBoards = Crew Monitoring Boards
+    .desc = Has two crew monitoring console and server replacements. Requires engineering access to open.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_circuitboards.yml
@@ -1,0 +1,9 @@
+﻿- type: cargoProduct
+  id: CrewMonitoringBoards
+  icon:
+    sprite: Objects/Misc/module.rsi
+    state: cpuboard
+  product: CrateCrewMonitoringBoards
+  cost: 2000
+  category: Circuitboards
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/circuitboards.yml
@@ -1,0 +1,10 @@
+﻿- type: entity
+  id: CrateCrewMonitoringBoards
+  parent: CrateEngineeringSecure
+  components:
+    - type: StorageFill
+      contents:
+        - id: CrewMonitoringComputerCircuitboard
+          amount: 2
+        - id: CrewMonitoringServerMachineCircuitboard
+          amount: 2

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -185,7 +185,6 @@
   unlockedRecipes:
   - ChemMasterMachineCircuitboard
   - ChemDispenserMachineCircuitboard
-  - CrewMonitoringComputerCircuitboard
   - HandheldCrewMonitor
   - BiomassReclaimerMachineCircuitboard
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -286,7 +286,6 @@
       - CloningPodMachineCircuitboard
       - MedicalScannerMachineCircuitboard
       - CryoPodMachineCircuitboard
-      - CrewMonitoringComputerCircuitboard
       - VaccinatorMachineCircuitboard
       - DiagnoserMachineCircuitboard
       - ChemMasterMachineCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -259,14 +259,6 @@
      Gold: 100
 
 - type: latheRecipe
-  id: CrewMonitoringComputerCircuitboard
-  result: CrewMonitoringComputerCircuitboard
-  completetime: 4
-  materials:
-     Steel: 100
-     Glass: 900
-
-- type: latheRecipe
   id: ShuttleConsoleCircuitboard
   result: ShuttleConsoleCircuitboard
   completetime: 4


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

A slight alternative to #16191

This moves both the crew monitoring console and server boards to cargo.
The crate comes with four boards - two crew monitoring console boards and two crew monitoring server boards.

Crew monitoring really should not be printed at will as it can be an exceptionally powerful tool that both security and antags get better mileage out of it than medical. While this does add to a cargo-dependency issue, it brings:
1) More crew interaction (for ordering the boards, and having engineering build them)
2) Engineering something to do since the crate is locked to engineers.

Spare boards will be added into tech storage if they're not already in there in a different PR.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Adds crew monitoring console and server boards to cargo.
- add: A new category was added to cargo: circuitboards.
- remove: Removed crew monitoring console boards from lathes.
