### PR TITLE
Purge IoC resolves from integration tests

### DIFF
--- a/Content.IntegrationTests/Tests/Body/LegTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LegTest.cs
@@ -35,14 +35,13 @@ namespace Content.IntegrationTests.Tests.Body
             var server = pairTracker.Pair.Server;
 
             AppearanceComponent appearance = null;
+            var entityManager = server.ResolveDependency<IEntityManager>();
+            var mapManager = server.ResolveDependency<IMapManager>();
 
             await server.WaitAssertion(() =>
             {
-                var mapManager = IoCManager.Resolve<IMapManager>();
-
                 var mapId = mapManager.CreateMap();
 
-                var entityManager = IoCManager.Resolve<IEntityManager>();
                 var human = entityManager.SpawnEntity("HumanBodyAndAppearanceDummy",
                     new MapCoordinates(Vector2.Zero, mapId));
 
@@ -52,7 +51,7 @@ namespace Content.IntegrationTests.Tests.Body
                 Assert.That(!appearance.TryGetData(RotationVisuals.RotationState, out RotationState _));
 
                 var bodySystem = entityManager.System<BodySystem>();
-                var legs = bodySystem.GetBodyChildrenOfType(body.Owner, BodyPartType.Leg, body);
+                var legs = bodySystem.GetBodyChildrenOfType(human, BodyPartType.Leg, body);
 
                 foreach (var leg in legs)
                 {

--- a/Content.IntegrationTests/Tests/Cleanup/EuiManagerTest.cs
+++ b/Content.IntegrationTests/Tests/Cleanup/EuiManagerTest.cs
@@ -20,11 +20,11 @@ public sealed class EuiManagerTest
             var server = pairTracker.Pair.Server;
 
             var sPlayerManager = server.ResolveDependency<IPlayerManager>();
+            var eui = server.ResolveDependency<EuiManager>();
 
             await server.WaitAssertion(() =>
             {
                 var clientSession = sPlayerManager.ServerSessions.Single();
-                var eui = IoCManager.Resolve<EuiManager>();
                 var ui = new AdminAnnounceEui();
                 eui.OpenEui(ui, clientSession);
             });

--- a/Content.IntegrationTests/Tests/ContainerOcclusionTest.cs
+++ b/Content.IntegrationTests/Tests/ContainerOcclusionTest.cs
@@ -42,14 +42,15 @@ namespace Content.IntegrationTests.Tests
             var c = pairTracker.Pair.Client;
 
             var cEntities = c.ResolveDependency<IEntityManager>();
+            var ent = s.ResolveDependency<IEntityManager>();
 
             EntityUid dummy = default;
-            var ent2 = s.ResolveDependency<IMapManager>();
+            var mapManager = s.ResolveDependency<IMapManager>();
+            var mapId = mapManager.CreateMap();
+
             await s.WaitPost(() =>
             {
-                var mapId = ent2.GetAllMapIds().Last();
                 var pos = new MapCoordinates(Vector2.Zero, mapId);
-                var ent = IoCManager.Resolve<IEntityManager>();
                 var entStorage = ent.EntitySysManager.GetEntitySystem<EntityStorageSystem>();
                 var container = ent.SpawnEntity("ContainerOcclusionA", pos);
                 dummy = ent.SpawnEntity("ContainerOcclusionDummy", pos);
@@ -78,14 +79,15 @@ namespace Content.IntegrationTests.Tests
             var c = pairTracker.Pair.Client;
 
             var cEntities = c.ResolveDependency<IEntityManager>();
-            var ent2 = s.ResolveDependency<IMapManager>();
+            var ent = s.ResolveDependency<IEntityManager>();
 
             EntityUid dummy = default;
+            var mapManager = s.ResolveDependency<IMapManager>();
+            var mapId = mapManager.CreateMap();
+
             await s.WaitPost(() =>
             {
-                var mapId = ent2.GetAllMapIds().Last();
                 var pos = new MapCoordinates(Vector2.Zero, mapId);
-                var ent = IoCManager.Resolve<IEntityManager>();
                 var entStorage = ent.EntitySysManager.GetEntitySystem<EntityStorageSystem>();
                 var container = ent.SpawnEntity("ContainerOcclusionB", pos);
                 dummy = ent.SpawnEntity("ContainerOcclusionDummy", pos);
@@ -113,15 +115,16 @@ namespace Content.IntegrationTests.Tests
             var s = pairTracker.Pair.Server;
             var c = pairTracker.Pair.Client;
 
-            var ent2 = s.ResolveDependency<IMapManager>();
             var cEntities = c.ResolveDependency<IEntityManager>();
+            var ent = s.ResolveDependency<IEntityManager>();
 
             EntityUid dummy = default;
+            var mapManager = s.ResolveDependency<IMapManager>();
+            var mapId = mapManager.CreateMap();
+
             await s.WaitPost(() =>
             {
-                var mapId = ent2.GetAllMapIds().Last();
                 var pos = new MapCoordinates(Vector2.Zero, mapId);
-                var ent = IoCManager.Resolve<IEntityManager>();
                 var entStorage = ent.EntitySysManager.GetEntitySystem<EntityStorageSystem>();
                 var containerA = ent.SpawnEntity("ContainerOcclusionA", pos);
                 var containerB = ent.SpawnEntity("ContainerOcclusionB", pos);

--- a/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
@@ -105,7 +105,7 @@ namespace Content.IntegrationTests.Tests.Damageable
                 var coordinates = new MapCoordinates(0, 0, map);
 
                 sDamageableEntity = sEntityManager.SpawnEntity("TestDamageableEntityId", coordinates);
-                sDamageableComponent = IoCManager.Resolve<IEntityManager>().GetComponent<DamageableComponent>(sDamageableEntity);
+                sDamageableComponent = sEntityManager.GetComponent<DamageableComponent>(sDamageableEntity);
                 sDamageableSystem = sEntitySystemManager.GetEntitySystem<DamageableSystem>();
 
                 group1 = sPrototypeManager.Index<DamageGroupPrototype>("TestGroup1");

--- a/Content.IntegrationTests/Tests/DeleteInventoryTest.cs
+++ b/Content.IntegrationTests/Tests/DeleteInventoryTest.cs
@@ -20,14 +20,15 @@ namespace Content.IntegrationTests.Tests
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true});
             var server = pairTracker.Pair.Server;
             var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var entMgr = server.ResolveDependency<IEntityManager>();
+            var sysManager = server.ResolveDependency<IEntitySystemManager>();
             var coordinates = testMap.GridCoords;
 
             await server.WaitAssertion(() =>
             {
                 // Spawn everything.
-                var invSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<InventorySystem>();
+                var invSystem = sysManager.GetEntitySystem<InventorySystem>();
 
-                var entMgr = IoCManager.Resolve<IEntityManager>();
                 var container = entMgr.SpawnEntity(null, coordinates);
                 entMgr.EnsureComponent<InventoryComponent>(container);
                 entMgr.EnsureComponent<ContainerManagerComponent>(container);
@@ -35,7 +36,7 @@ namespace Content.IntegrationTests.Tests
                 var child = entMgr.SpawnEntity(null, coordinates);
                 var item = entMgr.EnsureComponent<ClothingComponent>(child);
 
-                IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ClothingSystem>().SetSlots(item.Owner, SlotFlags.HEAD, item);
+                sysManager.GetEntitySystem<ClothingSystem>().SetSlots(child, SlotFlags.HEAD, item);
 
                 // Equip item.
                 Assert.That(invSystem.TryEquip(container, child, "head"), Is.True);

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
@@ -26,6 +26,7 @@ namespace Content.IntegrationTests.Tests.Destructible
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var sEntitySystemManager = server.ResolveDependency<IEntitySystemManager>();
+            var protoManager = server.ResolveDependency<IPrototypeManager>();
 
             EntityUid sDestructibleEntity = default;
             DamageableComponent sDamageableComponent = null;
@@ -37,7 +38,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                 var coordinates = testMap.GridCoords;
 
                 sDestructibleEntity = sEntityManager.SpawnEntity(DestructibleDamageTypeEntityId, coordinates);
-                sDamageableComponent = IoCManager.Resolve<IEntityManager>().GetComponent<DamageableComponent>(sDestructibleEntity);
+                sDamageableComponent = sEntityManager.GetComponent<DamageableComponent>(sDestructibleEntity);
                 sTestThresholdListenerSystem = sEntitySystemManager.GetEntitySystem<TestDestructibleListenerSystem>();
                 sTestThresholdListenerSystem.ThresholdsReached.Clear();
                 sDamageableSystem = sEntitySystemManager.GetEntitySystem<DamageableSystem>();
@@ -52,8 +53,8 @@ namespace Content.IntegrationTests.Tests.Destructible
 
             await server.WaitAssertion(() =>
             {
-                var bluntDamageType = IoCManager.Resolve<IPrototypeManager>().Index<DamageTypePrototype>("TestBlunt");
-                var slashDamageType = IoCManager.Resolve<IPrototypeManager>().Index<DamageTypePrototype>("TestSlash");
+                var bluntDamageType = protoManager.Index<DamageTypePrototype>("TestBlunt");
+                var slashDamageType = protoManager.Index<DamageTypePrototype>("TestSlash");
 
                 var bluntDamage = new DamageSpecifier(bluntDamageType,5);
                 var slashDamage = new DamageSpecifier(slashDamageType,5);

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
@@ -41,7 +41,7 @@ namespace Content.IntegrationTests.Tests.Destructible
 
             await server.WaitAssertion(() =>
             {
-                var coordinates = IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(sDestructibleEntity).Coordinates;
+                var coordinates = sEntityManager.GetComponent<TransformComponent>(sDestructibleEntity).Coordinates;
                 var bruteDamageGroup = sPrototypeManager.Index<DamageGroupPrototype>("TestBrute");
                 DamageSpecifier bruteDamage = new(bruteDamageGroup,50);
 

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -156,6 +156,8 @@ namespace Content.IntegrationTests.Tests.Disposal
             EntityUid wrench = default!;
             EntityUid disposalUnit = default!;
             EntityUid disposalTrunk = default!;
+
+            EntityUid unitUid = default;
             DisposalUnitComponent unitComponent = default!;
 
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -168,22 +170,22 @@ namespace Content.IntegrationTests.Tests.Disposal
                 wrench = entityManager.SpawnEntity("WrenchDummy", coordinates);
                 disposalUnit = entityManager.SpawnEntity("DisposalUnitDummy", coordinates);
                 disposalTrunk = entityManager.SpawnEntity("DisposalTrunkDummy",
-                    IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(disposalUnit).MapPosition);
+                    entityManager.GetComponent<TransformComponent>(disposalUnit).MapPosition);
 
                 // Test for components existing
-                ref DisposalUnitComponent? comp = ref unitComponent!;
-                Assert.True(entityManager.TryGetComponent(disposalUnit, out comp));
+                unitUid = disposalUnit;
+                Assert.True(entityManager.TryGetComponent(disposalUnit, out unitComponent));
                 Assert.True(entityManager.HasComponent<DisposalEntryComponent>(disposalTrunk));
 
                 // Can't insert, unanchored and unpowered
-                entityManager.GetComponent<TransformComponent>(unitComponent!.Owner).Anchored = false;
+                entityManager.GetComponent<TransformComponent>(unitUid).Anchored = false;
                 UnitInsertContains(unitComponent, false, human, wrench, disposalUnit, disposalTrunk);
             });
 
             await server.WaitAssertion(() =>
             {
                 // Anchor the disposal unit
-                entityManager.GetComponent<TransformComponent>(unitComponent.Owner).Anchored = true;
+                entityManager.GetComponent<TransformComponent>(unitUid).Anchored = true;
 
                 // No power
                 Assert.False(unitComponent.Powered);

--- a/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
+++ b/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
@@ -67,13 +67,14 @@ namespace Content.IntegrationTests.Tests.DoAfter
             await server.WaitIdleAsync();
 
             var entityManager = server.ResolveDependency<IEntityManager>();
+            var timing = server.ResolveDependency<IGameTiming>();
             var doAfterSystem = entityManager.EntitySysManager.GetEntitySystem<SharedDoAfterSystem>();
             var ev = new TestDoAfterEvent();
 
             // That it finishes successfully
             await server.WaitPost(() =>
             {
-                var tickTime = 1.0f / IoCManager.Resolve<IGameTiming>().TickRate;
+                var tickTime = 1.0f / timing.TickRate;
                 var mob = entityManager.SpawnEntity("Dummy", MapCoordinates.Nullspace);
                 var args = new DoAfterArgs(mob, tickTime / 2, ev, null) { Broadcast = true };
                 Assert.That(doAfterSystem.TryStartDoAfter(args));
@@ -92,14 +93,14 @@ namespace Content.IntegrationTests.Tests.DoAfter
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
             var entityManager = server.ResolveDependency<IEntityManager>();
+            var timing = server.ResolveDependency<IGameTiming>();
             var doAfterSystem = entityManager.EntitySysManager.GetEntitySystem<SharedDoAfterSystem>();
-            DoAfterId? id = default;
+            DoAfterId? id;
             var ev = new TestDoAfterEvent();
-
 
             await server.WaitPost(() =>
             {
-                var tickTime = 1.0f / IoCManager.Resolve<IGameTiming>().TickRate;
+                var tickTime = 1.0f / timing.TickRate;
 
                 var mob = entityManager.SpawnEntity("Dummy", MapCoordinates.Nullspace);
                 var args = new DoAfterArgs(mob, tickTime * 2, ev, null) { Broadcast = true };

--- a/Content.IntegrationTests/Tests/DummyIconTest.cs
+++ b/Content.IntegrationTests/Tests/DummyIconTest.cs
@@ -17,14 +17,15 @@ namespace Content.IntegrationTests.Tests
         {
             await using var pairTracker = await PoolManager.GetServerClient();
             var client = pairTracker.Pair.Client;
+            var prototypeManager = client.ResolveDependency<IPrototypeManager>();
+            var resourceCache = client.ResolveDependency<IResourceCache>();
 
             await client.WaitAssertion(() =>
             {
-                var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-                var resourceCache = IoCManager.Resolve<IResourceCache>();
                 foreach (var proto in prototypeManager.EnumeratePrototypes<EntityPrototype>())
                 {
-                    if (proto.NoSpawn || proto.Abstract || !proto.Components.ContainsKey("Sprite")) continue;
+                    if (proto.NoSpawn || proto.Abstract || !proto.Components.ContainsKey("Sprite"))
+                        continue;
 
                     Assert.DoesNotThrow(() =>
                     {

--- a/Content.IntegrationTests/Tests/FollowerSystemTest.cs
+++ b/Content.IntegrationTests/Tests/FollowerSystemTest.cs
@@ -22,12 +22,14 @@ public sealed class FollowerSystemTest
         await using var pairTracker = await PoolManager.GetServerClient(new (){NoClient = true});
         var server = pairTracker.Pair.Server;
 
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var sysMan = server.ResolveDependency<IEntitySystemManager>();
+        var logMan = server.ResolveDependency<ILogManager>();
+        var logger = logMan.RootSawmill;
+
         await server.WaitPost(() =>
         {
-            var mapMan = IoCManager.Resolve<IMapManager>();
-            var entMan = IoCManager.Resolve<IEntityManager>();
-            var sysMan = IoCManager.Resolve<IEntitySystemManager>();
-            var logger = IoCManager.Resolve<ILogManager>().RootSawmill;
             var followerSystem = sysMan.GetEntitySystem<FollowerSystem>();
 
             // Create a map to spawn the observers on.

--- a/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
@@ -49,13 +49,15 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
             CuffableComponent cuffed;
             HandsComponent hands;
 
+            var entityManager = server.ResolveDependency<IEntityManager>();
+            var mapManager = server.ResolveDependency<IMapManager>();
+            var host = server.ResolveDependency<IServerConsoleHost>();
+
             await server.WaitAssertion(() =>
             {
-                var mapManager = IoCManager.Resolve<IMapManager>();
                 var mapId = mapManager.CreateMap();
                 var coordinates = new MapCoordinates(Vector2.Zero, mapId);
 
-                var entityManager = IoCManager.Resolve<IEntityManager>();
                 var cuffableSys = entityManager.System<CuffableSystem>();
 
                 // Spawn the entities
@@ -81,8 +83,8 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
                     "Handcuffing a player did not result in their hands being cuffed");
 
                 // Test to ensure a player with 4 hands will still only have 2 hands cuffed
-                AddHand(human);
-                AddHand(human);
+                AddHand(human, host);
+                AddHand(human, host);
 
                 Assert.That(cuffed.CuffedHandCount, Is.EqualTo(2));
                 Assert.That(hands.SortedHands.Count, Is.EqualTo(4));
@@ -95,9 +97,8 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
             await pairTracker.CleanReturnAsync();
         }
 
-        private void AddHand(EntityUid to)
+        private void AddHand(EntityUid to, IServerConsoleHost host)
         {
-            var host = IoCManager.Resolve<IServerConsoleHost>();
             host.ExecuteCommand(null, $"addhand {to}");
         }
     }

--- a/Content.IntegrationTests/Tests/GravityGridTest.cs
+++ b/Content.IntegrationTests/Tests/GravityGridTest.cs
@@ -38,6 +38,7 @@ namespace Content.IntegrationTests.Tests
 
             EntityUid generator = default;
             var entityMan = server.ResolveDependency<IEntityManager>();
+            var mapMan = server.ResolveDependency<IMapManager>();
 
             MapGridComponent grid1 = null;
             MapGridComponent grid2 = null;
@@ -45,8 +46,6 @@ namespace Content.IntegrationTests.Tests
             // Create grids
             await server.WaitAssertion(() =>
             {
-                var mapMan = IoCManager.Resolve<IMapManager>();
-
                 var mapId = testMap.MapId;
                 grid1 = mapMan.CreateGrid(mapId);
                 grid2 = mapMan.CreateGrid(mapId);

--- a/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
+++ b/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
@@ -69,12 +69,11 @@ namespace Content.IntegrationTests.Tests
             EntityUid pocketItem = default;
 
             InventorySystem invSystem = default!;
+            var entityMan = server.ResolveDependency<IEntityManager>();
 
             await server.WaitAssertion(() =>
             {
-                invSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<InventorySystem>();
-                var mapMan = IoCManager.Resolve<IMapManager>();
-                var entityMan = IoCManager.Resolve<IEntityManager>();
+                invSystem = entityMan.System<InventorySystem>();
 
                 human = entityMan.SpawnEntity("HumanDummy", coordinates);
                 uniform = entityMan.SpawnEntity("UniformDummy", coordinates);
@@ -96,8 +95,8 @@ namespace Content.IntegrationTests.Tests
                 Assert.That(invSystem.CanEquip(human, tooBigItem, "pocket1", out _), Is.False); // Still failing!
                 Assert.That(invSystem.TryEquip(human, pocketItem, "pocket1"));
 
-                Assert.That(IsDescendant(idCard, human));
-                Assert.That(IsDescendant(pocketItem, human));
+                Assert.That(IsDescendant(idCard, human, entityMan));
+                Assert.That(IsDescendant(pocketItem, human, entityMan));
 
                 // Now drop the jumpsuit.
                 Assert.That(invSystem.TryUnequip(human, "jumpsuit"));
@@ -108,9 +107,9 @@ namespace Content.IntegrationTests.Tests
             await server.WaitAssertion(() =>
             {
                 // Items have been dropped!
-                Assert.That(IsDescendant(uniform, human), Is.False);
-                Assert.That(IsDescendant(idCard, human), Is.False);
-                Assert.That(IsDescendant(pocketItem, human), Is.False);
+                Assert.That(IsDescendant(uniform, human, entityMan), Is.False);
+                Assert.That(IsDescendant(idCard, human, entityMan), Is.False);
+                Assert.That(IsDescendant(pocketItem, human, entityMan), Is.False);
 
                 // Ensure everything null here.
                 Assert.That(!invSystem.TryGetSlotEntity(human, "jumpsuit", out _));
@@ -121,9 +120,9 @@ namespace Content.IntegrationTests.Tests
             await pairTracker.CleanReturnAsync();
         }
 
-        private static bool IsDescendant(EntityUid descendant, EntityUid parent)
+        private static bool IsDescendant(EntityUid descendant, EntityUid parent, IEntityManager entManager)
         {
-            var xforms = IoCManager.Resolve<IEntityManager>().GetEntityQuery<TransformComponent>();
+            var xforms = entManager.GetEntityQuery<TransformComponent>();
             var tmpParent = xforms.GetComponent(descendant).ParentUid;
             while (tmpParent.IsValid())
             {

--- a/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
+++ b/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
@@ -47,11 +47,10 @@ namespace Content.IntegrationTests.Tests
             var server = pairTracker.Pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
+            var systemMan = sEntities.EntitySysManager;
 
             await server.WaitAssertion(() =>
             {
-                var mapMan = IoCManager.Resolve<IMapManager>();
-                var systemMan = IoCManager.Resolve<IEntitySystemManager>();
                 var human = sEntities.SpawnEntity("InventoryStunnableDummy", MapCoordinates.Nullspace);
                 var invSystem = systemMan.GetEntitySystem<InventorySystem>();
 

--- a/Content.IntegrationTests/Tests/Lobby/ServerReloginTest.cs
+++ b/Content.IntegrationTests/Tests/Lobby/ServerReloginTest.cs
@@ -13,18 +13,18 @@ public sealed class ServerReloginTest
     [Test]
     public async Task Relogin()
     {
-        IConfigurationManager serverConfig = default;
-        IPlayerManager serverPlayerMgr = default;
-        IClientNetManager clientNetManager = default;
         await using var pairTracker = await PoolManager.GetServerClient();
         var server = pairTracker.Pair.Server;
         var client = pairTracker.Pair.Client;
         int originalMaxPlayers = 0;
         string username = null;
+
+        var serverConfig = server.ResolveDependency<IConfigurationManager>();
+        var serverPlayerMgr = server.ResolveDependency<IPlayerManager>();
+        var clientNetManager = client.ResolveDependency<IClientNetManager>();
+
         await server.WaitAssertion(() =>
         {
-            serverConfig = IoCManager.Resolve<IConfigurationManager>();
-            serverPlayerMgr = IoCManager.Resolve<IPlayerManager>();
             Assert.That(serverPlayerMgr.PlayerCount, Is.EqualTo(1));
             originalMaxPlayers = serverConfig.GetCVar(CCVars.SoftMaxPlayers);
             username = serverPlayerMgr.Sessions.First().Name;
@@ -35,7 +35,6 @@ public sealed class ServerReloginTest
 
         await client.WaitAssertion(() =>
         {
-            clientNetManager = IoCManager.Resolve<IClientNetManager>();
             clientNetManager.ClientDisconnect("For testing");
         });
 

--- a/Content.IntegrationTests/Tests/Networking/ReconnectTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/ReconnectTest.cs
@@ -16,7 +16,10 @@ namespace Content.IntegrationTests.Tests.Networking
             var server = pairTracker.Pair.Server;
             var client = pairTracker.Pair.Client;
 
-            await client.WaitPost(() => IoCManager.Resolve<IClientConsoleHost>().ExecuteCommand("disconnect"));
+            var host = client.ResolveDependency<IClientConsoleHost>();
+            var netManager = client.ResolveDependency<IClientNetManager>();
+
+            await client.WaitPost(() => host.ExecuteCommand("disconnect"));
 
             // Run some ticks for the disconnect to complete and such.
             await PoolManager.RunTicksSync(pairTracker.Pair, 5);
@@ -26,7 +29,7 @@ namespace Content.IntegrationTests.Tests.Networking
             // Reconnect.
             client.SetConnectTarget(server);
 
-            await client.WaitPost(() => IoCManager.Resolve<IClientNetManager>().ClientConnect(null, 0, null));
+            await client.WaitPost(() => netManager.ClientConnect(null, 0, null));
 
             // Run some ticks for the handshake to complete and such.
             await PoolManager.RunTicksSync(pairTracker.Pair, 10);

--- a/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
@@ -70,7 +70,7 @@ namespace Content.IntegrationTests.Tests.Networking
                 var map = sMapManager.CreateMap();
                 var player = sPlayerManager.ServerSessions.Single();
                 serverEnt = sEntityManager.SpawnEntity(null, new MapCoordinates((0, 0), map));
-                serverComponent = IoCManager.Resolve<IEntityManager>().AddComponent<PredictionTestComponent>(serverEnt);
+                serverComponent = sEntityManager.AddComponent<PredictionTestComponent>(serverEnt);
 
                 // Make client "join game" so they receive game state updates.
                 player.JoinGame();
@@ -364,7 +364,7 @@ namespace Content.IntegrationTests.Tests.Networking
                     Assert.That(clientComponent.Foo, Is.True);
                 }
             }
-            
+
             cfg.SetCVar(CVars.NetLogging, log);
             await pairTracker.CleanReturnAsync();
         }
@@ -432,7 +432,7 @@ namespace Content.IntegrationTests.Tests.Networking
 
             private void HandleMessage(SetFooMessage message, EntitySessionEventArgs args)
             {
-                var component = IoCManager.Resolve<IEntityManager>().GetComponent<PredictionTestComponent>(message.Uid);
+                var component = EntityManager.GetComponent<PredictionTestComponent>(message.Uid);
                 var old = component.Foo;
                 if (Allow)
                 {

--- a/Content.IntegrationTests/Tests/RestartRoundTest.cs
+++ b/Content.IntegrationTests/Tests/RestartRoundTest.cs
@@ -14,10 +14,11 @@ namespace Content.IntegrationTests.Tests
         {
             await using var pairTracker = await PoolManager.GetServerClient();
             var server = pairTracker.Pair.Server;
+            var sysManager = server.ResolveDependency<IEntitySystemManager>();
 
             await server.WaitPost(() =>
             {
-                IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<GameTicker>().RestartRound();
+                sysManager.GetEntitySystem<GameTicker>().RestartRound();
             });
 
             await PoolManager.RunTicksSync(pairTracker.Pair, 10);

--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -22,6 +22,7 @@ namespace Content.IntegrationTests.Tests
 
             var server = pairTracker.Pair.Server;
 
+            var entManager = server.ResolveDependency<IEntityManager>();
             var config = server.ResolveDependency<IConfigurationManager>();
             var sysManager = server.ResolveDependency<IEntitySystemManager>();
             var ticker = sysManager.GetEntitySystem<GameTicker>();
@@ -42,7 +43,7 @@ namespace Content.IntegrationTests.Tests
 
             await server.WaitAssertion(() =>
             {
-                var bus = IoCManager.Resolve<IEntityManager>().EventBus;
+                var bus = entManager.EventBus;
                 bus.SubscribeEvent<RoundEndSystemChangedEvent>(EventSource.Local, this, _ => {
                     Interlocked.Increment(ref eventCount);
                 });


### PR DESCRIPTION
PoolManager still uses them. This may also fix the other player state issue as it was resolving IMapManager via the static resolve and grabbing the last map to use.