### PR TITLE
Set marker drawdepth to Overdoors

### DIFF
--- a/Resources/Prototypes/Entities/Markers/marker_base.yml
+++ b/Resources/Prototypes/Entities/Markers/marker_base.yml
@@ -10,6 +10,7 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Sprite
+    drawdepth: Overdoors
     sprite: Markers/cross.rsi
 # If serialization was cool this would work.
 #    layers:


### PR DESCRIPTION
Markers have a tendency to show under tables when reloading a map. Overdoors should be good enough.