### PR TITLE
add CannotSuicide to queen and dragon

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -233,6 +233,9 @@
         - MobMask
         layer:
         - MobLayer
+  - type: Tag
+    tags:
+    - CannotSuicide
 
 - type: entity
   name: Ravager

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -4,6 +4,7 @@
   suffix: ""
   name: space dragon
   description: A flying leviathan, loosely related to space carps.
+  abstract: true
   components:
   - type: GhostRole
     allowMovement: true

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -112,6 +112,9 @@
       icon: Interface/Actions/devour.png
       name: action-name-devour
       description: action-description-devour
+  - type: Tag
+    tags:
+    - CannotSuicide
 
 - type: entity
   parent: BaseMobDragon


### PR DESCRIPTION
## About the PR
a few times ive ftld to an expedition only to see 0 megafauna remaining, the target got in, saw map was paused then did /suicide
this will let someone else control them later instead of killing for free

**Media**

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun