### PR TITLE
remove hardsuits from lockers that have suit storages

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -84,6 +84,8 @@
     - id: GasAnalyzer
     - id: MedkitOxygenFilled
     - id: HolofanProjector
+    - id: ClothingOuterSuitAtmosFire
+    - id: ClothingHeadHelmetAtmosFire
 
 - type: entity
   id: LockerEngineerFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -5,40 +5,40 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterVestHazard
-        prob: 0.4
-      - id: FlashlightLantern
-        prob: 0.7
-      - id: Screwdriver
-        prob: 0.7
-      - id: Wrench
-        prob: 0.7
-      - id: Welder
-        prob: 0.7
-      - id: Crowbar
-        prob: 0.7
-      - id: Wirecutter
-        prob: 0.7
-      - id: Multitool
-        prob: 0.2
-      - id: trayScanner
-        prob: 0.7
-      - id: GasAnalyzer
-        prob: 0.7
-      - id: ClothingBeltUtility
-        prob: 0.2
-      - id: ClothingHandsGlovesColorYellow
-        prob: 0.05
-      - id: ClothingHeadHatHardhatRed
-        prob: 0.4
-      - id: CableApcStack
-        prob: 0.3
-      - id: CableApcStack
-        prob: 0.3
-      - id: CableApcStack
-        prob: 0.3
-      - id: AirlockPainter
-        prob: 0.7
+    - id: ClothingOuterVestHazard
+      prob: 0.4
+    - id: FlashlightLantern
+      prob: 0.7
+    - id: Screwdriver
+      prob: 0.7
+    - id: Wrench
+      prob: 0.7
+    - id: Welder
+      prob: 0.7
+    - id: Crowbar
+      prob: 0.7
+    - id: Wirecutter
+      prob: 0.7
+    - id: Multitool
+      prob: 0.2
+    - id: trayScanner
+      prob: 0.7
+    - id: GasAnalyzer
+      prob: 0.7
+    - id: ClothingBeltUtility
+      prob: 0.2
+    - id: ClothingHandsGlovesColorYellow
+      prob: 0.05
+    - id: ClothingHeadHatHardhatRed
+      prob: 0.4
+    - id: CableApcStack
+      prob: 0.3
+    - id: CableApcStack
+      prob: 0.3
+    - id: CableApcStack
+      prob: 0.3
+    - id: AirlockPainter
+      prob: 0.7
 
 - type: entity
   id: LockerElectricalSuppliesFilled
@@ -47,16 +47,16 @@
   components:
   - type: StorageFill
     contents:
-      - id: ToolboxElectricalFilled
-        prob: 0.7
-      - id: FirelockElectronics
-        prob: 0.05
-      - id: APCElectronics
-        prob: 0.1
-      - id: CableMVStack
-        prob: 0.2
-      - id: CableApcStack
-        prob: 0.3
+    - id: ToolboxElectricalFilled
+      prob: 0.7
+    - id: FirelockElectronics
+      prob: 0.05
+    - id: APCElectronics
+      prob: 0.1
+    - id: CableMVStack
+      prob: 0.2
+    - id: CableApcStack
+      prob: 0.3
 
 - type: entity
   id: LockerWeldingSuppliesFilled
@@ -65,13 +65,13 @@
   components:
   - type: StorageFill
     contents:
-      - id: WelderMini
-      - id: Welder
-        prob: 0.7
-      - id: WelderIndustrial
-        prob: 0.5
-      - id: ClothingHeadHatWelding
-        prob: 0.5
+    - id: WelderMini
+    - id: Welder
+      prob: 0.7
+    - id: WelderIndustrial
+      prob: 0.5
+    - id: ClothingHeadHatWelding
+      prob: 0.5
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -80,15 +80,10 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterHardsuitAtmos
-      - id: ClothingMaskGasAtmos
-      - id: YellowOxygenTankFilled
-      - id: NitrogenTankFilled
-      - id: ClothingOuterSuitAtmosFire
-      - id: ClothingHeadHelmetAtmosFire
-      - id: GasAnalyzer
-      - id: MedkitOxygenFilled
-      - id: HolofanProjector
+    - id: ClothingMaskGasAtmos
+    - id: GasAnalyzer
+    - id: MedkitOxygenFilled
+    - id: HolofanProjector
 
 - type: entity
   id: LockerEngineerFilled
@@ -97,12 +92,9 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterHardsuitEngineering
-      - id: ClothingHandsGlovesColorYellow
-      - id: ClothingMaskGas
-      - id: OxygenTankFilled
-      - id: NitrogenTankFilled
-      - id: ClothingShoesBootsMag
+    - id: ClothingHandsGlovesColorYellow
+    - id: ClothingMaskGas
+    - id: trayScanner
 
 - type: entity
   id: ClosetRadiationSuitFilled
@@ -111,9 +103,9 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingHeadHatHoodRad
-        amount: 2
-      - id: ClothingOuterSuitRad
-        amount: 2
-      - id: GeigerCounter
-        amount: 2
+    - id: ClothingHeadHatHoodRad
+      amount: 2
+    - id: ClothingOuterSuitRad
+      amount: 2
+    - id: GeigerCounter
+      amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -20,7 +20,6 @@
       - id: ClothingOuterWinterWarden
       - id: RubberStampWarden
       - id: DoorRemoteArmory
-      - id: ClothingOuterHardsuitWarden
       - id: HoloprojectorSecurity
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -12,7 +12,7 @@
         - id: ClothingOuterHardsuitEVA
         - id: ClothingHeadHelmetEVA
         - id: ClothingMaskBreath
-        
+
 #Prisoner EVA
 - type: entity
   id: SuitStorageEVAPrisoner


### PR DESCRIPTION
## About the PR
fixes #16431
should only be merged once every map has suit storages

also gave engi locker a t-ray since:
1. atmos locker has gas analyzer
2. it had just insuls and gasmask lol

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun