### PR TITLE
Block `TickerJoinGameEvent` in replays

### DIFF
--- a/Content.Client/Replay/ContentReplayPlaybackManager.cs
+++ b/Content.Client/Replay/ContentReplayPlaybackManager.cs
@@ -119,7 +119,7 @@ public sealed class ContentReplayPlaybackManager
             case TickerJoinGameEvent:
                 if (!_entMan.EntityExists(_player.LocalPlayer?.ControlledEntity))
                     _entMan.System<ReplaySpectatorSystem>().SetSpectatorPosition(default);
-                return false;
+                return true;
         }
 
         if (!skipEffects)


### PR DESCRIPTION
This changes how `TickerJoinGameEvent` is handled by replays by adding them to the horrible event switch-block. It also moves some stuff around and fixes some indentation. I swear I'll get rid of the switch block eventually.

Should fix #17629, but playing back recordings that start without any location where the spectator can be dumped (e.g., in the lobby) are still janky. Added this to the list of issues in #17170