### PR TITLE
make mice not eat uranium bananium and pills

### DIFF
--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -133,6 +133,10 @@ public sealed class NPCUtilitySystem : EntitySystem
                 if (!_food.IsDigestibleBy(owner, targetUid, food))
                     return 0f;
 
+                // no mouse don't eat the uranium-235
+                if (HasComp<BadFoodComponent>(targetUid))
+                    return 0f;
+
                 return 1f;
             }
             case TargetAccessibleCon:

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -121,6 +121,7 @@ public sealed class NPCUtilitySystem : EntitySystem
 
     private float GetScore(NPCBlackboard blackboard, EntityUid targetUid, UtilityConsideration consideration)
     {
+        var avoidBadFood = HasComp<IgnoreBadFoodComponent>(owner);
         switch (consideration)
         {
             case FoodValueCon:
@@ -134,7 +135,7 @@ public sealed class NPCUtilitySystem : EntitySystem
                     return 0f;
 
                 // no mouse don't eat the uranium-235
-                if (HasComp<BadFoodComponent>(targetUid))
+                if (avoidBadFood && HasComp<BadFoodComponent>(targetUid))
                     return 0f;
 
                 return 1f;

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -121,7 +121,7 @@ public sealed class NPCUtilitySystem : EntitySystem
 
     private float GetScore(NPCBlackboard blackboard, EntityUid targetUid, UtilityConsideration consideration)
     {
-        var avoidBadFood = HasComp<IgnoreBadFoodComponent>(owner);
+        var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
         switch (consideration)
         {
             case FoodValueCon:
@@ -129,12 +129,11 @@ public sealed class NPCUtilitySystem : EntitySystem
                 if (!TryComp<FoodComponent>(targetUid, out var food))
                     return 0f;
 
-                var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
-
                 if (!_food.IsDigestibleBy(owner, targetUid, food))
                     return 0f;
 
                 // no mouse don't eat the uranium-235
+                var avoidBadFood = !HasComp<IgnoreBadFoodComponent>(owner);
                 if (avoidBadFood && HasComp<BadFoodComponent>(targetUid))
                     return 0f;
 
@@ -165,7 +164,6 @@ public sealed class NPCUtilitySystem : EntitySystem
             }
             case TargetDistanceCon:
             {
-                var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
                 var radius = blackboard.GetValueOrDefault<float>(NPCBlackboard.VisionRadius, EntityManager);
 
                 if (!TryComp<TransformComponent>(targetUid, out var targetXform) ||
@@ -188,14 +186,12 @@ public sealed class NPCUtilitySystem : EntitySystem
             }
             case TargetInLOSCon:
             {
-                var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
                 var radius = blackboard.GetValueOrDefault<float>(NPCBlackboard.VisionRadius, EntityManager);
 
                 return ExamineSystemShared.InRangeUnOccluded(owner, targetUid, radius + 0.5f, null) ? 1f : 0f;
             }
             case TargetInLOSOrCurrentCon:
             {
-                var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
                 var radius = blackboard.GetValueOrDefault<float>(NPCBlackboard.VisionRadius, EntityManager);
                 const float bufferRange = 0.5f;
 

--- a/Content.Server/Nutrition/Components/BadFoodComponent.cs
+++ b/Content.Server/Nutrition/Components/BadFoodComponent.cs
@@ -3,7 +3,7 @@ using Content.Server.Nutrition.EntitySystems;
 namespace Content.Server.Nutrition.Components;
 
 /// <summary>
-/// This component prevents ai mobs like mice from wanting to eat something that is edible but is not exactly food.
+/// This component prevents NPC mobs like mice from wanting to eat something that is edible but is not exactly food.
 /// Including but not limited to: uranium, death pills, insulation
 /// </summary>
 [RegisterComponent, Access(typeof(FoodSystem))]

--- a/Content.Server/Nutrition/Components/BadFoodComponent.cs
+++ b/Content.Server/Nutrition/Components/BadFoodComponent.cs
@@ -1,0 +1,12 @@
+using Content.Server.Nutrition.EntitySystems;
+
+namespace Content.Server.Nutrition.Components;
+
+/// <summary>
+/// This component prevents ai mobs like mice from wanting to eat something that is edible but is not exactly food.
+/// Including but not limited to: uranium, death pills, insulation
+/// </summary>
+[RegisterComponent, Access(typeof(FoodSystem))]
+public sealed class BadFoodComponent : Component
+{
+}

--- a/Content.Server/Nutrition/Components/IgnoreBadFoodComponent.cs
+++ b/Content.Server/Nutrition/Components/IgnoreBadFoodComponent.cs
@@ -3,7 +3,7 @@ using Content.Server.Nutrition.EntitySystems;
 namespace Content.Server.Nutrition.Components;
 
 /// <summary>
-/// This component allows ai mobs to eat food with BadFoodComponent.
+/// This component allows NPC mobs to eat food with BadFoodComponent.
 /// See MobMouseAdmeme for usage.
 /// </summary>
 [RegisterComponent, Access(typeof(FoodSystem))]

--- a/Content.Server/Nutrition/Components/IgnoreBadFoodComponent.cs
+++ b/Content.Server/Nutrition/Components/IgnoreBadFoodComponent.cs
@@ -1,0 +1,12 @@
+using Content.Server.Nutrition.EntitySystems;
+
+namespace Content.Server.Nutrition.Components;
+
+/// <summary>
+/// This component allows ai mobs to eat food with BadFoodComponent.
+/// See MobMouseAdmeme for usage.
+/// </summary>
+[RegisterComponent, Access(typeof(FoodSystem))]
+public sealed class IgnoreBadFoodComponent : Component
+{
+}

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -947,6 +947,17 @@
 
 - type: entity
   parent: MobMouse
+  id: MobMouseAdmeme
+  suffix: Admeme
+  components:
+  # allow admeme mouse to eat pills
+  - type: IgnoreBadFood
+  # intended for swarms that eat pills so only temporary
+  - type: TimedDespawn
+    lifetime: 60
+
+- type: entity
+  parent: MobMouse
   id: MobMouse1
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -157,6 +157,7 @@
   - type: Material
   - type: Food
     transferAmount: 10
+  - type: BadFood
   - type: PhysicalComposition
     materialComposition:
       Uranium: 100

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -322,6 +322,7 @@
       - banana
   - type: Food
     trash: TrashBananiumPeel
+  - type: BadFood
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -292,6 +292,7 @@
     transferAmount: null
     eatMessage: food-swallow
     useSound: /Audio/Items/pill.ogg
+  - type: BadFood
   - type: FlavorProfile
     ignoreReagents: []
   - type: SolutionContainerManager


### PR DESCRIPTION
## About the PR
fixes #16149 by adding BadFood marker component and gives it to uranium, bananium ore and pill items
ai will ignore food with BadFood

afaik no ore is edible so ore wasnt an issue, material sheets (uranium) were

**Media**
mouse not eat pill or uranium
![01:39:56](https://github.com/space-wizards/space-station-14/assets/39013340/c0f834d4-60a3-4fc3-bc1d-0ddb3029a7df)

mouse still eat breab
![01:40:03](https://github.com/space-wizards/space-station-14/assets/39013340/484f7f01-e80c-4551-bdf2-9f4deae9d624)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: CentCom's Ministry Of Truth has trained station mice to stop eating uranium.
