### PR TITLE
Fix action bar not filling with mappables

### DIFF
--- a/Content.Client/Decals/DecalPlacementSystem.cs
+++ b/Content.Client/Decals/DecalPlacementSystem.cs
@@ -157,6 +157,7 @@ public sealed class DecalPlacementSystem : EntitySystem
             DisplayName = $"{_decalId} ({_decalColor.ToHex()}, {(int) _decalAngle.Degrees})", // non-unique actions may be considered duplicates when saving/loading.
             Icon = decalProto.Sprite,
             Repeat = true,
+            ClientExclusive = true,
             CheckCanAccess = false,
             CheckCanInteract = false,
             Range = -1,

--- a/Content.Client/Mapping/MappingSystem.cs
+++ b/Content.Client/Mapping/MappingSystem.cs
@@ -84,6 +84,7 @@ public sealed partial class MappingSystem : EntitySystem
 
             ev.Action = new InstantAction()
             {
+                ClientExclusive = true,
                 CheckCanInteract = false,
                 Event = actionEvent,
                 DisplayName = Loc.GetString(tileDef.Name),
@@ -97,6 +98,7 @@ public sealed partial class MappingSystem : EntitySystem
         {
             ev.Action = new InstantAction()
             {
+                ClientExclusive = true,
                 CheckCanInteract = false,
                 Event = actionEvent,
                 DisplayName = "action-name-mapping-erase",
@@ -111,6 +113,7 @@ public sealed partial class MappingSystem : EntitySystem
 
         ev.Action = new InstantAction()
         {
+            ClientExclusive = true,
             CheckCanInteract = false,
             Event = actionEvent,
             DisplayName = actionEvent.EntityType,

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -668,7 +668,18 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
     {
         if (args.Function == EngineKeyFunctions.UIClick)
         {
-            _menuDragHelper.MouseDown(button);
+            if (button.Action == null)
+            {
+                var ev = new FillActionSlotEvent();
+                IoCManager.Resolve<IEntityManager>().EventBus.RaiseEvent(EventSource.Local, ev);
+                if (ev.Action != null)
+                    SetAction(button, ev.Action);
+            }
+            else
+            {
+                _menuDragHelper.MouseDown(button);
+            }
+
             args.Handle();
         }
         else if (args.Function == EngineKeyFunctions.UIRightClick)


### PR DESCRIPTION
`FillActionSlotEvent` existed, but the call to fire it must've been lost in the refactor from months ago. `ClientExclusive` was necessary to get this working again.

![image](https://github.com/space-wizards/space-station-14/assets/114301317/28677194-cd2e-49f4-9724-a65387807677)

To clarify, this lets mappers click on empty action buttons to fill it with the entity/tile/decal of their choice. This behavior used to exist, and now it's back.