### PR TITLE
half bloodred slowdown

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -430,8 +430,8 @@
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
## About the PR
nukies have to wear dufflebag so bloodred made them too slow, this just changes it to 10% slowdown (half of what it was after nerf)

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Blood-red hardsuits now slow you half as much as before.
