### PR TITLE
Add random zombie marker for admins

### DIFF
--- a/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
@@ -4,6 +4,9 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Server.Ghost.Roles.Components
 {
+    /// <summary>
+    ///   Base class for spawning of an entity for a Ghost
+    /// </summary>
     public abstract class GhostRoleSpawnerComponent : Component
     {
         [ViewVariables(VVAccess.ReadWrite)] [DataField("deleteOnSpawn")]
@@ -17,7 +20,7 @@ namespace Content.Server.Ghost.Roles.Components
     }
 
     /// <summary>
-    ///     Allows a ghost to take this role, spawning a new entity.
+    ///   Allows a ghost to take this role, spawning a new entity.
     /// </summary>
     [RegisterComponent]
     [Access(typeof(GhostRoleSystem))]
@@ -29,7 +32,7 @@ namespace Content.Server.Ghost.Roles.Components
     }
 
     /// <summary>
-    ///     Allows a ghost to take this role, spawning a new entity.
+    ///   Allows a ghost to take this role, spawning a randomized Humanoid
     /// </summary>
     [RegisterComponent]
     [Access(typeof(GhostRoleSystem))]

--- a/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
@@ -1,14 +1,10 @@
-﻿using Robust.Shared.Prototypes;
+﻿using Content.Shared.Humanoid.Prototypes;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Ghost.Roles.Components
 {
-    /// <summary>
-    ///     Allows a ghost to take this role, spawning a new entity.
-    /// </summary>
-    [RegisterComponent]
-    [Access(typeof(GhostRoleSystem))]
-    public sealed class GhostRoleMobSpawnerComponent : Component
+    public abstract class GhostRoleSpawnerComponent : Component
     {
         [ViewVariables(VVAccess.ReadWrite)] [DataField("deleteOnSpawn")]
         public bool DeleteOnSpawn = true;
@@ -18,9 +14,30 @@ namespace Content.Server.Ghost.Roles.Components
 
         [ViewVariables]
         public int CurrentTakeovers = 0;
+    }
 
+    /// <summary>
+    ///     Allows a ghost to take this role, spawning a new entity.
+    /// </summary>
+    [RegisterComponent]
+    [Access(typeof(GhostRoleSystem))]
+    public sealed class GhostRoleMobSpawnerComponent : GhostRoleSpawnerComponent
+    {
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("prototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string? Prototype { get; private set; }
     }
+
+    /// <summary>
+    ///     Allows a ghost to take this role, spawning a new entity.
+    /// </summary>
+    [RegisterComponent]
+    [Access(typeof(GhostRoleSystem))]
+    public sealed class GhostRoleRandomSpawnerComponent : GhostRoleSpawnerComponent
+    {
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("settings", customTypeSerializer: typeof(PrototypeIdSerializer<RandomHumanoidSettingsPrototype>))]
+        public string Settings = default!;
+    }
+
 }

--- a/Content.Server/Humanoid/Components/RandomHumanoidSpawnerComponent.cs
+++ b/Content.Server/Humanoid/Components/RandomHumanoidSpawnerComponent.cs
@@ -5,8 +5,9 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.Humanoid.Components;
 
 /// <summary>
-///     This is added to a marker entity in order to spawn a randomized
-///     humanoid ingame.
+///   This is added to a marker entity in order to spawn a randomized
+///   humanoid ingame.
+///   If you are using a GhostRoleSpawnerComponent, replace it with GhostRoleRandomSpawnerComponent instead of this.
 /// </summary>
 [RegisterComponent]
 public sealed class RandomHumanoidSpawnerComponent : Component

--- a/Content.Server/Humanoid/Systems/RandomHumanoidSystem.cs
+++ b/Content.Server/Humanoid/Systems/RandomHumanoidSystem.cs
@@ -28,6 +28,8 @@ public sealed class RandomHumanoidSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, RandomHumanoidSpawnerComponent component, MapInitEvent args)
     {
+        // Note: This is why GhostRoleMobSpawner doesn't play nice with RandomHumanoidSpawner - we bait and switch
+        // the entity IDs here. Use GhostRoleRandomSpawnerComponent instead.
         QueueDel(uid);
         SpawnRandomHumanoid(component.SettingsPrototypeId, Transform(uid).Coordinates, MetaData(uid).EntityName);
     }

