### PR TITLE
Auto-orient rotation for arrivals

### DIFF
--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -153,7 +153,7 @@ public sealed class ArrivalsSystem : EntitySystem
         _cfgManager.UnsubValueChanged(CCVars.ArrivalsShuttles, SetArrivals);
     }
 
-    private void OnArrivalsFTL(EntityUid uid, ArrivalsShuttleComponent component, ref FTLStartedEvent args)
+    private void OnArrivalsFTL(EntityUid shuttleUid, ArrivalsShuttleComponent component, ref FTLStartedEvent args)
     {
         // Any mob then yeet them off the shuttle.
         if (!_cfgManager.GetCVar(CCVars.ArrivalsReturns) && args.FromMapUid != null)
@@ -162,7 +162,7 @@ public sealed class ArrivalsSystem : EntitySystem
             var arrivalsBlacklistQuery = GetEntityQuery<ArrivalsBlacklistComponent>();
             var mobQuery = GetEntityQuery<MobStateComponent>();
             var xformQuery = GetEntityQuery<TransformComponent>();
-            DumpChildren(uid, ref args, pendingEntQuery, arrivalsBlacklistQuery, mobQuery, xformQuery);
+            DumpChildren(shuttleUid, ref args, pendingEntQuery, arrivalsBlacklistQuery, mobQuery, xformQuery);
         }
 
         var pendingQuery = AllEntityQuery<PendingClockInComponent, TransformComponent>();
@@ -171,11 +171,11 @@ public sealed class ArrivalsSystem : EntitySystem
         while (pendingQuery.MoveNext(out var pUid, out _, out var xform))
         {
             // Cheaper to iterate pending arrivals than all children
-            if (xform.GridUid != uid)
+            if (xform.GridUid != shuttleUid)
                 continue;
 
             RemCompDeferred<PendingClockInComponent>(pUid);
-            RemCompDeferred<AutoOrientComponent>(uid);
+            RemCompDeferred<AutoOrientComponent>(pUid);
         }
     }
 

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Server.Administration;
-using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Events;
 using Content.Server.Shuttles.Components;
@@ -12,9 +11,9 @@ using Content.Server.Station.Systems;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Movement.Components;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Spawners.Components;
-using Content.Shared.Tag;
 using Content.Shared.Tiles;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
@@ -22,7 +21,6 @@ using Robust.Shared.Console;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -138,6 +136,7 @@ public sealed class ArrivalsSystem : EntitySystem
                         break;
                     }
 
+                    RemCompDeferred<AutoOrientComponent>(uid);
                     RemCompDeferred<PendingClockInComponent>(uid);
                     shell.WriteLine(Loc.GetString("cmd-arrivals-forced", ("uid", ToPrettyString(uid))));
                 }
@@ -176,6 +175,7 @@ public sealed class ArrivalsSystem : EntitySystem
                 continue;
 
             RemCompDeferred<PendingClockInComponent>(pUid);
+            RemCompDeferred<AutoOrientComponent>(uid);
         }
     }
 
@@ -238,6 +238,7 @@ public sealed class ArrivalsSystem : EntitySystem
                     ev.Station);
 
                 EnsureComp<PendingClockInComponent>(ev.SpawnResult.Value);
+                EnsureComp<AutoOrientComponent>(ev.SpawnResult.Value);
                 return;
             }
         }

--- a/Content.Shared/Movement/Components/AutoOrientComponent.cs
+++ b/Content.Shared/Movement/Components/AutoOrientComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Movement.Components;
+
+/// <summary>
+/// Automatically rotates eye upon grid traversals.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed class AutoOrientComponent : Component
+{
+
+}

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -52,6 +52,8 @@ namespace Content.Shared.Movement.Systems
             SubscribeLocalEvent<InputMoverComponent, ComponentHandleState>(OnInputHandleState);
             SubscribeLocalEvent<InputMoverComponent, EntParentChangedMessage>(OnInputParentChange);
 
+            SubscribeLocalEvent<AutoOrientComponent, EntParentChangedMessage>(OnAutoParentChange);
+
             SubscribeLocalEvent<FollowedComponent, EntParentChangedMessage>(OnFollowedParentChange);
 
             _configManager.OnValueChanged(CCVars.CameraRotationLocked, SetCameraRotationLocked, true);
@@ -109,6 +111,11 @@ namespace Content.Shared.Movement.Systems
         private void SetDiagonalMovement(bool value) => DiagonalMovementEnabled = value;
 
         protected virtual void HandleShuttleInput(EntityUid uid, ShuttleButtons button, ushort subTick, bool state) {}
+
+        private void OnAutoParentChange(EntityUid uid, AutoOrientComponent component, ref EntParentChangedMessage args)
+        {
+            ResetCamera(uid);
+        }
 
         public void RotateCamera(EntityUid uid, Angle angle)
         {


### PR DESCRIPTION
I thought about just doing it on FTL completion but I think this makes it clearer on when someone should be touching their camera controls?

:cl:
- add: Arrivals will auto-orient your camera upon traversal.