### PR TITLE
Fixes metamorphic glasses

### DIFF
--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsComponent.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsComponent.cs
@@ -33,10 +33,5 @@ namespace Content.Client.Chemistry.Visualizers
         public bool Metamorphic = false;
         [DataField("metamorphicDefaultSprite")]
         public SpriteSpecifier MetamorphicDefaultSprite = SpriteSpecifier.Invalid;
-        [DataField("metamorphicNameFull")]
-        public string MetamorphicNameFull = "transformable-container-component-glass";
-
-        public string InitialName = string.Empty;
-        public string InitialDescription = string.Empty;
     }
 }

--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -10,11 +10,6 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-    }
-
     protected override void OnAppearanceChange(EntityUid uid, SolutionContainerVisualsComponent component, ref AppearanceChangeEvent args)
     {
         if (!AppearanceSystem.TryGetData<float>(uid, SolutionContainerVisuals.FillFraction, out var fraction, args.Component))
@@ -45,8 +40,6 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
                         args.Component))
                 {
                     _prototype.TryIndex<ReagentPrototype>(baseOverride, out var reagentProto);
-
-                    var metadata = MetaData(uid);
 
                     if (reagentProto?.MetamorphicSprite is { } sprite)
                     {

--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -13,14 +13,6 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<SolutionContainerVisualsComponent, MapInitEvent>(OnMapInit);
-    }
-
-    private void OnMapInit(EntityUid uid, SolutionContainerVisualsComponent component, MapInitEvent args)
-    {
-        var meta = MetaData(uid);
-        component.InitialName = meta.EntityName;
-        component.InitialDescription = meta.EntityDescription;
     }
 
     protected override void OnAppearanceChange(EntityUid uid, SolutionContainerVisualsComponent component, ref AppearanceChangeEvent args)
@@ -62,9 +54,6 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
                         args.Sprite.LayerSetVisible(fillLayer, false);
                         if (hasOverlay)
                             args.Sprite.LayerSetVisible(overlayLayer, false);
-                        metadata.EntityName = Loc.GetString(component.MetamorphicNameFull,
-                            ("name", reagentProto.LocalizedName));
-                        metadata.EntityDescription = reagentProto.LocalizedDescription;
                         return;
                     }
                     else
@@ -72,8 +61,6 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
                         if (hasOverlay)
                             args.Sprite.LayerSetVisible(overlayLayer, true);
                         args.Sprite.LayerSetSprite(baseLayer, component.MetamorphicDefaultSprite);
-                        metadata.EntityName = component.InitialName;
-                        metadata.EntityDescription = component.InitialDescription;
                     }
                 }
             }

--- a/Content.Server/Chemistry/Components/SolutionManager/SolutionContainerManagerComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionManager/SolutionContainerManagerComponent.cs
@@ -10,5 +10,17 @@ namespace Content.Server.Chemistry.Components.SolutionManager
         [DataField("solutions")]
         [Access(typeof(SolutionContainerSystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
         public readonly Dictionary<string, Solution> Solutions = new();
+		
+		[DataField("matchContents")]
+		public bool MatchContents = false;
+		
+        [DataField("matchNameFull")]
+        public string MatchNameFull = "transformable-container-component-glass";
+
+		[DataField("emptyName")]
+        public string EmptyName = string.Empty;
+		
+		[DataField("emptyDescription")]
+        public string EmptyDescription = string.Empty;
     }
 }

--- a/Content.Server/Chemistry/Components/SolutionManager/SolutionContainerManagerComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionManager/SolutionContainerManagerComponent.cs
@@ -11,8 +11,8 @@ namespace Content.Server.Chemistry.Components.SolutionManager
         [Access(typeof(SolutionContainerSystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
         public readonly Dictionary<string, Solution> Solutions = new();
 		
-		[DataField("matchContents")]
-		public bool MatchContents = false;
+		[DataField("matchContentsName")]
+		public bool MatchContentsName = false;
 		
         [DataField("matchNameFull")]
         public string MatchNameFull = "transformable-container-component-glass";

--- a/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
@@ -168,7 +168,7 @@ public sealed partial class SolutionContainerSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 		
-		if(!component.MatchContents)
+		if(!component.MatchContentsName)
 			return;
 		
 		var metadata = MetaData(uid);

--- a/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
@@ -162,6 +162,31 @@ public sealed partial class SolutionContainerSystem : EntitySystem
             _appearance.SetData(uid, SolutionContainerVisuals.BaseOverride, string.Empty, appearanceComponent);
         }
     }
+	
+	public void UpdateName(EntityUid uid, Solution solution, SolutionContainerManagerComponent? component = null)
+	{
+        if (!Resolve(uid, ref component))
+            return;
+		
+		if(!component.MatchContents)
+			return;
+		
+		var metadata = MetaData(uid);
+		
+		if (solution.GetPrimaryReagentId() is { } reagent)
+		{
+			_prototypeManager.TryIndex<ReagentPrototype>(reagent, out var reagentProto);
+		
+			if (reagentProto?.MetamorphicSprite is { } sprite)
+			{
+				metadata.EntityName = Loc.GetString(component.MatchNameFull, ("name", reagentProto.LocalizedName));
+				metadata.EntityDescription = reagentProto.LocalizedDescription;
+				return;
+			}
+		}
+		metadata.EntityName = component.EmptyName;
+		metadata.EntityDescription = component.EmptyDescription;
+	}
 
     /// <summary>
     ///     Removes part of the solution in the container.
@@ -207,6 +232,7 @@ public sealed partial class SolutionContainerSystem : EntitySystem
         }
 
         UpdateAppearance(uid, solutionHolder);
+		UpdateName(uid, solutionHolder);
         RaiseLocalEvent(uid, new SolutionChangedEvent(solutionHolder));
     }
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -100,6 +100,9 @@
     solutions:
       drink:
         maxVol: 30
