### PR TITLE
Add cryopod logs

### DIFF
--- a/Content.Server/Administration/Logs/Converters/GasMixtureStringRepresentationConverter.cs
+++ b/Content.Server/Administration/Logs/Converters/GasMixtureStringRepresentationConverter.cs
@@ -14,7 +14,7 @@ public sealed class GasMixtureStringRepresentationConverter : AdminLogConverter<
         writer.WriteNumber("temperature", value.Temperature);
         writer.WriteNumber("pressure", value.Pressure);
 
-        writer.WriteStartObject();
+        writer.WriteStartObject("gases");
         foreach (var x in value.MolesPerGas)
         {
             writer.WriteNumber(x.Key, x.Value);

--- a/Content.Server/Administration/Logs/Converters/GasMixtureStringRepresentationConverter.cs
+++ b/Content.Server/Administration/Logs/Converters/GasMixtureStringRepresentationConverter.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json;
+using Content.Server.Atmos;
+
+namespace Content.Server.Administration.Logs.Converters;
+
+[AdminLogConverter]
+public sealed class GasMixtureStringRepresentationConverter : AdminLogConverter<GasMixtureStringRepresentation>
+{
+    public override void Write(Utf8JsonWriter writer, GasMixtureStringRepresentation value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        writer.WriteNumber("mol", value.TotalMoles);
+        writer.WriteNumber("temperature", value.Temperature);
+        writer.WriteNumber("pressure", value.Pressure);
+
+        writer.WriteStartObject();
+        foreach (var x in value.MolesPerGas)
+        {
+            writer.WriteNumber(x.Key, x.Value);
+        }
+        writer.WriteEndObject();
+
+        writer.WriteEndObject();
+    }
+}

--- a/Content.Server/Atmos/GasMixture.cs
+++ b/Content.Server/Atmos/GasMixture.cs
@@ -207,6 +207,20 @@ namespace Content.Server.Atmos
             Array.Resize(ref Moles, Atmospherics.AdjustedNumberOfGases);
         }
 
+        public GasMixtureStringRepresentation ToPrettyString()
+        {
+            var molesPerGas = new Dictionary<string, float>();
+            for (int i = 0; i < Moles.Length; i++)
+            {
+                if (Moles[i] == 0)
+                    continue;
+
+                molesPerGas.Add(((Gas) i).ToString(), Moles[i]);
+            }
+
+            return new GasMixtureStringRepresentation(TotalMoles, Temperature, Pressure, molesPerGas);
+        }
+
         public override bool Equals(object? obj)
         {
             if (obj is GasMixture mix)

--- a/Content.Server/Atmos/GasMixtureStringRepresentation.cs
+++ b/Content.Server/Atmos/GasMixtureStringRepresentation.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+
+namespace Content.Server.Atmos;
+
+public readonly record struct GasMixtureStringRepresentation(float TotalMoles, float Temperature, float Pressure, Dictionary<string, float> MolesPerGas) : IFormattable
+{
+    public override string ToString()
+    {
+        return $"{Temperature}K {Pressure} kPa";
+    }
+
+    public string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return ToString();
+    }
+
+    public static implicit operator string(GasMixtureStringRepresentation rep) => rep.ToString();
+}

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -154,8 +154,6 @@ public sealed partial class CryoPodSystem: SharedCryoPodSystem
                     $"{ToPrettyString(args.User)} inserted {ToPrettyString(args.Args.Target.Value)} into {ToPrettyString(uid)}");
 
             _adminLogger.Add(LogType.Action, LogImpact.Medium,
-                $"{ToPrettyString(args.User)} inserted {ToPrettyString(args.Args.Target.Value)} into {ToPrettyString(uid)}");
-            _adminLogger.Add(LogType.Action, LogImpact.Medium,
                 $"{ToPrettyString(args.User)} inserted {ToPrettyString(args.Args.Target.Value)} into {ToPrettyString(uid)} which contains gas: {cryoPodAir!.Air.ToPrettyString():gasMix}");
         }
         args.Handled = true;

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Administration.Logs;
 using Content.Server.Atmos;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
@@ -17,6 +18,7 @@ using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Emag.Systems;
@@ -46,6 +48,7 @@ public sealed partial class CryoPodSystem: SharedCryoPodSystem
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly MetaDataSystem _metaDataSystem = default!;
     [Dependency] private readonly ReactiveSystem _reactiveSystem = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
 
     public override void Initialize()
     {
@@ -110,14 +113,15 @@ public sealed partial class CryoPodSystem: SharedCryoPodSystem
         }
     }
 
-    public override void EjectBody(EntityUid uid, CryoPodComponent? cryoPodComponent)
+    public override EntityUid? EjectBody(EntityUid uid, CryoPodComponent? cryoPodComponent)
     {
         if (!Resolve(uid, ref cryoPodComponent))
-            return;
+            return null;
         if (cryoPodComponent.BodyContainer.ContainedEntity is not {Valid: true} contained)
-            return;
+            return null;
         base.EjectBody(uid, cryoPodComponent);
         _climbSystem.ForciblySetClimbing(contained, uid);
+        return contained;
     }
 
     #region Interaction
