### PR TITLE
Allow early salvage launches

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -5,6 +5,8 @@ using Content.Server.Shuttles.Events;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Components;
 using Content.Shared.Chat;
+using Content.Shared.Humanoid;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Salvage;
 using Content.Shared.Shuttles.Components;
 using Robust.Shared.Audio;
@@ -25,6 +27,33 @@ public sealed partial class SalvageSystem
         SubscribeLocalEvent<FTLRequestEvent>(OnFTLRequest);
         SubscribeLocalEvent<FTLStartedEvent>(OnFTLStarted);
         SubscribeLocalEvent<FTLCompletedEvent>(OnFTLCompleted);
+        SubscribeLocalEvent<ConsoleFTLAttemptEvent>(OnConsoleFTLAttempt);
+    }
+
+    private void OnConsoleFTLAttempt(ref ConsoleFTLAttemptEvent ev)
+    {
+        if (!TryComp<TransformComponent>(ev.Uid, out var xform) ||
+            !TryComp<SalvageExpeditionComponent>(xform.MapUid, out var salvage))
+        {
+            return;
+        }
+
+        // TODO: This is terrible but need bluespace harnesses or something.
+        var query = EntityQueryEnumerator<HumanoidAppearanceComponent, MobStateComponent, TransformComponent>();
+
+        while (query.MoveNext(out var _, out var _, out var mobXform))
+        {
+            if (mobXform.MapUid != xform.MapUid)
+                continue;
+
+            // Okay they're on salvage, so are they on the shuttle.
+            if (mobXform.GridUid != ev.Uid)
+            {
+                ev.Cancelled = true;
+                ev.Reason = Loc.GetString("salvage-expedition-not-all-present");
+                return;
+            }
+        }
     }
 
     /// <summary>
@@ -74,8 +103,6 @@ public sealed partial class SalvageSystem
             Announce(args.MapUid, Loc.GetString("salvage-expedition-announcement-dungeon", ("direction", component.DungeonLocation.GetDir())));
 
         component.Stage = ExpeditionStage.Running;
-        // At least for now stop them FTLing back until the mission is over.
-        EnsureComp<PreventPilotComponent>(args.Entity);
     }
 
     private void OnFTLStarted(ref FTLStartedEvent ev)
@@ -96,9 +123,6 @@ public sealed partial class SalvageSystem
         {
             return;
         }
-
-        // Let them pilot again when they get back.
-        RemCompDeferred<PreventPilotComponent>(ev.Entity);
 
         // Check if any shuttles remain.
         var query = EntityQueryEnumerator<ShuttleComponent, TransformComponent>();
@@ -122,6 +146,9 @@ public sealed partial class SalvageSystem
         // Run the basic mission timers (e.g. announcements, auto-FTL, completion, etc)
         while (query.MoveNext(out var uid, out var comp))
         {
+            if (comp.Completed)
+                continue;
+
             var remaining = comp.EndTime - _timing.CurTime;
 
             if (comp.Stage < ExpeditionStage.FinalCountdown && remaining < TimeSpan.FromSeconds(30))
@@ -170,11 +197,6 @@ public sealed partial class SalvageSystem
                         break;
                     }
                 }
-            }
-
-            if (remaining < TimeSpan.Zero)
-            {
-                QueueDel(uid);
             }
         }
 

--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -146,9 +146,6 @@ public sealed partial class SalvageSystem
         // Run the basic mission timers (e.g. announcements, auto-FTL, completion, etc)
         while (query.MoveNext(out var uid, out var comp))
         {
-            if (comp.Completed)
-                continue;
-
             var remaining = comp.EndTime - _timing.CurTime;
 
             if (comp.Stage < ExpeditionStage.FinalCountdown && remaining < TimeSpan.FromSeconds(30))
@@ -197,6 +194,11 @@ public sealed partial class SalvageSystem
                         break;
                     }
                 }
+            }
+
+            if (remaining < TimeSpan.Zero)
+            {
+                QueueDel(uid);
             }
         }
 

--- a/Content.Server/Shuttles/Events/ConsoleFTLAttemptEvent.cs
+++ b/Content.Server/Shuttles/Events/ConsoleFTLAttemptEvent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server.Shuttles.Events;
+
+/// <summary>
+/// Raised when a shuttle console is trying to FTL via UI input.
+/// </summary>
+/// <param name="Cancelled"></param>
+/// <param name="Reason"></param>
+[ByRefEvent]
+public record struct ConsoleFTLAttemptEvent(EntityUid Uid, bool Cancelled, string Reason);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -96,6 +96,18 @@ public sealed partial class ShuttleSystem
             return false;
         }
 
+        if (uid != null)
+        {
+            var ev = new ConsoleFTLAttemptEvent(uid.Value, false, string.Empty);
+            RaiseLocalEvent(uid.Value, ref ev, true);
+
+            if (ev.Cancelled)
+            {
+                reason = ev.Reason;
+                return false;
+            }
+        }
+
         reason = null;
         return true;
     }

--- a/Resources/Locale/en-US/procedural/expeditions.ftl
+++ b/Resources/Locale/en-US/procedural/expeditions.ftl
@@ -36,6 +36,8 @@ salvage-expedition-difficulty-Hazardous = Hazardous
 salvage-expedition-difficulty-Extreme = Extreme
 
 # Runner
+salvage-expedition-not-all-present = Not all salvagers are aboard the shuttle!
+
 salvage-expedition-announcement-countdown-minutes = {$duration} minutes remaining to complete the expedition.
 salvage-expedition-announcement-countdown-seconds = {$duration} seconds remaining to complete the expedition.
 salvage-expedition-announcement-dungeon = Dungeon is located {$direction}.


### PR DESCRIPTION
Not my ideal long-term solution (ideally it'd be some kind of device that prevents it) but it at least gets people running them more for more testing so.

:cl:
- tweak: Salvage expedition early launches now allowed if everyone is onboard.