### PR TITLE
Frezon reaction requires 50:1 Oxy:Trit ratio

### DIFF
--- a/Content.Server/Atmos/Reactions/FrezonProductionReaction.cs
+++ b/Content.Server/Atmos/Reactions/FrezonProductionReaction.cs
@@ -20,14 +20,18 @@ public sealed class FrezonProductionReaction : IGasReactionEffect
         var efficiency = mixture.Temperature / Atmospherics.FrezonProductionMaxEfficiencyTemperature;
         var loss = 1 - efficiency;
 
+        // How much the catalyst (N2) will allow us to produce
         // Less N2 is required the more efficient it is.
-        var minimumN2 = (initialOxy + initialTrit) / (Atmospherics.FrezonProductionNitrogenRatio * efficiency);
+        var catalystLimit = initialN2 * (Atmospherics.FrezonProductionNitrogenRatio / efficiency);
+        var oxyLimit = Math.Min(initialOxy, catalystLimit) / Atmospherics.FrezonProductionTritRatio;
 
-        if (initialN2 < minimumN2)
-            return ReactionResult.NoReaction;
+        // Amount of tritium & oxygen that are reacting
+        var tritBurned = Math.Min(oxyLimit, initialTrit);
+        var oxyBurned = tritBurned * Atmospherics.FrezonProductionTritRatio;
+        var burnRatio = tritBurned / initialTrit;
 
-        var oxyConversion = initialOxy / Atmospherics.FrezonProductionConversionRate;
-        var tritConversion = initialTrit / Atmospherics.FrezonProductionConversionRate;
+        var oxyConversion = oxyBurned / Atmospherics.FrezonProductionConversionRate;
+        var tritConversion = tritBurned / Atmospherics.FrezonProductionConversionRate;
         var total = oxyConversion + tritConversion;
 
         mixture.AdjustMoles(Gas.Oxygen, -oxyConversion);

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -225,6 +225,14 @@ namespace Content.Shared.Atmos
         /// </summary>
         public const float FrezonProductionNitrogenRatio = 10f;
 
+        /// <summary>
+        ///     1 mol of Tritium is required per X mol of oxygen.
+        /// </summary>
+        public const float FrezonProductionTritRatio = 50.0f;
+
+        /// <summary>
+        ///     1 / X of the tritium is converted into Frezon each tick
+        /// </summary>
         public const float FrezonProductionConversionRate = 50f;
 
         /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR changes the reaction which creates Freezon, resolving an issue with the amount of tritium used. Previously only 0.01 moles of Tritium were required to cause this reaction in the presense of oxygen, nitrogen and cold. only 1/50 of whatever Tritium was there would be used, making the process too cheap, with Freezon production only requiring a small initial stock of Tritium.

Also, the reaction was finicky, requiring exactly the right amount of nitrogen or it wouldn't happen at all.

- The reaction now uses a fixed ratio of oxygen to Tritium to generate Frezon
- As before, the amount created from given ingredients scales based on the temperature of the reaction (from 0K to 72K) with nitrogen created as a waste product.
- Reaction will now scale to always take place, using whatever catalyst (N2) and Tritium is available. 

- Some Atmos technicians will need to adapt, creating Tritium throughout the round instead of only early on.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Here is the setup I used to test this change, using oxygen reuse from the Tritium step to heat both input oxy to plasma burn and also to reheat the frezon system. There is an oxygen filter under the heater, along with nitrogen being piped up from below.

![image](https://github.com/space-wizards/space-station-14/assets/5285589/0e96fe60-fe4d-436e-b486-11a3376b6f8b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Frezon is slightly harder to make. The reaction always consumes Tritium and Oxygen at a 1:50 ratio. But the reaction is easier to initiate, requiring only Nitrogen, Oxygen, Tritium and <73.15K. 