### PR TITLE
Nerf zombies - Slower, take more damage, less infectious.

### DIFF
--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -21,16 +21,10 @@ namespace Content.Shared.Zombies
         public float OtherZombieDamageCoefficient = 0.25f;
 
         /// <summary>
-        /// The baseline infection chance you have if you are completely nude
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float MaxZombieInfectionChance = 0.40f;
-
-        /// <summary>
         /// Chance that this zombie be permanently killed (rolled once on crit->death transition)
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float ZombiePermadeathChance = 0.70f;
+        public float ZombiePermadeathChance = 0.80f;
 
         /// <summary>
         /// Chance that this zombie will be healed (rolled each second when in crit or dead)
@@ -46,21 +40,27 @@ namespace Content.Shared.Zombies
         public bool Permadeath = false;
 
         /// <summary>
+        /// The baseline infection chance you have if you are completely nude
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float MaxZombieInfectionChance = 0.30f;
+
+        /// <summary>
         /// The minimum infection chance possible. This is simply to prevent
         /// being invincible by bundling up.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MinZombieInfectionChance = 0.10f;
+        public float MinZombieInfectionChance = 0.05f;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public float ZombieMovementSpeedDebuff = 0.75f;
+        public float ZombieMovementSpeedDebuff = 0.70f;
 
         /// <summary>
         /// How long it takes our bite victims to turn in seconds (max).
         ///   Will roll 25% - 100% of this on bite.
         /// </summary>
         [DataField("zombieInfectionTurnTime"), ViewVariables(VVAccess.ReadWrite)]
-        public float ZombieInfectionTurnTime = 240.0f;
+        public float ZombieInfectionTurnTime = 480.0f;
 
         /// <summary>
         /// The skin color of the zombie
@@ -115,10 +115,12 @@ namespace Content.Shared.Zombies
 
         public EmoteSoundsPrototype? EmoteSounds;
 
-        // Heal on tick
         [DataField("nextTick", customTypeSerializer:typeof(TimeOffsetSerializer))]
         public TimeSpan NextTick;
 
+        /// <summary>
+        /// Healing each second
+        /// </summary>
         [DataField("damage")] public DamageSpecifier Damage = new()
         {
             DamageDict = new ()

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -130,11 +130,11 @@
 - type: damageModifierSet
   id: Zombie #Blunt resistent and immune to biological threats, but can be hacked apart and burned
   coefficients:
-    Blunt: 0.5
-    Slash: 0.7
-    Piercing: 0.7
+    Blunt: 0.7
+    Slash: 1.1
+    Piercing: 0.9
     Shock: 1.5
-    Cold: 0.2
+    Cold: 0.3
     Heat: 2.0
     Poison: 0.0
     Radiation: 0.0


### PR DESCRIPTION
## About the PR
Zombies become:
- Fractionally slower 0.75 -> 0.7 
- Less likely to come back from dead 30% -> 20%
- Generally take twice as long to turn (2 min - 8 min) (This depends on damage and healing)
- Infection chance back down to 30%-5% per hit.
- Substantially less damage reduction
- Blunt 0.5 - 0.7
- Slash 0.7 to 1.1
- Piercing 0.7 to 0.9
- Cold 0.2 to 0.3

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: NanaTrasen has selectively bred less dangerous zombies. Your standard jumpsuit deflects their attacks better, they are slower and easier to kill. But they still rise from the dead.