### PR TITLE
Add support for pulsing lights

### DIFF
--- a/Content.Client/Light/Components/LightBehaviourComponent.cs
+++ b/Content.Client/Light/Components/LightBehaviourComponent.cs
@@ -108,61 +108,6 @@ namespace Content.Client.Light.Components
     }
 
     /// <summary>
-    /// A light behaviour that alternates between StartValue and EndValue
-    /// </summary>
-    [UsedImplicitly]
-    public sealed class PulseBehaviour : LightBehaviourAnimationTrack
-    {
-        public override (int KeyFrameIndex, float FramePlayingTime) AdvancePlayback(
-            object context, int prevKeyFrameIndex, float prevPlayingTime, float frameTime)
-        {
-            var playingTime = prevPlayingTime + frameTime;
-            var interpolateValue = playingTime / MaxTime;
-
-            if (Property == "Enabled") // special case for boolean
-            {
-                ApplyProperty(interpolateValue < 0.5f);
-                return (-1, playingTime);
-            }
-
-            if (interpolateValue < 0.5f)
-            {
-                switch (InterpolateMode)
-                {
-                    case AnimationInterpolationMode.Linear:
-                        ApplyProperty(InterpolateLinear(StartValue, EndValue, interpolateValue * 2f));
-                        break;
-                    case AnimationInterpolationMode.Cubic:
-                        ApplyProperty(InterpolateCubic(EndValue, StartValue, EndValue, StartValue, interpolateValue * 2f));
-                        break;
-                    default:
-                    case AnimationInterpolationMode.Nearest:
-                        ApplyProperty(StartValue);
-                        break;
-                }
-            }
-            else
-            {
-                switch (InterpolateMode)
-                {
-                    case AnimationInterpolationMode.Linear:
-                        ApplyProperty(InterpolateLinear(EndValue, StartValue, (interpolateValue - 0.5f) * 2f));
-                        break;
-                    case AnimationInterpolationMode.Cubic:
-                        ApplyProperty(InterpolateCubic(StartValue, EndValue, StartValue, EndValue, (interpolateValue - 0.5f) * 2f));
-                        break;
-                    default:
-                    case AnimationInterpolationMode.Nearest:
-                        ApplyProperty(EndValue);
-                        break;
-                }
-            }
-
-            return (-1, playingTime);
-        }
-    }
-
-    /// <summary>
     /// A light behaviour that interpolates from StartValue to EndValue
     /// </summary>
     [UsedImplicitly]

--- a/Content.Client/Light/HandheldLightSystem.cs
+++ b/Content.Client/Light/HandheldLightSystem.cs
@@ -2,15 +2,14 @@ using Content.Client.Items;
 using Content.Client.Light.Components;
 using Content.Shared.Light;
 using Content.Shared.Toggleable;
-using Robust.Client.Animations;
 using Robust.Client.GameObjects;
-using Robust.Shared.Animations;
 
 namespace Content.Client.Light;
 
 public sealed class HandheldLightSystem : SharedHandheldLightSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedPulsingLightSystem _pulsingLight = default!;
 
     public override void Initialize()
     {
@@ -58,12 +57,14 @@ public sealed class HandheldLightSystem : SharedHandheldLightSystem
             switch (state)
             {
                 case HandheldLightPowerStates.FullPower:
+                    _pulsingLight.SetEnabled(uid, false, dirty: false);
                     break; // We just needed to reset all behaviours
                 case HandheldLightPowerStates.LowPower:
+                    _pulsingLight.SetEnabled(uid, false, dirty: false);
                     lightBehaviour.StartLightBehaviour(component.RadiatingBehaviourId);
                     break;
                 case HandheldLightPowerStates.Dying:
-                    lightBehaviour.StartLightBehaviour(component.BlinkingBehaviourId);
+                    _pulsingLight.SetEnabled(uid, true, dirty: false);
                     break;
             }
         }