--- a/Content.Server/Zombies/MakeZombieComponent.cs
+++ b/Content.Server/Zombies/MakeZombieComponent.cs
@@ -1,0 +1,9 @@
+﻿namespace Content.Server.Zombies;
+
+/// <summary>
+///   Place on a spawner to turn the spawned mob into a zombie immediately
+/// </summary>
+[RegisterComponent]
+public sealed class MakeZombieComponent: Component
+{
+}

--- a/Content.Server/Zombies/MakeZombieComponent.cs
+++ b/Content.Server/Zombies/MakeZombieComponent.cs
@@ -1,7 +1,7 @@
 ﻿namespace Content.Server.Zombies;
 
 /// <summary>
-///   Place on a spawner to turn the spawned mob into a zombie immediately
+///   Place on an entity to turn this mob into a zombie immediately
 /// </summary>
 [RegisterComponent]
 public sealed class MakeZombieComponent: Component

--- a/Content.Server/Zombies/MakeZombieSystem.cs
+++ b/Content.Server/Zombies/MakeZombieSystem.cs
@@ -1,0 +1,30 @@
+﻿using Content.Server.Ghost.Roles.Events;
+
+namespace Content.Server.Zombies;
+
+public sealed class MakeZombieSystem : EntitySystem
+{
+    [Dependency] private readonly ZombieSystem _zombie = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MakeZombieComponent, MapInitEvent>(OnSpawnZombie);
+        SubscribeLocalEvent<MakeZombieComponent, GhostRoleSpawnerUsedEvent>(OnGhostSpawnZombie);
+    }
+
+    private void OnGhostSpawnZombie(EntityUid uid, MakeZombieComponent component, GhostRoleSpawnerUsedEvent args)
+    {
+        // You're alive! Now you're undead! (spawner version)
+        RemCompDeferred <MakeZombieComponent>(uid);
+        _zombie.ZombifyEntity(uid);
+    }
+
+    private void OnSpawnZombie(EntityUid uid, MakeZombieComponent component, MapInitEvent args)
+    {
+        // You're alive! Now you're undead!
+        RemCompDeferred <MakeZombieComponent>(uid);
+        _zombie.ZombifyEntity(uid);
+    }
+}

--- a/Content.Server/Zombies/MakeZombieSystem.cs
+++ b/Content.Server/Zombies/MakeZombieSystem.cs
@@ -4,7 +4,7 @@ namespace Content.Server.Zombies;
 
 public sealed class MakeZombieSystem : EntitySystem
 {
-    [Dependency] private readonly ZombieSystem _zombie = default!;
+    [Dependency] private readonly ZombifyOnDeathSystem _zombie = default!;
 
     public override void Initialize()
     {

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -93,3 +93,22 @@
       - state: green
       - sprite: Structures/Wallmounts/signs.rsi
         state: radiation
+
+- type: entity
+  id: SpawnPointHumanCivilianZombie
+  name: ghost role spawn point
+  suffix: zombie
+  parent: MarkerBase
+  components:
+    - type: GhostRole
+      name: Zombie
+      description: A malevolent creature of the dead.
+      rules: You are an antagonist. Search out the living and bite them in order to infect them and turn them into zombies. Work together with other the zombies to overtake the station.
+    - type: GhostRoleRandomSpawner
+      settings: RandCivilianZombie
+    - type: Sprite
+      sprite: Markers/jobs.rsi
+      layers:
+        - state: passenger
+        - sprite: Structures/Wallmounts/signs.rsi
+          state: medium_biohazard

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -1,5 +1,18 @@
 # Random humanoids
 
+## Civilian
+- type: randomHumanoidSettings
+  id: RandCivilianZombie
+  randomizeName: true
+  components:
+    - type: Loadout
+      prototypes: [ PassengerGear, BartenderGear, BotanistGear, ChaplainGear, ChefGear, ClownGear, JanitorGear, LawyerGear, LibrarianGear ]
+    - type: MakeZombie
+    - type: RandomMetadata
+      nameSegments:
+        - names_first
+        - names_last
+
 ## ERT Leader
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- Add Zombie Ghost Role Spawns for Admins to place
- Make it possible to randomize humanoids for ghost role spawners

https://github.com/space-wizards/space-station-14/assets/5285589/7e118d71-53f0-4a8b-b90c-317fac6bbe09

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Nothing for players to see