### PR TITLE
Fix setting up mailing units.

### DIFF
--- a/Content.Client/Configurable/UI/ConfigurationMenu.cs
+++ b/Content.Client/Configurable/UI/ConfigurationMenu.cs
@@ -92,7 +92,7 @@ namespace Content.Client.Configurable.UI
                 var input = new LineEdit
                 {
                     Name = field.Key + "-input",
-                    Text = field.Value,
+                    Text = field.Value ?? "",
                     IsValid = Validate,
                     HorizontalExpand = true,
                     SizeFlagsStretchRatio = .8f

--- a/Content.Server/Configurable/ConfigurationSystem.cs
+++ b/Content.Server/Configurable/ConfigurationSystem.cs
@@ -33,6 +33,7 @@ public sealed class ConfigurationSystem : EntitySystem
             return;
 
         args.Handled = _uiSystem.TryOpen(uid, ConfigurationUiKey.Key, actor.PlayerSession);
+        UpdateUi(uid, component);
     }
 
     private void OnStartup(EntityUid uid, ConfigurationComponent component, ComponentStartup args)

--- a/Content.Server/Configurable/ConfigurationSystem.cs
+++ b/Content.Server/Configurable/ConfigurationSystem.cs
@@ -33,7 +33,6 @@ public sealed class ConfigurationSystem : EntitySystem
             return;
 
         args.Handled = _uiSystem.TryOpen(uid, ConfigurationUiKey.Key, actor.PlayerSession);
-        UpdateUi(uid, component);
     }
 
     private void OnStartup(EntityUid uid, ConfigurationComponent component, ComponentStartup args)

--- a/Content.Shared/Configurable/ConfigurationComponent.cs
+++ b/Content.Shared/Configurable/ConfigurationComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Configurable
     public sealed class ConfigurationComponent : Component
     {
         [DataField("config")]
-        public readonly Dictionary<string, string> Config = new();
+        public readonly Dictionary<string, string?> Config = new();
 
         [DataField("qualityNeeded", customTypeSerializer: typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
         public string QualityNeeded = "Pulsing";
@@ -21,9 +21,9 @@ namespace Content.Shared.Configurable
         [Serializable, NetSerializable]
         public sealed class ConfigurationBoundUserInterfaceState : BoundUserInterfaceState
         {
-            public Dictionary<string, string> Config { get; }
+            public Dictionary<string, string?> Config { get; }
 
-            public ConfigurationBoundUserInterfaceState(Dictionary<string, string> config)
+            public ConfigurationBoundUserInterfaceState(Dictionary<string, string?> config)
             {
                 Config = config;
             }

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -135,6 +135,8 @@
     transmitFrequencyId: MailingUnit
   - type: WiredNetworkConnection
   - type: Configuration
+    config:
+      tag:
   - type: Appearance
   - type: UserInterface
     interfaces:


### PR DESCRIPTION
## About the PR
This PR fixes the yaml for the mailing unit which was missing the tag configuration value on the configuration component.
It also improves the configuration system by making the configuration value nullable.
(People should use the configuration system. It saves you from writing UI every time you just need to set a value)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Fixed not being able to set up mailing units
