### PR TITLE
Misc state-handling changes

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -59,7 +59,8 @@ namespace Content.Client.Actions
             if (args.Current is not ActionsComponentState state)
                 return;
 
-            var serverActions = new SortedSet<ActionType>(state.Actions);
+            state.SortedActions ??= new SortedSet<ActionType>(state.Actions);
+            var serverActions = state.SortedActions;
             var removed = new List<ActionType>();
 
             foreach (var act in component.Actions.ToList())

--- a/Content.Client/IconSmoothing/IconSmoothSystem.cs
+++ b/Content.Client/IconSmoothing/IconSmoothSystem.cs
@@ -123,7 +123,7 @@ namespace Content.Client.IconSmoothing
         public void DirtyNeighbours(EntityUid uid, IconSmoothComponent? comp = null, TransformComponent? transform = null, EntityQuery<IconSmoothComponent>? smoothQuery = null)
         {
             smoothQuery ??= GetEntityQuery<IconSmoothComponent>();
-            if (!smoothQuery.Value.Resolve(uid, ref comp))
+            if (!smoothQuery.Value.Resolve(uid, ref comp) || !comp.Running)
                 return;
 
             _dirtyEntities.Enqueue(uid);
@@ -195,8 +195,9 @@ namespace Content.Client.IconSmoothing
             // Generation on the component is set after an update so we can cull updates that happened this generation.
             if (!smoothQuery.Resolve(uid, ref smooth, false)
                 || smooth.Mode == IconSmoothingMode.NoSprite
-                || smooth.UpdateGeneration == _generation ||
-                !smooth.Enabled)
+                || smooth.UpdateGeneration == _generation
+                || !smooth.Enabled
+                || !smooth.Running)
             {
                 if (smooth is { Enabled: true } &&
                     TryComp<SmoothEdgeComponent>(uid, out var edge) &&

--- a/Content.Shared/Actions/ActionTypes/ActionType.cs
+++ b/Content.Shared/Actions/ActionTypes/ActionType.cs
@@ -38,6 +38,13 @@ public abstract class ActionType : IEquatable<ActionType>, IComparable, ICloneab
     public string DisplayName = string.Empty;
 
     /// <summary>
+    /// This is just <see cref="DisplayName"/> with localized strings resolved and markup removed. If null, will be
+    /// inferred from <see cref="DisplayName"/>. This is cached to speed up game state handling.
+    /// </summary>
+    [NonSerialized]
+    public string? RawName;
+
+    /// <summary>
     ///     Description to show in UI. Accepts formatting.
     /// </summary>
     [DataField("description")]
@@ -179,10 +186,11 @@ public abstract class ActionType : IEquatable<ActionType>, IComparable, ICloneab
         if (Priority != otherAction.Priority)
             return otherAction.Priority - Priority;
 
-        var name = FormattedMessage.RemoveMarkup(Loc.GetString(DisplayName));
-        var otherName = FormattedMessage.RemoveMarkup(Loc.GetString(otherAction.DisplayName));
-        if (name != otherName)
-            return string.Compare(name, otherName, StringComparison.CurrentCulture);
+        RawName ??= FormattedMessage.RemoveMarkup(Loc.GetString(DisplayName));
+        otherAction.RawName ??= FormattedMessage.RemoveMarkup(Loc.GetString(otherAction.DisplayName));
+        var cmp = string.Compare(RawName, otherAction.RawName, StringComparison.CurrentCulture);
+        if (cmp != 0)
+            return cmp;
 
         if (Provider != otherAction.Provider)
         {
@@ -217,6 +225,7 @@ public abstract class ActionType : IEquatable<ActionType>, IComparable, ICloneab
         Icon = toClone.Icon;
         IconOn = toClone.IconOn;
         DisplayName = toClone.DisplayName;
+        RawName = null;
         Description = toClone.Description;
         Provider = toClone.Provider;
         AttachedEntity = toClone.AttachedEntity;

--- a/Content.Shared/Actions/ActionsComponent.cs
+++ b/Content.Shared/Actions/ActionsComponent.cs
@@ -22,6 +22,9 @@ public sealed class ActionsComponentState : ComponentState
 {
     public readonly List<ActionType> Actions;
 
+    [NonSerialized]
+    public SortedSet<ActionType>? SortedActions;
+
     public ActionsComponentState(List<ActionType> actions)
     {
         Actions = actions;

--- a/Content.Shared/Storage/Components/SharedMapLayerData.cs
+++ b/Content.Shared/Storage/Components/SharedMapLayerData.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Content.Shared.Whitelist;
 using Robust.Shared.Serialization;
 
@@ -37,21 +38,22 @@ namespace Content.Shared.Storage.Components
     [Serializable, NetSerializable]
     public sealed class ShowLayerData : ICloneable
     {
-        public IReadOnlyList<string> QueuedEntities { get; internal set; }
+        public readonly IReadOnlyList<string> QueuedEntities;
 
         public ShowLayerData()
         {
             QueuedEntities = new List<string>();
         }
 
-        public ShowLayerData(IEnumerable<string> other)
+        public ShowLayerData(IReadOnlyList<string> other)
         {
-            QueuedEntities = new List<string>(other);
+            QueuedEntities = other;
         }
 
         public object Clone()
         {
-            return new ShowLayerData(QueuedEntities);
+            // QueuedEntities should never be getting modified after this object is created.
+            return this;
         }
     }
 }

--- a/Content.Shared/Storage/EntitySystems/SharedItemMapperSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedItemMapperSystem.cs
@@ -79,7 +79,7 @@ namespace Content.Shared.Storage.EntitySystems
         /// <returns>false if <c>msg.Container.Owner</c> is not a storage, true otherwise.</returns>
         private bool TryGetLayers(ContainerModifiedMessage msg,
             ItemMapperComponent itemMapper,
-            out IReadOnlyList<string> showLayers)
+            out List<string> showLayers)
         {
             var containedLayers = _container.GetAllContainers(msg.Container.Owner)
                 .Where(c => itemMapper.ContainerWhitelist?.Contains(c.ID) ?? true).SelectMany(cont => cont.ContainedEntities).ToArray();


### PR DESCRIPTION
Makes some component state code a bit faster, as well as ensuring `IconSmoothingSystem` doesn't error when encountering uninitialized entities. Spun off from #15001
