### PR TITLE
Fix artifacts being worth 0 spacebucks

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class ArtifactSystem : EntitySystem
     /// </remarks>
     private void GetPrice(EntityUid uid, ArtifactComponent component, ref PriceCalculationEvent args)
     {
-        args.Price =+ GetResearchPointValue(uid, component) * component.PriceMultiplier;
+        args.Price += (GetResearchPointValue(uid, component) + component.ConsumedPoints) * component.PriceMultiplier;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #16737

Also fixes sussy `=+` operator, which is not a real operator and just does assign instead of increment.

**Changelog**
:cl:
- tweak: Artifacts now retain their monetary value after extracting points.