### PR TITLE
Add missing WirePanel components

### DIFF
--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -237,10 +237,7 @@ public sealed class WiresSystem : SharedWiresSystem
 
     private void OnWiresStartup(EntityUid uid, WiresComponent component, ComponentStartup args)
     {
-        if (!String.IsNullOrEmpty(component.LayoutId))
-            SetOrCreateWireLayout(uid, component);
-
-        UpdateUserInterface(uid);
+        EnsureComp<WiresPanelComponent>(uid);
     }
     #endregion
 
@@ -498,17 +495,16 @@ public sealed class WiresSystem : SharedWiresSystem
 
     private void OnMapInit(EntityUid uid, WiresComponent component, MapInitEvent args)
     {
-        EnsureComp<WiresPanelComponent>(uid);
+        if (!string.IsNullOrEmpty(component.LayoutId))
+            SetOrCreateWireLayout(uid, component);
+
         if (component.SerialNumber == null)
-        {
             GenerateSerialNumber(uid, component);
-        }
 
         if (component.WireSeed == 0)
-        {
             component.WireSeed = _random.Next(1, int.MaxValue);
-            UpdateUserInterface(uid);
-        }
+
+        UpdateUserInterface(uid);
     }
     #endregion
 

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
@@ -162,6 +162,7 @@
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: Appearance
   - type: WiresVisuals
+  - type: WiresPanel
   - type: Wires
     BoardName: "DawInstrument"
     LayoutId: DawInstrument

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -36,6 +36,7 @@
   - type: Physics
     bodyType: KinematicController
   - type: Clickable
+  - type: WiresPanel
   - type: Wires #we just want the panel
     BoardName: Mech
     LayoutId: Mech

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -69,3 +69,5 @@
       beakerSlot: !type:ContainerSlot
   - type: StaticPrice
     price: 1000
+  - type: Wires
+  - type: WiresPanel

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -74,6 +74,7 @@
   - type: Electrified
     enabled: false
     usesApcPower: true
+  - type: WiresPanel
   - type: Wires
     BoardName: "Airlock Control"
     LayoutId: Airlock

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -3,6 +3,8 @@
   parent: BaseStructure
   name: high security door
   description: Keeps the bad out and keeps the good in.
+  placement:
+    mode: SnapgridCenter
   components:
   - type: InteractionOutline
   - type: Sprite
@@ -65,6 +67,7 @@
   - type: Electrified
     enabled: false
     usesApcPower: true
+  - type: WiresPanel
   - type: Wires
     BoardName: "HighSec Control"
     LayoutId: HighSec
@@ -90,5 +93,3 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
-  placement:
-    mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -84,6 +84,7 @@
     - type: Firelock
     - type: Appearance
     - type: WiresVisuals
+    - type: WiresPanel
     - type: Wires
       BoardName: "Firelock Control"
       LayoutId: Firelock

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -115,6 +115,7 @@
   - type: Electrified
     enabled: false
     usesApcPower: true
+  - type: WiresPanel
   - type: Wires
     BoardName: "Windoor Control"
     LayoutId: Airlock

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -35,6 +35,7 @@
   components:
   - type: SpaceVillainArcade
     rewardAmount: 0
+  - type: WiresPanel
   - type: Wires
     LayoutId: Arcade
     BoardName: "Arcade"
@@ -76,6 +77,7 @@
   - type: ActivatableUI
     key: enum.BlockGameUiKey.Key
   - type: ActivatableUIRequiresPower
+  - type: WiresPanel
   - type: Wires
     LayoutId: Arcade
     BoardName: "Arcade"

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -50,6 +50,7 @@
   - type: Machine
     board: CryoPodMachineCircuitboard
   - type: WiresVisuals
+  - type: WiresPanel
   - type: Wires
     BoardName: "Cryo pod"
     LayoutId: CryoPod

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -36,6 +36,7 @@
     energy: 2
     color: "#fca3c0"
   - type: Appearance
+  - type: WiresPanel
   - type: Wires
     BoardName: "Vessel"
     LayoutId: Vessel
@@ -167,6 +168,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: Appearance
+  - type: WiresPanel
   - type: WiresVisuals
   - type: Wires
     BoardName: "Ape"
@@ -244,6 +246,7 @@
   - type: Repairable
     fuelCost: 10
     doAfterDelay: 5
+  - type: WiresPanel
   - type: Wires
     BoardName: "AnomalyGenerator"
     LayoutId: AnomalyGenerator

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -60,6 +60,7 @@
           True: { visible: true }
           False: { visible: false }
   # Machine / Construction stuff
+  - type: WiresPanel
   - type: Wires
     BoardName: "chem_master"
     LayoutId: chem_master

--- a/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
@@ -60,6 +60,7 @@
   - type: MaterialStorage
     materialWhiteList:
     - Biomass
+  - type: WiresPanel
   - type: Wires
     BoardName: "CloningPod"
     LayoutId: CloningPod

--- a/Resources/Prototypes/Entities/Structures/Machines/fatextractor.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fatextractor.yml
@@ -95,6 +95,7 @@
         acts: ["Destruction"]
   - type: Machine
     board: FatExtractorMachineCircuitboard
