### PR TITLE
tech disk 1984 (no tier 3)

### DIFF
--- a/Content.Server/Research/TechnologyDisk/Components/DiskConsoleComponent.cs
+++ b/Content.Server/Research/TechnologyDisk/Components/DiskConsoleComponent.cs
@@ -7,15 +7,27 @@ namespace Content.Server.Research.TechnologyDisk.Components;
 [RegisterComponent]
 public sealed class DiskConsoleComponent : Component
 {
+    /// <summary>
+    /// How much it costs to print a disk
+    /// </summary>
     [DataField("pricePerDisk"), ViewVariables(VVAccess.ReadWrite)]
-    public int PricePerDisk = 2500;
+    public int PricePerDisk = 1000;
 
-    [DataField("diskPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    /// <summary>
+    /// The prototype of what's being printed
+    /// </summary>
+    [DataField("diskPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>)), ViewVariables(VVAccess.ReadWrite)]
     public string DiskPrototype = "TechnologyDisk";
 
-    [DataField("printDuration")]
+    /// <summary>
+    /// How long it takes to print <see cref="DiskPrototype"/>
+    /// </summary>
+    [DataField("printDuration"), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan PrintDuration = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// The sound made when printing occurs
+    /// </summary>
     [DataField("printSound")]
     public SoundSpecifier PrintSound = new SoundPathSpecifier("/Audio/Machines/printer.ogg");
 }

--- a/Content.Server/Research/TechnologyDisk/Systems/DiskConsoleSystem.cs
+++ b/Content.Server/Research/TechnologyDisk/Systems/DiskConsoleSystem.cs
@@ -30,13 +30,14 @@ public sealed class DiskConsoleSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        foreach (var (printing, console, xform) in EntityQuery<DiskConsolePrintingComponent, DiskConsoleComponent, TransformComponent>())
+        var query = EntityQueryEnumerator<DiskConsolePrintingComponent, DiskConsoleComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var printing, out var console, out var xform))
         {
             if (printing.FinishTime > _timing.CurTime)
                 continue;
 
-            RemComp(printing.Owner, printing);
-            EntityManager.SpawnEntity(console.DiskPrototype, xform.Coordinates);
+            RemComp(uid, printing);
+            Spawn(console.DiskPrototype, xform.Coordinates);
         }
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
you can no longer use tech disks to spoof t3 techs.
i'm fine with having alternative methods but this just turned into people unlocking everything and then using the printer to bypass the lockout to get le funny stuff.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Tech disks no longer contain exclusive discipline technology.
- tweak: Printing tech disks now costs fewer points.
