### PR TITLE
Recognizable chemicals

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
@@ -96,7 +96,7 @@ public sealed partial class SolutionContainerSystem : EntitySystem
                 : "shared-solution-container-component-on-examine-worded-amount-multiple-reagents")),
             ("desc", primary.LocalizedPhysicalDescription)));
 
-
+        // Add descriptions of immediately recognizable reagents, like water or beer
         var recognized = new List<ReagentPrototype>();
         foreach (var (id, _) in solutionHolder)
         {
@@ -113,6 +113,7 @@ public sealed partial class SolutionContainerSystem : EntitySystem
             recognized.Add(proto);
         }
 
+        // Skip if there's nothing recognizable
         if (recognized.Count == 0)
             return;
 
@@ -126,6 +127,8 @@ public sealed partial class SolutionContainerSystem : EntitySystem
             }
             else if (reagent == recognized[^1])
             {
+                // this loc specifically  requires space to be appended, fluent doesnt support whitespace
+                msg.Append(' ');
                 part = "examinable-solution-recognized-last";
             }
             else

--- a/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using Content.Server.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
@@ -65,7 +66,9 @@ public sealed partial class SolutionContainerSystem : EntitySystem
         SolutionContainerManagerComponent? solutionsManager = null;
         if (!Resolve(args.Examined, ref solutionsManager)
             || !solutionsManager.Solutions.TryGetValue(examinableComponent.Solution, out var solutionHolder))
+        {
             return;
+        }
 
         var primaryReagent = solutionHolder.GetPrimaryReagentId();
 
@@ -75,7 +78,7 @@ public sealed partial class SolutionContainerSystem : EntitySystem
             return;
         }
 
