### PR TITLE
Give chemistry bottles visualizers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -154,7 +154,7 @@
 - type: entity
   id: EpinephrineChemistryBottle
   name: epinephrine bottle
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -171,7 +171,7 @@
   id: RobustHarvestChemistryBottle
   name: robust harvest bottle
   description: This will increase the potency of your plants.
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -188,7 +188,7 @@
   id: UnstableMutagenChemistryBottle
   name: unstable mutagen bottle
   description: This will cause rapid mutations in your plants.
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -205,7 +205,7 @@
   id: NocturineChemistryBottle
   name: nocturine bottle
   description: This will make someone fall down almost immediately. Hard to overdose on.
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -221,7 +221,7 @@
 - type: entity
   id: EphedrineChemistryBottle
   name: ephedrine bottle
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:
@@ -237,7 +237,7 @@
 - type: entity
   id: OmnizineChemistryBottle
   name: omnizine bottle
-  parent: BaseChemistryEmptyBottle
+  parent: ChemistryEmptyBottle01
   components:
   - type: SolutionContainerManager
     solutions:


### PR DESCRIPTION
## About the PR
Chemistry bottles have visualizers that show the contents' color and fill level. These visualizers are missing from the prototypes for the pre-filled chemistry bottles, which cause these bottles to be missing these visualizers even if they are emptied and re-filled.

This change reparents these stock chemistry bottles from `BaseChemistryEmptyBottle` (which is missing the visualizer) to `ChemistryEmptyBottle01` (which has the visualizer for one bottle style).

**Media**
![image](https://github.com/space-wizards/space-station-14/assets/3229565/7abc13c4-6f96-4a48-a313-d67cbaf932bf)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
N/A