### PR TITLE
Fix bug where space music would play even when on station

### DIFF
--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -130,7 +130,7 @@ public sealed class BackgroundAudioSystem : EntitySystem
     {
         if (_playMan.LocalPlayer is null
             || _playMan.LocalPlayer.ControlledEntity != message.Entity
-            || !_timing.IsFirstTimePredicted)
+            || !(_timing.IsFirstTimePredicted || _timing.ApplyingState))
             return;
 
         // Check if we traversed to grid.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Very rarely, when moving on and off a grid rapidly, the space ambience music will get stuck playing, even when on station. I'm not 100% certain this totally fixes the issue, as it's pretty difficult to repro (and debug) but it _seems_ to work.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Cripes
- fix: Space tunes should now only be heard in space
