### PR TITLE
Adjust crusher white colour

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -14,6 +14,7 @@
       iconOn: Objects/Tools/flashlight.rsi/flashlight-on.png
       event: !type:ToggleActionEvent
   - type: PointLight
+    color: "#ffeead"
     enabled: false
     radius: 4
 


### PR DESCRIPTION
Saw warden helmet use this colour and looks a bit better than pure white

:cl:
- tweak: Adjust salvage crusher colour to be slightly more muted.