### PR TITLE
make salvage magnets upgradable with capacitors

### DIFF
--- a/Content.Server/Salvage/SalvageMagnetComponent.cs
+++ b/Content.Server/Salvage/SalvageMagnetComponent.cs
@@ -24,14 +24,14 @@ namespace Content.Server.Salvage
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("offsetRadiusMin")]
-        public float OffsetRadiusMin = 0f;
+        public float OffsetRadiusMin = 24f;
 
         /// <summary>
         ///     Maximum distance from the offset position that will be used as a salvage's spawnpoint.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("offsetRadiusMax")]
-        public float OffsetRadiusMax = 0f;
+        public float OffsetRadiusMax = 48f;
 
         /// <summary>
         ///     The entity attached to the magnet
@@ -52,28 +52,35 @@ namespace Content.Server.Salvage
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("attachingTime")]
-        public TimeSpan AttachingTime = TimeSpan.FromSeconds(10);
+        public TimeSpan AttachingTime = TimeSpan.FromSeconds(30);
 
         /// <summary>
         ///     How long the magnet can hold the debris until it starts losing the lock
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("baseHoldTime")]
+        public TimeSpan BaseHoldTime = TimeSpan.FromSeconds(240);
+
+        /// <summary>
+        /// How long the magnet can actually hold the debris until it starts losing the lock
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
         [DataField("holdTime")]
-        public TimeSpan HoldTime = TimeSpan.FromSeconds(10);
+        public TimeSpan HoldTime = TimeSpan.FromSeconds(240);
 
         /// <summary>
         ///     How long the magnet can hold the debris while losing the lock
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("detachingTime")]
-        public TimeSpan DetachingTime = TimeSpan.FromSeconds(10);
+        public TimeSpan DetachingTime = TimeSpan.FromSeconds(30);
 
         /// <summary>
         ///     How long the magnet has to cool down after use
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("cooldownTime")]
-        public TimeSpan CooldownTime = TimeSpan.FromSeconds(10);
+        public TimeSpan CooldownTime = TimeSpan.FromSeconds(60);
 
         [DataField("salvageChannel", customTypeSerializer: typeof(PrototypeIdSerializer<RadioChannelPrototype>))]
         public string SalvageChannel = "Supply";

--- a/Content.Server/Salvage/SalvageMagnetComponent.cs
+++ b/Content.Server/Salvage/SalvageMagnetComponent.cs
@@ -6,77 +6,84 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.Salvage
 {
     /// <summary>
-    ///     A salvage magnet.
+    /// A salvage magnet.
     /// </summary>
     [NetworkedComponent, RegisterComponent]
     [Access(typeof(SalvageSystem))]
     public sealed class SalvageMagnetComponent : SharedSalvageMagnetComponent
     {
         /// <summary>
-        ///     Offset relative to magnet used as centre of the placement circle.
+        /// Offset relative to magnet used as centre of the placement circle.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("offset")]
         public Vector2 Offset = Vector2.Zero; // TODO: Maybe specify a direction, and find the nearest edge of the magnets grid the salvage can fit at
 
         /// <summary>
-        ///     Minimum distance from the offset position that will be used as a salvage's spawnpoint.
+        /// Minimum distance from the offset position that will be used as a salvage's spawnpoint.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("offsetRadiusMin")]
         public float OffsetRadiusMin = 24f;
 
         /// <summary>
-        ///     Maximum distance from the offset position that will be used as a salvage's spawnpoint.
+        /// Maximum distance from the offset position that will be used as a salvage's spawnpoint.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("offsetRadiusMax")]
         public float OffsetRadiusMax = 48f;
 
         /// <summary>
-        ///     The entity attached to the magnet
+        /// The entity attached to the magnet
         /// </summary>
         [ViewVariables(VVAccess.ReadOnly)]
         [DataField("attachedEntity")]
         public EntityUid? AttachedEntity = null;
 
         /// <summary>
-        ///     Current state of this magnet
+        /// Current state of this magnet
         /// </summary>
         [ViewVariables(VVAccess.ReadOnly)]
         [DataField("magnetState")]
         public MagnetState MagnetState = MagnetState.Inactive;
 
         /// <summary>
-        ///     How long it takes for the magnet to pull in the debris
+        /// How long it takes for the magnet to pull in the debris
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("baseAttachingTime")]
+        public TimeSpan BaseAttachingTime = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// How long it actually takes for the magnet to pull in the debris
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("attachingTime")]
         public TimeSpan AttachingTime = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        ///     How long the magnet can hold the debris until it starts losing the lock
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("baseHoldTime")]
-        public TimeSpan BaseHoldTime = TimeSpan.FromSeconds(240);
-
-        /// <summary>
-        /// How long the magnet can actually hold the debris until it starts losing the lock
+        /// How long the magnet can hold the debris until it starts losing the lock
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("holdTime")]
         public TimeSpan HoldTime = TimeSpan.FromSeconds(240);
 
         /// <summary>