-        if (!_prototypeManager.TryIndex(primaryReagent, out ReagentPrototype? proto))
+        if (!_prototypeManager.TryIndex(primaryReagent, out ReagentPrototype? primary))
         {
             Logger.Error(
                 $"{nameof(Solution)} could not find the prototype associated with {primaryReagent}.");
@@ -91,7 +94,50 @@ public sealed partial class SolutionContainerSystem : EntitySystem
             ("wordedAmount", Loc.GetString(solutionHolder.Contents.Count == 1
                 ? "shared-solution-container-component-on-examine-worded-amount-one-reagent"
                 : "shared-solution-container-component-on-examine-worded-amount-multiple-reagents")),
-            ("desc", proto.LocalizedPhysicalDescription)));
+            ("desc", primary.LocalizedPhysicalDescription)));
+
+
+        var recognized = new List<ReagentPrototype>();
+        foreach (var (id, _) in solutionHolder)
+        {
+            if (!_prototypeManager.TryIndex<ReagentPrototype>(id, out var proto))
+            {
+                continue;
+            }
+
+            if (!proto.Recognizable)
+            {
+                continue;
+            }
+
+            recognized.Add(proto);
+        }
+
+        if (recognized.Count == 0)
+            return;
+
+        var msg = new StringBuilder();
+        foreach (var reagent in recognized)
+        {
+            string part;
+            if (reagent == recognized[0])
+            {
+                part = "examinable-solution-recognized-first";
+            }
+            else if (reagent == recognized[^1])
+            {
+                part = "examinable-solution-recognized-last";
+            }
+            else
+            {
+                part = "examinable-solution-recognized-next";
+            }
+
+            msg.Append(Loc.GetString(part, ("color", reagent.SubstanceColor.ToHexNoAlpha()),
+                ("chemical", reagent.LocalizedName)));
+        }
+
+        args.PushMarkup(Loc.GetString("examinable-solution-has-recognizable-chemicals", ("recognizedString", msg.ToString())));
     }
 
     public void UpdateAppearance(EntityUid uid, Solution solution,

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -52,6 +52,12 @@ namespace Content.Shared.Chemistry.Reagent
         [ViewVariables(VVAccess.ReadOnly)]
         public string LocalizedPhysicalDescription => Loc.GetString(PhysicalDescription);
 
+        /// <summary>
+        ///     Is this reagent recognizable to the average spaceman (water, welding fuel, ketchup, etc)?
+        /// </summary>
+        [DataField("recognizable")]
+        public bool Recognizable = false;
+
         [DataField("flavor")]
         public string Flavor { get; } = default!;
 
@@ -81,7 +87,7 @@ namespace Content.Shared.Chemistry.Reagent
         public bool Slippery = false;
 
         /// <summary>
-        /// How much reagent slows entities down if it's part of a puddle. 
+        /// How much reagent slows entities down if it's part of a puddle.
         /// 0 - no slowdown; 1 - can't move.
         /// </summary>
         [DataField("viscosity")]

--- a/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
+++ b/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
@@ -1,4 +1,9 @@
 shared-solution-container-component-on-examine-empty-container = Contains no chemicals.
-shared-solution-container-component-on-examine-main-text = It contains a [color={$color}]{$desc}[/color] {$wordedAmount}
+shared-solution-container-component-on-examine-main-text = It contains {INDEFINITE($desc)} [color={$color}]{$desc}[/color] {$wordedAmount}
 shared-solution-container-component-on-examine-worded-amount-one-reagent = chemical.
 shared-solution-container-component-on-examine-worded-amount-multiple-reagents = mixture of chemicals.
+
+examinable-solution-has-recognizable-chemicals = You can recognize {$recognizedString} in the solution.
+examinable-solution-recognized-first = [color={$color}]{$chemical}[/color]
+examinable-solution-recognized-next = , [color={$color}]{$chemical}[/color]
+examinable-solution-recognized-last = and [color={$color}]

--- a/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
+++ b/Resources/Locale/en-US/chemistry/solution/components/shared-solution-container-component.ftl
@@ -6,4 +6,4 @@ shared-solution-container-component-on-examine-worded-amount-multiple-reagents =
 examinable-solution-has-recognizable-chemicals = You can recognize {$recognizedString} in the solution.
 examinable-solution-recognized-first = [color={$color}]{$chemical}[/color]
 examinable-solution-recognized-next = , [color={$color}]{$chemical}[/color]
-examinable-solution-recognized-last = and [color={$color}]
+examinable-solution-recognized-last = and [color={$color}]{$chemical}[/color]

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -158,3 +158,5 @@
       transferAmount: 1
       solution: puddle
       examinable: false
+    - type: ExaminableSolution
+      solution: puddle

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -75,6 +75,8 @@
   - type: PhysicalComposition
     materialComposition:
       Glass: 25
+  - type: ExaminableSolution
+    solution: drink
 
 # Transformable container - normal glass
 - type: entity

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -29,6 +29,7 @@
   physicalDesc: reagent-physical-desc-bubbly
   flavor: ale
   color: "#663100"
+  recognizable: true
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/aleglass.rsi
     state: icon
@@ -41,6 +42,7 @@
   physicalDesc: reagent-physical-desc-bubbly
   flavor: beer
   color: "#cfa85f"
+  recognizable: true
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/beerglass.rsi
     state: icon
@@ -73,6 +75,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: alcohol
   color: "#AB3C05"
+  recognizable: true
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/cognacglass.rsi
     state: icon
@@ -171,6 +174,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: alcohol
   color: "#664300"
+  recognizable: true
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/ginvodkaglass.rsi
     state: icon
@@ -253,6 +257,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: rum
   color: "#664300"
+  recognizable: true
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/rumglass.rsi
     state: icon
@@ -311,6 +316,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: vodka
   color: "#d1d1d155"
+  recognizable: true
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/ginvodkaglass.rsi
     state: icon
@@ -331,6 +337,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: whiskey
   color: "#664300"
+  recognizable: true
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/whiskeyglass.rsi
     state: icon
@@ -351,6 +358,7 @@
   physicalDesc: reagent-physical-desc-translucent
   flavor: shittywine
   color: "#7E4043"
+  recognizable: true
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/wineglass.rsi
     state: icon

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -6,6 +6,7 @@
   physicalDesc: reagent-physical-desc-aromatic
   flavor: coffee
   color: "#664300"
+  recognizable: true
   metabolisms:
     Drink:
       effects:
@@ -134,6 +135,7 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: milk
   color: "#DFDFDF"
+  recognizable: true
   plantMetabolism:
     - !type:PlantAdjustNutrition
       amount: 0.1
@@ -159,6 +161,7 @@
   physicalDesc: reagent-physical-desc-refreshing
   flavor: oats
   color: "#DEDACD"
+  recognizable: true
   metabolisms:
     Drink:
       effects:
@@ -256,6 +259,7 @@
   physicalDesc: reagent-physical-desc-aromatic
   flavor: tea
   color: "#8a5a3a"
+  recognizable: true
   metabolisms:
     Drink:
       effects:
@@ -283,6 +287,7 @@
   physicalDesc: reagent-physical-desc-translucent
   flavor: water
   color: "#75b1f0"
+  recognizable: true
   boilingPoint: 100.0
   meltingPoint: 0.0
   metabolisms:
@@ -298,6 +303,7 @@
   physicalDesc: reagent-physical-desc-frosty
   flavor: cold
   color: "#bed8e6"
+  recognizable: true
   meltingPoint: 0.0
   boilingPoint: 100.0
   plantMetabolism:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
@@ -6,6 +6,7 @@
   physicalDesc: reagent-physical-desc-crisp
   flavor: apple
   color: "#FDAD01"
+  recognizable: true
 
 - type: reagent
   id: JuiceBanana
@@ -42,17 +43,6 @@
         damage:
           types:
             Poison: 1
-
-#TODO: restore eyesight
-#if(..())
-#return 1
-# M.eye_blurry = max(M.eye_blurry - 1 , 0)
-# M.eye_blind = max(M.eye_blind - 1 , 0)
-# switch(data)
-# if(21 to INFINITY)
-# if(prob(data - 10))
-# M.disabilities &= ~NEARSIGHTED
-# data++
 
 - type: reagent
   id: JuiceCarrot

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -6,6 +6,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: soda
   color: "#422912"
+  recognizable: true
 
 - type: reagent
   id: ChangelingSting
@@ -59,6 +60,7 @@
   physicalDesc: reagent-physical-desc-creamy
   flavor: icecream
   color: "#fffbd6"
+  recognizable: true
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/icecreamglass.rsi
     state: icon
@@ -101,7 +103,7 @@
   name: reagent-name-root-beer-float
   parent: BaseSoda
   desc: reagent-desc-root-beer-float
-  physicalDesc: reagent-physical-desc-fizzy and creamy
+  physicalDesc: reagent-physical-desc-fizzy-and-creamy
   flavor: soda
   color: "#4f361f"
   metamorphicSprite:

--- a/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
@@ -6,6 +6,7 @@
   physicalDesc: reagent-physical-desc-sugary
   flavor: sweet
   color: aquamarine
+  recognizable: true
 
 - type: reagent
   id: BbqSauce
@@ -15,6 +16,7 @@
   physicalDesc: reagent-physical-desc-gloopy
   flavor: sweet
   color: darkred
+  recognizable: true
 
 - type: reagent
   id: Cornoil
@@ -24,6 +26,7 @@
   physicalDesc: reagent-physical-desc-oily
   flavor: oily
   color: yellow
+  recognizable: true
 
 - type: reagent
   id: Frostoil
@@ -42,6 +45,7 @@
   physicalDesc: reagent-physical-desc-overpowering
   flavor: spicy
   color: gray
+  recognizable: true
 
 - type: reagent
   id: Hotsauce
@@ -51,6 +55,7 @@
   physicalDesc: reagent-physical-desc-spicy
   flavor: spicy
   color: red
+  recognizable: true
 
 - type: reagent
   id: Ketchup
@@ -60,6 +65,7 @@
   physicalDesc: reagent-physical-desc-tangy
   flavor: tomato
   color: red
+  recognizable: true
 
 - type: reagent
   id: Ketchunaise
@@ -69,6 +75,7 @@
   physicalDesc: reagent-physical-desc-saucey
   flavor: piquant
   color: "#fba399"
+  recognizable: true
 
 - type: reagent
   id: Mayo
@@ -78,6 +85,7 @@
   physicalDesc: reagent-physical-desc-thick
   flavor: sour
   color: "#f9f5e5"
+  recognizable: true
 
 - type: reagent
   id: Vinaigrette
@@ -87,6 +95,7 @@
   physicalDesc: reagent-physical-desc-sour
   flavor: sour
   color: "#efdaae"
+  recognizable: true
 
 - type: reagent
   id: Soysauce
@@ -96,6 +105,7 @@
   physicalDesc: reagent-physical-desc-salty
   flavor: salty
   color: saddlebrown
+  recognizable: true
   metabolisms:
     Food:
       effects:
@@ -112,6 +122,7 @@
   physicalDesc: reagent-physical-desc-grainy
   flavor: salty
   color: "#a1000b"
+  recognizable: true
   boilingPoint: 1465.0
   meltingPoint: 800.7
   plantMetabolism:

--- a/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
@@ -6,6 +6,7 @@
   physicalDesc: reagent-physical-desc-powdery
   flavor: chalky
   color: white
+  recognizable: true
   metabolisms:
     Food:
       effects:
@@ -70,6 +71,7 @@
   physicalDesc: reagent-physical-desc-mucus-like
   flavor: egg
   color: white
+  recognizable: true
   metabolisms:
     Food:
       effects:
@@ -85,6 +87,7 @@
   physicalDesc: reagent-physical-desc-grainy
   flavor: peppery
   color: black
+  recognizable: true
 
 - type: reagent
   id: Vinegar
@@ -94,6 +97,7 @@
   physicalDesc: reagent-physical-desc-sour
   flavor: bitter
   color: tan
+  recognizable: true
   metabolisms:
     Food:
       effects:
@@ -117,6 +121,7 @@
   physicalDesc: reagent-physical-desc-chewy
   flavor: rice
   color: white
+  recognizable: true
   metabolisms:
     Food:
       effects:
@@ -135,6 +140,7 @@
   physicalDesc: reagent-physical-desc-oily
   flavor: oily
   color: olive
+  recognizable: true
   metabolisms:
     Food:
       effects:
@@ -149,6 +155,7 @@
   desc: reagent-desc-oil
   physicalDesc: reagent-physical-desc-oily
   flavor: oily
+  recognizable: true
   color: "#b67823"
   boilingPoint: 300.0
   meltingPoint: -16.0
@@ -162,6 +169,7 @@
   physicalDesc: reagent-physical-desc-oily
   flavor: spicy
   color: "#FF0000"
+  recognizable: true
   meltingPoint: 146
   boilingPoint: 410 # Really high boiling point compared to its melting
   metabolisms:

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -5,6 +5,7 @@
   desc: reagent-desc-blood
   flavor: metallic
   color: "#800000"
+  recognizable: true
   physicalDesc: reagent-physical-desc-ferrous
   slippery: false
   metabolisms:
@@ -24,6 +25,7 @@
   desc: reagent-desc-slime
   flavor: slimy
   color: "#2cf274"
+  recognizable: true
   physicalDesc: reagent-physical-desc-viscous
   slippery: false
   viscosity: 0.25
@@ -43,6 +45,7 @@
   desc: reagent-desc-spider-blood
   flavor: metallic
   color: "#162581"
+  recognizable: true
   physicalDesc: reagent-physical-desc-ferrous
   slippery: false
   metabolisms:
@@ -63,6 +66,7 @@
   physicalDesc: reagent-physical-desc-roaring
   flavor: metallic
   color: "#f4692e"
+  recognizable: true
   metabolisms:
     Drink:
       effects:

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -27,6 +27,7 @@
   physicalDesc: reagent-physical-desc-lemony-fresh
   flavor: bitter
   color: "#c8ff69"
+  recognizable: true
   boilingPoint: 147.0 # Made this up, loosely based on bleach
   meltingPoint: -11.0
   tileReactions:
@@ -41,6 +42,7 @@
   physicalDesc: reagent-physical-desc-shiny
   flavor: funny
   color: "#77b58e"
+  recognizable: true
   boilingPoint: 290.0 # Glycerin
   meltingPoint: 18.2
   tileReactions:

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -43,6 +43,7 @@
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
   color: "#7e009e"
+  recognizable: true
   boilingPoint: -127.3 # Random values picked between the actual values for CO2 and O2
   meltingPoint: -186.4
   tileReactions:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -145,6 +145,7 @@
   slippery: true
   flavor: bitter
   color: "#a76b1c"
+  recognizable: true
   boilingPoint: -84.7 # Acetylene. Close enough.
   meltingPoint: -80.7
   tileReactions:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -84,6 +84,7 @@
   desc: reagent-desc-mold
   flavor: bitter
   color: "#8a9a5b"
+  recognizable: true
   physicalDesc: reagent-physical-desc-fuzzy
   metabolisms:
     Poison:
@@ -180,6 +181,7 @@
   physicalDesc: reagent-physical-desc-oily
   flavor: acidic
   color: "#BF8C00"
+  recognizable: true
   boilingPoint: 337.0
   meltingPoint: 10.31
   plantMetabolism:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

certain 'obviously recognizable' reagents are now visible to spacemen in examinable solutions

it doesnt make a whole lotsa sense that they can pick out individual reagents from slurries but we will suspend disbelief to make reagent-system discoverability better

makes puddles/glass drinks examinable now

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://github.com/space-wizards/space-station-14/assets/19853115/f86c9809-b93d-4b1b-900d-a287b31b83e6)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Spacemen can now recognize common reagents, like water or beer, in examinable solutions.
- tweak: Puddle and glass drink solution contents are now examinable.