### PR TITLE
Move StylesheetManager initialization to `PostInit()`

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -123,7 +123,6 @@ namespace Content.Client.Entry
 
             _componentFactory.GenerateNetIds();
             _adminManager.Initialize();
-            _stylesheetManager.Initialize();
             _screenshotHook.Initialize();
             _changelogManager.Initialize();
             _rulesManager.Initialize();
@@ -143,6 +142,9 @@ namespace Content.Client.Entry
         public override void PostInit()
         {
             base.PostInit();
+
+            _stylesheetManager.Initialize();
+
             // Setup key contexts
             ContentContexts.SetupContexts(_inputManager.Contexts);
 


### PR DESCRIPTION
Ensures that the content stylesheet is used instead of the default one added in space-wizards/RobustToolbox/pull/4017