### PR TITLE
Make item size scale with stack size

### DIFF
--- a/Content.Client/Stack/StackSystem.cs
+++ b/Content.Client/Stack/StackSystem.cs
@@ -38,9 +38,7 @@ namespace Content.Client.Stack
                 return;
             }
 
-            // Dirty the UI now that the stack count has changed.
-            if (component is StackComponent clientComp)
-                clientComp.UiUpdateNeeded = true;
+            component.UiUpdateNeeded = true;
         }
 
         private void OnAppearanceChange(EntityUid uid, StackComponent comp, ref AppearanceChangeEvent args)

--- a/Content.IntegrationTests/Tests/StackTest.cs
+++ b/Content.IntegrationTests/Tests/StackTest.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using Content.Server.Storage.Components;
+using Content.Shared.Item;
+using Content.Shared.Stacks;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests;
+
+[TestFixture]
+public sealed class StackTest
+{
+    [Test]
+    public async Task StackCorrectItemSize()
+    {
+        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true});
+        var server = pairTracker.Pair.Server;
+
+        var protoManager = server.ResolveDependency<IPrototypeManager>();
+
+        Assert.Multiple(() =>
+        {
+            foreach (var entity in PoolManager.GetEntityPrototypes<StackComponent>(server))
+            {
+                if (!entity.TryGetComponent<StackComponent>("Stack", out var stackComponent) ||
+                    !entity.TryGetComponent<ItemComponent>("Item", out var itemComponent))
+                    continue;
+
+                if (!protoManager.TryIndex<StackPrototype>(stackComponent.StackTypeId, out var stackProto) ||
+                    stackProto.ItemSize == null)
+                    continue;
+
+                var expectedSize = stackProto.ItemSize * stackComponent.Count;
+                Assert.That(itemComponent.Size, Is.EqualTo(expectedSize), $"Prototype id: {entity.ID} has an item size of {itemComponent.Size} but expected size of {expectedSize}.");
+            }
+        });
+
+        await pairTracker.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/StackTest.cs
+++ b/Content.IntegrationTests/Tests/StackTest.cs
@@ -18,13 +18,14 @@ public sealed class StackTest
         var server = pairTracker.Pair.Server;
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
+        var compFact = server.ResolveDependency<IComponentFactory>();
 
         Assert.Multiple(() =>
         {
             foreach (var entity in PoolManager.GetEntityPrototypes<StackComponent>(server))
             {
-                if (!entity.TryGetComponent<StackComponent>("Stack", out var stackComponent) ||
-                    !entity.TryGetComponent<ItemComponent>("Item", out var itemComponent))
+                if (!entity.TryGetComponent<StackComponent>(out var stackComponent, compFact) ||
+                    !entity.TryGetComponent<ItemComponent>(out var itemComponent, compFact))
                     continue;
 
                 if (!protoManager.TryIndex<StackPrototype>(stackComponent.StackTypeId, out var stackProto) ||

--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -50,13 +50,10 @@ namespace Content.Server.Stack
             if (!Resolve(uid, ref stack))
                 return null;
 
-            if (stack.StackTypeId == null)
-                return null;
-
             // Get a prototype ID to spawn the new entity. Null is also valid, although it should rarely be picked...
             var prototype = _prototypeManager.TryIndex<StackPrototype>(stack.StackTypeId, out var stackType)
                 ? stackType.Spawn
-                : Prototype(stack.Owner)?.ID;
+                : Prototype(uid)?.ID;
 
             // Try to remove the amount of things we want to split from the original stack...
             if (!Use(uid, amount, stack))
@@ -113,7 +110,7 @@ namespace Content.Server.Stack
 
         private void OnStackAlternativeInteract(EntityUid uid, StackComponent stack, GetVerbsEvent<AlternativeVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract || args.Hands == null)
+            if (!args.CanAccess || !args.CanInteract || args.Hands == null || stack.Count == 1)
                 return;
 
             AlternativeVerb halve = new()
@@ -158,7 +155,7 @@ namespace Content.Server.Stack
 
             if (amount <= 0)
             {
-                PopupSystem.PopupCursor(Loc.GetString("comp-stack-split-too-small"), userUid, PopupType.Medium);
+                Popup.PopupCursor(Loc.GetString("comp-stack-split-too-small"), userUid, PopupType.Medium);
                 return;
             }
 
@@ -171,9 +168,9 @@ namespace Content.Server.Stack
                 _storage.UpdateStorageUI(container.Owner, storage);
             }
 
-            HandsSystem.PickupOrDrop(userUid, split);
+            Hands.PickupOrDrop(userUid, split);
 
-            PopupSystem.PopupCursor(Loc.GetString("comp-stack-split"), userUid);
+            Popup.PopupCursor(Loc.GetString("comp-stack-split"), userUid);
         }
     }
 }

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -1,15 +1,18 @@
 using Content.Shared.CombatMode;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Stacks;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Item;
 
 public abstract class SharedItemSystem : EntitySystem
 {
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private   readonly SharedHandsSystem _handsSystem = default!;
     [Dependency] private   readonly SharedCombatModeSystem _combatMode = default!;
     [Dependency] protected readonly SharedContainerSystem Container = default!;
@@ -19,6 +22,7 @@ public abstract class SharedItemSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<ItemComponent, GetVerbsEvent<InteractionVerb>>(AddPickupVerb);
         SubscribeLocalEvent<ItemComponent, InteractHandEvent>(OnHandInteract);
+        SubscribeLocalEvent<ItemComponent, StackCountChangedEvent>(OnStackCountChanged);
 
         SubscribeLocalEvent<ItemComponent, ComponentGetState>(OnGetState);
         SubscribeLocalEvent<ItemComponent, ComponentHandleState>(OnHandleState);
@@ -72,6 +76,18 @@ public abstract class SharedItemSystem : EntitySystem
             return;
 
         args.Handled = _handsSystem.TryPickup(args.User, uid, animateUser: false);
+    }
+
+    private void OnStackCountChanged(EntityUid uid, ItemComponent component, StackCountChangedEvent args)
+    {
+        if (!TryComp<StackComponent>(uid, out var stack))
+            return;
+
+        if (!_prototype.TryIndex<StackPrototype>(stack.StackTypeId, out var stackProto) ||
+            stackProto.ItemSize is not { } size)
+            return;
+
+        SetSize(uid, args.NewCount * size, component);
     }
 
     private void OnHandleState(EntityUid uid, ItemComponent component, ref ComponentHandleState args)

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared.CombatMode;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
-using Content.Shared.Inventory.Events;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
@@ -29,7 +28,7 @@ public abstract class SharedItemSystem : EntitySystem
 
     public void SetSize(EntityUid uid, int size, ItemComponent? component = null)
     {
-        if (!Resolve(uid, ref component))
+        if (!Resolve(uid, ref component, false))
             return;
 
         component.Size = size;

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Examine;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Item;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
 using Robust.Shared.GameStates;
@@ -19,11 +20,12 @@ namespace Content.Shared.Stacks
         [Dependency] private readonly IPrototypeManager _prototype = default!;
         [Dependency] private readonly IViewVariablesManager _vvm = default!;
         [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
-        [Dependency] protected readonly SharedHandsSystem HandsSystem = default!;
+        [Dependency] protected readonly SharedHandsSystem Hands = default!;
+        [Dependency] private readonly SharedItemSystem _item = default!;
         [Dependency] protected readonly SharedTransformSystem Xform = default!;
         [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;
-        [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
+        [Dependency] protected readonly SharedPopupSystem Popup = default!;
 
         public override void Initialize()
         {
@@ -75,18 +77,18 @@ namespace Content.Shared.Stacks
             switch (transfered)
             {
                 case > 0:
-                    PopupSystem.PopupCoordinates($"+{transfered}", popupPos, Filter.Local(), false);
+                    Popup.PopupCoordinates($"+{transfered}", popupPos, Filter.Local(), false);
 
                     if (GetAvailableSpace(recipientStack) == 0)
                     {
-                        PopupSystem.PopupCoordinates(Loc.GetString("comp-stack-becomes-full"),
+                        Popup.PopupCoordinates(Loc.GetString("comp-stack-becomes-full"),
                             popupPos.Offset(new Vector2(0, -0.5f)), Filter.Local(), false);
                     }
 
                     break;
 
                 case 0 when GetAvailableSpace(recipientStack) == 0:
-                    PopupSystem.PopupCoordinates(Loc.GetString("comp-stack-already-full"), popupPos, Filter.Local(), false);
+                    Popup.PopupCoordinates(Loc.GetString("comp-stack-already-full"), popupPos, Filter.Local(), false);
                     break;
             }
         }
@@ -133,12 +135,12 @@ namespace Content.Shared.Stacks
             if (!Resolve(item, ref itemStack, false))
             {
                 // This isn't even a stack. Just try to pickup as normal.
-                HandsSystem.PickupOrDrop(user, item, handsComp: hands);
+                Hands.PickupOrDrop(user, item, handsComp: hands);
                 return;
             }
 
             // This is shit code until hands get fixed and give an easy way to enumerate over items, starting with the currently active item.
-            foreach (var held in HandsSystem.EnumerateHeld(user, hands))
+            foreach (var held in Hands.EnumerateHeld(user, hands))
             {
                 TryMergeStacks(item, held, out _, donorStack: itemStack);
 
@@ -146,16 +148,12 @@ namespace Content.Shared.Stacks
                     return;
             }
 
-            HandsSystem.PickupOrDrop(user, item, handsComp: hands);
+            Hands.PickupOrDrop(user, item, handsComp: hands);
         }
 
         public virtual void SetCount(EntityUid uid, int amount, StackComponent? component = null)
         {
             if (!Resolve(uid, ref component))
-                return;
-
-            // Do nothing if amount is already the same.
-            if (amount == component.Count)
                 return;
 
             // Store old value for event-raising purposes...
@@ -168,6 +166,8 @@ namespace Content.Shared.Stacks
             component.Count = amount;
             Dirty(component);
 
+            if (_prototype.TryIndex<StackPrototype>(component.StackTypeId, out var stackProto) && stackProto.ItemSize is { } size)
+                _item.SetSize(uid, amount * size);
             Appearance.SetData(uid, StackVisuals.Actual, component.Count);
             RaiseLocalEvent(uid, new StackCountChangedEvent(old, component.Count));
         }

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -156,6 +156,10 @@ namespace Content.Shared.Stacks
             if (!Resolve(uid, ref component))
                 return;
 
+            // Do nothing if amount is already the same.
+            if (amount == component.Count)
+                return;
+
             // Store old value for event-raising purposes...
             var old = component.Count;
 

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -21,7 +21,6 @@ namespace Content.Shared.Stacks
         [Dependency] private readonly IViewVariablesManager _vvm = default!;
         [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
         [Dependency] protected readonly SharedHandsSystem Hands = default!;
-        [Dependency] private readonly SharedItemSystem _item = default!;
         [Dependency] protected readonly SharedTransformSystem Xform = default!;
         [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;
@@ -170,8 +169,6 @@ namespace Content.Shared.Stacks
             component.Count = amount;
             Dirty(component);
 
-            if (_prototype.TryIndex<StackPrototype>(component.StackTypeId, out var stackProto) && stackProto.ItemSize is { } size)
-                _item.SetSize(uid, amount * size);
             Appearance.SetData(uid, StackVisuals.Actual, component.Count);
             RaiseLocalEvent(uid, new StackCountChangedEvent(old, component.Count));
         }

--- a/Content.Shared/Stacks/StackPrototype.cs
+++ b/Content.Shared/Stacks/StackPrototype.cs
@@ -2,40 +2,46 @@
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Utility;
 
-namespace Content.Shared.Stacks
+namespace Content.Shared.Stacks;
+
+[Prototype("stack")]
+public sealed class StackPrototype : IPrototype
 {
-    [Prototype("stack")]
-    public sealed class StackPrototype : IPrototype
-    {
-        [ViewVariables]
-        [IdDataField]
-        public string ID { get; } = default!;
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; } = default!;
 
-        /// <summary>
-        ///     Human-readable name for this stack type e.g. "Steel"
-        /// </summary>
-        /// <remarks>This is a localization string ID.</remarks>
-        [DataField("name")]
-        public string Name { get; } = string.Empty;
+    /// <summary>
+    ///     Human-readable name for this stack type e.g. "Steel"
+    /// </summary>
+    /// <remarks>This is a localization string ID.</remarks>
+    [DataField("name")]
+    public string Name { get; } = string.Empty;
 
-        /// <summary>
-        ///     An icon that will be used to represent this stack type.
-        /// </summary>
-        [DataField("icon")]
-        public SpriteSpecifier? Icon { get; }
+    /// <summary>
+    ///     An icon that will be used to represent this stack type.
+    /// </summary>
+    [DataField("icon")]
+    public SpriteSpecifier? Icon { get; }
 
-        /// <summary>
-        ///     The entity id that will be spawned by default from this stack.
-        /// </summary>
-        [DataField("spawn", required: true, customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
-        public string Spawn { get; } = string.Empty;
+    /// <summary>
+    ///     The entity id that will be spawned by default from this stack.
+    /// </summary>
+    [DataField("spawn", required: true, customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string Spawn { get; } = string.Empty;
 
-        /// <summary>
-        ///     The maximum amount of things that can be in a stack.
-        ///     Can be overriden on <see cref="StackComponent"/>
-        ///     if null, simply has unlimited max count.
-        /// </summary>
-        [DataField("maxCount")]
-        public int? MaxCount { get; }
-    }
+    /// <summary>
+    ///     The maximum amount of things that can be in a stack.
+    ///     Can be overriden on <see cref="StackComponent"/>
+    ///     if null, simply has unlimited max count.
+    /// </summary>
+    [DataField("maxCount")]
+    public int? MaxCount { get; }
+
+    /// <summary>
+    /// The size of an individual unit of this stack.
+    /// </summary>
+    [DataField("itemSize")]
+    public int? ItemSize;
 }
+

--- a/Resources/Maps/Shuttles/striker.yml
+++ b/Resources/Maps/Shuttles/striker.yml
@@ -1928,7 +1928,7 @@ entities:
       type: Transform
     - canCollide: False
       type: Physics
-- proto: MedkitCombatFilled
+- proto: MedkitCombat
   entities:
   - uid: 172
     components:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -192,7 +192,7 @@
   description: A special box for sensitive people.
   components:
   - type: Storage
-    capacity: 60
+    capacity: 30
   - type: Sprite
     layers:
       - state: box_hug
@@ -202,7 +202,7 @@
   - type: StorageFill
     contents:
       - id: Brutepack
-        amount: 6
+        amount: 3
   - type: Tag
     tags:
       - BoxHug

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -191,6 +191,8 @@
   id: BoxHugHealing
   description: A special box for sensitive people.
   components:
+  - type: Storage
+    capacity: 60
   - type: Sprite
     layers:
       - state: box_hug

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -75,9 +75,9 @@
       - id: Brutepack
         amount: 2
       - id: Ointment
-        amount: 2
+        amount: 1
       - id: Bloodpack
-        amount: 2
+        amount: 1
       - id: Gauze
       - id: EmergencyMedipen #You never know what people are going to latejoin into
 

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -30,14 +30,14 @@
       - id: Screwdriver
       - id: Crowbar
       - id: Wirecutter
-      - id: CableApcStack
-      - id: CableMVStack
+      - id: CableApcStack10
+      - id: CableMVStack10
       - id: trayScanner
         prob: 0.9
       - id: ClothingHandsGlovesColorYellow
         prob: 0.05
         orGroup: GlovesOrWires
-      - id: CableHVStack
+      - id: CableHVStack10
         orGroup: GlovesOrWires
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -238,6 +238,7 @@
   - type: Clothing
     sprite: Clothing/Belt/medical.rsi
   - type: Storage
+    capacity: 60
     whitelist:
       tags:
         - Wrench

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/rolling_paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/rolling_paper.yml
@@ -9,11 +9,11 @@
       tags:
       - RollingPaper
       - CigFilter
-    capacity: 16
+    capacity: 20
   - type: StorageFill
     contents:
       - id: PaperRolling
-        amount: 8
+        amount: 4
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Cigarettes/paper.rsi
     state: cigpapers
@@ -35,9 +35,9 @@
   - type: StorageFill
     contents:
       - id: PaperRolling
-        amount: 8
+        amount: 2
       - id: CigaretteFilter
-        amount: 8
+        amount: 2
 
 - type: entity
   id: PaperRolling
@@ -54,7 +54,7 @@
     state: cigpaper
   - type: Item
     sprite: Objects/Consumable/Smokeables/Cigarettes/paper.rsi
-    size: 2
+    size: 5
   - type: Tag
     tags:
     - RollingPaper
@@ -68,6 +68,8 @@
   components:
     - type: Stack
       count: 1
+    - type: Item
+      size: 1
 
 - type: entity
   id: CigaretteFilter
@@ -84,7 +86,7 @@
     state: cigfilter
   - type: Item
     sprite: Objects/Consumable/Smokeables/Cigarettes/paper.rsi
-    size: 2
+    size: 10
   - type: Tag
     tags:
     - CigFilter
@@ -97,3 +99,5 @@
   components:
     - type: Stack
       count: 1
+    - type: Item
+      size: 2

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -9,6 +9,7 @@
     sprite: Objects/Materials/Sheets/glass.rsi
   - type: Item
     sprite: Objects/Materials/Sheets/glass.rsi
+    size: 30
   - type: StaticPrice
     price: 0
   - type: ItemStatus
@@ -83,6 +84,8 @@
   - type: Stack
     stackType: Glass
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: SheetGlassBase
@@ -148,6 +151,8 @@
   - type: Stack
     stackType: ReinforcedGlass
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: SheetGlassBase
@@ -173,6 +178,7 @@
       map: ["base"]
   - type: Item
     heldPrefix: pglass
+    size: 30
   - type: Construction
     graph: Glass
     node: SheetPGlass
@@ -210,6 +216,8 @@
   - type: Stack
     stackType: PlasmaGlass
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: SheetPGlass
@@ -250,6 +258,8 @@
   - type: Stack
     stackType: ReinforcedPlasmaGlass
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: SheetGlassBase
@@ -312,6 +322,8 @@
   - type: Stack
     stackType: UraniumGlass
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: SheetUGlass
@@ -351,3 +363,5 @@
   - type: Stack
     stackType: ReinforcedUraniumGlass
     count: 1
+  - type: Item
+    size: 1

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -8,6 +8,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
   - type: Item
     sprite: Objects/Materials/Sheets/metal.rsi
+    size: 30
   - type: StaticPrice
     price: 0
   - type: ItemStatus
@@ -63,6 +64,8 @@
   name: steel
   suffix: Single
   components:
+  - type: Item
+    size: 1
   - type: Sprite
     state: steel
   - type: Stack
@@ -106,3 +109,5 @@
   - type: Stack
     stackType: Plasteel
     count: 1
+  - type: Item
+    size: 1

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -8,6 +8,7 @@
     sprite: Objects/Materials/Sheets/other.rsi
   - type: Item
     sprite: Objects/Materials/Sheets/other.rsi
+    size: 30
   - type: ItemStatus
   - type: Tag
     tags:
@@ -56,6 +57,8 @@
     state: paper
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: SheetOtherBase
@@ -104,6 +107,8 @@
     state: plasma
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: SheetOtherBase
@@ -134,6 +139,7 @@
       map: ["base"]
   - type: Item
     heldPrefix: plastic
+    size: 30
   - type: Appearance
 
 - type: entity
@@ -144,6 +150,8 @@
   components:
   - type: Sprite
     state: plastic
+  - type: Item
+    size: 1
   - type: Stack
     count: 1
 
@@ -192,6 +200,8 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: SheetOtherBase
@@ -233,3 +243,5 @@
       state: meat
     - type: Stack
       count: 1
+    - type: Item
+      size: 1

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -8,6 +8,7 @@
     sprite: Objects/Materials/ingots.rsi
   - type: Item
     sprite: Objects/Materials/ingots.rsi
+    size: 30
   - type: StaticPrice
     price: 0
   - type: ItemStatus
@@ -62,6 +63,8 @@
     state: gold
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: IngotBase
@@ -99,3 +102,5 @@
     state: silver
   - type: Stack
     count: 1
+  - type: Item
+    size: 1

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -8,6 +8,7 @@
     sprite: Objects/Materials/materials.rsi
   - type: Item
     sprite: Objects/Materials/materials.rsi
+    size: 30
   - type: ItemStatus
   - type: Tag
     tags:
@@ -47,6 +48,8 @@
     - state: cardboard_3
       map: ["base"]
   - type: Appearance
+  - type: Item
+    size: 30
 
 - type: entity
   parent: MaterialCardboard
@@ -57,6 +60,8 @@
     state: cardboard
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: MaterialBase
@@ -103,6 +108,8 @@
     - state: cloth_3
       map: ["base"]
   - type: Appearance
+  - type: Item
+    size: 30
 
 - type: entity
   parent: MaterialCloth
@@ -113,6 +120,8 @@
     state: cloth
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: MaterialBase
@@ -150,6 +159,8 @@
     state: durathread
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: MaterialBase
@@ -184,6 +195,8 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: MaterialBase
@@ -205,6 +218,8 @@
   - type: GuideHelp
     guides:
     - Cloning
+  - type: Item
+    size: 100
 
 - type: entity
   parent: MaterialBiomass
@@ -213,6 +228,8 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 # Following not used currently
 - type: entity
@@ -255,6 +272,7 @@
     state: diamond
   - type: Item
     heldPrefix: diamond
+    size: 60
 
 - type: entity
   parent: MaterialDiamond
@@ -263,6 +281,8 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 2
 
 - type: entity
   parent: MaterialBase
@@ -283,6 +303,9 @@
     - state: cotton_3
       map: ["base"]
   - type: Appearance
+  - type: Item
+    size: 30
+
 
 - type: entity
   parent: MaterialCotton
@@ -293,6 +316,8 @@
     state: cotton
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: MaterialBase
@@ -343,6 +368,8 @@
       - ReagentId: Honk
         Quantity: 5
   - type: Appearance
+  - type: Item
+    size: 20
 
 - type: entity
   parent: MaterialBananium
@@ -353,3 +380,5 @@
     state: bananium
   - type: Stack
     count: 1
+  - type: Item
+    size: 2

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -8,7 +8,7 @@
     sprite: Objects/Materials/ore.rsi
   - type: Item
     sprite: Objects/Materials/ore.rsi
-    size: 30
+    size: 60
   - type: ItemStatus
   - type: Tag
     tags:
@@ -58,6 +58,8 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 2
 
 - type: entity
   parent: OreBase
@@ -81,6 +83,8 @@
   components:
     - type: Stack
       count: 1
+    - type: Item
+      size: 2
 
 - type: entity
   parent: OreBase
@@ -104,6 +108,8 @@
   components:
     - type: Stack
       count: 1
+    - type: Item
+      size: 2
 
 - type: entity
   parent: OreBase
@@ -127,6 +133,8 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 2
 
 - type: entity
   parent: OreBase
@@ -150,6 +158,8 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 2
 
 - type: entity
   parent: OreBase
@@ -173,6 +183,8 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 2
 
 
 - type: entity
@@ -197,3 +209,5 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 2

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -44,7 +44,8 @@
     layers:
     - state: rods_5
       map: ["base"]
-#  - type: Item
+  - type: Item
+    size: 30
 #    heldPrefix: rods
   - type: Construction
     graph: MetalRod
@@ -73,3 +74,5 @@
     state: rods
   - type: Stack
     count: 1
+  - type: Item
+    size: 1

--- a/Resources/Prototypes/Entities/Objects/Misc/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/box.yml
@@ -10,7 +10,6 @@
     size: 30
   - type: Storage
     capacity: 30
-    size: 10
   - type: ContainerContainer
     containers:
       storagebase: !type:Container

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
@@ -62,6 +62,8 @@
   - type: Tag
     tags:
       - Smokable
+  - type: Item
+    size: 1
 
 - type: entity
   name: tobacco leaves
@@ -118,3 +120,5 @@
   - type: Tag
     tags:
       - Smokable
+  - type: Item
+    size: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -6,6 +6,7 @@
   - type: Sprite
     sprite: Objects/Specific/Medical/medical.rsi
   - type: Item
+    size: 10
     sprite: Objects/Specific/Medical/medical.rsi
     heldPrefix: ointment
   # Inherited
@@ -17,6 +18,7 @@
   description: Used to treat those nasty burns. Less effective on caustic burns.
   parent: BaseHealingItem
   id: Ointment
+  suffix: Full
   components:
   - type: Tag
     tags:
@@ -47,16 +49,20 @@
 - type: entity
   id: Ointment1
   parent: Ointment
+  suffix: Single
   components:
   - type: Stack
     stackType: Ointment
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   name: bruise pack
   description: A therapeutic gel pack and bandages designed to treat blunt-force trauma.
   parent: BaseHealingItem
   id: Brutepack
+  suffix: Full
   components:
   - type: Tag
     tags:
@@ -82,16 +88,20 @@
 - type: entity
   id: Brutepack1
   parent: Brutepack
+  suffix: Single
   components:
   - type: Stack
     stackType: Brutepack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   name: blood pack
   description: Contains a groundbreaking universal blood replacement created by Nanotrasen's advanced medical science.
   parent: BaseHealingItem
   id: Bloodpack
+  suffix: Full
   components:
   - type: Tag
     tags:
@@ -120,6 +130,7 @@
   description: Some sterile gauze to wrap around bloody stumps.
   parent: BaseHealingItem
   id: Gauze
+  suffix: Full
   components:
   - type: Tag
     tags:
@@ -150,9 +161,12 @@
 - type: entity
   id: Gauze1
   parent: Gauze
+  suffix: Single
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   name: aloe cream
@@ -284,7 +298,7 @@
         reagents:
         - ReagentId: Bicaridine
           Quantity: 10
-          
+
 - type: entity
   name: romerol pill
   parent: Pill
@@ -362,8 +376,8 @@
         maxVol: 15
         reagents:
         - ReagentId: Bicaridine
-          Quantity: 15        
-          
+          Quantity: 15
+
 - type: entity
   name: ipecac syringe
   parent: BaseSyringe

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -10,7 +10,7 @@
   - type: Storage
     capacity: 60
   - type: Item
-    size: 35
+    size: 60
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     heldPrefix: firstaid
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -8,7 +8,7 @@
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: firstaid
   - type: Storage
-    capacity: 35
+    capacity: 60
   - type: Item
     size: 35
     sprite: Objects/Specific/Medical/firstaidkits.rsi
@@ -92,8 +92,8 @@
   - type: Sprite
     state: blackkit
   - type: Item
-    heldPrefix: blackkit  
+    heldPrefix: blackkit
     size: 50
   - type: Storage
     capacity: 50
-    
+

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -10,6 +10,7 @@
     state: telecrystal
   - type: Item
     sprite: Objects/Specific/Syndicate/telecrystal.rsi
+    size: 20
   - type: Stack
     count: 20
     stackType: Telecrystal
@@ -28,6 +29,8 @@
   components:
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: Telecrystal
@@ -36,6 +39,8 @@
   components:
   - type: Stack
     count: 5
+  - type: Item
+    size: 5
 
 - type: entity
   parent: Telecrystal
@@ -44,6 +49,8 @@
   components:
   - type: Stack
     count: 10
+  - type: Item
+    size: 10
 
 # Uplinks
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -19,7 +19,7 @@
     sprite: Objects/Tools/cable-coils.rsi
   - type: Item
     sprite: Objects/Tools/cable-coils.rsi
-    size: 10
+    size: 30
   - type: CablePlacer
   - type: Clickable
   - type: StaticPrice
@@ -55,6 +55,18 @@
 
 - type: entity
   parent: CableHVStack
+  id: CableHVStack10
+  suffix: 10
+  components:
+  - type: Sprite
+    state: coilhv-10
+  - type: Stack
+    count: 10
+  - type: Item
+    size: 10
+
+- type: entity
+  parent: CableHVStack
   id: CableHVStack1
   suffix: 1
   components:
@@ -62,6 +74,8 @@
     state: coilhv-10
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: CableStack
@@ -91,6 +105,18 @@
 
 - type: entity
   parent: CableMVStack
+  id: CableMVStack10
+  suffix: 10
+  components:
+  - type: Sprite
+    state: coilmv-10
+  - type: Stack
+    count: 10
+  - type: Item
+    size: 10
+
+- type: entity
+  parent: CableMVStack
   id: CableMVStack1
   suffix: 1
   components:
@@ -98,6 +124,8 @@
     state: coilmv-10
   - type: Stack
     count: 1
+  - type: Item
+    size: 1
 
 - type: entity
   parent: CableStack
@@ -126,6 +154,18 @@
 
 - type: entity
   parent: CableApcStack
+  id: CableApcStack10
+  suffix: 10
+  components:
+    - type: Sprite
+      state: coillv-10
+    - type: Stack
+      count: 10
+    - type: Item
+      size: 10
+
+- type: entity
+  parent: CableApcStack
   id: CableApcStack1
   suffix: 1
   components:
@@ -133,3 +173,5 @@
     state: coillv-10
   - type: Stack
     count: 1
+  - type: Item
+    size: 1

--- a/Resources/Prototypes/Entities/Objects/Tools/inflatable_wall.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/inflatable_wall.yml
@@ -13,7 +13,7 @@
       state: item_wall
     - type: Item
       sprite: Objects/Misc/inflatable_wall.rsi
-      size: 5
+      size: 10
     - type: SpawnAfterInteract
       prototype: InflatableWall
       doAfter: 1
@@ -39,7 +39,7 @@
       state: item_door
     - type: Item
       sprite: Objects/Misc/inflatable_door.rsi
-      size: 5
+      size: 4
     - type: SpawnAfterInteract
       prototype: InflatableDoor
       doAfter: 1
@@ -58,7 +58,7 @@
     - type: Sprite
       state: item_wall
     - type: Item
-      size: 5
+      size: 1
     - type: Stack
       count: 1
 
@@ -70,6 +70,6 @@
     - type: Sprite
       state: item_door
     - type: Item
-      size: 5
+      size: 1
     - type: Stack
       count: 1

--- a/Resources/Prototypes/Stacks/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Stacks/Materials/Sheets/glass.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: glass }
   spawn: SheetGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: ReinforcedGlass
@@ -11,6 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: rglass }
   spawn: SheetRGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: PlasmaGlass
@@ -18,6 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: pglass }
   spawn: SheetPGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: ReinforcedPlasmaGlass
@@ -25,6 +28,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: rpglass }
   spawn: SheetRPGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: UraniumGlass
@@ -32,6 +36,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: uglass }
   spawn: SheetUGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: ReinforcedUraniumGlass
@@ -39,3 +44,4 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: ruglass }
   spawn: SheetRUGlass1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Stacks/Materials/Sheets/metal.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/metal.rsi, state: steel }
   spawn: SheetSteel1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Plasteel
@@ -11,3 +12,4 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/metal.rsi, state: plasteel }
   spawn: SheetPlasteel1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Stacks/Materials/Sheets/other.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/other.rsi, state: paper }
   spawn: SheetPaper1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Plasma
