### PR TITLE
Don't show grilles in the power monitor

### DIFF
--- a/Content.Server/Power/Components/PowerConsumerComponent.cs
+++ b/Content.Server/Power/Components/PowerConsumerComponent.cs
@@ -16,6 +16,10 @@ namespace Content.Server.Power.Components
         [ViewVariables(VVAccess.ReadWrite)]
         public float DrawRate { get => NetworkLoad.DesiredPower; set => NetworkLoad.DesiredPower = value; }
 
+        [DataField("showInMonitor")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool ShowInMonitor { get; set; } = true;
+
         /// <summary>
         ///     How much power this is currently receiving from <see cref="PowerSupplierComponent"/>s.
         /// </summary>

--- a/Content.Server/Power/EntitySystems/PowerMonitoringConsoleSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerMonitoringConsoleSystem.cs
@@ -53,6 +53,9 @@ internal sealed class PowerMonitoringConsoleSystem : EntitySystem
         {
             foreach (PowerConsumerComponent pcc in netQ.Consumers)
             {
+                if (!pcc.ShowInMonitor)
+                    continue;
+
                 loads.Add(LoadOrSource(pcc, pcc.DrawRate, false));
                 totalLoads += pcc.DrawRate;
             }

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -35,6 +35,7 @@
       damageContainer: Inorganic
       damageModifierSet: FlimsyMetallic
     - type: PowerConsumer
+      showInMonitor: false
     - type: Electrified
       requirePower: true
       noWindowInTile: true


### PR DESCRIPTION
## About the PR
Title

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- tweak: You can't see grilles in the power monitoring console anymore
