### PR TITLE
Use texture theme path instead of texture path for buttons

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionPageButtons.xaml
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionPageButtons.xaml
@@ -3,7 +3,7 @@
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Systems.Actions.Controls">
     <BoxContainer Orientation="Horizontal">
         <Control HorizontalExpand="True" SizeFlagsStretchRatio="1"/>
-        <TextureButton TexturePath="left_arrow.svg.192dpi"
+        <TextureButton TextureThemePath="left_arrow.svg.192dpi"
                        SizeFlagsStretchRatio="1"
                        Scale="0.5 0.5"
                        HorizontalAlignment="Center"
@@ -13,7 +13,7 @@
         <Control HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
         <Label Text="1" SizeFlagsStretchRatio="1" Name="Label" Access="Public" />
         <Control HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
-        <TextureButton TexturePath="right_arrow.svg.192dpi"
+        <TextureButton TextureThemePath="right_arrow.svg.192dpi"
                        SizeFlagsStretchRatio="1"
                        Scale="0.5 0.5"
                        HorizontalAlignment="Center"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Companion PR to engine change to make sure arrow buttons don't become error buttons if the below engine change hits

Requires https://github.com/space-wizards/RobustToolbox/pull/4048
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/22365940/8253b3e7-1e26-4093-b958-a35baa621663)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fix images on paper, mech UI, and targetting dummy
