### PR TITLE
Move Centcom Scarf

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
@@ -13,4 +13,5 @@
     ClothingMaskGasCentcom: 3
     ClothingHeadsetCentCom: 3
     ClothingOuterWinterCentcom: 3
+    ClothingNeckScarfStripedCentcom: 3
     

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
@@ -17,3 +17,4 @@
   emaggedInventory:
     ClothingNeckScarfStripedSyndieGreen: 3
     ClothingNeckScarfStripedSyndieRed: 3
+    ClothingNeckScarfStripedCentcom: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
@@ -13,9 +13,7 @@
     ClothingOuterCoatBomber: 3
     ClothingHeadHatSantahat: 2
     ClothingHeadHatXmasCrown: 2
-    ClothingNeckScarfStripedCentcom: 1
 
   emaggedInventory:
     ClothingNeckScarfStripedSyndieGreen: 3
     ClothingNeckScarfStripedSyndieRed: 3
-    ClothingNeckScarfStripedCentcom: 3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Moves the Centcom scarf to the Centdrobe

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Potato1234_x
- tweak: The Centcom scarf has been moved to the Centdrobe