### PR TITLE
dont lock escape pod

### DIFF
--- a/Resources/Maps/Shuttles/escape_pod_small.yml
+++ b/Resources/Maps/Shuttles/escape_pod_small.yml
@@ -100,7 +100,7 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: SpreaderGrid
-- proto: AirlockExternalShuttleLocked
+- proto: AirlockGlassShuttle
   entities:
   - uid: 12
     components:


### PR DESCRIPTION
## About the PR
fixes #16784 by replacing external locked shuttle airlock with glass shuttle airlock
- anyone can board a pod now
- you can see into it if its closed

**Media**
funny map render bot
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun