### PR TITLE
Shiv balance pass (+ shards now weigh less)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -27,6 +27,7 @@
         Slash: 3.5
   - type: Item
     sprite: Objects/Materials/Shards/shard.rsi
+    size: 4
   - type: CollisionWake
     enabled: false
   - type: Fixtures
@@ -129,7 +130,7 @@
   description: A small piece of plasma glass.
   components:
   - type: Sprite
-    color: "#f3b489"
+    color: "#FF72E7"
   - type: WelderRefinable
     refineResult:
     - SheetGlass1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -188,10 +188,8 @@
         Slash: 9
   - type: Item
     sprite: Objects/Weapons/Melee/plasma_shiv.rsi
-    state: icon
   - type: Sprite
     sprite: Objects/Weapons/Melee/plasma_shiv.rsi
-    state: icon
 
 - type: entity
   name: uranium shiv

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -27,119 +27,6 @@
       path: /Audio/Items/Culinary/chop.ogg
 
 - type: entity
-  name: shiv
-  parent: BaseKnife
-  id: Shiv
-  description: A crude weapon fashioned from  a piece of cloth and a glass shard.
-  components:
-  - type: Tag
-    tags:
-    - CombatKnife
-    - Knife
-  - type: Construction
-    graph: Shiv
-    node: icon
-  - type: Sprite
-    sprite: Objects/Weapons/Melee/shiv.rsi
-    size: 2
-    state: icon
-  - type: MeleeWeapon
-    attackRate: 1.5
-    damage:
-      types:
-        Slash: 5
-  - type: Item
-    size: 10
-    sprite: Objects/Weapons/Melee/shiv.rsi
-  - type: DisarmMalus
-    malus: 0.225
-
-- type: entity
-  name: reinforced shiv
-  parent: BaseKnife
-  id: ReinforcedShiv
-  description: A crude weapon fashioned from  a piece of cloth and a reinforced glass shard.
-  components:
-  - type: Tag
-    tags:
-    - CombatKnife
-    - Knife
-  - type: Construction
-    graph: ReinforcedShiv
-    node: icon 
-  - type: Sprite
-    sprite: Objects/Weapons/Melee/reinforced_shiv.rsi
-    size: 2
-    state: icon
-  - type: MeleeWeapon
-    attackRate: 1.5
-    damage:
-      types:
-        Slash: 10
-  - type: Item
-    size: 10
-    sprite: Objects/Weapons/Melee/reinforced_shiv.rsi
-  - type: DisarmMalus
-    malus: 0.225
-
-- type: entity
-  name: plasma shiv
-  parent: BaseKnife
-  id: PlasmaShiv
-  description: A crude weapon fashioned from  a piece of cloth and a plasma shard.
-  components:
-  - type: Tag
-    tags:
-    - CombatKnife
-    - Knife
-  - type: Construction
-    graph: PlasmaShiv
-    node: icon 
-  - type: Sprite
-    sprite: Objects/Weapons/Melee/plasma_shiv.rsi
-    size: 2
-    state: icon
-  - type: MeleeWeapon
-    attackRate: 1.5
-    damage:
-      types:
-        Slash: 15
-  - type: Item
-    size: 10
-    sprite: Objects/Weapons/Melee/plasma_shiv.rsi
-  - type: DisarmMalus
-    malus: 0.225
-
-- type: entity
-  name: uranium shiv
-  parent: BaseKnife
-  id: UraniumShiv
-  description: A crude weapon fashioned from  a piece of cloth and a uranium shard.
-  components:
-  - type: Tag
-    tags:
-    - CombatKnife
-    - Knife
-  - type: Construction
-    graph: UraniumShiv
-    node: icon 
-  - type: Sprite
-    sprite: Objects/Weapons/Melee/uranium_shiv.rsi
-    size: 2
-    state: icon
-  - type: MeleeWeapon
-    attackRate: 1.5
-    damage:
-      types:
-        Slash: 10
-        Radiation: 5
-  - type: Item
-    size: 10
-    sprite: Objects/Weapons/Melee/uranium_shiv.rsi
-  - type: DisarmMalus
-    malus: 0.225
-
-- type: entity
   name: kitchen knife
   parent: BaseKnife
   id: KitchenKnife
