### PR TITLE
Feat/hdr lights

### DIFF
--- a/Content.Client/Eye/EyeExposureSystem.cs
+++ b/Content.Client/Eye/EyeExposureSystem.cs
@@ -1,0 +1,73 @@
+using System.Runtime.InteropServices;
+using Content.Shared.Follower.Components;
+using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Systems;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Physics;
+using Robust.Client.Player;
+using Robust.Shared.Collections;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Eye;
+
+public sealed class EyeExposureSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly SharedMoverController _mover = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        UpdatesOutsidePrediction = true;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        UpdateViewportExposure(frameTime);
+    }
+
+    private void UpdateViewportExposure(float frameTime)
+    {
+        if (!_entityManager.TryGetComponent(_playerManager.LocalPlayer?.ControlledEntity, out EyeComponent? eyeComp))
+            return;
+
+        if (eyeComp.Eye == null || eyeComp.Eye.AutoExpose == null)
+            return;
+
+        var eye = eyeComp.Eye;
+        var auto = eye.AutoExpose;
+
+        // How much should we increase or decrease brightness as a ratio to land at 80% lighting?
+        // By limiting the ranges goalChange can take on and avoiding div/0 here it is much easier to tune this.
+        var goalChange = Math.Clamp(auto.GoalBrightness / Math.Max(0.0001f, auto.LastBrightness), 0.2f, 5.0f);
+        var goalExposure = eye.Exposure * goalChange;
+
+        if (goalChange < 1.0f)
+        {
+            // Reduce exposure
+            var speed = MathHelper.Lerp(auto.RampDown, auto.RampDownNight, Math.Clamp(eye.Exposure / auto.Max, 0.0f, 1.0f));
+            eye.Exposure = MathHelper.Lerp(eye.Exposure, goalExposure, frameTime * auto.RampDown * 0.2f);
+        }
+        else
+        {
+            // Increase exposure
+            var speed = MathHelper.Lerp(auto.RampUp, auto.RampUpNight, Math.Clamp(eye.Exposure / auto.Max, 0.0f, 1.0f));
+            eye.Exposure = MathHelper.Lerp(eye.Exposure, goalExposure, frameTime * speed * 0.2f);
+        }
+
+        // Reset
+        if (float.IsNaN(eye.Exposure))
+        {
+            eye.Exposure = 1.0f;
+        }
+        // Clamp to a range
+        eye.Exposure = Math.Clamp(eye.Exposure, auto.Min, auto.Max);
+    }
+
+}

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -26,6 +26,14 @@
   - type: Appearance
   - type: Eye
     drawFov: false
+    autoExpose: # Ghost has quite powerful & fast night vision
+      max: 12
+      rampDown: 0.2
+      rampUp: 0.1
+      rampUpNight: 0.01
+    nightVision:
+      range: 1.0
+      power: 1.0
   - type: Input
     context: "ghost"
   - type: Examiner

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -27,13 +27,16 @@
   - type: Eye
     drawFov: false
     autoExpose: # Ghost has quite powerful & fast night vision
-      max: 12
+      max: 10
       rampDown: 0.2
       rampUp: 0.1
       rampUpNight: 0.01
     nightVision:
+      color: "#C0E0FFFF"
+      minExposure: 1.2
+      lightIntolerance: 0.05 # Hardly notices over-bright lighting
       range: 1.0
-      power: 1.0
+      power: 1.5
   - type: Input
     context: "ghost"
   - type: Examiner


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- Iterative HDR style exposure control to adjust brightness of scene to keep it consistent
- Night vision is possible, but only powerful for ghosts (in this PR) 
- Game looks really nice

The Brightness is adjusted in this loop:

1. Samples a square (about 32x32 pixels, 1/64 screen size) of the screen where the player is to see how bright the lighting is each frame. (This is done in Robust Client, value stored into Eye)
2. Adjusts "Eye.Exposure" to try to make that square 95% brightness in the lighting system (Client's EyeExposureSystem)
3. Exposure moves between limits say 0.8x -> 4.0x for this PR or 0.8x -> 10.0x for the next PR. The rate is quite slow, esp when increasing exposure
4. Exposure increases the power of all lights and also increases the range of all lights (In Robust Client's lighting system)
5. If exposure goes above a threshold (say 1.3x) a point light begins fading in on the player's location - called "NightVision" (Clientside, in Robust Client)
6. Different characters will initialize EyeComponent with different ranges for exposure, different power of night vision, different nightvision color and different adjustment speed.
7. I've set very powerful good looking settings for this on the Observation Ghost.

Requires: https://github.com/space-wizards/RobustToolbox/pull/4106

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://github.com/space-wizards/space-station-14/assets/5285589/72323086-2e55-46ab-a7f1-009ac5593822)

A video showcasing the night vision of a regular human, which is quite mild in this PR. A later PR will make it more powerful and add spider / dwarf etc night vision also.


https://github.com/space-wizards/space-station-14/assets/5285589/7b115825-1b7f-47a4-b7d7-7dbec04fd9e0


![image](https://github.com/space-wizards/space-station-14/assets/5285589/4f327427-f2b2-4a43-a098-d4ee8a4b348a)

![image](https://github.com/space-wizards/space-station-14/assets/5285589/d92d8224-c47d-4d81-b435-e1cd4e078f80)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Your eyes adjust to the gloom or brightness on the station enough to make the lighting really sparkle
- add: Ghosts can see much better in the dark without having to disable lighting.