### PR TITLE
Let holobarriers be climbable with alt. action

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -42,7 +42,7 @@
   id: HolosignSecurity
   parent: HolosignWetFloor
   name: holographic barrier
-  description: A barrier of hard light that blocks movenment, but pretty weak.
+  description: A barrier of hard light that blocks movement, but pretty weak.
   components:
     - type: Physics
       bodyType: Static
@@ -76,3 +76,4 @@
       radius: 3
       color: red
     - type: Climbable
+    - type: Clickable


### PR DESCRIPTION
Fix a typo, too.

:cl:
- fix: Holobarriers can be climbed like tables with the alternate activate entity in world action.
