### PR TITLE
Make melee damage not go through MeleeHitEvent.cs

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.NodeContainer.Nodes;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Power.NodeGroups;
+using Content.Server.Weapons.Melee;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Database;
@@ -37,6 +38,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly SharedJitteringSystem _jittering = default!;
+    [Dependency] private readonly MeleeWeaponSystem _meleeWeapon = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedStutteringSystem _stuttering = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -161,12 +163,8 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             if (!electrified.OnAttacked)
                 return;
 
-            //Dont shock if the attacker used a toy
-            if (EntityManager.TryGetComponent<MeleeWeaponComponent>(args.Used, out var meleeWeaponComponent))
-            {
-                if (meleeWeaponComponent.Damage.Total == 0)
-                    return;
-            }
+            if (_meleeWeapon.GetDamage(args.Used).Total == 0)
+                return;
 
             TryDoElectrifiedAct(uid, args.User, 1, electrified);
     }
@@ -220,7 +218,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
                     entity,
                     uid,
                     (int) (electrified.ShockDamage * MathF.Pow(RecursiveDamageMultiplier, depth)),
-                    TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth)), 
+                    TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth)),
                     true,
                     electrified.SiemensCoefficient
                 );
@@ -249,7 +247,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
                     uid,
                     node,
                     (int) (electrified.ShockDamage * MathF.Pow(RecursiveDamageMultiplier, depth) * damageMult),
-                    TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth) * timeMult), 
+                    TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth) * timeMult),
                     true,
                     electrified.SiemensCoefficient);
             }
@@ -374,7 +372,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
         {
             return false;
         }
-        
+
         if (!_statusEffects.TryAddStatusEffect<ElectrocutedComponent>(uid, StatusEffectKey, time, refresh, statusEffects))
             return false;
 

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Power.Components;
 using Content.Server.Power.Events;
 using Content.Server.Stunnable.Components;
 using Content.Shared.Audio;
+using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Examine;
 using Content.Shared.Interaction.Events;
@@ -27,15 +28,16 @@ namespace Content.Server.Stunnable.Systems
             SubscribeLocalEvent<StunbatonComponent, UseInHandEvent>(OnUseInHand);
             SubscribeLocalEvent<StunbatonComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<StunbatonComponent, StaminaDamageOnHitAttemptEvent>(OnStaminaHitAttempt);
-            SubscribeLocalEvent<StunbatonComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<StunbatonComponent, GetMeleeDamageEvent>(OnGetMeleeDamage);
         }
 
-        private void OnMeleeHit(EntityUid uid, StunbatonComponent component, MeleeHitEvent args)
+        private void OnGetMeleeDamage(EntityUid uid, StunbatonComponent component, ref GetMeleeDamageEvent args)
         {
-            if (!component.Activated) return;
+            if (!component.Activated)
+                return;
 
             // Don't apply damage if it's activated; just do stamina damage.
-            args.BonusDamage -= args.BaseDamage;
+            args.Damage = new DamageSpecifier();
         }
 
         private void OnStaminaHitAttempt(EntityUid uid, StunbatonComponent component, ref StaminaDamageOnHitAttemptEvent args)

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -44,13 +44,13 @@ namespace Content.Server.Tools
             SubscribeLocalEvent<WelderComponent, ToolDoAfterEvent>(OnWelderDoAfter);
             SubscribeLocalEvent<WelderComponent, ComponentShutdown>(OnWelderShutdown);
             SubscribeLocalEvent<WelderComponent, ComponentGetState>(OnWelderGetState);
-            SubscribeLocalEvent<WelderComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<WelderComponent, GetMeleeDamageEvent>(OnGetMeleeDamage);
         }
 
-        private void OnMeleeHit(EntityUid uid, WelderComponent component, MeleeHitEvent args)
+        private void OnGetMeleeDamage(EntityUid uid, WelderComponent component, ref GetMeleeDamageEvent args)
         {
-            if (!args.Handled && component.Lit)
-                args.BonusDamage += component.LitMeleeDamageBonus;
+            if (component.Lit)
+                args.Damage += component.LitMeleeDamageBonus;
         }
 
         public (FixedPoint2 fuel, FixedPoint2 capacity) GetWelderFuelAndCapacity(EntityUid uid, WelderComponent? welder = null, SolutionContainerManagerComponent? solutionContainer = null)

--- a/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
@@ -28,7 +28,7 @@ public sealed class EnergySwordSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<EnergySwordComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<EnergySwordComponent, MeleeHitEvent>(OnMeleeHit);
+        SubscribeLocalEvent<EnergySwordComponent, GetMeleeDamageEvent>(OnGetMeleeDamage);
         SubscribeLocalEvent<EnergySwordComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<EnergySwordComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<EnergySwordComponent, IsHotEvent>(OnIsHotEvent);
@@ -42,13 +42,13 @@ public sealed class EnergySwordSystem : EntitySystem
             comp.BladeColor = _random.Pick(comp.ColorOptions);
     }
 
-    private void OnMeleeHit(EntityUid uid, EnergySwordComponent comp, MeleeHitEvent args)
+    private void OnGetMeleeDamage(EntityUid uid, EnergySwordComponent comp, ref GetMeleeDamageEvent args)
     {
         if (!comp.Activated)
             return;
 
         // Overrides basic blunt damage with burn+slash as set in yaml
-        args.BonusDamage = comp.LitDamageBonus;
+        args.Damage = comp.LitDamageBonus;
     }
 
     private void OnUseInHand(EntityUid uid, EnergySwordComponent comp, UseInHandEvent args)