+    matchContents: true
+    emptyName: metamorphic glass
+    emptyDescription: A metamorphic glass that automagically turns into a glass appropriate for the drink within. There's a sanded off patent number on the bottom.
   - type: SolutionContainerVisuals
     maxFillLevels: 9
     fillBaseName: fill
@@ -134,7 +137,7 @@
       fillBaseName: fill
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkAbsintheGlass
   name: absinthe glass
   description: Wormwood, anise, oh my.
@@ -146,11 +149,9 @@
         reagents:
         - ReagentId: Absinthe
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/absintheglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkAcidSpitGlass
   name: acid spit glass
   description: A drink from the company archives. Made from live aliens.
@@ -162,11 +163,9 @@
         reagents:
         - ReagentId: AcidSpit
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/acidspitglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkAleGlass
   name: ale glass
   description: A freezing pint of delicious ale
@@ -178,11 +177,9 @@
         reagents:
         - ReagentId: Ale
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/aleglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkAlliesCocktail
   name: allies cocktail
   description: A drink made from your allies.
@@ -194,11 +191,9 @@
         reagents:
         - ReagentId: AlliesCocktail
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/alliescocktail.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkAloe
   name: aloe glass
   description: Very, very, very good.
@@ -210,11 +205,9 @@
         reagents:
         - ReagentId: Aloe
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/aloe.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkAmasecGlass
   name: amasec glass
   description: Always handy before COMBAT!!!
@@ -226,11 +219,9 @@
         reagents:
         - ReagentId: Amasec
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/amasecglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkAndalusia
   name: andalusia glass
   description: A nice drink with a strange name.
@@ -242,11 +233,9 @@
         reagents:
         - ReagentId: Andalusia
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/andalusia.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkAntifreeze
   name: anti-freeze glass
   description: The ultimate refreshment.
@@ -258,12 +247,9 @@
         reagents:
         - ReagentId: Antifreeze
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/antifreeze.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkAtomicBombGlass
   name: atomic bomb glass
   description: We cannot take legal responsibility for your actions after imbibing.
@@ -275,12 +261,9 @@
         reagents:
         - ReagentId: AtomicBomb
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/atomicbombglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkB52Glass
   name: b-52 glass
   description: Coffee, Irish Cream, and cognac. You will get bombed.
@@ -292,12 +275,9 @@
         reagents:
         - ReagentId: B52
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/b52glass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBahamaMama
   name: bahama mama glass
   description: Tropical cocktail.
@@ -309,12 +289,9 @@
         reagents:
         - ReagentId: BahamaMama
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/bahama_mama.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBananaHonkGlass
   name: banana honk glass
   description: A drink from Banana Heaven.
@@ -326,12 +303,9 @@
         reagents:
         - ReagentId: BananaHonk
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/bananahonkglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBarefootGlass
   name: barefoot glass
   description: Barefoot and pregnant.
@@ -343,12 +317,9 @@
         reagents:
         - ReagentId: Barefoot
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/b&p.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBeepskySmashGlass
   name: beepsky smash glass
   description: Heavy, hot and strong. Just like the Iron fist of the LAW.
@@ -360,12 +331,9 @@
         reagents:
         - ReagentId: BeepskySmash
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/beepskysmashglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBeerglass
   name: beer glass
   description: A freezing pint of beer.
@@ -377,11 +345,9 @@
         reagents:
         - ReagentId: Beer
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/beerglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBerryJuice
   name: berry juice
   description: Berry juice. Or maybe it's jam. Who cares?
@@ -394,11 +360,9 @@
         reagents:
         - ReagentId: JuiceBerry
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/berryjuice.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBlackRussianGlass
   name: black russian glass
   description: For the lactose-intolerant. Still as classy as a White Russian.
@@ -410,12 +374,9 @@
         reagents:
         - ReagentId: BlackRussian
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/blackrussianglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBlueCuracaoGlass
   name: blue curacao
   description: Exotically blue, fruity drink, distilled from oranges.
@@ -428,11 +389,9 @@
         reagents:
         - ReagentId: BlueCuracao
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/curacaoglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBloodyMaryGlass
   name: bloody mary glass
   description: Tomato juice, mixed with Vodka and a lil' bit of lime. Tastes like liquid murder.
@@ -444,12 +403,9 @@
         reagents:
         - ReagentId: BloodyMary
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/bloodymaryglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBooger
   name: booger
   description: Ewww...
@@ -461,12 +417,9 @@
         reagents:
         - ReagentId: Booger
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/booger.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkBraveBullGlass
   name: brave bull glass
   description: Tequilla and coffee liquor, brought together in a mouthwatering mixture. Drink up.
@@ -478,12 +431,9 @@
         reagents:
         - ReagentId: BraveBull
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/bravebullglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkCarrotJuice
   name: carrot juice
   description: It's just like a carrot but without crunching.
@@ -496,8 +446,6 @@
         reagents:
         - ReagentId: JuiceCarrot
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/carrotjuice.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -526,7 +474,7 @@
     sprite: Objects/Consumable/Drinks/coffee.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkCognacGlass
   name: cognac glass
   description: Damn, you feel like some kind of French aristocrat just by holding this.
@@ -538,8 +486,6 @@
         reagents:
         - ReagentId: Cognac
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/cognacglass.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -558,7 +504,7 @@
     sprite: Objects/Consumable/Drinks/cream.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkCubaLibreGlass
   name: cuba libre glass
   description: A classic mix of rum and cola.
@@ -570,11 +516,9 @@
         reagents:
         - ReagentId: CubaLibre
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/cubalibreglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkDeadRumGlass
   name: deadrum glass
   description: Popular with the sailors. Not very popular with everyone else.
@@ -586,12 +530,9 @@
         reagents:
         - ReagentId: DeadRum
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/rumglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkDemonsBlood
   name: demons blood
   description: Just looking at this thing makes the hair at the back of your neck stand up.
@@ -603,12 +544,9 @@
         reagents:
         - ReagentId: DemonsBlood
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/demonsblood.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkDevilsKiss
   name: devil's kiss
   description: Creepy time!
@@ -620,12 +558,9 @@
         reagents:
         - ReagentId: DevilsKiss
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/devilskiss.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkDoctorsDelightGlass
   name: the doctor's delight
   description: A healthy mixture of juices, guaranteed to keep you healthy until the next toolboxing takes place.
@@ -637,12 +572,9 @@
         reagents:
         - ReagentId: DoctorsDelight
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/doctorsdelightglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkDriestMartiniGlass
   name: driest martini glass
   description: Only for the experienced. You think you see sand floating in the glass.
@@ -654,12 +586,9 @@
         reagents:
         - ReagentId: DriestMartini
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/driestmartiniglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkDrGibbGlass
   name: Dr. Gibb glass
   description: Dr. Gibb. Not as dangerous as the name might imply.
@@ -671,12 +600,9 @@
         reagents:
         - ReagentId: DrGibb
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/dr_gibb_glass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkErikaSurprise
   name: erika surprise
   description: The surprise is, it's green!
@@ -688,12 +614,9 @@
         reagents:
         - ReagentId: ErikaSurprise
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/erikasurprise.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkFourteenLokoGlass
   name: Fourteen loko glass
   description: This is a container of Fourteen Loko, it appears to be of the highest quality. The drink, not the container.
@@ -705,12 +628,9 @@
         reagents:
         - ReagentId: FourteenLoko
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/fourteen_loko_glass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGargleBlasterGlass
   name: pan-galactic gargle blaster
   description: Does... does this mean that Arthur and Ford are on the ship? Oh joy.
