### PR TITLE
Remove zombies preset

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -73,20 +73,20 @@
     - Nukeops
     - BasicStationEventScheduler
 
-- type: gamePreset
-  id: Zombie
-  alias:
-    - zombie
-    - zombies
-    - Zombies
-    - zz14
-    - zomber
-  name: zombie-title
-  description: zombie-description
-  showInVote: false
-  rules:
-    - Zombie
-    - BasicStationEventScheduler
+#- type: gamePreset
+#  id: Zombie
+#  alias:
+#    - zombie
+#    - zombies
+##    - Zombies
+#    - zz14
+#    - zomber
+#  name: zombie-title
+#  description: zombie-description
+#  showInVote: false
+#  rules:
+#    - Zombie
+#    - BasicStationEventScheduler
 
 - type: gamePreset
   id: Pirates


### PR DESCRIPTION
Needs more time in the oven.

:cl:
- tweak: Disabled zombies preset temporarily until they have more work done.
