### PR TITLE
give regular crowbar same damage as emergency

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -142,7 +142,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 6
+        Blunt: 8
         Structural: 3
   - type: Tool
     qualities:
@@ -163,7 +163,7 @@
   components:
   - type: Tag
     tags:
-    - Crowbar
+    - Crwowbar
     - CrowbarRed
   - type: Sprite
     sprite: Objects/Tools/crowbar.rsi
@@ -175,7 +175,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 8 #free man
+        Blunt: 6 # encourage powergamers to use regular crowbars so emergency toolboxes still have them
         Structural: 3
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -168,15 +168,6 @@
   - type: Sprite
     sprite: Objects/Tools/crowbar.rsi
     state: red-icon
-  - type: Item
-    sprite: Objects/Tools/crowbar.rsi
-    size: 10
-    heldPrefix: red
-  - type: MeleeWeapon
-    damage:
-      types:
-        Blunt: 8
-        Structural: 3
 
 - type: entity
   name: multitool

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -175,7 +175,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 6 # encourage powergamers to use regular crowbars so emergency toolboxes still have them
+        Blunt: 8
         Structural: 3
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -163,7 +163,7 @@
   components:
   - type: Tag
     tags:
-    - Crwowbar
+    - Crowbar
     - CrowbarRed
   - type: Sprite
     sprite: Objects/Tools/crowbar.rsi

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -157,17 +157,18 @@
     price: 22
 
 - type: entity
-  name: emergency crowbar
   parent: Crowbar
   id: CrowbarRed
+  name: emergency crowbar
   components:
   - type: Tag
     tags:
     - Crowbar
     - CrowbarRed
   - type: Sprite
-    sprite: Objects/Tools/crowbar.rsi
     state: red-icon
+  - type: Item
+    heldPrefix: red
 
 - type: entity
   name: multitool


### PR DESCRIPTION
## About the PR
before this you would never see an emergency toolbox with a crowbar in it because powergamers stole it for the +2 damage
hopefully now that they are the same they will stop doing this and leave them for actual emergencies

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Emergency crowbar and regular crowbar now do the same damage. Please leave emergency crowbars for emergencies!!!
