### PR TITLE
breaker pops after 5 seconds

### DIFF
--- a/Content.Server/Power/Components/BreakerComponent.cs
+++ b/Content.Server/Power/Components/BreakerComponent.cs
@@ -7,8 +7,27 @@ namespace Content.Server.Power.Components;
 public sealed class BreakerComponent : Component
 {
     /// <summary>
-    /// Once power supplied exceeds this limit the breaker will pop.
+    /// Once power supplied exceeds this limit the breaker will start to pop.
     /// </summary>
     [DataField("limit", required: true), ViewVariables(VVAccess.ReadWrite)]
     public float Limit;
+
+    /// <summary>
+    /// Time that supply must exceed limit for the breaker to pop.
+    /// </summary>
+    [DataField("popTime"), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan PopTime = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Whether the breaker is starting to pop.
+    /// </summary>
+    [ViewVariables]
+    public bool Overloaded;
+
+    /// <summary>
+    /// When the breaker will pop.
+    /// Set when supply first exceeds limit.
+    /// </summary>
+    [ViewVariables]
+    public TimeSpan NextPop;
 }


### PR DESCRIPTION
## About the PR
fixes #17238

you must be overloading an apc for 5 seconds continuously to pop its breaker
this makes rage cages only brownout and not pop, while too many sinks will still pop it eventually.

**Media**
grille not popping: internet is trolling but trust me bro


2 artifact analyzers will pop:

https://github.com/space-wizards/space-station-14/assets/39013340/98a8c421-4f09-4e54-b8dd-0714e456183b



- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Budget testing is more dangerous due to breakers not instantly popping, you will be shocked.
