### PR TITLE
space glue recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -23,3 +23,14 @@
       amount: 1
   products:
     BuzzochloricBees: 3
+
+- type: reaction
+  id: SpaceGlue
+  minTemp: 370
+  reactants:
+    SpaceLube:
+      amount: 1
+    Slime:
+      amount: 1
+  products:
+    SpaceGlue: 2


### PR DESCRIPTION
## About the PR
i love eating glue!!!!!

1 slime + 1 lube = 2 glue
(slime is sticky and lube is the opposite of glue so)
(also melting horses -> melting slimes)

slimepeople might think twice before vaulting the chem counter now...

requires heating so slimes cant just bleed over lube to turn it into glue

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: You can now make glue by heating a mixture of lube and slime.
