### PR TITLE
give handheld radio its own channel

### DIFF
--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -13,3 +13,6 @@ chat-radio-security = Security
 chat-radio-service = Service
 chat-radio-supply = Supply
 chat-radio-syndicate = Syndicate
+
+# not headset but whatever
+chat-radio-handheld = Handheld

--- a/Resources/Prototypes/Entities/Objects/Devices/radio.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/radio.yml
@@ -5,7 +5,10 @@
   id: RadioHandheld
   components:
   - type: RadioMicrophone
+    broadcastChannel: Handheld
   - type: RadioSpeaker
+    channels:
+    - Handheld
   - type: Speech
   - type: Sprite
     sprite: Objects/Devices/communication.rsi

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -69,3 +69,11 @@
   frequency: 1213
   color: "#8f4a4b"
   longRange: true
+
+- type: radioChannel
+  id: Handheld
+  name: chat-radio-handheld
+  frequency: 1330
+  color: "#d39f01"
+  # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
+  longRange: true


### PR DESCRIPTION
## About the PR
... that is long range

so you dont need to make telecomms for expeditions, it changes handheld radio from mime's trolling device to an actual tool that makes sense in a salvage vendor since they would actually use it

tested and it works with no comms, does not go from station to centcom as expected

currently uses funny radio channel named handheld, idk what else to call it

also ghosts dont see [Handheld] handheld radio says, "whatever" which is nice

also fixes #11713 since it no longer just spews out common (which could be seen as bad for bomb makers that want to activate a bomb using common)

**Media**
![19:02:46](https://github.com/space-wizards/space-station-14/assets/39013340/878f72df-6f40-4010-b8d5-8260d6e17da2)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Handheld radios now use their own channel and will work without a telecomms server.
