### PR TITLE
Add missing guide button to network configurator

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -254,6 +254,9 @@
         - DroneUsable
     - type: StaticPrice
       price: 60
+    - type: GuideHelp
+      guides:
+        - NetworkConfigurator
 
 - type: entity
   name: power drill

--- a/Resources/ServerInfo/Guidebook/Engineering.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering.xml
@@ -13,6 +13,7 @@ Engineering is a combination of construction work, repair work, maintaining a de
 <Box>
 <GuideEntityEmbed Entity="Welder"/>
 <GuideEntityEmbed Entity="Multitool"/>
+<GuideEntityEmbed Entity="NetworkConfigurator"/>
 </Box>
 Your core toolset is a small variety of tools. If you're an engineer, then you should have a belt on your waist containing one of each, if not you can likely find them in maintenance and tool storage within assorted toolboxes and vending machines.
 

--- a/Resources/ServerInfo/Guidebook/Science/Xenoarchaeology.xml
+++ b/Resources/ServerInfo/Guidebook/Science/Xenoarchaeology.xml
@@ -11,7 +11,7 @@ Artifacts consist of a randomly-generated graph structure. They consist of nodes
 
 Each node has two main components: a [color=#a4885c]stimulus[/color] and a [color=#a4885c]reaction[/color]. A stimulus is the external behavior that triggers the reaction. Some reactions are instantaneous effects while others are permanent changes. Triggering the reaction causes the artifact to move to one of the node's edges.
 
-With these basic principles, you can begin to grasp how the different nodes of an artifact are interconnected, and how one can move between them by repeatedly activating nodes. 
+With these basic principles, you can begin to grasp how the different nodes of an artifact are interconnected, and how one can move between them by repeatedly activating nodes.
 
 While it might seem random to an untrained eye, a skilled scientist can learn to understand the internal structure of any artifact.
 
@@ -20,9 +20,9 @@ While it might seem random to an untrained eye, a skilled scientist can learn to
 <GuideEntityEmbed Entity="MachineArtifactAnalyzer"/>
 <GuideEntityEmbed Entity="ComputerAnalysisConsole"/>
 </Box>
-The main equipment that you'll be using for Xenoarchaeology is the [color=#a4885c]artifact analyzer[/color] and the [color=#a4885c]analysis console[/color]. You can use these to create reports that contain valuable information about an artifact. 
+The main equipment that you'll be using for Xenoarchaeology is the [color=#a4885c]artifact analyzer[/color] and the [color=#a4885c]analysis console[/color]. You can use these to create reports that contain valuable information about an artifact.
 
-To set them up, simply link them with a multitool, set an artifact on top of the analyzer, and press the [color=#a4885c]Scan[/color] button.
+To set them up, simply link them with a network configurator, set an artifact on top of the analyzer, and press the [color=#a4885c]Scan[/color] button.
 
 Using the console, you can extract points from the artifact using the [color=#a4885c]Extract[/color] button. The amount of points you extract is based on how many of the nodes of the artifact have been activated.
 


### PR DESCRIPTION
This also changes the **one** occurrence of multitool still being used for linking in guides
There was a guidebook entry from the beginning:
![image](https://github.com/space-wizards/space-station-14/assets/8915246/e7443298-f5e8-448e-a746-6ce3c0b4a563)

