### PR TITLE
Remove devices from device lists when they get deleted

### DIFF
--- a/Content.Client/NetworkConfigurator/Systems/DeviceListSystem.cs
+++ b/Content.Client/NetworkConfigurator/Systems/DeviceListSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.DeviceNetwork;
+using Content.Shared.DeviceNetwork.Systems;
 
 namespace Content.Client.NetworkConfigurator.Systems;
 

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Atmos.Monitor;
 using Content.Shared.Atmos.Monitor.Components;
 using Content.Shared.Atmos.Piping.Unary.Components;
 using Content.Shared.DeviceNetwork;
+using Content.Shared.DeviceNetwork.Systems;
 using Content.Shared.Interaction;
 using Content.Shared.Wires;
 using Robust.Server.GameObjects;

--- a/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.AlertLevel;
 using Content.Shared.Atmos.Monitor;
 using Content.Shared.CCVar;
 using Content.Shared.DeviceNetwork;
+using Content.Shared.DeviceNetwork.Systems;
 using Content.Shared.Interaction;
 using Content.Shared.Emag.Systems;
 using Robust.Server.GameObjects;

--- a/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
@@ -107,7 +107,7 @@ namespace Content.Server.DeviceNetwork.Components
         ///     When a device subscribes to the deletion of another device the entity id of the device being subscribed
         ///     to also gets saved on the subscribing device.
         /// </summary>
-        [DataField("OnDeletionSubscribers")]
+        [DataField("ShutdownSubscribers")]
         public HashSet<EntityUid> ShutdownSubscribers = new();
     }
 }

--- a/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
@@ -103,7 +103,7 @@ namespace Content.Server.DeviceNetwork.Components
         public bool SendBroadcastAttemptEvent = false;
 
         /// <summary>
-        ///     A list of entities that get sent the <see cref="DeviceShutdownEvent"/> when this entity gets deleted.<br/><br/>
+        ///     A list of entities that get sent the <see cref="DeviceShutDownEvent"/> when this entity gets deleted.<br/><br/>
         ///     When a device subscribes to the deletion of another device the entity id of the device being subscribed
         ///     to also gets saved on the subscribing device.
         /// </summary>

--- a/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
@@ -101,5 +101,13 @@ namespace Content.Server.DeviceNetwork.Components
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("sendBroadcastAttemptEvent")]
         public bool SendBroadcastAttemptEvent = false;
+
+        /// <summary>
+        ///     A list of entities that get sent the <see cref="DeviceShutdownEvent"/> when this entity gets deleted.<br/><br/>
+        ///     When a device subscribes to the deletion of another device the entity id of the device being subscribed
+        ///     to also gets saved on the subscribing device.
+        /// </summary>
+        [DataField("OnDeletionSubscribers")]
+        public HashSet<EntityUid> ShutdownSubscribers = new();
     }
 }

--- a/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
@@ -61,7 +61,7 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
         return devices;
     }
 
-    protected override void UpdateRemovalSubscription(EntityUid uid, List<EntityUid> newDevices, List<EntityUid> oldDevices)
+    protected override void UpdateShutdownSubscription(EntityUid uid, List<EntityUid> newDevices, List<EntityUid> oldDevices)
     {
         foreach (var device in newDevices)
         {

--- a/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
@@ -22,7 +22,7 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
         SubscribeLocalEvent<DeviceListComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<DeviceListComponent, BeforeBroadcastAttemptEvent>(OnBeforeBroadcast);
         SubscribeLocalEvent<DeviceListComponent, BeforePacketSentEvent>(OnBeforePacketSent);
-        SubscribeLocalEvent<DeviceListComponent, DeviceShutdownEvent>(OnDeviceShutdown);
+        SubscribeLocalEvent<DeviceListComponent, DeviceShutDownEvent>(OnDeviceShutdown);
         SubscribeLocalEvent<BeforeSaveEvent>(OnMapSave);
         _sawmill = Logger.GetSawmill("devicelist");
     }
@@ -106,9 +106,9 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
             args.Cancel();
     }
 
-    private void OnDeviceShutdown(EntityUid uid, DeviceListComponent component, ref DeviceShutdownEvent args)
+    private void OnDeviceShutdown(EntityUid uid, DeviceListComponent component, ref DeviceShutDownEvent args)
     {
-        component.Devices.Remove(args.DeletedEntityUid);
+        component.Devices.Remove(args.ShutDownEntityUid);
         Dirty(component);
     }
 

