### PR TITLE
megafauna elimination expedition, and fishe

### DIFF
--- a/Content.Server/Salvage/Expeditions/SalvageEliminationExpeditionComponent.cs
+++ b/Content.Server/Salvage/Expeditions/SalvageEliminationExpeditionComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Salvage;
+
+namespace Content.Server.Salvage.Expeditions.Structure;
+
+/// <summary>
+/// Tracks expedition data for <see cref="SalvageMissionType.Elimination"/>
+/// </summary>
+[RegisterComponent, Access(typeof(SalvageSystem), typeof(SpawnSalvageMissionJob))]
+public sealed class SalvageEliminationExpeditionComponent : Component
+{
+    /// <summary>
+    /// List of mobs that need to be killed for the mission to be complete.
+    /// </summary>
+    [DataField("megafauna")]
+    public readonly List<EntityUid> Megafauna = new();
+}

--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -33,6 +33,8 @@ public abstract class SharedSalvageSystem : EntitySystem
                 return Loc.GetString("salvage-expedition-desc-structure",
                     ("count", GetStructureCount(mission.Difficulty)),
                     ("structure", _loc.GetEntityData(proto).Name));
+            case SalvageMissionType.Elimination:
+                return Loc.GetString("salvage-expedition-desc-elimination");
             default:
                 throw new NotImplementedException();
         }
@@ -219,6 +221,11 @@ public enum SalvageMissionType : byte
     /// Destroy the specified structures in a dungeon.
     /// </summary>
     Destruction,
+
+    /// <summary>
+    /// Kill a large creature in a dungeon.
+    /// </summary>
+    Elimination,
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/procedural/expeditions.ftl
+++ b/Resources/Locale/en-US/procedural/expeditions.ftl
@@ -4,6 +4,8 @@ salvage-expedition-structure-remaining = {$count ->
     *[other] {$count} structures remaining.
 }
 
+salvage-expedition-megafauna-remaining = {$count} megafauna remaining.
+
 salvage-expedition-window-title = Salvage expeditions
 salvage-expedition-window-difficulty = Difficulty:
 salvage-expedition-window-details = Details:
@@ -25,9 +27,11 @@ salvage-expedition-desc-structure = {$count ->
     [one] Destroy {$count} {$structure} inside the area.
     *[other] Destroy {$count} {$structure}s inside the area.
 }
+salvage-expedition-desc-elimination = Kill a large and dangerous creature inside the area.
 
 salvage-expedition-type-Mining = Mining
 salvage-expedition-type-Destruction = Destruction
+salvage-expedition-type-Elimination = Elimination
 
 salvage-expedition-difficulty-Minimal = Minimal
 salvage-expedition-difficulty-Minor = Minor

--- a/Resources/Prototypes/Procedural/biome_markers.yml
+++ b/Resources/Prototypes/Procedural/biome_markers.yml
@@ -8,6 +8,10 @@
   id: Xenos
   proto: MobXeno
 
+- type: biomeMarkerLayer
+  id: Carps
+  proto: MobCarp
+
 
 #- type: biomeMarkerLayer
 #  id: Experiment

--- a/Resources/Prototypes/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/Procedural/salvage_factions.yml
@@ -1,16 +1,36 @@
 - type: salvageFaction
   id: Xenos
   groups:
-    - entries:
-        - id: MobXeno
-          amount: 2
-          maxAmount: 3
-        - id: MobXenoDrone
-          amount: 1
-    - entries:
-        - id: MobXenoRavager
-          amount: 1
-      prob: 0.1
+  - entries:
+    - id: MobXeno
+      amount: 2
+      maxAmount: 3
+    - id: MobXenoDrone
+      amount: 1
+  - entries:
+    - id: MobXenoRavager
+      amount: 1
+    prob: 0.1
   configs:
     DefenseStructure: XenoWardingTower
     Mining: Xenos
+    Megafauna: MobXenoQueen
+
+- type: salvageFaction
+  id: Carps
+  groups:
+  - entries:
+    - id: MobCarp
+      amount: 2
+      maxAmount: 5
+    - id: MobCarpMagic
+      amount: 1
+  - entries:
+    - id: MobCarpHolo
+      amount: 1
+    prob: 0.5
+  configs:
+    # TODO: fish tower
+    DefenseStructure: XenoWardingTower
+    Mining: Carps
+    Megafuna: MobCarpDragon


### PR DESCRIPTION
## About the PR
adds megafauna elimination as a mission type:
- your goal is to kill some megafauna (currently hardcoded to only spawn 1, should i change?)
- spawns less random mobs than destruction missions since theres megafauna to deal with
- each salvage faction has a megafauna, xenos get queen
- megafauna can be player controlled since theres just 1 per mission

also adds the carp faction:
- spawns more mobs than xenos faction does
- carp instead of xenos obviously
- megafauna is a full blown dragon, dont let him onto your shuttle like that bozo did with a ravager one time!!!

TODO:
[ ] make a fish version of warding tower since it just uses xeno one rn

**Media**

elimination mission offer:
![04:20:11](https://github.com/space-wizards/space-station-14/assets/39013340/66250e3e-dd23-41df-87a4-bbddca7265cf)

the queen that spawned:
![04:23:02](https://github.com/space-wizards/space-station-14/assets/39013340/11c17c36-1c8e-4e10-b3b0-2a941b7273f5)

dead queen:
![04:23:38](https://github.com/space-wizards/space-station-14/assets/39013340/cac45694-86dd-4990-8cdc-325981345069)

have not seen carp faction yet so that soon

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Deep Rock NanoTrasen now offers elimination missions for daring salvagers willing to kill very big game.
