### PR TITLE
Rigged stunbatons

### DIFF
--- a/Content.Server/Stunnable/Components/StunbatonComponent.cs
+++ b/Content.Server/Stunnable/Components/StunbatonComponent.cs
@@ -5,9 +5,15 @@ using Robust.Shared.Audio;
 namespace Content.Server.Stunnable.Components
 {
     [RegisterComponent, Access(typeof(StunbatonSystem))]
+
     public sealed class StunbatonComponent : Component
     {
         public bool Activated = false;
+        public const string SolutionName = "baton";
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("rigged")]
+        public bool IsRigged = false;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("energyPerUse")]

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -44,6 +44,18 @@
           False: {state: stunbaton_off}
   - type: StaticPrice
     price: 100
+  - type: Explosive
+    explosionType: Default
+    intensitySlope: 1.5
+    maxIntensity: 200
+  - type: SolutionContainerManager
+    solutions:
+      baton:
+        maxVol: 10
+  - type: InjectableSolution
+    solution: baton
+  - type: DrawableSolution
+    solution: baton
 
 - type: entity
   name: flash


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Allows stunbatons to be injected with up 10 units of plasma, injecting 5u and over makes the stunbaton rigged to explode upon being turned on.

The explosion can rip tiles but is unable to crit a healthy person outright.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/109166122/bde1aefa-953a-4be0-b5ab-e805cf1fc1aa


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: The clown has figured out how to inject plasma into stunbatons and has now taught this knowledge to the entire station to the detriment of security officers worldwide.
