### PR TITLE
Bleed Tweaks

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -35,13 +35,13 @@ namespace Content.Server.Body.Components
         ///     How much should bleeding should be reduced every update interval?
         /// </summary>
         [DataField("bleedReductionAmount")]
-        public float BleedReductionAmount = 0.5f;
+        public float BleedReductionAmount = 1.0f;
 
         /// <summary>
         ///     How high can <see cref="BleedAmount"/> go?
         /// </summary>
         [DataField("maxBleedAmount")]
-        public float MaxBleedAmount = 20.0f;
+        public float MaxBleedAmount = 10.0f;
 
         /// <summary>
         ///     What percentage of current blood is necessary to avoid dealing blood loss damage?
@@ -67,7 +67,7 @@ namespace Content.Server.Body.Components
         ///     How frequently should this bloodstream update, in seconds?
         /// </summary>
         [DataField("updateInterval")]
-        public float UpdateInterval = 5.0f;
+        public float UpdateInterval = 3.0f;
 
         // TODO shouldn't be hardcoded, should just use some organ simulation like bone marrow or smth.
         /// <summary>
@@ -80,7 +80,7 @@ namespace Content.Server.Body.Components
         ///     How much blood needs to be in the temporary solution in order to create a puddle?
         /// </summary>
         [DataField("bleedPuddleThreshold")]
-        public FixedPoint2 BleedPuddleThreshold = 5.0f;
+        public FixedPoint2 BleedPuddleThreshold = 1.0f;
 
         /// <summary>
         ///     A modifier set prototype ID corresponding to how damage should be modified


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Bleed Tweaks


Passive bleed wound clotting doubled (0.5 - 1)
Max bleed rate halved (20u - 10u)
Minimum blood lost amount to create a puddle decreased (5u-1u)
Bloodstream refresh rate decreased (5s - 3s):

- 	Faster bleeding
- 	Faster passive clotting
- 	Faster passive blood recovery
- 	Faster accumulation of bloodloss damage

Urist takes 20 bloodloss damage if his bleedrate is maxed and he is not treated in any way.
In terms of combat, bloodloss should no longer kill people that took very minor injuries but aquired a lot
of sustained bleeding.

bloodloss as a status will wear off faster, but still be relevant!

Puddles having a lower requirement allows bleeding to be a lot more visable, regardless of how little bleed you have
This could be improved with smaller blood-drop-style puddles, although it looks fine as is.

Concerns: 

- Bleed treatments may not be required as much anymore
 		(Using gauze or cauterization may not be done anymore due to passive clotting working fine)
- Blood levels overall will remain a lot higher and not require the iron and blood pack buffs (They can be nerfed)



**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Whisper
- tweak: The rate of which bleeding wounds passively clot has been doubled. (0.5u to 1.0u)
- tweak: Max bleed rate has been halved (20u to 10u)
- tweak: blood puddles will always be created at a minimum of 1u of blood lost. (5u to 1u)
- tweak: The refresh rate for all bloodstream effects (Losing blood, Regaining blood, taking damage, Wound clotting) has been reduced to 3 seconds. This will mean players will both bleed faster but also recover faster.