@@ -11,6 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/other.rsi, state: plasma }
   spawn: SheetPlasma1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Plastic
@@ -18,6 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/other.rsi, state: plastic }
   spawn: SheetPlastic1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Uranium
@@ -25,3 +28,4 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/other.rsi, state: uranium }
   spawn: SheetUranium1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/crystals.yml
+++ b/Resources/Prototypes/Stacks/Materials/crystals.yml
@@ -3,3 +3,4 @@
   name: telecrystal
   icon: Objects/Specific/Syndicate/telecrystal.rsi
   spawn: Telecrystal1
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/ingots.yml
+++ b/Resources/Prototypes/Stacks/Materials/ingots.yml
@@ -4,6 +4,7 @@
   icon: { sprite: "/Textures/Objects/Materials/ingots.rsi", state: gold }
   spawn: IngotGold1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Silver
@@ -11,3 +12,4 @@
   icon: { sprite: "/Textures/Objects/Materials/ingots.rsi", state: silver }
   spawn: IngotSilver1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/materials.yml
+++ b/Resources/Prototypes/Stacks/Materials/materials.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Misc/monkeycube.rsi, state: cube }
   spawn: MaterialBiomass1
   maxCount: 100
+  itemSize: 1
 
 - type: stack
   id: WoodPlank
