### PR TITLE
Fix being able to set spray amounts in bottles and vapor sprites

### DIFF
--- a/Content.Server/Fluids/Components/SprayComponent.cs
+++ b/Content.Server/Fluids/Components/SprayComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Fluids.EntitySystems;
+using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -10,6 +11,9 @@ namespace Content.Server.Fluids.Components;
 public sealed class SprayComponent : Component
 {
     public const string SolutionName = "spray";
+
+    [DataField("transferAmount")]
+    public FixedPoint2 TransferAmount = 10;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("sprayDistance")]
     public float SprayDistance = 3.5f;

--- a/Content.Server/Fluids/EntitySystems/SpraySystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpraySystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Cooldown;
 using Content.Server.Extinguisher;
 using Content.Server.Fluids.Components;
 using Content.Server.Popups;
-using Content.Shared.Chemistry.Components;
 using Content.Shared.Cooldown;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
@@ -62,9 +61,6 @@ public sealed class SpraySystem : EntitySystem
             return;
         }
 
-        if (!TryComp<SolutionTransferComponent>(uid, out var transfer))
-            return;
-
         var xformQuery = GetEntityQuery<TransformComponent>();
         var userXform = xformQuery.GetComponent(args.User);
 
@@ -89,7 +85,7 @@ public sealed class SpraySystem : EntitySystem
         var threeQuarters = diffNorm * 0.75f;
         var quarter = diffNorm * 0.25f;
 
-        var amount = Math.Max(Math.Min((solution.Volume / transfer.TransferAmount).Int(), component.VaporAmount), 1);
+        var amount = Math.Max(Math.Min((solution.Volume / component.TransferAmount).Int(), component.VaporAmount), 1);
         var spread = component.VaporSpread / amount;
         // TODO: Just use usedelay homie.
         var cooldownTime = 0f;
@@ -107,7 +103,7 @@ public sealed class SpraySystem : EntitySystem
             if (distance > component.SprayDistance)
                 target = userMapPos.Offset(diffNorm * component.SprayDistance);
 
-            var newSolution = _solutionContainer.SplitSolution(uid, solution, transfer.TransferAmount);
+            var newSolution = _solutionContainer.SplitSolution(uid, solution, component.TransferAmount);
 
             if (newSolution.Volume <= FixedPoint2.Zero)
                 break;

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -27,6 +27,7 @@
   - type: SolutionTransfer
   - type: ItemCooldown
   - type: Spray
+    transferAmount: 10
     spraySound:
       path: /Audio/Effects/extinguish.ogg
     sprayedPrototype: ExtinguisherSpray

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -27,7 +27,9 @@
     canChangeTransferAmount: true
   - type: ItemCooldown
   - type: Spray
+    transferAmount: 10
     sprayVelocity: 2
+    sprayDistance: 4.5
     spraySound:
       path: /Audio/Effects/spray2.ogg
   - type: TrashOnEmpty
@@ -49,8 +51,9 @@
       spray:
         maxVol: 250
   - type: Spray
+    transferAmount: 15
     sprayedPrototype: BigVapor
-    sprayVelocity: 5
+    sprayVelocity: 3
     spraySound:
       path: /Audio/Effects/spray2.ogg
 
@@ -106,7 +109,7 @@
   - type: Sprite
     netsync: false
     sprite: Effects/chempuff.rsi
-    rotation: 90
+    rotation: 180
     layers:
     - state: chempuff
       map: ["enum.VaporVisualLayers.Base"]
@@ -133,7 +136,7 @@
   - type: Sprite
     netsync: false
     sprite: Effects/chempuff.rsi
-    rotation: 90
+    rotation: 180
     layers:
     - state: chempuff
       scale: 2, 2

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -29,7 +29,6 @@
   - type: Spray
     transferAmount: 10
     sprayVelocity: 2
-    sprayDistance: 4.5
     spraySound:
       path: /Audio/Effects/spray2.ogg
   - type: TrashOnEmpty
@@ -54,6 +53,7 @@
     transferAmount: 15
     sprayedPrototype: BigVapor
     sprayVelocity: 3
+    sprayDistance: 4.5
     spraySound:
       path: /Audio/Effects/spray2.ogg
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes #16794 

Changes to sprays made it so you can set how much liquid is in a single vapor, which led to things like 50u napalm sprays or acid sprays that one-hit killed.

Just moves the amount back to the component

also buffed the mega spray bottle while i was here.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed being able to override the amount of the amount of liquid shot out of a spray bottle.
- fix: Fixed vapor sprites being rotated in the wrong direction.
- tweak: Slightly buffed mega spray bottle.
