### PR TITLE
add pkas back to salv vendor

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -14,7 +14,6 @@
 #      - id: ClothingEyesGlassesMeson
       - id: ClothingBeltUtilityFilled
       - id: SurvivalKnife
-      - id: WeaponProtoKineticAccelerator
 
 - type: entity
   id: LockerSalvageSpecialistFilled
@@ -27,4 +26,3 @@
 #      - id: ClothingEyesGlassesMeson
       - id: ClothingBeltUtilityFilled
       - id: SurvivalKnife
-      - id: WeaponProtoKineticAccelerator

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -14,6 +14,7 @@
 #      - id: ClothingEyesGlassesMeson
       - id: ClothingBeltUtilityFilled
       - id: SurvivalKnife
+      - id: WeaponProtoKineticAccelerator
 
 - type: entity
   id: LockerSalvageSpecialistFilled
@@ -26,3 +27,4 @@
 #      - id: ClothingEyesGlassesMeson
       - id: ClothingBeltUtilityFilled
       - id: SurvivalKnife
+      - id: WeaponProtoKineticAccelerator

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -11,3 +11,4 @@
     RadioHandheld: 2
     WeaponCrusher: 2
     WeaponCrusherDagger: 2
+    WeaponProtoKineticAccelerator: 2


### PR DESCRIPTION
## About the PR
reasons:
- still cant dual pka trollage without scis help so thats fine
- salv is a fucking joke with just crushers, always order guns or beg hos/warden for armoury guns roundstart
- by the time sci can research pka, salv already has guns without fail so theres no point not having roundstart pka so robust individuals can just start expeds

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Proto-kinetic accelerators have returned to the salvage vendor.
