### PR TITLE
Transferring a chocolate box

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-vending.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-vending.ftl
@@ -54,3 +54,6 @@ ent-CrateVendingMachineRestockTankDispenser = { ent-CrateVendingMachineRestockTa
 
 ent-CrateVendingMachineRestockHappyHonk = { ent-CrateVendingMachineRestockHappyHonkFilled }
     .desc = { ent-CrateVendingMachineRestockHappyHonkFilled.desc }
+
+ent-CrateVendingMachineRestockGetmoreChocolateCorp = { ent-CrateVendingMachineRestockGetmoreChocolateCorpFilled }
+    .desc = { ent-CrateVendingMachineRestockGetmoreChocolateCorpFilled.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-vending.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-vending.ftl
@@ -57,3 +57,12 @@ ent-CrateVendingMachineRestockHappyHonk = { ent-CrateVendingMachineRestockHappyH
 
 ent-CrateVendingMachineRestockGetmoreChocolateCorp = { ent-CrateVendingMachineRestockGetmoreChocolateCorpFilled }
     .desc = { ent-CrateVendingMachineRestockGetmoreChocolateCorpFilled.desc }
+
+ent-CrateVendingMachineRestockChang = { ent-CrateVendingMachineRestockChangFilled }
+    .desc = { ent-CrateVendingMachineRestockChangFilled.desc }
+
+ent-CrateVendingMachineRestockDiscountDans = { ent-CrateVendingMachineRestockDiscountDansFilled }
+    .desc = { ent-CrateVendingMachineRestockDiscountDansFilled.desc }
+
+ent-CrateVendingMachineRestockDonut = { ent-CrateVendingMachineRestockDonutFilled }
+    .desc = { ent-CrateVendingMachineRestockDonutFilled.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-vending.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-vending.ftl
@@ -40,9 +40,6 @@ ent-CrateVendingMachineRestockSeeds = { ent-CrateVendingMachineRestockSeedsFille
 ent-CrateVendingMachineRestockSmokes = { ent-CrateVendingMachineRestockSmokesFilled }
     .desc = { ent-CrateVendingMachineRestockSmokesFilled.desc }
 
-ent-CrateVendingMachineRestockSnacks = { ent-CrateVendingMachineRestockSnacksFilled }
-    .desc = { ent-CrateVendingMachineRestockSnacksFilled.desc }
-
 ent-CrateVendingMachineRestockVendomat = { ent-CrateVendingMachineRestockVendomatFilled }
     .desc = { ent-CrateVendingMachineRestockVendomatFilled.desc }
 

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/vending-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/vending-crates.ftl
@@ -41,7 +41,7 @@ ent-CrateVendingMachineRestockSmokesFilled = ShadyCigs restock crate
     .desc = Contains two restock boxes for the ShadyCigs vending machine.
 
 ent-CrateVendingMachineRestockSnacksFilled = Snack restock crate
-    .desc = Contains four restock boxes, each covering a different snack vendor. Mr. Chang's, Discount Dans, Robust Donuts, and Getmore Chocolate are featured on the advertisement.
+    .desc = Contains four restock boxes, each covering a different snack vendor. Mr. Chang's, Discount Dans, and Robust Donuts are featured on the advertisement.
 
 ent-CrateVendingMachineRestockVendomatFilled = Vendomat restock crate
     .desc = Contains a restock box for a Vendomat vending machine.
@@ -55,3 +55,5 @@ ent-CrateVendingMachineRestockTankDispenserFilled = Tank dispenser restock crate
 ent-CrateVendingMachineRestockHappyHonkFilled = Happy honk restock crate
     .desc = Contains a restock box for a happy honk dispenser.
 
+ent-CrateVendingMachineRestockGetmoreChocolateCorpFilled = Getmore Chocolate Corp restock crate
+    .desc = Contains a restock box for a Getmore Chocolate Corp dispenser.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/vending-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/vending-crates.ftl
@@ -40,9 +40,6 @@ ent-CrateVendingMachineRestockSeedsFilled = MegaSeed restock crate
 ent-CrateVendingMachineRestockSmokesFilled = ShadyCigs restock crate
     .desc = Contains two restock boxes for the ShadyCigs vending machine.
 
-ent-CrateVendingMachineRestockSnacksFilled = Snack restock crate
-    .desc = Contains four restock boxes, each covering a different snack vendor. Mr. Chang's, Discount Dans, and Robust Donuts are featured on the advertisement.
-
 ent-CrateVendingMachineRestockVendomatFilled = Vendomat restock crate
     .desc = Contains a restock box for a Vendomat vending machine.
 

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/vending-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/vending-crates.ftl
@@ -57,3 +57,12 @@ ent-CrateVendingMachineRestockHappyHonkFilled = Happy honk restock crate
 
 ent-CrateVendingMachineRestockGetmoreChocolateCorpFilled = Getmore Chocolate Corp restock crate
     .desc = Contains a restock box for a Getmore Chocolate Corp dispenser.
+
+ent-CrateVendingMachineRestockChangFilled = Chang restock crate
+    .desc = Contains a restock box for a Mr. Chang dispenser.
+
+ent-CrateVendingMachineRestockDiscountDansFilled = Discount Dans restock crate
+    .desc = Contains a restock box for a Discount Dan's dispenser.
+
+ent-CrateVendingMachineRestockDonutFilled = Donut restock crate
+    .desc = Contains a restock box for a Monkin' Donuts dispenser.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -205,3 +205,33 @@
   cost: 1200
   category: Service
   group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockChang
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockChangFilled
+  cost: 1200
+  category: Service
+  group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockDiscountDans
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockDiscountDansFilled
+  cost: 1200
+  category: Service
+  group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockDonut
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockDonutFilled
+  cost: 1200
+  category: Service
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -147,16 +147,6 @@
   group: market
 
 - type: cargoProduct
-  id: CrateVendingMachineRestockSnacks
-  icon:
-    sprite: Objects/Specific/Service/vending_machine_restock.rsi
-    state: base
-  product: CrateVendingMachineRestockSnacksFilled
-  cost: 3000
-  category: Service
-  group: market
-
-- type: cargoProduct
   id: CrateVendingMachineRestockVendomat
   icon:
     sprite: Objects/Specific/Service/vending_machine_restock.rsi

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -195,3 +195,13 @@
   cost: 2100
   category: Service
   group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockGetmoreChocolateCorp
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockGetmoreChocolateCorpFilled
+  cost: 1200
+  category: Service
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -123,7 +123,6 @@
       - id: VendingMachineRestockChang
       - id: VendingMachineRestockDiscountDans
       - id: VendingMachineRestockDonut
-      - id: VendingMachineRestockGetmoreChocolateCorp
 
 - type: entity
   id: CrateVendingMachineRestockVendomatFilled
@@ -156,4 +155,13 @@
   - type: StorageFill
     contents:
       - id: VendingMachineRestockHappyHonk
+        amount: 2
+
+- type: entity
+  id: CrateVendingMachineRestockGetmoreChocolateCorpFilled
+  parent: CratePlastic
+  components:
+  - type: StorageFill
+    contents:
+      - id: VendingMachineRestockGetmoreChocolateCorp
         amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -165,3 +165,30 @@
     contents:
       - id: VendingMachineRestockGetmoreChocolateCorp
         amount: 2
+        
+- type: entity
+  id: CrateVendingMachineRestockChangFilled
+  parent: CratePlastic
+  components:
+  - type: StorageFill
+    contents:
+      - id: VendingMachineRestockChang
+        amount: 2
+
+- type: entity
+  id: CrateVendingMachineRestockDiscountDansFilled
+  parent: CratePlastic
+  components:
+  - type: StorageFill
+    contents:
+      - id: VendingMachineRestockDiscountDans
+        amount: 2
+
+- type: entity
+  id: CrateVendingMachineRestockDonutFilled
+  parent: CratePlastic
+  components:
+  - type: StorageFill
+    contents:
+      - id: VendingMachineRestockDonut
+        amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -115,16 +115,6 @@
         amount: 2
 
 - type: entity
-  id: CrateVendingMachineRestockSnacksFilled
-  parent: CratePlastic
-  components:
-  - type: StorageFill
-    contents:
-      - id: VendingMachineRestockChang
-      - id: VendingMachineRestockDiscountDans
-      - id: VendingMachineRestockDonut
-
-- type: entity
   id: CrateVendingMachineRestockVendomatFilled
   parent: CratePlastic
   components:
@@ -165,7 +155,7 @@
     contents:
       - id: VendingMachineRestockGetmoreChocolateCorp
         amount: 2
-        
+
 - type: entity
   id: CrateVendingMachineRestockChangFilled
   parent: CratePlastic


### PR DESCRIPTION

## About the PR
Previously GetMore Chocolate restock box was in Snack restore create. Getmore Chocolate Corp vending machines are almost always in crowded places, so they quickly deplete their stocks. As a result, they are not even replenished because of the high price of "3000".
I want to remove them from the Snack restore create and sell them freely for 1200.
**Media**
- [x] This PR does not require an ingame showcase
