### PR TITLE
Add configuration capability back to multitool

### DIFF
--- a/Resources/Locale/en-US/devices/network-configurator.ftl
+++ b/Resources/Locale/en-US/devices/network-configurator.ftl
@@ -33,7 +33,7 @@ network-configurator-tooltip-set = Sets targets device list
 network-configurator-tooltip-add = Adds to targets device list
 network-configurator-tooltip-edit = Edit targets device list
 network-configurator-tooltip-clear = Clear targets device list
-network-configurator-tooltip-copy = Copy targets device list to multitool
+network-configurator-tooltip-copy = Copy targets device list to held tool
 network-configurator-tooltip-show = Show a holographic visualization of targets device list
 
 # examine

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -11,7 +11,6 @@
       - id: Wirecutter
       - id: Welder
       - id: Multitool
-      - id: NetworkConfigurator
 
 - type: entity
   id: ClothingBeltChiefEngineerFilled
@@ -25,7 +24,6 @@
       - id: WelderExperimental
       - id: Multitool
       - id: CableApcStack
-      - id: NetworkConfigurator
 
 - type: entity
   id: ClothingBeltSecurityFilled
@@ -68,7 +66,7 @@
         amount: 2
       - id: Gauze
       - id: EmergencyMedipen #You never know what people are going to latejoin into
-      
+
 - type: entity
   id: ClothingBeltParamedicFilled
   parent: ClothingBeltMedical

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -34,6 +34,8 @@
       - id: CableMVStack
       - id: trayScanner
         prob: 0.9
+      - id: NetworkConfigurator
+        prob: 0.6
       - id: ClothingHandsGlovesColorYellow
         prob: 0.05
         orGroup: GlovesOrWires

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -34,8 +34,6 @@
       - id: CableMVStack
       - id: trayScanner
         prob: 0.9
-      - id: NetworkConfigurator
-        prob: 0.6
       - id: ClothingHandsGlovesColorYellow
         prob: 0.05
         orGroup: GlovesOrWires

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -11,3 +11,5 @@
       - id: ClothingOuterCoatRnd
       - id: AnomalyScanner
       - id: NodeScanner
+      - id: NetworkConfigurator
+        prob: 0.5

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -8,6 +8,7 @@
     Wrench: 5
     Screwdriver: 5
     trayScanner: 5
+    NetworkConfigurator: 3
     GasAnalyzer: 5
     FlashlightLantern: 5
     ClothingHandsGlovesColorYellowBudget: 5

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -196,6 +196,18 @@
   - type: Tool
     qualities:
       - Pulsing
+  - type: NetworkConfigurator
+  - type: ActivatableUI
+    key: enum.NetworkConfiguratorUiKey.List
+    inHandsOnly: true
+  - type: UserInterface
+    interfaces:
+      - key: enum.NetworkConfiguratorUiKey.List
+        type: NetworkConfiguratorBoundUserInterface
+      - key: enum.NetworkConfiguratorUiKey.Configure
+        type: NetworkConfiguratorBoundUserInterface
+      - key: enum.NetworkConfiguratorUiKey.Link
+        type: NetworkConfiguratorBoundUserInterface
   - type: Tag
     tags:
       - Multitool


### PR DESCRIPTION
## About the PR
As mentioned in this issue #16241, this PR adds the linking and list functionality back to the multitool.
Further changes like making the multitool rarer or adding a dedicated probing tool can be done in a later PR.

Fixes #16241
