### PR TITLE
Fix filter popup prediction spam

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.GameTicking;
 using Content.Shared.Popups;
 using Robust.Client.Graphics;
@@ -122,6 +123,9 @@ namespace Content.Client.Popups
 
         public override void PopupEntity(string message, EntityUid uid, Filter filter, bool recordReplay, PopupType type=PopupType.Small)
         {
+            if (!filter.Recipients.Contains(_playerManager.LocalPlayer?.Session))
+                return;
+
             PopupEntity(message, uid, type);
         }
 


### PR DESCRIPTION
Client never checked it matched filters so would always spam this if it were called in shared (pretty much always Filter.PvsExcept(client)). Should I also wrap this in IsFirstTimePredicted?

:cl:
- fix: Fix popup spam in some instances.