### PR TITLE
Fix "Next" never sending admin logs for rounds outside the cache, show a round's total logs on the UI

### DIFF
--- a/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
@@ -54,6 +54,7 @@ public sealed partial class AdminLogsControl : Control
     public string Search => LogSearch.Text;
     private int ShownLogs { get; set; }
     private int TotalLogs { get; set; }
+    private int RoundLogs { get; set; }
     public bool IncludeNonPlayerLogs { get; set; }
 
     public HashSet<LogType> SelectedTypes { get; } = new();
@@ -485,7 +486,7 @@ public sealed partial class AdminLogsControl : Control
         AddLogs(logs);
     }
 
-    private void UpdateCount(int? shown = null, int? total = null)
+    public void UpdateCount(int? shown = null, int? total = null, int? round = null)
     {
         if (shown != null)
         {
@@ -497,7 +498,15 @@ public sealed partial class AdminLogsControl : Control
             TotalLogs = total.Value;
         }
 
-        Count.Text = Loc.GetString("admin-logs-count", ("showing", ShownLogs), ("total", TotalLogs));
+        if (round != null)
+        {
+            RoundLogs = round.Value;
+        }
+
+        Count.Text = Loc.GetString(
+            "admin-logs-count",
+            ("showing", ShownLogs), ("total", TotalLogs), ("round", RoundLogs)
+        );
     }
 
     protected override void Dispose(bool disposing)

--- a/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
@@ -117,6 +117,7 @@ public sealed class AdminLogsEui : BaseEui
 
         LogsControl.SetCurrentRound(s.RoundId);
         LogsControl.SetPlayers(s.Players);
+        LogsControl.UpdateCount(round: s.RoundLogs);
 
         if (!FirstState)
         {

--- a/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
@@ -70,6 +70,7 @@ public sealed class AdminLogsEui : BaseEui
 
     private void NextLogs()
     {
+        LogsControl.NextButton.Disabled = true;
         var request = new NextLogsRequest();
         SendMessage(request);
     }

--- a/Content.Client/Administration/UI/Logs/AdminLogsWindow.xaml
+++ b/Content.Client/Administration/UI/Logs/AdminLogsWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<DefaultWindow xmlns="https://spacestation14.io"
             xmlns:logs="clr-namespace:Content.Client.Administration.UI.Logs"
             Title="{Loc admin-logs-title}"
-            SetSize="1000 400">
+            SetSize="1100 400">
     <logs:AdminLogsControl Name="Logs" Access="Public"/>
 </DefaultWindow>

--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -374,4 +374,9 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
     {
         return Round(_currentRoundId);
     }
+
+    public Task<int> CountLogs(int round)
+    {
+        return _db.CountAdminLogs(round);
+    }
 }

--- a/Content.Server/Administration/Logs/AdminLogsEui.cs
+++ b/Content.Server/Administration/Logs/AdminLogsEui.cs
@@ -120,7 +120,7 @@ public sealed class AdminLogsEui : BaseEui
                     AnyPlayers = request.AnyPlayers,
                     AllPlayers = request.AllPlayers,
                     IncludeNonPlayers = request.IncludeNonPlayers,
-                    LastLogId = 0,
+                    LastLogId = null,
                     Limit = _clientBatchSize
                 };
 

--- a/Content.Server/Administration/Logs/AdminLogsEui.cs
+++ b/Content.Server/Administration/Logs/AdminLogsEui.cs
@@ -29,10 +29,11 @@ public sealed class AdminLogsEui : BaseEui
     private int _clientBatchSize;
     private bool _isLoading = true;
     private readonly Dictionary<Guid, string> _players = new();
+    private int _roundLogs;
     private CancellationTokenSource _logSendCancellation = new();
     private LogFilter _filter;
 
-    private DefaultObjectPool<List<SharedAdminLog>> _adminLogListPool =
+    private readonly DefaultObjectPool<List<SharedAdminLog>> _adminLogListPool =
         new(new ListPolicy<SharedAdminLog>());
 
     public AdminLogsEui()
@@ -59,7 +60,7 @@ public sealed class AdminLogsEui : BaseEui
         _adminManager.OnPermsChanged += OnPermsChanged;
 
         var roundId = _filter.Round ?? EntitySystem.Get<GameTicker>().RoundId;
-        LoadFromDb(roundId);
+        await LoadFromDb(roundId);
     }
 
     private void ClientBatchSizeChanged(int value)
@@ -79,13 +80,13 @@ public sealed class AdminLogsEui : BaseEui
     {
         if (_isLoading)
         {
-            return new AdminLogsEuiState(CurrentRoundId, new Dictionary<Guid, string>())
+            return new AdminLogsEuiState(CurrentRoundId, new Dictionary<Guid, string>(), 0)
             {
                 IsLoading = true
             };
         }
 
-        var state = new AdminLogsEuiState(CurrentRoundId, _players);
+        var state = new AdminLogsEuiState(CurrentRoundId, _players, _roundLogs);
 
         return state;
     }
@@ -125,7 +126,7 @@ public sealed class AdminLogsEui : BaseEui
                 };
 
                 var roundId = _filter.Round ??= EntitySystem.Get<GameTicker>().RoundId;