-        ///     How long the magnet can hold the debris while losing the lock
+        /// How long the magnet can hold the debris while losing the lock
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("detachingTime")]
         public TimeSpan DetachingTime = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        ///     How long the magnet has to cool down after use
+        /// How long the magnet has to cool down for after use
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("baseCooldownTime")]
+        public TimeSpan BaseCooldownTime = TimeSpan.FromSeconds(60);
+
+        /// <summary>
+        /// How long the magnet actually has to cool down for after use
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("cooldownTime")]
@@ -86,17 +93,17 @@ namespace Content.Server.Salvage
         public string SalvageChannel = "Supply";
 
         /// <summary>
-        ///     Current how much charge the magnet currently has
+        /// Current how much charge the magnet currently has
         /// </summary>
         public int ChargeRemaining = 5;
 
         /// <summary>
-        ///     How much capacity the magnet can hold
+        /// How much capacity the magnet can hold
         /// </summary>
         public int ChargeCapacity = 5;
 
         /// <summary>
-        ///     Used as a guard to prevent spamming the appearance system
+        /// Used as a guard to prevent spamming the appearance system
         /// </summary>
         public int PreviousCharge = 5;
 

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Construction;
 using Content.Server.GameTicking;
 using Content.Server.Radio.Components;
 using Content.Server.Radio.EntitySystems;
@@ -61,6 +62,8 @@ namespace Content.Server.Salvage
 
             _sawmill = Logger.GetSawmill("salvage");
             SubscribeLocalEvent<SalvageMagnetComponent, InteractHandEvent>(OnInteractHand);
+            SubscribeLocalEvent<SalvageMagnetComponent, RefreshPartsEvent>(OnRefreshParts);
+            SubscribeLocalEvent<SalvageMagnetComponent, UpgradeExamineEvent>(OnUpgradeExamine);
             SubscribeLocalEvent<SalvageMagnetComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<SalvageMagnetComponent, ComponentShutdown>(OnMagnetRemoval);
             SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoval);
@@ -167,6 +170,17 @@ namespace Content.Server.Salvage
                 Report(uid, component.SalvageChannel, "salvage-system-announcement-spawn-no-debris-available");
             }
             component.MagnetState = MagnetState.Inactive;
+        }
+
+        private void OnRefreshParts(EntityUid uid, SalvageMagnetComponent component, RefreshPartsEvent args)
+        {
+            var rating = args.PartRatings[component.MachinePartHoldTime] - 1;
+            component.HoldTime = component.BaseHoldTime * MathF.Pow(component.PartRatingHoldTime, rating);
+        }
+
+        private void OnUpgradeExamine(EntityUid uid, SalvageMagnetComponent component, UpgradeExamineEvent args)
+        {
+            args.AddPercentageUpgrade("salvage-system-magnet-hold-time-upgrade", (float) (component.HoldTime / component.BaseHoldTime));
         }
 
         private void OnExamined(EntityUid uid, SalvageMagnetComponent component, ExaminedEvent args)

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -174,13 +174,15 @@ namespace Content.Server.Salvage
 
         private void OnRefreshParts(EntityUid uid, SalvageMagnetComponent component, RefreshPartsEvent args)
         {
-            var rating = args.PartRatings[component.MachinePartHoldTime] - 1;
-            component.HoldTime = component.BaseHoldTime * MathF.Pow(component.PartRatingHoldTime, rating);
+            var rating = args.PartRatings[component.MachinePartDelay] - 1;
+            var factor = MathF.Pow(component.PartRatingDelay, rating);
+            component.AttachingTime = component.BaseAttachingTime * factor;
+            component.CooldownTime = component.BaseCooldownTime * factor;
         }
 
         private void OnUpgradeExamine(EntityUid uid, SalvageMagnetComponent component, UpgradeExamineEvent args)
         {
-            args.AddPercentageUpgrade("salvage-system-magnet-hold-time-upgrade", (float) (component.HoldTime / component.BaseHoldTime));
+            args.AddPercentageUpgrade("salvage-system-magnet-delay-upgrade", (float) (component.CooldownTime / component.BaseCooldownTime));
         }
 
         private void OnExamined(EntityUid uid, SalvageMagnetComponent component, ExaminedEvent args)

