### PR TITLE
robust harvest 1984

### DIFF
--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -134,7 +134,17 @@
         conditions:
         - !type:OrganType
           type: Plant
-
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Plant
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          types:
+            Asphyxiation: 1
+            Burn: 2
+            Poison: 1
 - type: reagent
   id: WeedKiller
   name: reagent-name-weed-killer


### PR DESCRIPTION
## About the PR
ods at 30u for 6 damage/s so you cant just permanently have 300u of robust in you to be invincible

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Implemented a new robust harvest overdose threshold for Diona, preventing them from achieving immortality.
