### PR TITLE
Issue#16849 - Master volume applies without saving changes

### DIFF
--- a/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
@@ -76,7 +76,6 @@ namespace Content.Client.Options.UI.Tabs
 
         private void OnMasterVolumeSliderChanged(Range range)
         {
-            _clydeAudio.SetMasterVolume(MasterVolumeSlider.Value / 100);
             UpdateChanges();
         }
 


### PR DESCRIPTION
- Removed the call function to change value on the spot.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Removed the line that was updating the volume dynamically. The line to save the CVAR was already present, so nothing else seems to have been necessary.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [V ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:

https://github.com/space-wizards/space-station-14/assets/20630607/1fb1b5d5-d017-43ae-ac3a-f84d8807063c


bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

https://github.com/space-wizards/space-station-14/assets/20630607/6dffbe73-c30f-4661-a0ff-dbb317b360e0

