### PR TITLE
Fix sqlite ban time conversion

### DIFF
--- a/Content.Server/Database/ServerDbSqlite.cs
+++ b/Content.Server/Database/ServerDbSqlite.cs
@@ -312,8 +312,9 @@ namespace Content.Server.Database
                 uid,
                 ban.Address,
                 ban.HWId == null ? null : ImmutableArray.Create(ban.HWId),
-                ban.BanTime,
-                ban.ExpirationTime,
+                // SQLite apparently always reads DateTime as unspecified, but we always write as UTC.
+                DateTime.SpecifyKind(ban.BanTime, DateTimeKind.Utc),
+                ban.ExpirationTime == null ? null : DateTime.SpecifyKind(ban.ExpirationTime.Value, DateTimeKind.Utc),
                 ban.Reason,
                 aUid,
                 unban,
@@ -336,7 +337,8 @@ namespace Content.Server.Database
             return new ServerRoleUnbanDef(
                 unban.Id,
                 aUid,
-                unban.UnbanTime);
+                // SQLite apparently always reads DateTime as unspecified, but we always write as UTC.
+                DateTime.SpecifyKind(unban.UnbanTime, DateTimeKind.Utc));
         }
         #endregion
 
@@ -377,8 +379,9 @@ namespace Content.Server.Database
                 uid,
                 ban.Address,
                 ban.HWId == null ? null : ImmutableArray.Create(ban.HWId),
-                ban.BanTime,
-                ban.ExpirationTime,
+                // SQLite apparently always reads DateTime as unspecified, but we always write as UTC.
+                DateTime.SpecifyKind(ban.BanTime, DateTimeKind.Utc),
+                ban.ExpirationTime == null ? null : DateTime.SpecifyKind(ban.ExpirationTime.Value, DateTimeKind.Utc),
                 ban.Reason,
                 aUid,
                 unban);
@@ -400,7 +403,8 @@ namespace Content.Server.Database
             return new ServerUnbanDef(
                 unban.Id,
                 aUid,
-                unban.UnbanTime);
+                // SQLite apparently always reads DateTime as unspecified, but we always write as UTC.
+                DateTime.SpecifyKind(unban.UnbanTime, DateTimeKind.Utc));
         }
 
         public override async Task<int>  AddConnectionLogAsync(


### PR DESCRIPTION
Apparently sqlite awlays reads `DateTime` as unspecified even if its written as UTC, and this is currently causing the pardon command tests to fail when run locally on my computer. This PR just casts ban related times back to UTC when reading. Postgresql doesn't seem to have the same issue.

I dunno if this is the right way to fix this, all I can say is it fixes my local tests.