### PR TITLE
change 70 liter volume tanks to 15 liter

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -52,7 +52,7 @@
   - type: GasTank
     outputPressure: 21.27825
     air:
-      volume: 70
+      volume: 15
       temperature: 293.15
     tankLowPressure: 30.0
   - type: Clothing
@@ -178,7 +178,7 @@
     - type: GasTank
       outputPressure: 101.325
       air:
-        volume: 70
+        volume: 15
         temperature: 293.15
     - type: Clothing
       sprite: Objects/Tanks/generic.rsi
@@ -197,7 +197,7 @@
     - type: GasTank
       outputPressure: 101.325
       air:
-        volume: 70
+        volume: 15
         temperature: 293.15
     - type: Clothing
       sprite: Objects/Tanks/anesthetic.rsi
@@ -216,7 +216,7 @@
     - type: GasTank
       outputPressure: 101.325
       air:
-        volume: 70
+        volume: 15
         temperature: 293.15
     - type: Item
       size: 10


### PR DESCRIPTION
## About the PR
in english this means that you can no longer get an oxygen tank from maint roundstart and be on internals for the rest of the round, they just last 5x an emergency tank by default.

fixes #16420 (for gas tanks havent touched jetpacks)

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Due to budget cuts in atmos, large gas tanks had their volume reduced by 78%.