### PR TITLE
Limit the width of the action bar

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/Widgets/ActionsBar.xaml
+++ b/Content.Client/UserInterface/Systems/Actions/Widgets/ActionsBar.xaml
@@ -11,6 +11,7 @@
         <controls:ActionButtonContainer
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
+            MaxSize="64 9999"
             Name="ActionsContainer"
             Access="Public"/>
         <controls:ActionPageButtons Name="PageButtons" Access="Public"/>


### PR DESCRIPTION
This is to prevent >1 variant tile actions from stretching out of bounds of the action bar.

![image](https://github.com/space-wizards/space-station-14/assets/114301317/3625734c-b809-4dc6-9d00-0cececc68aed)
