### PR TITLE
fix rotting not pausing sometimes

### DIFF
--- a/Content.Server/Atmos/Miasma/RottingSystem.cs
+++ b/Content.Server/Atmos/Miasma/RottingSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Rejuvenate;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
 using Robust.Shared.Physics.Components;
-using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.Miasma;
@@ -19,7 +18,6 @@ namespace Content.Server.Atmos.Miasma;
 public sealed class RottingSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
@@ -171,12 +169,12 @@ public sealed class RottingSystem : EntitySystem
         var rotQuery = EntityQueryEnumerator<RottingComponent, PerishableComponent, TransformComponent>();
         while (rotQuery.MoveNext(out var uid, out var rotting, out var perishable, out var xform))
         {
-            if (!IsRotProgressing(uid, perishable))
-                continue;
-
             if (_timing.CurTime < rotting.NextRotUpdate) // This is where it starts to get noticable on larger animals, no need to run every second
                 continue;
             rotting.NextRotUpdate += rotting.RotUpdateRate;
+
+            if (!IsRotProgressing(uid, perishable))
+                continue;
             rotting.TotalRotTime += rotting.RotUpdateRate;
 
             if (rotting.DealDamage)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
if a person already was rotting and the rotting was then paused, the NextRotUpdate var would fall super behind CurTime, causing it to trigger multiple times in a row once rotting resumed.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed a bug that caused rotting bodies to continue rotting even when they shouldn't be.