@@ -11,6 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: wood }
   spawn: MaterialWoodPlank1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Cardboard
@@ -18,6 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cardboard }
   spawn: MaterialCardboard1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Cloth
@@ -25,6 +28,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cloth }
   spawn: MaterialCloth1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Durathread
@@ -32,6 +36,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: durathread }
   spawn: MaterialDurathread1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Diamond
@@ -39,6 +44,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: diamond }
   spawn: MaterialDiamond1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: Cotton
@@ -46,6 +52,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cotton }
   spawn: MaterialCotton1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Bananium
@@ -53,6 +60,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: bananium }
   spawn: MaterialBananium1
   maxCount: 10
+  itemSize: 2
 
 - type: stack
   id: MeatSheets
@@ -60,3 +68,4 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/meaterial.rsi, state: meat }
   spawn: MaterialSheetMeat1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/ore.yml
+++ b/Resources/Prototypes/Stacks/Materials/ore.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: gold }
   spawn: GoldOre1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: SteelOre
@@ -11,6 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: iron }
   spawn: SteelOre1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: PlasmaOre
@@ -18,6 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: plasma }
   spawn: PlasmaOre1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: SilverOre
@@ -25,6 +28,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: silver }
   spawn: SilverOre1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: SpaceQuartz
@@ -32,6 +36,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: spacequartz }
   spawn: SpaceQuartz1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: UraniumOre
