### PR TITLE
Pyroclastic anomaly tweak (anti-box)

### DIFF
--- a/Content.Server/Anomaly/Components/TempReactingAnomalyComponent.cs
+++ b/Content.Server/Anomaly/Components/TempReactingAnomalyComponent.cs
@@ -1,0 +1,63 @@
+using Robust.Shared.Utility;
+
+namespace Content.Server.Anomaly.Components;
+
+/// <summary>
+/// Causes the anomaly to react to different temperatures.
+/// </summary>
+/// <remarks>
+/// This could later be extended to react only to specific gasses.
+/// </remarks>
+[RegisterComponent]
+public sealed class TempReactingAnomalyComponent : Component
+{
+    /// <summary>
+    /// A list of reactions that happen at certain temperatures.
+    /// </summary>
+    [DataField("reactions")]
+    public List<TempReaction> Reactions = new();
+}
+
+/// <summary>
+/// Modifies stability, severity, or health of an anomaly when temperature is within the specified range.
+/// </summary>
+[DataDefinition]
+public sealed class TempReaction
+{
+    /// <summary>
+    /// The lower end of the temperature range for the reaction to occur.
+    /// </summary>
+    [DataField("minTempKelvin")]
+    public float MinTempKelvin = 0;
+
+    /// <summary>
+    /// The upper end of the temperature range for the reaction to occur.
+    /// </summary>
+    [DataField("maxTempKelvin")]
+    public float MaxTempKelvin = float.MaxValue;
+
+    /// <summary>
+    /// The amount of stability added per second when temp is in range.
+    /// </summary>
+    [DataField("stabilityPerPulse")]
+    public float StabilityPerPulse = 0;
+
+    /// <summary>
+    /// The amount of stability added per second when temp is in range.
+    /// </summary>
+    [DataField("severityPerPulse")]
+    public float SeverityPerPulse = 0;
+
+    /// <summary>
+    /// The amount of stability added per second when temp is in range.
+    /// </summary>
+    [DataField("healthPerPulse")]
+    public float HealthPerPulse = 0;
+
+    public bool TempInRange(float temp)
+    {
+        DebugTools.Assert(MinTempKelvin <= MaxTempKelvin);
+
+        return temp >= MinTempKelvin && temp < MaxTempKelvin;
+    }
+}

--- a/Content.Server/Anomaly/Components/TempReactingAnomalyComponent.cs
+++ b/Content.Server/Anomaly/Components/TempReactingAnomalyComponent.cs
@@ -14,7 +14,7 @@ public sealed class TempReactingAnomalyComponent : Component
     /// <summary>
     /// A list of reactions that happen at certain temperatures.
     /// </summary>
-    [DataField("reactions")]
+    [DataField("reactions", required: true)]
     public List<TempReaction> Reactions = new();
 }
 

--- a/Content.Server/Anomaly/Effects/TempReactingAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/TempReactingAnomalySystem.cs
@@ -1,0 +1,45 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Anomaly.Components;
+using Content.Shared.Anomaly;
+using Content.Shared.Anomaly.Components;
+using Robust.Server.GameObjects;
+
+namespace Content.Server.Anomaly.Effects;
+
+/// <summary>
+/// This handles <see cref="TempReactingAnomalyComponent"/>
+/// </summary>
+public sealed class TempReactingAnomalySystem : EntitySystem
+{
+    [Dependency] private readonly SharedAnomalySystem _anomalySystem = default!;
+    [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
+    [Dependency] private readonly TransformSystem _transformSystem = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TempReactingAnomalyComponent, AnomalyPulseEvent>(OnPulse);
+    }
+
+    private void OnPulse(EntityUid uid, TempReactingAnomalyComponent tempReactingAnomaly, ref AnomalyPulseEvent args)
+    {
+        var tf = Transform(uid);
+        var grid = tf.GridUid;
+        var map = tf.MapUid;
+        var indices = _transformSystem.GetGridOrMapTilePosition(uid, tf);
+        var mixture = _atmosphereSystem.GetTileMixture(grid, map, indices);
+
+        if (mixture is null)
+            return;
+
+        foreach (var reaction in tempReactingAnomaly.Reactions)
+        {
+            if (reaction.TempInRange(mixture.Temperature) && TryComp<AnomalyComponent>(uid, out var anomaly))
+            {
+                _anomalySystem.ChangeAnomalyStability(uid, reaction.StabilityPerPulse, anomaly);
+                _anomalySystem.ChangeAnomalySeverity(uid, reaction.SeverityPerPulse, anomaly);
+                _anomalySystem.ChangeAnomalyHealth(uid, reaction.HealthPerPulse, anomaly);
+            }
+        }
+    }
+}

