### PR TITLE
space glue 1984

### DIFF
--- a/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentClogRuleComponent.cs
@@ -46,7 +46,10 @@ public sealed class VentClogRuleComponent : Component
     /// Reagents that gets the weak numbers used instead of regular ones.
     /// </summary>
     [DataField("weakReagents", customTypeSerializer: typeof(PrototypeIdListSerializer<ReagentPrototype>))]
-    public IReadOnlyList<string> WeakReagents = new[] { "SpaceLube" };
+    public IReadOnlyList<string> WeakReagents = new[]
+    {
+        "SpaceLube", "SpaceGlue"
+    };
 
     /// <summary>
     /// Quantity of weak reagents to put in the foam.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Merge this if the glue is too much to handle. It does a #15996 to it.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- tweak: Too many people were drinking space glue puddles, so rationing has been put in to effect (less space glue from scrubbers event).