--- a/Content.Shared/Salvage/SharedSalvageMagnetComponent.cs
+++ b/Content.Shared/Salvage/SharedSalvageMagnetComponent.cs
@@ -1,8 +1,24 @@
+using Content.Shared.Construction.Prototypes;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Salvage;
 
-public abstract class SharedSalvageMagnetComponent : Component {}
+public abstract class SharedSalvageMagnetComponent : Component
+{
+    /// <summary>
+    /// The machine part that affects the hold time
+    /// </summary>
+    [DataField("machinePartHoldTime", customTypeSerializer: typeof(PrototypeIdSerializer<MachinePartPrototype>)), ViewVariables(VVAccess.ReadWrite)]
+    public string MachinePartHoldTime = "Capacitor";
+
+    /// <summary>
+    /// A multiplier applied to the hold time for each level of <see cref="MachinePartHoldTime"/>
+    /// </summary>
+    [DataField("partRatingHoldTime"), ViewVariables(VVAccess.ReadWrite)]
+    public float PartRatingHoldTime = 1.25f;
+}
 
 [Serializable, NetSerializable]
 public enum SalvageMagnetVisuals : byte

--- a/Content.Shared/Salvage/SharedSalvageMagnetComponent.cs
+++ b/Content.Shared/Salvage/SharedSalvageMagnetComponent.cs
@@ -8,16 +8,16 @@ namespace Content.Shared.Salvage;
 public abstract class SharedSalvageMagnetComponent : Component
 {
     /// <summary>
-    /// The machine part that affects the hold time
+    /// The machine part that affects the attaching and cooldown times
     /// </summary>
-    [DataField("machinePartHoldTime", customTypeSerializer: typeof(PrototypeIdSerializer<MachinePartPrototype>)), ViewVariables(VVAccess.ReadWrite)]
-    public string MachinePartHoldTime = "Capacitor";
+    [DataField("machinePartDelay", customTypeSerializer: typeof(PrototypeIdSerializer<MachinePartPrototype>)), ViewVariables(VVAccess.ReadWrite)]
+    public string MachinePartDelay = "Capacitor";
 
     /// <summary>
-    /// A multiplier applied to the hold time for each level of <see cref="MachinePartHoldTime"/>
+    /// A multiplier applied to the attaching and cooldown times for each level of <see cref="MachinePartDelay"/>
     /// </summary>
-    [DataField("partRatingHoldTime"), ViewVariables(VVAccess.ReadWrite)]
-    public float PartRatingHoldTime = 1.25f;
+    [DataField("partRatingDelay"), ViewVariables(VVAccess.ReadWrite)]
+    public float PartRatingDelay = 0.75f;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/salvage/salvage-system.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-system.ftl
@@ -19,5 +19,5 @@ salvage-system-magnet-examined-active = The salvage magnet is holding salvage in
 }
 salvage-system-magnet-examined-releasing = The salvage magnet is releasing the salvage.
 salvage-system-magnet-examined-cooling-down = The salvage magnet is cooling down. It will be ready in: {$timeLeft} seconds.
-salvage-system-magnet-hold-time-upgrade = Hold time
+salvage-system-magnet-delay-upgrade = Attaching/cooldown delay
 

