### PR TITLE
clean up glass sheets and make their destruction consistent

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -2,10 +2,10 @@
   abstract: true
   parent: BaseItem
   id: SheetGlassBase
+  name: glass
   description: A sheet of glass, used often on the station in various applications.
   components:
   - type: Sprite
-    netsync: false
     sprite: Objects/Materials/Sheets/glass.rsi
   - type: Item
     sprite: Objects/Materials/Sheets/glass.rsi
@@ -16,9 +16,11 @@
     tags:
     - Sheet
     - DroneUsable
+  - type: Material
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Glass
+  - type: Appearance
   - type: Destructible
     thresholds:
     - trigger:
@@ -37,7 +39,7 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           ShardGlass:
-            min: 0
+            min: 1
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -45,10 +47,8 @@
 - type: entity
   parent: SheetGlassBase
   id: SheetGlass
-  name: glass
   suffix: Full
   components:
-  - type: Material
   - type: PhysicalComposition
     materialComposition:
       Glass: 100
@@ -66,7 +66,6 @@
       map: ["base"]
   - type: Item
     heldPrefix: glass
-  - type: Appearance
   - type: FloorTile
     outputs:
     - FloorGlass
@@ -77,7 +76,6 @@
 - type: entity
   parent: SheetGlass
   id: SheetGlass1
-  name: glass
   suffix: Single
   components:
   - type: Sprite
@@ -93,7 +91,6 @@
   description: A reinforced sheet of glass.
   suffix: Full
   components:
-  - type: Material
   - type: PhysicalComposition
     materialComposition:
       ReinforcedGlass: 100
@@ -111,13 +108,34 @@
       map: ["base"]
   - type: Item
     heldPrefix: rglass
-  - type: Appearance
   - type: FloorTile
     outputs:
     - FloorRGlass
   - type: Construction
     graph: Glass
     node: SheetRGlass
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ShardGlassReinforced:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: SheetRGlass
@@ -138,7 +156,6 @@
   description: A sheet of translucent plasma.
   suffix: Full
   components:
-  - type: Material
   - type: PhysicalComposition
     materialComposition:
       PlasmaGlass: 100
@@ -156,10 +173,31 @@
       map: ["base"]
   - type: Item
     heldPrefix: pglass
-  - type: Appearance
   - type: Construction
     graph: Glass
     node: SheetPGlass
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ShardGlassPlasma:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: SheetPGlass
@@ -174,13 +212,12 @@
     count: 1
 
 - type: entity
-  parent: SheetGlassBase
+  parent: SheetPGlass
   id: SheetRPGlass
   name: reinforced plasma glass
   description: A reinforced sheet of translucent plasma.
   suffix: Full
   components:
-  - type: Material
   - type: PhysicalComposition
     materialComposition:
       ReinforcedPlasmaGlass: 100
@@ -198,7 +235,6 @@
       map: ["base"]
   - type: Item
     heldPrefix: rpglass
-  - type: Appearance
   - type: Construction
     graph: Glass
     node: SheetRPGlass
@@ -222,7 +258,6 @@
   description: A sheet of uranium glass.
   suffix: Full
   components:
-  - type: Material
   - type: PhysicalComposition
     materialComposition:
       UraniumGlass: 100
@@ -240,10 +275,31 @@
       map: ["base"]
   - type: Item
     heldPrefix: uglass
-  - type: Appearance
   - type: Construction
     graph: Glass
     node: SheetUGlass
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ShardGlassUranium:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: SheetUGlass
@@ -258,13 +314,11 @@
     count: 1
 
 - type: entity
-  parent: SheetGlassBase
+  parent: SheetUGlass
   id: SheetRUGlass
   name: reinforced uranium glass
   description: A reinforced sheet of uranium.
-  suffix: Full
   components:
-  - type: Material
   - type: PhysicalComposition
     materialComposition:
       ReinforcedUraniumGlass: 100
@@ -282,7 +336,6 @@
       map: ["base"]
   - type: Item
     heldPrefix: ruglass
-  - type: Appearance
   - type: Construction
     graph: Glass
     node: SheetRUGlass


### PR DESCRIPTION
## About the PR
- copy pasted components are now in the base sheet
- instead of rng its just break 1 sheet get 1 shard (still ignores stacks didnt fix that)
- uranium and plasma glass sheets turn into their shards
- reinforced variants extend the normal sheets instead of base sheet to share some stuff

**Media**
trust me bro it work

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun