### PR TITLE
Specify shell.nix dependencies using "packages", not "inputsFrom"

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -21,7 +21,7 @@ let
 in pkgs.mkShell {
   name = "space-station-14-devshell";
   buildInputs = [ pkgs.gtk3 ];
-  inputsFrom = dependencies;
+  packages = dependencies;
   shellHook = ''
     export GLIBC_TUNABLES=glibc.rtld.dynamic_sort=1
     export ROBUST_SOUNDFONT_OVERRIDE=${pkgs.soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->
Should fix dotnet being missing from $PATH when using the nix shell.
According to the [nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell) `packages` should be the right way to add executables to the $PATH when using mkShell.