### PR TITLE
wallmount gen board cheaper

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
@@ -34,18 +34,21 @@
 
 # Wallmount Generator
 - type: entity
-  id: WallmountGeneratorElectronics
   parent: BaseElectronics
+  id: WallmountGeneratorElectronics
   name: wallmount generator electronics
   description: Circuit used to construct a wallmount generator.
   components:
-    - type: Sprite
-      sprite: Objects/Misc/module.rsi
-      state: charger_APC
-    - type: Tag
-      tags:
-        - DroneUsable
-        - WallmountGeneratorElectronics
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: charger_APC
+  - type: PhysicalComposition
+    materialComposition:
+      Glass: 90
+  - type: Tag
+    tags:
+      - DroneUsable
+      - WallmountGeneratorElectronics
 
 # APU
 - type: entity

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -451,7 +451,7 @@
   completetime: 4
   materials:
      Steel: 50
-     Glass: 350
+     Glass: 150
 
 - type: latheRecipe
   id: WallmountGeneratorAPUElectronics


### PR DESCRIPTION
## About the PR
since it makes half of apu, now it costs 2 less glass so it has some kind of reason to exist
fixes #13995

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Wallmount generator board is now cheaper to compensate for less power output.