### PR TITLE
Disallow tile placement close to grids

### DIFF
--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -61,6 +61,8 @@ public sealed class FloorTileSystem : EntitySystem
 
         // Disallow placement close to grids.
         // FTLing close is okay but this makes alignment too finnicky.
+        // While you may already have a tile close you want to replace when we get half-tiles that may also be finnicky
+        // so we're just gon with this for now.
         const bool weh = true;
         var state = (weh, location.EntityId);
         _mapManager.FindGridsIntersecting(map.MapId, new Box2(map.Position - 1f, map.Position + 1f), ref state,


### PR DESCRIPTION
Probably prevents some finnicky interactions.

:cl:
- tweak: Disallow tile placement close to other grids.