### PR TITLE
ListObjectivesCommand localisation and completion

### DIFF
--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -21,14 +21,14 @@ namespace Content.Server.Objectives.Commands
             }
             else if (player == null || !IoCManager.Resolve<IPlayerManager>().TryGetPlayerDataByUsername(args[0], out data))
             {
-                shell.WriteLine(LocalizationManager.GetString("cmd-lsobjectives-player"));
+                shell.WriteError(LocalizationManager.GetString("shell-target-player-does-not-exist"));
                 return;
             }
 
             var mind = data.ContentData()?.Mind;
             if (mind == null)
             {
-                shell.WriteLine(LocalizationManager.GetString("cmd-lsobjectives-mind"));
+                shell.WriteError(LocalizationManager.GetString("shell-target-entity-does-not-have-message", ("missing", "mind")));
                 return;
             }
 
@@ -49,9 +49,7 @@ namespace Content.Server.Objectives.Commands
         {
             if (args.Length == 1)
             {
-                var playerMgr = IoCManager.Resolve<IPlayerManager>();
-                var options = playerMgr.ServerSessions.Select(c => c.Name).OrderBy(c => c).ToArray();
-                return CompletionResult.FromHintOptions(options, LocalizationManager.GetString("cmd-lsobjectives-hint"));
+                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), LocalizationManager.GetString("shell-argument-username-hint"));
             }
 
             return CompletionResult.Empty;

--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -11,8 +11,6 @@ namespace Content.Server.Objectives.Commands
     public sealed class ListObjectivesCommand : LocalizedCommands
     {
         public override string Command => "lsobjectives";
-        //public string Description => "Lists all objectives in a players mind.";
-        //public string Help => "lsobjectives [<username>]";
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var player = shell.Player as IPlayerSession;

--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -8,12 +8,12 @@ using Robust.Shared.Console;
 namespace Content.Server.Objectives.Commands
 {
     [AdminCommand(AdminFlags.Logs)]
-    public sealed class ListObjectivesCommand : IConsoleCommand
+    public sealed class ListObjectivesCommand : LocalizedCommands
     {
-        public string Command => "lsobjectives";
-        public string Description => "Lists all objectives in a players mind.";
-        public string Help => "lsobjectives [<username>]";
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        public override string Command => "lsobjectives";
+        //public string Description => "Lists all objectives in a players mind.";
+        //public string Help => "lsobjectives [<username>]";
+        public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var player = shell.Player as IPlayerSession;
             IPlayerData? data;
@@ -23,14 +23,14 @@ namespace Content.Server.Objectives.Commands
             }
             else if (player == null || !IoCManager.Resolve<IPlayerManager>().TryGetPlayerDataByUsername(args[0], out data))
             {
-                shell.WriteLine("Can't find the playerdata.");
+                shell.WriteLine(LocalizationManager.GetString("cmd-lsobjectives-player"));
                 return;
             }
 
             var mind = data.ContentData()?.Mind;
             if (mind == null)
             {
-                shell.WriteLine("Can't find the mind.");
+                shell.WriteLine(LocalizationManager.GetString("cmd-lsobjectives-mind"));
                 return;
             }
 
@@ -47,13 +47,13 @@ namespace Content.Server.Objectives.Commands
 
         }
 
-        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
         {
             if (args.Length == 1)
             {
                 var playerMgr = IoCManager.Resolve<IPlayerManager>();
                 var options = playerMgr.ServerSessions.Select(c => c.Name).OrderBy(c => c).ToArray();
-                return CompletionResult.FromHintOptions(options, "<name/user ID>");
+                return CompletionResult.FromHintOptions(options, LocalizationManager.GetString("cmd-lsobjectives-hint"));
             }
 
             return CompletionResult.Empty;

--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -46,5 +46,17 @@ namespace Content.Server.Objectives.Commands
             }
 
         }
+
+        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 1)
+            {
+                var playerMgr = IoCManager.Resolve<IPlayerManager>();
+                var options = playerMgr.ServerSessions.Select(c => c.Name).OrderBy(c => c).ToArray();
+                return CompletionResult.FromHintOptions(options, "<name/user ID>");
+            }
+
+            return CompletionResult.Empty;
+        }
     }
 }

--- a/Resources/Locale/en-US/objectives/commands/lsobjectives.ftl
+++ b/Resources/Locale/en-US/objectives/commands/lsobjectives.ftl
@@ -1,6 +1,3 @@
 # lsobjectives
 cmd-lsobjectives-desc = Lists all objectives in a players mind.
 cmd-lsobjectives-help = Usage: lsobjectives <username>
-cmd-lsobjectives-player = Can't find the playerdata.
-cmd-lsobjectives-mind = Can't find the mind.
-cmd-lsobjectives-hint = <username>

--- a/Resources/Locale/en-US/objectives/commands/lsobjectives.ftl
+++ b/Resources/Locale/en-US/objectives/commands/lsobjectives.ftl
@@ -1,0 +1,6 @@
+# lsobjectives
+cmd-lsobjectives-desc = Lists all objectives in a players mind.
+cmd-lsobjectives-help = Usage: lsobjectives <username>
+cmd-lsobjectives-player = Can't find the playerdata.
+cmd-lsobjectives-mind = Can't find the mind.
+cmd-lsobjectives-hint = <username>

--- a/Resources/Locale/en-US/shell.ftl
+++ b/Resources/Locale/en-US/shell.ftl
@@ -42,3 +42,6 @@ shell-argument-number-must-be-between = Argument {$index} must be a number betwe
 shell-argument-station-id-invalid = Argument {$index} must be a valid station id!
 shell-argument-map-id-invalid = Argument {$index} must be a valid map id!
 shell-argument-number-invalid = Argument {$index} must be a valid number!
+
+# Hints
+shell-argument-username-hint = <username>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
I have added localisation and completion to the `lsobjectives` command.
I have no idea if I've done it correctly, other than the fact it works.
Do I need a changelog if it only affects admins?

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/44417085/21491555-4fa2-406e-a361-88d833f5a9c6)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- tweak: The lsobjectives command now has autocompletion.