--- a/Content.Client/Light/PulsingLightSystem.cs
+++ b/Content.Client/Light/PulsingLightSystem.cs
@@ -1,0 +1,58 @@
+﻿using Content.Shared.Light;
+using Content.Shared.Light.Component;
+using Robust.Client.GameObjects;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Light;
+
+/// <inheritdoc/>
+public sealed class PulsingLightSystem : SharedPulsingLightSystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly PointLightSystem _pointLight = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PulsingLightComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, PulsingLightComponent component, MapInitEvent args)
+    {
+        if (component.RandomlyOffset)
+            component.RandomOffset = _random.NextFloat(component.Period);
+    }
+
+    private void UpdateLight(EntityUid uid, float val, PulsingLightComponent component, PointLightComponent light)
+    {
+        val -= component.RandomOffset; // horizontal offset
+        var bA = (component.MaxBrightness - component.MinBrightness) / 2; // amplitude of brightness
+        var rA = (component.MaxRadius - component.MinRadius) / 2; // amplitude of radius
+        var b = 2 * MathF.PI / component.Period; // period
+        var bD = component.MinBrightness + bA; // vertical shift for brightness
+        var rD = component.MinRadius + rA; // vertical shift for radius
+
+        var brightness = bA * MathF.Sin(b * val) + bD;
+        var radius = rA * MathF.Sin(b * val) + rD;
+
+        light.Energy = brightness;
+        _pointLight.SetRadius(uid, radius, light);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<PulsingLightComponent, PointLightComponent>();
+        while (query.MoveNext(out var uid, out var pulsing, out var light))
+        {
+            if (!pulsing.Enabled)
+                continue;
+
+            UpdateLight(uid, (float) _timing.CurTime.TotalSeconds, pulsing, light);
+        }
+    }
+}

--- a/Content.Client/Light/PulsingLightSystem.cs
+++ b/Content.Client/Light/PulsingLightSystem.cs
@@ -29,22 +29,30 @@ public sealed class PulsingLightSystem : SharedPulsingLightSystem
     private void UpdateLight(EntityUid uid, float val, PulsingLightComponent component, PointLightComponent light)
     {
         val -= component.RandomOffset; // horizontal offset
-        var bA = (component.MaxBrightness - component.MinBrightness) / 2; // amplitude of brightness
-        var rA = (component.MaxRadius - component.MinRadius) / 2; // amplitude of radius
         var b = 2 * MathF.PI / component.Period; // period
-        var bD = component.MinBrightness + bA; // vertical shift for brightness
-        var rD = component.MinRadius + rA; // vertical shift for radius
 
-        var brightness = bA * MathF.Sin(b * val) + bD;
-        var radius = rA * MathF.Sin(b * val) + rD;
+        if (component.MaxBrightness != null && component.MinBrightness != null)
+        {
+            var bA = (component.MaxBrightness - component.MinBrightness).Value / 2; // amplitude of brightness
+            var bD = component.MinBrightness.Value + bA; // vertical shift for brightness
 
-        light.Energy = brightness;
-        _pointLight.SetRadius(uid, radius, light);
+            var brightness = bA * MathF.Sin(b * val) + bD;
+            light.Energy = brightness;
+        }
+
+        if (component.MaxRadius != null && component.MinRadius != null)
+        {
+            var rA = (component.MaxRadius - component.MinRadius).Value / 2; // amplitude of radius
+            var rD = component.MinRadius.Value + rA; // vertical shift for radius
+
+            var radius = rA * MathF.Sin(b * val) + rD;
+            _pointLight.SetRadius(uid, radius, light);
+        }
     }
 
-    public override void Update(float frameTime)
+    public override void FrameUpdate(float frameTime)
     {
-        base.Update(frameTime);
+        base.FrameUpdate(frameTime);
 
         var query = EntityQueryEnumerator<PulsingLightComponent, PointLightComponent>();
         while (query.MoveNext(out var uid, out var pulsing, out var light))

--- a/Content.Server/Light/EntitySystems/PulsingLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PulsingLightSystem.cs
@@ -1,0 +1,9 @@
+﻿using Content.Shared.Light;
+
+namespace Content.Server.Light.EntitySystems;
+
+/// <inheritdoc/>
+public sealed class PulsingLightSystem : SharedPulsingLightSystem
+{
+
+}

--- a/Content.Shared/Light/Component/PulsingLightComponent.cs
+++ b/Content.Shared/Light/Component/PulsingLightComponent.cs
@@ -20,25 +20,25 @@ public sealed partial class PulsingLightComponent : Robust.Shared.GameObjects.Co
     /// The minimum brightness of the light
     /// </summary>
     [DataField("minBrightness"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public float MinBrightness;
+    public float? MinBrightness;
 
     /// <summary>
     /// The maximum brightness of the light
     /// </summary>
     [DataField("maxBrightness"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public float MaxBrightness;
+    public float? MaxBrightness;
 
     /// <summary>
     /// The minimum brightness of the light
     /// </summary>
     [DataField("minRadius"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public float MinRadius;
+    public float? MinRadius;
 
     /// <summary>
     /// The maximum brightness of the light
     /// </summary>
     [DataField("maxRadius"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public float MaxRadius;
+    public float? MaxRadius;
 
     /// <summary>
     /// How long does it take the light to complete one "cycle"

--- a/Content.Shared/Light/Component/PulsingLightComponent.cs
+++ b/Content.Shared/Light/Component/PulsingLightComponent.cs
@@ -1,0 +1,61 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Light.Component;
+
+/// <summary>
+/// This is used for lights that increase in brightness/radius in a cyclical manner
+/// Modeled with a cosine function.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedPulsingLightSystem)), AutoGenerateComponentState]
+public sealed partial class PulsingLightComponent : Robust.Shared.GameObjects.Component
+{
+    /// <summary>
+    /// Whether or not the pulsing effect is enabled.
+    /// Setting this to false simply halts the pulse, but does not reset the value.
+    /// </summary>
+    [DataField("enabled"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public bool Enabled = true;
+
+    /// <summary>
+    /// The minimum brightness of the light
+    /// </summary>
+    [DataField("minBrightness"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public float MinBrightness;
+
+    /// <summary>
+    /// The maximum brightness of the light
+    /// </summary>
+    [DataField("maxBrightness"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public float MaxBrightness;
+
+    /// <summary>
+    /// The minimum brightness of the light
+    /// </summary>
+    [DataField("minRadius"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public float MinRadius;
+
+    /// <summary>
+    /// The maximum brightness of the light
+    /// </summary>
+    [DataField("maxRadius"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public float MaxRadius;
+
+    /// <summary>
+    /// How long does it take the light to complete one "cycle"
+    /// Value is in seconds.
+    /// </summary>
+    [DataField("period"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public float Period;
+
+    /// <summary>
+    /// Whether or not the value of the pulse should be randomly offset
+    /// </summary>
+    [DataField("randomlyOffset")]
+    public bool RandomlyOffset = true;
+
+    /// <summary>
+    /// The random offset of the pulse
+    /// </summary>
+    [DataField("randomOffset"), ViewVariables(VVAccess.ReadWrite)]
+    public float RandomOffset;
+}

--- a/Content.Shared/Light/SharedPulsingLightSystem.cs
+++ b/Content.Shared/Light/SharedPulsingLightSystem.cs
@@ -1,0 +1,52 @@
+﻿using Content.Shared.Light.Component;
+using JetBrains.Annotations;
+
+namespace Content.Shared.Light;
+
+/// <summary>
+/// This handles logic relating to <see cref="PulsingLightComponent"/>
+/// </summary>
+public abstract class SharedPulsingLightSystem : EntitySystem
+{
+    [PublicAPI]
+    public void SetEnabled(EntityUid uid, bool enabled, PulsingLightComponent? component = null, bool dirty = true)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+        component.Enabled = enabled;
+        if (dirty)
+            Dirty(component);
+    }
+
+    [PublicAPI]
+    public void SetBrightness(EntityUid uid, float min, float max, PulsingLightComponent? component = null, bool dirty = true)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+        component.MinBrightness = min;
+        component.MaxBrightness = max;
+        if (dirty)
+            Dirty(component);
+    }
+
+    [PublicAPI]
+    public void SetRadius(EntityUid uid, float min, float max, PulsingLightComponent? component = null, bool dirty = true)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+        component.MinRadius = min;
+        component.MaxRadius = max;
+        if (dirty)
+            Dirty(component);
+    }
+
+    [PublicAPI]
+    public void SetPeriod(EntityUid uid, float period, PulsingLightComponent? component = null, bool dirty = true)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+        component.Period = period;
+        if (dirty)
+            Dirty(component);
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -70,7 +70,6 @@
   - type: Appearance
   - type: HandheldLight
     addPrefix: true
-    blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating
   - type: LightBehaviour
     behaviours:
@@ -84,15 +83,11 @@
         property: Radius
         enabled: false
         reverseWhenFinished: true
-      - !type:PulseBehaviour
-        id: blinking
-        interpolate: Nearest
-        maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
-        isLooped: true
-        property: Radius
-        enabled: false
+  - type: PulsingLight
+    period: 1
+    minRadius: 0.1
+    maxRadius: 2
+    enabled: false
   - type: PowerCellSlot
     cellSlotId: cell_slot
   - type: ItemSlots
@@ -189,7 +184,6 @@
   - type: Appearance
   - type: HandheldLight
     addPrefix: true
-    blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating
   - type: LightBehaviour
     behaviours:
@@ -203,15 +197,11 @@
         property: Radius
         enabled: false
         reverseWhenFinished: true
-      - !type:PulseBehaviour
-        id: blinking
-        interpolate: Nearest
-        maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
-        isLooped: true
-        property: Radius
-        enabled: false
+  - type: PulsingLight
+    period: 1
+    minRadius: 0.1
+    maxRadius: 2
+    enabled: false
   - type: Battery
     maxCharge: 600 #lights drain 3/s but recharge of 2 makes this 1/s. Therefore 600 is 10 minutes of light.
     startingCharge: 600

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -22,7 +22,6 @@
   - type: Appearance
   - type: HandheldLight
     addPrefix: false
-    blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating
   - type: LightBehaviour
     behaviours:
@@ -36,15 +35,11 @@
         property: Radius
         enabled: false
         reverseWhenFinished: true
-      - !type:PulseBehaviour
-        id: blinking
-        interpolate: Nearest
-        maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
-        isLooped: true
-        property: Radius
-        enabled: false
+  - type: PulsingLight
+    period: 1
+    minRadius: 0.1
+    maxRadius: 2
+    enabled: false
   - type: ToggleableLightVisuals
     spriteLayer: light
     inhandVisuals:

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -6,7 +6,6 @@
   components:
   - type: HandheldLight
     addPrefix: true
-    blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating
   - type: LightBehaviour
     behaviours:
@@ -20,15 +19,11 @@
         property: Radius
         enabled: false
         reverseWhenFinished: true
-      - !type:PulseBehaviour
-        id: blinking
-        interpolate: Nearest
-        maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
-        isLooped: true
-        property: Radius
-        enabled: false
+  - type: PulsingLight
+    period: 1
+    minRadius: 0.1
+    maxRadius: 2
+    enabled: false
   - type: PowerCellSlot
     cellSlotId: cell_slot
   - type: ItemSlots

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -10,7 +10,6 @@
     - DroneUsable
   - type: HandheldLight
     addPrefix: false
-    blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating
   - type: LightBehaviour
     behaviours:
@@ -24,15 +23,11 @@
         property: Radius
         enabled: false
         reverseWhenFinished: true
-      - !type:PulseBehaviour
-        id: blinking
-        interpolate: Nearest
-        maxDuration: 1.0
-        minValue: 0.1
-        maxValue: 2.0
-        isLooped: true
-        property: Radius
-        enabled: false
+  - type: PulsingLight
+    period: 1
+    minRadius: 0.1
+    maxRadius: 2
+    enabled: false
   - type: ToggleableLightVisuals
     spriteLayer: light
     inhandVisuals:

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -112,37 +112,6 @@
 # THE FOLLOWING ARE ALL DUMMY ENTITIES USED TO TEST THE LIGHT BEHAVIOUR SYSTEM
 # ----------------------------------------------------------------------------
 - type: entity
-  name: light pulse test
-  parent: BaseItem
-  id: LightBehaviourTest1
-  noSpawn: true
-  components:
-    - type: Sprite
-      sprite: Objects/Misc/glowstick.rsi
-      layers:
-        - state: glowstick_base
-        - state: glowstick_unlit
-          shader: unshaded
-          color: "#FF0000"
-    - type: Item
-      sprite: Objects/Misc/glowstick.rsi
-      heldPrefix: unlit
-    - type: PointLight
-      enabled: true
-      color: "#FF0000"
-      radius: 5
-    - type: LightBehaviour
-      behaviours:
-        - !type:PulseBehaviour
-          interpolate: Cubic
-          maxDuration: 10.0
-          minValue: 1.0
-          maxValue: 7.0
-          isLooped: true
-          property: Energy
-          enabled: true
-
-- type: entity
   name: color cycle test
   parent: BaseItem
   id: LightBehaviourTest2
@@ -196,13 +165,13 @@
       radius: 5
     - type: LightBehaviour
       behaviours:
-        - !type:PulseBehaviour
-          interpolate: Nearest
-          minDuration: 0.2
-          maxDuration: 1.0
-          maxValue: 0.2
-          property: Enabled
+        - !type:FadeBehaviour
+          interpolate: Cubic
+          maxDuration: 5.0
+          minValue: 0.0
+          maxValue: 10.0
           isLooped: true
+          property: Energy
           enabled: true
         - !type:ColorCycleBehaviour
           interpolate: Cubic
@@ -265,17 +234,6 @@
       enabled: false
       color: "#FF0000"
       radius: 5
-    - type: LightBehaviour
-      behaviours:
-        - !type:PulseBehaviour
-          interpolate: Cubic
-          minDuration: 1.0
-          maxDuration: 5.0
-          minValue: 2.0
-          maxValue: 10.0
-          isLooped: true
-          property: Radius
-          enabled: true
 
 - type: entity
   name: light randomize radius test

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -6,7 +6,6 @@
   components:
     - type: HandheldLight
       addPrefix: true
-      blinkingBehaviourId: blinking
       radiatingBehaviourId: radiating
     - type: LightBehaviour
       behaviours:
@@ -20,15 +19,11 @@
           property: Radius
           enabled: false
           reverseWhenFinished: true
-        - !type:PulseBehaviour
-          id: blinking
-          interpolate: Nearest
-          maxDuration: 1.0
-          minValue: 0.1
-          maxValue: 2.0
-          isLooped: true
-          property: Radius
-          enabled: false
+    - type: PulsingLight
+      period: 1
+      minRadius: 0.1
+      maxRadius: 2
+      enabled: false
     - type: Sprite
       sprite: Objects/Tools/lantern.rsi
       layers:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
adds PulsingLightComponent, which makes a light's energy and radius grow and shrink in a regular interval based on a sine graph.
Just a nice tool for making some moody setpieces or something.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://media.discordapp.net/attachments/675078881425752124/1111083870033563669/Content.Client_oTLQOAzwaS.gif)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun
