### PR TITLE
bible is a book

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -43,6 +43,9 @@
     interfaces:
     - key: enum.StorageUiKey.Key
       type: StorageBoundUserInterface
+  - type: Tag
+    tags:
+    - Book
 
 - type: entity
   parent: Bible


### PR DESCRIPTION
## About the PR
fixes #16658

bibles and necronomicons are books and can now fit into bookshelves and book bags

they still cannot be faxed to prevent infinite good boy glitch

**Media**
![23:34:10](https://github.com/space-wizards/space-station-14/assets/39013340/31ab868d-6196-404d-aacf-27da7f3f36e3)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The Head Curator has allowed bibles and necronomicons to be stored in bookshelves and book bags.