### PR TITLE
Fix unassigned suit sensors not getting assigned to a station

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -112,7 +112,7 @@ namespace Content.Client.Medical.CrewMonitoring
 
                 if (sensor.Coordinates != null && NavMap.Visible)
                 {
-                    NavMap.TrackedCoordinates.Add(sensor.Coordinates.Value, (true, Color.FromHex("#B02E26")));
+                    NavMap.TrackedCoordinates.TryAdd(sensor.Coordinates.Value, (true, Color.FromHex("#B02E26")));
                     nameLabel.MouseFilter = MouseFilterMode.Stop;
 
                     // Hide all others upon mouseover.

--- a/Content.Server/DeviceNetwork/Systems/StationLimitedNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/StationLimitedNetworkSystem.cs
@@ -31,6 +31,18 @@ namespace Content.Server.DeviceNetwork.Systems
         }
 
         /// <summary>
+        /// Tries to set the station id to the current station if the device is currently on a station
+        /// </summary>
+        public bool TrySetStationId(EntityUid uid, StationLimitedNetworkComponent? component = null)
+        {
+            if (!Resolve(uid, ref component) || !Transform(uid).GridUid.HasValue)
+                return false;
+
+            component.StationId = _stationSystem.GetOwningStation(uid);
+            return component.StationId.HasValue;
+        }
+
+        /// <summary>
         /// Set the station id to the one the entity is on when the station limited component is added
         /// </summary>
         private void OnMapInit(EntityUid uid, StationLimitedNetworkComponent networkComponent, MapInitEvent args)
@@ -43,6 +55,9 @@ namespace Content.Server.DeviceNetwork.Systems
         /// </summary>
         private void OnBeforePacketSent(EntityUid uid, StationLimitedNetworkComponent component, BeforePacketSentEvent args)
         {
+            if (!component.StationId.HasValue)
+                TrySetStationId(uid, component);
+
             if (!CheckStationId(args.Sender, component.AllowNonStationPackets, component.StationId))
             {
                 args.Cancel();
@@ -61,6 +76,9 @@ namespace Content.Server.DeviceNetwork.Systems
 
             if (!Resolve(senderUid, ref sender, false))
                 return allowNonStationPackets;
+
+            if (!sender.StationId.HasValue)
+                TrySetStationId(senderUid, sender);
 
             return sender.StationId == receiverStationId;
         }


### PR DESCRIPTION
## About the PR
This PR assigns unassigned suit sensors and devices having a `StationLimitedNetworkComponent` to a station when they update/send or receive a packet and are on a station grid.

Also fixes an exception when someone changes jumpsuits while a crew monitor console is open.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Fixed suit sensors for crew arriving via arrivals shuttle