@@ -143,7 +147,17 @@ public sealed partial class CryoPodSystem: SharedCryoPodSystem
         if (args.Cancelled || args.Handled || args.Args.Target == null)
             return;
 
-        InsertBody(uid, args.Args.Target.Value, component);
+        if (InsertBody(uid, args.Args.Target.Value, component))
+        {
+            if (!TryComp(uid, out CryoPodAirComponent? cryoPodAir))
+                _adminLogger.Add(LogType.Action, LogImpact.Medium,
+                    $"{ToPrettyString(args.User)} inserted {ToPrettyString(args.Args.Target.Value)} into {ToPrettyString(uid)}");
+
+            _adminLogger.Add(LogType.Action, LogImpact.Medium,
+                $"{ToPrettyString(args.User)} inserted {ToPrettyString(args.Args.Target.Value)} into {ToPrettyString(uid)}");
+            _adminLogger.Add(LogType.Action, LogImpact.Medium,
+                $"{ToPrettyString(args.User)} inserted {ToPrettyString(args.Args.Target.Value)} into {ToPrettyString(uid)} which contains gas: {cryoPodAir!.Air.ToPrettyString():gasMix}");
+        }
         args.Handled = true;
     }
 

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -1,5 +1,7 @@
 using Content.Server.Medical.Components;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Body.Components;
+using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Emag.Systems;
@@ -21,6 +23,7 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
     public override void Initialize()
     {
@@ -60,13 +63,13 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
         _appearanceSystem.SetData(uid, CryoPodComponent.CryoPodVisuals.IsOn, cryoPodEnabled, appearance);
     }
 
-    public void InsertBody(EntityUid uid, EntityUid target, CryoPodComponent cryoPodComponent)
+    public bool InsertBody(EntityUid uid, EntityUid target, CryoPodComponent cryoPodComponent)
     {
         if (cryoPodComponent.BodyContainer.ContainedEntity != null)
-            return;
+            return false;
 
         if (!HasComp<MobStateComponent>(target))
-            return;
+            return false;
 
         var xform = Transform(target);
         cryoPodComponent.BodyContainer.Insert(target, transform: xform);
@@ -75,6 +78,7 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
         _standingStateSystem.Stand(target, force: true); // Force-stand the mob so that the cryo pod sprite overlays it fully
 
         UpdateAppearance(uid, cryoPodComponent);
+        return true;
     }
 
     public void TryEjectBody(EntityUid uid, EntityUid userId, CryoPodComponent? cryoPodComponent)
@@ -90,16 +94,24 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
             return;
         }
 
-        EjectBody(uid, cryoPodComponent);
+        var ejected = EjectBody(uid, cryoPodComponent);
+        if (ejected != null)
+            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ejected.Value)} ejected from {ToPrettyString(uid)} by {ToPrettyString(userId)}");
     }
 
-    public virtual void EjectBody(EntityUid uid, CryoPodComponent? cryoPodComponent)
+    /// <summary>
+    /// Ejects the contained body
+    /// </summary>
+    /// <param name="uid">The cryopod entity</param>
+    /// <param name="cryoPodComponent">Cryopod component of <see cref="uid"/></param>
+    /// <returns>Ejected entity</returns>
+    public virtual EntityUid? EjectBody(EntityUid uid, CryoPodComponent? cryoPodComponent)
     {
         if (!Resolve(uid, ref cryoPodComponent))
-            return;
+            return null;
 
         if (cryoPodComponent.BodyContainer.ContainedEntity is not {Valid: true} contained)
-            return;
+            return null;
 
         cryoPodComponent.BodyContainer.Remove(contained);
         // InsideCryoPodComponent is removed automatically in its EntGotRemovedFromContainerMessage listener
@@ -116,6 +128,7 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
         }
 
         UpdateAppearance(uid, cryoPodComponent);
+        return contained;
     }
 
     protected void AddAlternativeVerbs(EntityUid uid, CryoPodComponent cryoPodComponent, GetVerbsEvent<AlternativeVerb> args)
@@ -153,7 +166,9 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
         if (args.Cancelled)
             return;
 
-        EjectBody(uid, cryoPodComponent);
+        var ejected = EjectBody(uid, cryoPodComponent);
+        if (ejected != null)
+            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ejected.Value)} ejected from {ToPrettyString(uid)} by pry from {ToPrettyString(args.User)}");
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -168,7 +168,7 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
 
         var ejected = EjectBody(uid, cryoPodComponent);
         if (ejected != null)
-            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ejected.Value)} ejected from {ToPrettyString(uid)} by pry from {ToPrettyString(args.User)}");
+            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ejected.Value)} pried out of {ToPrettyString(uid)} by {ToPrettyString(args.User)}");
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adds a ToPrettyString for `GasMix`es. I want to make improvements to this but that'll have to wait for another PR.

Logs insertions and removal of patients into cryopods along with the supplied gas at time of insertion. Log string only shows the temp and pressure but the log contains the moles per gas breakdown which should be visible on SS14.Admin.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase