### PR TITLE
Zombies recover faster from crit. They heal Piercing damage

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -63,6 +63,9 @@ namespace Content.Server.Zombies
             var query = EntityQueryEnumerator<PendingZombieComponent>();
             var curTime = _timing.CurTime;
 
+            var zombQuery = EntityQueryEnumerator<ZombieComponent>();
+            var stateQuery = GetEntityQuery<MobStateComponent>();
+
             // Hurt the living infected
             while (query.MoveNext(out var uid, out var comp))
             {
@@ -78,10 +81,8 @@ namespace Content.Server.Zombies
                 _damageable.TryChangeDamage(uid, comp.Damage * pain_multiple, true, false);
             }
 
-            var zomb_query = EntityQueryEnumerator<ZombieComponent>();
-            var state_query = GetEntityQuery<MobStateComponent>();
             // Heal the zombified
-            while (zomb_query.MoveNext(out var uid, out var comp))
+            while (zombQuery.MoveNext(out var uid, out var comp))
             {
                 // Process only once per second
                 if (comp.NextTick + TimeSpan.FromSeconds(1) > curTime)
@@ -90,7 +91,7 @@ namespace Content.Server.Zombies
                 comp.NextTick = curTime;
 
                 // Healing increases over time for zombies currently in crit
-                if (state_query.TryGetComponent(uid, out var mobstate) && mobstate.CurrentState == MobState.Critical)
+                if (stateQuery.TryGetComponent(uid, out var mobstate) && mobstate.CurrentState == MobState.Critical)
                 {
                     comp.SecondsCrit += 1;
                 }

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
@@ -38,6 +39,7 @@ namespace Content.Server.Zombies
         [Dependency] private readonly HumanoidAppearanceSystem _humanoidSystem = default!;
         [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
         [Dependency] private readonly MobStateSystem _mobState = default!;
+        [Dependency] private readonly SharedPopupSystem _popup = default!;
 
         public override void Initialize()
         {
@@ -109,6 +111,10 @@ namespace Content.Server.Zombies
                     comp.SecondsCrit += 1;
                 }
 
+                if (comp.SecondsCrit > 5 && comp.SecondsCrit % 15 == 0)
+                {
+                    _popup.PopupEntity(Loc.GetString("zombie-healing"), uid, uid);
+                }
                 // Healing increases over 50 seconds to a maximum of 10x rate. They will be half healed by then at least.
                 //   At that rate most zombies will revive from the remaining 50 (of 100) damage after a further 25sec
                 float healMultiple = 1.0f + Math.Min(comp.SecondsCrit * 0.2f, 20.0f);

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -92,6 +92,11 @@ namespace Content.Shared.Zombies
         // Heal on tick
         [DataField("nextTick", customTypeSerializer:typeof(TimeOffsetSerializer))]
         public TimeSpan NextTick;
+
+        /// <summary>
+        /// Number of seconds that this zombie has been in crit, which scales healing over time. Updated by ZombieSystem
+        /// </summary>
+        [DataField("secondsCrit")]
         public int SecondsCrit;
 
         [DataField("damage")] public DamageSpecifier Damage = new()

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -36,7 +36,7 @@ namespace Content.Shared.Zombies
         /// Heal multiplier for one big heal on coming back to life.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float ZombieRevivalHealingMult = 80.0f;
+        public float ZombieRevivalHealingMult = 200.0f;
 
         /// <summary>
         /// Has this zombie stopped healing now that it's died for real?
@@ -121,9 +121,9 @@ namespace Content.Shared.Zombies
         {
             DamageDict = new ()
             {
-                { "Blunt", -0.3 },
-                { "Slash", -0.1 },
-                { "Piercing", -0.1 },
+                { "Blunt", -0.4 },
+                { "Slash", -0.2 },
+                { "Piercing", -0.2 },
                 { "Heat", -0.2 },
                 { "Cold", -0.2 },
                 { "Shock", -0.2 },

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -27,6 +27,24 @@ namespace Content.Shared.Zombies
         public float MaxZombieInfectionChance = 0.40f;
 
         /// <summary>
+        /// Chance that this zombie will survive getting killed
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float ZombieReviveChance = 0.30f;
+
+        /// <summary>
+        /// Heal multiplier for one big heal on coming back to life.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float ZombieRevivalHealingMult = 80.0f;
+
+        /// <summary>
+        /// Has this zombie stopped healing now that it's died for real?
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool Permadeath = false;
+
+        /// <summary>
         /// The minimum infection chance possible. This is simply to prevent
         /// being invincible by bundling up.
         /// </summary>

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -111,5 +111,13 @@ namespace Content.Shared.Zombies
                 { "Shock", -0.2 },
             }
         };
+
+        [DataField("forceDeathDamage")] public DamageSpecifier ForceDeathDamage = new()
+        {
+            DamageDict = new ()
+            {
+                { "Blunt", 100.0 },
+            }
+        };
     }
 }

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -27,16 +27,17 @@ namespace Content.Shared.Zombies
         public float MaxZombieInfectionChance = 0.40f;
 
         /// <summary>
