### PR TITLE
fix nuke when arming off station

### DIFF
--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -440,6 +440,30 @@ public sealed class StationSystem : EntitySystem
     {
         return EntityQuery<StationDataComponent>().Select(x => x.Owner).ToHashSet();
     }
+
+    /// <summary>
+    /// Returns the first station that has a grid in a certain map.
+    /// If the map has no stations, null is returned instead.
+    /// </summary>
+    /// </remarks
+    /// If there are multiple stations on a map it is probably arbitrary which one is returned.
+    /// </remarks>
+    public EntityUid? GetStationInMap(MapId map)
+    {
+        var query = EntityQueryEnumerator<StationDataComponent>();
+        while (query.MoveNext(out var uid, out var data))
+        {
+            foreach (var gridUid in data.Grids)
+            {
+                if (Transform(gridUid).MapID == map)
+                {
+                    return uid;
+                }
+            }
+        }
+
+        return null;
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## About the PR
it now announces and sets alert level when armed off station

GetStationInMap could probably be implemented better idk

**Media**

comms console working as normal
![19:03:53](https://github.com/space-wizards/space-station-14/assets/39013340/a05b61eb-ea90-4336-9167-bac7de1ef615)

nuke now works properly
![19:05:17](https://github.com/space-wizards/space-station-14/assets/39013340/748040f9-ba1c-4bd7-b5b3-ee1b9c4bf700)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: NanoTrasen technicians have fixed armed nuclear devices not sending alerts when off station.