--- a/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.DeviceNetwork.Components;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Components;
+using Content.Shared.DeviceNetwork.Systems;
 using Content.Shared.Interaction;
 using JetBrains.Annotations;
 using Robust.Shared.Map.Events;
@@ -13,14 +14,102 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
 {
     private ISawmill _sawmill = default!;
 
+    [Dependency] private DeviceNetworkSystem _deviceNetworkSystem = null!;
+
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<DeviceListComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<DeviceListComponent, BeforeBroadcastAttemptEvent>(OnBeforeBroadcast);
         SubscribeLocalEvent<DeviceListComponent, BeforePacketSentEvent>(OnBeforePacketSent);
+        SubscribeLocalEvent<DeviceListComponent, DeviceShutdownEvent>(OnDeviceShutdown);
         SubscribeLocalEvent<BeforeSaveEvent>(OnMapSave);
         _sawmill = Logger.GetSawmill("devicelist");
+    }
+
+    public void OnInit(EntityUid uid, DeviceListComponent component, ComponentInit args)
+    {
+        Dirty(component);
+    }
+
+    /// <summary>
+    /// Gets the given device list as a dictionary
+    /// </summary>
+    /// <remarks>
+    /// If any entity in the device list is pre-map init, it will show the entity UID of the device instead.
+    /// </remarks>
+    public Dictionary<string, EntityUid> GetDeviceList(EntityUid uid, DeviceListComponent? deviceList = null)
+    {
+        if (!Resolve(uid, ref deviceList))
+            return new Dictionary<string, EntityUid>();
+
+        var devices = new Dictionary<string, EntityUid>(deviceList.Devices.Count);
+
+        foreach (var deviceUid in deviceList.Devices)
+        {
+            if (!TryComp(deviceUid, out DeviceNetworkComponent? deviceNet))
+                continue;
+
+            var address = MetaData(deviceUid).EntityLifeStage == EntityLifeStage.MapInitialized
+                ? deviceNet.Address
+                : $"UID: {deviceUid.ToString()}";
+
+            devices.Add(address, deviceUid);
+
+        }
+
+        return devices;
+    }
+
+    protected override void UpdateRemovalSubscription(EntityUid uid, List<EntityUid> newDevices, List<EntityUid> oldDevices)
+    {
+        foreach (var device in newDevices)
+        {
+            _deviceNetworkSystem.SubscribeToDeviceShutdown(uid, device);
+        }
+
+        var removedDevices = oldDevices.Except(newDevices);
+        foreach (var device in removedDevices)
+        {
+            _deviceNetworkSystem.UnsubscribeFromDeviceShutdown(uid, device);
+        }
+    }
+
+    /// <summary>
+    /// Filters the broadcasts recipient list against the device list as either an allow or deny list depending on the components IsAllowList field
+    /// </summary>
+    private void OnBeforeBroadcast(EntityUid uid, DeviceListComponent component, BeforeBroadcastAttemptEvent args)
+    {
+        //Don't filter anything if the device list is empty
+        if (component.Devices.Count == 0)
+        {
+            if (component.IsAllowList) args.Cancel();
+            return;
+        }
+
+        HashSet<DeviceNetworkComponent> filteredRecipients = new(args.Recipients.Count);
+
+        foreach (var recipient in args.Recipients)
+        {
+            if (component.Devices.Contains(recipient.Owner) == component.IsAllowList) filteredRecipients.Add(recipient);
+        }
+
+        args.ModifiedRecipients = filteredRecipients;
+    }
+
+    /// <summary>
+    /// Filters incoming packets if that is enabled <see cref="OnBeforeBroadcast"/>
+    /// </summary>
+    private void OnBeforePacketSent(EntityUid uid, DeviceListComponent component, BeforePacketSentEvent args)
+    {
+        if (component.HandleIncomingPackets && component.Devices.Contains(args.Sender) != component.IsAllowList)
+            args.Cancel();
+    }
+
+    private void OnDeviceShutdown(EntityUid uid, DeviceListComponent component, ref DeviceShutdownEvent args)
+    {
+        component.Devices.Remove(args.DeletedEntityUid);
+        Dirty(component);
     }
 
     private void OnMapSave(BeforeSaveEvent ev)
@@ -63,70 +152,5 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
             Dirty(device);
             toRemove.Clear();
         }
