### PR TITLE
fix key debug assert on round restart

### DIFF
--- a/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
+++ b/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
@@ -22,7 +22,7 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
         SubscribeLocalEvent<HeadsetComponent, EncryptionChannelsChangedEvent>(OnKeysChanged);
 
         SubscribeLocalEvent<WearingHeadsetComponent, EntitySpokeEvent>(OnSpeak);
-        
+
         SubscribeLocalEvent<HeadsetComponent, EmpPulseEvent>(OnEmpPulse);
     }
 
@@ -33,7 +33,8 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
 
     private void UpdateRadioChannels(EntityUid uid, HeadsetComponent headset, EncryptionKeyHolderComponent? keyHolder = null)
     {
-        if (!headset.Enabled)
+        // make sure to not add ActiveRadioComponent when headset is being deleted
+        if (!headset.Enabled || MetaData(uid).EntityLifeStage >= EntityLifeStage.Terminating)
             return;
 
         if (!Resolve(uid, ref keyHolder))


### PR DESCRIPTION
## About the PR
fixes #16290
adds the same check used in the assert, dunno if theres a nicer one available like checking comp.Deleted or something

**Media**
![07:35:45](https://github.com/space-wizards/space-station-14/assets/39013340/2813e87a-c5db-4c0d-acdc-98783204d704)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun