### PR TITLE
make taser require silver

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -65,6 +65,7 @@
     Steel: 700
     Plastic: 300
     Gold: 250
+    Silver: 500
 
 - type: latheRecipe
   id: ForensicPad


### PR DESCRIPTION
## About the PR
taser ops at least requires silver now so salv has to do something

inb4 wrong id, ci will see probably

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun