### PR TITLE
Drink cans and Vending machine

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
@@ -6,6 +6,8 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
+    DrinkDrGibbCan: 2
     DrinkFourteenLokoCan: 2
   emaggedInventory:
     DrinkNukieCan: 2
+    DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
@@ -7,4 +7,5 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
+    DrinkDrGibbCan: 2
     DrinkFourteenLokoCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
@@ -6,4 +6,5 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
+    DrinkDrGibbCan: 2
     DrinkFourteenLokoCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
@@ -6,4 +6,8 @@
     DrinkRootBeerCan: 3
     DrinkIcedTeaCan: 3
     DrinkLemonLimeCan: 3
+    DrinkDrGibbCan: 3
     DrinkFourteenLokoCan: 3
+  emaggedInventory:
+    DrinkNukieCan: 3
+    DrinkChangelingStingCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sovietsoda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sovietsoda.yml
@@ -1,4 +1,6 @@
 - type: vendingMachineInventory
   id: BodaInventory
   startingInventory:
-    DrinkColaCan: 10 #typically hacked product. Default product is "soda"
+    DrinkSodaWaterCan: 10 #typically hacked product. Default product is "soda"
+  emaggedInventory:
+    DrinkColaCan: 10

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
@@ -7,4 +7,7 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
+    DrinkDrGibbCan: 2
     DrinkFourteenLokoCan: 2
+  emaggedInventory:
+    DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
@@ -6,4 +6,7 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
+    DrinkDrGibbCan: 2
     DrinkFourteenLokoCan: 2
+  emaggedInventory:
+    DrinkChangelingStingCan: 2


### PR DESCRIPTION
Update vending machines with drinks cans

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This is a reimagining of my previous closed PR. This update adds dr. gibb into vending machines with drinks (a can of this drink was just lying around, except for a random spawn of food). Also added new emag, i added a changeling sting to some drink vending machines, and also added nuke robust to the soda machine, also i changed the soviet soda vending machine, now it dispenses soda water, but if you emag the vending machine, it will spawn 10 a can of Cola

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Beverage producers Dr. Gibb are back in production with cans of their signature drink, sold in all vending machines with drinks
- tweak: Manufacturers of VODA Vending Machines have changed the filling of their machines and now sell soda water, but there have been cases of cola being found in hacked machines
- tweak: Some hacked vending machines were found to contain strange drinks that change their appearance