-                LoadFromDb(roundId);
+                await LoadFromDb(roundId);
 
                 SendLogs(true);
                 break;
@@ -192,13 +193,16 @@ public sealed class AdminLogsEui : BaseEui
         _logSendCancellation.Dispose();
     }
 
-    private async void LoadFromDb(int roundId)
+    private async Task LoadFromDb(int roundId)
     {
         _isLoading = true;
         StateDirty();
 
-        var round = await Task.Run(() => _adminLogs.Round(roundId));
-        var players = round.Players
+        var round = _adminLogs.Round(roundId);
+        var count = _adminLogs.CountLogs(roundId);
+        await Task.WhenAll(round, count);
+
+        var players = (await round).Players
             .ToDictionary(player => player.UserId, player => player.LastSeenUserName);
 
         _players.Clear();
@@ -207,6 +211,8 @@ public sealed class AdminLogsEui : BaseEui
         {
             _players.Add(id, name);
         }
+
+        _roundLogs = await count;
 
         _isLoading = false;
         StateDirty();

--- a/Content.Server/Administration/Logs/IAdminLogManager.cs
+++ b/Content.Server/Administration/Logs/IAdminLogManager.cs
@@ -23,4 +23,5 @@ public interface IAdminLogManager : ISharedAdminLogManager
     IAsyncEnumerable<string> CurrentRoundMessages(LogFilter? filter = null);
     IAsyncEnumerable<JsonDocument> CurrentRoundJson(LogFilter? filter = null);
     Task<Round> CurrentRound();
+    Task<int> CountLogs(int round);
 }

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -794,8 +794,8 @@ INSERT INTO player_round (players_id, rounds_id) VALUES ({players[player]}, {id}
             {
                 query = filter.DateOrder switch
                 {
-                    DateOrder.Ascending => query.Where(log => log.Id < filter.LastLogId),
-                    DateOrder.Descending => query.Where(log => log.Id > filter.LastLogId),
+                    DateOrder.Ascending => query.Where(log => log.Id > filter.LastLogId),
+                    DateOrder.Descending => query.Where(log => log.Id < filter.LastLogId),
                     _ => throw new ArgumentOutOfRangeException(nameof(filter),
                         $"Unknown {nameof(DateOrder)} value {filter.DateOrder}")
                 };

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -862,6 +862,12 @@ INSERT INTO player_round (players_id, rounds_id) VALUES ({players[player]}, {id}
             }
         }
 
+        public async Task<int> CountAdminLogs(int round)
+        {
+            await using var db = await GetDb();
+            return await db.DbContext.AdminLog.CountAsync(log => log.RoundId == round);
+        }
+
         #endregion
 
         #region Whitelist

--- a/Content.Server/Database/ServerDbManager.cs
+++ b/Content.Server/Database/ServerDbManager.cs
@@ -205,6 +205,7 @@ namespace Content.Server.Database
         IAsyncEnumerable<string> GetAdminLogMessages(LogFilter? filter = null);
         IAsyncEnumerable<SharedAdminLog> GetAdminLogs(LogFilter? filter = null);
         IAsyncEnumerable<JsonDocument> GetAdminLogsJson(LogFilter? filter = null);
+        Task<int> CountAdminLogs(int round);
 
         #endregion
 
@@ -586,6 +587,12 @@ namespace Content.Server.Database
         {
             DbReadOpsMetric.Inc();
             return _db.GetAdminLogsJson(filter);
+        }
+
+        public Task<int> CountAdminLogs(int round)
+        {
+            DbReadOpsMetric.Inc();
+            return _db.CountAdminLogs(round);
         }
 
         public Task<bool> GetWhitelistStatusAsync(NetUserId player)

--- a/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
+++ b/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
@@ -7,10 +7,11 @@ namespace Content.Shared.Administration.Logs;
 [Serializable, NetSerializable]
 public sealed class AdminLogsEuiState : EuiStateBase
 {
-    public AdminLogsEuiState(int roundId, Dictionary<Guid, string> players)
+    public AdminLogsEuiState(int roundId, Dictionary<Guid, string> players, int roundLogs)
     {
         RoundId = roundId;
         Players = players;
+        RoundLogs = roundLogs;
     }
 
     public bool IsLoading { get; set; }
@@ -18,6 +19,8 @@ public sealed class AdminLogsEuiState : EuiStateBase
     public int RoundId { get; }
 
     public Dictionary<Guid, string> Players { get; }
+
+    public int RoundLogs { get; }
 }
 
 public static class AdminLogsEuiMsg

--- a/Resources/Locale/en-US/administration/ui/admin-logs.ftl
+++ b/Resources/Locale/en-US/administration/ui/admin-logs.ftl
@@ -1,5 +1,5 @@
 ﻿admin-logs-title = Admin Logs Panel
-admin-logs-count = Showing {$showing}/{$total}
+admin-logs-count = Showing {$showing}/{$total} of {$round}
 admin-logs-pop-out = Pop Out
 
 # Round


### PR DESCRIPTION
## About the PR
**Media**

https://github.com/space-wizards/space-station-14/assets/10968691/58bc75c5-2237-406e-84d9-93b74c34447f

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed admin logs next button sometimes not working, added a round's total log count to the UI.