### PR TITLE
Fix empty character preview on initial connect 

### DIFF
--- a/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
+++ b/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
@@ -5,7 +5,6 @@ using Content.Client.Preferences;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.GameTicking;
 using Content.Shared.Humanoid.Prototypes;
-using Content.Shared.Inventory;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Robust.Client.GameObjects;
@@ -13,6 +12,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
 
 namespace Content.Client.Lobby.UI
@@ -76,7 +76,6 @@ namespace Content.Client.Lobby.UI
             UpdateUI();
 
             _preferencesManager.OnServerDataLoaded += UpdateUI;
-            _entityManager.EntityDeleted += OnEntityDeleted;
         }
 
         public Button CharacterSetupButton { get; }
@@ -85,7 +84,6 @@ namespace Content.Client.Lobby.UI
         {
             base.Dispose(disposing);
             _preferencesManager.OnServerDataLoaded -= UpdateUI;
-            _entityManager.EntityDeleted -= OnEntityDeleted;
 
             if (!disposing) return;
             if (_previewDummy != null) _entityManager.DeleteEntity(_previewDummy.Value);
@@ -168,9 +166,9 @@ namespace Content.Client.Lobby.UI
             }
         }
 
-        private void OnEntityDeleted(EntityUid ent)
+        protected override void FrameUpdate(FrameEventArgs args)
         {
-            if (ent == _previewDummy)
+            if (_entityManager.Deleted(_previewDummy))
             {
                 // Our preview entiy was deleted. This can happen on initial connect,
                 // when the server applies the game state. Update the UI to recreate it.

--- a/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
+++ b/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
@@ -76,6 +76,7 @@ namespace Content.Client.Lobby.UI
             UpdateUI();
 
             _preferencesManager.OnServerDataLoaded += UpdateUI;
+            _entityManager.EntityDeleted += OnEntityDeleted;
         }
 
         public Button CharacterSetupButton { get; }
@@ -84,6 +85,7 @@ namespace Content.Client.Lobby.UI
         {
             base.Dispose(disposing);
             _preferencesManager.OnServerDataLoaded -= UpdateUI;
+            _entityManager.EntityDeleted -= OnEntityDeleted;
 
             if (!disposing) return;
             if (_previewDummy != null) _entityManager.DeleteEntity(_previewDummy.Value);
@@ -163,6 +165,16 @@ namespace Content.Client.Lobby.UI
                         invSystem.TryEquip(dummy, item, slot.Name, true, true);
                     }
                 }
+            }
+        }
+
+        private void OnEntityDeleted(EntityUid ent)
+        {
+            if (ent == _previewDummy)
+            {
+                // Our preview entiy was deleted. This can happen on initial connect,
+                // when the server applies the game state. Update the UI to recreate it.
+                UpdateUI();
             }
         }
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

When connecting to a server, the character preview does not display the image of the character. The image _is_ correctly displayed if you edit the character and save.

What was happening is that the LobbyCharacterPreviewPanel constructed the character preview, but then a server update applies state and deletes the entity with the callstack (I added LobbyCharacterPreviewPanel.OnEntityDeleted temporarily to detect it):

```
┆   3     - Thread 664987: <No name> (paused)
┆   4       0: Content.Client.Lobby.UI.LobbyCharacterPreviewPanel.OnEntityDeleted()@LobbyCharacterPreviewPanel.cs:173
┆   5       1: Robust.Shared.GameObjects.EntityManager.RecursiveDeleteEntity()@EntityManager.cs:550
┆   6       2: Robust.Shared.GameObjects.EntityManager.DeleteEntity()@EntityManager.cs:453
┆   7       3: Robust.Client.GameStates.ClientGameStateManager.PartialStateReset()@ClientGameStateManager.cs:859
┆   8       4: Robust.Client.GameStates.ClientGameStateManager.ApplyGameState()@ClientGameStateManager.cs:273
┆   9       5: Robust.Client.GameController.Tick()@GameController.cs:538
┆  10       6: Robust.Client.GameController.<StartupContinue>b__51_0()@GameController.cs:203
┆  11       7: Robust.Shared.Timing.GameLoop.Run()@GameLoop.cs:218
┆  12       8: Robust.Client.GameController.ContinueStartupAndLoop()@GameController.Standalone.cs:133
┆  13       9: Robust.Client.GameController.GameThreadMain()@GameController.Standalone.cs:118
┆  14       10: Robust.Client.GameController.<>c__DisplayClass92_0.<Run>b__0()@GameController.Standalone.cs:85``

```

To workaround, I'm just detecting if the preview entity has been deleted before we draw the character and recreate it.

Fixes #13067
Fixes #15649

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Cripes
- fix: Character preview is displayed in lobby again
