### PR TITLE
Color Coded Anchor Examine Text

### DIFF
--- a/Resources/Locale/en-US/examine/examine-system.ftl
+++ b/Resources/Locale/en-US/examine/examine-system.ftl
@@ -6,6 +6,6 @@ examine-system-cant-see-entity = You can't make out whatever that is.
 
 examine-verb-name = Basic
 
-examinable-anchored = It is anchored to the floor
+examinable-anchored = It is [color=darkgreen]anchored[/color] to the floor
 
-examinable-unanchored = It is unanchored from the floor
+examinable-unanchored = It is [color=darkred]unanchored[/color] from the floor


### PR DESCRIPTION
## About the PR
Colors the examine text for anchorable objects red and green. Because people suffer massive blindness and skill issue.

**Media**
![image](https://github.com/space-wizards/space-station-14/assets/110078045/25db789a-3515-47a1-a9b5-34b138d3de58)
![image](https://github.com/space-wizards/space-station-14/assets/110078045/e2d43af8-b75e-4fed-9599-815b83378f8e)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl:
- tweak: Changed anchored and unanchored examine text to be green and red respectfully.
