### PR TITLE
Stop puddles and soap from blocking doors

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -30,6 +30,7 @@ public abstract class SharedDoorSystem : EntitySystem
     [Dependency] protected readonly SharedAppearanceSystem AppearanceSystem = default!;
     [Dependency] private readonly OccluderSystem _occluder = default!;
 
+
     /// <summary>
     ///     A body must have an intersection percentage larger than this in order to be considered as colliding with a
     ///     door. Used for safety close-blocking and crushing.
@@ -444,6 +445,9 @@ public abstract class SharedDoorSystem : EntitySystem
                 continue;
 
             if (!otherPhysics.CanCollide)
+                continue;
+
+            if (!otherPhysics.Hard)
                 continue;
 
             if ((physics.CollisionMask & otherPhysics.CollisionLayer) == 0 && (otherPhysics.CollisionMask & physics.CollisionLayer) == 0)

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -5,11 +5,11 @@ using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
+using Content.Shared.Physics;
 using Content.Shared.Stunnable;
 using Content.Shared.Tag;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
-using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
@@ -446,9 +446,8 @@ public abstract class SharedDoorSystem : EntitySystem
             if (!otherPhysics.CanCollide)
                 continue;
 
-            //If the colliding entity is a slippable item (banana peel, soap, liquids, magic runes) ignore it by the airlock
-            // CollisionLayer 20 = SlipLayer, CollionMask 10 = ItemMask
-            if (otherPhysics.CollisionLayer == 20 && otherPhysics.CollisionMask == 10)
+            //If the colliding entity is a slippable item ignore it by the airlock
+            if (otherPhysics.CollisionLayer == (int) CollisionGroup.SlipLayer && otherPhysics.CollisionMask == (int) CollisionGroup.ItemMask)
                 continue;
 
             if ((physics.CollisionMask & otherPhysics.CollisionLayer) == 0 && (otherPhysics.CollisionMask & physics.CollisionLayer) == 0)

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -30,7 +30,6 @@ public abstract class SharedDoorSystem : EntitySystem
     [Dependency] protected readonly SharedAppearanceSystem AppearanceSystem = default!;
     [Dependency] private readonly OccluderSystem _occluder = default!;
 
-
     /// <summary>
     ///     A body must have an intersection percentage larger than this in order to be considered as colliding with a
     ///     door. Used for safety close-blocking and crushing.

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -446,7 +446,9 @@ public abstract class SharedDoorSystem : EntitySystem
             if (!otherPhysics.CanCollide)
                 continue;
 
-            if (!otherPhysics.Hard)
+            //If the colliding entity is a slippable item (banana peel, soap, liquids, magic runes) ignore it by the airlock
+            // CollisionLayer 20 = SlipLayer, CollionMask 10 = ItemMask
+            if (otherPhysics.CollisionLayer == 20 && otherPhysics.CollisionMask == 10)
                 continue;
 
             if ((physics.CollisionMask & otherPhysics.CollisionLayer) == 0 && (otherPhysics.CollisionMask & physics.CollisionLayer) == 0)

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -85,7 +85,6 @@
       layers:
         - sprite: Fluids/puddle.rsi
           state: splat0
-      netsync: false
       drawdepth: FloorObjects
       color: "#FFFFFF80"
     - type: Physics

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -37,7 +37,6 @@
         density: 10
         mask:
         - ItemMask
-        hard: false
 
 - type: entity
   name: soap

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -21,7 +21,6 @@
     enabled: false
   - type: Physics
     bodyType: Dynamic
-    hard: false
   - type: Fixtures
     fixtures:
       slips:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -21,15 +21,16 @@
     enabled: false
   - type: Physics
     bodyType: Dynamic
+    hard: false
   - type: Fixtures
     fixtures:
       slips:
         shape:
           !type:PhysShapeAabb
           bounds: "-0.4,-0.3,0.4,0.3"
-        hard: false
         layer:
         - SlipLayer
+        hard: false
       fix1:
         shape:
           !type:PhysShapeAabb
@@ -37,6 +38,7 @@
         density: 10
         mask:
         - ItemMask
+        hard: false
 
 - type: entity
   name: soap


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Stops puddles and soap from blocking doors
Fixes #16167, #15253

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->


https://user-images.githubusercontent.com/46636558/236931309-cf709052-712e-4f44-b977-42d120aae8ce.mp4



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Mumohan
- fix: Airlocks are no longer scared of puddles and soap. They should now close properly.