@@ -722,12 +642,9 @@
         reagents:
         - ReagentId: GargleBlaster
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/gargleblasterglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGinGlass
   name: Gin
   description: Crystal clear Griffeater gin.
@@ -739,12 +656,9 @@
         reagents:
         - ReagentId: Gin
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/ginvodkaglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGinFizzGlass
   name: gin fizz glass
   description: Refreshingly lemony, deliciously dry.
@@ -756,12 +670,9 @@
         reagents:
         - ReagentId: GinFizz
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/ginfizzglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGinTonicglass
   name: gin and tonic
   description: A mild but still great cocktail. Drink up, like a true Englishman.
@@ -773,12 +684,9 @@
         reagents:
         - ReagentId: GinTonic
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/gintonicglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGoldschlagerGlass
   name: goldschlager glass
   description: 100 proof that teen girls will drink anything with gold in it.
@@ -790,9 +698,6 @@
         reagents:
         - ReagentId: Goldschlager
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/goldschlagerglass.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -812,17 +717,21 @@
     sprite: Objects/Consumable/Drinks/grapejuice.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGrapeSodaGlass
   name: grape soda glass
   description: Looks like a delicious drink!
   components:
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/gsodaglass.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: GrapeSoda
+          Quantity: 30
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGreenTeaGlass
   name: green tea glass
   description: Tasty green tea. It has antioxidants; it's good for you!
@@ -834,12 +743,9 @@
         reagents:
         - ReagentId: GreenTea
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/glass_green.rsi #Placeholder
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGrenadineGlass
   name: grenadine syrup glass
   description: Sweet and tangy, a bar syrup used to add color or flavor to drinks.
@@ -851,12 +757,9 @@
         reagents:
         - ReagentId: Grenadine
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/grenadineglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGrogGlass
   name: grog glass
   description: A fine and cepa drink for Space.
@@ -868,22 +771,23 @@
         reagents:
         - ReagentId: Grog
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/grogglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkHippiesDelightGlass
   name: hippies' delight glass
   description: A drink enjoyed by people during the 1960's.
   components:
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/hippiesdelightglass.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: HippiesDelight
+          Quantity: 30
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkHoochGlass
   name: hooch
   description: You've really hit rock bottom now... your liver packed its bags and left last night.
@@ -895,12 +799,9 @@
         reagents:
         - ReagentId: Hooch
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/glass_brown2.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkIcedCoffeeGlass
   name: iced coffee glass
   description: A drink to perk you up and refresh you!
@@ -912,12 +813,9 @@
         reagents:
         - ReagentId: IcedCoffee
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/icedcoffeeglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkIcedGreenTeaGlass
   name: iced green tea glass
   description: It looks like green tea with ice. One might even call it iced green tea.
@@ -929,12 +827,9 @@
         reagents:
         - ReagentId: IcedGreenTea
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/glass_green.rsi #Placeholder
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkIcedTeaGlass
   name: iced tea
   description: A refreshing southern beverage.
@@ -946,22 +841,23 @@
         reagents:
         - ReagentId: IcedTea
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/icedteaglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkIcedBeerGlass
   name: iced beer glass
   description: A beer so frosty, the air around it freezes.
   components:
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/iced_beerglass.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: IcedBeer
+          Quantity: 30
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkIceGlass
   name: ice glass
   description: Generally, you're supposed to put something else in there too...
@@ -973,11 +869,9 @@
         reagents:
         - ReagentId: Ice
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/iceglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkIceCreamGlass
   name: ice cream glass
   description: A glass full of good old ice cream. Might want a spoon.
@@ -989,13 +883,9 @@
         reagents:
         - ReagentId: IceCream
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/icecreamglass.rsi
-    state: icon
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkIrishCarBomb
   name: irish car bomb
   description: An irish car bomb.
@@ -1007,11 +897,9 @@
         reagents:
         - ReagentId: IrishCarBomb
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/irishcarbomb.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkIrishCoffeeGlass
   name: irish coffee glass
   description: Coffee and alcohol. More fun than a Mimosa to drink in the morning.
@@ -1023,11 +911,9 @@
         reagents:
         - ReagentId: IrishCoffee
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/irishcoffeeglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkIrishCreamGlass
   name: irish cream glass
   description: It's cream, mixed with whiskey. What else would you expect from the Irish?
@@ -1039,11 +925,9 @@
         reagents:
         - ReagentId: IrishCream
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/irishcreamglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkCoffeeLiqueurGlass
   name: Coffee Liqueur glass
   description: DAMN, THIS THING LOOKS ROBUST
@@ -1055,11 +939,9 @@
         reagents:
         - ReagentId: CoffeeLiqueur
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/coffeeliqueurglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkKiraSpecial
   name: kira special
   description: Long live the guy who everyone had mistaken for a girl. Baka!
@@ -1071,12 +953,9 @@
         reagents:
         - ReagentId: KiraSpecial
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/kiraspecial.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkLemonadeGlass
   name: lemonade glass
   description: Oh the nostalgia...
@@ -1088,12 +967,9 @@
         reagents:
         - ReagentId: Lemonade
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/lemonadeglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkLemonJuice
   name: lemon juice
   description: Sour...
@@ -1106,11 +982,9 @@
         reagents:
         - ReagentId: JuiceLemon
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/lemonjuice.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkLemonLime
   name: lemon lime
   description: A tangy substance made of 0.5% natural citrus!
@@ -1123,16 +997,13 @@
         reagents:
         - ReagentId: LemonLime
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/lemonlime.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkLimeJuice
   name: lime juice
   description: It's some sweet-sour lime juice.
   components:
-  - type: Drink
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -1140,11 +1011,9 @@
         reagents:
         - ReagentId: JuiceLime
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/limejuice.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkLongIslandIcedTeaGlass
   name: long island iced tea glass
   description: The liquor cabinet, brought together in a delicious mix. Intended for middle-aged alcoholic women only.
@@ -1156,12 +1025,9 @@
         reagents:
         - ReagentId: LongIslandIcedTea
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/longislandicedteaglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkManhattanGlass
   name: manhattan glass
   description: The Detective's undercover drink of choice. He never could stomach gin...
@@ -1173,12 +1039,9 @@
         reagents:
         - ReagentId: Manhattan
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/manhattanglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkManhattanProjectGlass
   name: manhattan project glass
   description: A scientist's drink of choice, for pondering ways to blow up the station.
@@ -1190,12 +1053,9 @@
         reagents:
         - ReagentId: ManhattanProject
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/proj_manhattanglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkManlyDorfGlass
   name: the manly dorf glass
   description: A manly concotion made from Ale and Beer. Intended for true men only.
@@ -1207,11 +1067,9 @@
         reagents:
         - ReagentId: ManlyDorf
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/manlydorfglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkMargaritaGlass
   name: margarita glass
   description: On the rocks with salt on the rim. Arriba~!
@@ -1223,12 +1081,9 @@
         reagents:
         - ReagentId: Margarita
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/margaritaglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkMartiniGlass
   name: classic martini glass
   description: Damn, the bartender even stirred it, not shook it.
@@ -1240,12 +1095,9 @@
         reagents:
         - ReagentId: Martini
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/martiniglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkMeadGlass
   name: mead glass
   description: A Viking's beverage, though a cheap one.
@@ -1257,9 +1109,6 @@
         reagents:
         - ReagentId: Mead
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/meadglass.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -1272,7 +1121,7 @@
     sprite: Objects/Consumable/Drinks/milkshake.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkMojito
   name: mojito
   description: Fresh from Spesscuba.
@@ -1284,12 +1133,9 @@
         reagents:
         - ReagentId: Mojito
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/mojito.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkNeurotoxinGlass
   name: neurotoxin glass
   description: A drink that is guaranteed to knock you silly.
@@ -1301,12 +1147,9 @@
         reagents:
         - ReagentId: Neurotoxin
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/neurotoxinglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkNothing
   name: nothing
   description: Absolutely nothing.
@@ -1318,12 +1161,9 @@
         reagents:
         - ReagentId: Nothing
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/nothing.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkNTCahors
   name: neotheology cahors whine
   description: It looks like wine, but more dark.
@@ -1335,12 +1175,9 @@
         reagents:
         - ReagentId: NTCahors
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/ntcahors.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkNuclearColaGlass
   name: nuclear cola glass
   description: Don't cry, Don't raise your eye, It's only nuclear wasteland.
@@ -1352,9 +1189,6 @@
         reagents:
         - ReagentId: NuclearCola
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/nuclear_colaglass.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -1374,7 +1208,7 @@
     sprite: Objects/Consumable/Drinks/orangejuice.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkPatronGlass
   name: patron glass
   description: Drinking patron in the bar, with all the subpar ladies.
