### PR TITLE
Salvage Guide

### DIFF
--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -12,6 +12,7 @@ guide-entry-singularity = Singularity
 guide-entry-controls = Controls
 guide-entry-radio = Radio
 guide-entry-jobs = Jobs
+guide-entry-salvage = Salvage
 guide-entry-survival = Survival
 guide-entry-ss14 = Space Station 14
 

--- a/Resources/Prototypes/Guidebook/salvage.yml
+++ b/Resources/Prototypes/Guidebook/salvage.yml
@@ -1,0 +1,4 @@
+- type: guideEntry
+  id: Salvage
+  name: guide-entry-salvage
+  text: "/ServerInfo/Guidebook/Salvage.xml"

--- a/Resources/Prototypes/Guidebook/shiftandcrew.yml
+++ b/Resources/Prototypes/Guidebook/shiftandcrew.yml
@@ -7,6 +7,7 @@
   - Engineering
   - Science
   - Security
+  - Salvage
 
 - type: guideEntry
   id: Survival

--- a/Resources/ServerInfo/Guidebook/Salvage.xml
+++ b/Resources/ServerInfo/Guidebook/Salvage.xml
@@ -1,0 +1,56 @@
+<Document>
+# Salvage
+
+Salvage is one of Cargo's key sources of income... until atmos comes along with a bajillion dollars worth of frezon. Until then though, your main job will be making them money, and totally not making a shuttle
+
+## How to prepare for a salvage
+
+Firstly you need a few things before you can commence on your salvaging.
+
+<Box>
+<GuideEntityEmbed Entity="ClothingOuterHardsuitSpatio"/>
+<GuideEntityEmbed Entity="ClothingShoesBootsMag"/>
+</Box>
+Your Hardsuit is important, as it provides EVA protection. Meaning the lack of pressure and tempurature of space wont kill you. It will also provide minor defense against any space fauna you may encounter. The magboots will ensure you can move smoothly on a salvage and pull things in and out. They also make you slip proof!
+
+<Box>
+<GuideEntityEmbed Entity="JetpackBlue"/>
+<GuideEntityEmbed Entity="JetpackMini"/>
+</Box>
+Jetpacks will be needed to move thoughout space, since without floors and gravity, you will not be able to move. Its fueled by gases like oxygen, nitrogen, water vapor, or other gases that can be found in canisters.
+
+<Box>
+<GuideEntityEmbed Entity="ClothingMaskGasExplorer"/>
+<GuideEntityEmbed Entity="OxygenTankFilled"/>
+<GuideEntityEmbed Entity="YellowOxygenTankFilled"/>
+<GuideEntityEmbed Entity="NitrogenTankFilled"/>
+</Box>
+Internals will be important, given all species need to breathe, and space doesnt have any gases. Your mask is used to connect the gas tank to your mouth to breath, while the gas tanks hold consumable gases and can be refilled at gas canisters. All species breathe oxygen (blue + yellow tanks) except slimes, which need nitrogen (red tanks)
+
+<Box>
+<GuideEntityEmbed Entity="WeaponCrusherGlaive"/>
+<GuideEntityEmbed Entity="WeaponCrusherDagger"/>
+<GuideEntityEmbed Entity="WeaponProtoKineticAccelerator"/>
+</Box>
+The crusher devices are your first and last line of defense against space fauna and other things that want to bring cargo harm. While the dagger is just a standard knife, the glaive is has a special property that if you shoot something with it, then follow up with a melee attack, it deals 2x more damage. The protokinetic accelerator is like a recharging weapon that can provide thrust in the scenerio that your jetpack runs dry, or mine for you.
+
+<Box>
+<GuideEntityEmbed Entity="Pickaxe"/>
+<GuideEntityEmbed Entity="MiningDrill"/>
+<GuideEntityEmbed Entity="OreBag"/>
+<GuideEntityEmbed Entity="ClothingBeltUtilityFilled"/>
+</Box>
+Mining equipment and a full utility belt are needed to be able to plunder the full value of a salvage. The mining to quickly gather ore for the ore processor to make usefull, and the tools of the utility belt for breaking things apart and moving high value objects out.
+
+## How to make money as a salvager
+<Box>
+<GuideEntityEmbed Entity="SalvageMagnet"/>
+</Box>
+<Box>
+<GuideEntityEmbed Entity="ComputerSalvageExpedition"/>
+</Box>
+There are 2 primary forms of income for salvage. The magnet and Expeditions.
+The salvage magnet, when activated, calls in one of many random salvages to be generated somewhere within space. Once you find the salvage, you will need to fight off any present space fauna as well as loot it as much possible. A salvage will only be present for 4 minutes, before dissapearing, taking everything unlooted with it. And in worse case scenerios, will take the bodies of other salvagers in critical condition or dead. Afterwards, the magnet needs some time to recharge before being usable again.
+Expeditions are like adventures that you can do with your salvage buddies. First you must pick a mission from the salvage console, each of which of varying difficulty and reward. Afterwards you must FTL to the location via a shuttle. Once you arrive, the chat will tell you in which direction the dungeon of the salvage is, and you must go and conquer the dangers and gain the loot!
+
+</Document>


### PR DESCRIPTION
## About the PR
This PR adds a salvage section to the guide book. The salvage section is thorough given that its a job that can easily be messed up, and doesn't really tell you a lot without a external guide. Cargo wasn't merged into it, since I feel that there isn't enough cargo content to warrant it's own guide section. 

**Media**
![salvGuide-1](https://github.com/space-wizards/space-station-14/assets/112997230/4426fa77-0f7f-4e0a-9e78-40aff036744e)
![salvGuide-2](https://github.com/space-wizards/space-station-14/assets/112997230/d095dae6-c3fb-40aa-9a12-8e2fbfacaf86)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Added a salvage section to the guide book
