### PR TITLE
Make potency visuals 1x scaling by default

### DIFF
--- a/Content.Client/Botany/Components/PotencyVisualsComponent.cs
+++ b/Content.Client/Botany/Components/PotencyVisualsComponent.cs
@@ -4,8 +4,8 @@ namespace Content.Client.Botany.Components;
 public sealed class PotencyVisualsComponent : Component
 {
     [DataField("minimumScale")]
-    public float MinimumScale = 0.5f;
+    public float MinimumScale = 1f;
 
     [DataField("maximumScale")]
-    public float MaximumScale = 1.5f;
+    public float MaximumScale = 2f;
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
non integer scaling still looks shit but this alleviates my pain by having it be 1x scaling by default.
Now, rather than having small fruit which become normal which become big, you have normal fruit which become big which become comically large.

Who doesn't love a big potato?

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/bf4fe4be-f94c-42bd-b796-c5036091a827)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Botany's produce is now larger on average.