-    }
-
-    public void OnInit(EntityUid uid, DeviceListComponent component, ComponentInit args)
-    {
-        Dirty(component);
-    }
-
-    /// <summary>
-    /// Gets the given device list as a dictionary
-    /// </summary>
-    /// <remarks>
-    /// If any entity in the device list is pre-map init, it will show the entity UID of the device instead.
-    /// </remarks>
-    public Dictionary<string, EntityUid> GetDeviceList(EntityUid uid, DeviceListComponent? deviceList = null)
-    {
-        if (!Resolve(uid, ref deviceList))
-            return new Dictionary<string, EntityUid>();
-
-        var devices = new Dictionary<string, EntityUid>(deviceList.Devices.Count);
-
-        foreach (var deviceUid in deviceList.Devices)
-        {
-            if (!TryComp(deviceUid, out DeviceNetworkComponent? deviceNet))
-                continue;
-
-            var address = MetaData(deviceUid).EntityLifeStage == EntityLifeStage.MapInitialized
-                ? deviceNet.Address
-                : $"UID: {deviceUid.ToString()}";
-
-            devices.Add(address, deviceUid);
-
-        }
-
-        return devices;
-    }
-
-    /// <summary>
-    /// Filters the broadcasts recipient list against the device list as either an allow or deny list depending on the components IsAllowList field
-    /// </summary>
-    private void OnBeforeBroadcast(EntityUid uid, DeviceListComponent component, BeforeBroadcastAttemptEvent args)
-    {
-        //Don't filter anything if the device list is empty
-        if (component.Devices.Count == 0)
-        {
-            if (component.IsAllowList) args.Cancel();
-            return;
-        }
-
-        HashSet<DeviceNetworkComponent> filteredRecipients = new(args.Recipients.Count);
-
-        foreach (var recipient in args.Recipients)
-        {
-            if (component.Devices.Contains(recipient.Owner) == component.IsAllowList) filteredRecipients.Add(recipient);
-        }
-
-        args.ModifiedRecipients = filteredRecipients;
-    }
-
-    /// <summary>
-    /// Filters incoming packets if that is enabled <see cref="OnBeforeBroadcast"/>
-    /// </summary>
-    private void OnBeforePacketSent(EntityUid uid, DeviceListComponent component, BeforePacketSentEvent args)
-    {
-        if (component.HandleIncomingPackets && component.Devices.Contains(args.Sender) != component.IsAllowList)
-            args.Cancel();
     }
 }

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -111,6 +111,17 @@ namespace Content.Server.DeviceNetwork.Systems
         /// </summary>
         private void OnNetworkShutdown(EntityUid uid, DeviceNetworkComponent component, ComponentShutdown args)
         {
+            var eventArgs = new DeviceShutdownEvent(uid);
+
+            foreach (var shutdownSubscriberId in component.ShutdownSubscribers)
+            {
+                RaiseLocalEvent(shutdownSubscriberId, ref eventArgs);
+
+                DeviceNetworkComponent? device = null!;
+                if (Resolve(shutdownSubscriberId, ref device))
+                    device.ShutdownSubscribers.Remove(uid);
+            }
+
             GetNetwork(component.DeviceNetId).Remove(component);
         }
 
@@ -222,6 +233,36 @@ namespace Content.Server.DeviceNetwork.Systems
             device.CustomAddress = false;
             device.Address = "";
             deviceNet.Add(device);
+        }
+
+        public void SubscribeToDeviceShutdown(
+            EntityUid subscriberId, EntityUid targetId,
+            DeviceNetworkComponent? subscribingDevice = null,
+            DeviceNetworkComponent? targetDevice = null)
+        {
+            if (subscriberId == targetId)
+                return;
+
+            if (!Resolve(subscriberId, ref subscribingDevice) || !Resolve(targetId, ref targetDevice))
+                return;
+
+            targetDevice.ShutdownSubscribers.Add(subscriberId);
+            subscribingDevice.ShutdownSubscribers.Add(targetId);
+        }
+        
+        public void UnsubscribeFromDeviceShutdown(
+            EntityUid subscriberId, EntityUid targetId,
+            DeviceNetworkComponent? subscribingDevice = null,
+            DeviceNetworkComponent? targetDevice = null)
+        {
+            if (subscriberId == targetId)
+                return;
+
+            if (!Resolve(subscriberId, ref subscribingDevice) || !Resolve(targetId, ref targetDevice))
+                return;
+
+            targetDevice.ShutdownSubscribers.Remove(subscriberId);
+            subscribingDevice.ShutdownSubscribers.Remove(targetId);
         }
 
         /// <summary>
@@ -408,4 +449,7 @@ namespace Content.Server.DeviceNetwork.Systems
             Data = data;
         }
     }
