### PR TITLE
Stack storage fixes

### DIFF
--- a/Content.Server/Item/ItemSystem.cs
+++ b/Content.Server/Item/ItemSystem.cs
@@ -1,7 +1,22 @@
-﻿using Content.Shared.Item;
+﻿using Content.Server.Storage.Components;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Item;
+using Content.Shared.Stacks;
 
 namespace Content.Server.Item;
 
 public sealed class ItemSystem : SharedItemSystem
 {
+    [Dependency] private readonly StorageSystem _storage = default!;
+
+    protected override void OnStackCountChanged(EntityUid uid, ItemComponent component, StackCountChangedEvent args)
+    {
+        base.OnStackCountChanged(uid, component, args);
+
+        if (!Container.TryGetContainingContainer(uid, out var container) ||
+            !TryComp<ServerStorageComponent>(container.Owner, out var storage))
+            return;
+        _storage.RecalculateStorageUsed(storage);
+        _storage.UpdateStorageUI(container.Owner, storage);
+    }
 }

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -484,7 +484,7 @@ namespace Content.Server.Storage.EntitySystems
         /// <summary>
         ///     Verifies if an entity can be stored and if it fits
         /// </summary>
-        /// <param name="entity">The entity to check</param>
+        /// <param name="uid">The entity to check</param>
         /// <param name="reason">If returning false, the reason displayed to the player</param>
         /// <returns>true if it can be inserted, false otherwise</returns>
         public bool CanInsert(EntityUid uid, EntityUid insertEnt, out string? reason, ServerStorageComponent? storageComp = null)
@@ -523,16 +523,8 @@ namespace Content.Server.Storage.EntitySystems
             if (TryComp(insertEnt, out ItemComponent? itemComp) &&
                 itemComp.Size > storageComp.StorageCapacityMax - storageComp.StorageUsed)
             {
-                // If this is a stack, we may be able to combine it with an existing stack in the storage.
-                // If so, no extra space would be used.
-                //
-                // TODO: This doesn't allow any sort of top-up behavior.
-                // You either combine the whole stack, or insert nothing.
-                if (!TryComp(insertEnt, out StackComponent? stackComp) || !CanCombineStacks(storageComp, stackComp))
-                {
-                    reason = "comp-storage-insufficient-capacity";
-                    return false;
-                }
+                reason = "comp-storage-insufficient-capacity";
+                return false;
             }
 
             reason = null;

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -78,7 +78,7 @@ public abstract class SharedItemSystem : EntitySystem
         args.Handled = _handsSystem.TryPickup(args.User, uid, animateUser: false);
     }
 
-    private void OnStackCountChanged(EntityUid uid, ItemComponent component, StackCountChangedEvent args)
+    protected virtual void OnStackCountChanged(EntityUid uid, ItemComponent component, StackCountChangedEvent args)
     {
         if (!TryComp<StackComponent>(uid, out var stack))
             return;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
fixes two bugs:
- you could combine stacks inside of storage, exceeding the total space of the storage itself
- splitting stacks in storage wouldn't update the available capacity.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed being able to use stacks to overload storage containers
- fix: Fixed splitting stacks inside of storage not updating the available capacity.