@@ -1386,9 +1220,6 @@
         reagents:
         - ReagentId: Patron
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/patronglass.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -1408,7 +1239,7 @@
     sprite: Objects/Consumable/Drinks/poisonberryjuice.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkPoisonWineGlass
   name: poison wine glass
   description: A black ichor with an oily purple sheer on top. Are you sure you should drink this?
@@ -1420,12 +1251,9 @@
         reagents:
         - ReagentId: PoisonWine
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/pwineglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkPoscaGlass
   name: posca glass
   description: Poor warriors' drink from a forgotten era.
@@ -1437,12 +1265,9 @@
         reagents:
         - ReagentId: Posca
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/glass_light_yellow.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkRedMeadGlass
   name: red mead glass
   description: A true Viking's beverage, though its color is strange.
@@ -1454,12 +1279,9 @@
         reagents:
         - ReagentId: RedMead
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/red_meadglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkRewriter
   name: rewriter
   description: The secret of the sanctuary of the Libarian...
@@ -1471,12 +1293,9 @@
         reagents:
         - ReagentId: Rewriter
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/rewriter.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkRootBeerGlass
   name: root beer glass
   description: Fizzy, foamy, and full of sweet, non-caffienated goodness.
@@ -1488,13 +1307,9 @@
         reagents:
         - ReagentId: RootBeer
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/rootbeerglass.rsi
-    state: icon
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkRootBeerFloatGlass
   name: root beer float glass
   description: Fizzy, foamy, and now with ice cream on top! Amazing!
@@ -1506,13 +1321,9 @@
         reagents:
         - ReagentId: RootBeerFloat
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/rootbeerfloatglass.rsi
-    state: icon
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkRumGlass
   name: rum glass
   description: Now you want to Pray for a pirate suit, don't you?
@@ -1524,12 +1335,9 @@
         reagents:
         - ReagentId: Rum
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/rumglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkSakeGlass
   name: sake glass
   description: Wine made from rice, it's sake!
@@ -1541,12 +1349,9 @@
         reagents:
         - ReagentId: Sake
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/ginvodkaglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkSbitenGlass
   name: sbiten glass
   description: A spicy mix of Vodka and Spice. Very hot.
@@ -1558,12 +1363,9 @@
         reagents:
         - ReagentId: Sbiten
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/sbitenglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkScrewdriverCocktailGlass
   name: screwdriver glass
   description: A simple, yet superb mixture of Vodka and orange juice. Just the thing for the tired engineer.
@@ -1575,12 +1377,9 @@
         reagents:
         - ReagentId: ScrewdriverCocktail
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/screwdriverglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkCogChampBase
   name: cogchamp glass
   description: This mix of Cognac, Screwdriver and Welding Fuel will have you seeing His light surely!
@@ -1592,12 +1391,9 @@
           reagents:
             - ReagentId: CogChamp
               Quantity: 30
-    - type: Drink
-    - type: Sprite
-      sprite: Objects/Consumable/Drinks/cogchamp.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkSuiDreamGlass
   name: sui dream glass
   description: A froofy, fruity, and sweet mixed drink. Understanding the name only brings shame.
@@ -1609,12 +1405,9 @@
         reagents:
         - ReagentId: SuiDream
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/sdreamglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkEmeraldGlass
   name: melon liquor
   description: A relatively sweet and fruity 46 proof liquor.
@@ -1626,12 +1419,9 @@
         reagents:
         - ReagentId: MelonLiquor
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/emeraldglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkMoonshineGlass
   name: moonshine
   description: You've really hit rock bottom now... your liver packed its bags and left last night.
@@ -1643,12 +1433,9 @@
         reagents:
         - ReagentId: Moonshine
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/glass_clear.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkGlassWhite
   name: milk
   description: White and nutritious goodness!
@@ -1660,11 +1447,9 @@
         reagents:
         - ReagentId: Milk
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/glass_white.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkSilencerGlass
   name: silencer glass
   description: A drink from Mime Heaven.
@@ -1676,12 +1461,9 @@
         reagents:
         - ReagentId: Silencer
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/silencerglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkSingulo
   name: singulo
   description: A blue-space beverage!
@@ -1693,12 +1475,9 @@
         reagents:
         - ReagentId: Singulo
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/singulo.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkSnowWhite
   name: snow white
   description: A cold refreshment.
@@ -1710,9 +1489,6 @@
         reagents:
         - ReagentId: SnowWhite
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/snowwhite.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -1732,7 +1508,7 @@
     sprite: Objects/Consumable/Drinks/soy_latte.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkSpaceUpGlass
   name: space-up glass
   description: Space-up. It helps keep your cool.