@@ -39,6 +44,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: uranium }
   spawn: UraniumOre1
   maxCount: 30
+  itemSize: 2
 
 
 - type: stack
@@ -47,3 +53,4 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: bananium }
   spawn: BananiumOre1
   maxCount: 30
+  itemSize: 2

--- a/Resources/Prototypes/Stacks/Materials/parts.yml
+++ b/Resources/Prototypes/Stacks/Materials/parts.yml
@@ -4,3 +4,4 @@
   icon: { sprite: /Textures/Objects/Materials/parts.rsi, state: rods }
   spawn: PartRodMetal1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/consumable_stacks.yml
+++ b/Resources/Prototypes/Stacks/consumable_stacks.yml
@@ -5,6 +5,7 @@
   name: pancake
   spawn: FoodBakedPancake
   maxCount: 3
+  itemSize: 1
 
 # Food Containers
 
@@ -14,6 +15,7 @@
   icon: { sprite: Objects/Consumable/Food/Baked/pizza.rsi, state: box }
   spawn: FoodBoxPizza
   maxCount: 30
+  itemSize: 10
 
 # Smokeables
 
@@ -23,6 +25,7 @@
   icon: { sprite: /Textures/Objects/Consumable/Smokeables/Cigarettes/paper.rsi, state: cigpaper }
   spawn: PaperRolling
   maxCount: 5
