### PR TITLE
reduce bicaridine overdose damage

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -151,14 +151,13 @@
           min: 15
         damage:
           types:
-            Asphyxiation: 1
-            Poison: 3
-            Brute: 1
+            Asphyxiation: 0.5
+            Poison: 1.5
       - !type:ChemVomit
         conditions:
         - !type:ReagentThreshold
           min: 30
-        probability: 0.02           
+        probability: 0.02
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
## About the PR
what i see constantly happening in medbay is someone comes in with 60 brute damage, 2 doctors give the patient 15u bicar and he has to be cloned from the ridiculous amount of poison damage that can't be healed without a hypospray.

excluding the brute healing, a pill did 10 damage per unit, close to amatoxin

this pr:
- removes the brute damage since it makes little sense
- reduces the rest to 1 asphyxiation and 3 poison

so now it does a relatively mild 4 damage per unit

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: New safety standards have made bicaridine overdoses less fatal than before.
