### PR TITLE
Proximity mine wet floor sign

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -169,6 +169,9 @@ uplink-hot-potato-desc = Once activated, this time bomb can't be dropped - only 
 uplink-chimp-ammo-name = Box of 10 Omega Cartridges.
 uplink-chimp-ammo-desc = A box of 10 omega particle cartridges for the CHIMP. Omega particles inflict severe burns and cause anomalies to go supercritical.
 
+uplink-proximity-mine-name = Proximity Mine
+uplink-proximity-mine-desc = A mine disguised as a wet floor sign.
+
 # Armor
 uplink-chameleon-name = Chameleon Kit
 uplink-chameleon-desc = A backpack full of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more!

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -683,6 +683,20 @@
       whitelist:
         - Scientist
 
+- type: listing
+  id: uplinkProximityMine
+  name: uplink-proximity-mine-name
+  description: uplink-proximity-mine-desc
+  productEntity: WetFloorSignMineExplosive
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkJob
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist:
+    - Janitor
+
 # Armor
 
 - type: listing

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -167,6 +167,52 @@
     tags:
       - WetFloorSign
 
+
+- type: entity
+  name: wet floor sign
+  suffix: Explosive
+  description: Caution! Wet Floor!
+  parent: BaseItem
+  id: WetFloorSignMineExplosive
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Janitorial/wet_floor_sign.rsi
+    state: caution
+  - type: Item
+    sprite: Objects/Specific/Janitorial/wet_floor_sign.rsi
+    size: 15
+  - type: StepTrigger
+    intersectRatio: 0.2
+    requiredTriggeredSpeed: 0
+  - type: CollisionWake
+    enabled: false
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      slips:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.2,-0.2,0.2,0.2"
+        hard: false
+        layer:
+          - LowImpassable
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.2,-0.2,0.2,0.2"
+        density: 30
+        mask:
+        - ItemMask
+  - type: LandMine
+  - type: ExplodeOnTrigger
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 5 # about a ~67.5 total damage
+    totalIntensity: 60 # about a ~3 tile radius
+    canCreateVacuum: false
+  - type: DeleteOnTrigger
+
 - type: entity
   name: janitorial trolley
   id: JanitorialTrolley


### PR DESCRIPTION
## About the PR
Added Proximity Mine disguised as a wet floor sign. When stepped on, it explodes with a radius of about 3 tiles and a total damage of about 67.5. It costs 4 telecrystal and is sold only to janitors.

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame

**Changelog**
:cl: Lomcastar
- add: Added Proximity Mine disguised as a wet floor sign.

https://github.com/space-wizards/space-station-14/assets/129697969/c4a6b932-c52a-429a-82d9-cf60ae29b7d5