@@ -1744,12 +1520,9 @@
         reagents:
         - ReagentId: SpaceUp
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/space-up_glass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkSpaceMountainWindGlass
   name: space mountain wind glass
   description: Space Mountain Wind. As you know, there are no mountains in space, only wind.
@@ -1761,12 +1534,9 @@
         reagents:
         - ReagentId: SpaceMountainWind
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/space_mountain_wind_glass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkSyndicatebomb
   name: syndicate bomb
   description: Tastes like terrorism!
@@ -1778,11 +1548,9 @@
         reagents:
         - ReagentId: SyndicateBomb
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/syndicatebomb.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkTeaGlass
   name: tea glass
   description: Tasty black tea. It has antioxidants; it's good for you!
@@ -1794,8 +1562,6 @@
         reagents:
         - ReagentId: Tea
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/teaglass.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -1814,7 +1580,7 @@
     sprite: Objects/Consumable/Drinks/teapot.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkTequilaGlass
   name: tequila glass
   description: Now all that's missing is the weird colored shades!
@@ -1826,12 +1592,9 @@
         reagents:
         - ReagentId: Tequila
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/tequillaglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkTequilaSunriseGlass
   name: tequila sunrise glass
   description: Oh great, now you feel nostalgic about sunrises back on Terra...
@@ -1843,12 +1606,9 @@
         reagents:
         - ReagentId: TequilaSunrise
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/tequillasunriseglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkThreeMileIslandGlass
   name: three mile island glass
   description: A glass of this is sure to prevent a meltdown.
@@ -1860,9 +1620,6 @@
         reagents:
         - ReagentId: ThreeMileIsland
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/threemileislandglass.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -1882,7 +1639,7 @@
     sprite: Objects/Consumable/Drinks/tomatojuice.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkToxinsSpecialGlass
   name: toxins special glass
   description: Woah, this thing is on FIRE
@@ -1894,12 +1651,9 @@
         reagents:
         - ReagentId: ToxinsSpecial
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/toxinsspecialglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkVermouthGlass
   name: vermouth glass
   description: You wonder why you're even drinking this straight.
@@ -1911,12 +1665,9 @@
         reagents:
         - ReagentId: Vermouth
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/vermouthglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkVodkaGlass
   name: vodka glass
   description: Number one drink and fueling choice for Russians worldwide.
@@ -1928,12 +1679,9 @@
         reagents:
         - ReagentId: Vodka
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/ginvodkaglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkVodkaMartiniGlass
   name: vodka martini glass
   description: A bastardisation of the classic martini. Still great.
@@ -1945,12 +1693,9 @@
         reagents:
         - ReagentId: VodkaMartini
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/martiniglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkVodkaTonicGlass
   name: vodka tonic glass
   description: For when a gin and tonic isn't russian enough.
@@ -1962,9 +1707,6 @@
         reagents:
         - ReagentId: VodkaTonic
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/vodkatonicglass.rsi
 
 - type: entity
   parent: DrinkGlassBase
@@ -1984,12 +1726,11 @@
     sprite: Objects/Consumable/Drinks/water.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkWatermelonJuice
   name: watermelon juice
   description: Delicious juice made from watermelon.
   components:
-  - type: Drink
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -1997,11 +1738,9 @@
         reagents:
         - ReagentId: JuiceWatermelon
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/watermelon.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkWhiskeyColaGlass
   name: whiskey cola glass
   description: An innocent-looking mixture of cola and Whiskey. Delicious.
@@ -2013,11 +1752,9 @@
         reagents:
         - ReagentId: WhiskeyCola
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/whiskeycolaglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkWhiskeyGlass
   name: whiskey glass
   description: The silky, smoky whiskey goodness inside makes the drink look very classy.
@@ -2029,11 +1766,9 @@
         reagents:
         - ReagentId: Whiskey
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/whiskeyglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkWhiskeySodaGlass
   name: whiskey soda glass
   description: Ultimate refreshment.
@@ -2045,12 +1780,9 @@
         reagents:
         - ReagentId: WhiskeySoda
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/whiskeysodaglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkWhiteRussianGlass
   name: white russian glass
   description: A very nice looking drink. But that's just, like, your opinion, man.
@@ -2062,12 +1794,9 @@
         reagents:
         - ReagentId: WhiteRussian
           Quantity: 30
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/whiterussianglass.rsi
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkWineGlass
   name: wine glass
   description: A very classy looking drink.
