### PR TITLE
Remove static ILocalizationManager resolves.

### DIFF
--- a/Content.Client/Crayon/CrayonSystem.cs
+++ b/Content.Client/Crayon/CrayonSystem.cs
@@ -62,7 +62,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
             }
 
             _parent.UIUpdateNeeded = false;
-            _label.SetMarkup(Loc.GetString("crayon-drawing-label",
+            _label.SetMarkup(Robust.Shared.Localization.Loc.GetString("crayon-drawing-label",
                 ("color",_parent.Color),
                 ("state",_parent.SelectedState),
                 ("charges", _parent.Charges),

--- a/Content.Client/NetworkConfigurator/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Client/NetworkConfigurator/Systems/NetworkConfiguratorSystem.cs
@@ -147,8 +147,8 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
                 ? "network-configurator-examine-mode-link"
                 : "network-configurator-examine-mode-list";
 
-            _label.SetMarkup(Loc.GetString("network-configurator-item-status-label",
-                ("mode", Loc.GetString(modeLocString)),
+            _label.SetMarkup(Robust.Shared.Localization.Loc.GetString("network-configurator-item-status-label",
+                ("mode", Robust.Shared.Localization.Loc.GetString(modeLocString)),
                 ("keybinding", _keyBindingName)));
         }
     }

--- a/Content.Server/Armor/ArmorSystem.cs
+++ b/Content.Server/Armor/ArmorSystem.cs
@@ -85,7 +85,7 @@ namespace Content.Server.Armor
             _examine.AddDetailedExamineVerb(args, component, examineMarkup, Loc.GetString("armor-examinable-verb-text"), "/Textures/Interface/VerbIcons/dot.svg.192dpi.png", Loc.GetString("armor-examinable-verb-message"));
         }
 
-        private static FormattedMessage GetArmorExamine(DamageModifierSet armorModifiers)
+        private FormattedMessage GetArmorExamine(DamageModifierSet armorModifiers)
         {
             var msg = new FormattedMessage();
 

--- a/Content.Server/Chat/SuicideSystem.cs
+++ b/Content.Server/Chat/SuicideSystem.cs
@@ -61,7 +61,7 @@ namespace Content.Server.Chat
         /// <summary>
         /// If not handled, does the default suicide, which is biting your own tongue
         /// </summary>
-        private static void DefaultSuicideHandler(EntityUid victim, SuicideEvent suicideEvent)
+        private void DefaultSuicideHandler(EntityUid victim, SuicideEvent suicideEvent)
         {
             if (suicideEvent.Handled)
                 return;

--- a/Content.Server/Examine/ExamineSystem.cs
+++ b/Content.Server/Examine/ExamineSystem.cs
@@ -14,21 +14,14 @@ namespace Content.Server.Examine
     {
         [Dependency] private readonly VerbSystem _verbSystem = default!;
 
-        private static readonly FormattedMessage _entityNotFoundMessage;
-
-        private static readonly FormattedMessage _entityOutOfRangeMessage;
-
-        static ExamineSystem()
-        {
-            _entityNotFoundMessage = new FormattedMessage();
-            _entityNotFoundMessage.AddText(Loc.GetString("examine-system-entity-does-not-exist"));
-            _entityOutOfRangeMessage = new FormattedMessage();
-            _entityOutOfRangeMessage.AddText(Loc.GetString("examine-system-cant-see-entity"));
-        }
+        private readonly FormattedMessage _entityNotFoundMessage = new();
+        private readonly FormattedMessage _entityOutOfRangeMessage = new();
 
         public override void Initialize()
         {
             base.Initialize();
+            _entityNotFoundMessage.AddText(Loc.GetString("examine-system-entity-does-not-exist"));
+            _entityOutOfRangeMessage.AddText(Loc.GetString("examine-system-cant-see-entity"));
 
             SubscribeNetworkEvent<ExamineSystemMessages.RequestExamineInfoMessage>(ExamineInfoRequest);
         }


### PR DESCRIPTION
This PR just has changes required for an engine PR which is meant to remove localization manager resolves. 

This PR should be fine to merge on its own, but just to thoroughly test the engine PR: requires space-wizards/RobustToolbox/pull/4145.

