### PR TITLE
Cannot stack binary and trinary Atmos pumps and devices. 5x Filter rate boost

### DIFF
--- a/Content.Client/Atmos/UI/GasFilterBoundUserInterface.cs
+++ b/Content.Client/Atmos/UI/GasFilterBoundUserInterface.cs
@@ -14,7 +14,6 @@ namespace Content.Client.Atmos.UI
     {
 
         private GasFilterWindow? _window;
-        private const float MaxTransferRate = Atmospherics.MaxTransferRate;
 
         public GasFilterBoundUserInterface(ClientUserInterfaceComponent owner, Enum uiKey) : base(owner, uiKey)
         {
@@ -49,7 +48,6 @@ namespace Content.Client.Atmos.UI
         private void OnFilterTransferRatePressed(string value)
         {
             float rate = float.TryParse(value, out var parsed) ? parsed : 0f;
-            if (rate > MaxTransferRate) rate = MaxTransferRate;
 
             SendMessage(new GasFilterChangeRateMessage(rate));
         }

--- a/Content.Client/Atmos/UI/GasFilterWindow.xaml
+++ b/Content.Client/Atmos/UI/GasFilterWindow.xaml
@@ -9,7 +9,7 @@
 
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
             <Label Text="{Loc comp-gas-filter-ui-filter-transfer-rate}"/>
-            <LineEdit Name="FilterTransferRateInput" MinSize="40 0" />
+            <LineEdit Name="FilterTransferRateInput" MinSize="60 0" />
             <Button Name="SetFilterRate" Text="{Loc comp-gas-filter-ui-filter-set-rate}" Disabled="True"/>
         </BoxContainer>
 

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Client.Popups;
 using Content.Shared.Construction;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Examine;
@@ -24,6 +25,7 @@ namespace Content.Client.Construction
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+        [Dependency] private readonly PopupSystem _popupSystem = default!;
 
         private readonly Dictionary<int, ConstructionGhostComponent> _ghosts = new();
         private readonly Dictionary<string, ConstructionGuide> _guideCache = new();
@@ -181,7 +183,15 @@ namespace Content.Client.Construction
             foreach (var condition in prototype.Conditions)
             {
                 if (!condition.Condition(user, loc, dir))
+                {
+                    var message = condition.GenerateGuideEntry()?.Localization;
+                    if (message != null)
+                    {
+                        // Show the reason to the user:
+                        _popupSystem.PopupCoordinates(Loc.GetString(message), loc);
+                    }
                     return false;
+                }
             }
 
             ghost = EntityManager.SpawnEntity("constructionghost", loc);

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -180,19 +180,8 @@ namespace Content.Client.Construction
             if (!_interactionSystem.InRangeUnobstructed(user, loc, 20f, predicate: predicate))
                 return false;
 
-            foreach (var condition in prototype.Conditions)
-            {
-                if (!condition.Condition(user, loc, dir))
-                {
-                    var message = condition.GenerateGuideEntry()?.Localization;
-                    if (message != null)
-                    {
-                        // Show the reason to the user:
-                        _popupSystem.PopupCoordinates(Loc.GetString(message), loc);
-                    }
-                    return false;
-                }
-            }
+            if (!CheckConstructionConditions(prototype, loc, dir, user))
+                return false;
 
             ghost = EntityManager.SpawnEntity("constructionghost", loc);
             var comp = EntityManager.GetComponent<ConstructionGhostComponent>(ghost.Value);
@@ -213,6 +202,27 @@ namespace Content.Client.Construction
 
             if (prototype.CanBuildInImpassable)
                 EnsureComp<WallMountComponent>(ghost.Value).Arc = new(Math.Tau);
+
+            return true;
+        }
+
+        private bool CheckConstructionConditions(ConstructionPrototype prototype, EntityCoordinates loc, Direction dir,
+            EntityUid user)
+        {
+            foreach (var condition in prototype.Conditions)
+            {
+                if (!condition.Condition(user, loc, dir))
+                {
+                    var message = condition.GenerateGuideEntry()?.Localization;
+                    if (message != null)
+                    {
+                        // Show the reason to the user:
+                        _popupSystem.PopupCoordinates(Loc.GetString(message), loc);
+                    }
+
+                    return false;
+                }
+            }
 
             return true;
         }

--- a/Content.Server/Construction/AnchorableSystem.cs
+++ b/Content.Server/Construction/AnchorableSystem.cs
@@ -1,13 +1,16 @@
 using Content.Server.Administration.Logs;
+using Content.Server.Construction.Components;
 using Content.Server.Coordinates.Helpers;
 using Content.Server.Popups;
 using Content.Server.Pulling;
 using Content.Shared.Construction.Components;
+using Content.Shared.Construction.Conditions;
 using Content.Shared.Construction.EntitySystems;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Pulling.Components;
+using Content.Shared.Tag;
 using Content.Shared.Tools;
 using Content.Shared.Tools.Components;
 using Robust.Shared.Map;
@@ -24,6 +27,7 @@ namespace Content.Server.Construction
         [Dependency] private readonly SharedToolSystem _tool = default!;
         [Dependency] private readonly PullingSystem _pulling = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly TagSystem _tagSystem = default!;
 
         public override void Initialize()
         {
@@ -85,7 +89,26 @@ namespace Content.Server.Construction
             // TODO: Anchoring snaps rn anyway!
             if (component.Snap)
             {
-                _transform.SetCoordinates(uid, xform.Coordinates.SnapToGrid(EntityManager, _mapManager));
+                var coordinates = xform.Coordinates.SnapToGrid(EntityManager, _mapManager);
+
+                if (_tagSystem.HasTag(uid, "Unstackable"))
+                {
+                    // Need to enforce the unstackable rules on anchoring also.
+                    var condition = new NoUnstackableInTile();
+                    if (!condition.Condition(args.User, coordinates, Direction.Invalid))
+                    {
+                        var message = condition.GenerateGuideEntry()?.Localization;
+                        if (message != null)
+                        {
+                            // Show the reason to the user:
+                            _popup.PopupEntity(Loc.GetString(message), uid, args.User);
+                        }
+
+                        return;
+                    }
+                }
+
+                _transform.SetCoordinates(uid, coordinates);
             }
 
             RaiseLocalEvent(uid, new BeforeAnchoredEvent(args.User, used));

--- a/Content.Server/Construction/AnchorableSystem.cs
+++ b/Content.Server/Construction/AnchorableSystem.cs
@@ -95,7 +95,7 @@ namespace Content.Server.Construction
                 {
                     // Need to enforce the unstackable rules on anchoring also.
                     var condition = new NoUnstackableInTile();
-                    if (!condition.Condition(args.User, coordinates, Direction.Invalid))
+                    if (NoUnstackableInTile.AnyUnstackableTiles(coordinates, _tagSystem))
                     {
                         var message = condition.GenerateGuideEntry()?.Localization;
                         if (message != null)

--- a/Content.Shared/Construction/Conditions/NoUnstackableInTile.cs
+++ b/Content.Shared/Construction/Conditions/NoUnstackableInTile.cs
@@ -13,13 +13,24 @@ namespace Content.Shared.Construction.Conditions
         {
             var tagSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<TagSystem>();
 
-            foreach (var entity in location.GetEntitiesInTile(LookupFlags.Approximate | LookupFlags.Static | LookupFlags.Sundries))
-            {
-                if (tagSystem.HasTag(entity, "Unstackable"))
-                    return false;
-            }
+            if (AnyUnstackableTiles(location, tagSystem))
+                return false;
 
             return true;
+        }
+
+        public static bool AnyUnstackableTiles(EntityCoordinates location, TagSystem tagSystem)
+        {
+            var lookup = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+
+            foreach (var entity in lookup.GetEntitiesIntersecting(location, LookupFlags.Approximate | LookupFlags.Static |
+                                                                            LookupFlags.Sundries))
+            {
+                if (tagSystem.HasTag(entity, "Unstackable"))
+                    return true;
+            }
+
+            return false;
         }
 
         public ConstructionGuideEntry GenerateGuideEntry()

--- a/Content.Shared/Construction/Conditions/NoUnstackableInTile.cs
+++ b/Content.Shared/Construction/Conditions/NoUnstackableInTile.cs
@@ -1,0 +1,33 @@
+﻿using Content.Shared.Maps;
+using Content.Shared.Tag;
+using JetBrains.Annotations;
+using Robust.Shared.Map;
+
+namespace Content.Shared.Construction.Conditions
+{
+    [UsedImplicitly]
+    [DataDefinition]
+    public sealed class NoUnstackableInTile : IConstructionCondition
+    {
+        public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
+        {
+            var tagSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<TagSystem>();
+
+            foreach (var entity in location.GetEntitiesInTile(LookupFlags.Approximate | LookupFlags.Static | LookupFlags.Sundries))
+            {
+                if (tagSystem.HasTag(entity, "Unstackable"))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public ConstructionGuideEntry GenerateGuideEntry()
+        {
+            return new ConstructionGuideEntry
+            {
+                Localization = "construction-step-condition-no-unstackable-in-tile"
+            };
+        }
+    }
+}

--- a/Content.Shared/Construction/Conditions/NoWindowsInTile.cs
+++ b/Content.Shared/Construction/Conditions/NoWindowsInTile.cs
@@ -12,8 +12,9 @@ namespace Content.Shared.Construction.Conditions
         public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
         {
             var tagSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<TagSystem>();
+            var lookup = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
 
-            foreach (var entity in location.GetEntitiesInTile(LookupFlags.Approximate | LookupFlags.Static))
+            foreach (var entity in lookup.GetEntitiesIntersecting(location, LookupFlags.Approximate | LookupFlags.Static))
             {
                 if (tagSystem.HasTag(entity, "Window"))
                     return false;

--- a/Resources/Locale/en-US/construction/conditions/no-unstackable-in-tile.ftl
+++ b/Resources/Locale/en-US/construction/conditions/no-unstackable-in-tile.ftl
@@ -1,0 +1,1 @@
+construction-step-condition-no-unstackable-in-tile = You cannot make a stack of similar devices.

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -6,6 +6,9 @@
     mode: SnapgridCenter
   components:
   - type: AtmosDevice
+  - type: Tag
+    tags:
+      - Unstackable
   - type: SubFloorHide
     blockInteractions: false
     blockAmbience: false

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -6,6 +6,9 @@
     mode: SnapgridCenter
   components:
     - type: AtmosDevice
+    - type: Tag
+      tags:
+        - Unstackable
     - type: SubFloorHide
       blockInteractions: false
       blockAmbience: false
@@ -55,11 +58,16 @@
           type: GasFilterBoundUserInterface
     - type: GasFilter
       enabled: false
+      transferRate: 1000
+      maxTransferRate: 1000
     - type: Flippable
       mirrorEntity: GasFilterFlipped
     - type: Construction
       graph: GasTrinary
       node: filter
+      conditions:
+        - !type:TileNotBlocked
+        - !type:NoUnstackableInTile
     - type: AmbientSound
       enabled: false
       volume: -9
@@ -205,6 +213,9 @@
     mode: SnapgridCenter
   components:
     - type: AtmosDevice
+    - type: Tag
+      tags:
+        - Unstackable
     - type: SubFloorHide
       blockInteractions: false
       blockAmbience: false

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -483,6 +483,7 @@
     state: pumpPressure
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   name: volumetric gas pump
@@ -504,6 +505,7 @@
     state: pumpVolume
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasPassiveGate
@@ -525,6 +527,7 @@
     state: pumpPassiveGate
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasValve
@@ -546,6 +549,7 @@
     state: pumpManualValve
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: SignalControlledValve
@@ -567,6 +571,7 @@
     state: pumpSignalValve
   conditions:
   - !type:TileNotBlocked {}
+  - !type:NoUnstackableInTile
 
 - type: construction
   id: GasPort
@@ -588,6 +593,7 @@
     state: gasCanisterPort
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasDualPortVentPump
@@ -626,6 +632,24 @@
     state: gasFilter
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
+
+- type: construction
+  id: GasFilterFlipped
+  name: gas filter [flipped]
+  description: Very useful for filtering gases.
+  graph: GasTrinary
+  startNode: start
+  targetNode: filter
+  category: construction-category-utilities
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  icon:
+    sprite: Structures/Piping/Atmospherics/gasfilter.rsi
+    state: gasFilterF
+  conditions:
+    - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasMixer
@@ -641,7 +665,25 @@
     sprite: Structures/Piping/Atmospherics/gasmixer.rsi
     state: gasMixer
   conditions:
-    - !type:TileNotBlocked {}
+    - !type:TileNotBlocked
+    - !type:NoUnstackableInTile
+
+- type: construction
+  id: GasMixerFlipped
+  name: gas mixer [flipped]
+  description: Very useful for mixing gases.
+  graph: GasTrinary
+  startNode: start
+  targetNode: mixer
+  category: construction-category-utilities
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  icon:
+    sprite: Structures/Piping/Atmospherics/gasmixer.rsi
+    state: gasMixerF
+  conditions:
+    - !type:TileNotBlocked
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: PressureControlledValve
@@ -657,7 +699,8 @@
     sprite: Structures/Piping/Atmospherics/pneumaticvalve.rsi
     state: off
   conditions:
-    - !type:TileNotBlocked {}
+    - !type:TileNotBlocked
+    - !type:NoUnstackableInTile
 
 # INTERCOM
 - type: construction

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -698,6 +698,9 @@
   id: TrashBag
 
 - type: Tag
+  id: Unstackable # To prevent things like atmos devices (filters etc) being stacked on one tile. See NoUnstackableInTile
+
+- type: Tag
   id: VehicleKey
 
 - type: Tag


### PR DESCRIPTION
## About the PR
Atmos Technicians were creating stacks (5-20!) of filters and similar devices on the same tile. That wasn't the intent of the system and it makes their designs visually unreadable which is not what we want. 

However the main reason for stacking was because the gas filter is woefully underpowered at only 200 Litres / Sec which is especially bad for hot gasses like Tritium from a plasma fire pipe.

- Gas Mixers, Filters, pumps and similar devices are all tagged as unstackable and this is enforced with a new construction rule NoUnstackableInTile
- There is a matching check when anchoring to prevent stacking through re-anchoring structures.
- Filters now have a 5x max volume to compensate for no more stacking, so a max filterrate of 200 L/S
- Filter UI no longer enforces the max rate, as this was already enforced in the GasFilter system, the UI wasn't reading the actual max from the GasFilter component.
- Filter UI has a large enough region to type 1000 L/S into.
- Flipped Gas Filter and Gas Mixer are in the construction menu to aid discoverability

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/5285589/4e2c6752-77de-436a-8d72-ad4d45cc9b8c)
![image](https://github.com/space-wizards/space-station-14/assets/5285589/ac6ce107-29f1-41f7-9a9f-372e78711772)
![image](https://github.com/space-wizards/space-station-14/assets/5285589/1094772a-ebee-4835-9e7a-3aa7cef71638)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- remove: You cannot stack Gas Filters, Mixers or several other Atmos devices like pumps and valves. Pipes can still be stacked.
- tweak: Gas filters can now filter 5x faster (up to 1000 L/S) to compensate for no more filter stacks. This is their new default rate
- tweak: Gas Filters and mixers now have a flipped version visible in the construction menu. Hint: You can still right click on an un-anchored filter / mixer and choose rotate -> Flip
