### PR TITLE
welder stuff

### DIFF
--- a/Content.Client/Tools/ToolSystem.cs
+++ b/Content.Client/Tools/ToolSystem.cs
@@ -62,5 +62,10 @@ namespace Content.Client.Tools
             welder.Lit = state.Lit;
             welder.UiUpdateNeeded = true;
         }
+
+        protected override bool IsWelder(EntityUid uid)
+        {
+            return HasComp<WelderComponent>(uid);
+        }
     }
 }

--- a/Content.Server/Construction/Components/WelderRefinableComponent.cs
+++ b/Content.Server/Construction/Components/WelderRefinableComponent.cs
@@ -16,9 +16,6 @@ namespace Content.Server.Construction.Components
         [DataField("refineTime")]
         public float RefineTime = 2f;
 
-        [DataField("refineFuel")]
-        public float RefineFuel = 0f;
-
         [DataField("qualityNeeded", customTypeSerializer:typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
         public string QualityNeeded = "Welding";
     }

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -347,7 +347,6 @@ namespace Content.Server.Construction
                     if (validation)
                     {
                         // Then we only really need to check whether the tool entity has that quality or not.
-                        // TODO fuel consumption?
                         return _toolSystem.HasQuality(interactUsing.Used, toolInsertStep.Tool)
                             ? HandleResult.Validated
                             : HandleResult.False;
@@ -364,8 +363,7 @@ namespace Content.Server.Construction
                         TimeSpan.FromSeconds(toolInsertStep.DoAfter),
                         new [] { toolInsertStep.Tool },
                         new ConstructionInteractDoAfterEvent(interactUsing),
-                        out var doAfter,
-                        fuel: toolInsertStep.Fuel);
+                        out var doAfter);
 
                     return result && doAfter != null ? HandleResult.DoAfter : HandleResult.False;
                 }

--- a/Content.Server/Construction/RefiningSystem.cs
+++ b/Content.Server/Construction/RefiningSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Server.Construction
             if (args.Handled)
                 return;
 
-            args.Handled = _toolSystem.UseTool(args.Used, args.User, uid, component.RefineTime, component.QualityNeeded, new WelderRefineDoAfterEvent(), component.RefineFuel);
+            args.Handled = _toolSystem.UseTool(args.Used, args.User, uid, component.RefineTime, component.QualityNeeded, new WelderRefineDoAfterEvent());
         }
 
         private void OnDoAfter(EntityUid uid, WelderRefinableComponent component, WelderRefineDoAfterEvent args)

--- a/Content.Server/Repairable/RepairableSystem.cs
+++ b/Content.Server/Repairable/RepairableSystem.cs
@@ -55,7 +55,7 @@ namespace Content.Server.Repairable
                 return;
 
             // Only try repair the target if it is damaged
-            if (!EntityManager.TryGetComponent(uid, out DamageableComponent? damageable) || damageable.TotalDamage == 0)
+            if (!TryComp<DamageableComponent>(uid, out var damageable) || damageable.TotalDamage == 0)
                 return;
 
             float delay = component.DoAfterDelay;
@@ -64,8 +64,8 @@ namespace Content.Server.Repairable
             if (args.User == args.Target)
                 delay *= component.SelfRepairPenalty;
 
-            // Can the tool actually repair this, does it have enough fuel?
-            args.Handled = _toolSystem.UseTool(args.Used, args.User, uid, delay, component.QualityNeeded, new RepairFinishedEvent(), component.FuelCost);
+            // Run the repairing doafter
+            args.Handled = _toolSystem.UseTool(args.Used, args.User, uid, delay, component.QualityNeeded, new RepairFinishedEvent());
         }
     }
 }

--- a/Content.Server/Tools/Components/WeldableComponent.cs
+++ b/Content.Server/Tools/Components/WeldableComponent.cs
@@ -27,13 +27,6 @@ public sealed class WeldableComponent : SharedWeldableComponent
     public bool Weldable = true;
 
     /// <summary>
-    ///     How much fuel does it take to weld/unweld entity.
-    /// </summary>
-    [DataField("fuel")]
-    [ViewVariables(VVAccess.ReadWrite)]
-    public float FuelConsumption = 3f;
-
-    /// <summary>
     ///     How much time does it take to weld/unweld entity.
     /// </summary>
     [DataField("time")]

