### PR TITLE
Allow specific entities to bypass DoAfter delays

### DIFF
--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
@@ -38,7 +38,7 @@ namespace Content.IntegrationTests.Tests.Interaction;
 [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 public abstract partial class InteractionTest
 {
-    protected virtual string PlayerPrototype => "AdminObserver";
+    protected virtual string PlayerPrototype => "MobInteractionTestObserver";
 
     protected PairTracker PairTracker = default!;
     protected TestMapData MapData = default!;
@@ -118,7 +118,36 @@ public abstract partial class InteractionTest
     [SetUp]
     public virtual async Task Setup()
     {
-        PairTracker = await PoolManager.GetServerClient(new PoolSettings());
+        const string TestPrototypes = @"
+- type: entity
+  id: MobInteractionTestObserver
+  name: observer
+  noSpawn: true
+  save: false
+  description: Boo!
+  components:
+  - type: Access
+    groups:
+    - AllAccess
+  - type: Body
+    prototype: Aghost
+  - type: DoAfter
+  - type: Ghost
+    canInteract: true
+  - type: Hands
+  - type: Mind
+  - type: Stripping
+  - type: Tag
+    tags:
+    - CanPilot
+    - BypassInteractionRangeChecks
+  - type: Thieving
+    stripTimeReduction: 9999
+    stealthy: true
+  - type: UserInterface
+";
+
+        PairTracker = await PoolManager.GetServerClient(new PoolSettings{ExtraPrototypes = TestPrototypes});
 
         // server dependencies
         SEntMan = Server.ResolveDependency<IEntityManager>();

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.Hands.Components;
 using Content.Shared.Mobs;
+using Content.Shared.Tag;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
@@ -16,6 +17,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     [Dependency] protected readonly IGameTiming GameTiming = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
 
     /// <summary>
     ///     We'll use an excess time so stuff like finishing effects can show.
@@ -221,7 +223,8 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         if (args.AttemptFrequency == AttemptFrequency.StartAndEnd && !TryAttemptEvent(doAfter))
             return false;
 
-        if (args.Delay <= TimeSpan.Zero)
+        if (args.Delay <= TimeSpan.Zero ||
+            _tag.HasTag(args.User, "InstantDoAfters"))
         {
             RaiseDoAfterEvents(doAfter, comp);
             // We don't store instant do-afters. This is just a lazy way of hiding them from client-side visuals.

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -9,6 +9,7 @@
     maxZoom: 8.916104, 8.916104
   - type: Tag
     tags:
+    - InstantDoAfters
     - CanPilot
     - BypassInteractionRangeChecks
   - type: Input

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -410,6 +410,9 @@
   id: Ingot
 
 - type: Tag
+  id: InstantDoAfters
+
+- type: Tag
   id: IntercomElectronics
 
 - type: Tag


### PR DESCRIPTION
This adds the InstantDoAfters tag to the admin ghost for mappers.

Fixes #17176

https://github.com/space-wizards/space-station-14/assets/114301317/fb44545f-09fa-4452-9da9-930cae02f1ae