-        /// Chance that this zombie will survive getting killed
+        /// Chance that this zombie be permanently killed (rolled once on crit->death transition)
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float ZombieReviveChance = 0.30f;
+        public float ZombiePermadeathChance = 0.70f;
 
         /// <summary>
-        /// Heal multiplier for one big heal on coming back to life.
+        /// Chance that this zombie will be healed (rolled each second when in crit or dead)
+        ///   3% means you have a 60% chance after 30 secs and a 84% chance after 60.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float ZombieRevivalHealingMult = 200.0f;
+        public float ZombieReviveChance = 0.03f;
 
         /// <summary>
         /// Has this zombie stopped healing now that it's died for real?
@@ -110,12 +111,6 @@ namespace Content.Shared.Zombies
         // Heal on tick
         [DataField("nextTick", customTypeSerializer:typeof(TimeOffsetSerializer))]
         public TimeSpan NextTick;
-
-        /// <summary>
-        /// Number of seconds that this zombie has been in crit, which scales healing over time. Updated by ZombieSystem
-        /// </summary>
-        [DataField("secondsCrit")]
-        public int SecondsCrit;
 
         [DataField("damage")] public DamageSpecifier Damage = new()
         {

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -124,13 +124,5 @@ namespace Content.Shared.Zombies
                 { "Shock", -0.2 },
             }
         };
-
-        [DataField("forceDeathDamage")] public DamageSpecifier ForceDeathDamage = new()
-        {
-            DamageDict = new ()
-            {
-                { "Blunt", 100.0 },
-            }
-        };
     }
 }

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -92,13 +92,15 @@ namespace Content.Shared.Zombies
         // Heal on tick
         [DataField("nextTick", customTypeSerializer:typeof(TimeOffsetSerializer))]
         public TimeSpan NextTick;
+        public int SecondsCrit;
 
         [DataField("damage")] public DamageSpecifier Damage = new()
         {
             DamageDict = new ()
             {
                 { "Blunt", -0.3 },
-                { "Slash", -0.2 },
+                { "Slash", -0.1 },
+                { "Piercing", -0.1 },
                 { "Heat", -0.2 },
                 { "Cold", -0.2 },
                 { "Shock", -0.2 },

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-zombies.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-zombies.ftl
@@ -5,6 +5,7 @@ zombie-not-enough-ready-players = Not enough players readied up for the game! Th
 zombie-no-one-ready = No players readied up! Can't start Zombies.
 
 zombie-patientzero-role-greeting = You are patient 0. Hide your infection, get supplies, and be prepared to turn once you die.
+zombie-healing = You feel a stirring in your flesh
 
 zombie-alone = You feel entirely alone.
 

--- a/Resources/Locale/en-US/zombies/zombie.ftl
+++ b/Resources/Locale/en-US/zombies/zombie.ftl
@@ -5,3 +5,5 @@ zombie-generic = zombie
 zombie-name-prefix = Zombified {$target}
 zombie-role-desc =  A malevolent creature of the dead.
 zombie-role-rules = You are an antagonist. Search out the living and bite them in order to infect them and turn them into zombies. Work together with other the zombies to overtake the station.
+
+zombie-permadeath = This time, you're dead for real.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Resolve a bug where Zombies would never heal from piercing damage (guns for instance). Also the healing now scales over time in crit so we don't have bored zombie players dead for multiple minutes (up to 8 minutes before).

- Add Piercing damage (leaving it out was a mistake, did I miss any other damage types?)
- Healing scales over time the zombie is in crit, to 2x rate after 5 seconds up to 10x rate after 45 seconds. If the zombie has 200 damage (100 over crit) they will take up to 70 seconds to be up and moving again.
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: "Dead" zombies have a chance to spring back to life at any moment, they also passively heal most damage types slowly while alive. If you crit or kill them you have a chance to perma-kill.
