### PR TITLE
Add AME Part and Solar Assembly Part to Drone interaction allowlist

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/antimatter_part.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/antimatter_part.yml
@@ -15,3 +15,6 @@
     price: 500
   - type: GuideHelp
     guides: [ AME, Power ]
+  - type: Tag
+    tags:
+      - DroneUsable

--- a/Resources/Prototypes/Entities/Objects/Power/antimatter_part.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/antimatter_part.yml
@@ -15,6 +15,3 @@
     price: 500
   - type: GuideHelp
     guides: [ AME, Power ]
-  - type: Tag
-    tags:
-      - DroneUsable

--- a/Resources/Prototypes/Entities/Objects/Power/solar_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/solar_parts.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: BaseItem
   id: SolarAssemblyPart
   name: solar assembly part
@@ -11,3 +11,4 @@
   - type: Tag
     tags:
       - SolarAssemblyPart
+      - DroneUsable

--- a/Resources/Prototypes/Entities/Objects/Power/solar_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/solar_parts.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   parent: BaseItem
   id: SolarAssemblyPart
   name: solar assembly part
@@ -11,4 +11,3 @@
   - type: Tag
     tags:
       - SolarAssemblyPart
-      - DroneUsable


### PR DESCRIPTION
## About the PR
It is a very frequent concern raised by players in bug reports and suggestions and general channels. Drone laws include _improving_ and _powering_ the station. So why are unable to improve the power of the station?

This PR simply adds the `DroneUsable` tag to the AME Part and the Solar Assembly Part.

**Media**
![image](https://github.com/space-wizards/space-station-14/assets/20689511/067ba520-4e61-40ee-8a93-6b01658c919a)


