### PR TITLE
double carp price

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -570,7 +570,7 @@
   description: uplink-carp-dehydrated-desc
   productEntity: DehydratedSpaceCarp
   cost:
-    Telecrystal: 2
+    Telecrystal: 4
   categories:
   - UplinkTools
 


### PR DESCRIPTION
## About the PR
nerfes carp so:
- as a syndie you cant buy **10** fish to instacrit anything that goes into disposals, this now requires coordination or simply accepting that it wont instacrit
- as a nukie you cant solo fishops buying **20** fish, this requires everyone to pitch in now

as a massive proponent of fishops of any scale i feel this is necessary
also i think in ss13 its fucking 1 tc lmao

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Due to space dragons supplying less carp to the syndicate, dehydrated carp price has been increased to 4 TC.