### PR TITLE
Space about 30% faster, spacing fights fires better

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -468,7 +468,8 @@ namespace Content.Server.Atmos.EntitySystems
                 }
 
                 // Pressure as a multiple of normal air pressure (takes temperature into account)
-                float pressureMultiple = (otherTile.Air.Pressure / 110.0f);
+                //   Allow more wind at higher pressures, but cap at 0.5 so low pressures aren't slowed by wind.
+                float pressureMultiple = Math.Max(0.5f, otherTile.Air.Pressure / 110.0f);
                 var sum = otherTile.Air.TotalMoles * Atmospherics.SpacingEscapeRatio * pressureMultiple;
                 if (sum < Atmospherics.SpacingMinGas)
                 {

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -504,7 +504,15 @@ namespace Content.Server.Atmos.EntitySystems
                         // Temperature reduces as air drains. But nerf the real temperature reduction a bit
                         //   Also, limit the temperature loss to remain > 10 Deg.C for convenience
                         float realtemploss = (otherTile.Air.TotalMoles - sum) / otherTile.Air.TotalMoles;
-                        otherTile.Air.Temperature *= 0.9f + 0.1f * realtemploss;
+                        if (otherTile.Air.Temperature > 500.0f)
+                        {
+                            // For really hot air, drop temperature faster
+                            otherTile.Air.Temperature *= 0.7f + 0.3f * realtemploss;
+                        }
+                        else
+                        {
+                            otherTile.Air.Temperature *= 0.9f + 0.1f * realtemploss;
+                        }
                     }
                 }
                 else

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -313,14 +313,14 @@ namespace Content.Shared.Atmos
         ///     What fraction of air from a spaced tile escapes every tick.
         ///     1.0 for instant spacing, 0.2 means 20% of remaining air lost each time
         /// </summary>
-        public const float SpacingEscapeRatio = 0.05f;
+        public const float SpacingEscapeRatio = 0.07f;
 
         /// <summary>
         ///     Minimum amount of air allowed on a spaced tile before it is reset to 0 immediately in kPa
         ///     Since the decay due to SpacingEscapeRatio follows a curve, it would never reach 0.0 exactly
         ///     unless we truncate it somewhere.
         /// </summary>
-        public const float SpacingMinGas = 2.0f;
+        public const float SpacingMinGas = 4.0f;
 
         /// <summary>
         ///     How much wind can go through a single tile before that tile doesn't depressurize itself


### PR DESCRIPTION
## About the PR
- 30% faster spacing overall
- 60->40s to clear plasma bombed dev (one plasma canister, full burn, space to 7kPa)
- Faster space cooling for very hot rooms.

Players have been complaining that the new spacing is too slow. This is probably STILL too slow for many but it's a tradeoff for kindness vs speed.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

I don't think this needs media.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Space has become 30% more hungry for our precious atmosphere. Keep those airlocks closed people!