+  itemSize: 1
 
 - type: stack
   id: CigaretteFilter
@@ -30,6 +33,7 @@
   icon: { sprite: /Textures/Objects/Consumable/Smokeables/Cigarettes/paper.rsi, state: cigfilter }
   spawn: CigaretteFilter
   maxCount: 5
+  itemSize: 2
 
 - type: stack
   id: GroundTobacco
@@ -37,13 +41,15 @@
   icon: { sprite: /Textures/Objects/Misc/reagent_fillings.rsi, state: powderpile }
   spawn: GroundTobacco
   maxCount: 5
+  itemSize: 1
 
 - type: stack
   id: GroundCannabis
   name: ground cannabis
   icon: { sprite: /Textures/Objects/Misc/reagent_fillings.rsi, state: powderpile }
   spawn: GroundCannabis
-  maxCount: 5
+  maxCount:
+  itemSize: 1
 
 - type: stack
   id: LeavesTobaccoDried
@@ -51,6 +57,7 @@
   icon: { sprite: /Textures/Objects/Specific/Hydroponics/tobacco.rsi, state: dried }
   spawn: LeavesTobaccoDried
   maxCount: 5
+  itemSize: 5
 
 - type: stack
   id: LeavesCannabisDried
@@ -58,3 +65,4 @@
   icon: { sprite: /Textures/Objects/Specific/Hydroponics/tobacco.rsi, state: dried }
   spawn: LeavesCannabisDried
   maxCount: 5
