### PR TITLE
Issues #17034: Changed Dead Mob DrawDepth from FloorObjects to Items

### DIFF
--- a/Content.Client/DamageState/DamageStateVisualizerSystem.cs
+++ b/Content.Client/DamageState/DamageStateVisualizerSystem.cs
@@ -40,10 +40,10 @@ public sealed class DamageStateVisualizerSystem : VisualizerSystem<DamageStateVi
         // So they don't draw over mobs anymore
         if (data == MobState.Dead)
         {
-            if (sprite.DrawDepth > (int) DrawDepth.FloorObjects)
+            if (sprite.DrawDepth > (int) DrawDepth.Items)
             {
                 component.OriginalDrawDepth = sprite.DrawDepth;
-                sprite.DrawDepth = (int) DrawDepth.FloorObjects;
+                sprite.DrawDepth = (int) DrawDepth.Items;
             }
         }
         else if (component.OriginalDrawDepth != null)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
As per #17034, made dead mobs change to the "Items" DrawDepth instead of "FloorObjects", which should put them above things like puddles, but below things like living mobs.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/space-wizards/space-station-14/assets/57199800/07399ac2-76ab-4746-9dbb-d98f0b7f1608)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Dead mobs now appear above puddles!