--- a/Content.Server/Anomaly/Effects/TempReactingAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/TempReactingAnomalySystem.cs
@@ -32,9 +32,12 @@ public sealed class TempReactingAnomalySystem : EntitySystem
         if (mixture is null)
             return;
 
+        if (!TryComp<AnomalyComponent>(uid, out var anomaly))
+            return;
+
         foreach (var reaction in tempReactingAnomaly.Reactions)
         {
-            if (reaction.TempInRange(mixture.Temperature) && TryComp<AnomalyComponent>(uid, out var anomaly))
+            if (reaction.TempInRange(mixture.Temperature))
             {
                 _anomalySystem.ChangeAnomalyStability(uid, reaction.StabilityPerPulse, anomaly);
                 _anomalySystem.ChangeAnomalySeverity(uid, reaction.SeverityPerPulse, anomaly);

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -234,6 +234,9 @@ public abstract class SharedAnomalySystem : EntitySystem
     /// <param name="component"></param>
     public void ChangeAnomalyStability(EntityUid uid, float change, AnomalyComponent? component = null)
     {
+        if (change == 0)
+            return;
+
         if (!Resolve(uid, ref component))
             return;
 
@@ -254,6 +257,9 @@ public abstract class SharedAnomalySystem : EntitySystem
     /// <param name="component"></param>
     public void ChangeAnomalySeverity(EntityUid uid, float change, AnomalyComponent? component = null)
     {
+        if (change == 0)
+            return;
+
         if (!Resolve(uid, ref component))
             return;
 
@@ -277,6 +283,9 @@ public abstract class SharedAnomalySystem : EntitySystem
     /// <param name="component"></param>
     public void ChangeAnomalyHealth(EntityUid uid, float change, AnomalyComponent? component = null)
     {
+        if (change == 0)
+            return;
+
         if (!Resolve(uid, ref component))
             return;
 

--- a/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
@@ -72,6 +72,19 @@
   - type: GasProducerAnomaly
     releasedGas: 3
     releaseOnMaxSeverity: true
+  - type: TempReactingAnomaly
+    reactions:
+    # Really low temperature causes anomaly to decay.
+    - maxTempKelvin: 250 # about -20 degrees Celsius
+      stabilityPerPulse: -0.05 # note: less stability = more stable. more stability = less stable.
+    # High temperatures causes instability.
+    - minTempKelvin: 600 # about 300 degrees Celsius
+      maxTempKelvin: 2000
+      stabilityPerPulse: 0.05
+    # This is pretty much impossible to reach unless you box it in without a cooling solution. Anomaly will quickly go critical if temps reach this point.
+    - minTempKelvin: 2000
+      stabilityPerPulse: 0.12
+      severityPerPulse: 0.12
 
 - type: entity
   id: AnomalyGravity


### PR DESCRIPTION
Pyroclastic anomaly will now get more unstable at very high temperatures, so if you box it in you will need a freezer to avoid it going critical.

The reason for this change is that before, you could just box it in with glass and not have to deal with it. This is quite boring and Emo has mentioned wanting to change this. See PR #17293.

It's implemented with a `TempReactingAnomalyComponent` that is reusable for other anomalies.

:cl:
- tweak: The pyroclastic anomaly will become more unstable at extreme temperatures, such as when confined to a small space.