### PR TITLE
Fix duped lathe recipes

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -101,7 +101,7 @@ namespace Content.Server.Lathe
         {
             var ev = new LatheGetRecipesEvent(uid)
             {
-                Recipes = component.StaticRecipes
+                Recipes = new List<string>(component.StaticRecipes)
             };
             RaiseLocalEvent(uid, ev);
             return ev.Recipes;
@@ -195,7 +195,7 @@ namespace Content.Server.Lathe
 
             foreach (var recipe in latheComponent.DynamicRecipes)
             {
-                if (!component.UnlockedRecipes.Contains(recipe))
+                if (!component.UnlockedRecipes.Contains(recipe) || args.Recipes.Contains(recipe))
                     continue;
                 args.Recipes.Add(recipe);
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
two bugs:
- LatheGetRecipesEvent allows the same recipe to be added even when it's already present.
- LatheGetRecipesEvent passes the list of static recipes *by ref* which means that when it was handled and more recipes were added to the list, they were actually being appended to the list of static recipes.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Lathe recipes no longer permanently duplicate and accumulate when trying to sync.
