### PR TITLE
add an event to prevent gun shooting

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Components;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Collections;
@@ -72,6 +73,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         SubscribeLocalEvent<MeleeWeaponComponent, ComponentHandleState>(OnHandleState);
         SubscribeLocalEvent<MeleeWeaponComponent, HandDeselectedEvent>(OnMeleeDropped);
         SubscribeLocalEvent<MeleeWeaponComponent, HandSelectedEvent>(OnMeleeSelected);
+        SubscribeLocalEvent<MeleeWeaponComponent, ShotAttemptedEvent>(OnMeleeShotAttempted);
         SubscribeLocalEvent<MeleeWeaponComponent, GunShotEvent>(OnMeleeShot);
         SubscribeLocalEvent<BonusMeleeDamageComponent, GetMeleeDamageEvent>(OnGetBonusMeleeDamage);
 
@@ -91,6 +93,12 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (component.NextAttack > Timing.CurTime)
             Logger.Warning($"Initializing a map that contains an entity that is on cooldown. Entity: {ToPrettyString(uid)}");
 #endif
+    }
+
+    private void OnMeleeShotAttempted(EntityUid uid, MeleeWeaponComponent comp, ShotAttemptedEvent args)
+    {
+        if (comp.NextAttack > Timing.CurTime)
+            args.Cancel();
     }
 
     private void OnMeleeShot(EntityUid uid, MeleeWeaponComponent component, ref GunShotEvent args)

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -95,7 +95,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 #endif
     }
 
-    private void OnMeleeShotAttempted(EntityUid uid, MeleeWeaponComponent comp, ShotAttemptedEvent args)
+    private void OnMeleeShotAttempted(EntityUid uid, MeleeWeaponComponent comp, ref ShotAttemptedEvent args)
     {
         if (comp.NextAttack > Timing.CurTime)
             args.Cancel();

--- a/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
@@ -4,10 +4,29 @@ namespace Content.Shared.Weapons.Ranged.Events;
 /// Raised on a gun when someone is attempting to shoot it.
 /// Cancel this event to prevent it from shooting.
 /// </summary>
-public sealed class ShotAttemptedEvent : CancellableEntityEventArgs
+[ByRefEvent]
+public record struct ShotAttemptedEvent
 {
     /// <summary>
     /// The user attempting to shoot the gun.
     /// </summary>
     public EntityUid User;
+
+    public bool Cancelled { get; private set; }
+
+    /// </summary>
+    /// Prevent the gun from shooting
+    /// </summary>
+    public void Cancel()
+    {
+        Cancelled = true;
+    }
+
+    /// </summary>
+    /// Allow the gun to shoot again, only use if you know what you are doing
+    /// </summary>
+    public void Uncancel()
+    {
+        Cancelled = false;
+    }
 }

--- a/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
@@ -1,0 +1,13 @@
+namespace Content.Shared.Weapons.Ranged.Events;
+
+/// <summary>
+/// Raised on a gun when someone is attempting to shoot it.
+/// Cancel this event to prevent it from shooting.
+/// </summary>
+public sealed class ShotAttemptedEvent : CancellableEntityEventArgs
+{
+    /// <summary>
+    /// The user attempting to shoot the gun.
+    /// </summary>
+    public EntityUid User;
+}

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -221,8 +221,13 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         var curTime = Timing.CurTime;
 
-        // Maybe Raise an event for this? CanAttack doesn't seem appropriate.
-        if (TryComp<MeleeWeaponComponent>(gunUid, out var melee) && melee.NextAttack > curTime)
+        // check if anything wants to prevent shooting
+        var prevention = new ShotAttemptedEvent
+        {
+            User = user
+        };
+        RaiseLocalEvent(gunUid, prevention);
+        if (prevention.Cancelled)
             return;
 
         // Need to do this to play the clicking sound for empty automatic weapons

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -226,7 +226,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         {
             User = user
         };
-        RaiseLocalEvent(gunUid, prevention);
+        RaiseLocalEvent(gunUid, ref prevention);
         if (prevention.Cancelled)
             return;
 


### PR DESCRIPTION
## About the PR
sloth silently removed GunsDisabled tag when adding crusher (sabotaging ninja!!!!??!) so this adds it back in a better form
this pr adds ShotAttemptedEvent which can be cancelled if you dont want a gun to and makes crusher's cooldown thing use this event

crusher and glaive still work as expected

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun