### PR TITLE
Winterdrobe emag

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -57,7 +57,3 @@
     ClothingHeadFishCap: 2
     ClothingHeadRastaHat: 2
     ClothingBeltStorageWaistbag: 3
-
-  emaggedInventory:
-    ClothingNeckScarfStripedSyndieGreen: 3
-    ClothingNeckScarfStripedSyndieRed: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
@@ -13,3 +13,7 @@
     ClothingOuterCoatBomber: 3
     ClothingHeadHatSantahat: 2
     ClothingHeadHatXmasCrown: 2
+
+  emaggedInventory:
+    ClothingNeckScarfStripedSyndieGreen: 3
+    ClothingNeckScarfStripedSyndieRed: 3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
After the introduction of winterdrobe, I noticed that they forgot to transfer the syndicate scarves that appear after the clothing machine emag, I moved the syndicate scarves to where they make more sense

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: moved syndicate scarves from clothing vending machine to winterdrobe, they will appear after winterdrobe emag
