### PR TITLE
Fix crew monitoring direction & memory leak

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
@@ -38,14 +38,8 @@ namespace Content.Client.Medical.CrewMonitoring
             {
                 case CrewMonitoringState st:
                     _entManager.TryGetComponent<TransformComponent>(Owner.Owner, out var xform);
-                    Vector2 localPosition = Vector2.Zero;
 
-                    if (_entManager.TryGetComponent<TransformComponent>(xform?.GridUid, out var gridXform))
-                    {
-                        localPosition = gridXform.InvWorldMatrix.Transform(xform.WorldPosition);
-                    }
-
-                    _menu?.ShowSensors(st.Sensors, localPosition, st.Snap, st.Precision);
+                    _menu?.ShowSensors(st.Sensors, xform?.Coordinates, st.Snap, st.Precision);
                     break;
             }
         }


### PR DESCRIPTION
## About the PR
Should fix #14610 (the memory leak with the crew monitoring window) and the issue with it displaying the wrong directions.
(It's assumed the right directions are based on Eye, hence the involvement of Eye.)
This also clarifies a few variable names, and generally tries to use EntityCoordinates to be more understandable.

**Media**
Not applicable.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: After a terrible accident involving an unfortunately rotated circuit board revision, the crew monitoring devices now should show the correct directions again and shouldn't be too harmful to look at for long periods of time.
