### PR TITLE
Add pathfinding support for NPCs climbing tables

### DIFF
--- a/Content.IntegrationTests/Tests/Climbing/ClimbingTest.cs
+++ b/Content.IntegrationTests/Tests/Climbing/ClimbingTest.cs
@@ -29,7 +29,7 @@ public sealed class ClimbingTest : MovementTest
 
         // Try to start climbing
         var sys = SEntMan.System<ClimbSystem>();
-        await Server.WaitPost(() => sys.TryClimb(Player, Player, Target.Value));
+        await Server.WaitPost(() => sys.TryClimb(Player, Player, Target.Value, out _));
         await AwaitDoAfters();
 
         // Player should now be climbing
@@ -49,7 +49,7 @@ public sealed class ClimbingTest : MovementTest
         Assert.That(Delta(), Is.LessThan(0));
 
         // Start climbing
-        await Server.WaitPost(() => sys.TryClimb(Player, Player, Target.Value));
+        await Server.WaitPost(() => sys.TryClimb(Player, Player, Target.Value, out _));
         await AwaitDoAfters();
         Assert.That(comp.IsClimbing, Is.True);
         Assert.That(comp.DisabledFixtureMasks.Count, Is.GreaterThan(0));

--- a/Content.Server/Climbing/ClimbSystem.cs
+++ b/Content.Server/Climbing/ClimbSystem.cs
@@ -94,7 +94,7 @@ public sealed class ClimbSystem : SharedClimbSystem
         // TODO VERBS ICON add a climbing icon?
         args.Verbs.Add(new AlternativeVerb
         {
-            Act = () => TryClimb(args.User, args.User, args.Target, component),
+            Act = () => TryClimb(args.User, args.User, args.Target, out _, component),
             Text = Loc.GetString("comp-climbable-verb-climb")
         });
     }
@@ -105,22 +105,25 @@ public sealed class ClimbSystem : SharedClimbSystem
         // but don't have computer access and i have to do this without syntax
         if (args.Handled || args.User != args.Dragged && !HasComp<HandsComponent>(args.User))
             return;
-        TryClimb(args.User, args.Dragged, uid, component);
+        TryClimb(args.User, args.Dragged, uid, out _, component);
     }
 
