### PR TITLE
give shuttle airlocks a wire layout

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -17,8 +17,6 @@
       path: /Audio/Machines/airlock_deny.ogg
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/external.rsi
-  - type: Appearance
-  - type: WiresVisuals
   - type: PaintableAirlock
     group: External
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -1,8 +1,8 @@
 - type: entity
-  id: AirlockShuttle
   parent: Airlock
-  name: external airlock
+  id: AirlockShuttle
   suffix: Docking
+  name: external airlock
   description: Necessary for connecting two space craft together.
   components:
   - type: Docking

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -11,6 +11,10 @@
 
 - type: wireLayout
   parent: Airlock
+  id: Docking
+
+- type: wireLayout
+  parent: Airlock
   id: AirlockSecurity
 
 - type: wireLayout

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -11,10 +11,6 @@
 
 - type: wireLayout
   parent: Airlock
-  id: Docking
-
-- type: wireLayout
-  parent: Airlock
   id: AirlockSecurity
 
 - type: wireLayout
@@ -88,3 +84,15 @@
   - !type:ParticleAcceleratorLimiterWireAction
   - !type:ParticleAcceleratorPowerWireAction
   - !type:ParticleAcceleratorStrengthWireAction
+
+- type: wireLayout
+  id: Docking
+  dummyWires: 2
+  wires:
+  - !type:PowerWireAction
+  - !type:PowerWireAction
+    pulseTimeout: 15
+  - !type:DoorBoltWireAction
+  - !type:DoorBoltLightWireAction
+  - !type:DoorTimingWireAction
+  - !type:DoorSafetyWireAction


### PR DESCRIPTION
## About the PR
same as a normal door + 2 dummy wires :trollface:
i tried parenting originally but it had 2 of each wire fsr so copy paste is the answer

fixes #14148

**Media**

https://github.com/space-wizards/space-station-14/assets/39013340/44616a5a-de63-47ff-9219-ad71f91e1ccf

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Shuttle airlocks now have wires and can be hacked.