### PR TITLE
Device network address improvements

### DIFF
--- a/Content.Server/DeviceNetwork/DeviceNet.cs
+++ b/Content.Server/DeviceNetwork/DeviceNet.cs
@@ -228,7 +228,10 @@ public sealed class DeviceNet
         prefix = string.IsNullOrWhiteSpace(prefix) ? null : Loc.GetString(prefix);
         string address;
         do
-            address = $"{prefix}{_random.Next():x}";
+        {
+            var num = _random.Next();
+            address = $"{prefix}{num >> 16:X4}-{num & 0xFFFF:X4}";
+        }
         while (Devices.ContainsKey(address));
 
         return address;

--- a/Resources/Locale/en-US/devices/device-network.ftl
+++ b/Resources/Locale/en-US/devices/device-network.ftl
@@ -21,14 +21,14 @@ device-frequency-prototype-name-surveillance-camera-general = General Cameras
 device-frequency-prototype-name-surveillance-camera-entertainment = Entertainment Cameras
 
 # prefixes for randomly generated device addresses
-device-address-prefix-vent = Vnt-
-device-address-prefix-scrubber = Scr-
-device-address-prefix-sensor = Sns-
+device-address-prefix-vent = VNT-
+device-address-prefix-scrubber = SCR-
+device-address-prefix-sensor = SNS-
 
 #PDAs and terminals
-device-address-prefix-console = Cls-
-device-address-prefix-fire-alarm = Fir-
-device-address-prefix-air-alarm = Air-
+device-address-prefix-console = CLS-
+device-address-prefix-fire-alarm = FIR-
+device-address-prefix-air-alarm = AIR-
 
 device-address-examine-message = The device's address is {$address}.
 


### PR DESCRIPTION
## About the PR

All prefixes are now upper case.

Made the random number generated as 0X0X-0X0X (upper case hex, always 8 digits, separator in the middle)

**Media**
![image](https://github.com/space-wizards/space-station-14/assets/8107459/b4267b1f-eddb-44a2-b0d1-ea30961b44b0)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Device network addresses now look prettier.
