### PR TITLE
Autolathe Price Adjustments

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -468,6 +468,8 @@
         Glass: 200
       chemicalComposition:
         Silicon: 20
+    - type: StaticPrice
+      price: 58
 
 - type: entity
   parent: BaseMachineCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/atmos_alarms.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/atmos_alarms.yml
@@ -11,6 +11,8 @@
     tags:
       - DroneUsable
       - AirAlarmElectronics
+  - type: StaticPrice
+    price: 61
 
 - type: entity
   id: FireAlarmElectronics
@@ -25,3 +27,5 @@
     tags:
       - DroneUsable
       - FireAlarmElectronics
+  - type: StaticPrice
+    price: 61

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/disposal.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/disposal.yml
@@ -11,3 +11,5 @@
       tags:
         - DroneUsable
         - MailingUnitElectronics
+    - type: StaticPrice
+      price: 55

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
@@ -12,3 +12,5 @@
       tags:
         - DoorElectronics
         - DroneUsable
+    - type: StaticPrice
+      price: 55

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
@@ -12,3 +12,5 @@
       tags:
       - DroneUsable
       - FirelockElectronics
+    - type: StaticPrice
+      price: 61

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/intercom.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/intercom.yml
@@ -11,4 +11,5 @@
     tags:
       - DroneUsable
       - IntercomElectronics
-
+  - type: StaticPrice
+    price: 55

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
@@ -15,6 +15,8 @@
         Glass: 50
       chemicalComposition:
         Silicon: 20
+    - type: StaticPrice
+      price: 34
 
 # Wallmount Substation
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -98,6 +98,8 @@
   components:
   - type: Spillable
     solution: beaker
+  - type: StaticPrice
+    price: 10
 
 - type: entity
   name: large beaker

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -39,7 +39,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 40
+    price: 30
 
 - type: entity
   name: screwdriver
@@ -81,7 +81,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 40
+    price: 30
 
 - type: entity
   name: wrench
@@ -116,7 +116,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 40
+    price: 22
 
 - type: entity
   name: crowbar
@@ -152,7 +152,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 40
+    price: 22
 
 - type: entity
   name: emergency crowbar
@@ -205,7 +205,7 @@
       Steel: 100
       Plastic: 100
   - type: StaticPrice
-    price: 60
+    price: 56
 
 - type: entity
   name: network configurator
@@ -253,7 +253,7 @@
       tags:
         - DroneUsable
     - type: StaticPrice
-      price: 60
+      price: 56
     - type: GuideHelp
       guides:
         - NetworkConfigurator

--- a/Resources/Prototypes/Reagents/Materials/glass.yml
+++ b/Resources/Prototypes/Reagents/Materials/glass.yml
@@ -12,7 +12,7 @@
   name: materials-reinforced-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: rglass }
   color: "#549bb0"
-  price: 0.22 # 2-1 mix of glass and metal.
+  price: 0.16 # 1-0.5 mix of glass and metal.
 
 - type: material
   id: PlasmaGlass

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -3,8 +3,8 @@
   result: FirelockElectronics
   completetime: 2
   materials:
-     Steel: 50
-     Plastic: 50
+     Steel: 100
+     Plastic: 300
 
 - type: latheRecipe
   id: MailingUnitElectronics
@@ -12,7 +12,7 @@
   completetime: 4
   materials:
     Steel: 50
-    Plastic: 50
+    Plastic: 300
 
 - type: latheRecipe
   id: DoorElectronics
@@ -20,15 +20,15 @@
   completetime: 2
   materials:
      Steel: 50
-     Plastic: 50
+     Plastic: 300
 
 - type: latheRecipe
   id: AirAlarmElectronics
   result: AirAlarmElectronics
   completetime: 2
   materials:
-     Steel: 50
-     Plastic: 50
+     Steel: 100
+     Plastic: 300
 
 - type: latheRecipe
   id: IntercomElectronics
@@ -36,15 +36,15 @@
   completetime: 2
   materials:
      Steel: 50
-     Plastic: 50
+     Plastic: 300
 
 - type: latheRecipe
   id: FireAlarmElectronics
   result: FireAlarmElectronics
   completetime: 2
   materials:
-     Steel: 50
-     Plastic: 50
+     Steel: 100
+     Plastic: 300
 
 - type: latheRecipe
   id: SignalTimerElectronics
@@ -361,7 +361,7 @@
   completetime: 2
   materials:
      Steel: 50
-     Glass: 100
+     Glass: 250
 
 - type: latheRecipe
   id: SubstationMachineCircuitboard


### PR DESCRIPTION
## About the PR
Changes most selling prices of items in the autolathe to be non-exploitable. Also includes some slight balances to material requirements as to avoid making certain items (mostly the electronics) completely worthless.

Quick list;
Air alarm electronics: $61
APC electronics: $34
Beaker: $10
Crowbar: $22
Door electronics: $55
Fire alarm electronics: $61
Firelock electronics: $61
Intercom electronics: $55
Mailing unit electronics: $55
Multitool: $56
Network configurator: $56
Reinforced glass: $16
Screwdriver: $30
Substation machine board: $58
Wirecutter: $30
Wrench: $22

**Media**
- [X] This PR does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changed the selling price of most autolathe products.
- tweak: Slightly adjusted the production price of most electronics in the autolathe.