### PR TITLE
Support multiple containers for HealingComponent

### DIFF
--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -1,8 +1,7 @@
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
-using Content.Shared.DoAfter;
 using Robust.Shared.Audio;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
 namespace Content.Server.Medical.Components
 {
@@ -36,8 +35,8 @@ namespace Content.Server.Medical.Components
         ///     HealingComponent this filters what damage container type this component should work on. If null,
         ///     all damage container types are supported.
         /// </remarks>
-        [DataField("damageContainer", customTypeSerializer: typeof(PrototypeIdSerializer<DamageContainerPrototype>))]
-        public string? DamageContainerID;
+        [DataField("damageContainers", customTypeSerializer: typeof(PrototypeIdListSerializer<DamageContainerPrototype>))]
+        public List<string>? DamageContainers;
 
         /// <summary>
         /// How long it takes to apply the damage.

--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -51,8 +51,12 @@ public sealed class HealingSystem : EntitySystem
         if (args.Handled || args.Cancelled)
             return;
 
-        if (component.DamageContainerID is not null && !component.DamageContainerID.Equals(component.DamageContainerID))
+        if (healing.DamageContainers is not null &&
+            component.DamageContainerID is not null &&
+            !healing.DamageContainers.Contains(component.DamageContainerID))
+        {
             return;
+        }
 
         // Heal some bloodloss damage.
         if (healing.BloodlossModifier != 0)
@@ -140,9 +144,12 @@ public sealed class HealingSystem : EntitySystem
         if (!TryComp<DamageableComponent>(target, out var targetDamage))
             return false;
 
-        if (component.DamageContainerID is not null &&
-            !component.DamageContainerID.Equals(targetDamage.DamageContainerID))
+        if (component.DamageContainers is not null &&
+            targetDamage.DamageContainerID is not null &&
+            !component.DamageContainers.Contains(targetDamage.DamageContainerID))
+        {
             return false;
+        }
 
         if (user != target && !_interactionSystem.InRangeUnobstructed(user, target, popup: true))
             return false;

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -71,7 +71,8 @@
     - DroneUsable
     - Gauze
   - type: Healing
-    damageContainer: Biological
+    damageContainers:
+      - Biological
     damage:
       types:
         Slash: -0.5

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -26,7 +26,8 @@
   - type: Item
     heldPrefix: ointment
   - type: Healing
-    damageContainer: Biological
+    damageContainers:
+      - Biological
     damage:
       types:
         Heat: -5
@@ -55,7 +56,8 @@
   - type: Sprite
     state: brutepack
   - type: Healing
-    damageContainer: Biological
+    damageContainers:
+      - Biological
     damage:
       groups:
         Brute: -15 # 5 for each type in the group
@@ -81,7 +83,8 @@
   - type: Sprite
     state: bloodpack
   - type: Healing
-    damageContainer: Biological
+    damageContainers:
+      - Biological
     damage:
       types:
         Bloodloss: -0.5 #lowers bloodloss damage
@@ -111,7 +114,8 @@
     graph: Gauze
     node: gauze
   - type: Healing
-    damageContainer: Biological
+    damageContainers:
+      - Biological
     damage:
       types:
         Slash: -2.5


### PR DESCRIPTION
Created to solve a downstream issue where some players have a different damageContainer but should still be able to use the regular healing items.