### PR TITLE
Swords now use bladeslice.ogg

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -13,6 +13,8 @@
     damage:
       types:
         Slash: 17 #cmon, it has to be at least BETTER than the rest.
+    soundHit:
+        path: /Audio/Weapons/bladeslice.ogg
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/captain_sabre.rsi
@@ -38,6 +40,8 @@
     damage:
       types:
         Slash: 25
+    soundHit:
+        path: /Audio/Weapons/bladeslice.ogg
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/katana.rsi
@@ -60,6 +64,8 @@
     damage:
       types:
         Slash: 20
+    soundHit:
+        path: /Audio/Weapons/bladeslice.ogg
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/machete.rsi
@@ -80,6 +86,8 @@
     damage:
       types:
         Slash: 33
+    soundHit:
+        path: /Audio/Weapons/bladeslice.ogg
   - type: Item
     size: 20
   - type: Clothing
@@ -105,6 +113,8 @@
     damage:
       types:
         Slash: 16
+    soundHit:
+        path: /Audio/Weapons/bladeslice.ogg
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/cutlass.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
For some reason almost every melee weapon seems to use the generic 'clank' sound, even when better sounds exist.
This PR makes all the swords use bladeslice.ogg, because swords don't clank.

TODO:
Make them clank when you hit a wall/table/etc.
Give better sounds to other melee weapons, namely welder, baton, maybe spear.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Swords no longer clank

