### PR TITLE
Allow Atmos Technicians to be antagonist, but start with 10TC only

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -10,7 +10,7 @@
   startingGear: AtmosphericTechnicianGear
   icon: "AtmosphericTechnician"
   supervisors: job-supervisors-ce
-  canBeAntag: false
+  antagAdvantage: 10
   access:
   - Maintenance
   - Engineering


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Allows atmos to become antag.

I believe that atmos is ready to become antag because the ability to out-nuke Nuclear Operatives has been neutered with #16016 and the ability to [reduce the amount of TC an antag receives at round start](https://github.com/space-wizards/space-station-14/blob/ff7a5a384446205314402976ec0655bda8d0b3f6/Content.Shared/Roles/JobPrototype.cs#L70).

In this case specifically Atmos only starts with **10 TC** at start due to easy access to engineering gear and the fireaxe in atmos, thus limiting the amount of traitor gear they can obtain via the uplink (and not allowing them to buy a surplus bundle/super surplus with another traitor).

Plasmaflooding in my honest opinion is a very conspicious action that can be spotted by anyone and stopped by CE/other atmos techs, and for its efficiency scrubbers would have to be set to panic which requires the traitor to go around the station to mess with air alarms, all this incriminating the department.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: NanoTrasen Counterintelligence has uncovered that threat actors have started recruiting atmospheric technicians into their ranks. Whether this is genuine or a red herring remains to be seen.
