### PR TITLE
Gravity "Inherent" property for planet maps

### DIFF
--- a/Content.Server/Gravity/GravitySystem.cs
+++ b/Content.Server/Gravity/GravitySystem.cs
@@ -22,10 +22,10 @@ namespace Content.Server.Gravity
             if (!Resolve(uid, ref gravity))
                 return;
 
-            var enabled = false;
-
             if (gravity.Inherent)
                 return;
+
+            var enabled = false;
 
             foreach (var (comp, xform) in EntityQuery<GravityGeneratorComponent, TransformComponent>(true))
             {
@@ -55,12 +55,17 @@ namespace Content.Server.Gravity
             RefreshGravity(uid);
         }
 
+        /// <summary>
+        /// Enables gravity. Note that this is a fast-path for GravityGeneratorSystem.
+        /// This means it does nothing if Inherent is set and it might be wiped away with a refresh
+        ///  if you're not supposed to be doing whatever you're doing.
+        /// </summary>
         public void EnableGravity(EntityUid uid, GravityComponent? gravity = null)
         {
             if (!Resolve(uid, ref gravity))
                 return;
 
-            if (gravity.Enabled)
+            if (gravity.Enabled || gravity.Inherent)
                 return;
 
             gravity.Enabled = true;

--- a/Content.Server/Gravity/GravitySystem.cs
+++ b/Content.Server/Gravity/GravitySystem.cs
@@ -24,6 +24,9 @@ namespace Content.Server.Gravity
 
             var enabled = false;
 
+            if (gravity.Inherent)
+                return;
+
             foreach (var (comp, xform) in EntityQuery<GravityGeneratorComponent, TransformComponent>(true))
             {
                 if (!comp.GravityActive || xform.ParentUid != uid)

--- a/Content.Server/Maps/PlanetCommand.cs
+++ b/Content.Server/Maps/PlanetCommand.cs
@@ -70,6 +70,7 @@ public sealed class PlanetCommand : IConsoleCommand
 
         var gravity = _entManager.EnsureComponent<GravityComponent>(mapUid);
         gravity.Enabled = true;
+        gravity.Inherent = true;
         _entManager.Dirty(gravity, metadata);
 
         // Day lighting

--- a/Content.Shared/Gravity/GravityComponent.cs
+++ b/Content.Shared/Gravity/GravityComponent.cs
@@ -31,6 +31,7 @@ namespace Content.Shared.Gravity
         /// <summary>
         /// Inherent gravity ensures GravitySystem won't change Enabled according to the gravity generators attached to this entity.
         /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
         [DataField("inherent")]
         public bool Inherent;
     }

--- a/Content.Shared/Gravity/GravityComponent.cs
+++ b/Content.Shared/Gravity/GravityComponent.cs
@@ -27,5 +27,11 @@ namespace Content.Shared.Gravity
 
         [DataField("enabled")]
         public bool Enabled;
+
+        /// <summary>
+        /// Inherent gravity ensures GravitySystem won't change Enabled according to the gravity generators attached to this entity.
+        /// </summary>
+        [DataField("inherent")]
+        public bool Inherent;
     }
 }


### PR DESCRIPTION
## About the PR
When trying to create maps with inherent gravity (say, parallax-based planet maps) a problem arises.
During component init, the GravityComponent refreshes gravity based on available generators.
As such, the gravity is lost (because the map entity won't have any available generators).
This PR adds an "inherent" attribute to Gravity which disables gravity refresh, locking the gravity state to provided parameters (outside of direct intervention).
Maps and grids with inherent gravity *can't* lose gravity due to loss of the gravity generator or such, and ideally, once made inherent, their state shouldn't change without administrative intervention.

This goes towards #5369.

**Media**
n/a

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
n/a