-    public void TryClimb(EntityUid user,
+    public bool TryClimb(EntityUid user,
         EntityUid entityToMove,
         EntityUid climbable,
+        out DoAfterId? id,
         ClimbableComponent? comp = null,
         ClimbingComponent? climbing = null)
     {
+        id = null;
+
         if (!Resolve(climbable, ref comp) || !Resolve(entityToMove, ref climbing))
-            return;
+            return false;
 
         // Note, IsClimbing does not mean a DoAfter is active, it means the target has already finished a DoAfter and
         // is currently on top of something..
         if (climbing.IsClimbing)
-            return;
+            return true;
 
         var args = new DoAfterArgs(user, comp.ClimbDelay, new ClimbDoAfterEvent(), entityToMove, target: climbable, used: entityToMove)
         {
@@ -129,7 +132,8 @@ public sealed class ClimbSystem : SharedClimbSystem
             BreakOnDamage = true
         };
 
-        _doAfterSystem.TryStartDoAfter(args);
+        _doAfterSystem.TryStartDoAfter(args, out id);
+        return true;
     }
 
     private void OnDoAfter(EntityUid uid, ClimbingComponent component, ClimbDoAfterEvent args)
@@ -278,7 +282,7 @@ public sealed class ClimbSystem : SharedClimbSystem
     /// <param name="target">The object that is being vaulted</param>
     /// <param name="reason">The reason why it cant be dropped</param>
     /// <returns></returns>
-    private bool CanVault(ClimbableComponent component, EntityUid user, EntityUid target, out string reason)
+    public bool CanVault(ClimbableComponent component, EntityUid user, EntityUid target, out string reason)
     {
         if (!_actionBlockerSystem.CanInteract(user, target))
         {
@@ -314,7 +318,7 @@ public sealed class ClimbSystem : SharedClimbSystem
     /// <param name="target">The object that is being vaulted onto</param>
     /// <param name="reason">The reason why it cant be dropped</param>
     /// <returns></returns>
-    private bool CanVault(ClimbableComponent component, EntityUid user, EntityUid dragged, EntityUid target,
+    public bool CanVault(ClimbableComponent component, EntityUid user, EntityUid dragged, EntityUid target,
         out string reason)
     {
         if (!_actionBlockerSystem.CanInteract(user, dragged) || !_actionBlockerSystem.CanInteract(user, target))

--- a/Content.Server/NPC/NPCBlackboard.cs
+++ b/Content.Server/NPC/NPCBlackboard.cs
@@ -226,6 +226,11 @@ public sealed class NPCBlackboard : IEnumerable<KeyValuePair<string, object>>
     public const string NavSmash = "NavSmash";
 
     /// <summary>
+    /// Can the NPC climb obstacles for steering.
+    /// </summary>
+    public const string NavClimb = "NavClimb";
+
+    /// <summary>
     /// Default key storage for a movement pathfind.
     /// </summary>
     public const string PathfindKey = "MovementPathfind";

--- a/Content.Server/NPC/Pathfinding/PathFlags.cs
+++ b/Content.Server/NPC/Pathfinding/PathFlags.cs
@@ -21,7 +21,12 @@ public enum PathFlags : byte
     Smashing = 1 << 2,
 
     /// <summary>
+    /// Can we climb it like a table or railing.
+    /// </summary>
+    Climbing = 1 << 3,
+
+    /// <summary>
     /// Can we open stuff that requires interaction (e.g. click-open doors).
     /// </summary>
-    Interact = 1 << 3,
+    Interact = 1 << 4,
 }

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Common.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Common.cs
@@ -57,6 +57,7 @@ public sealed partial class PathfindingSystem
         {
             var isDoor = (end.Data.Flags & PathfindingBreadcrumbFlag.Door) != 0x0;
             var isAccess = (end.Data.Flags & PathfindingBreadcrumbFlag.Access) != 0x0;
+            var isClimb = (end.Data.Flags & PathfindingBreadcrumbFlag.Climb) != 0x0;
 
             // TODO: Handling power + door prying
             // Door we should be able to open
@@ -72,6 +73,10 @@ public sealed partial class PathfindingSystem
             else if ((request.Flags & PathFlags.Smashing) != 0x0 && end.Data.Damage > 0f)
             {
                 modifier += 10f + end.Data.Damage / 100f;
+            }
+            else if (isClimb && (request.Flags & PathFlags.Climbing) != 0x0)
+            {
+                modifier += 0.5f;
             }
             else
             {

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Destructible;
 using Content.Shared.Access.Components;
+using Content.Shared.Climbing;
 using Content.Shared.Doors.Components;
 using Content.Shared.NPC;
 using Content.Shared.Physics;
@@ -151,11 +152,12 @@ public sealed partial class PathfindingSystem
                 var accessQuery = GetEntityQuery<AccessReaderComponent>();
                 var destructibleQuery = GetEntityQuery<DestructibleComponent>();
                 var doorQuery = GetEntityQuery<DoorComponent>();
+                var climbableQuery = GetEntityQuery<ClimbableComponent>();
                 var fixturesQuery = GetEntityQuery<FixturesComponent>();
                 var physicsQuery = GetEntityQuery<PhysicsComponent>();
                 var xformQuery = GetEntityQuery<TransformComponent>();
-                BuildBreadcrumbs(dirt[i], mapGridComp, accessQuery, destructibleQuery, doorQuery, fixturesQuery,
-                    physicsQuery, xformQuery);
+                BuildBreadcrumbs(dirt[i], mapGridComp, accessQuery, destructibleQuery, doorQuery, climbableQuery,
+                    fixturesQuery, physicsQuery, xformQuery);
             });
 
             const int Division = 4;
@@ -406,6 +408,7 @@ public sealed partial class PathfindingSystem
         EntityQuery<AccessReaderComponent> accessQuery,
         EntityQuery<DestructibleComponent> destructibleQuery,
         EntityQuery<DoorComponent> doorQuery,
+        EntityQuery<ClimbableComponent> climbableQuery,
         EntityQuery<FixturesComponent> fixturesQuery,
         EntityQuery<PhysicsComponent> physicsQuery,
         EntityQuery<TransformComponent> xformQuery)
@@ -521,6 +524,11 @@ public sealed partial class PathfindingSystem
                             if (doorQuery.HasComponent(ent))
                             {
                                 flags |= PathfindingBreadcrumbFlag.Door;
+                            }
+
+                            if (climbableQuery.HasComponent(ent))
+                            {
+                                flags |= PathfindingBreadcrumbFlag.Climb;
                             }
 
                             if (destructibleQuery.TryGetComponent(ent, out var damageable))

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Administration.Managers;
 using Content.Server.Destructible;
 using Content.Server.NPC.Components;
 using Content.Shared.Administration;
+using Content.Shared.Climbing;
 using Content.Shared.Interaction;
 using Content.Shared.NPC;
 using Robust.Server.Player;
@@ -433,6 +434,11 @@ namespace Content.Server.NPC.Pathfinding
             if (blackboard.TryGetValue<bool>(NPCBlackboard.NavSmash, out var smash, EntityManager) && smash)
             {
                 flags |= PathFlags.Smashing;
+            }
+
+            if (blackboard.TryGetValue<bool>(NPCBlackboard.NavClimb, out var climb, EntityManager) && climb)
+            {
+                flags |= PathFlags.Climbing;
             }
 
             if (blackboard.TryGetValue<bool>(NPCBlackboard.NavInteract, out var interact, EntityManager) && interact)

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Server.Examine;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.Pathfinding;
+using Content.Shared.Climbing;
 using Content.Shared.Interaction;
 using Content.Shared.Movement.Components;
 using Content.Shared.NPC;
@@ -33,6 +34,30 @@ public sealed partial class NPCSteeringSystem
     }
 
     #region Seek
+
+    /// <summary>
+    /// Takes into account agent-specific context that may allow it to bypass a node which is not FreeSpace.
+    /// </summary>
+    private bool IsFreeSpace(
+        EntityUid uid,
+        NPCSteeringComponent steering,
+        PathPoly node)
+    {
+        if (node.Data.IsFreeSpace)
+        {
+            return true;
+        }
+        // Handle the case where the node is a climb, we can climb, and we are climbing.
+        else if ((node.Data.Flags & PathfindingBreadcrumbFlag.Climb) != 0x0 &&
+            (steering.Flags & PathFlags.Climbing) != 0x0 &&
+            TryComp<ClimbingComponent>(uid, out var climbing) &&
+            climbing.IsClimbing)
+        {
+            return true;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Attempts to head to the target destination, either via the next pathfinding node or the final target.
@@ -90,7 +115,7 @@ public sealed partial class NPCSteeringSystem
         }
         // If next node is a free tile then get within its bounds.
         // This is to avoid popping it too early
-        else if (steering.CurrentPath.TryPeek(out var node) && node.Data.IsFreeSpace)
+        else if (steering.CurrentPath.TryPeek(out var node) && IsFreeSpace(uid, steering, node))
         {
             arrivalDistance = MathF.Min(node.Box.Width / 2f, node.Box.Height / 2f) - 0.01f;
         }
@@ -117,7 +142,7 @@ public sealed partial class NPCSteeringSystem
         if (direction.Length <= arrivalDistance)
         {
             // Node needs some kind of special handling like access or smashing.
-            if (steering.CurrentPath.TryPeek(out var node) && !node.Data.IsFreeSpace)
+            if (steering.CurrentPath.TryPeek(out var node) && !IsFreeSpace(uid, steering, node))
             {
                 // Ignore stuck while handling obstacles.
                 ResetStuck(steering, ourCoordinates);

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Obstacles.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Obstacles.cs
@@ -1,6 +1,7 @@
 using Content.Server.Destructible;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.Pathfinding;
+using Content.Shared.Climbing;
 using Content.Shared.CombatMode;
 using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
@@ -74,6 +75,7 @@ public sealed partial class NPCSteeringSystem
             GetObstacleEntities(poly, mask, layer, bodyQuery, obstacleEnts);
             var isDoor = (poly.Data.Flags & PathfindingBreadcrumbFlag.Door) != 0x0;
             var isAccessRequired = (poly.Data.Flags & PathfindingBreadcrumbFlag.Access) != 0x0;
+            var isClimbable = (poly.Data.Flags & PathfindingBreadcrumbFlag.Climb) != 0x0;
 
             // Just walk into it stupid
             if (isDoor && !isAccessRequired)
@@ -115,6 +117,38 @@ public sealed partial class NPCSteeringSystem
 
                         component.DoAfterId = id;
                         return SteeringObstacleStatus.Continuing;
+                    }
+                }
+
+                if (obstacleEnts.Count == 0)
+                    return SteeringObstacleStatus.Completed;
+            }
+            // Try climbing obstacles
+            else if ((component.Flags & PathFlags.Climbing) != 0x0 && isClimbable)
+            {
+                if (TryComp<ClimbingComponent>(uid, out var climbing))
+                {
+                    if (climbing.IsClimbing)
+                    {
+                        return SteeringObstacleStatus.Completed;
+                    }
+                    else if (climbing.OwnerIsTransitioning)
+                    {
+                        return SteeringObstacleStatus.Continuing;
+                    }
+
+                    var climbableQuery = GetEntityQuery<ClimbableComponent>();
+
+                    // Get the relevant obstacle
+                    foreach (var ent in obstacleEnts)
+                    {
+                        if (climbableQuery.TryGetComponent(ent, out var table) &&
+                            _climb.CanVault(table, uid, uid, out _) &&
+                            _climb.TryClimb(uid, uid, ent, out id, table, climbing))
+                        {
+                            component.DoAfterId = id;
+                            return SteeringObstacleStatus.Continuing;
+                        }
                     }
                 }
 

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Administration.Managers;
+using Content.Server.Climbing;
 using Content.Server.DoAfter;
 using Content.Server.Doors.Systems;
 using Content.Server.NPC.Components;
@@ -48,6 +49,7 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IParallelManager _parallel = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly ClimbSystem _climb = default!;
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly DoorSystem _doors = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;

--- a/Content.Shared/NPC/PathfindingBreadcrumb.cs
+++ b/Content.Shared/NPC/PathfindingBreadcrumb.cs
@@ -115,4 +115,9 @@ public enum PathfindingBreadcrumbFlag : ushort
     /// Is there access required
     /// </summary>
     Access = 1 << 3,
+
+    /// <summary>
+    /// Is there climbing involved
+    /// </summary>
+    Climb = 1 << 4,
 }


### PR DESCRIPTION
This works almost perfectly. There's a slight pause after they climb up the table, and the melee steer backup has no concept of terrain advantage, so they have a tendency to attack in melee, then backup off the table and have to climb again, but they're actually able to vault climbable obstacles instead of destroying them (which is usually preferable).

I had to make an agent-specific exception method for IsFreeSpace, otherwise they would get to the table, climb up, then just hang in midair on the edge of the table if you were directly on the other side.

I don't know much about the pathfinding system, but I'm looking forward to feedback. I assume the interest/danger map could be used to inform terrain advantage, but that's beyond me at this point.

[navclimb1.webm](https://github.com/space-wizards/space-station-14/assets/114301317/1b2eeb56-5aed-4c23-8d09-8fd313f8fbed)

There is an oddity shown in the beginning of this video where the creature was initially still considered climbing, which I believe would be fixed by the proposed rewrite mentioned in #16977.