### PR TITLE
Ensure CentCom fields are cleared before round start.

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -163,7 +163,7 @@ public sealed partial class EmergencyShuttleSystem
                     if (!TryComp<ShuttleComponent>(comp.EmergencyShuttle, out var shuttle))
                         continue;
 
-                    if (Deleted(CentCom))
+                    if (Deleted(CentComGrid))
                     {
                         // TODO: Need to get non-overlapping positions.
                         _shuttle.FTLTravel(comp.EmergencyShuttle.Value, shuttle,
@@ -174,7 +174,7 @@ public sealed partial class EmergencyShuttleSystem
                     else
                     {
                         _shuttle.FTLTravel(comp.EmergencyShuttle.Value, shuttle,
-                            CentCom.Value, _consoleAccumulator, TransitTime, true);
+                            CentComGrid.Value, _consoleAccumulator, TransitTime, true);
                     }
                 }
 
@@ -194,12 +194,12 @@ public sealed partial class EmergencyShuttleSystem
 
         while (podLaunchQuery.MoveNext(out var uid, out var pod, out var shuttle))
         {
-            if (CentCom == null || pod.LaunchTime == null || pod.LaunchTime < _timing.CurTime)
+            if (CentComGrid == null || pod.LaunchTime == null || pod.LaunchTime < _timing.CurTime)
                 continue;
 
             // Don't dock them. If you do end up doing this then stagger launch.
             _shuttle.FTLTravel(uid, shuttle,
-                CentCom.Value, hyperspaceTime: TransitTime);
+                CentComGrid.Value, hyperspaceTime: TransitTime);
 
             RemCompDeferred<EscapePodComponent>(uid);
         }
@@ -218,8 +218,8 @@ public sealed partial class EmergencyShuttleSystem
         if (_consoleAccumulator < minTime)
         {
             // Guarantees that emergency shuttle arrives first before anyone else can FTL.
-            if (CentCom != null)
-                _shuttle.AddFTLDestination(CentCom.Value, true);
+            if (CentComGrid != null)
+                _shuttle.AddFTLDestination(CentComGrid.Value, true);
         }
     }
 

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Content.Server.Access.Systems;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
@@ -22,6 +23,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -53,7 +55,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
    private ISawmill _sawmill = default!;
 
    public MapId? CentComMap { get; private set; }
-   public EntityUid? CentCom { get; private set; }
+   public EntityUid? CentComGrid { get; private set; }
 
    /// <summary>
    /// Used for multiple shuttle spawn offsets.
@@ -200,6 +202,17 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
 
    private void OnRoundStart(RoundStartingEvent ev)
    {
+       if (CentComMap != null)
+           _mapManager.DeleteMap(CentComMap.Value);
+
+       // Just in case the grid isn't on the map.
+       DebugTools.Assert(Deleted(CentComGrid));
+       if (CentComGrid != null)
+           Del(CentComGrid.Value);
+
+       CentComGrid = null;
+       CentComMap = null;
+
        CleanupEmergencyConsole();
        SetupEmergencyShuttle();
    }
@@ -247,10 +260,10 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
        if (!string.IsNullOrEmpty(centComPath))
        {
            var centcomm = _map.LoadGrid(CentComMap.Value, "/Maps/centcomm.yml");
-           CentCom = centcomm;
+           CentComGrid = centcomm;
 
-           if (CentCom != null)
-               _shuttle.AddFTLDestination(CentCom.Value, false);
+           if (CentComGrid != null)
+               _shuttle.AddFTLDestination(CentComGrid.Value, false);
        }
        else
        {


### PR DESCRIPTION
Prevents the server from recycling the same MapId, which will cause clients to receive a game state where two different entities with the same MapId are sent to clients, with one being deleted and the other created.

Also renames `CentCom` to `CentComGrid` to make it clear that it is the EntityUid of the grid, and not the `CentComMap` entity (which Is what I assumed).