### PR TITLE
give ert jani advanced mop

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -278,6 +278,7 @@
         - id: BoxLightMixed
         - id: Soap
         - id: CrowbarRed
+        - id: AdvMopItem
 
 - type: entity
   noSpawn: true


### PR DESCRIPTION
## About the PR
ert jani had no way to clean stuff so now there is

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Due to a recent economic boom, NT is now able to supply ERT cleanup crews with mops.