### PR TITLE
Remove TickerLobbyReadyEvent

### DIFF
--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -49,7 +49,6 @@ namespace Content.Client.GameTicking.Managers
 
         public event Action? InfoBlobUpdated;
         public event Action? LobbyStatusUpdated;
-        public event Action? LobbyReadyUpdated;
         public event Action? LobbyLateJoinStatusUpdated;
         public event Action<IReadOnlyDictionary<EntityUid, Dictionary<string, uint?>>>? LobbyJobsAvailableUpdated;
 
@@ -62,7 +61,6 @@ namespace Content.Client.GameTicking.Managers
             SubscribeNetworkEvent<TickerLobbyStatusEvent>(LobbyStatus);
             SubscribeNetworkEvent<TickerLobbyInfoEvent>(LobbyInfo);
             SubscribeNetworkEvent<TickerLobbyCountdownEvent>(LobbyCountdown);
-            SubscribeNetworkEvent<TickerLobbyReadyEvent>(LobbyReady);
             SubscribeNetworkEvent<RoundEndMessageEvent>(RoundEnd);
             SubscribeNetworkEvent<RequestWindowAttentionEvent>(msg =>
             {
@@ -122,11 +120,6 @@ namespace Content.Client.GameTicking.Managers
         {
             StartTime = message.StartTime;
             Paused = message.Paused;
-        }
-
-        private void LobbyReady(TickerLobbyReadyEvent message)
-        {
-            LobbyReadyUpdated?.Invoke();
         }
 
         private void RoundEnd(RoundEndMessageEvent message)

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -78,22 +78,6 @@ namespace Content.Server.GameTicking
                 ("roundId", RoundId), ("playerCount", playerCount), ("readyCount", readyCount), ("mapName", stationNames.ToString()),("gmTitle", gmTitle),("desc", desc));
         }
 
-        private TickerLobbyReadyEvent GetStatusSingle(ICommonSession player, PlayerGameStatus gameStatus)
-        {
-            return new (new Dictionary<NetUserId, PlayerGameStatus> { { player.UserId, gameStatus } });
-        }
-
-        private TickerLobbyReadyEvent GetPlayerStatus()
-        {
-            var players = new Dictionary<NetUserId, PlayerGameStatus>();
-            foreach (var player in _playerGameStatuses.Keys)
-            {
-                _playerGameStatuses.TryGetValue(player, out var status);
-                players.Add(player, status);
-            }
-            return new TickerLobbyReadyEvent(players);
-        }
-
         private TickerLobbyStatusEvent GetStatusMsg(IPlayerSession session)
         {
             _playerGameStatuses.TryGetValue(session.UserId, out var status);
@@ -160,7 +144,6 @@ namespace Content.Server.GameTicking
                 if (!_playerManager.TryGetSessionById(playerUserId, out var playerSession))
                     continue;
                 RaiseNetworkEvent(GetStatusMsg(playerSession), playerSession.ConnectedClient);
-                RaiseNetworkEvent(GetStatusSingle(playerSession, status));
             }
         }
 
@@ -180,7 +163,6 @@ namespace Content.Server.GameTicking
             var status = ready ? PlayerGameStatus.ReadyToPlay : PlayerGameStatus.NotReadyToPlay;
             _playerGameStatuses[player.UserId] = ready ? PlayerGameStatus.ReadyToPlay : PlayerGameStatus.NotReadyToPlay;
             RaiseNetworkEvent(GetStatusMsg(player), player.ConnectedClient);
-            RaiseNetworkEvent(GetStatusSingle(player, status));
             // update server info to reflect new ready count
             UpdateInfoText();
         }

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -163,7 +163,6 @@ namespace Content.Server.GameTicking
             RaiseNetworkEvent(new TickerJoinLobbyEvent(), client);
             RaiseNetworkEvent(GetStatusMsg(session), client);
             RaiseNetworkEvent(GetInfoMsg(), client);
-            RaiseNetworkEvent(GetPlayerStatus(), client);
             RaiseLocalEvent(new PlayerJoinedLobbyEvent(session));
         }
 

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -271,7 +271,6 @@ namespace Content.Server.GameTicking
 
             PlayerJoinGame(player);
             SpawnObserver(player);
-            RaiseNetworkEvent(GetStatusSingle(player, PlayerGameStatus.JoinedGame));
         }
 
         /// <summary>

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -117,20 +117,6 @@ namespace Content.Shared.GameTicking
     }
 
     [Serializable, NetSerializable]
-    public sealed class TickerLobbyReadyEvent : EntityEventArgs
-    {
-        /// <summary>
-        /// The Status of the Player in the lobby (ready, observer, ...)
-        /// </summary>
-        public Dictionary<NetUserId, PlayerGameStatus> Status { get; }
-
-        public TickerLobbyReadyEvent(Dictionary<NetUserId, PlayerGameStatus> status)
-        {
-            Status = status;
-        }
-    }
-
-    [Serializable, NetSerializable]
     public sealed class TickerJobsAvailableEvent : EntityEventArgs
     {
         /// <summary>


### PR DESCRIPTION
I'm not really sure what `TickerLobbyReadyEvent` was intended to be used for, but as far as I can tell it currently does nothing.
It sends data to clients via a networked event, but the data is unused and it just causes the `LobbyReadyUpdated` c# event to be invoked, though that event also has no listeners.

Given that it seems to do nothing, and just makes the already complicated `GameTicker` logic more confusing, its probably best to just remove it?