--- a/Content.Server/Tools/Components/WelderComponent.cs
+++ b/Content.Server/Tools/Components/WelderComponent.cs
@@ -13,25 +13,25 @@ namespace Content.Server.Tools.Components
         /// <summary>
         ///     Solution on the entity that contains the fuel.
         /// </summary>
-        [DataField("fuelSolution")]
+        [DataField("fuelSolution"), ViewVariables(VVAccess.ReadWrite)]
         public string FuelSolution { get; } = "Welder";
 
         /// <summary>
         ///     Reagent that will be used as fuel for welding.
         /// </summary>
-        [DataField("fuelReagent", customTypeSerializer:typeof(PrototypeIdSerializer<ReagentPrototype>))]
+        [DataField("fuelReagent", customTypeSerializer:typeof(PrototypeIdSerializer<ReagentPrototype>)), ViewVariables(VVAccess.ReadWrite)]
         public string FuelReagent { get; } = "WeldingFuel";
 
         /// <summary>
         ///     Fuel consumption per second, while the welder is active.
         /// </summary>
-        [DataField("fuelConsumption")]
-        public FixedPoint2 FuelConsumption { get; } = FixedPoint2.New(1.0f);
+        [DataField("fuelConsumption"), ViewVariables(VVAccess.ReadWrite)]
+        public FixedPoint2 FuelConsumption { get; } = FixedPoint2.New(2.0f);
 
         /// <summary>
         ///     A fuel amount to be consumed when the welder goes from being unlit to being lit.
         /// </summary>
-        [DataField("welderOnConsume")]
+        [DataField("fuelLitCost"), ViewVariables(VVAccess.ReadWrite)]
         public FixedPoint2 FuelLitCost { get; } = FixedPoint2.New(0.5f);
 
         /// <summary>

--- a/Content.Server/Tools/Components/WelderComponent.cs
+++ b/Content.Server/Tools/Components/WelderComponent.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Tools.Components
         ///     Fuel consumption per second, while the welder is active.
         /// </summary>
         [DataField("fuelConsumption")]
-        public FixedPoint2 FuelConsumption { get; } = FixedPoint2.New(0.05f);
+        public FixedPoint2 FuelConsumption { get; } = FixedPoint2.New(1.0f);
 
         /// <summary>
         ///     A fuel amount to be consumed when the welder goes from being unlit to being lit.

--- a/Content.Server/Tools/Systems/WeldableSystem.cs
+++ b/Content.Server/Tools/Systems/WeldableSystem.cs
@@ -68,7 +68,8 @@ public sealed class WeldableSystem : EntitySystem
         if (!CanWeld(uid, tool, user, component))
             return false;
 
-        if (!_toolSystem.UseTool(tool, user, uid, component.WeldingTime.Seconds, component.WeldingQuality, new WeldFinishedEvent(), fuel: component.FuelConsumption))
+        // require a minimum of 1u of fuel before cancelling the doafter
+        if (!_toolSystem.UseTool(tool, user, uid, component.WeldingTime.Seconds, component.WeldingQuality, new WeldFinishedEvent(), fuel: 1f))
             return false;
 
         // Log attempt

--- a/Content.Server/Tools/Systems/WeldableSystem.cs
+++ b/Content.Server/Tools/Systems/WeldableSystem.cs
@@ -68,8 +68,7 @@ public sealed class WeldableSystem : EntitySystem
         if (!CanWeld(uid, tool, user, component))
             return false;
 
-        // require a minimum of 1u of fuel before cancelling the doafter
-        if (!_toolSystem.UseTool(tool, user, uid, component.WeldingTime.Seconds, component.WeldingQuality, new WeldFinishedEvent(), fuel: 1f))
+        if (!_toolSystem.UseTool(tool, user, uid, component.WeldingTime.Seconds, component.WeldingQuality, new WeldFinishedEvent()))
             return false;
 
         // Log attempt

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -41,7 +41,6 @@ namespace Content.Server.Tools
             SubscribeLocalEvent<WelderComponent, ActivateInWorldEvent>(OnWelderActivate);
             SubscribeLocalEvent<WelderComponent, AfterInteractEvent>(OnWelderAfterInteract);
             SubscribeLocalEvent<WelderComponent, DoAfterAttemptEvent<ToolDoAfterEvent>>(OnWelderToolUseAttempt);
