### PR TITLE
buff grilles

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -9,6 +9,18 @@
     Blunt: 5
     Heat: 5
 
+- type: damageModifierSet
+  id: PerforatedMetallic
+  coefficients:
+    Blunt: 2
+    Slash: 0.6
+    Piercing: 0.2
+    Shock: 1.2
+  flatReductions:
+    Blunt: 5
+    Heat: 5
+    Piercing: 10
+
 # Like metallic, but without flat reduction so it can be damaged with fists.
 - type: damageModifierSet
   id: FlimsyMetallic

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -8,3 +8,4 @@
     damage:
       types:
         Piercing: 49
+        Structural: 30

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -32,7 +32,7 @@
       deconstructionTarget: start
     - type: Damageable
       damageContainer: Inorganic
-      damageModifierSet: FlimsyMetallic
+      damageModifierSet: PerforatedMetallic
     - type: PowerConsumer
       showInMonitor: false
     - type: Electrified
@@ -66,13 +66,13 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 50 #excess damage (nuke?). avoid computational cost of spawning entities.
+            damage: 130 #excess damage (nuke?). avoid computational cost of spawning entities.
           behaviors:
             - !type:DoActsBehavior
               acts: ["Destruction"]
         - trigger:
             !type:DamageTrigger
-            damage: 20
+            damage: 100
           behaviors:
             - !type:ChangeConstructionNodeBehavior
               node: grilleBroken


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Addresses electrified grilles being easily bypassable by thrown tiles or spears. Mitigates the issue of grilles under windows being hittable with the window up. An unintended side effect is that grilles can't be destroyed by hand, but I think this should be fine since they're metal grilles, not plastic meshes. Hristov buffed so that it is still somewhat effective against grilles, but bullets shouldn't be very effective against something with holes in it.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Nanotrasen has invested in higher quality grilles.
- tweak: The Hristov now does structural damage.