@@ -2079,8 +1808,6 @@
         reagents:
         - ReagentId: Wine
           Quantity: 30
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/wineglass.rsi
 
 # TODO: MOVE
 
@@ -2171,7 +1898,7 @@
           Quantity: 5
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkGlass
   id: DrinkTheMartinez
   name: The Martinez glass
   description: The edgerunner legend.  Remembered by a drink, Forgotten by a drunk.
@@ -2183,5 +1910,3 @@
           reagents:
             - ReagentId: TheMartinez
               Quantity: 30
-    - type: Sprite
-      sprite: Objects/Consumable/Drinks/the_martinez.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -100,7 +100,7 @@
     solutions:
       drink:
         maxVol: 30
-    matchContents: true
+    matchContentsName: true
     emptyName: metamorphic glass
     emptyDescription: A metamorphic glass that automagically turns into a glass appropriate for the drink within. There's a sanded off patent number on the bottom.
   - type: SolutionContainerVisuals

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -278,6 +278,9 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: sake
   color: "#DDDDDD"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/ginvodkaglass.rsi
+    state: icon
 
 - type: reagent
   id: Tequila
@@ -287,6 +290,9 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: tequila
   color: "#d7d1d155"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/tequillaglass.rsi
+    state: icon
   metabolisms:
     Drink:
       effects:
@@ -1024,6 +1030,9 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: alcohol
   color: "#d1d7d155"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_clear.rsi
+    state: icon
   metabolisms:
     Drink:
       effects:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -154,6 +154,9 @@
   physicalDesc: reagent-physical-desc-opaque
   flavor: milk
   color: "#DFDFDF"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glass_white.rsi
+    state: icon
   recognizable: true
   plantMetabolism:
     - !type:PlantAdjustNutrition
@@ -279,6 +282,9 @@
   flavor: tea
   color: "#8a5a3a"
   recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/teaglass.rsi
+    state: icon
   metabolisms:
     Drink:
       effects:
@@ -322,6 +328,9 @@
   physicalDesc: reagent-physical-desc-frosty
   flavor: cold
   color: "#bed8e6"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/iceglass.rsi
+    state: icon
   recognizable: true
   meltingPoint: 0.0
   boilingPoint: 100.0

--- a/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
@@ -63,6 +63,9 @@
   physicalDesc: reagent-physical-desc-citric
   flavor: sour
   color: "#fff690"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/lemonjuice.rsi
+    state: icon
 
 - type: reagent
   id: JuiceLime
@@ -72,6 +75,9 @@
   physicalDesc: reagent-physical-desc-citric
   flavor: sour
   color: "#99bb43"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/glassgreen.rsi
+    state: icon
 
 # /datum/reagent/drink/orangejuice/on_mob_life(var/mob/living/M)
 
@@ -125,3 +131,6 @@
   physicalDesc: reagent-physical-desc-sweet
   flavor: watermelon
   color: "#EF3520"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/watermelon.rsi
+    state: icon

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -51,6 +51,9 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: soda
   color: "#ae94a6"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/gsodaglass.rsi
+    state: icon
 
 - type: reagent
   id: IceCream
@@ -118,6 +121,9 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: soda
   color: "#102000"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/space_mountain_wind_glass.rsi
+    state: icon
 
 - type: reagent
   id: SpaceUp
@@ -127,6 +133,9 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: soda
   color: "#00FF00"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/space-up_glass.rsi
+    state: icon
 
 - type: reagent
   id: Starkist
@@ -159,6 +168,9 @@
         damage:
           types:
             Poison: 1
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/fourteen_loko_glass.rsi
+    state: icon
 
 - type: reagent
   id: ShamblersJuice


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Metamorphic glasses are supposed to change their appearance, name and description based on the reagents inside them. At the moment, only the appearance change actually works.

This makes metamorphic glasses properly change their name and description. Additionally, the drinks that spawn around the station are proper metamorphic glasses now and no longer retain their filled sprite no matter what.

I am entirely uncertain whether the way I made this work is shitcode or not.


**Media**
![mglass0](https://github.com/space-wizards/space-station-14/assets/84070966/26c91ba0-69f5-4b9d-afbe-d8ce3e821770)
![mglass1](https://github.com/space-wizards/space-station-14/assets/84070966/f5f57379-08f8-4f4f-b56d-a633ea8d2d88)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl: Sigil
- fix: Metamorphic glasses now properly change their names and descriptions when filled.
- fix: The drinks that spawn around the station at roundstart are now proper metamorphic glasses and can change appearance.