-            SubscribeLocalEvent<WelderComponent, ToolDoAfterEvent>(OnWelderDoAfter);
             SubscribeLocalEvent<WelderComponent, ComponentShutdown>(OnWelderShutdown);
             SubscribeLocalEvent<WelderComponent, ComponentGetState>(OnWelderGetState);
             SubscribeLocalEvent<WelderComponent, GetMeleeDamageEvent>(OnGetMeleeDamage);
@@ -276,25 +275,13 @@ namespace Content.Server.Tools
                 return;
             }
 
+            // make sure that the fuel is above a minimum threshold, it is not consumed but requires that you don't run out of fuel.
             var (fuel, _) = GetWelderFuelAndCapacity(uid, welder);
-
             if (FixedPoint2.New(args.Event.Fuel) > fuel)
             {
                 _popupSystem.PopupEntity(Loc.GetString("welder-component-cannot-weld-message"), uid, user);
                 args.Cancel();
             }
-        }
-
-        private void OnWelderDoAfter(EntityUid uid, WelderComponent welder, ToolDoAfterEvent args)
-        {
-            if (args.Cancelled)
-                return;
-
-            if (!_solutionContainerSystem.TryGetSolution(uid, welder.FuelSolution, out var solution))
-                return;
-
-            solution.RemoveReagent(welder.FuelReagent, FixedPoint2.New(args.Fuel));
-            _entityManager.Dirty(welder);
         }
 
         private void OnWelderShutdown(EntityUid uid, WelderComponent welder, ComponentShutdown args)

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -265,7 +265,6 @@ namespace Content.Server.Tools
 
         private void OnWelderToolUseAttempt(EntityUid uid, WelderComponent welder, DoAfterAttemptEvent<ToolDoAfterEvent> args)
         {
-            DebugTools.Assert(args.Event.Fuel > 0);
             var user = args.DoAfter.Args.User;
 
             if (!welder.Lit)
@@ -273,14 +272,6 @@ namespace Content.Server.Tools
                 _popupSystem.PopupEntity(Loc.GetString("welder-component-welder-not-lit-message"), uid, user);
                 args.Cancel();
                 return;
-            }
-
-            // make sure that the fuel is above a minimum threshold, it is not consumed but requires that you don't run out of fuel.
-            var (fuel, _) = GetWelderFuelAndCapacity(uid, welder);
-            if (FixedPoint2.New(args.Event.Fuel) > fuel)
-            {
-                _popupSystem.PopupEntity(Loc.GetString("welder-component-cannot-weld-message"), uid, user);
-                args.Cancel();
             }
         }
 

--- a/Content.Server/Tools/ToolSystem.cs
+++ b/Content.Server/Tools/ToolSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Popups;
+using Content.Server.Tools.Components;
 using Content.Shared.Tools;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
@@ -31,6 +32,11 @@ namespace Content.Server.Tools
             base.Update(frameTime);
 
             UpdateWelders(frameTime);
+        }
+
+        protected override bool IsWelder(EntityUid uid)
+        {
+            return HasComp<WelderComponent>(uid);
         }
     }
 }

--- a/Content.Shared/Tools/Components/ToolComponent.cs
+++ b/Content.Shared/Tools/Components/ToolComponent.cs
@@ -23,16 +23,13 @@ namespace Content.Shared.Tools.Components
 
     /// <summary>
     ///     Attempt event called *before* any do afters to see if the tool usage should succeed or not.
-    ///     You can change the fuel consumption by changing the Fuel property.
     /// </summary>
     public sealed class ToolUseAttemptEvent : CancellableEntityEventArgs
     {
-        public float Fuel { get; set; }
         public EntityUid User { get; }
 
-        public ToolUseAttemptEvent(float fuel, EntityUid user)
+        public ToolUseAttemptEvent(EntityUid user)
         {
-            Fuel = fuel;
             User = user;
         }
     }

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -54,7 +54,6 @@ public abstract partial class SharedToolSystem : EntitySystem
     /// <param name="toolQualitiesNeeded">The qualities needed for this tool to work.</param>
     /// <param name="doAfterEv">The event that will be raised when the tool has finished (including cancellation). Event
     /// will be directed at the tool target.</param>
-    /// <param name="fuel">Minimum amount of fuel needed in the tool.</param>
     /// <param name="toolComponent">The tool component.</param>
     /// <returns>Returns true if any interaction takes place.</returns>
     public bool UseTool(
@@ -64,7 +63,6 @@ public abstract partial class SharedToolSystem : EntitySystem
         float doAfterDelay,
         IEnumerable<string> toolQualitiesNeeded,
         DoAfterEvent doAfterEv,
-        float fuel = 0f,
         ToolComponent? toolComponent = null)
     {
         return UseTool(tool,
@@ -74,7 +72,6 @@ public abstract partial class SharedToolSystem : EntitySystem
             toolQualitiesNeeded,
             doAfterEv,
             out _,
-            fuel,
             toolComponent);
     }
 
@@ -92,7 +89,6 @@ public abstract partial class SharedToolSystem : EntitySystem
     /// will be directed at the tool target.</param>
     /// <param name="id">The id of the DoAfter that was created. This may be null even if the function returns true in
     /// the event that this tool-use cancelled an existing DoAfter</param>
-    /// <param name="fuel">Minimum amount of fuel needed in the tool.</param>
     /// <param name="toolComponent">The tool component.</param>
     /// <returns>Returns true if any interaction takes place.</returns>
     public bool UseTool(
@@ -103,29 +99,30 @@ public abstract partial class SharedToolSystem : EntitySystem
         IEnumerable<string> toolQualitiesNeeded,
         DoAfterEvent doAfterEv,
         out DoAfterId? id,
-        float fuel = 0f,
         ToolComponent? toolComponent = null)
     {
         id = null;
         if (!Resolve(tool, ref toolComponent, false))
             return false;
 
-        if (!CanStartToolUse(tool, user, target, fuel, toolQualitiesNeeded, toolComponent))
+        if (!CanStartToolUse(tool, user, target, toolQualitiesNeeded, toolComponent))
             return false;
 
-        var toolEvent = new ToolDoAfterEvent(fuel, doAfterEv, target);
+        var toolEvent = new ToolDoAfterEvent(doAfterEv, target);
         var doAfterArgs = new DoAfterArgs(user, delay / toolComponent.SpeedModifier, toolEvent, tool, target: target, used: tool)
         {
             BreakOnDamage = true,
             BreakOnTargetMove = true,
             BreakOnUserMove = true,
             NeedHand = tool != user,
-            AttemptFrequency = fuel <= 0 ? AttemptFrequency.Never : AttemptFrequency.EveryTick
+            AttemptFrequency = IsWelder(tool) ? AttemptFrequency.Never : AttemptFrequency.EveryTick
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs, out id);
         return true;
     }
+
+    protected abstract bool IsWelder(EntityUid uid);
 
     /// <summary>
     ///     Attempts to use a tool on some entity, which will start a DoAfter. Returns true if an interaction occurred.
@@ -141,7 +138,6 @@ public abstract partial class SharedToolSystem : EntitySystem
     /// will be directed at the tool target.</param>
     /// <param name="id">The id of the DoAfter that was created. This may be null even if the function returns true in
     /// the event that this tool-use cancelled an existing DoAfter</param>
-    /// <param name="fuel">Amount of fuel that should be taken from the tool.</param>
     /// <param name="toolComponent">The tool component.</param>
     /// <returns>Returns true if any interaction takes place.</returns>
     public bool UseTool(
@@ -151,7 +147,6 @@ public abstract partial class SharedToolSystem : EntitySystem
         float doAfterDelay,
         string toolQualityNeeded,
         DoAfterEvent doAfterEv,
-        float fuel = 0,
         ToolComponent? toolComponent = null)
     {
         return UseTool(tool,
@@ -161,7 +156,6 @@ public abstract partial class SharedToolSystem : EntitySystem
             new[] { toolQualityNeeded },
             doAfterEv,
             out _,
-            fuel,
             toolComponent);
     }
 
@@ -181,7 +175,7 @@ public abstract partial class SharedToolSystem : EntitySystem
         return Resolve(uid, ref tool, false) && tool.Qualities.ContainsAll(qualities);
     }
 
