### PR TITLE
Replace industrial welder with experimental welder for Advanced Tools tech

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -250,7 +250,7 @@
       - ClothingBackpackHolding
       - ClothingBackpackSatchelHolding
       - ClothingBackpackDuffelHolding
-      - WelderIndustrialAdvanced
+      - WelderExperimental
       - JawsOfLife
 
 - type: entity

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -186,8 +186,8 @@
     Plastic: 100
 
 - type: latheRecipe
-  id: WelderIndustrialAdvanced
-  result: WelderIndustrialAdvanced
+  id: WelderExperimental
+  result: WelderExperimental
   completetime: 6
   materials:
     Steel: 800

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -181,7 +181,7 @@
   tier: 2
   cost: 10000
   recipeUnlocks:
-    - WelderIndustrialAdvanced
+    - WelderExperimental
     - PowerDrill
     - JawsOfLife
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
a 250 capacity welder is a garbage upgrade.
instead, replace it with the actual good welder (which is the icon, anyways)

Closes #17111 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Advanced tools now has the recipe for the Experimental welding tool instead of the Industrial welding tool
