### PR TITLE
Nerf stims

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -900,21 +900,6 @@
   - UplinkMisc
 
 - type: listing
-  id: UplinkStimpackExperimental
-  name: uplink-experimental-stimpack-name
-  description: uplink-experimental-stimpack-desc
-  productEntity: StimpackExperimental
-  cost:
-    Telecrystal: 8
-  categories:
-  - UplinkMisc
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
-
-- type: listing
   id: UplinkSyndicateSegwayCrate
   name: uplink-syndicate-segway-crate-name
   description: uplink-syndicate-segway-crate-desc

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -307,9 +307,9 @@
         maxVol: 30
         reagents:
         - ReagentId: Stimulants
-          Quantity: 10
+          Quantity: 5
         - ReagentId: NuclearCola
-          Quantity: 15
+          Quantity: 20
         - ReagentId: Ice
           Quantity: 5
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -179,13 +179,13 @@
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 60
+        maxVol: 30
         reagents:
         - ReagentId: Stimulants
-          Quantity: 60
+          Quantity: 30
   - type: Hypospray
     solutionName: pen
-    transferAmount: 60
+    transferAmount: 30
   - type: StaticPrice
     price: 500
   - type: Tag
@@ -195,7 +195,7 @@
   name: stimulant microinjector
   parent: ChemicalMedipen
   id: StimpackMini
-  description: A microinjector of stimulants that give you about one minute of the chemical's effects.
+  description: A microinjector of stimulants that give you about fifteen seconds of the chemical's effects.
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/medipen.rsi
@@ -214,35 +214,6 @@
           Quantity: 15
   - type: StaticPrice
     price: 100
-  - type: Tag
-    tags: []
-
-- type: entity
-  name: experimental stimulant injector
-  parent: ChemicalMedipen
-  id: StimpackExperimental
-  description: There's a red label on the side of it. It says "PRODUCT HAS EXTREME SIDE EFFECTS, PRODUCTION HALTED. DO NOT DISTRIBUTE."
-  components:
-  - type: Sprite
-    sprite: Objects/Specific/Medical/medipen.rsi
-    layers:
-    - state: stimpen
-      map: ["enum.SolutionContainerLayers.Fill"]
-  - type: Item
-    sprite: Objects/Specific/Medical/medipen.rsi
-    size: 10
-  - type: SolutionContainerManager
-    solutions:
-      pen:
-        maxVol: 60
-        reagents:
-        - ReagentId: ExperimentalStimulants
-          Quantity: 60
-  - type: Hypospray
-    solutionName: pen
-    transferAmount: 60
-  - type: StaticPrice
-    price: 1000
   - type: Tag
     tags: []
 

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -104,7 +104,7 @@
   meltingPoint: 170.0
   metabolisms:
     Narcotic:
-      metabolismRate: 0.2
+      metabolismRate: 1.0
       effects:
       - !type:MovespeedModifier
         walkSpeedModifier: 1.3
@@ -125,7 +125,7 @@
         time: 3
         type: Remove
     Medicine:
-      metabolismRate: 0.2
+      metabolismRate: 1.0
       effects:
         - !type:ResetNarcolepsy
         - !type:SatiateHunger
@@ -141,117 +141,6 @@
             groups:
               Burn: -1
               Brute: -1
-
-# a chemical prototype to surpass epinephrine
-- type: reagent
-  id: ExperimentalStimulants
-  name: reagent-name-experimental-stimulants
-  group: Narcotics
-  desc: reagent-desc-experimental-stimulants
-  physicalDesc: reagent-physical-desc-exhilarating
-  flavor: bottledlightning
-  color: "#AE0101"
-  boilingPoint: 212.0
-  meltingPoint: 170.0
-  metabolisms:
-    Narcotic:
-      metabolismRate: 0.25 # lasts for 4 minutes instead of 5
-      effects:
-      - !type:MovespeedModifier # nyoom
-        conditions:
-        - !type:ReagentThreshold
-          min: 10
-        walkSpeedModifier: 1.8
-        sprintSpeedModifier: 1.8
-      - !type:MovespeedModifier # antinyoom
-        conditions:
-        - !type:ReagentThreshold
-          max: 10 # ghetto withdrawal
-        walkSpeedModifier: 0.7
-        sprintSpeedModifier: 0.7
-      - !type:Electrocute
-        conditions:
-          - !type:ReagentThreshold
-            max: 10 # ghetto withdrawal effect
-        probability: 0.1 # get stunlocked nerd
-      - !type:Jitter
-        conditions:
-        - !type:ReagentThreshold
-          max: 10 # ghetto withdrawal
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          max: 10 # ghetto withdrawal
-        key: Stutter
-        component: StutteringAccent
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          min: 10
-        damage:
-          types:
-            Poison: 1 # You will be laying on the floor in crit in 100 seconds if you don't have antitoxin meds (Ideally this should deal twice as much damage but since nukies don't have access to stellbinin it would kill them)
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          min: 60
-        damage:
-          types:
-            Poison: 8 # TODO this should ideally kill your liver instead
-      # effectively negates stamcrits
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          min: 10
-        key: Stun
-        time: 6
-        type: Remove
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          min: 10
-        key: KnockedDown
-        time: 6
-        type: Remove
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          min: 10
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Remove
-    Medicine:
-      metabolismRate: 0.25
-      effects:
-        - !type:ResetNarcolepsy
-        - !type:SatiateHunger
-          factor: 1
-        - !type:SatiateThirst
-          factor: 1
-        - !type:HealthChange
-          conditions:
-          - !type:ReagentThreshold
-            min: 10
-          damage:
-            groups:
-              Brute: -4
-              Burn: -4
-        # stops CMOs from hypoing you with lexorin and sec from filling you with tranq shells
-        - !type:AdjustReagent
-          conditions:
-          - !type:ReagentThreshold
-            reagent: Lexorin
-            min: 1
-          reagent: Lexorin
-          amount: -3
-        - !type:AdjustReagent
-          conditions:
-          - !type:ReagentThreshold
-            reagent: ChloralHydrate
-            min: 1
-          reagent: ChloralHydrate
-          amount: -3
 
 - type: reagent
   id: THC


### PR DESCRIPTION
80% extra movespeed is no, idc if it does poison and needs anti-toxin (and hey nukies have infinite time with their chem dispenser).

:cl:
- remove: Removed experimental stims.
- tweak: Bumped stimulants metabolism from 0.2 to 1.0 per second
- tweak: Reduced stimpacks from 5 minutes to 30 seconds.