### PR TITLE
Give categories to some reagents

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -111,6 +111,25 @@
         amount: 0.05
 
 - type: reagent
+  id: JuiceBerryPoison
+  name: reagent-name-juice-berry-poison
+  group: Drinks
+  desc: reagent-desc-juice-berry-poison
+  physicalDesc: reagent-physical-desc-sickly
+  flavor: bitter
+  color: "#6600CC"
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 1
+
+- type: reagent
   id: Lemonade
   name: reagent-name-lemonade
   group: Drinks

--- a/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
@@ -27,24 +27,6 @@
   color: "#660099"
 
 - type: reagent
-  id: JuiceBerryPoison
-  name: reagent-name-juice-berry-poison
-  desc: reagent-desc-juice-berry-poison
-  physicalDesc: reagent-physical-desc-sickly
-  flavor: bitter
-  color: "#6600CC"
-  metabolisms:
-    Drink:
-      effects:
-      - !type:SatiateThirst
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 1
-
-- type: reagent
   id: JuiceCarrot
   name: reagent-name-juice-carrot
   parent: BaseDrink

--- a/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
@@ -165,6 +165,7 @@
 - type: reagent
   id: CapsaicinOil
   name: reagent-name-capsaicin-oil
+  group: Foods
   desc: reagent-desc-capsaicin-oil
   physicalDesc: reagent-physical-desc-oily
   flavor: spicy

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -370,6 +370,7 @@
 - type: reagent
   id: VentCrud
   name: reagent-name-vent-crud
+  group: Toxins
   desc: reagent-desc-vent-crud
   physicalDesc: reagent-physical-desc-sticky
   flavor: bitter
@@ -385,6 +386,7 @@
 - type: reagent
   id: Corpium
   name: reagent-name-corpium
+  group: Toxins
   desc: reagent-desc-corpium
   physicalDesc: reagent-physical-desc-necrotic
   flavor: bitter
@@ -400,6 +402,7 @@
 - type: reagent
   id: UncookedAnimalProteins
   name: reagent-name-uncooked-animal-proteins
+  group: Foods
   desc: reagent-desc-uncooked-animal-proteins
   physicalDesc: reagent-physical-desc-clumpy
   flavor: bitter
@@ -424,6 +427,7 @@
 - type: reagent
   id: Allicin
   name: reagent-name-allicin
+  group: Foods
   desc: reagent-desc-allicin
   physicalDesc: reagent-physical-desc-pungent
   flavor: bitter
@@ -445,6 +449,7 @@
 - type: reagent
   id: Pax
   name: reagent-name-pax
+  group: Narcotics
   desc: reagent-desc-pax
   physicalDesc: reagent-physical-desc-soothing
   color: "#AAAAAA"
@@ -460,6 +465,7 @@
 - type: reagent
   id: Honk
   name: reagent-name-honk
+  group: Toxins
   desc: reagent-desc-honk
   physicalDesc: reagent-physical-desc-pungent
   flavor: bitter


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
a bunch of reagents didn't have groups when they really should. This made them show up in the "Other" section of the guidebook instead of where they should be.

## The new categorization:
drinks:
- poison berry juice

Foods:
- capsaicin oil
- uncooked animal proteins
- allicin

Toxins:
- Vent crud
- corpium
- Honk

Narcotics:
- pax

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed several reagents showing up in the "other" section of the chem guidebook when they shouldn't have been.
