### PR TITLE
Fix shield modifiers

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -55,7 +55,7 @@ public sealed partial class BlockingSystem
             if (_proto.TryIndex(blockingComponent.ActiveBlockDamageModifier, out DamageModifierSetPrototype? activeBlockModifier) && blockingComponent.IsBlocking)
             {
                 args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, activeBlockModifier);
-                _audio.PlayPvs(blockingComponent.BlockSound, component.Owner, AudioParams.Default.WithVariation(0.2f));
+                _audio.PlayPvs(blockingComponent.BlockSound, uid, AudioParams.Default.WithVariation(0.2f));
             }
         }
     }

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -12,8 +12,8 @@ public sealed partial class BlockingSystem
 
     private void InitializeUser()
     {
-        SubscribeLocalEvent<BlockingUserComponent, DamageChangedEvent>(OnDamageChanged);
         SubscribeLocalEvent<BlockingUserComponent, DamageModifyEvent>(OnUserDamageModified);
+        SubscribeLocalEvent<BlockingComponent, DamageModifyEvent>(OnDamageModified);
 
         SubscribeLocalEvent<BlockingUserComponent, EntParentChangedMessage>(OnParentChanged);
         SubscribeLocalEvent<BlockingUserComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
@@ -39,32 +39,35 @@ public sealed partial class BlockingSystem
         UserStopBlocking(uid, component);
     }
 
-    private void OnDamageChanged(EntityUid uid, BlockingUserComponent component, DamageChangedEvent args)
-    {
-        if (args.DamageDelta != null && args.DamageIncreased)
-            _damageable.TryChangeDamage(component.BlockingItem, args.DamageDelta, origin: args.Origin);
-    }
-
     private void OnUserDamageModified(EntityUid uid, BlockingUserComponent component, DamageModifyEvent args)
     {
         if (TryComp<BlockingComponent>(component.BlockingItem, out var blocking))
         {
-            _proto.TryIndex<DamageModifierSetPrototype>(blocking.PassiveBlockDamageModifer, out var passiveblockModifier);
-            _proto.TryIndex<DamageModifierSetPrototype>(blocking.ActiveBlockDamageModifier, out var activeBlockModifier);
+            var blockFraction = blocking.IsBlocking ? blocking.ActiveBlockFraction : blocking.PassiveBlockFraction;
+            blockFraction = Math.Clamp(blockFraction, 0, 1);
+            _damageable.TryChangeDamage(component.BlockingItem, blockFraction * args.OriginalDamage);
 
-            var modifier = blocking.IsBlocking ? activeBlockModifier : passiveblockModifier;
-            if (modifier == null)
-            {
-                return;
-            }
+            args.Damage *= (1 - blockFraction);
 
-            args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, modifier);
-            
             if (blocking.IsBlocking)
             {
                 _audio.PlayPvs(blocking.BlockSound, uid, AudioParams.Default.WithVariation(0.2f));
             }
         }
+    }
+
+    private void OnDamageModified(EntityUid uid, BlockingComponent component, DamageModifyEvent args)
+    {
+        _proto.TryIndex<DamageModifierSetPrototype>(component.PassiveBlockDamageModifer, out var passiveblockModifier);
+        _proto.TryIndex<DamageModifierSetPrototype>(component.ActiveBlockDamageModifier, out var activeBlockModifier);
+
+        var modifier = component.IsBlocking ? activeBlockModifier : passiveblockModifier;
+        if (modifier == null)
+        {
+            return;
+        }
+
+        args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, modifier);
     }
 
     private void OnEntityTerminating(EntityUid uid, BlockingUserComponent component, ref EntityTerminatingEvent args)

--- a/Content.Shared/Blocking/Components/BlockingComponent.cs
+++ b/Content.Shared/Blocking/Components/BlockingComponent.cs
@@ -59,4 +59,18 @@ public sealed class BlockingComponent : Component
     /// </summary>
     [DataField("blockSound")]
     public SoundSpecifier BlockSound = new SoundPathSpecifier("/Audio/Weapons/block_metal1.ogg");
+
+    /// <summary>
+    /// Fraction of original damage shield will take instead of user
+    /// when not blocking
+    /// </summary>
+    [DataField("passiveBlockFraction"), ViewVariables(VVAccess.ReadWrite)]
+    public float PassiveBlockFraction = 0.5f;
+
+    /// <summary>
+    /// Fraction of original damage shield will take instead of user
+    /// when blocking
+    /// </summary>
+    [DataField("activeBlockFraction"), ViewVariables(VVAccess.ReadWrite)]
+    public float ActiveBlockFraction = 1.0f;
 }

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -313,10 +313,12 @@ namespace Content.Shared.Damage
         // Whenever locational damage is a thing, this should just check only that bit of armour.
         public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
 
+        public readonly DamageSpecifier OriginalDamage;
         public DamageSpecifier Damage;
 
         public DamageModifyEvent(DamageSpecifier damage)
         {
+            OriginalDamage = damage;
             Damage = damage;
         }
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
closes #17065, closes #16339, closes #16302

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![Peek 2023-06-02 15-01](https://github.com/space-wizards/space-station-14/assets/40753025/22bc216d-0d6f-4822-9a8d-a09c55ce00db)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: shields by default now block 50% of damage when not blocking and 100% of damage when blocking.
- fix: fixed shields affected by owner damage modifiers
- fix: fixed shields taking damage from pressure if owner taking damage from pressure (and etc.)
- fix: fixed shields making owner less resistant to damage
