### PR TITLE
Crazy Glue Fix

### DIFF
--- a/Content.Server/Glue/GlueSystem.cs
+++ b/Content.Server/Glue/GlueSystem.cs
@@ -39,8 +39,6 @@ namespace Content.Server.Glue
                 return;
             }
 
-
-
             if (HasComp<ItemComponent>(target))
             {
                 _audio.PlayPvs(component.Squeeze, uid);

--- a/Content.Server/Glue/GlueSystem.cs
+++ b/Content.Server/Glue/GlueSystem.cs
@@ -40,10 +40,10 @@ namespace Content.Server.Glue
             }
 
 
+
             if (HasComp<ItemComponent>(target))
             {
                 _audio.PlayPvs(component.Squeeze, uid);
-                EnsureComp<UnremoveableComponent>(target);
                 _popup.PopupEntity(Loc.GetString("glue-success", ("target", Identity.Entity(target, EntityManager))), args.User,
                 args.User, PopupType.Medium);
                 EnsureComp<GluedComponent>(target);

--- a/Content.Server/Glue/GluedSystem.cs
+++ b/Content.Server/Glue/GluedSystem.cs
@@ -1,8 +1,7 @@
 using Content.Shared.Interaction.Components;
 using Robust.Shared.Timing;
-using Content.Shared.Interaction;
 using Content.Shared.Glue;
-using Content.Shared.Hands.Components;
+using Content.Shared.Hands;
 
 namespace Content.Server.Glue;
 
@@ -16,7 +15,7 @@ public sealed class GluedSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<GluedComponent, ComponentInit>(OnGluedInit);
-        SubscribeLocalEvent<GluedComponent, InteractHandEvent>(OnPickUp);
+        SubscribeLocalEvent<GluedComponent, GotEquippedHandEvent>(OnHandPickUp);
     }
 
     // Timing to remove glued and unremoveable.
@@ -52,13 +51,10 @@ public sealed class GluedSystem : EntitySystem
     }
 
     // Timers start only when the glued item is picked up.
-    private void OnPickUp(EntityUid uid, GluedComponent component, InteractHandEvent args)
+    private void OnHandPickUp(EntityUid uid, GluedComponent component, GotEquippedHandEvent args)
     {
-        var userHands = Comp<HandsComponent>(args.User);
-        if (userHands.ActiveHandEntity == uid)
-        {
-            component.GlueBroken = true;
-            component.GlueTime = _timing.CurTime + component.GlueCooldown;
-        }
+        EnsureComp<UnremoveableComponent>(uid);
+        component.GlueBroken = true;
+        component.GlueTime = _timing.CurTime + component.GlueCooldown;
     }
 }


### PR DESCRIPTION
Was an issue with crazy glue when applying it to an item inside a container that item would be perma glued. Now the unremoveable component is only added when the item is in a hand.

fixes #17261

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

