### PR TITLE
Ghost role Accept dialog much friendlier

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRoleRulesWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRoleRulesWindow.xaml.cs
@@ -14,6 +14,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
     {
         [Dependency] private readonly IConfigurationManager _cfg = IoCManager.Resolve<IConfigurationManager>();
         private float _timer;
+        public bool RoleHasGone = false;
 
         public GhostRoleRulesWindow(string rules, Action<BaseButton.ButtonEventArgs> requestAction)
         {
@@ -23,7 +24,10 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
 
             if (ghostRoleTime > 0f)
             {
-                RequestButton.Text = Loc.GetString("ghost-roles-window-request-role-button-timer", ("time", $"{_timer:0.0}"));
+                var button_str = RoleHasGone
+                    ? "ghost-roles-window-request-role-button-timer-gone"
+                    : "ghost-roles-window-request-role-button-timer";
+                RequestButton.Text = Loc.GetString(button_str, ("time", $"{_timer:0.0}"));
                 TopBanner.SetMessage(FormattedMessage.FromMarkupPermissive(rules + "\n" + Loc.GetString("ghost-roles-window-rules-footer", ("time", ghostRoleTime))));
                 RequestButton.Disabled = true;
             }
@@ -31,20 +35,24 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             RequestButton.OnPressed += requestAction;
         }
 
-
         protected override void FrameUpdate(FrameEventArgs args)
         {
             base.FrameUpdate(args);
-            if (!RequestButton.Disabled) return;
             if (_timer > 0.0)
             {
                 _timer -= args.DeltaSeconds;
-                RequestButton.Text = Loc.GetString("ghost-roles-window-request-role-button-timer", ("time", $"{_timer:0.0}"));
+                var button_str = RoleHasGone
+                    ? "ghost-roles-window-request-role-button-timer-gone"
+                    : "ghost-roles-window-request-role-button-timer";
+                RequestButton.Text = Loc.GetString(button_str, ("time", $"{_timer:0.0}"));
             }
             else
             {
                 RequestButton.Disabled = false;
-                RequestButton.Text = Loc.GetString("ghost-roles-window-request-role-button");
+                var button_str = RoleHasGone
+                    ? "ghost-roles-window-request-role-button-gone"
+                    : "ghost-roles-window-request-role-button";
+                RequestButton.Text = Loc.GetString(button_str);
             }
         }
     }

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -3,15 +3,20 @@ using Content.Client.Eui;
 using Content.Shared.Eui;
 using Content.Shared.Ghost.Roles;
 using JetBrains.Annotations;
+using Robust.Shared.Random;
 
 namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
 {
     [UsedImplicitly]
     public sealed class GhostRolesEui : BaseEui
     {
+        [Dependency] private readonly IRobustRandom _random = default!;
+
         private readonly GhostRolesWindow _window;
         private GhostRoleRulesWindow? _windowRules = null;
+
         private uint _windowRulesId = 0;
+        private string _windowRulesName = "";
 
         public GhostRolesEui()
         {
@@ -21,16 +26,39 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             {
                 if (_windowRules != null)
                     _windowRules.Close();
-                _windowRules = new GhostRoleRulesWindow(info.Rules, _ =>
+
+                if (info.Rules != _window.LastRulesAccepted)
                 {
+                    // First ghost role you accept as a specific ghost, you get shown the rules
+                    //   OR if the rules are different from the last ghost role you attempted to get.
+                    _windowRules = new GhostRoleRulesWindow(info.Rules, _ =>
+                    {
+                        _window.LastRulesAccepted = info.Rules;
+                        // If the user was not too slow, attempt to take it.
+                        if (!_windowRules?.RoleHasGone ?? true)
+                        {
+                            // Note, _windowRulesId might have changed while dialog was shown if the previous role
+                            //   (with same name) was no longer available (drat faster players!)
+                            SendMessage(new GhostRoleTakeoverRequestMessage(_windowRulesId));
+                        }
+
+                        _windowRules?.Close();
+                    });
+
+                    _windowRulesId = info.Identifier;
+                    _windowRulesName = info.Name;
+                    _windowRules.OnClose += () =>
+                    {
+                        _windowRules = null;
+                    };
+                    _windowRules.OpenCentered();
+                }
+                else
+                {
+                    // If you accepted a role which went away (likely on a multiplayer server) you don't need to read
+                    //   the SAME rules again for 3 seconds prior to accepting the role.
                     SendMessage(new GhostRoleTakeoverRequestMessage(info.Identifier));
-                });
-                _windowRulesId = info.Identifier;
-                _windowRules.OnClose += () =>
-                {
-                    _windowRules = null;
-                };
-                _windowRules.OpenCentered();
+                }
             };
 
             _window.OnRoleFollow += info =>
@@ -53,6 +81,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
         public override void Closed()
         {
             base.Closed();
+            _window.LastRulesAccepted = null;
             _window.Close();
             _windowRules?.Close();
         }
@@ -74,10 +103,29 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
                 _window.AddEntry(name, description, group);
             }
 
-            var closeRulesWindow = ghostState.GhostRoles.All(role => role.Identifier != _windowRulesId);
-            if (closeRulesWindow)
+            if (_windowRules != null && !_windowRules.RoleHasGone)
             {
-                _windowRules?.Close();
+                // Perhaps the user won't be able to get this role now.
+                _windowRules.RoleHasGone = ghostState.GhostRoles.All(role => role.Identifier != _windowRulesId);
+
+                if (_windowRules.RoleHasGone)
+                {
+                    var replacements =
+                        ghostState.GhostRoles.Where(role => role.Name == _windowRulesName).Select(role=> role.Identifier).ToList();
+
+                    if (replacements.Count == 1)
+                    {
+                        _windowRulesId = replacements[0];
+                        _windowRules.RoleHasGone = false;
+                    }
+                    else if (replacements.Count >= 2)
+                    {
+                        // Pick randomly or else multiple queued players will all drop until the first element
+                        var index = _random.Next(replacements.Count - 1);
+                        _windowRulesId = replacements[index];
+                        _windowRules.RoleHasGone = false;
+                    }
+                }
             }
         }
     }

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesWindow.xaml.cs
@@ -10,6 +10,9 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
         public event Action<GhostRoleInfo>? OnRoleRequested;
         public event Action<GhostRoleInfo>? OnRoleFollow;
 
+        // When you accept rules but fail to land a ghost role, next role no longer requires an accept.
+        public string? LastRulesAccepted;
+
         public void ClearEntries()
         {
             NoRolesMessage.Visible = true;

--- a/Resources/Locale/en-US/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-gui.ftl
@@ -16,7 +16,9 @@ ghost-target-window-current-button = Warp: {$name}
 
 ghost-roles-window-title = Ghost Roles
 ghost-roles-window-request-role-button = Request
+ghost-roles-window-request-role-button-gone = Agree for next role
 ghost-roles-window-request-role-button-timer = Request ({$time}s)
+ghost-roles-window-request-role-button-timer-gone = Agree for next ({$time}s)
 ghost-roles-window-follow-role-button = Follow
 ghost-roles-window-no-roles-available-label = There are currently no available ghost roles.
 ghost-roles-window-rules-footer = The button will enable after {$time} seconds (this delay is to make sure you read the rules).


### PR DESCRIPTION
## About the PR
- Automatically shift to same-named ghost role if the old one goes away
- If you fail to land the role, the next one (with same rules) does not require another dialog
 
**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/5285589/9e25d977-7a20-40a1-819e-7bf2d1ce96e9


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: As a ghost, it's easier to pick a ghost role. The rules dialog auto-finds any role for you with the same name. If it can't, "Accept for next role" will skip the dialog for any next role you pick with the same rules.
