### PR TITLE
Add leech to crusher

### DIFF
--- a/Content.Shared/Weapons/Marker/LeechOnMarkerComponent.cs
+++ b/Content.Shared/Weapons/Marker/LeechOnMarkerComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Marker;
+
+/// <summary>
+/// Applies leech upon hitting a damage marker target.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed class LeechOnMarkerComponent : Component
+{
+    // TODO: Can't network damagespecifiers yet last I checked.
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("leech", required: true)]
+    public DamageSpecifier Leech = new();
+}

--- a/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
+++ b/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
@@ -12,6 +12,7 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _netManager = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
 
     public override void Initialize()
     {
@@ -29,6 +30,11 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
         args.BonusDamage += component.Damage;
         RemCompDeferred<DamageMarkerComponent>(uid);
         _audio.PlayPredicted(component.Sound, uid, args.User);
+
+        if (TryComp<LeechOnMarkerComponent>(args.Used, out var leech))
+        {
+            _damageable.TryChangeDamage(args.User, leech.Leech, true, false, origin: args.Used);
+        }
     }
 
     public override void Update(float frameTime)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -30,6 +30,10 @@
   - type: UseDelayOnShoot
   - type: UseDelay
     delay: 1.9
+  - type: LeechOnMarker
+    leech:
+      groups:
+        Brute: -10
   - type: Gun
     soundGunshot: /Audio/Weapons/plasma_cutter.ogg
     fireRate: 0.5
@@ -89,6 +93,10 @@
     fireRate: 1
   - type: RechargeBasicEntityAmmo
     rechargeCooldown: 0.5
+  - type: LeechOnMarker
+    leech:
+      groups:
+        Brute: -15
   - type: Sprite
     sprite: Objects/Weapons/Melee/crusher_glaive.rsi
   - type: MeleeWeapon


### PR DESCRIPTION
Resolves https://github.com/space-wizards/space-station-14/issues/17466

Hitting damage markers consistently is hard so this seemed fair (also it only works on mobs).

:cl:
- add: Crushers now leech 10 hp upon hitting damage marker targets.