### PR TITLE
Construction Price Adjustments

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -47,7 +47,7 @@
         sound:
           path: /Audio/Effects/metalbreak.ogg
   - type: StaticPrice
-    price: 50
+    price: 10
 
 - type: entity
   name: chair

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -32,6 +32,8 @@
     graph: Toilet
     node: toilet
   - type: Appearance
+  - type: StaticPrice
+    price: 25
 
 - type: entity
   id: ToiletDirtyWater

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -49,7 +49,7 @@
     sound:
       path: /Audio/Ambience/Objects/gas_hiss.ogg
   - type: StaticPrice
-    price: 100
+    price: 22
 
 #Note: The PipeDirection of the PipeNode should be the south-facing version, because the entity starts at an angle of 0 (south)
 

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -54,7 +54,7 @@
     containers:
       DisposalTube: !type:Container
   - type: StaticPrice
-    price: 100
+    price: 22
 
 - type: entity
   id: DisposalHolder

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -72,7 +72,7 @@
     containers:
       DisposalUnit: !type:Container
   - type: StaticPrice
-    price: 100
+    price: 62
   - type: PowerSwitch
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -217,6 +217,8 @@
   - type: Construction
     graph: WallmountGenerator
     node: generator
+  - type: StaticPrice
+    price: 14
 
 - type: entity
   parent: BaseGeneratorWallmount
@@ -230,6 +232,8 @@
   - type: Construction
     graph: WallmountGenerator
     node: APU
+  - type: StaticPrice
+    price: 38
 
 # RTG - no fuel requirement
 

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -23,7 +23,7 @@
     containers:
     - entity_storage
   - type: StaticPrice
-    price: 150
+    price: 80
 
 - type: entity
   parent: CrateBaseWeldable

--- a/Resources/Prototypes/Entities/Structures/Storage/storage.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/storage.yml
@@ -57,4 +57,4 @@
         acts: [ "Destruction" ]
   - type: Climbable
   - type: StaticPrice
-    price: 150
+    price: 22

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -44,7 +44,7 @@
     graph: PlasticFlapsGraph
     node: plasticFlaps
   - type: StaticPrice
-    price: 150
+    price: 83
 
 - type: entity
   id: PlasticFlapsOpaque

--- a/Resources/Prototypes/Reagents/Materials/glass.yml
+++ b/Resources/Prototypes/Reagents/Materials/glass.yml
@@ -28,7 +28,7 @@
   name: materials-reinforced-plasma-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: rpglass }
   color: "#8c4069"
-  price: 0.66 # 2-2-1 mix of plasma, glass, and metal.
+  price: 0.40 # 1-1-0.5 mix of plasma, glass, and metal.
 
 - type: material
   id: UraniumGlass


### PR DESCRIPTION
## About the PR
Goes through everything in the construction menu and adjusts it's price to be non-exploitable.

**New Pricing List;**
-air injector: $22
-air scrubber: $22
-air vent: $22
-bar stool: $10
-broken disposal pipe: $22
-chair: $10
-comfy chair: $10
-connector port: $22
-dark office chair: $10
-disposal bend: $22
-disposal junction: $22
-disposal pipe: $22
-disposal router: $22
-disposal tagger: $22
-disposal trunk: $22
-disposal unit: $62
-disposal y-junction: $22
-dual-port air vent: $22
-folding chair: $10
-gas filter: $22
-gas mixer: $22
-gas pipe bend: $22
-gas pipe fourway: $22
-gas pipe half: $22
-gas pipe straight: $22
-gas pipe t-junction: $22
-gas pump: $22
-manual valve: $22
-office chair: $10
-passive gate: $22
-passive vent: $22
-pilot chair: $10
-plastic crate: $80
-plastic flaps: $83
-pneumatic valve: $22
-rack: $22
-reinforced plasma glass: $40
-signal valve: $22
-stool: $10
-toilet: $25
-volumetric gas pump: $22
-wallmount apu: $138
-wallmount generator: $114

**Media**
- [x] This PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Changed the price of most objects found in the construction menu.
