### PR TITLE
Tech disk 4891

### DIFF
--- a/Content.Server/Research/TechnologyDisk/Components/TechnologyDiskComponent.cs
+++ b/Content.Server/Research/TechnologyDisk/Components/TechnologyDiskComponent.cs
@@ -8,4 +8,10 @@ public sealed class TechnologyDiskComponent : Component
     /// </summary>
     [DataField("recipes")]
     public List<string>? Recipes;
+
+    /// <summary>
+    /// A weighted random prototype for how rare each tier should be.
+    /// </summary>
+    [DataField("tierWeightPrototype")]
+    public string TierWeightPrototype = "TechDiskTierWeights";
 }

--- a/Content.Server/Research/TechnologyDisk/Components/TechnologyDiskComponent.cs
+++ b/Content.Server/Research/TechnologyDisk/Components/TechnologyDiskComponent.cs
@@ -1,4 +1,7 @@
-﻿namespace Content.Server.Research.TechnologyDisk.Components;
+﻿using Content.Shared.Random;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Research.TechnologyDisk.Components;
 
 [RegisterComponent]
 public sealed class TechnologyDiskComponent : Component
@@ -12,6 +15,6 @@ public sealed class TechnologyDiskComponent : Component
     /// <summary>
     /// A weighted random prototype for how rare each tier should be.
     /// </summary>
-    [DataField("tierWeightPrototype")]
+    [DataField("tierWeightPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomPrototype>))]
     public string TierWeightPrototype = "TechDiskTierWeights";
 }

--- a/Content.Server/Research/TechnologyDisk/Systems/DiskConsoleSystem.cs
+++ b/Content.Server/Research/TechnologyDisk/Systems/DiskConsoleSystem.cs
@@ -85,7 +85,9 @@ public sealed class DiskConsoleSystem : EntitySystem
         {
             totalPoints = server.Points;
         }
-        var canPrint = !HasComp<DiskConsolePrintingComponent>(uid) && totalPoints >= component.PricePerDisk;
+
+        var canPrint = !(TryComp<DiskConsolePrintingComponent>(uid, out var printing) && printing.FinishTime >= _timing.CurTime) &&
+                       totalPoints >= component.PricePerDisk;
 
         var state = new DiskConsoleBoundUserInterfaceState(totalPoints, component.PricePerDisk, canPrint);
         _ui.TrySetUiState(uid, DiskConsoleUiKey.Key, state);

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -169,7 +169,7 @@
 - type: entity
   parent: BaseComputerCircuitboard
   id: TechDiskComputerCircuitboard
-  name: technology disk terminal board
+  name: tech disk terminal board
   description: A computer printed circuit board for a technology disk terminal.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
@@ -54,3 +54,5 @@
     - enum.DamageStateVisualLayers.Base:
         datadisk_base: Sixteen
   - type: TechnologyDisk
+  - type: StaticPrice
+    price: 50

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseComputer
   id: ComputerTechnologyDiskTerminal
-  name: technology disk terminal
+  name: tech disk terminal
   description: A terminal used to print out technology disks.
   components:
   - type: Sprite
@@ -31,3 +31,10 @@
     radius: 0.8
     energy: 0.5
     color: "#b53ca1"
+
+- type: weightedRandom
+  id: TechDiskTierWeights
+  weights:
+    1: 25
+    2: 10
+    3: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Implements a full random system for tech disks, allowing repeats of technologies.
also has a weight that prioritizes t1 and t2 technology over t3.

this is hopefully rare enough that it's still a bit of a hassle for people to get t3 tech.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Tech disks can now contain Tier 3 technology.
- tweak: Tech disk terminals can now print duplicate disks.
- fix: Fixed tech disk terminal print button not updating correctly.