### PR TITLE
Fix badly parsing changelog

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -2923,7 +2923,7 @@ Entries:
   time: '2023-06-26T20:33:50.0000000+00:00'
 - author: router
   changes:
-  - {message: 'Added an alternative emotes prefix, \*. Note that it doesn''t get treated
+  - {message: 'Added an alternative emotes prefix, *. Note that it doesn''t get treated
       any differently than the normal @ prefix.', type: Add}
   id: 4096
   time: '2023-06-26T21:20:09.0000000+00:00'


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

not actually sure what is parsing wrong about this