### PR TITLE
Flip curTime and NextUpdate in UpdateGrid

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -103,7 +103,7 @@ public sealed partial class PathfindingSystem
         while (query.MoveNext(out var comp))
         {
             if (comp.DirtyChunks.Count == 0 ||
-                comp.NextUpdate < curTime ||
+                curTime < comp.NextUpdate ||
                 !TryComp<MapGridComponent>(comp.Owner, out var mapGridComp))
             {
                 continue;


### PR DESCRIPTION
Seems like they were backwards. It should iterate less often now.