--- a/Resources/Locale/en-US/salvage/salvage-system.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-system.ftl
@@ -19,3 +19,5 @@ salvage-system-magnet-examined-active = The salvage magnet is holding salvage in
 }
 salvage-system-magnet-examined-releasing = The salvage magnet is releasing the salvage.
 salvage-system-magnet-examined-cooling-down = The salvage magnet is cooling down. It will be ready in: {$timeLeft} seconds.
+salvage-system-magnet-hold-time-upgrade = Hold time
+

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -819,3 +819,18 @@
       materialRequirements:
         Steel: 1
         Cable: 2
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  id: SalvageMagnetMachineCircuitboard
+  name: salvage magnet machine board
+  description: A machine printed circuit board for a salvage magnet.
+  components:
+  - type: MachineBoard
+    prototype: SalvageMagnet
+    requirements:
+      Capacitor: 4
+    materialRequirements:
+      Steel: 5
+      CableHV: 5
+      Cable: 2

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -1,29 +1,28 @@
 - type: entity
+  parent: [ BaseMachinePowered, ConstructibleMachine ]
   id: SalvageMagnet
-  parent: BaseMachinePowered
   name: salvage magnet
-  description: "Pulls in salvage."
+  description: Pulls in salvage.
   components:
   - type: Sprite
-    netsync: false
     sprite: Structures/Machines/salvage.rsi
     layers:
-      - state: salvage-magnet
-      - state: salvage-magnet-ready
-        visible: false
-        map: [ "ready" ]
-      - state: salvage-magnet-ready-blinking
-        visible: false
-        map: [ "readyBlinking" ]
-      - state: salvage-magnet-unready
-        visible: false
-        map: [ "unready" ]
-      - state: salvage-magnet-unready-blinking
-        visible: false
-        map: [ "unreadyBlinking" ]
-      - state: salvage-magnet-o4
-        map: ["chargeState"]
-        shader: unshaded
+    - state: salvage-magnet
+    - state: salvage-magnet-ready
+      visible: false
+      map: [ "ready" ]
+    - state: salvage-magnet-ready-blinking
+      visible: false
+      map: [ "readyBlinking" ]
+    - state: salvage-magnet-unready
+      visible: false
+      map: [ "unready" ]
+    - state: salvage-magnet-unready-blinking
+      visible: false
+      map: [ "unreadyBlinking" ]
+    - state: salvage-magnet-o4
+      map: ["chargeState"]
+      shader: unshaded
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -59,25 +58,19 @@
     channels:
     - Supply
   - type: SalvageMagnet
-    offset: 0, 0
-    offsetRadiusMin: 24
-    offsetRadiusMax: 48
-    attachingTime: 30
-    holdTime: 240
-    detachingTime: 30
-    cooldownTime: 60
   - type: ApcPowerReceiver
     powerLoad: 2500 # TODO change this to a HV power draw that really hits the grid hard WHEN active
+  - type: Machine
+    board: SalvageMagnetMachineCircuitboard
 
 # For Knightship
 - type: entity
-  id: SalvageLocator
   parent: SalvageMagnet
+  id: SalvageLocator
   name: salvage locator
-  description: "Locates salvage."
+  description: Locates salvage.
   components:
   - type: SalvageMagnet
-    offset: 0, 0
     offsetRadiusMin: 12
     offsetRadiusMax: 48
   - type: ApcPowerReceiver


### PR DESCRIPTION
## About the PR
- add machine board so you can upgrade without rped, has no recipe (yet?)
- capacitors tier decreases attach and cooldown times.
- 4 bluespace capacitors to get 42% attach and cooldown times.

**Media**
![17:47:07](https://github.com/space-wizards/space-station-14/assets/39013340/1b8b5393-b7f2-433b-98dd-606bb147c62b)
![17:47:56](https://github.com/space-wizards/space-station-14/assets/39013340/7e38578d-8cba-4550-b697-83e9680f14e2)
![17:56:58](https://github.com/space-wizards/space-station-14/assets/39013340/e8db8533-7286-4d91-8057-2605721331cb)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: R&D has figured out how to upgrade salvage magnets using high-tier capacitors.
