### PR TITLE
Triple strength of THC

### DIFF
--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -273,7 +273,7 @@
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add
-        time: 5
+        time: 16
         refresh: false
 
 - type: reagent
@@ -291,7 +291,7 @@
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add
-        time: 5
+        time: 16
         refresh: false
 
 - type: reagent


### PR DESCRIPTION
Smokable THC like joints and blunts do not show the status effect until it has run a sufficient time. With the previous SeeingRainbows time of 5, the effect would end shortly after it started because smokable items do not inhale enough solution for it to continue.

This change introduces a tripling of the time added to the SeeingRainbows effect in order to counteract the lack of visible effect from smokables.

Now, the effect will trigger within a few seconds and last a little over a minute after the blunt has burned out.

:cl:
- fix: Joints and blunts will get you high again.
