### PR TITLE
Misc implant fixes

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
@@ -1,7 +1,7 @@
 ﻿using Content.Server.Explosion.Components;
+using Content.Shared.Implants;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs;
-using Robust.Shared.Player;
 
 namespace Content.Server.Explosion.EntitySystems;
 
@@ -11,6 +11,9 @@ public sealed partial class TriggerSystem
     {
         SubscribeLocalEvent<TriggerOnMobstateChangeComponent, MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<TriggerOnMobstateChangeComponent, SuicideEvent>(OnSuicide);
+
+        SubscribeLocalEvent<TriggerOnMobstateChangeComponent, ImplantRelayEvent<SuicideEvent>>(OnSuicideRelay);
+        SubscribeLocalEvent<TriggerOnMobstateChangeComponent, ImplantRelayEvent<MobStateChangedEvent>>(OnMobStateRelay);
     }
 
     private void OnMobStateChanged(EntityUid uid, TriggerOnMobstateChangeComponent component, MobStateChangedEvent args)
@@ -44,5 +47,15 @@ public sealed partial class TriggerSystem
             _popupSystem.PopupEntity(Loc.GetString("suicide-prevented"), args.Victim, args.Victim);
             args.BlockSuicideAttempt(component.PreventSuicide);
         }
+    }
+
+    private void OnSuicideRelay(EntityUid uid, TriggerOnMobstateChangeComponent component, ImplantRelayEvent<SuicideEvent> args)
+    {
+        OnSuicide(uid, component, args.Event);
+    }
+
+    private void OnMobStateRelay(EntityUid uid, TriggerOnMobstateChangeComponent component, ImplantRelayEvent<MobStateChangedEvent> args)
+    {
+        OnMobStateChanged(uid, component, args.Event);
     }
 }

--- a/Content.Server/Implants/ImplanterSystem.cs
+++ b/Content.Server/Implants/ImplanterSystem.cs
@@ -48,10 +48,12 @@ public sealed partial class ImplanterSystem : SharedImplanterSystem
         }
         else
         {
+            if (!CanImplant(args.User, args.Target.Value, uid, component, out _, out _))
+                return;
+
             //Implant self instantly, otherwise try to inject the target.
             if (args.User == args.Target)
-                Implant(uid, args.Target.Value, component);
-
+                Implant(args.User, args.Target.Value, uid, component);
             else
                 TryImplant(component, args.User, args.Target.Value, uid);
         }
@@ -117,7 +119,7 @@ public sealed partial class ImplanterSystem : SharedImplanterSystem
         if (args.Cancelled || args.Handled || args.Target == null || args.Used == null)
             return;
 
-        Implant(args.Used.Value, args.Target.Value, component);
+        Implant(args.User, args.Target.Value, args.Used.Value, component);
 
         args.Handled = true;
     }

--- a/Content.Server/Implants/SubdermalImplantSystem.cs
+++ b/Content.Server/Implants/SubdermalImplantSystem.cs
@@ -5,44 +5,31 @@ using Content.Shared.Cuffs.Components;
 using Content.Shared.Implants;
 using Content.Shared.Implants.Components;
 using Content.Shared.Interaction;
-using Content.Shared.Interaction.Events;
-using Content.Shared.Mobs;
 using Content.Shared.Popups;
-using Robust.Shared.Containers;
 
 namespace Content.Server.Implants;
 
 public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
 {
     [Dependency] private readonly CuffableSystem _cuffable = default!;
-    [Dependency] private readonly SharedContainerSystem _container = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly StoreSystem _store = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<SubdermalImplantComponent, UseFreedomImplantEvent>(OnFreedomImplant);
-
-        SubscribeLocalEvent<StoreComponent, AfterInteractUsingEvent>(OnUplinkInteractUsing);
-
-        SubscribeLocalEvent<ImplantedComponent, MobStateChangedEvent>(RelayToImplantEvent);
-        SubscribeLocalEvent<ImplantedComponent, AfterInteractUsingEvent>(RelayToImplantEvent);
-        SubscribeLocalEvent<ImplantedComponent, SuicideEvent>(RelayToImplantEvent);
+        SubscribeLocalEvent<StoreComponent, ImplantRelayEvent<AfterInteractUsingEvent>>(OnStoreRelay);
     }
 
-    private void OnFreedomImplant(EntityUid uid, SubdermalImplantComponent component, UseFreedomImplantEvent args)
+    private void OnStoreRelay(EntityUid uid, StoreComponent store, ImplantRelayEvent<AfterInteractUsingEvent> implantRelay)
     {
-        if (!TryComp<CuffableComponent>(component.ImplantedEntity, out var cuffs) || cuffs.Container.ContainedEntities.Count < 1)
+        var args = implantRelay.Event;
+
+        if (args.Handled)
             return;
 
-        _cuffable.Uncuff(component.ImplantedEntity.Value, cuffs.LastAddedCuffs, cuffs.LastAddedCuffs);
-        args.Handled = true;
-    }
-
-    private void OnUplinkInteractUsing(EntityUid uid, StoreComponent store, AfterInteractUsingEvent args)
-    {
         // can only insert into yourself to prevent uplink checking with renault
         if (args.Target != args.User)
             return;
@@ -61,46 +48,12 @@ public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
         QueueDel(args.Used);
     }
 
