### PR TITLE
Add Trash tag to FoodBadRecipe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -572,3 +572,6 @@
           Quantity: 2
         - ReagentId: Toxin
           Quantity: 3
+  - type: Tag
+    tags:
+    - Trash


### PR DESCRIPTION
This is so these waste items can be destroyed in the recycler.

FoodBadRecipe is the result of an unlucky microwaving-an-ID roll.