### PR TITLE
Connect to the closest ExtensionCable instead of the first

### DIFF
--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -249,7 +249,7 @@ namespace Content.Server.Power.EntitySystems
             var coordinates = xform.Coordinates;
             var nearbyEntities = grid.GetCellsInSquareArea(coordinates, (int) Math.Ceiling(range / grid.TileSize));
 
-            var candidates = new List<Tuple<float, ExtensionCableProviderComponent>>();
+            var candidates = new List<(float Distance, ExtensionCableProviderComponent Provider)>();
             foreach (var entity in nearbyEntities)
             {
                 if (entity == owner || !EntityManager.TryGetComponent<ExtensionCableProviderComponent?>(entity, out var provider)) continue;
@@ -263,12 +263,12 @@ namespace Content.Server.Power.EntitySystems
                 var distance = (Transform(entity).LocalPosition - xform.LocalPosition).Length;
                 if (distance > Math.Min(range, provider.TransferRange)) continue;
 
-                candidates.Add(new Tuple<float, ExtensionCableProviderComponent>(distance, provider));
+                candidates.Add((Distance: distance, Provider: provider));
             }
 
+            candidates.Sort((x, y) => x.Distance.CompareTo(y.Distance));
             foundProvider = candidates
-                .OrderBy(entity => entity.Item1)
-                .Select(entity => entity.Item2)
+                .Select(entity => entity.Provider)
                 .FirstOrDefault();
 
             return foundProvider != default;

--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -249,7 +249,8 @@ namespace Content.Server.Power.EntitySystems
             var coordinates = xform.Coordinates;
             var nearbyEntities = grid.GetCellsInSquareArea(coordinates, (int) Math.Ceiling(range / grid.TileSize));
 
-            var candidates = new List<(float Distance, ExtensionCableProviderComponent Provider)>();
+            foundProvider = default;
+            var closestDistanceFound = float.MaxValue;
             foreach (var entity in nearbyEntities)
             {
                 if (entity == owner || !EntityManager.TryGetComponent<ExtensionCableProviderComponent?>(entity, out var provider)) continue;
@@ -261,16 +262,12 @@ namespace Content.Server.Power.EntitySystems
                 if (!provider.Connectable) continue;
 
                 var distance = (Transform(entity).LocalPosition - xform.LocalPosition).Length;
-                if (distance > Math.Min(range, provider.TransferRange)) continue;
+                // Is the provider out of range or have we already found a closer one?
+                if (distance > Math.Min(range, provider.TransferRange) || distance >= closestDistanceFound) continue;
 
-                candidates.Add((Distance: distance, Provider: provider));
+                foundProvider = provider;
+                closestDistanceFound = distance;
             }
-
-            candidates.Sort((x, y) => x.Distance.CompareTo(y.Distance));
-            foundProvider = candidates
-                .Select(entity => entity.Provider)
-                .FirstOrDefault();
-
             return foundProvider != default;
         }
 


### PR DESCRIPTION
closes #17251

Order the viable ExtensionCables and connect to the closest one instead of the first one found.
This prevents the confusion in #17251 where a machine connected to a power cable in the room below it.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
As it changes the way things connect this may have an effect on maps, but I think the current logic is counter-intuitive, the picture I've attached in #17251 shows the issue perfectly.
The console is on top of a power cable but still connects to a cable in another room.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Cables now connect to the closest net instead of the first one it finds.
