### PR TITLE
remove artifact static price

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -9,7 +9,6 @@
     - type: Lock
     - type: Sprite
       drawdepth: Objects
-      netsync: false
       sprite: Structures/Storage/Crates/artifact.rsi
       layers:
         - state: artifact_container

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -50,8 +50,6 @@
     - key: enum.InstrumentUiKey.Key
       type: InstrumentBoundUserInterface
   - type: Appearance
-  - type: StaticPrice
-    price: 500
   - type: Item
     size: 40
     sprite: Objects/Specific/Xenoarchaeology/item_artifacts.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -7,7 +7,6 @@
   components:
   - type: Sprite
     sprite: Objects/Specific/Xenoarchaeology/item_artifacts.rsi
-    netsync: false
     layers:
     - state: ano01
       map: [ "enum.ArtifactsVisualLayers.Base" ]

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/node_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/node_scanner.yml
@@ -7,7 +7,6 @@
     - type: Sprite
       sprite: Objects/Specific/Xenoarchaeology/node_scanner.rsi
       state: icon
-      netsync: false
     - type: Item
       sprite: Objects/Specific/Xenoarchaeology/node_scanner.rsi
     - type: NodeScanner

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
@@ -43,8 +43,6 @@
     - type: Artifact
     - type: RandomArtifactSprite
     - type: Appearance
-    - type: StaticPrice
-      price: 500
     - type: Actions
     - type: GuideHelp
       guides:

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
@@ -8,7 +8,6 @@
     - type: Sprite
       drawdepth: SmallObjects
       sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
-      netsync: false
       layers:
       - state: ano01
         map: [ "enum.ArtifactsVisualLayers.Base" ]


### PR DESCRIPTION
## About the PR
artifacts had static price for like 8 months for some reason, nobody noticed it
removing *should* enable the actual artifact pricing to be used but i will double check ingame

**Media**
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Cargo trade stations now offer better prices for artifacts that have been explored thoroughly.
