### PR TITLE
Maint ambience tweaks

### DIFF
--- a/Content.Shared/Random/RulesPrototype.cs
+++ b/Content.Shared/Random/RulesPrototype.cs
@@ -125,6 +125,12 @@ public sealed class NearbyAccessRule : RulesRule
 
 public sealed class NearbyComponentsRule : RulesRule
 {
+    /// <summary>
+    /// Does the entity need to be anchored.
+    /// </summary>
+    [DataField("anchored")]
+    public bool Anchored = true;
+
     [DataField("count")] public int Count;
 
     [DataField("components", required: true)]

--- a/Content.Shared/Random/RulesPrototype.cs
+++ b/Content.Shared/Random/RulesPrototype.cs
@@ -129,7 +129,7 @@ public sealed class NearbyComponentsRule : RulesRule
     /// Does the entity need to be anchored.
     /// </summary>
     [DataField("anchored")]
-    public bool Anchored = true;
+    public bool Anchored;
 
     [DataField("count")] public int Count;
 

--- a/Content.Shared/Random/RulesPrototype.cs
+++ b/Content.Shared/Random/RulesPrototype.cs
@@ -55,6 +55,11 @@ public sealed class NearbyEntitiesRule : RulesRule
 
 public sealed class NearbyTilesPercentRule : RulesRule
 {
+    /// <summary>
+    /// If there are anchored entities on the tile do we ignore the tile.
+    /// </summary>
+    [DataField("anchored")] public bool Anchored;
+
     [DataField("percent", required: true)]
     public float Percent;
 

--- a/Content.Shared/Random/RulesSystem.cs
+++ b/Content.Shared/Random/RulesSystem.cs
@@ -178,6 +178,9 @@ public sealed class RulesSystem : EntitySystem
                         if (!tiles.Tiles.Contains(_tileDef[tile.Tile.TypeId].ID))
                             continue;
 
+                        if (tiles.Anchored && grid.GetAnchoredEntitiesEnumerator(tile.GridIndices).MoveNext(out _))
+                            continue;
+
                         matchingTileCount++;
                     }
 

--- a/Content.Shared/Random/RulesSystem.cs
+++ b/Content.Shared/Random/RulesSystem.cs
@@ -94,7 +94,9 @@ public sealed class RulesSystem : EntitySystem
                 }
                 case NearbyComponentsRule nearbyComps:
                 {
-                    if (!TryComp<TransformComponent>(uid, out var xform) ||
+                    var xformQuery = GetEntityQuery<TransformComponent>();
+
+                    if (!xformQuery.TryGetComponent(uid, out var xform) ||
                         xform.MapUid == null)
                     {
                         return false;
@@ -104,19 +106,25 @@ public sealed class RulesSystem : EntitySystem
                     var worldPos = _transform.GetWorldPosition(xform);
                     var count = 0;
 
-                    foreach (var comp in nearbyComps.Components.Values)
+                    foreach (var compType in nearbyComps.Components.Values)
                     {
                         // TODO: Update this when we get the callback version
-                        foreach (var _ in _lookup.GetComponentsInRange(comp.Component.GetType(), xform.MapID,
+                        foreach (var comp in _lookup.GetComponentsInRange(compType.Component.GetType(), xform.MapID,
                                      worldPos, nearbyComps.Range))
                         {
+                            if (nearbyComps.Anchored &&
+                                (!xformQuery.TryGetComponent(comp.Owner, out var compXform) || !compXform.Anchored))
+                            {
+                                continue;
+                            }
+
                             count++;
 
-                            if (count >= nearbyComps.Count)
-                            {
-                                found = true;
-                                break;
-                            }
+                            if (count < nearbyComps.Count)
+                                continue;
+
+                            found = true;
+                            break;
                         }
 
                         if (found)

--- a/Resources/Prototypes/audio.yml
+++ b/Resources/Prototypes/audio.yml
@@ -244,6 +244,7 @@
   id: NearPrayable
   rules:
     - !type:NearbyComponentsRule
+      anchored: true
       components:
         - type: Prayable
       range: 5

--- a/Resources/Prototypes/audio.yml
+++ b/Resources/Prototypes/audio.yml
@@ -225,10 +225,11 @@
   id: NearMaintenance
   rules:
     - !type:NearbyTilesPercentRule
+      anchored: false
       percent: 0.25
       tiles:
         - Plating
-      range: 3
+      range: 2
 
 - type: rules
   id: NearMedical


### PR DESCRIPTION
I think it's playing more than it should due to plating under walls so I nerfed the range check a bit and made it ignore walls.

:cl:
- fix: Maintenance ambience should play less frequently in corridors.