+  - type: WiresPanel
   - type: Wires
     BoardName: FatExtractor
     LayoutId: FatExtractor

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -51,6 +51,7 @@
         - Sheet
         - RawMaterial
         - Ingot
+  - type: WiresPanel
   - type: Wires
     BoardName: "Autolathe"
     LayoutId: Autolathe
@@ -158,6 +159,7 @@
         acts: ["Destruction"]
   - type: Machine
     board: ProtolatheMachineCircuitboard
+  - type: WiresPanel
   - type: Wires
     BoardName: "Protolathe"
     LayoutId: Protolathe

--- a/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
@@ -58,6 +58,7 @@
         acts: ["Destruction"]
   - type: Machine
     board: MaterialReclaimerMachineCircuitboard
+  - type: WiresPanel
   - type: Wires
     BoardName: "reclaimer"
     LayoutId: Reclaimer

--- a/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
@@ -77,6 +77,7 @@
         acts: ["Destruction"]
   - type: Machine
     board: MedicalScannerMachineCircuitboard
+  - type: WiresPanel
   - type: Wires
     BoardName: "MedicalScanner"
     LayoutId: MedicalScanner

--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -48,6 +48,7 @@
         acts: ["Destruction"]
   - type: Machine
     board: TelecomServerCircuitboard
+  - type: WiresPanel
   - type: Wires
     BoardName: "TelecomServer"
     LayoutId: TelecomServer

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -63,6 +63,7 @@
       type: VendingMachineBoundUserInterface
     - key: enum.WiresUiKey.Key
       type: WiresBoundUserInterface
+  - type: WiresPanel
   - type: Wires
     BoardName: "Vending Machine"
     LayoutId: Vending

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -242,6 +242,7 @@
     - type: ActivatableUI
       inHandsOnly: false
       key: enum.ThermomachineUiKey.Key
+    - type: WiresPanel
     - type: Wires
       BoardName: "Thermomachine"
       LayoutId: Thermomachine

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -32,6 +32,7 @@
           type: ParticleAcceleratorBoundUserInterface
         - key: enum.WiresUiKey.Key
           type: WiresBoundUserInterface
+    - type: WiresPanel
     - type: Wires
       BoardName: "Mk2 Particle Accelerator"
       LayoutId: ParticleAccelerator

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -180,6 +180,7 @@
   - type: Sprite
     sprite: Structures/Power/Generation/portable_generator.rsi
     state: portgen0_1
+  - type: WiresPanel
   - type: Wires
     BoardName: "GeneratorPlasma"
     LayoutId: GeneratorPlasma
@@ -199,6 +200,7 @@
   - type: Sprite
     sprite: Structures/Power/Generation/portable_generator.rsi
     state: portgen1_1
+  - type: WiresPanel
   - type: Wires
     BoardName: "GeneratorUranium"
     LayoutId: GeneratorUranium

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -90,6 +90,7 @@
     supplyRampTolerance: 1000
     supplyRampRate: 500
   - type: WallMount
+  - type: WiresPanel
   - type: Wires
     BoardName: "APC"
     LayoutId: APC

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -62,6 +62,7 @@
       energy: 1.6
       color: "#c9c042"
       castShadows: false
+    - type: WiresPanel
     - type: Wires
       BoardName: "SMES"
       LayoutId: SMES

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -77,6 +77,7 @@
     maxIntensity: 100
     intensitySlope: 2
     totalIntensity: 200
+  - type: WiresPanel
   - type: Wires
     BoardName: "Substation"
     LayoutId: Substation

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -45,6 +45,7 @@
       type: AirAlarmBoundUserInterface
     - key: enum.WiresUiKey.Key
       type: WiresBoundUserInterface
+  - type: WiresPanel
   - type: Wires
     BoardName: "Air Alarm"
     LayoutId: AirAlarm

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -58,6 +58,7 @@
     interfaces:
     - key: enum.WiresUiKey.Key
       type: WiresBoundUserInterface
+  - type: WiresPanel
   - type: Wires
     BoardName: "Fire Alarm"
     LayoutId: FireAlarm

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
@@ -30,6 +30,7 @@
   - type: Transform
     noRot: false
     anchored: true
+  - type: WiresPanel
   - type: Wires
     BoardName: "Intercom"
     LayoutId: Intercom

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -20,6 +20,7 @@
   - type: DeviceNetworkRequiresPower
   - type: Transform
     anchored: true
+  - type: WiresPanel
   - type: Wires
     alwaysRandomize: true
     LayoutId: SurveillanceCamera

--- a/Resources/Prototypes/Entities/Structures/hydro_tray.yml
+++ b/Resources/Prototypes/Entities/Structures/hydro_tray.yml
@@ -77,6 +77,7 @@
         acts: ["Destruction"]
   - type: Machine
     board: HydroponicsTrayMachineCircuitboard
+  - type: WiresPanel
   - type: Wires
     BoardName: "HydroponicsTray"
     LayoutId: HydroponicsTray


### PR DESCRIPTION
Adds WirePanelComponent to a bunch of prototypes and moves the `EnsureComp<>` out of the MapInit handler. 