### PR TITLE
Prevent infinite loops in device linking

### DIFF
--- a/Content.IntegrationTests/Tests/DeviceNetwork/DeviceNetworkTest.cs
+++ b/Content.IntegrationTests/Tests/DeviceNetwork/DeviceNetworkTest.cs
@@ -91,7 +91,7 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
                 deviceNetSystem.QueuePacket(device1, networkComponent2.Address, payload, networkComponent2.ReceiveFrequency.Value);
             });
 
-            await server.WaitRunTicks(1);
+            await server.WaitRunTicks(2);
             await server.WaitIdleAsync();
 
             await server.WaitAssertion(() => {
@@ -146,7 +146,7 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
                 deviceNetSystem.QueuePacket(device1, networkComponent2.Address, payload, networkComponent2.ReceiveFrequency.Value);
             });
 
-            await server.WaitRunTicks(1);
+            await server.WaitRunTicks(2);
             await server.WaitIdleAsync();
 
             await server.WaitAssertion(() => {
@@ -200,7 +200,7 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
                 ["testbool"] = true
             };
 
-            await server.WaitRunTicks(1);
+            await server.WaitRunTicks(2);
             await server.WaitIdleAsync();
 
             await server.WaitAssertion(() => {

--- a/Content.Server/DeviceLinking/Components/Overload/SoundOnOverloadComponent.cs
+++ b/Content.Server/DeviceLinking/Components/Overload/SoundOnOverloadComponent.cs
@@ -4,7 +4,9 @@ using Robust.Shared.Audio;
 namespace Content.Server.DeviceLinking.Components.Overload;
 
 /// <summary>
-/// Plays a sound when a device link overloads
+/// Plays a sound when a device link overloads.
+/// An overload happens when a device link sink is invoked to many times per tick
+/// and it raises a <see cref="Content.Server.DeviceLinking.Events.DeviceLinkOverloadedEvent"/>
 /// </summary>
 [RegisterComponent]
 [Access(typeof(DeviceLinkOverloadSystem))]

--- a/Content.Server/DeviceLinking/Components/Overload/SoundOnOverloadComponent.cs
+++ b/Content.Server/DeviceLinking/Components/Overload/SoundOnOverloadComponent.cs
@@ -1,0 +1,24 @@
+﻿using Content.Server.DeviceLinking.Systems;
+using Robust.Shared.Audio;
+
+namespace Content.Server.DeviceLinking.Components.Overload;
+
+/// <summary>
+/// Plays a sound when a device link overloads
+/// </summary>
+[RegisterComponent]
+[Access(typeof(DeviceLinkOverloadSystem))]
+public sealed class SoundOnOverloadComponent : Component
+{
+    /// <summary>
+    /// Sound to play when the device overloads
+    /// </summary>
+    [DataField("sound")]
+    public SoundSpecifier? OverloadSound = new SoundPathSpecifier("/Audio/Items/Defib/defib_zap.ogg");
+
+    /// <summary>
+    /// Modifies the volume the sound is played at
+    /// </summary>
+    [DataField("volumeModifier")]
+    public float VolumeModifier;
+}

--- a/Content.Server/DeviceLinking/Components/Overload/SpawnOnOverloadComponent.cs
+++ b/Content.Server/DeviceLinking/Components/Overload/SpawnOnOverloadComponent.cs
@@ -1,0 +1,19 @@
+﻿using Content.Server.DeviceLinking.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.DeviceLinking.Components.Overload;
+
+/// <summary>
+/// Spawns an entity when a device link overloads
+/// </summary>
+[RegisterComponent]
+[Access(typeof(DeviceLinkOverloadSystem))]
+public sealed class SpawnOnOverloadComponent : Component
+{
+    /// <summary>
+    /// The entity prototype to spawn when the device overloads
+    /// </summary>
+    [DataField("spawnedPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string Prototype = "PuddleSparkle";
+}

--- a/Content.Server/DeviceLinking/Components/Overload/SpawnOnOverloadComponent.cs
+++ b/Content.Server/DeviceLinking/Components/Overload/SpawnOnOverloadComponent.cs
@@ -5,7 +5,9 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.DeviceLinking.Components.Overload;
 
 /// <summary>
-/// Spawns an entity when a device link overloads
+/// Spawns an entity when a device link overloads.
+/// An overload happens when a device link sink is invoked to many times per tick
+/// and it raises a <see cref="Content.Server.DeviceLinking.Events.DeviceLinkOverloadedEvent"/>
 /// </summary>
 [RegisterComponent]
 [Access(typeof(DeviceLinkOverloadSystem))]

--- a/Content.Server/DeviceLinking/Events/DeviceLinkOverloadedEvent.cs
+++ b/Content.Server/DeviceLinking/Events/DeviceLinkOverloadedEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Server.DeviceLinking.Events;
+
+[ByRefEvent]
+public readonly record struct DeviceLinkOverloadedEvent;

--- a/Content.Server/DeviceLinking/Systems/DeviceLinkOverloadSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DeviceLinkOverloadSystem.cs
@@ -1,0 +1,29 @@
+﻿using Content.Server.DeviceLinking.Components;
+using Content.Server.DeviceLinking.Components.Overload;
+using Content.Server.DeviceLinking.Events;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+
+namespace Content.Server.DeviceLinking.Systems;
+
+public sealed class DeviceLinkOverloadSystem : EntitySystem
+{
+    [Dependency] private readonly AudioSystem _audioSystem = default!;
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<SoundOnOverloadComponent, DeviceLinkOverloadedEvent>(OnOverloadSound);
+        SubscribeLocalEvent<SpawnOnOverloadComponent, DeviceLinkOverloadedEvent>(OnOverloadSpawn);
+    }
+
+    private void OnOverloadSound(EntityUid uid, SoundOnOverloadComponent component, ref DeviceLinkOverloadedEvent args)
+    {
+
+        _audioSystem.PlayPvs(component.OverloadSound, uid, AudioParams.Default.WithVolume(component.VolumeModifier));
+    }
+
+
+    private void OnOverloadSpawn(EntityUid uid, SpawnOnOverloadComponent component, ref DeviceLinkOverloadedEvent args)
+    {
+        Spawn(component.Prototype, Transform(uid).Coordinates);
+    }
+}

--- a/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
@@ -89,9 +89,7 @@ public sealed class DeviceLinkSystem : SharedDeviceLinkSystem
 
             if (!TryComp<DeviceLinkSinkComponent>(sinkUid, out var sinkComponent))
                 continue;
-
-
-
+            
             foreach (var (source, sink) in links)
             {
                 if (source != port)

--- a/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
@@ -23,7 +23,7 @@ public sealed class DeviceLinkSystem : SharedDeviceLinkSystem
     {
         var query = EntityQueryEnumerator<DeviceLinkSinkComponent>();
 
-        while (query.MoveNext(out var uid, out var component))
+        while (query.MoveNext(out var component))
         {
             if (component.InvokeLimit < 1)
             {
@@ -33,14 +33,6 @@ public sealed class DeviceLinkSystem : SharedDeviceLinkSystem
 
             if(component.InvokeCounter > 0)
                 component.InvokeCounter--;
-
-            if (component.InvokeCounter <= component.InvokeLimit)
-                continue;
-
-            component.InvokeCounter = 0;
-            var args = new DeviceLinkOverloadedEvent();
-            RaiseLocalEvent(uid, ref args);
-            RemoveAllFromSink(uid, component);
         }
     }
 
@@ -94,6 +86,15 @@ public sealed class DeviceLinkSystem : SharedDeviceLinkSystem
             {
                 if (source != port)
                     continue;
+
+                if (sinkComponent.InvokeCounter > sinkComponent.InvokeLimit)
+                {
+                    sinkComponent.InvokeCounter = 0;
+                    var args = new DeviceLinkOverloadedEvent();
+                    RaiseLocalEvent(sinkUid, ref args);
+                    RemoveAllFromSink(sinkUid, sinkComponent);
+                    continue;
+                }
 
                 sinkComponent.InvokeCounter++;
 

--- a/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
@@ -89,7 +89,7 @@ public sealed class DeviceLinkSystem : SharedDeviceLinkSystem
 
             if (!TryComp<DeviceLinkSinkComponent>(sinkUid, out var sinkComponent))
                 continue;
-            
+
             foreach (var (source, sink) in links)
             {
                 if (source != port)

--- a/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Server.DeviceLinking.Systems
             {
                 if (state == SignalState.High || state == SignalState.Momentary)
                 {
-                    if (door.State != DoorState.Open)
+                    if (door.State == DoorState.Closed)
                         _doorSystem.TryOpen(uid, door);
                 }
             }
@@ -51,7 +51,7 @@ namespace Content.Server.DeviceLinking.Systems
             {
                 if (state == SignalState.High || state == SignalState.Momentary)
                 {
-                    if (door.State != DoorState.Closed)
+                    if (door.State == DoorState.Open)
                         _doorSystem.TryClose(uid, door);
                 }
             }
@@ -59,7 +59,8 @@ namespace Content.Server.DeviceLinking.Systems
             {
                 if (state == SignalState.High || state == SignalState.Momentary)
                 {
-                    _doorSystem.TryToggleDoor(uid, door);
+                    if (door.State is DoorState.Closed or DoorState.Open)
+                        _doorSystem.TryToggleDoor(uid, door);
                 }
             }
             else if (args.Port == component.InBolt)

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -3,11 +3,9 @@ using Content.Shared.DeviceNetwork;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Utility;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Examine;
-using static Content.Server.DeviceNetwork.Components.DeviceNetworkComponent;
 
 namespace Content.Server.DeviceNetwork.Systems
 {
@@ -23,21 +21,39 @@ namespace Content.Server.DeviceNetwork.Systems
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
         private readonly Dictionary<int, DeviceNet> _networks = new(4);
-        private readonly Queue<DeviceNetworkPacketEvent> _packets = new();
+        private readonly Queue<DeviceNetworkPacketEvent> _queueA = new();
+        private readonly Queue<DeviceNetworkPacketEvent> _queueB = new();
+
+        /// <summary>
+        /// The queue being processed in the current tick
+        /// </summary>
+        private Queue<DeviceNetworkPacketEvent> _activeQueue = null!;
+
+        /// <summary>
+        /// The queue that will be processed in the next tick
+        /// </summary>
+        private Queue<DeviceNetworkPacketEvent> _nextQueue = null!;
+
 
         public override void Initialize()
         {
             SubscribeLocalEvent<DeviceNetworkComponent, MapInitEvent>(OnMapInit);
             SubscribeLocalEvent<DeviceNetworkComponent, ComponentShutdown>(OnNetworkShutdown);
             SubscribeLocalEvent<DeviceNetworkComponent, ExaminedEvent>(OnExamine);
+
+            _activeQueue = _queueA;
+            _nextQueue = _queueB;
         }
 
         public override void Update(float frameTime)
         {
-            while (_packets.TryDequeue(out var packet))
+
+            while (_activeQueue.TryDequeue(out var packet))
             {
                 SendPacket(packet);
             }
+
+            SwapQueues();
         }
 
         /// <summary>
@@ -62,8 +78,18 @@ namespace Content.Server.DeviceNetwork.Systems
             if (frequency == null)
                 return false;
 
-            _packets.Enqueue(new DeviceNetworkPacketEvent(device.DeviceNetId, address, frequency.Value, device.Address, uid, data));
+            _nextQueue.Enqueue(new DeviceNetworkPacketEvent(device.DeviceNetId, address, frequency.Value, device.Address, uid, data));
             return true;
+        }
+
+        /// <summary>
+        /// Swaps the active queue.
+        /// Queues are swapped so that packets being sent in the current tick get processed in the next tick.
+        /// </summary>
+        private void SwapQueues()
+        {
+            _nextQueue = _activeQueue;
+            _activeQueue = _activeQueue == _queueA ? _queueB : _queueA;
         }
 
         private void OnExamine(EntityUid uid, DeviceNetworkComponent device, ExaminedEvent args)

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -86,6 +86,9 @@ namespace Content.Server.DeviceNetwork.Systems
         /// Swaps the active queue.
         /// Queues are swapped so that packets being sent in the current tick get processed in the next tick.
         /// </summary>
+        /// <remarks>
+        /// This prevents infinite loops while sending packets
+        /// </remarks>
         private void SwapQueues()
         {
             _nextQueue = _activeQueue;

--- a/Content.Shared/DeviceLinking/DeviceLinkSinkComponent.cs
+++ b/Content.Shared/DeviceLinking/DeviceLinkSinkComponent.cs
@@ -19,4 +19,20 @@ public sealed class DeviceLinkSinkComponent : Component
     /// </summary>
     [DataField("links")]
     public HashSet<EntityUid> LinkedSources = new();
+
+    /// <summary>
+    /// Counts the amount of times a sink has been invoked for severing the link if this counter gets to high
+    /// The counter is counted down by one every tick if it's higher than 0
+    /// This is for preventing infinite loops
+    /// </summary>
+    [DataField("invokeCounter")]
+    public int InvokeCounter;
+
+    /// <summary>
+    /// How high the invoke counter is allowed to get before the links to the sink are removed and the DeviceLinkOverloadedEvent gets raised
+    /// If the invoke limit is smaller than 1 the sink can't overload
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("invokeLimit")]
+    public int InvokeLimit = 10;
 }

--- a/Content.Shared/DeviceLinking/SharedDeviceLinkSystem.cs
+++ b/Content.Shared/DeviceLinking/SharedDeviceLinkSystem.cs
@@ -316,6 +316,20 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
     }
 
     /// <summary>
+    /// Removes every link from the given sink
+    /// </summary>
+    public void RemoveAllFromSink(EntityUid sinkUid, DeviceLinkSinkComponent? sinkComponent = null)
+    {
+        if (!Resolve(sinkUid, ref sinkComponent))
+            return;
+
+        foreach (var sourceUid in sinkComponent.LinkedSources)
+        {
+            RemoveSinkFromSource(sourceUid, sinkUid, null, sinkComponent);
+        }
+    }
+
+    /// <summary>
     /// Removes all links between a source and a sink
     /// </summary>
     public void RemoveSinkFromSource(
@@ -332,7 +346,7 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
 
         if (sourceComponent == null && sinkComponent == null)
         {
-            // Both were delted?
+            // Both were deleted?
             return;
         }
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -94,6 +94,7 @@
   - type: DeviceLinkSource
     ports:
       - DoorStatus
+  - type: SoundOnOverload
   - type: UserInterface
     interfaces:
     - key: enum.WiresUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -95,6 +95,7 @@
     ports:
       - DoorStatus
   - type: SoundOnOverload
+  - type: SpawnOnOverload
   - type: UserInterface
     interfaces:
     - key: enum.WiresUiKey.Key


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->

This PR detects infinite loops caused by device linking, removes the links to the offending device and raises the `DeviceLinkOverloadedEvent`.

This PR also adds a system that handles the overloaded event with two components.
The `SoundOnOverloadComponent` which plays a sound and the `SpawnOnOverloadComponent` which spawns an entity when the device is overloaded.

Both are combined to create a sparking effect on doors that get overloaded.

The `DeviceNetworkSystem` is also changed to not queue new packets into the same queue that is currently being processed.


**Media**

https://github.com/space-wizards/space-station-14/assets/8915246/75542f8d-0e33-4013-be02-f48eded88d64

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase







