### PR TITLE
Add dungeon templates as uninitialized maps

### DIFF
--- a/Content.Server/Procedural/DungeonSystem.cs
+++ b/Content.Server/Procedural/DungeonSystem.cs
@@ -150,6 +150,7 @@ public sealed partial class DungeonSystem : EntitySystem
         }
 
         var mapId = _mapManager.CreateMap();
+        _mapManager.AddUninitializedMap(mapId);
         _loader.Load(mapId, proto.AtlasPath.ToString());
         var mapUid = _mapManager.GetMapEntityId(mapId);
         _mapManager.SetMapPaused(mapId, true);


### PR DESCRIPTION
This will allow random spawners to generate something different on a per-room basis when a dungeon room is created, rather than having the spawners spawn when the atlas itself is created.
