### PR TITLE
Tool damage rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
@@ -14,7 +14,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Pierce: 0
+    attackRate: 2
   - type: Tool
     qualities:
     - Cutting
@@ -37,9 +38,10 @@
     sprite: Objects/Tools/Cowtools/moodriver.rsi
   - type: ItemCooldown
   - type: MeleeWeapon
+    attackRate: 1.5
     damage:
       types:
-        Piercing: 10
+        Blunt: 0.1 #poke poke poke
   - type: Tool
     qualities:
     - Screwing
@@ -60,9 +62,10 @@
     sprite: Objects/Tools/Cowtools/wronch.rsi
   - type: ItemCooldown
   - type: MeleeWeapon
+    attackRate: 1.5
     damage:
       types:
-        Blunt: 10
+        Blunt: 0.1
   - type: Tool
     qualities:
     - Anchoring
@@ -85,7 +88,9 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 1 #have you ever swung at someone with a plastic bat? that shit hurts
+  - type: StaminaDamageOnHit
+    damage: 5 #have you ever been hit with a plastic bat? that shit hurts
   - type: Tool
     qualities:
     - Prying
@@ -159,6 +164,10 @@
     state: cow_toolbox
   - type: Item
     sprite: Objects/Tools/Cowtools/cow_toolbox.rsi
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 4
 
 - type: entity
   id: CowToolboxFilled
@@ -176,4 +185,3 @@
     - id: Cowelder
     - id: Milkalyzer
 
-# I hate these fucking cowtools I hope the burn in hell -Swept

--- a/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
@@ -88,7 +88,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 1 #have you ever swung at someone with a plastic bat? that shit hurts
+        Blunt: 1
   - type: StaminaDamageOnHit
     damage: 5 #have you ever been hit with a plastic bat? that shit hurts
   - type: Tool

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -41,6 +41,10 @@
           state: jaws_cutter
         useSound: /Audio/Items/jaws_cut.ogg
         changeSound: /Audio/Items/change_jaws.ogg
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   name: syndicate jaws of life
@@ -71,3 +75,7 @@
           state: syn_jaws_cutter
         useSound: /Audio/Items/jaws_cut.ogg
         changeSound: /Audio/Items/change_jaws.ogg
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 14

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -11,7 +11,7 @@
   - type: Storage
     capacity: 60
   - type: Item
-    size: 110
+    size: 9999
   - type: ItemCooldown
   - type: MeleeWeapon
     damage:

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -11,12 +11,12 @@
   - type: Storage
     capacity: 60
   - type: Item
-    size: 9999
+    size: 110
   - type: ItemCooldown
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 12
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -65,10 +65,10 @@
     sprite: Objects/Tools/screwdriver.rsi
   - type: ItemCooldown
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 1
     damage:
       types:
-        Piercing: 7 #could probably stand to be nerfed if someone adds poking your eyes out so that this has a niche over the wrench, but this is probably fine for now.
+        Piercing: 6
   - type: Tool
     qualities:
       - Screwing
@@ -88,7 +88,7 @@
   name: wrench
   parent: BaseItem
   id: Wrench
-  description: 'A common tool for assembly and disassembly. Remember: righty tighty, lefty loosey.'
+  description: A common tool for assembly and disassembly. Remember: righty tighty, lefty loosey.
   components:
   - type: EmitSoundOnLand
     sound:
@@ -107,7 +107,7 @@
     attackRate: 1.5
     damage:
       types:
-        Blunt: 6.5
+        Blunt: 4.5
   - type: Tool
     qualities:
       - Anchoring
@@ -143,7 +143,7 @@
     damage:
       types:
         Blunt: 6
-        Structural: 3
+        Structural: 2
   - type: Tool
     qualities:
       - Prying
@@ -175,8 +175,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 7 #free man
-        Structural: 3
+        Blunt: 8 #free man
+        Structural: 2
 
 - type: entity
   name: multitool

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -24,6 +24,8 @@
       types:
         Piercing: 2
     attackRate: 2 #open and close that shit on their arm like hell! because you sure aren't doing any damage with this
+    soundHit:
+      path: "/Audio/Items/wirecutter.ogg"
   - type: Tool
     qualities:
       - Cutting
@@ -69,6 +71,8 @@
     damage:
       types:
         Piercing: 6
+    soundHit:
+      path: "/Audio/Weapons/bladeslice.ogg"
   - type: Tool
     qualities:
       - Screwing
@@ -278,7 +282,7 @@
         - NetworkConfigurator
 
 #Power tools
-#These do not have the melee weapon component yet because they should change damage when switching types.
+#Later on these should switch probably switch damage when changing the tool behavior.
 - type: entity
   name: power drill
   parent: BaseItem
@@ -324,6 +328,18 @@
       Plastic: 100
   - type: StaticPrice
     price: 100
+  - type: MeleeWeapon
+    attackRate: 1.5
+    damage:
+      types:
+        Blunt: 4.5
+  - type: MeleeWeapon
+    attackRate: 1.5
+    damage:
+      types:
+        Piercing: 8
+    soundHit:
+      path: "/Audio/Items/drill_hit.ogg"
 
 - type: entity
   name: RCD

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -175,7 +175,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 8
+        Blunt: 7 #free man
         Structural: 3
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -22,7 +22,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Piercing: 2
+    attackRate: 2 #open and close that shit on their arm like hell! because you sure aren't doing any damage with this
   - type: Tool
     qualities:
       - Cutting
@@ -67,7 +68,7 @@
     attackRate: 1.5
     damage:
       types:
-        Piercing: 7
+        Piercing: 7 #could probably stand to be nerfed if someone adds poking your eyes out so that this has a niche over the wrench, but this is probably fine for now.
   - type: Tool
     qualities:
       - Screwing
@@ -141,7 +142,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 6
+        Structural: 3
   - type: Tool
     qualities:
       - Prying
@@ -170,6 +172,11 @@
     sprite: Objects/Tools/crowbar.rsi
     size: 10
     heldPrefix: red
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 8
+        Structural: 3
 
 - type: entity
   name: multitool
@@ -270,6 +277,8 @@
       guides:
         - NetworkConfigurator
 
+#Power tools
+#These do not have the melee weapon component yet because they should change damage when switching types.
 - type: entity
   name: power drill
   parent: BaseItem
@@ -385,32 +394,6 @@
     price: 60
 
 - type: entity
-  name: shovel
-  parent: BaseItem
-  id: Shovel
-  description: A large tool for digging and moving dirt.
-  components:
-  - type: Tag
-    tags:
-    - Shovel
-  - type: Sprite
-    sprite: Objects/Tools/shovel.rsi
-    state: icon
-  - type: ItemCooldown
-  - type: MeleeWeapon
-    damage:
-      types:
-        Blunt: 10
-  - type: Item
-    sprite: Objects/Tools/shovel.rsi
-  - type: PhysicalComposition
-    materialComposition:
-      Steel: 100
-      Wood: 50
-  - type: StaticPrice
-    price: 25
-
-- type: entity
   name: omnitool
   parent: BaseItem
   id: Omnitool
@@ -473,3 +456,30 @@
           state: omnitool-pulsing
         changeSound:
           path: /Audio/Items/change_drill.ogg
+
+#Other
+- type: entity
+  name: shovel
+  parent: BaseItem
+  id: Shovel
+  description: A large tool for digging and moving dirt.
+  components:
+  - type: Tag
+    tags:
+    - Shovel
+  - type: Sprite
+    sprite: Objects/Tools/shovel.rsi
+    state: icon
+  - type: ItemCooldown
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 14
+  - type: Item
+    sprite: Objects/Tools/shovel.rsi
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 100
+      Wood: 50
+  - type: StaticPrice
+    price: 25

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -88,7 +88,7 @@
   name: wrench
   parent: BaseItem
   id: Wrench
-  description: A common tool for assembly and disassembly. Remember: righty tighty, lefty loosey.
+  description: 'A common tool for assembly and disassembly. Remember: righty tighty, lefty loosey.'
   components:
   - type: EmitSoundOnLand
     sound:

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -143,7 +143,7 @@
     damage:
       types:
         Blunt: 6
-        Structural: 2
+        Structural: 3
   - type: Tool
     qualities:
       - Prying
@@ -176,7 +176,7 @@
     damage:
       types:
         Blunt: 8 #free man
-        Structural: 2
+        Structural: 3
 
 - type: entity
   name: multitool

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -332,11 +332,6 @@
     attackRate: 1.5
     damage:
       types:
-        Blunt: 4.5
-  - type: MeleeWeapon
-    attackRate: 1.5
-    damage:
-      types:
         Piercing: 8
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -33,7 +33,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 5 #i mean... i GUESS you could use it like that
   - type: ItemStatus
   - type: RefillableSolution
     solution: Welder
@@ -50,7 +50,7 @@
     qualities: Welding
   - type: Welder
     litMeleeDamageBonus:
-      types: # When lit, negate standard melee damage and replace with heat
+      types:
         Heat: 10
         Blunt: -10
   - type: PointLight

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -51,8 +51,8 @@
   - type: Welder
     litMeleeDamageBonus:
       types:
-        Heat: 10
-        Blunt: -10
+        Heat: 8
+        Blunt: -5
   - type: PointLight
     netsync: false
     enabled: false


### PR DESCRIPTION
## About the PR
Rebalances most of the tools to no longer deal only 10 blunt damage.

The crowbar now does 6 blunt since it was really strong w/mob mentality and overshadowed most other crew weapons. It also deals 3 structural in addition however, so it's still good at destroying windows.
The red crowbar now deals two more blunt more than the base one.
The screwdriver and wrench are weaker so they don't outshine the crowbar, and should now probably have their own small niche.
The shovel now does 14 blunt damage because it's a fucking shovel.
Toolboxes deal 12 damage like they did in SS13.
Wirecutters and cow tools now deal pitiful amounts of damage.
Power tools can now deal damage.
...and some other more minor stuff not worth mentioning.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Most tools no longer deal 10 blunt damage, and are across-the-board weaker.
- tweak: The red crowbar is now stronger than the grey crowbar.
- tweak: Shovels and toolboxes are now much more robust.
- tweak: Power tools can now deal damage.