### PR TITLE
Atmos Changes Rollback

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -66,7 +66,7 @@
         Blunt: 0.90
         Slash: 0.90
         Piercing: 0.95
-        Heat: 0.6
+        Heat: 0.2
         Radiation: 0.5
   - type: TemperatureProtection
     coefficient: 0.005

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -262,14 +262,14 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 1
-        Slash: 1
-        Piercing: 1
-        Heat: 0.4
-        Radiation: 1
+        Blunt: 0.90
+        Slash: 0.90
+        Piercing: 0.95
+        Heat: 0.5
+        Radiation: 0/95
   - type: PressureProtection
-    highPressureMultiplier: 0.25
-    lowPressureMultiplier: 1
+    highPressureMultiplier: 0.45
+    lowPressureMultiplier: 1000
   - type: IdentityBlocker
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -121,10 +121,10 @@
   - type: Sprite
     sprite: Clothing/OuterClothing/Suits/atmos_firesuit.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.25
-    lowPressureMultiplier: 1
+    highPressureMultiplier: 0.45
+    lowPressureMultiplier: 1000
   - type: TemperatureProtection
-    coefficient: 0.005
+    coefficient: 0.01
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/atmos_firesuit.rsi
   - type: Armor


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Return to the atmos firesuit of the characteristics that it needs to work in space conditions.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Thanks to numerous complaints from our employees, Nanotrasen have decided not to skimp on atmos firesuits anymore. Unfortunately, for this it was necessary to cut funding for the production of atmos hardsuits and now they have returned to their past characteristics.
