### PR TITLE
Make electrocutions look nicer on the power monitor.

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -323,6 +323,10 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
         var electrocutionNode = Comp<NodeContainerComponent>(electrocutionEntity).GetNode<ElectrocutionNode>("electrocution");
         var electrocutionComponent = Comp<ElectrocutionComponent>(electrocutionEntity);
 
+        // This shows up in the power monitor.
+        // Yes. Yes exactly.
+        MetaData(electrocutionEntity).EntityName = MetaData(uid).EntityName;
+
         electrocutionNode.CableEntity = sourceUid;
         electrocutionNode.NodeName = node.Name;
 

--- a/Resources/Prototypes/Entities/Virtual/electrocution.yml
+++ b/Resources/Prototypes/Entities/Virtual/electrocution.yml
@@ -1,7 +1,17 @@
 ﻿# Special entity used to attach to power networks as load when somebody gets electrocuted.
 - type: entity
+  id: VirtualElectrocutionLoadBase
+  noSpawn: true
+  components:
+  - type: Electrocution
+  - type: Icon
+    # Shows up inside the power monitoring console.
+    sprite: "Structures/Wallmounts/signs.rsi"
+    state: "shock"
+
+- type: entity
   id: VirtualElectrocutionLoadHVPower
-  name: ELECTROCUTION ENTITY YOU SHOULD NOT SEE THIS
+  parent: VirtualElectrocutionLoadBase
   noSpawn: true
   components:
   - type: NodeContainer
@@ -12,11 +22,10 @@
   - type: PowerConsumer
     voltage: High
     drawRate: 50000
-  - type: Electrocution
 
 - type: entity
   id: VirtualElectrocutionLoadMVPower
-  name: ELECTROCUTION ENTITY YOU SHOULD NOT SEE THIS
+  parent: VirtualElectrocutionLoadBase
   noSpawn: true
   components:
   - type: NodeContainer
@@ -27,11 +36,10 @@
   - type: PowerConsumer
     voltage: Medium
     drawRate: 50000
-  - type: Electrocution
 
 - type: entity
   id: VirtualElectrocutionLoadApc
-  name: ELECTROCUTION ENTITY YOU SHOULD NOT SEE THIS
+  parent: VirtualElectrocutionLoadBase
   noSpawn: true
   components:
   - type: NodeContainer
@@ -42,4 +50,3 @@
   - type: PowerConsumer
     voltage: Apc
     drawRate: 50000
-  - type: Electrocution


### PR DESCRIPTION
## About the PR
:godo:

**Media**
![image](https://github.com/space-wizards/space-station-14/assets/8107459/66491c54-7656-4f34-be15-0193a319ae9f)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Players being electrocuted now shows up nicer on the power monitoring console.