@@ -57,7 +57,7 @@ public sealed class EnergySwordSystem : EntitySystem
             return;
 
         args.Handled = true;
-        
+
         if (comp.Activated)
         {
             var ev = new EnergySwordDeactivatedEvent();
@@ -120,7 +120,7 @@ public sealed class EnergySwordSystem : EntitySystem
         {
             malus.Malus += comp.LitDisarmMalus;
         }
-        
+
         _audio.Play(comp.ActivateSound, Filter.Pvs(uid, entityManager: EntityManager), uid, true, comp.ActivateSound.Params);
 
         comp.Activated = true;

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -62,16 +62,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (!args.CanInteract || !args.CanAccess || component.HideFromExamine)
             return;
 
-        var getDamage = new MeleeHitEvent(new List<EntityUid>(), args.User, uid, component.Damage);
-        getDamage.IsHit = false;
-        RaiseLocalEvent(uid, getDamage);
-
-        var damageSpec = GetDamage(component);
-
-        if (damageSpec == null)
-            damageSpec = new DamageSpecifier();
-
-        damageSpec += getDamage.BonusDamage;
+        var damageSpec = GetDamage(uid, component);
 
         if (damageSpec.Total == FixedPoint2.Zero)
             return;
@@ -115,10 +106,6 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         return true;
     }
 
-    private DamageSpecifier? GetDamage(MeleeWeaponComponent component)
-    {
-        return component.Damage.Total > FixedPoint2.Zero ? component.Damage : null;
-    }
 
     protected override void Popup(string message, EntityUid? uid, EntityUid? user)
     {

--- a/Content.Shared/Weapons/Melee/Components/BonusMeleeDamageComponent.cs
+++ b/Content.Shared/Weapons/Melee/Components/BonusMeleeDamageComponent.cs
@@ -1,0 +1,17 @@
+﻿using Content.Shared.Damage;
+
+namespace Content.Shared.Weapons.Melee.Components;
+
+/// <summary>
+/// This is used for adding in bonus damage via <see cref="GetMeleeWeaponEvent"/>
+/// This exists only for event relays and doing entity shenanigans.
+/// </summary>
+[RegisterComponent]
+public sealed class BonusMeleeDamageComponent : Component
+{
+    /// <summary>
+    /// The damage that will be applied.
+    /// </summary>
+    [DataField("bonusDamage", required: true)]
+    public DamageSpecifier BonusDamage = default!;
+}

--- a/Content.Shared/Weapons/Melee/Components/BonusMeleeDamageComponent.cs
+++ b/Content.Shared/Weapons/Melee/Components/BonusMeleeDamageComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Weapons.Melee.Components;
 /// This is used for adding in bonus damage via <see cref="GetMeleeWeaponEvent"/>
 /// This exists only for event relays and doing entity shenanigans.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 public sealed class BonusMeleeDamageComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Weapons/Melee/Events/MeleeHitEvent.cs
+++ b/Content.Shared/Weapons/Melee/Events/MeleeHitEvent.cs
@@ -66,3 +66,10 @@ public sealed class MeleeHitEvent : HandledEntityEventArgs
         BaseDamage = baseDamage;
     }
 }
+
+/// <summary>
+/// Raised on a melee weapon to calculate potential damage bonuses or decreases.
+/// </summary>
+/// <param name="Damage"></param>
+[ByRefEvent]
+public record struct GetMeleeDamageEvent(DamageSpecifier Damage);

--- a/Content.Shared/Wieldable/WieldableSystem.cs
+++ b/Content.Shared/Wieldable/WieldableSystem.cs
@@ -9,7 +9,6 @@ using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Melee.Components;
-using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Systems;
 using Content.Shared.Wieldable.Components;
@@ -41,7 +40,7 @@ public sealed class WieldableSystem : EntitySystem
         SubscribeLocalEvent<MeleeRequiresWieldComponent, AttemptMeleeEvent>(OnMeleeAttempt);
         SubscribeLocalEvent<GunRequiresWieldComponent, AttemptShootEvent>(OnShootAttempt);
 
-        SubscribeLocalEvent<IncreaseDamageOnWieldComponent, MeleeHitEvent>(OnMeleeHit);
+        SubscribeLocalEvent<IncreaseDamageOnWieldComponent, GetMeleeDamageEvent>(OnGetMeleeDamage);
     }
 
     private void OnMeleeAttempt(EntityUid uid, MeleeRequiresWieldComponent component, ref AttemptMeleeEvent args)
@@ -244,16 +243,13 @@ public sealed class WieldableSystem : EntitySystem
             AttemptUnwield(args.BlockingEntity, component, args.User);
     }
 
-    private void OnMeleeHit(EntityUid uid, IncreaseDamageOnWieldComponent component, MeleeHitEvent args)
+    private void OnGetMeleeDamage(EntityUid uid, IncreaseDamageOnWieldComponent component, ref GetMeleeDamageEvent args)
     {
-        if (EntityManager.TryGetComponent<WieldableComponent>(uid, out var wield))
-        {
-            if (!wield.Wielded)
-                return;
-        }
-        if (args.Handled)
+        if (!TryComp<WieldableComponent>(uid, out var wield))
+            return;
+        if (!wield.Wielded)
             return;
 
-        args.BonusDamage += component.BonusDamage;
+        args.Damage += component.BonusDamage;
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
changes some internal melee code to no longer use dummy MeleeHitEvent calls to get weapon damage. 
Instead, components now subscribe to GetMeleeDamageEvent and add their bonus damage there.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
i tested it bro trust me bro
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun
