### PR TITLE
fixed poppy potencydivisor

### DIFF
--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -685,7 +685,7 @@
     Bicaridine:
       Min: 1
       Max: 20
-      PotencyDivisor: 20
+      PotencyDivisor: 5
 
 - type: seed
   id: aloe


### PR DESCRIPTION
fixed poppy potency divisor, which would have taken 400 (instead of 100) potency to reach the regent limit.


**Changelog**

:cl:
- fix: Fixed Poppy potency scaling