### PR TITLE
Ore tweaks

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -362,7 +362,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         var loadedMarkers = component.LoadedMarkers;
         var spawnSet = new HashSet<Vector2i>();
         var spawns = new List<Vector2i>();
-        var frontier = new Queue<Vector2i>();
+        var frontier = new ValueList<Vector2i>();
 
         foreach (var (layer, chunks) in markers)
         {
@@ -426,11 +426,14 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                     }
 
                     // BFS search
-                    frontier.Enqueue(point);
+                    frontier.Add(point);
                     var groupCount = layerProto.GroupCount;
 
-                    while (frontier.TryDequeue(out var node) && groupCount > 0)
+                    while (frontier.Count > 0 && groupCount > 0)
                     {
+                        var frontierIndex = _random.Next(frontier.Count);
+                        var node = frontier[frontierIndex];
+                        frontier.RemoveSwap(frontierIndex);
                         var enumerator = grid.GetAnchoredEntitiesEnumerator(node);
 
                         if (enumerator.MoveNext(out _))
@@ -463,7 +466,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                                 if (!spawnSet.Contains(neighbor))
                                     continue;
 
-                                frontier.Enqueue(neighbor);
+                                frontier.Add(neighbor);
                                 // Rather than doing some uggo remove check on the list we'll defer it until later
                                 spawnSet.Remove(neighbor);
                             }

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -205,6 +205,15 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         }
 
         // Handle loot
+        // We'll always add this loot if possible
+        foreach (var lootProto in _prototypeManager.EnumeratePrototypes<SalvageLootPrototype>())
+        {
+            if (!lootProto.Guaranteed)
+                continue;
+
+            await SpawnDungeonLoot(dungeon, lootProto, mapUid, grid, random, reservedTiles);
+        }
+
         foreach (var (loot, count) in mission.Loot)
         {
             for (var i = 0; i < count; i++)

--- a/Content.Shared/Procedural/Loot/SalvageLootPrototype.cs
+++ b/Content.Shared/Procedural/Loot/SalvageLootPrototype.cs
@@ -12,6 +12,11 @@ public sealed class SalvageLootPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 
+    /// <summary>
+    /// Should this loot always spawn if possible. Used for stuff such as ore.
+    /// </summary>
+    [DataField("guaranteed")] public bool Guaranteed;
+
     [DataField("desc")] public string Description = string.Empty;
 
     /// <summary>

--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -120,7 +120,7 @@ public abstract class SharedSalvageSystem : EntitySystem
             mods.Add(time.Description);
         }
 
-        var loots = GetLoot(config, _proto.EnumeratePrototypes<SalvageLootPrototype>().ToList(), GetDifficulty(difficulty), seed);
+        var loots = GetLoot(config, _proto.EnumeratePrototypes<SalvageLootPrototype>().Where(o => !o.Guaranteed).ToList(), GetDifficulty(difficulty), seed);
         return new SalvageMission(seed, difficulty, dungeon.ID, faction.ID, config, biome.ID, light?.Color, duration, loots, mods);
     }
 

--- a/Resources/Prototypes/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates.yml
@@ -3,7 +3,7 @@
   id: OreTin
   proto: WallRockTin
   entityMask: WallRock
-  maxCount: 5
+  maxCount: 15
   groupCount: 10
   radius: 4
 
@@ -13,7 +13,7 @@
   id: OreGold
   proto: WallRockGold
   entityMask: WallRock
-  maxCount: 5
+  maxCount: 15
   groupCount: 5
   radius: 4
 
@@ -22,7 +22,7 @@
   id: OreSilver
   proto: WallRockSilver
   entityMask: WallRock
-  maxCount: 5
+  maxCount: 15
   groupCount: 5
   radius: 4
 
@@ -32,7 +32,7 @@
   id: OrePlasma
   proto: WallRockPlasma
   entityMask: WallRock
-  maxCount: 2
+  maxCount: 6
   groupCount: 5
   radius: 4
 
@@ -41,7 +41,7 @@
   id: OreUranium
   proto: WallRockUranium
   entityMask: WallRock
-  maxCount: 2
+  maxCount: 6
   groupCount: 5
   radius: 4
 
@@ -49,6 +49,6 @@
   id: OreBananium
   proto: WallRockBananium
   entityMask: WallRock
-  maxCount: 2
+  maxCount: 6
   groupCount: 5
   radius: 4

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -55,6 +55,7 @@
 - type: salvageLoot
   id: OreTin
   desc: Veins of steel
+  guaranteed: true
   loots:
     - !type:BiomeMarkerLoot
       proto: OreTin
@@ -63,6 +64,7 @@
 - type: salvageLoot
   id: OreGold
   desc: Veins of gold ore
+  guaranteed: true
   loots:
     - !type:BiomeMarkerLoot
       proto: OreGold
@@ -70,6 +72,7 @@
 - type: salvageLoot
   id: OreSilver
   desc: Veins of silver ore
+  guaranteed: true
   loots:
     - !type:BiomeMarkerLoot
       proto: OreSilver
@@ -78,6 +81,7 @@
 - type: salvageLoot
   id: OrePlasma
   desc: Veins of plasma ore
+  guaranteed: true
   loots:
     - !type:BiomeMarkerLoot
       proto: OrePlasma
@@ -85,6 +89,7 @@
 - type: salvageLoot
   id: OreUranium
   desc: Veins of uranium ore
+  guaranteed: true
   loots:
     - !type:BiomeMarkerLoot
       proto: OreUranium

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -2,46 +2,32 @@
 - type: ore
   id: OreSteel
   oreEntity: SteelOre1
-  minOreYield: 3
-  maxOreYield: 7
 
 - type: ore
   id: OreSpaceQuartz
   oreEntity: SpaceQuartz1
-  minOreYield: 3
-  maxOreYield: 7
 
 # Medium yields
 - type: ore
   id: OreGold
   oreEntity: GoldOre1
-  minOreYield: 2
-  maxOreYield: 5
 
 - type: ore
   id: OreSilver
   oreEntity: SilverOre1
-  minOreYield: 2
-  maxOreYield: 5
 
 # Low yields
 - type: ore
   id: OrePlasma
   oreEntity: PlasmaOre1
-  minOreYield: 1
-  maxOreYield: 3
 
 - type: ore
   id: OreUranium
   oreEntity: UraniumOre1
-  minOreYield: 1
-  maxOreYield: 3
 
 - type: ore
   id: OreBananium
   oreEntity: BananiumOre1
-  minOreYield: 1
-  maxOreYield: 3
 
 - type: weightedRandom
   id: RandomOreDistributionStandard


### PR DESCRIPTION
- Guaranteed spawns in salvage
- Triple vein count
- Made it so rocks only drop 1 as it's kinda whacky (I believe they still convert differently to bars).
- Made it so veins pick randomly for frontier so their shapes are more random.

Requires https://github.com/space-wizards/RobustToolbox/pull/4093

![image](https://github.com/space-wizards/space-station-14/assets/31366439/5aae8399-e353-4fba-9e61-6240e1e37035)

@DogZeroX 

:cl:
- tweak: All ore veins are guaranteed on expeditions, tripled the vein count, but made it so veins only drop 1 ore each.
