### PR TITLE
[FIX] HoP detective acces

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -40,6 +40,7 @@
   - Engineering
   - Quartermaster
   - Research
+  - Detective
   - Salvage
   - Security
   - Brig


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Due to #14699
![image](https://github.com/space-wizards/space-station-14/assets/124214523/194ada52-f667-4bb4-b88d-8441917d3cb1)
Detective access wasnt added

**Changelog**

:cl: lzk
- fix: hop now has detective acces