### PR TITLE
big cardboard box improvements

### DIFF
--- a/Content.Server/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Server/CardboardBox/CardboardBoxSystem.cs
@@ -31,11 +31,27 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         SubscribeLocalEvent<CardboardBoxComponent, StorageAfterOpenEvent>(AfterStorageOpen);
         SubscribeLocalEvent<CardboardBoxComponent, StorageBeforeOpenEvent>(BeforeStorageOpen);
         SubscribeLocalEvent<CardboardBoxComponent, StorageAfterCloseEvent>(AfterStorageClosed);
+		SubscribeLocalEvent<CardboardBoxComponent, ActivateInWorldEvent>(OnInteracted);
         SubscribeLocalEvent<CardboardBoxComponent, InteractedNoHandEvent>(OnNoHandInteracted);
         SubscribeLocalEvent<CardboardBoxComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
         SubscribeLocalEvent<CardboardBoxComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
 
         SubscribeLocalEvent<CardboardBoxComponent, DamageChangedEvent>(OnDamage);
+    }
+	
+	private void OnInteracted(EntityUid uid, CardboardBoxComponent component, ActivateInWorldEvent args)
+    {
+		if (!TryComp<EntityStorageComponent>(uid, out var box))
+            return;
+
+        args.Handled = true;
+        _storage.ToggleOpen(args.User, uid, box);
+
+		if (box.Contents.Contains(args.User) && !box.Open)
+		{
+			_mover.SetRelay(args.User, uid);
+			component.Mover = args.User;
+		}
     }
 
     private void OnNoHandInteracted(EntityUid uid, CardboardBoxComponent component, InteractedNoHandEvent args)
@@ -49,6 +65,9 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
 
     private void BeforeStorageOpen(EntityUid uid, CardboardBoxComponent component, ref StorageBeforeOpenEvent args)
     {
+		if (component.Quiet)
+			return;
+
         //Play effect & sound
         if (component.Mover != null)
         {
@@ -91,17 +110,11 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         if (!TryComp(args.Entity, out MobMoverComponent? mover))
             return;
 
-        if (component.Mover != null)
+        if (component.Mover == null)
         {
-            // player movers take priority
-            if (HasComp<ActorComponent>(component.Mover) || !HasComp<ActorComponent>(args.Entity))
-                return;
-
-            RemComp<RelayInputMoverComponent>(component.Mover.Value);
+            _mover.SetRelay(args.Entity, uid);
+			component.Mover = args.Entity;
         }
-
-        _mover.SetRelay(args.Entity, uid);
-        component.Mover = args.Entity;
     }
 
     /// <summary>

--- a/Content.Shared/CardboardBox/Components/CardboardBoxComponent.cs
+++ b/Content.Shared/CardboardBox/Components/CardboardBoxComponent.cs
@@ -34,6 +34,7 @@ public sealed class CardboardBoxComponent : Component
 	/// <summary>
 	/// Whether to prevent the box from making the sound and effect
 	/// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
 	[DataField("quiet")]
 	public bool Quiet = false;
 

--- a/Content.Shared/CardboardBox/Components/CardboardBoxComponent.cs
+++ b/Content.Shared/CardboardBox/Components/CardboardBoxComponent.cs
@@ -30,6 +30,12 @@ public sealed class CardboardBoxComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("effectSound")]
     public SoundSpecifier? EffectSound;
+	
+	/// <summary>
+	/// Whether to prevent the box from making the sound and effect
+	/// </summary>
+	[DataField("quiet")]
+	public bool Quiet = false;
 
     /// <summary>
     /// How far should the box opening effect go?

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -64,8 +64,6 @@
   parent: BaseBigBox
   description: Kept ya waiting, huh?
   components:
-    - type: CardboardBox
-      quiet: true
     - type: Damageable
       damageModifierSet: FlimsyMetallic #Syndicate boxes should have a bit of protection
     - type: Stealth

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -64,6 +64,8 @@
   parent: BaseBigBox
   description: Kept ya waiting, huh?
   components:
+    - type: CardboardBox
+      quiet: true
     - type: Damageable
       damageModifierSet: FlimsyMetallic #Syndicate boxes should have a bit of protection
     - type: Stealth


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
- makes big cardboard boxes always choose the person closing them as their controller
- if closer is not in box, an entity inside is chosen as the controller

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![boxPR](https://github.com/space-wizards/space-station-14/assets/57039557/d124770a-e98c-4f00-aad4-13e79836a6cf)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Big cardboard boxes no longer choose their driver randomly
