### PR TITLE
Fix interlocking airlocks

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -148,17 +148,19 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
             return;
         }
 
-        if (HasComp<DeviceLinkSourceComponent>(target) && HasComp<DeviceLinkSourceComponent>(configurator.ActiveDeviceLink)
-            || HasComp<DeviceLinkSinkComponent>(target) && HasComp<DeviceLinkSinkComponent>(configurator.ActiveDeviceLink))
+        if (configurator.ActiveDeviceLink.HasValue
+            && (HasComp<DeviceLinkSourceComponent>(target)
+            && HasComp<DeviceLinkSinkComponent>(configurator.ActiveDeviceLink)
+            || HasComp<DeviceLinkSinkComponent>(target)
+            && HasComp<DeviceLinkSourceComponent>(configurator.ActiveDeviceLink)))
         {
+            OpenDeviceLinkUi(uid, target, user, configurator);
             return;
         }
 
-        if (configurator.ActiveDeviceLink.HasValue)
-        {
-            OpenDeviceLinkUi( uid, target, user, configurator);
+        if (HasComp<DeviceLinkSourceComponent>(target) && HasComp<DeviceLinkSourceComponent>(configurator.ActiveDeviceLink)
+            || HasComp<DeviceLinkSinkComponent>(target) && HasComp<DeviceLinkSinkComponent>(configurator.ActiveDeviceLink))
             return;
-        }
 
         _popupSystem.PopupEntity(Loc.GetString("network-configurator-link-mode-started",  ("device", Name(target.Value))), target.Value, user);
         configurator.ActiveDeviceLink = target;


### PR DESCRIPTION
## About the PR
Fixes an oversight in network configurator that would prevent you from linking devices that have both link sinks and link sources

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed not being able to link airlocks using network configurator