### PR TITLE
space doafters, like doafters but in space

### DIFF
--- a/Content.Shared/DoAfter/DoAfter.cs
+++ b/Content.Shared/DoAfter/DoAfter.cs
@@ -48,10 +48,10 @@ public sealed class DoAfter
     public EntityCoordinates UserPosition;
 
     /// <summary>
-    ///     Position of the target relative to their parent when the do after was started.
+    ///     Distance from the user to the target when the do after was started.
     /// </summary>
-    [DataField("targetPosition")]
-    public EntityCoordinates TargetPosition;
+    [DataField("targetDistance")]
+    public float TargetDistance;
 
     /// <summary>
     ///     If <see cref="DoAfterArgs.NeedHand"/> is true, this is the hand that was selected when the doafter started.
@@ -94,7 +94,7 @@ public sealed class DoAfter
         CancelledTime = other.CancelledTime;
         Completed = other.Completed;
         UserPosition = other.UserPosition;
-        TargetPosition = other.TargetPosition;
+        TargetDistance = other.TargetDistance;
         InitialHand = other.InitialHand;
         InitialItem = other.InitialItem;
     }

--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -80,6 +80,13 @@ public sealed class DoAfterArgs
     public bool BreakOnUserMove;
 
     /// <summary>
+    ///     If this is true then any movement, even when weightless, will break the doafter.
+    ///     When there is no gravity, BreakOnUserMove is ignored. If it is false to begin with nothing will change.
+    /// </summary>
+    [DataField("breakOnWeightlessMove")]
+    public bool BreakOnWeightlessMove;
+
+    /// <summary>
     ///     If do_after stops when the target moves (if there is a target)
     /// </summary>
     [DataField("breakOnTargetMove")]
@@ -219,6 +226,7 @@ public sealed class DoAfterArgs
         NeedHand = other.NeedHand;
         BreakOnHandChange = other.BreakOnHandChange;
         BreakOnUserMove = other.BreakOnUserMove;
+        BreakOnWeightlessMove = other.BreakOnWeightlessMove;
         BreakOnTargetMove = other.BreakOnTargetMove;
         MovementThreshold = other.MovementThreshold;
         DistanceThreshold = other.DistanceThreshold;

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Gravity;
 using Content.Shared.Hands.Components;
 using Robust.Shared.Utility;
 
@@ -6,6 +7,7 @@ namespace Content.Shared.DoAfter;
 public abstract partial class SharedDoAfterSystem : EntitySystem
 {
     [Dependency] private readonly IDynamicTypeFactory _factory = default!;
+    [Dependency] private readonly SharedGravitySystem _gravity = default!;
 
     public override void Update(float frameTime)
     {
@@ -151,18 +153,23 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         if (args.Used is { } @using && !xformQuery.TryGetComponent(@using, out usedXform))
             return true;
 
-        // TODO: Handle Inertia in space
         // TODO: Re-use existing xform query for these calculations.
-        if (args.BreakOnUserMove && !userXform.Coordinates
-                .InRange(EntityManager, _transform, doAfter.UserPosition, args.MovementThreshold))
+        // when there is no gravity you will be drifting 99% of the time making many doafters impossible
+        // so this just ignores your movement if you are weightless (unless the doafter sets BreakOnWeightlessMove then moving will still break it)
+        if (args.BreakOnUserMove
+            && !userXform.Coordinates.InRange(EntityManager, _transform, doAfter.UserPosition, args.MovementThreshold)
+            && (args.BreakOnWeightlessMove || !_gravity.IsWeightless(args.User, xform: userXform)))
             return true;
 
         if (args.BreakOnTargetMove)
         {
             DebugTools.Assert(targetXform != null, "Break on move is true, but no target specified?");
-            if (targetXform != null && !targetXform.Coordinates.InRange(EntityManager, _transform,
-                    doAfter.TargetPosition, args.MovementThreshold))
-                return true;
+            if (targetXform != null && targetXform.Coordinates.TryDistance(EntityManager, userXform.Coordinates, out var distance))
+            {
+                // once the target moves too far from you the do after breaks
+                if (Math.Abs(distance - doAfter.TargetDistance) > args.MovementThreshold)
+                    return true;
+            }
         }
 
         if (args.AttemptFrequency == AttemptFrequency.EveryTick && !TryAttemptEvent(doAfter))

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -193,12 +193,15 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         id = new DoAfterId(args.User, comp.NextId++);
         var doAfter = new DoAfter(id.Value.Index, args, GameTiming.CurTime);
 
-        if (args.BreakOnUserMove)
+        if (args.BreakOnUserMove || args.BreakOnTargetMove)
             doAfter.UserPosition = Transform(args.User).Coordinates;
 
         if (args.Target != null && args.BreakOnTargetMove)
+        {
             // Target should never be null if the bool is set.
-            doAfter.TargetPosition = Transform(args.Target.Value).Coordinates;
+            var targetPosition = Transform(args.Target.Value).Coordinates;
+            doAfter.UserPosition.TryDistance(EntityManager, targetPosition, out doAfter.TargetDistance);
+        }
 
         // For this we need to stay on the same hand slot and need the same item in that hand slot
         // (or if there is no item there we need to keep it free).


### PR DESCRIPTION
## About the PR
doafters, by default, will ignore your own movement if you are weightless (can be disabled with BreakOnWeightlessMove, bikeshedding welcome its a sus name)
changed target position code to target *distance* so you can maintain the same distance and still do it

intended for stripping and cuffing to actually be possible with no gravity
coincidentally makes it so they can work with gravity so long as you maintain the same distance (so perfectly chasing a suspect or spinning them around you, which would be funny)
since cuffing works with no gravity sabotaging grav no longer makes it impossible for sec to cuff you

i have only tested these doafters so far, though i dont think it will break anything

this also enables you to heal yourself in space since before this any bit of drifting would cancel it

**Media**

stripping and cuffing with gravity, only change is the spinny part since distance

https://github.com/space-wizards/space-station-14/assets/39013340/1e13dcf1-8202-44b7-ad67-4a1450dfc6fb

stripping and cuffing without gravity, works even if you and the target are drifting (at the same speed)

https://github.com/space-wizards/space-station-14/assets/39013340/5a54ce33-94cb-435d-958f-d933b8220310

using a jetpack to change speed and thus distance, it fails now

https://github.com/space-wizards/space-station-14/assets/39013340/380e490a-12b3-4eff-b6d1-dc683fb4711b




- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: DoAfters (green bar above your head) now work when moving without gravity so you can cuff, strip and use meds in spess.