### PR TITLE
Fix gas tile overlays

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
@@ -307,7 +307,7 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 // Not all grids have atmospheres.
                 if (!TryComp(grid, out GasTileOverlayComponent? overlay))
-                    return;
+                    continue;
 
                 List<GasOverlayChunk> dataToSend = new();
                 ev.UpdatedChunks[grid] = dataToSend;
@@ -322,7 +322,9 @@ namespace Content.Server.Atmos.EntitySystems
                     if (previousChunks != null &&
                         previousChunks.Contains(index) &&
                         value.LastUpdate != curTick)
+                    {
                         continue;
+                    }
 
                     dataToSend.Add(value);
                 }


### PR DESCRIPTION
:cl:
- fix: Fix gas tile overlays not always showing, e.g. gas leaks on shuttles on planets.