### PR TITLE
nerf xeno speeds + add some xenos to faction

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -53,8 +53,8 @@
         - MobLayer
   - type: MobState
     allowedStates:
-      - Alive
-      - Dead
+    - Alive
+    - Dead
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -123,10 +123,6 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  - type: MobState
-    allowedStates:
-      - Alive
-      - Dead
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -135,7 +131,7 @@
     excess: 300
   - type: SlowOnDamage
     speedModifierThresholds:
-      250: 0.7
+      50: 0.7
   - type: Fixtures
     fixtures:
       fix1:
@@ -160,10 +156,6 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  - type: MobState
-    allowedStates:
-      - Alive
-      - Dead
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -172,11 +164,13 @@
     damage:
       groups:
         Brute: 5
-  - type: Stamina
-    excess: 200
   - type: MovementSpeedModifier
-    baseWalkSpeed : 3.0
-    baseSprintSpeed : 5.5
+    baseWalkSpeed: 2.0
+    baseSprintSpeed: 2.5
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      100: 0.4
+      50: 0.7
   - type: Fixtures
     fixtures:
       fix1:
@@ -201,10 +195,6 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  - type: MobState
-    allowedStates:
-      - Alive
-      - Dead
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -212,8 +202,8 @@
   - type: Stamina
     excess: 1500
   - type: MovementSpeedModifier
-    baseWalkSpeed : 2.8
-    baseSprintSpeed : 3.8
+    baseWalkSpeed: 2.8
+    baseSprintSpeed: 3.8
   - type: MeleeWeapon
     hidden: true
     damage:
@@ -221,7 +211,8 @@
        Brute: 20
   - type: SlowOnDamage
     speedModifierThresholds:
-      1000: 0.7
+      250: 0.4
+      200: 0.7
   - type: Fixtures
     fixtures:
       fix1:
@@ -249,10 +240,6 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  - type: MobState
-    allowedStates:
-      - Alive
-      - Dead
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -260,8 +247,8 @@
   - type: Stamina
     excess: 550
   - type: MovementSpeedModifier
-    baseWalkSpeed : 2.3
-    baseSprintSpeed : 4.2
+    baseWalkSpeed: 2.3
+    baseSprintSpeed: 4.2
   - type: MeleeWeapon
     hidden: true
     damage:
@@ -269,7 +256,8 @@
        Brute: 10
   - type: SlowOnDamage
     speedModifierThresholds:
-      450: 0.7
+      150: 0.5
+      100: 0.7
   - type: Fixtures
     fixtures:
       fix1:
@@ -294,19 +282,11 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  - type: MobState
-    allowedStates:
-      - Alive
-      - Dead
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      50: Dead
   - type: Stamina
     excess: 250
   - type: MovementSpeedModifier
-    baseWalkSpeed : 2.7
-    baseSprintSpeed : 6.0
+    baseWalkSpeed: 2.7
+    baseSprintSpeed: 6.0
   - type: MeleeWeapon
     hidden: true
     damage:
@@ -346,10 +326,6 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  - type: MobState
-    allowedStates:
-      - Alive
-      - Dead
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -358,7 +334,7 @@
     excess: 300
   - type: SlowOnDamage
     speedModifierThresholds:
-      250: 0.4
+      50: 0.4
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/Procedural/salvage_factions.yml
@@ -21,6 +21,10 @@
     - id: MobXenoRavager
       amount: 1
     prob: 0.1
+  - entries:
+    - id: MobXenoRouny
+      amount: 1
+    prob: 0.001
   configs:
     DefenseStructure: XenoWardingTower
     Mining: Xenos

--- a/Resources/Prototypes/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/Procedural/salvage_factions.yml
@@ -8,6 +8,16 @@
     - id: MobXenoDrone
       amount: 1
   - entries:
+    - id: MobXenoPraetorian
+      amount: 1
+      maxAmount: 2
+    prob: 0.5
+  - entries:
+    - id: MobXenoDrone
+      amount: 0
+      maxAmount: 2
+    prob: 0.25
+  - entries:
     - id: MobXenoRavager
       amount: 1
     prob: 0.1


### PR DESCRIPTION
## About the PR
made all xenos get slower after taking good damage:
- some didnt have it at all
- some used pre-nerf values like queen so they would never slow down before dying

you can also rarely find praetorians and runners on expeditions now to spice things up

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: The Praetorian and Runner xenos can now be rarely found on expeditions.
- tweak: All xenos now enjoy a slowdown when badly wounded.