### PR TITLE
ClownHardsuit Fix

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -9,6 +9,9 @@
     sprite: Clothing/Head/Helmets/eva.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/eva.rsi
+  - type: Tag
+    tags:
+    - HelmetEVA
 
 #Large EVA Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -9,6 +9,9 @@
     sprite: Clothing/OuterClothing/Suits/eva.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/eva.rsi
+  - type: Tag
+    tags:
+    - SuitEVA
 
 #Syndicate EVA
 - type: entity

--- a/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
@@ -53,5 +53,5 @@
     displayName: Suit
     whitelist:
       tags:
-        - HardsuitEVA
+        - SuitEVA
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/clothing/clown_hardsuit.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/clothing/clown_hardsuit.yml
@@ -9,14 +9,14 @@
             - material: Cloth
               amount: 5
               doAfter: 1
-            - tag: HardsuitEVA
-              name: EVA suit
+            - tag: SuitEVA
+              name: An EVA suit
               icon:
                 sprite: Clothing/OuterClothing/Suits/eva.rsi
                 state: icon
               doAfter: 1
             - tag: HelmetEVA
-              name: EVA helmet
+              name: An EVA helmet
               icon:
                 sprite: Clothing/Head/Helmets/eva.rsi
                 state: icon

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -356,9 +356,6 @@
   id: Hardsuit # Prevent melee injectors that can't penetrate hardsuits from injecting the wearer (nettles)
 
 - type: Tag
-  id: HardsuitEVA
-
-- type: Tag
   id: Head
 
 - type: Tag
@@ -709,6 +706,9 @@
 
 - type: Tag
   id: SubdermalImplant
+
+- type: Tag
+  id: SuitEVA
 
 - type: Tag
   id: SurveillanceCameraMonitorCircuitboard


### PR DESCRIPTION
Fixes the clownhardsuit so it can be crafted again (the tags were not added which were used to craft it when the new eva suit changes and sprites were merged).

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
