### PR TITLE
Fix device links saving deleted entities.

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
@@ -4,18 +4,65 @@ using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Interaction;
 using JetBrains.Annotations;
+using Robust.Shared.Map.Events;
 
 namespace Content.Server.DeviceNetwork.Systems;
 
 [UsedImplicitly]
 public sealed class DeviceListSystem : SharedDeviceListSystem
 {
+    private ISawmill _sawmill = default!;
+
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<DeviceListComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<DeviceListComponent, BeforeBroadcastAttemptEvent>(OnBeforeBroadcast);
         SubscribeLocalEvent<DeviceListComponent, BeforePacketSentEvent>(OnBeforePacketSent);
+        SubscribeLocalEvent<BeforeSaveEvent>(OnMapSave);
+        _sawmill = Logger.GetSawmill("devicelist");
+    }
+
+    private void OnMapSave(BeforeSaveEvent ev)
+    {
+        List<EntityUid> toRemove = new();
+        var query = GetEntityQuery<TransformComponent>();
+        var enumerator = AllEntityQuery<DeviceListComponent, TransformComponent>();
+        while (enumerator.MoveNext(out var uid, out var device, out var xform))
+        {
+            if (xform.MapUid != ev.Map)
+                continue;
+
+            foreach (var ent in device.Devices)
+            {
+                if (!query.TryGetComponent(ent, out var linkedXform))
+                {
+                    // Entity was deleted.
+                    // TODO remove these on deletion instead of on-save.
+                    toRemove.Add(ent);
+                    continue;
+                }
+
+                if (linkedXform.MapUid == ev.Map)
+                    continue;
+
+                toRemove.Add(ent);
+                // TODO full game saves.
+                // when full saves are supported, this should instead add data to the BeforeSaveEvent informing the
+                // saving system that this map (or null-space entity) also needs to be included in the save.
+                _sawmill.Error(
+                    $"Saving a device list ({ToPrettyString(uid)}) that has a reference to an entity on another map ({ToPrettyString(ent)}). Removing entity from list.");
+            }
+
+            if (toRemove.Count == 0)
+                continue;
+
+            var old = device.Devices.ToList();
+            device.Devices.ExceptWith(toRemove);
+            RaiseLocalEvent(uid, new DeviceListUpdateEvent(old, device.Devices.ToList()));
+            Dirty(device);
+            toRemove.Clear();
+        }
     }
 
     public void OnInit(EntityUid uid, DeviceListComponent component, ComponentInit args)


### PR DESCRIPTION
Fixes #15764 by just brute forcing it & enumerating over all device lists on map saves. Also fixes a similar error for device link sinks/sources which happens because `TryComp` & `Resolve` return false after component shutdown.

:cl:
- fix: Fixed an error when saving maps with device links that reference deleted entities.