+  itemSize: 5

--- a/Resources/Prototypes/Stacks/engineering_stacks.yml
+++ b/Resources/Prototypes/Stacks/engineering_stacks.yml
@@ -1,11 +1,14 @@
+# they're uninflated by default so they're tiny
 - type: stack
   id: InflatableWall
   name: inflatable wall
   spawn: InflatableWallStack1
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: InflatableDoor
   name: inflatable door
   spawn: InflatableDoorStack1
   maxCount: 4
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/floor_tile_stacks.yml
+++ b/Resources/Prototypes/Stacks/floor_tile_stacks.yml
@@ -3,315 +3,368 @@
   name: steel tile
   spawn: FloorTileItemSteel
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMetalDiamond
   name: steel tile
   spawn: FloorTileItemMetalDiamond
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileWood
   name: wood floor
   spawn: FloorTileItemWood
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileWhite
   name: white tile
   spawn: FloorTileItemWhite
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileDark
   name: dark tile
   spawn: FloorTileItemDark
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileTechmaint
   name: techmaint floor
   spawn: FloorTileItemTechmaint
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileFreezer
   name: freezer tile
   spawn: FloorTileItemFreezer
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileShowroom
   name: showroom tile
   spawn: FloorTileItemShowroom
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGCircuit
   name: green-circuit floor
   spawn: FloorTileItemGCircuit
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGold
   name: gold floor
   spawn: FloorTileItemGold
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileReinforced
   name: reinforced tile
   spawn: FloorTileItemReinforced
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMono
   name: mono tile
   spawn: FloorTileItemMono
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileLino
   name: linoleum floor
   spawn: FloorTileItemLino
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileHydro
   name: hydro tile
   spawn: FloorTileItemHydro
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileDirty
   name: dirty tile
   spawn: FloorTileItemDirty
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleWhite
   name: white shuttle tile
   spawn: FloorTileItemShuttleWhite
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleBlue
   name: blue shuttle tile
   spawn: FloorTileItemShuttleBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleOrange
   name: orange shuttle tile
   spawn: FloorTileItemShuttleOrange
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttlePurple
   name: purple shuttle tile
   spawn: FloorTileItemShuttlePurple
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleRed
   name: red shuttle tile
   spawn: FloorTileItemShuttleRed
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackEighties
   name: eighties floor tile
   spawn: FloorTileItemEighties
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackArcadeBlue
   name: blue arcade tile
   spawn: FloorTileItemArcadeBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackArcadeBlue2
   name: blue arcade tile
   spawn: FloorTileItemArcadeBlue2
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackArcadeRed
   name: red arcade tile
   spawn: FloorTileItemArcadeRed
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetRed
   name: red carpet tile
   spawn: FloorCarpetItemRed
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetBlack
   name: block carpet tile
   spawn: FloorCarpetItemBlack
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetBlue
   name: blue carpet tile
   spawn: FloorCarpetItemBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetGreen
   name: green carpet tile
   spawn: FloorCarpetItemGreen
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetOrange
   name: orange carpet tile
   spawn: FloorCarpetItemOrange
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetSkyBlue
   name: skyblue carpet tile
   spawn: FloorCarpetItemSkyBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetPurple
   name: purple carpet tile
   spawn: FloorCarpetItemPurple
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetPink
   name: pink carpet tile
   spawn: FloorCarpetItemPink
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackCarpetClown
   name: clown carpet tile
   spawn: FloorTileItemCarpetClown
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackCarpetOffice
   name: office carpet tile
   spawn: FloorTileItemCarpetOffice
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackBoxing
   name: boxing ring tile
   spawn: FloorTileItemBoxing
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackGym
   name: gym floor tile
   spawn: FloorTileItemGym
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileElevatorShaft
   name: elevator shaft tile
   spawn: FloorTileItemElevatorShaft
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileRockVault
   name: rock vault tile
   spawn: FloorTileItemRockVault
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileBlue
   name: blue floor tile
   spawn: FloorTileItemBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileBar
   name: item bar floor tile
   spawn: FloorTileItemBar
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileClown
   name: clown floor tile
   spawn: FloorTileItemClown
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMime
   name: mime floor tile
   spawn: FloorTileItemMime
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileKitchen
   name: kitchen floor tile
   spawn: FloorTileItemKitchen
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileLaundry
   name: laundry floor tile
   spawn: FloorTileItemLaundry
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileSilver
   name: silver floor tile
   spawn: FloorTileItemSilver
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileBCircuit
   name: bcircuit floor tile
   spawn: FloorTileItemBCircuit
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGrass
   name: grass floor tile
   spawn: FloorTileItemGrass
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGrassJungle
   name: grass jungle floor tile
   spawn: FloorTileItemGrassJungle
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileSnow
   name: snow floor tile
   spawn: FloorTileItemSnow
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileWoodPattern
   name: wood pattern floor
   spawn: FloorTileItemWoodPattern
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileFlesh
   name: flesh floor
   spawn: FloorTileItemFlesh
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileSteelMaint
   name: steel maint floor
   spawn: FloorTileItemSteelMaint
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGratingMaint
   name: grating maint floor
   spawn: FloorTileItemGratingMaint
   maxCount: 30
