### PR TITLE
microwave tweaks

### DIFF
--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -43,7 +43,14 @@ namespace Content.Server.Kitchen.Components
         /// For right now, I don't think any recipe cook time should be greater than 60 seconds.
         /// </summary>
         [DataField("currentCookTimerTime"), ViewVariables(VVAccess.ReadWrite)]
-        public uint CurrentCookTimerTime = 5;
+        public uint CurrentCookTimerTime = 0;
+
+        /// <summary>
+        /// The maximum number of seconds a microwave can be set to.
+        /// This is currently only used for validation and the client does not check this.
+        /// </summary>
+        [DataField("maxCookTime"), ViewVariables(VVAccess.ReadWrite)]
+        public uint MaxCookTime = 30;
 
         /// <summary>
         ///     The max temperature that this microwave can heat objects to.

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -479,15 +479,19 @@ namespace Content.Server.Kitchen.EntitySystems
             UpdateUserInterfaceState(uid, component);
         }
 
-        private void OnSelectTime(EntityUid uid, MicrowaveComponent component, MicrowaveSelectCookTimeMessage args)
+        private void OnSelectTime(EntityUid uid, MicrowaveComponent comp, MicrowaveSelectCookTimeMessage args)
         {
-            if (!HasContents(component) || HasComp<ActiveMicrowaveComponent>(uid) || !(TryComp<ApcPowerReceiverComponent>(uid, out var apc) && apc.Powered))
+            if (!HasContents(comp) || HasComp<ActiveMicrowaveComponent>(uid) || !(TryComp<ApcPowerReceiverComponent>(uid, out var apc) && apc.Powered))
                 return;
 
-            component.CurrentCookTimeButtonIndex = args.ButtonIndex;
-            component.CurrentCookTimerTime = args.NewCookTime;
-            _audio.PlayPvs(component.ClickSound, uid, AudioParams.Default.WithVolume(-2));
-            UpdateUserInterfaceState(uid, component);
+            // some validation to prevent trollage
+            if (args.NewCookTime % 5 != 0 || args.NewCookTime > comp.MaxCookTime)
+                return;
+
+            comp.CurrentCookTimeButtonIndex = args.ButtonIndex;
+            comp.CurrentCookTimerTime = args.NewCookTime;
+            _audio.PlayPvs(comp.ClickSound, uid, AudioParams.Default.WithVolume(-2));
+            UpdateUserInterfaceState(uid, comp);
         }
         #endregion
     }


### PR DESCRIPTION
## About the PR
- microwave now actually defaults to instant instead of 5 seconds, in line with the ui saying INSTANT
- added some basic validation since before you could just tell the server the microwave has to run for 2^32 - 1 seconds or a non multiple of 5 and it would do it???
  unfortunately since the max time is still on serverside microwave component the client isnt told so you cant VV a microwave that can have 5 mins selected on it, client is still hardcoded
- uh something else i think

verified ingame that instant is actually default now and microwaving for 30 seconds works

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed microwaves defaulting to 5 seconds when the ui said instant.
