### PR TITLE
blacklist banana peel from surplus

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -661,6 +661,10 @@
   - !type:BuyerJobCondition
     whitelist:
     - Clown
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
 
 - type: listing
   id: uplinkHotPotato


### PR DESCRIPTION
## About the PR
so you dont just walk on surplus and die :trollface:

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- remove: Cybersun monkeys have stopped putting peels of their explosive bananas in surplus crates.