### PR TITLE
D-Sword Tweak

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -175,19 +175,19 @@
         types:
             Slash: 9
             Heat: 9
-            Structural: 20
+            Structural: 15
             Blunt: -4.5
     litDisarmMalus: 0.7
   - type: MeleeWeapon
-    attackRate: 1.6
-    angle: 100
-    heavyWindupModifier: .9
-    heavyDamageModifier: 1.5
-    soundHit:
-      path: /Audio/Weapons/eblade1.ogg
     damage:
       types:
         Blunt: 4.5
+    attackRate: 1.3
+    angle: 100
+    heavyWindupModifier: 1.25
+    heavyDamageModifier: 1.5
+    soundHit:
+      path: /Audio/Weapons/eblade1.ogg
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_sword_double.rsi
     layers:
@@ -202,5 +202,5 @@
     sprite: Objects/Weapons/Melee/e_sword_double.rsi
   - type: Reflect
     enabled: true
-    reflectProb: .75
+    reflectProb: .5
     spread: 75

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -173,8 +173,8 @@
   - type: EnergySword
     litDamageBonus:
         types:
-            Slash: 9
-            Heat: 9
+            Slash: 15
+            Heat: 12
             Structural: 15
             Blunt: -4.5
     litDisarmMalus: 0.7
@@ -185,7 +185,7 @@
     attackRate: 1.4
     angle: 100
     heavyWindupModifier: 1.25
-    heavyDamageModifier: 1.5
+    heavyDamageModifier: 1.35
     soundHit:
       path: /Audio/Weapons/eblade1.ogg
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -182,7 +182,7 @@
     damage:
       types:
         Blunt: 4.5
-    attackRate: 1.3
+    attackRate: 1.4
     angle: 100
     heavyWindupModifier: 1.25
     heavyDamageModifier: 1.5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changes the d-sword, specifically:
- Increased wideswing charge (0.9 -> 1.25)
- (new) Increased slash damage (9 -> 15)
- (new) Increased heat damage (9 -> 12)
- Reduced structural damage (20 -> 15)
- Reduced attack speed (1.5 -> 1.4)
- Reduced reflect change (75% -> 50%)


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Alekshhh
- tweak: Changed d-sword to be less of a death hurricane, and more of a precise killer