-    private bool CanStartToolUse(EntityUid tool, EntityUid user, EntityUid? target, float fuel, IEnumerable<string> toolQualitiesNeeded, ToolComponent? toolComponent = null)
+    private bool CanStartToolUse(EntityUid tool, EntityUid user, EntityUid? target, IEnumerable<string> toolQualitiesNeeded, ToolComponent? toolComponent = null)
     {
         if (!Resolve(tool, ref toolComponent))
             return false;
@@ -194,7 +188,7 @@ public abstract partial class SharedToolSystem : EntitySystem
         if (!toolComponent.Qualities.ContainsAll(toolQualitiesNeeded))
             return false;
 
-        var beforeAttempt = new ToolUseAttemptEvent(fuel, user);
+        var beforeAttempt = new ToolUseAttemptEvent(user);
         RaiseLocalEvent(tool, beforeAttempt, false);
 
         return !beforeAttempt.Cancelled;
@@ -205,9 +199,6 @@ public abstract partial class SharedToolSystem : EntitySystem
     [Serializable, NetSerializable]
     protected sealed class ToolDoAfterEvent : DoAfterEvent
     {
-        [DataField("fuel")]
-        public readonly float Fuel;
-
         /// <summary>
         ///     Entity that the wrapped do after event will get directed at. If null, event will be broadcast.
         /// </summary>
@@ -221,11 +212,10 @@ public abstract partial class SharedToolSystem : EntitySystem
         {
         }
 
-        public ToolDoAfterEvent(float fuel, DoAfterEvent wrappedEvent, EntityUid? originalTarget)
+        public ToolDoAfterEvent(DoAfterEvent wrappedEvent, EntityUid? originalTarget)
         {
             DebugTools.Assert(wrappedEvent.GetType().HasCustomAttribute<NetSerializableAttribute>(), "Tool event is not serializable");
 
-            Fuel = fuel;
             WrappedEvent = wrappedEvent;
             OriginalTarget = originalTarget;
         }
@@ -238,7 +228,7 @@ public abstract partial class SharedToolSystem : EntitySystem
             if (evClone == WrappedEvent)
                 return this;
 
-            return new ToolDoAfterEvent(Fuel, evClone, OriginalTarget);
+            return new ToolDoAfterEvent(evClone, OriginalTarget);
         }
     }
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -54,7 +54,7 @@ public abstract partial class SharedToolSystem : EntitySystem
     /// <param name="toolQualitiesNeeded">The qualities needed for this tool to work.</param>
     /// <param name="doAfterEv">The event that will be raised when the tool has finished (including cancellation). Event
     /// will be directed at the tool target.</param>
-    /// <param name="fuel">Amount of fuel that should be taken from the tool.</param>
+    /// <param name="fuel">Minimum amount of fuel needed in the tool.</param>
     /// <param name="toolComponent">The tool component.</param>
     /// <returns>Returns true if any interaction takes place.</returns>
     public bool UseTool(
@@ -92,7 +92,7 @@ public abstract partial class SharedToolSystem : EntitySystem
     /// will be directed at the tool target.</param>
     /// <param name="id">The id of the DoAfter that was created. This may be null even if the function returns true in
     /// the event that this tool-use cancelled an existing DoAfter</param>
-    /// <param name="fuel">Amount of fuel that should be taken from the tool.</param>
+    /// <param name="fuel">Minimum amount of fuel needed in the tool.</param>
     /// <param name="toolComponent">The tool component.</param>
     /// <returns>Returns true if any interaction takes place.</returns>
     public bool UseTool(

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -60,7 +60,7 @@
         Blunt: 0 #this feels hacky, but is needed for burn damage while active (i think)
   - type: Welder
     fuelConsumption: 0.01
-    welderOnConsume: 0.1
+    fuelLitCost: 0.1
     litMeleeDamageBonus:
       types:
         Heat: 1

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -62,7 +62,6 @@
     containers:
       board: !type:Container
   - type: Weldable
-    fuel: 5
     time: 3
   - type: Airlock
   - type: DoorBolt

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -55,7 +55,6 @@
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
   - type: Weldable
-    fuel: 10
     time: 10
   - type: Airlock
   - type: DoorBolt

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -78,7 +78,6 @@
       openingAnimationTime: 0.6
       closingAnimationTime: 0.6
     - type: Weldable
-      fuel: 5
       time: 3
     - type: Firelock
     - type: Appearance


### PR DESCRIPTION
## About the PR
- being lit consumes 2 fuel/s
- added vv rw to most server weldercomponent fields
- no fuel used after welding something, cost is based solely off time required

**Media**
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Welders have been reworked to consume fuel when lit rather than after welding something.
