### PR TITLE
add carp bundle

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -119,6 +119,9 @@ uplink-c20r-bundle-desc = Old faithful: The classic C-20r Submachine Gun, bundle
 uplink-buldog-bundle-name = Bulldog Bundle
 uplink-buldog-bundle-desc = Lean and mean: Contains the popular Bulldog Shotgun, a 12g beanbag drum and 2 12g buckshot drums.
 
+uplink-carp-bundle-name = Carp Bundle
+uplink-carp-bundle-desc = A duffelbag filled to the brim with space carp, truly devastating for fishops. Water not included.
+
 uplink-grenade-launcher-bundle-name = China-Lake Bundle
 uplink-grenade-launcher-bundle-desc = An old China-Lake grenade launcher bundled with 8 rounds of various destruction capability.
 

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -279,3 +279,14 @@
       - id: WeaponPistolViper
       - id: PinpointerNuclear
       - id: HandheldHealthAnalyzer
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateAmmoBundle
+  id: ClothingBackpackDuffelSyndicateFilledCarp
+  name: carp bundle
+  description: "If you're reading this, it's already too late. RUN"
+  components:
+  - type: StorageFill
+    contents:
+    - id: DehydratedSpaceCarp
+      amount: 26

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -459,6 +459,17 @@
   - UplinkBundles
 
 - type: listing
+  id: UplinkCarpBundle
+  name: uplink-carp-bundle-name
+  description: uplink-carp-bundle-desc
+  icon: { sprite: /Textures/Objects/Fun/toys.rsi, state: carpplush }
+  productEntity: ClothingBackpackDuffelSyndicateFilledCarp
+  cost:
+    Telecrystal: 38
+  categories:
+  - UplinkBundles
+
+- type: listing
   id: UplinkL6SawBundle
   name: uplink-l6-saw-bundle-name
   description: uplink-l6-saw-bundle-desc


### PR DESCRIPTION
## About the PR
carp bundle to make it easier for fishops

38TC in the bundle section gets you 26 fish (2TC left over for noslips)

its a bit more efficient than buying individually since 7 bonus fish

requires #16885 to be fixed first

**Media**
uplink entry:
![13:46:25](https://github.com/space-wizards/space-station-14/assets/39013340/bf29ffcd-71cc-4bf3-876f-89131f1d8596)

it really is full of fish:
![13:43:00](https://github.com/space-wizards/space-station-14/assets/39013340/030b8fab-5668-4cab-9198-f5327740afbc)

desc:
![13:42:47](https://github.com/space-wizards/space-station-14/assets/39013340/caf5bf88-2b65-4087-827e-168c12fada63)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Syndicate High Command have noticed a rise in fishops and are now offering a 38 TC carp bundle!
