### PR TITLE
Add network configurator to non-engi utility belt fill

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -10,6 +10,7 @@
       - id: Screwdriver
       - id: Wirecutter
       - id: Welder
+      - id: NetworkConfigurator
 
 - type: entity
   id: ClothingBeltUtilityEngineering


### PR DESCRIPTION
#17244 removed multi from all the non-engi belts, not just salv. This PR puts a network configurator in its place that can't be used for hacking.

:cl:
- tweak: Pre-filled non-engineering utility belts now come with a network configurator.