### PR TITLE
Add space glue

### DIFF
--- a/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
@@ -41,6 +41,7 @@ namespace Content.Server.Chemistry.TileReactions
                 var speedModifier = 1 - reagent.Viscosity;
                 slow.WalkSpeedModifier = speedModifier;
                 slow.SprintSpeedModifier = speedModifier;
+                entityManager.Dirty(slow);
 
                 return reactVolume;
             }

--- a/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
@@ -3,8 +3,8 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reaction;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
+using Content.Shared.Movement.Components;
 using Content.Shared.Slippery;
-using Content.Shared.StepTrigger;
 using Content.Shared.StepTrigger.Components;
 using Content.Shared.StepTrigger.Systems;
 using JetBrains.Annotations;
@@ -36,6 +36,11 @@ namespace Content.Server.Chemistry.TileReactions
 
                 var step = entityManager.EnsureComponent<StepTriggerComponent>(puddleUid);
                 entityManager.EntitySysManager.GetEntitySystem<StepTriggerSystem>().SetRequiredTriggerSpeed(puddleUid, _requiredSlipSpeed, step);
+
+                var slow = entityManager.EnsureComponent<SlowContactsComponent>(puddleUid);
+                var speedModifier = 1 - reagent.Viscosity;
+                slow.WalkSpeedModifier = speedModifier;
+                slow.SprintSpeedModifier = speedModifier;
 
                 return reactVolume;
             }

--- a/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
@@ -8,7 +8,7 @@ public sealed class VentClogRuleComponent : Component
     [DataField("safeishVentChemicals")]
     public readonly IReadOnlyList<string> SafeishVentChemicals = new[]
     {
-        "Water", "Blood", "Slime", "SpaceDrugs", "SpaceCleaner", "Nutriment", "Sugar", "SpaceLube", "Ephedrine", "Ale", "Beer"
+        "Water", "Blood", "Slime", "SpaceDrugs", "SpaceCleaner", "Nutriment", "Sugar", "SpaceLube", "Ephedrine", "Ale", "Beer", "SpaceGlue"
     };
 
 }

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -80,6 +80,10 @@ namespace Content.Shared.Chemistry.Reagent
         [DataField("slippery")]
         public bool Slippery = false;
 
+        /// <summary>
+        /// How much reagent slows entities down if it's part of a puddle. 
+        /// 0 - no slowdown; 1 - can't move.
+        /// </summary>
         [DataField("viscosity")]
         public float Viscosity = 0;
 

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -80,6 +80,9 @@ namespace Content.Shared.Chemistry.Reagent
         [DataField("slippery")]
         public bool Slippery = false;
 
+        [DataField("viscosity")]
+        public float Viscosity = 0;
+
         [DataField("metabolisms", serverOnly: true, customTypeSerializer: typeof(PrototypeIdDictionarySerializer<ReagentEffectsEntry, MetabolismGroupPrototype>))]
         public Dictionary<string, ReagentEffectsEntry>? Metabolisms = null;
 

--- a/Resources/Locale/en-US/reagents/meta/cleaning.ftl
+++ b/Resources/Locale/en-US/reagents/meta/cleaning.ftl
@@ -8,4 +8,4 @@ reagent-name-space-lube = space lube
 reagent-desc-space-lube = Space Lube is a high performance lubricant intended for maintenance of extremely complex mechanical equipment (and certainly not used to make people slip).
 
 reagent-name-space-glue = space glue
-reagent-desc-space-glue = Space Glue
+reagent-desc-space-glue = Space Glue is a high performance glue intended for maintenance of extremely complex mechanical equipment (and certainly not used to make people stick to the floor).

--- a/Resources/Locale/en-US/reagents/meta/cleaning.ftl
+++ b/Resources/Locale/en-US/reagents/meta/cleaning.ftl
@@ -6,3 +6,6 @@ reagent-desc-space-cleaner = This is able to clean almost all surfaces of almost
 
 reagent-name-space-lube = space lube
 reagent-desc-space-lube = Space Lube is a high performance lubricant intended for maintenance of extremely complex mechanical equipment (and certainly not used to make people slip).
+
+reagent-name-space-glue = space glue
+reagent-desc-space-glue = Space Glue

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -70,3 +70,9 @@
         type: Add
         time: 5
         refresh: false
+      - !type:GenericStatusEffect
+        key: Muted
+        component: Muted
+        type: Add
+        time: 5
+        refresh: false

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -48,3 +48,16 @@
       paralyzeTime: 3
       launchForwardsMultiplier: 4
       requiredSlipSpeed: 1
+
+- type: reagent
+  id: SpaceGlue
+  name: reagent-name-space-glue
+  desc: reagent-desc-space-glue
+  physicalDesc: reagent-physical-desc-sticky
+  flavor: funny
+  color: "#ffffff"
+  boilingPoint: 250.0
+  meltingPoint: 380.0
+  viscosity: 0.5
+  tileReactions:
+    - !type:SpillTileReaction

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -61,3 +61,12 @@
   viscosity: 0.5
   tileReactions:
     - !type:SpillTileReaction
+  metabolisms:
+    Narcotic:
+      effects:
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 5
+        refresh: false


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
When on the floor slows you down
In the future I want to make it fix broken windows and broken computers (+ maybe vendomats?) and glue airlocks (for fun)
It also applies rainbow effect (maybe it should also poison you?)

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![Peek 2023-05-12 13-46](https://github.com/space-wizards/space-station-14/assets/40753025/99b54b0b-8957-42d7-a0fe-6cec892513a6)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: added space glue - its sticky and funny! When consumed mutes you and makes you see rainbows.
- add: space glue can now appear in vent clog events. Less lube for you!
