### PR TITLE
Remove the rifle ammo box from syndie uplink and change it to a single magazine

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -58,8 +58,8 @@ uplink-pistol-magazine-caseless-desc = Pistol magazine with 10 catridges. Compat
 uplink-speedloader-magnum-name = Speedloader (.45 magnum)
 uplink-speedloader-magnu-desc = Revolver speedloader with 6 catridges. Compatible with Python.
 
-uplink-mosin-ammo-name = Box of .30 rifle magazines
-uplink-mosin-ammo-desc = A box of cartridges for the surplus rifle.
+uplink-rifle-ammo-name = Rifle Magazine (.30 rifle)
+uplink-rifle-ammo-desc = A magazine for various rifles.
 
 # Utility
 uplink-holopara-kit-name = Holoparasite Kit

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -32,7 +32,7 @@
   categories:
   - UplinkWeapons
 
-# Poor accuracy, slow to fire, cheap option
+# Poor accuracy, slow to fire, cheap option.
 - type: listing
   id: UplinkRifleMosin
   name: uplink-rifle-mosin-name

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1,4 +1,4 @@
-# TODO: make more categories
+# TODO: make more categorie
 # Guns
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -210,12 +210,12 @@
   categories:
   - UplinkAmmo
 
-# For the mosin
+# For the mosin and AKMS
 - type: listing
-  id: UplinkMosinAmmo
-  name: uplink-mosin-ammo-name
-  description: uplink-mosin-ammo-desc
-  productEntity: BoxMagazineLightRifle
+  id: UplinkMagazineRifle
+  name: uplink-rifle-ammo-name
+  description: uplink-rifle-ammo-desc
+  productEntity: MagazineRifle
   cost:
     Telecrystal: 1
   categories:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1,4 +1,4 @@
-# TODO: make more categorie
+# TODO: make more categories
 # Guns
 
 - type: listing


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Removed the rifle ammo box from the syndicate uplink and replaced it with a single magazine
It's still 1TC though.
**NOTE:** I don't know why, but all uplink changes i do in my local server makes it so the tweaked/added item has a broken name and description. No idea if this happens in upstream. 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Change the rifle ammo box in syndie uplink to a single magazine
