### PR TITLE
Turns 90% of vomit into actual vomit

### DIFF
--- a/Content.Server/Medical/VomitSystem.cs
+++ b/Content.Server/Medical/VomitSystem.cs
@@ -70,11 +70,21 @@ namespace Content.Server.Medical
                     _solutionContainer.UpdateChemicals(stomach.Comp.Owner, sol);
                 }
             }
-            // And the small bit of the chem stream from earlier
+            // Adds a tiny amount of the chemstream along with vomit
             if (TryComp<BloodstreamComponent>(uid, out var bloodStream))
             {
-                var temp = _solutionContainer.SplitSolution(uid, bloodStream.ChemicalSolution, solutionSize);
-                solution.AddSolution(temp, _proto);
+                var chemMultiplier = 0.1;
+                var vomitMultiplier = 0.9;
+
+                // Makes a vomit solution the size of 90% of the chemicals removed from the chemstream
+                var vomitAmount = new Solution("Vomit", solutionSize * vomitMultiplier);
+
+                // Takes 10% of the chemicals removed from the chem stream
+                var vomitChemstreamAmount = _solutionContainer.SplitSolution(uid, bloodStream.ChemicalSolution, solutionSize * chemMultiplier);
+
+                _solutionContainer.SplitSolution(uid, bloodStream.ChemicalSolution, solutionSize * vomitMultiplier);
+                solution.AddSolution(vomitAmount, _proto);
+                solution.AddSolution(vomitChemstreamAmount, _proto);
             }
 
             if (_puddle.TrySpillAt(uid, solution, out var puddle, false))

--- a/Content.Server/Medical/VomitSystem.cs
+++ b/Content.Server/Medical/VomitSystem.cs
@@ -70,7 +70,7 @@ namespace Content.Server.Medical
                     _solutionContainer.UpdateChemicals(stomach.Comp.Owner, sol);
                 }
             }
-            // Adds a tiny amount of the chemstream along with vomit
+            // Adds a tiny amount of the chem stream from earlier along with vomit
             if (TryComp<BloodstreamComponent>(uid, out var bloodStream))
             {
                 var chemMultiplier = 0.1;

--- a/Resources/Locale/en-US/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/reagents/meta/biological.ftl
@@ -12,3 +12,6 @@ reagent-desc-ichor = An extremely potent regenerative chemical, perfected by spa
 
 reagent-name-fat = fat
 reagent-desc-fat = No matter how it was obtained, its application is important.
+
+reagent-name-vomit = vomit
+reagent-desc-vomit = You can see a few chunks of someones last meal in it.

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -97,3 +97,21 @@
   color: "#d8d8b0"
   physicalDesc: reagent-physical-desc-exotic-smelling
   slippery: false
+
+- type: reagent
+  id: Vomit
+  name: reagent-name-vomit
+  group: Biological
+  desc: reagent-desc-vomit
+  flavor: terrible
+  color: "#87ab08"
+  physicalDesc: reagent-physical-desc-pungent
+  slippery: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 0.5
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Instead of vomiting pure reagents, 90% of them are now turned into a vomit reagent upon vomiting. 
This will prevent chemical duping through vomit.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/137322659/058bdb51-ffc8-4292-9466-97fa964bd1ea


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Dygon
- tweak: Vomit now only contains 10% of the reagents removed from the chem stream

