### PR TITLE
Ups rot timer to 10 minutes.

### DIFF
--- a/Content.Shared/Atmos/Miasma/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Miasma/PerishableComponent.cs
@@ -13,7 +13,7 @@ public sealed class PerishableComponent : Component
     /// How long it takes after death to start rotting.
     /// </summary>
     [DataField("rotAfter"), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan RotAfter = TimeSpan.FromMinutes(5);
+    public TimeSpan RotAfter = TimeSpan.FromMinutes(10);
 
     /// <summary>
     /// How much rotting has occured


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
I've noticed bodies start to pile up very easily on the maps without cloning, (specifically Barratry, I haven't gotten to play Box as much. I think that's the other one?) This makes the window a little less tight on getting someone revived, and gives folks new to med time to figure out what to do. It can take a couple minutes for a body to get dragged to med, and by that time, medics don't have too much time left to work.

I guess it also makes it less likely that the chef or chemist will miasma bomb things, as it'll take a bit more time for carp, spiders, and other such things to rot?

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Rotting takes 10 minutes, up from 5.
