### PR TITLE
Overwrites parent slowdown from dufflebag variant of bag of holding

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -231,4 +231,4 @@
   - type: Storage
     capacity: 9999
   - type: ClothingSpeedModifier
-    sprintModifier: 1 // makes its stats identical to other variants of bag of holding
+    sprintModifier: 1 # makes its stats identical to other variants of bag of holding

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -230,3 +230,5 @@
       shader: unshaded
   - type: Storage
     capacity: 9999
+ - type: ClothingSpeedModifier
+    sprintModifier: 1 // makes its stats identical to other variants of bag of holding

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -230,5 +230,5 @@
       shader: unshaded
   - type: Storage
     capacity: 9999
- - type: ClothingSpeedModifier
+  - type: ClothingSpeedModifier
     sprintModifier: 1 // makes its stats identical to other variants of bag of holding


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
It makes the dufflebag of holding's stats identical to the bag of holding and satchel of holding. It doesn't make sense for it to retain its 10% sprint slowdown from its parent, given that the dufflebag of holding was a direct downgrade, stats-wise.
Addresses #16500 
(the SS14 servers are down for maintenance as of PR creation so i couldn't double-check the PR guideline docs)

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Overwritten the parent 0.9 sprintModifier of dufflebag of holding. Now its stats should be identical to other bags of holding.
