### PR TITLE
Fixes armour values for bio suits and winter coats

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -15,7 +15,7 @@
         Caustic: 0.5
 
 - type: entity
-  parent: ClothingOuterBaseLarge
+  parent: ClothingOuterBioGeneral
   id: ClothingOuterBioCmo
   name: bio suit
   suffix: CMO
@@ -63,7 +63,7 @@
     sprite: Clothing/OuterClothing/Bio/security.rsi
 
 - type: entity
-  parent: ClothingOuterBioCmo
+  parent: ClothingOuterBioGeneral
   id: ClothingOuterBioVirology
   name: bio suit
   suffix: Virology

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -101,6 +101,8 @@
   - type: Armor
     modifiers:
       coefficients:
+        Slash: 0.95
+        Heat: 0.75
         Caustic: 0.75
 
 - type: entity
@@ -115,6 +117,8 @@
   - type: Armor
     modifiers:
       coefficients:
+        Slash: 0.95
+        Heat: 0.75
         Caustic: 0.75
 
 - type: entity
@@ -149,6 +153,8 @@
   - type: Armor
     modifiers:
       coefficients:
+        Slash: 0.95
+        Heat: 0.75
         Caustic: 0.9
 
 - type: entity
@@ -193,6 +199,8 @@
   - type: Armor
     modifiers:
       coefficients:
+        Slash: 0.95
+        Heat: 0.75
         Caustic: 0.9
 
 - type: entity
@@ -207,6 +215,8 @@
   - type: Armor
     modifiers:
       coefficients:
+        Slash: 0.95
+        Heat: 0.75
         Caustic: 0.9
 
 - type: entity
@@ -241,6 +251,8 @@
   - type: Armor
     modifiers:
       coefficients:
+        Slash: 0.95
+        Heat: 0.75
         Caustic: 0.9
 
 - type: entity
@@ -265,6 +277,8 @@
   - type: Armor
     modifiers:
       coefficients:
+        Slash: 0.95
+        Heat: 0.75
         Caustic: 0.9
 
 - type: entity
@@ -289,6 +303,8 @@
   - type: Armor
     modifiers:
       coefficients:
+        Slash: 0.95
+        Heat: 0.75
         Caustic: 0.9
 
 - type: entity
@@ -313,6 +329,8 @@
   - type: Armor
     modifiers:
       coefficients:
+        Slash: 0.95
+        Heat: 0.75
         Caustic: 0.9
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The CMO and virology biosuits inherit from ClothingOuterBaseLarge instead of ClothingOuterBioGeneral and, therefore, don't have the 50% caustic armour all other biosuits get.

The chemistry, CMO, genetics, janitorial, medical, paramedic, RD, science and virology winter coats redefine the armour values from the basic winter coat and only have 25%/10% caustic, instead of that and the 25% heat and 5% slash winter coats normally get.

This fixes both of those issues.


**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Sigil
- fix: Fixed the armour values on all winter coats that have caustic armour as well as the CMO and virology bio suits.
