### PR TITLE
Removes diona thirst multiplier

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -8,6 +8,7 @@
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger
+  - type: Thirst
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -8,8 +8,6 @@
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger
-  - type: Thirst
-    baseDecayRate: 0.3
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi
     state: full


### PR DESCRIPTION
## About the PR
Removes the diona thirst multiplier entirely. I would argue that it is the main reason nobody really plays Diona, since in combination with the slow movement speed it just means you have to fucking _constantly_ ensure you have water on you and refill it every 20 minutes or so, or else you become unable to play the game due to the crippling combination of both status effects. It's just not fun to manage.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Diona no longer get thirsty quicker than other species.
