### PR TITLE
Add missing LV in Aspid medbay, powering server

### DIFF
--- a/Resources/Maps/aspid.yml
+++ b/Resources/Maps/aspid.yml
@@ -15180,6 +15180,13 @@ entities:
       type: Transform
     - fixtures: {}
       type: Fixtures
+  - uid: 7808
+    components:
+    - pos: 19.5,27.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
   - uid: 8830
     components:
     - pos: 1.5,-5.5


### PR DESCRIPTION
This works around the issue in #17251 but doesn't fix the underlying issue.
It does however fix the intended layout of the map by adding a missing LV-cable

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
The issue in #17251 is that the server connects weirdly (see A, additionally this can be worked around in-game by moving the server to below the bed)
But this PR adds a LV-cable to B which to me looks like the intended layout, otherwise there's nothing powering the room.
![image](https://github.com/space-wizards/space-station-14/assets/905507/8cc5597f-1a41-41d0-808d-53e6cb00d205)



**Media**
![image](https://github.com/space-wizards/space-station-14/assets/905507/14786a38-e1cc-4b7c-a1d6-68778d9f2ec1)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Aspid medbay upper is now powered again and the crew monitoring console works