### PR TITLE
Adds no access freezer.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -98,7 +98,7 @@
 - type: entity
   parent: AirlockFreezer
   id: AirlockFreezerLocked
-  suffix: Service, Locked
+  suffix: Kitchen, Locked
   components:
   - type: AccessReader
     access: [["Kitchen"]]

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -145,20 +145,28 @@
 
 # Freezer
 - type: entity
-  id: LockerFreezer
+  id: LockerFreezerBase
   parent: LockerBase
   name: freezer
+  suffix: No Access
   components:
   - type: Appearance
   - type: EntityStorageVisuals
     stateBaseClosed: freezer
     stateDoorOpen: freezer_open
     stateDoorClosed: freezer_door
-  - type: AccessReader
-    access: [ [ "Kitchen" ] ]
   - type: ExplosionResistance
     resistance: 0.90
   - type: AntiRottingContainer
+
+- type: entity
+  id: LockerFreezer
+  parent: LockerFreezerBase
+  name: freezer
+  suffix: Kitchen, Locked
+  components:
+  - type: AccessReader
+    access: [ [ "Kitchen" ] ]
 
 # Botanist
 - type: entity


### PR DESCRIPTION
## About the PR
- Adds a freezer for mapping with no access.
- Changes suffix of freezer door from "Service" -> "Kitchen" (Kitchen is less confusing as Service implies a wider group of roles with potential access.)    


**Media**
![image](https://github.com/space-wizards/space-station-14/assets/107660393/d67a1ad2-83a8-46b9-b5d5-f1f29b4ce692)
![image](https://github.com/space-wizards/space-station-14/assets/107660393/e591090e-c787-4e6d-b817-84e1186b00f2)

- [ x ] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

**Changelog**
No public CL necessary
