### PR TITLE
Make weapon arcs follow the player

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -140,23 +140,26 @@ public sealed partial class MeleeWeaponSystem
         sprite.Rotation = localPos.ToWorldAngle();
         var distance = Math.Clamp(localPos.Length / 2f, 0.2f, 1f);
 
+        var xformQuery = GetEntityQuery<TransformComponent>();
+        var xform = xformQuery.GetComponent(animationUid);
+
         switch (arcComponent.Animation)
         {
             case WeaponArcAnimation.Slash:
                 _animation.Play(animationUid, GetSlashAnimation(sprite, angle), SlashAnimationKey);
+                TransformSystem.SetParent(animationUid, xform, user, userXform);
                 if (arcComponent.Fadeout)
                     _animation.Play(animationUid, GetFadeAnimation(sprite, 0.065f, 0.065f + 0.05f), FadeAnimationKey);
                 break;
             case WeaponArcAnimation.Thrust:
                 _animation.Play(animationUid, GetThrustAnimation(sprite, distance), ThrustAnimationKey);
+                TransformSystem.SetParent(animationUid, xform, user, userXform);
                 if (arcComponent.Fadeout)
                     _animation.Play(animationUid, GetFadeAnimation(sprite, 0.05f, 0.15f), FadeAnimationKey);
                 break;
             case WeaponArcAnimation.None:
-                var xformQuery = GetEntityQuery<TransformComponent>();
                 var (mapPos, mapRot) = TransformSystem.GetWorldPositionRotation(userXform, xformQuery);
-                var xform = xformQuery.GetComponent(animationUid);
-                xform.AttachToGridOrMap();
+                TransformSystem.AttachToGridOrMap(animationUid, xform);
                 var worldPos = mapPos + (mapRot - userXform.LocalRotation).RotateVec(localPos);
                 var newLocalPos = TransformSystem.GetInvWorldMatrix(xform.ParentUid, xformQuery).Transform(worldPos);
                 TransformSystem.SetLocalPositionNoLerp(xform, newLocalPos);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
noticed that they wouldn't follow the player if they were moving while wide attacking.
This just sets the user as the parent so they are followed properly.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed weapon attack arcs lagging behind if a player attacked while moving.
