### PR TITLE
Set max length of battlecry to 12 chars.

### DIFF
--- a/Content.Server/Speech/EntitySystems/MeleeSpeechSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MeleeSpeechSystem.cs
@@ -1,6 +1,6 @@
 using Content.Server.Administration.Logs;
 using Content.Shared.Speech.Components;
-using Content.Shared.Weapons.Melee;
+using Content.Shared.Speech.EntitySystems;
 using Content.Shared.Database;
 
 
@@ -22,10 +22,15 @@ public sealed class MeleeSpeechSystem : SharedMeleeSpeechSystem
 	private void OnBattlecryChanged(EntityUid uid, MeleeSpeechComponent comp, MeleeSpeechBattlecryChangedMessage args)
 	{
 
-		if (!TryComp<MeleeSpeechComponent>(uid, out var meleeSpeechUser))
+        if (!TryComp<MeleeSpeechComponent>(uid, out var meleeSpeechUser))
 			return;
 
-		TryChangeBattlecry(uid, args.Battlecry, meleeSpeechUser);
+        string battlecry = args.Battlecry;
+
+        if (battlecry.Length > comp.MaxBattlecryLength)
+            battlecry = battlecry[..comp.MaxBattlecryLength];
+
+        TryChangeBattlecry(uid, battlecry, meleeSpeechUser);
 	}
 
 
@@ -41,12 +46,14 @@ public sealed class MeleeSpeechSystem : SharedMeleeSpeechSystem
 	public bool TryChangeBattlecry(EntityUid uid, string? battlecry, MeleeSpeechComponent? meleeSpeechComp = null)
 	{
 
-		if (!Resolve(uid, ref meleeSpeechComp))
+        if (!Resolve(uid, ref meleeSpeechComp))
 			return false;
 
 		if (!string.IsNullOrWhiteSpace(battlecry))
 		{
 			battlecry = battlecry.Trim();
+
+
 		}
 		else
 		{
@@ -56,6 +63,9 @@ public sealed class MeleeSpeechSystem : SharedMeleeSpeechSystem
 		if (meleeSpeechComp.Battlecry == battlecry)
 
 			return true;
+
+
+
 		meleeSpeechComp.Battlecry = battlecry;
 		Dirty(meleeSpeechComp);
 

--- a/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
+++ b/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
@@ -5,14 +5,12 @@ namespace Content.Shared.Speech.Components;
 
 [RegisterComponent]
 [AutoGenerateComponentState]
-[Access(typeof(SharedMeleeSpeechSystem), Other = AccessPermissions.ReadWrite)]
 public sealed partial class MeleeSpeechComponent : Component
 {
 
 	[ViewVariables(VVAccess.ReadWrite)]
 	[DataField("Battlecry")]
 	[AutoNetworkedField]
-	[Access(typeof(SharedMeleeSpeechSystem), Other = AccessPermissions.ReadWrite)]
 	public string? Battlecry;
 
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
+++ b/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
@@ -14,6 +14,10 @@ public sealed partial class MeleeSpeechComponent : Component
 	[AutoNetworkedField]
 	[Access(typeof(SharedMeleeSpeechSystem), Other = AccessPermissions.ReadWrite)]
 	public string? Battlecry;
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("MaxBattlecryLength")]
+    public int MaxBattlecryLength = 12;
 }
 
 /// <summary>

--- a/Content.Shared/Speech/EntitySystems/SharedMeleeSpeechSystem.cs
+++ b/Content.Shared/Speech/EntitySystems/SharedMeleeSpeechSystem.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.Serialization;
 
-namespace Content.Shared.Weapons.Melee;
+namespace Content.Shared.Speech.EntitySystems;
 
 public abstract class SharedMeleeSpeechSystem : EntitySystem
 {

--- a/Content.Shared/Weapons/Melee/SharedMeleeSpeechSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeSpeechSystem.cs
@@ -1,7 +1,0 @@
-using Robust.Shared.Serialization;
-
-namespace Content.Shared.Speech.EntitySystems;
-
-public abstract class SharedMeleeSpeechSystem : EntitySystem
-{
-}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Sets a max char limit of 12 for northstar gloves battlecry. 
Also deletes a duplicate file.
Fixes issue #16912

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: HerCoyote23
- fix: limited Northstar battlecry to 12 characters