### PR TITLE
Syndicate Elite Hardsuit in nuke op uplink (+ other misc. uplink fixes)

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -185,8 +185,11 @@ uplink-clothing-thieving-gloves-desc = Discretely steal from pockets and increas
 uplink-clothing-outer-vest-web-name = Web West
 uplink-clothing-outer-vest-web-desc = A synthetic armor vest. This one has added webbing and ballistic plates.
 
-uplink-hardsuit-syndie-name = Syndicate Hardsuit
-uplink-hardsuit-syndie-desc = The Syndicate's well known armored blood red hardsuit, capable of space walks and bullet resistant.
+uplink-hardsuit-syndie-name = Blood-red Hardsuit
+uplink-hardsuit-syndie-desc = The Syndicate's well known armored blood red hardsuit, capable of space walks and reducing the impact of many types of damage.
+
+uplink-hardsuit-syndie-elite-name = Syndicate Elite Hardsuit
+uplink-hardsuit-syndie-elite-desc = An upgraded version of the blood-red hardsuit that features enhanced fireproofing, pressure resist, and superior armor.
 
 uplink-clothing-shoes-boots-mag-syndie-name = Blood-red Magboots
 uplink-clothing-shoes-boots-mag-syndie-desc = A pair of magnetic boots that will keep you on the ground if the gravity fails or is sabotaged, giving you a mobility advantage. If activated with gravity they will protect from slips, but they will slow you down.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -183,10 +183,10 @@ uplink-clothing-thieving-gloves-name = Thieving Gloves
 uplink-clothing-thieving-gloves-desc = Discretely steal from pockets and increase your thieving technique with these fancy new gloves, all while looking like normal gloves!
 
 uplink-clothing-outer-vest-web-name = Web West
-uplink-clothing-outer-vest-web-desc = A synthetic armor vest. This one has added webbing and ballistic plates.
+uplink-clothing-outer-vest-web-desc = A synthetic armor vest that provides excellent protection against brute-force damage, and even better protection against bullets.
 
 uplink-hardsuit-syndie-name = Blood-red Hardsuit
-uplink-hardsuit-syndie-desc = The Syndicate's well known armored blood red hardsuit, capable of space walks and reducing the impact of many types of damage.
+uplink-hardsuit-syndie-desc = The Syndicate's infamous blood-red hardsuit, capable of space walks and reducing the impact of many types of damage.
 
 uplink-hardsuit-syndie-elite-name = Syndicate Elite Hardsuit
 uplink-hardsuit-syndie-elite-desc = An upgraded version of the blood-red hardsuit that features enhanced fireproofing, pressure resist, and superior armor.
@@ -210,8 +210,8 @@ uplink-decoy-disk-desc = A piece of plastic with a lenticular printing, made to 
 uplink-cigarettes-name = Syndicate Smokes Packet
 uplink-cigarettes-desc = Elite cigarettes for elite agents. Infused with medicine for when you need to do more than calm your nerves.
 
-uplink-soap-name = Soap
-uplink-soap-desc = An untrustworthy bar of soap. Smells of fear.
+uplink-soap-name = Syndicate Brand Soap
+uplink-soap-desc = An untrustworthy bar of soap. Slips people for an extra-long amount of time!.
 
 uplink-ultrabright-lantern-name = Extra-Bright Lantern
 uplink-ultrabright-lantern-desc = Blinding.
@@ -226,7 +226,7 @@ uplink-stimkit-name = Stimkit
 uplink-stimkit-desc = A medkit containing 6 stimulant microinjectors, which each inject you with enough stimulants to last for a minute.
 
 uplink-experimental-stimpack-name = Experimental Stimpack
-uplink-experimental-stimpack-desc = A prototype version of the Stimpack pulled from the market due to extreme side effects. Effects include virtual immunity to stuns, massively increased movement speed, and rapid tissue regeneration, but the chemical will constantly poison you while in your bloodstream.
+uplink-experimental-stimpack-desc = A prototype version of the Stimpack pulled from the market due to extreme side effects. Effects include virtual immunity to stuns, massively increased movement speed, and rapid tissue regeneration, but the chemical will severely poison you while in your bloodstream.
 
 uplink-syndicate-segway-crate-name = Syndicate Segway
 uplink-syndicate-segway-crate-desc = Be an enemy of the corporation, in style!

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -696,6 +696,10 @@
   - !type:BuyerJobCondition
     whitelist:
     - Janitor
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
 
 # Armor
 
@@ -750,6 +754,27 @@
     Telecrystal: 8
   categories:
   - UplinkArmor
+  conditions:
+    - !type:StoreWhitelistCondition
+      blacklist:
+        tags:
+          - NukeOpsUplink
+
+- type: listing
+  id: UplinkHardsuitSyndieElite
+  name: uplink-hardsuit-syndie-elite-name
+  description: uplink-hardsuit-syndie-elite-desc
+  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
+  productEntity: ClothingOuterHardsuitSyndieElite
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkArmor
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - NukeOpsUplink
 
 - type: listing
   id: UplinkClothingShoesBootsMagSyndie

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -767,7 +767,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingOuterHardsuitSyndieElite
   cost:
-    Telecrystal: 14
+    Telecrystal: 10
   categories:
   - UplinkArmor
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -767,7 +767,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingOuterHardsuitSyndieElite
   cost:
-    Telecrystal: 8
+    Telecrystal: 14
   categories:
   - UplinkArmor
   conditions:


### PR DESCRIPTION
## About the PR
What it says on the tin - adds the syndicate elite hardsuit to the nuclear operative uplink. Also makes some descriptions and names less weird since I was messing with the ftl file anyways and it was really bugging me.
ALSO fixes wet floor mines causing surplus crates to instantly explode as it happened multiple times in testing.

From what I can tell, this has been shot down before, but I've done this for a few reasons:
1. It gives nuke ops more variety in the kind of armor they can buy. Should you keep your decent armor and save TC, get the juggsuit to become a slow-moving tank, or buy the badass pricey upgraded hardsuit in exchange for a ton of TC?
2. It makes it to where you can't just instantly identify a medic.
3. The sprite just looks cool. I know this doesn't have much merit, but I just like it and think it's really cool thematically. It really _feels_ like an elite suit.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Nuclear Operatives can now buy the Elite Hardsuit in their uplink at a steep price.
- tweak: The syndicate has re-described several entries in its uplink catalog to be more gramatically correct and descriptive.
- fix: The wet floor sign proximity mine has been blacklisted from surplus crates, and will no longer cause them to instantly explode upon opening.