+
+    [ByRefEvent]
+    public readonly record struct DeviceShutdownEvent(EntityUid DeletedEntityUid);
 }

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -111,7 +111,7 @@ namespace Content.Server.DeviceNetwork.Systems
         /// </summary>
         private void OnNetworkShutdown(EntityUid uid, DeviceNetworkComponent component, ComponentShutdown args)
         {
-            var eventArgs = new DeviceShutdownEvent(uid);
+            var eventArgs = new DeviceShutDownEvent(uid);
 
             foreach (var shutdownSubscriberId in component.ShutdownSubscribers)
             {
@@ -249,7 +249,7 @@ namespace Content.Server.DeviceNetwork.Systems
             targetDevice.ShutdownSubscribers.Add(subscriberId);
             subscribingDevice.ShutdownSubscribers.Add(targetId);
         }
-        
+
         public void UnsubscribeFromDeviceShutdown(
             EntityUid subscriberId, EntityUid targetId,
             DeviceNetworkComponent? subscribingDevice = null,
@@ -450,6 +450,10 @@ namespace Content.Server.DeviceNetwork.Systems
         }
     }
 
+    /// <summary>
+    /// Gets raised on entities that subscribed to shutdown event of the shut down entity
+    /// </summary>
+    /// <param name="ShutDownEntityUid">The entity that was shut down</param>
     [ByRefEvent]
-    public readonly record struct DeviceShutdownEvent(EntityUid DeletedEntityUid);
+    public readonly record struct DeviceShutDownEvent(EntityUid ShutDownEntityUid);
 }

--- a/Content.Shared/DeviceNetwork/Components/DeviceListComponent.cs
+++ b/Content.Shared/DeviceNetwork/Components/DeviceListComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.DeviceNetwork.Systems;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.DeviceNetwork.Components;

--- a/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
+++ b/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using Content.Shared.DeviceNetwork.Components;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.DeviceNetwork;
+namespace Content.Shared.DeviceNetwork.Systems;
 
 public abstract class SharedDeviceListSystem : EntitySystem
 {
@@ -36,6 +36,8 @@ public abstract class SharedDeviceListSystem : EntitySystem
 
         deviceList.Devices = newDevices;
 
+        UpdateRemovalSubscription(uid, devicesList, oldDevices);
+
         RaiseLocalEvent(uid, new DeviceListUpdateEvent(oldDevices, devicesList));
 
         Dirty(deviceList);
@@ -50,6 +52,10 @@ public abstract class SharedDeviceListSystem : EntitySystem
             return new EntityUid[] { };
         }
         return component.Devices;
+    }
+
+    protected virtual void UpdateRemovalSubscription(EntityUid uid, List<EntityUid> devicesList, List<EntityUid> oldDevices)
+    {
     }
 
     private void GetDeviceListState(EntityUid uid, DeviceListComponent comp, ref ComponentGetState args)

--- a/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
+++ b/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
@@ -36,7 +36,7 @@ public abstract class SharedDeviceListSystem : EntitySystem
 
         deviceList.Devices = newDevices;
 
-        UpdateRemovalSubscription(uid, devicesList, oldDevices);
+        UpdateShutdownSubscription(uid, devicesList, oldDevices);
 
         RaiseLocalEvent(uid, new DeviceListUpdateEvent(oldDevices, devicesList));
 
@@ -54,7 +54,7 @@ public abstract class SharedDeviceListSystem : EntitySystem
         return component.Devices;
     }
 
-    protected virtual void UpdateRemovalSubscription(EntityUid uid, List<EntityUid> devicesList, List<EntityUid> oldDevices)
+    protected virtual void UpdateShutdownSubscription(EntityUid uid, List<EntityUid> devicesList, List<EntityUid> oldDevices)
     {
     }
 


### PR DESCRIPTION
This PR adds the ability to subscribe to device network devices shutting down allowing device lists to remove devices that are being deleted.

This is done by adding a list of `EntityUid`s to `DeviceNetworkComponent` and implementing methods on the `DeviceNetworkSystem` for subscribing and unsubscribing to device shutdowns.

Those methods ensure the subscription is bidirectional by adding the id of each other to both components.
When a device gets shut down the `DeviceShutDownEvent` is raised at the entities that subscribed to the shutdown of the device using `SubscribeToDeviceShutdown`.
(I had to google the difference between shut down and shutdown yes)

The `DeviceListSystem` makes use of this to remove devices that are being deleted from device lists.