### PR TITLE
Puddle drinking

### DIFF
--- a/Content.Server/Nutrition/Components/DrinkComponent.cs
+++ b/Content.Server/Nutrition/Components/DrinkComponent.cs
@@ -21,6 +21,7 @@ namespace Content.Server.Nutrition.Components
         internal bool DefaultToOpened;
 
         [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("transferAmount")]
         public FixedPoint2 TransferAmount { get; [UsedImplicitly] private set; } = FixedPoint2.New(5);
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -155,7 +155,7 @@ namespace Content.Server.Nutrition.EntitySystems
             if (component.Pressurized &&
                 !component.Opened &&
                 _random.Prob(0.25f) &&
-                _solutionContainerSystem.TryGetDrainableSolution(uid, out var interactions))
+                _solutionContainerSystem.TryGetSolution(uid, component.SolutionName, out var interactions))
             {
                 component.Opened = true;
                 UpdateAppearance(component);
@@ -229,7 +229,7 @@ namespace Content.Server.Nutrition.EntitySystems
                 return true;
             }
 
-            if (!_solutionContainerSystem.TryGetDrainableSolution(item, out var drinkSolution) ||
+            if (!_solutionContainerSystem.TryGetSolution(item, drink.SolutionName, out var drinkSolution) ||
                 drinkSolution.Volume <= 0)
             {
                 _popupSystem.PopupEntity(Loc.GetString("drink-component-try-use-drink-is-empty",

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -116,3 +116,8 @@
         puddle:
           !type:SpreaderNode
           nodeGroupID: Spreader
+    - type: Drink
+      isOpen: true
+      delay: 3
+      transferAmount: 1
+      solution: puddle


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

inefficient (1u/3sec) so people dont just do this over mopping

drainable changes in `DrinkSystem` should not affect anything currently existing, since it sets solutionname from the drainable if it exists on init anyway

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/19853115/886b9cf2-337a-454d-a107-f72e1fb72901

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: You can now drinky puddles (inefficiently)