### PR TITLE
Fix TriggerOnMobStateChanged

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
@@ -15,7 +15,7 @@ public sealed partial class TriggerSystem
 
     private void OnMobStateChanged(EntityUid uid, TriggerOnMobstateChangeComponent component, MobStateChangedEvent args)
     {
-        if (component.MobState < args.NewMobState)
+        if (component.MobState != args.NewMobState)
             return;
 
         //This chains Mobstate Changed triggers with OnUseTimerTrigger if they have it
@@ -30,7 +30,6 @@ public sealed partial class TriggerSystem
                 timerTrigger.InitialBeepDelay,
                 timerTrigger.BeepSound);
         }
-
         else
             Trigger(uid);
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Previously TriggerOnMobStateChanged would get triggered whenever the mob would transition from a higher state (Alive) to a lower one (Crit, Dead).
This PR changes it to only trigger on a transition to the target state which was previously completely ignored.

closes #14904

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: The sad trombone implant now correctly only triggers whenever a mob dies