### PR TITLE
Advanced mop wieldable + other janitor.yml cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -1,8 +1,8 @@
 # TODO: Add description (1)
 - type: entity
   parent: BaseItem
-  name: mop
   id: MopItem
+  name: mop
   description: A mop that can't be stopped, viscera cleanup detail awaits.
   components:
   - type: Sprite
@@ -35,27 +35,19 @@
       - Mop
 
 - type: entity
-  parent: BaseItem
-  name: advanced mop
+  parent: MopItem
   id: AdvMopItem
+  name: advanced mop
   description: Motorized mop that has a bigger reservoir and quickly replaces reagents inside with water. Automatic Clown Countermeasure not included.
   components:
     - type: Sprite
       sprite: Objects/Specific/Janitorial/advmop.rsi
       state: advmop
-    - type: MeleeWeapon
-      damage:
-        types:
-          Blunt: 10
-    - type: Spillable
-      solution: absorbed
     - type: Item
       size: 15
       sprite: Objects/Specific/Janitorial/advmop.rsi
     - type: Absorbent
       pickupAmount: 100
-    - type: UseDelay
-      delay: 1.0
     - type: SolutionRegeneration
       solution: absorbed
       generated:
@@ -67,18 +59,10 @@
       preserve:
       - Water
       quantity: 10
-    - type: SolutionContainerManager
-      solutions:
-        absorbed:
-          maxVol: 100
-    - type: Tag
-      tags:
-        - DroneUsable #No bucket because it holds chems, they can drag the cart or use a drain
-        - Mop
 
 - type: entity
-  name: mop bucket
   id: MopBucket
+  name: mop bucket
   description: Holds water and the tears of the janitor.
   components:
   - type: Clickable
@@ -133,9 +117,9 @@
     fillBaseName: mopbucket_water-
 
 - type: entity
-  name: mop bucket
-  id: MopBucketFull
   parent: MopBucket
+  id: MopBucketFull
+  name: mop bucket
   suffix: full
   components:
     - type: Sprite
@@ -152,9 +136,9 @@
               Quantity: 600
 
 - type: entity
-  name: wet floor sign
-  id: WetFloorSign
   parent: BaseItem
+  id: WetFloorSign
+  name: wet floor sign
   description: Caution! Wet Floor!
   components:
   - type: Sprite
@@ -169,18 +153,12 @@
 
 
 - type: entity
+  parent: WetFloorSign
+  id: WetFloorSignMineExplosive
   name: wet floor sign
   suffix: Explosive
   description: Caution! Wet Floor!
-  parent: BaseItem
-  id: WetFloorSignMineExplosive
   components:
-  - type: Sprite
-    sprite: Objects/Specific/Janitorial/wet_floor_sign.rsi
-    state: caution
-  - type: Item
-    sprite: Objects/Specific/Janitorial/wet_floor_sign.rsi
-    size: 15
   - type: StepTrigger
     intersectRatio: 0.2
     requiredTriggeredSpeed: 0
@@ -214,9 +192,9 @@
   - type: DeleteOnTrigger
 
 - type: entity
-  name: janitorial trolley
-  id: JanitorialTrolley
   parent: BaseStructureDynamic
+  id: JanitorialTrolley
+  name: janitorial trolley
   description: This is the alpha and omega of sanitation.
   components:
     - type: Sprite


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
I was originally going to make the advanced mop weldable, but I noticed a bunch of other problems while doing it. I parented the advanced mop to the mop, and removed duplicate components. Also removed unneeded components from the wet floor mine. Also I made the order of things match the [docs conventions](https://docs.spacestation14.io/en/getting-started/conventions#yaml).
The advanced mop has the wieldable component only becuase it now inherits from the normal mop.
Bug: it lacks a sprite and is invisible when wielded (#16484). 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- tweak: Advanced mop is now wieldable