+  itemSize: 5

--- a/Resources/Prototypes/Stacks/medical_stacks.yml
+++ b/Resources/Prototypes/Stacks/medical_stacks.yml
@@ -4,6 +4,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: ointment }
   spawn: Ointment
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: AloeCream
@@ -11,6 +12,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Hydroponics/aloe.rsi", state: cream }
   spawn: AloeCream
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: Gauze
@@ -18,6 +20,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Gauze
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: Brutepack
@@ -25,6 +28,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Brutepack
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: Bloodpack
@@ -32,3 +36,4 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: bloodpack }
   spawn: Bloodpack
   maxCount: 10
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/power_stacks.yml
+++ b/Resources/Prototypes/Stacks/power_stacks.yml
@@ -4,6 +4,7 @@
   icon: { sprite: "/Textures/Objects/Tools/cable-coils.rsi", state: coil-30 }
   spawn: CableApcStack1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: CableMV
@@ -11,6 +12,7 @@
   icon: { sprite: "/Textures/Objects/Tools/cable-coils.rsi", state: coilmv-30 }
   spawn: CableMVStack1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: CableHV
@@ -18,3 +20,4 @@
   icon: { sprite: "/Textures/Objects/Tools/cable-coils.rsi", state: coilhv-30 }
   spawn: CableHVStack1
   maxCount: 30
+  itemSize: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
you heard it here, folks. The size of an item now scales directly with how many of it is in a stack. 
No longer does 5 cables weigh 5 and 30 cables weigh 5.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/17b36e2b-b05b-4513-95f4-28f79b9e2fc4)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: The size of an item now scales with the amount of items in a stack. A single sheet of metal takes up less space than a stack of 30.