-    #region Relays
-
-    //Relays from the implanted to the implant
-    private void RelayToImplantEvent<T>(EntityUid uid, ImplantedComponent component, T args) where T: notnull
+    private void OnFreedomImplant(EntityUid uid, SubdermalImplantComponent component, UseFreedomImplantEvent args)
     {
-        if (!_container.TryGetContainer(uid, ImplanterComponent.ImplantSlotId, out var implantContainer))
+        if (!TryComp<CuffableComponent>(component.ImplantedEntity, out var cuffs) || cuffs.Container.ContainedEntities.Count < 1)
             return;
-        foreach (var implant in implantContainer.ContainedEntities)
-        {
-            RaiseLocalEvent(implant, args);
-        }
-    }
 
-    //Relays from the implanted to the implant
-    private void RelayToImplantEventByRef<T>(EntityUid uid, ImplantedComponent component, ref T args) where T: notnull
-    {
-        if (!_container.TryGetContainer(uid, ImplanterComponent.ImplantSlotId, out var implantContainer))
-            return;
-        foreach (var implant in implantContainer.ContainedEntities)
-        {
-            RaiseLocalEvent(implant,ref args);
-        }
+        _cuffable.Uncuff(component.ImplantedEntity.Value, cuffs.LastAddedCuffs, cuffs.LastAddedCuffs);
+        args.Handled = true;
     }
-
-    //Relays from the implant to the implanted
-    private void RelayToImplantedEvent<T>(EntityUid uid, SubdermalImplantComponent component, T args) where T : EntityEventArgs
-    {
-        if (component.ImplantedEntity != null)
-        {
-            RaiseLocalEvent(component.ImplantedEntity.Value, args);
-        }
-    }
-
-    private void RelayToImplantedEventByRef<T>(EntityUid uid, SubdermalImplantComponent component, ref T args) where T : EntityEventArgs
-    {
-        if (component.ImplantedEntity != null)
-        {
-            RaiseLocalEvent(component.ImplantedEntity.Value, ref args);
-        }
-    }
-
-    #endregion
 }

--- a/Content.Server/PDA/Ringer/RingerSystem.cs
+++ b/Content.Server/PDA/Ringer/RingerSystem.cs
@@ -34,9 +34,17 @@ namespace Content.Server.PDA.Ringer
             SubscribeLocalEvent<RingerComponent, RingerPlayRingtoneMessage>(RingerPlayRingtone);
             SubscribeLocalEvent<RingerComponent, RingerRequestUpdateInterfaceMessage>(UpdateRingerUserInterfaceDriver);
 
+            SubscribeLocalEvent<RingerUplinkComponent, CurrencyInsertAttemptEvent>(OnCurrencyInsert);
         }
 
         //Event Functions
+
+        private void OnCurrencyInsert(EntityUid uid, RingerUplinkComponent uplink, CurrencyInsertAttemptEvent args)
+        {
+            // if the store can be locked, it must be unlocked first before inserting currency. Stops traitor checking.
+            if (!uplink.Unlocked)
+                args.Cancel();
+        }
 
         private void RingerPlayRingtone(EntityUid uid, RingerComponent ringer, RingerPlayRingtoneMessage args)
         {

--- a/Content.Server/Store/Systems/StoreSystem.cs
+++ b/Content.Server/Store/Systems/StoreSystem.cs
@@ -70,12 +70,12 @@ public sealed partial class StoreSystem : EntitySystem
         if (args.Handled || !args.CanReach)
             return;
 
-        if (args.Target == null || !TryComp<StoreComponent>(args.Target, out var store))
+        if (!TryComp<StoreComponent>(args.Target, out var store))
             return;
 
-        // if the store can be locked, it must be unlocked first before inserting currency
-        var user = args.User;
-        if (TryComp<RingerUplinkComponent>(args.Target, out var uplink) && !uplink.Unlocked)
+        var ev = new CurrencyInsertAttemptEvent(args.User, args.Target.Value, args.Used, store);
+        RaiseLocalEvent(args.Target.Value, ev);
+        if (ev.Cancelled)
             return;
 
         args.Handled = TryAddCurrency(GetCurrencyValue(uid, component), args.Target.Value, store);
@@ -187,5 +187,21 @@ public sealed partial class StoreSystem : EntitySystem
         {
             _ui.SetUiState(ui, new StoreInitializeState(preset.StoreName));
         }
+    }
+}
+
+public sealed class CurrencyInsertAttemptEvent : CancellableEntityEventArgs
+{
+    public readonly EntityUid User;
+    public readonly EntityUid Target;
+    public readonly EntityUid Used;
+    public readonly StoreComponent Store;
+
+    public CurrencyInsertAttemptEvent(EntityUid user, EntityUid target, EntityUid used, StoreComponent store)
+    {
+        User = user;
+        Target = target;
+        Used = used;
+        Store = store;
     }
 }

--- a/Content.Shared/Implants/Components/ImplanterComponent.cs
+++ b/Content.Shared/Implants/Components/ImplanterComponent.cs
@@ -67,7 +67,7 @@ public sealed class ImplanterComponent : Component
     /// The <see cref="ItemSlot"/> for this implanter
     /// </summary>
     [ViewVariables]
-    [DataField("implanterSlot")]
+    [DataField("implanterSlot", required:true)]
     public ItemSlot ImplanterSlot = new();
 
     public bool UiUpdateNeeded;


### PR DESCRIPTION
- Implants now wrap relayed interactions in `ImplantRelayEvent<T>` rather than just blindly redirecting them, which is prone to introducing bugs. AFAIK these were only used by the trigger & store implants. If there were other uses the PR will need updating.
- Currency insertion now checks to see that the event is handled before adding currency.
- Adding an implant now raises an `AddImplantAttemptEvent`, so that implants can be blocked.

:cl:
- fix: Fixed a bug that allowed traitors to duplicate TCs
