### PR TITLE
Fixes map vote localisation issue

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -214,7 +214,8 @@ namespace Content.Server.Voting.Managers
                     }
                     else
                     {
-                        _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-map-notlobby-time"));
+                        var timeString = $"{ticker.RoundPreloadTime.Minutes:0}:{ticker.RoundPreloadTime.Seconds:00}";
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-map-notlobby-time", ("time", timeString)));
                     }
                 }
             };

--- a/Resources/Locale/en-US/voting/managers/vote-manager.ftl
+++ b/Resources/Locale/en-US/voting/managers/vote-manager.ftl
@@ -17,5 +17,5 @@ ui-vote-gamemode-win = { $winner } won the gamemode vote!
 ui-vote-map-title = Next map
 ui-vote-map-tie = Tie for map vote! Picking... { $picked }
 ui-vote-map-win = { $winner } won the map vote!
-ui-vote-map-notlobby-time = Voting for maps is only valid in the pre-round lobby!
+ui-vote-map-notlobby = Voting for maps is only valid in the pre-round lobby!
 ui-vote-map-notlobby-time = Voting for maps is only valid in the pre-round lobby with { $time } remaining!


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes #16291
Adds the actual time instead of displaying "Voting for maps is only valid in the pre-round lobby with { $time } remaining!"

Also fixes duplicate localization identifiers 

**Media**
![image](https://github.com/space-wizards/space-station-14/assets/25136265/24ecc854-4db7-4755-ae17-b352388cd99d)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Don't believe this is important enough to warrant a changelog