### PR TITLE
buff atmos firesuits, nerf atmos hardsuits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -52,7 +52,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.2
+        Heat: 0.4
         Radiation: 0.25
         Caustic: 0.85
   - type: TemperatureProtection

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -131,7 +131,7 @@
     modifiers:
       coefficients:
         Slash: 0.9
-        Heat: 0.35
+        Heat: 0.15
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.75


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Buffs atmos firesuits to be more heat resistant than the hardsuit. Hardsuit meta is bad I think and they already give you space resistance. Having the player be able to choose between heat resistance and space resistance would be a cool dynamic probably.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Nanotrasen realized they could stuff even more asbestos into the Atmospherics firesuits, and have promptly done so.
- tweak: Due to a recent reallocation in asbestos supply, the Atmospherics hardsuits are less heat resistant.
