### PR TITLE
only show flavor above 0.1u

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/FlavorProfileSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FlavorProfileSystem.cs
@@ -25,12 +25,12 @@ public sealed class FlavorProfileSystem : EntitySystem
     public string GetLocalizedFlavorsMessage(EntityUid uid, EntityUid user, Solution solution,
         FlavorProfileComponent? flavorProfile = null)
     {
-        var flavors = new HashSet<string>();
         if (!Resolve(uid, ref flavorProfile, false))
         {
             return Loc.GetString(BackupFlavorMessage);
         }
 
+        var flavors = new HashSet<string>();
         flavors.UnionWith(flavorProfile.Flavors);
         flavors.UnionWith(GetFlavorsFromReagents(solution, FlavorLimit - flavors.Count, flavorProfile.IgnoreReagents));
 
@@ -87,6 +87,12 @@ public sealed class FlavorProfileSystem : EntitySystem
         foreach (var reagent in solution.Contents)
         {
             if (toIgnore != null && toIgnore.Contains(reagent.ReagentId))
+            {
+                continue;
+            }
+
+            // don't care if the quantity is negligible
+            if (reagent.Quantity < 0.1)
             {
                 continue;
             }

--- a/Content.Server/Nutrition/EntitySystems/FlavorProfileSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FlavorProfileSystem.cs
@@ -91,18 +91,19 @@ public sealed class FlavorProfileSystem : EntitySystem
                 continue;
             }
 
-            // don't care if the quantity is negligible
-            if (reagent.Quantity < 0.1)
-            {
-                continue;
-            }
-
             if (flavors.Count == desiredAmount)
             {
                 break;
             }
 
-            var flavor = _prototypeManager.Index<ReagentPrototype>(reagent.ReagentId).Flavor;
+            var proto = _prototypeManager.Index<ReagentPrototype>(reagent.ReagentId);
+            // don't care if the quantity is negligible
+            if (reagent.Quantity < proto.FlavorMinimum)
+            {
+                continue;
+            }
+
+            var flavor = proto.Flavor;
 
             flavors.Add(flavor);
         }

--- a/Content.Server/Nutrition/EntitySystems/FlavorProfileSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FlavorProfileSystem.cs
@@ -30,8 +30,7 @@ public sealed class FlavorProfileSystem : EntitySystem
             return Loc.GetString(BackupFlavorMessage);
         }
 
-        var flavors = new HashSet<string>();
-        flavors.UnionWith(flavorProfile.Flavors);
+        var flavors = new HashSet<string>(flavorProfile.Flavors);
         flavors.UnionWith(GetFlavorsFromReagents(solution, FlavorLimit - flavors.Count, flavorProfile.IgnoreReagents));
 
         var ev = new FlavorProfileModificationEvent(user, flavors);

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -67,7 +67,7 @@ namespace Content.Shared.Chemistry.Reagent
         /// There must be at least this much quantity in a solution to be tasted.
         /// </summary>
         [DataField("flavorMinimum")]
-        public float FlavorMinimum = 0.1;
+        public float FlavorMinimum = 0.1f;
 
         [DataField("color")]
         public Color SubstanceColor { get; } = Color.White;

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -67,7 +67,7 @@ namespace Content.Shared.Chemistry.Reagent
         /// There must be at least this much quantity in a solution to be tasted.
         /// </summary>
         [DataField("flavorMinimum")]
-        public float FlavorMinimum = 0.1f;
+        public FixedPoint2 FlavorMinimum = FixedPoint2.New(0.1f);
 
         [DataField("color")]
         public Color SubstanceColor { get; } = Color.White;

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -63,6 +63,12 @@ namespace Content.Shared.Chemistry.Reagent
         [DataField("flavor")]
         public string Flavor { get; } = default!;
 
+        /// <summary>
+        /// There must be at least this much quantity in a solution to be tasted.
+        /// </summary>
+        [DataField("flavorMinimum")]
+        public float FlavorMinimum = 0.1;
+
         [DataField("color")]
         public Color SubstanceColor { get; } = Color.White;
 

--- a/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
@@ -139,6 +139,7 @@
   desc: reagent-desc-oil-olive
   physicalDesc: reagent-physical-desc-oily
   flavor: oily
+  flavorMinimum: 0.05
   color: olive
   recognizable: true
   metabolisms:
@@ -155,6 +156,7 @@
   desc: reagent-desc-oil
   physicalDesc: reagent-physical-desc-oily
   flavor: oily
+  flavorMinimum: 0.05
   recognizable: true
   color: "#b67823"
   boilingPoint: 300.0
@@ -169,6 +171,7 @@
   desc: reagent-desc-capsaicin-oil
   physicalDesc: reagent-physical-desc-oily
   flavor: spicy
+  flavorMinimum: 0.05
   color: "#FF0000"
   recognizable: true
   meltingPoint: 146

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -283,6 +283,7 @@
   desc: reagent-desc-thc-oil
   physicalDesc: reagent-physical-desc-skunky
   flavor: bitter
+  flavorMinimum: 0.05
   color: "#DAA520"
   metabolisms:
     Narcotic:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -144,6 +144,7 @@
   physicalDesc: reagent-physical-desc-oily
   slippery: true
   flavor: bitter
+  flavorMinimum: 0.01
   color: "#a76b1c"
   recognizable: true
   boilingPoint: -84.7 # Acetylene. Close enough.


### PR DESCRIPTION
## About the PR
if a pill has say 0.01u carbon you could taste it
this pr fixes and only lets you taste it if its above 0.1u in the solution being ingested

**Media**
less than 0.1u sugar
![22:53:01](https://github.com/space-wizards/space-station-14/assets/39013340/ff4eb028-8693-46f6-8391-0ededa0986ba)
does not taste sweet!
![22:53:07](https://github.com/space-wizards/space-station-14/assets/39013340/fbf57fab-8bbd-446b-aef0-7e3f4a731081)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun