### PR TITLE
Add cargo pallet to cargo products

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: CargoPallet
+  icon:
+    sprite: Structures/catwalk.rsi
+    state: catwalk_preview
+  product: CargoPallet
+  cost: 250
+  category: Cargo
+  group: market

--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
@@ -4,13 +4,44 @@
   description: Designates valid items to sell to CentCom when a shuttle is recalled.
   parent: BaseStructure
   components:
+  - type: InteractionOutline
+  - type: Anchorable
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.45"
+        density: 15
+        mask:
+          - MachineMask
   - type: CargoPallet
+  - type: StaticPrice
+    price: 100
   - type: Sprite
     drawdepth: FloorTiles
-    netsync: false
     layers:
     - sprite: Structures/catwalk.rsi
       state: catwalk_preview
-  - type: CollideOnAnchor
-  - type: Physics
-    canCollide: false
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 500
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 200
+        behaviors:
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              PartRodMetal: # takes two to construct, so drop less than that
+                min: 0
+                max: 1
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]


### PR DESCRIPTION
So they can expand their operation.
Resolves https://github.com/space-wizards/space-station-14/issues/17175

:cl:
- add: Added cargo pallets to the cargo product console.
