### PR TITLE
Biocoded clothing

### DIFF
--- a/Content.Shared/Clothing/Components/BiocodedClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/BiocodedClothingComponent.cs
@@ -1,0 +1,37 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing.Components;
+
+/// <summary>
+///     Restrict wearing this clothing for everyone, except owner.
+///     First person that equipped clothing is saved as clothing owner.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class BiocodedClothingComponent : Component
+{
+    /// <summary>
+    ///     If biocoding enabled? Can be toggled by verb.
+    /// </summary>
+    [DataField("enabled")]
+    [AutoNetworkedField]
+    public bool Enabled = true;
+
+    /// <summary>
+    ///     Person that currently wear this clothing.
+    ///     Null if no one wearing it.
+    /// </summary>
+    [DataField("wearer")]
+    [AutoNetworkedField]
+    public EntityUid? CurrentWearer;
+
+    /// <summary>
+    ///     Entity that is owner of biocoded item. Null if no owner.
+    /// </summary>
+    /// <remarks>
+    ///     If owner was cloned, this item will not recognize them.
+    /// </remarks>
+    [DataField("biocodedOwner")]
+    [AutoNetworkedField]
+    public EntityUid? BiocodedOwner;
+}

--- a/Content.Shared/Clothing/EntitySystems/BiocodedClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/BiocodedClothingSystem.cs
@@ -1,0 +1,140 @@
+using Content.Shared.Clothing.Components;
+using Content.Shared.Emag.Systems;
+using Content.Shared.Examine;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Clothing.EntitySystems;
+
+public sealed class BiocodedClothingSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BiocodedClothingComponent, ExaminedEvent>(OnExamine);
+        SubscribeLocalEvent<BiocodedClothingComponent, GetVerbsEvent<EquipmentVerb>>(AddVerb);
+        SubscribeLocalEvent<BiocodedClothingComponent, GotEquippedEvent>(OnGotEquipped);
+        SubscribeLocalEvent<BiocodedClothingComponent, GotUnequippedEvent>(OnGotUnequipped);
+        SubscribeLocalEvent<BiocodedClothingComponent, BeingEquippedAttemptEvent>(OnEquipAttempt);
+        SubscribeLocalEvent<BiocodedClothingComponent, GotEmaggedEvent>(OnGotEmagged);
+    }
+
+    private void OnExamine(EntityUid uid, BiocodedClothingComponent component, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        // print current armor status
+        string examineMsg;
+        if (!component.Enabled)
+        {
+            examineMsg = "biocoded-clothing-component-examine-disabled";
+        }
+        else
+        {
+            if (component.BiocodedOwner == null)
+                examineMsg = "biocoded-clothing-component-examine-no-owner";
+            else if (IsValidOwner(args.Examiner, uid, component))
+                examineMsg = "biocoded-clothing-component-examine-owner";
+            else
+                examineMsg = "biocoded-clothing-component-examine-wrong-owner";
+        }
+        args.PushMarkup(Loc.GetString(examineMsg));
+    }
+
+    private void AddVerb(EntityUid uid, BiocodedClothingComponent component, GetVerbsEvent<EquipmentVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        // only owner can toggle biocoding on/off
+        if (!IsValidOwner(args.User, args.Target, component))
+            return;
+
+        // add verb to toggle biocoding
+        var msg = component.Enabled
+            ? "biocoded-clothing-component-verb-disable"
+            : "biocoded-clothing-component-verb-enable";
+        var iconPath = component.Enabled
+            ? "/Textures/Interface/VerbIcons/unlock.svg.192dpi.png"
+            : "/Textures/Interface/VerbIcons/lock.svg.192dpi.png";
+        args.Verbs.Add(new EquipmentVerb
+        {
+            Text = Loc.GetString(msg),
+            Icon = new SpriteSpecifier.Texture(new ResPath(iconPath)),
+            Act = () => EnableBiocoding(uid, !component.Enabled, component)
+        });
+    }
+
+    private void OnGotEquipped(EntityUid uid, BiocodedClothingComponent component, GotEquippedEvent args)
+    {
+        // save current wearer
+        component.CurrentWearer = args.Equipee;
+        // save owner if it was equipped first time
+        component.BiocodedOwner ??= args.Equipee;
+        Dirty(component);
+    }
+
+    private void OnGotUnequipped(EntityUid uid, BiocodedClothingComponent component, GotUnequippedEvent args)
+    {
+        // reset current wearer
+        component.CurrentWearer = null;
+        Dirty(component);
+    }
+
+    private void OnEquipAttempt(EntityUid uid, BiocodedClothingComponent component, BeingEquippedAttemptEvent args)
+    {
+        var isValid = IsValidOwner(args.EquipTarget, uid, component);
+        if (!isValid)
+        {
+            args.Reason = "biocoded-clothing-component-equip-failed ";
+            args.Cancel();
+        }
+    }
+
+    private void OnGotEmagged(EntityUid uid, BiocodedClothingComponent component, ref GotEmaggedEvent args)
+    {
+        args.Repeatable = true;
+        args.Handled = true;
+        EnableBiocoding(uid, false, component);
+    }
+
+    public void EnableBiocoding(EntityUid uid, bool isEnabled, BiocodedClothingComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        if (!isEnabled)
+        {
+            // reset biocoding, forget about current owner
+            component.BiocodedOwner = null;
+        }
+        else
+        {
+            // set current wearer as a new owner
+            component.BiocodedOwner = component.CurrentWearer;
+        }
+
+        component.Enabled = isEnabled;
+        Dirty(component);
+    }
+
+    public bool IsValidOwner(EntityUid ownerUid, EntityUid itemUid, BiocodedClothingComponent? component = null)
+    {
+        if (!Resolve(itemUid, ref component))
+            return false;
+
+        // not enabled - you can wear it
+        if (!component.Enabled)
+            return true;
+        // no owner - you can wear it
+        if (component.BiocodedOwner == null)
+            return true;
+
+        // has owner - check if current equipee is owner
+        return component.BiocodedOwner == ownerUid;
+    }
+}

--- a/Content.Shared/Clothing/EntitySystems/BiocodedClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/BiocodedClothingSystem.cs
@@ -90,7 +90,7 @@ public sealed class BiocodedClothingSystem : EntitySystem
         var isValid = IsValidOwner(args.EquipTarget, uid, component);
         if (!isValid)
         {
-            args.Reason = "biocoded-clothing-component-equip-failed ";
+            args.Reason = "biocoded-clothing-component-equip-failed";
             args.Cancel();
         }
     }

--- a/Resources/Locale/en-US/clothing/components/biocoded-component.ftl
+++ b/Resources/Locale/en-US/clothing/components/biocoded-component.ftl
@@ -1,0 +1,13 @@
+
+## Examine
+biocoded-clothing-component-examine-disabled = Biocoding system [color=gray]is disabled[/color]. Anyone can wear it.
+biocoded-clothing-component-examine-no-owner = Biocoding system has [color=green]no owner[/color]. Equip it to become a new owner.
+biocoded-clothing-component-examine-owner = Biocoding system recognize [color=green]you as owner[/color]. Only you can wear it.
+biocoded-clothing-component-examine-wrong-owner = [color=darkred]Biocoding system prevent you from wearing it![/color]
+
+## Verb
+biocoded-clothing-component-verb-disable = Disable Biocoding
+biocoded-clothing-component-verb-enable = Enable Biocoding
+
+## Popup
+biocoded-clothing-component-equip-failed = It's biocoded!

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -447,6 +447,7 @@
     damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndie
+  - type: BiocodedClothing
 
 - type: entity
   parent: ClothingOuterHardsuitBase
@@ -591,6 +592,7 @@
     damageCoefficient: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
+  - type: BiocodedClothing
 
 - type: entity
   parent: ClothingOuterHardsuitBase
@@ -621,6 +623,7 @@
     damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
+  - type: BiocodedClothing
 
 - type: entity
   parent: ClothingOuterHardsuitBase
@@ -653,6 +656,7 @@
     damageCoefficient: 0.3
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
+  - type: BiocodedClothing
 
 - type: entity
   parent: ClothingOuterHardsuitBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adds biocoded clothing similar to Rimworld. Biocoded clothing will remember first wearer as its owner. It will refuse to be worn by anyone else until owner would disable biocoding or clothing would be emaged.

Biocoding added for all syndie hardsuits. Main motivation is that during nuke ops, greytiders really like to grab overpowered red hardsuits. This lead to confusion, friendly fire and powergaming.

I would also recommend to add this to other overpowered hardsuits, like ERT, death squad, CBURN, etc in separate PR.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below

 to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/6161335/af6f5ab5-4e85-4028-bff9-32d906d3ae5a


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Syndicate has added a biocoding system to all of their hardsuits. Biocoding allows hardsuit to remember its first wearer as the owner. It will refuse to be worn by anyone else.
- add: Clothing biocoding lock can be disabled by owner or emag.
