### PR TITLE
Fixed #17502. Zooming with blindness now changes blindness overlay size

### DIFF
--- a/Content.Client/Eye/Blinding/BlindOverlay.cs
+++ b/Content.Client/Eye/Blinding/BlindOverlay.cs
@@ -3,8 +3,6 @@ using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
-using Content.Shared.Eye.Blinding;
-using Content.Shared.Movement.Components;
 using Content.Shared.Eye.Blinding.Components;
 
 namespace Content.Client.Eye.Blinding

--- a/Content.Client/Eye/Blinding/BlindOverlay.cs
+++ b/Content.Client/Eye/Blinding/BlindOverlay.cs
@@ -4,6 +4,7 @@ using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Content.Shared.Eye.Blinding;
+using Content.Shared.Movement.Components;
 using Content.Shared.Eye.Blinding.Components;
 
 namespace Content.Client.Eye.Blinding
@@ -22,6 +23,8 @@ namespace Content.Client.Eye.Blinding
         private readonly ShaderInstance _circleMaskShader;
 
         private BlindableComponent _blindableComponent = default!;
+
+        private SharedEyeComponent _eyeComponent = default!;
 
         public BlindOverlay()
         {
@@ -57,6 +60,11 @@ namespace Content.Client.Eye.Blinding
                 return true;
             }
 
+            if (!_entityManager.TryGetComponent<SharedEyeComponent>(playerEntity, out var eyeComponent))
+                return false;
+
+            _eyeComponent = eyeComponent;
+
             return blind;
         }
 
@@ -73,6 +81,10 @@ namespace Content.Client.Eye.Blinding
             {
                 _blindableComponent.GraceFrame = false;
             }
+
+            var zoom_scale = _eyeComponent.Zoom;
+
+            _circleMaskShader?.SetParameter("ZOOM_SCALE", zoom_scale);
 
             _greyscaleShader?.SetParameter("SCREEN_TEXTURE", ScreenTexture);
 

--- a/Resources/Textures/Shaders/circle_mask.swsl
+++ b/Resources/Textures/Shaders/circle_mask.swsl
@@ -1,3 +1,5 @@
+uniform highp vec2 ZOOM_SCALE;
+
 highp vec4 circle(in highp vec2 uv, in highp vec2 pos, highp float rad, in highp vec3 color) {
     highp float d = length(pos - uv) - rad;
     highp float t = clamp(d, 0.0, 1.0);
@@ -5,13 +7,15 @@ highp vec4 circle(in highp vec2 uv, in highp vec2 pos, highp float rad, in highp
 }
 void fragment(){
 	highp vec2 uv = FRAGCOORD.xy;
+    highp vec2 uv_stretch = vec2(uv.x * ZOOM_SCALE.x, uv.y * ZOOM_SCALE.y);
     highp vec2 res_xy = vec2(1.0/SCREEN_PIXEL_SIZE.x, 1.0/SCREEN_PIXEL_SIZE.y);
     highp vec2 center = res_xy*0.5;
+    highp vec2 center_stretch = vec2(center.x * ZOOM_SCALE.x, center.y * ZOOM_SCALE.y);
     highp float radius = 0.05 * res_xy.y;
 
     highp vec4 layer1 = vec4(vec3(0.0), 0.0);
     
-    highp vec4 layer2 = circle(uv, center, radius, vec3(0.0));
+    highp vec4 layer2 = circle(uv_stretch, center_stretch, radius, vec3(0.0));
 
     COLOR = mix(layer1, layer2, layer2.a);
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR fixes #17502.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/31414089/8810077e-bd20-416d-922e-12b14e726858)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: plaba
- fix: Zooming with blindness now changes blindness circle size