@@ -196,7 +83,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 10
+        Slash: 13
   - type: Item
     size: 10
     sprite: Objects/Weapons/Melee/combat_knife.rsi
@@ -235,3 +122,93 @@
   - type: Item
     size: 10
     sprite: Objects/Weapons/Melee/kukri_knife.rsi
+
+- type: entity
+  name: shiv
+  parent: BaseKnife
+  id: Shiv
+  description: A crude weapon fashioned from a piece of cloth and a glass shard.
+  components:
+  - type: Tag
+    tags:
+    - CombatKnife
+    - Knife
+  - type: Construction
+    graph: Shiv
+    node: icon
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/shiv.rsi
+    size: 2
+    state: icon
+  - type: MeleeWeapon
+    attackRate: 1.5
+    damage:
+      types:
+        Slash: 5
+  - type: Item
+    size: 4 #as much as a regular glass shard
+    sprite: Objects/Weapons/Melee/shiv.rsi
+  - type: DisarmMalus
+    malus: 0.225
+
+- type: entity
+  name: reinforced shiv
+  parent: Shiv
+  id: ReinforcedShiv
+  description: A crude weapon fashioned from a piece of cloth and a reinforced glass shard.
+  components:
+  - type: Construction
+    graph: ReinforcedShiv
+    node: icon 
+    size: 2
+    state: icon
+  - type: MeleeWeapon
+    attackRate: 1.5
+    damage:
+      types:
+        Slash: 7 #each "tier" grants an additional 2 damage
+  - type: Item
+    sprite: Objects/Weapons/Melee/reinforced_shiv.rsi
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/reinforced_shiv.rsi
+
+- type: entity
+  name: plasma shiv
+  parent: Shiv
+  id: PlasmaShiv
+  description: A crude weapon fashioned from a piece of cloth and a plasma glass shard.
+  components:
+  - type: Construction
+    graph: PlasmaShiv
+    node: icon 
+  - type: MeleeWeapon
+    attackRate: 1.5
+    damage:
+      types:
+        Slash: 9
+  - type: Item
+    sprite: Objects/Weapons/Melee/plasma_shiv.rsi
+    state: icon
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/plasma_shiv.rsi
+    state: icon
+
+- type: entity
+  name: uranium shiv
+  parent: Shiv
+  id: UraniumShiv
+  description: A crude weapon fashioned from a piece of cloth and a uranium glass shard. Violates the geneva convention!
+  components:
+  - type: Construction
+    graph: UraniumShiv
+    node: icon 
+  - type: MeleeWeapon
+    attackRate: 1.5
+    damage:
+      types:
+        Slash: 7
+        Radiation: 4 #damage is high because apparently uranium glass is apparently a pain in the ass to make.
+  - type: Item
+    sprite: Objects/Weapons/Melee/uranium_shiv.rsi
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/uranium_shiv.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -144,7 +144,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 5
+        Slash: 5.5
   - type: Item
     size: 4 #as much as a regular glass shard
     sprite: Objects/Weapons/Melee/shiv.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -83,7 +83,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 13
+        Slash: 10
   - type: Item
     size: 10
     sprite: Objects/Weapons/Melee/combat_knife.rsi
@@ -207,7 +207,7 @@
     damage:
       types:
         Slash: 7
-        Radiation: 4 #damage is high because apparently uranium glass is apparently a pain in the ass to make.
+        Radiation: 4
   - type: Item
     sprite: Objects/Weapons/Melee/uranium_shiv.rsi
   - type: Sprite


### PR DESCRIPTION
## About the PR
Shivs were some of  the best knives in the game (plasma shivs just flat out _were,_) which was pretty dumb for a weapon as easy to get as it. This makes them into very fair pocket weapons, but nowhere near as good as any of the more bulky weapons like the spear / bat.

Also does a bunch of assorted minor shit while I'm at it:
Glass shards now only weigh 4, someone probably forgot to set the item size. Shivs also mirror this change.
The plasma glass shard is now the correct color.
All shiv variants are now parented off of Shiv instead of BaseKnife.
Fixes a very minor typo in the shiv description.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Shivs have been rebalanced. The regular glass shiv now does 5.5 damage, but the damage gain from the better tiers of glass is much lower.
- tweak: Glass shards now weigh a more appropriate size
- fix: Plasma glass shards are no longer orange