### PR TITLE
It's no longer possible to unbuckle if you are handcuffed

### DIFF
--- a/Content.Server/Cuffs/CuffableSystem.cs
+++ b/Content.Server/Cuffs/CuffableSystem.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using Content.Shared.Cuffs.Components;
 using Robust.Shared.GameStates;
 using Content.Shared.Buckle.Components;
+using Content.Shared.Hands.Components;
 
 namespace Content.Server.Cuffs
 {
@@ -44,7 +45,7 @@ namespace Content.Server.Cuffs
 
         private void OnBuckleAttemptEvent(EntityUid uid, CuffableComponent component, ref BuckleAttemptEvent args)
         {
-            if (component.CuffedHandCount > 0)
+            if (TryComp<HandsComponent>(uid, out var hands) && component.CuffedHandCount == hands.Count)
             {
                 args.Cancelled = true;
             }

--- a/Content.Server/Cuffs/CuffableSystem.cs
+++ b/Content.Server/Cuffs/CuffableSystem.cs
@@ -4,12 +4,16 @@ using Content.Shared.Cuffs.Components;
 using Robust.Shared.GameStates;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Hands.Components;
+using Robust.Shared.Network;
+using Content.Server.Popups;
 
 namespace Content.Server.Cuffs
 {
     [UsedImplicitly]
     public sealed class CuffableSystem : SharedCuffableSystem
     {
+        [Dependency] private readonly INetManager _netManager = default!;
+        [Dependency] private readonly PopupSystem _popupSystem = default!;
         public override void Initialize()
         {
             base.Initialize();
@@ -48,6 +52,9 @@ namespace Content.Server.Cuffs
             if (TryComp<HandsComponent>(uid, out var hands) && component.CuffedHandCount == hands.Count)
             {
                 args.Cancelled = true;
+                var message = Loc.GetString("handcuff-component-cuff-interrupt-buckled-message");
+                if (_netManager.IsServer)
+                    _popupSystem.PopupEntity(message, uid);
             }
         }
     }

--- a/Content.Server/Cuffs/CuffableSystem.cs
+++ b/Content.Server/Cuffs/CuffableSystem.cs
@@ -44,8 +44,7 @@ namespace Content.Server.Cuffs
 
         private void OnBuckleAttemptEvent(EntityUid uid, CuffableComponent component, ref BuckleAttemptEvent args)
         {
-            // one hand cuffed is able to unbuckle
-            if (component.CuffedHandCount == 2)
+            if (component.CuffedHandCount > 0)
             {
                 args.Cancelled = true;
             }

--- a/Content.Server/Cuffs/CuffableSystem.cs
+++ b/Content.Server/Cuffs/CuffableSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Cuffs;
 using JetBrains.Annotations;
 using Content.Shared.Cuffs.Components;
 using Robust.Shared.GameStates;
+using Content.Shared.Buckle.Components;
 
 namespace Content.Server.Cuffs
 {
@@ -14,6 +15,7 @@ namespace Content.Server.Cuffs
 
             SubscribeLocalEvent<HandcuffComponent, ComponentGetState>(OnHandcuffGetState);
             SubscribeLocalEvent<CuffableComponent, ComponentGetState>(OnCuffableGetState);
+            SubscribeLocalEvent<CuffableComponent, BuckleAttemptEvent>(OnBuckleAttemptEvent);
         }
 
         private void OnHandcuffGetState(EntityUid uid, HandcuffComponent component, ref ComponentGetState args)
@@ -38,6 +40,15 @@ namespace Content.Server.Cuffs
                 cuffs?.Color);
             // the iconstate is formatted as blah-2, blah-4, blah-6, etc.
             // the number corresponds to how many hands are cuffed.
+        }
+
+        private void OnBuckleAttemptEvent(EntityUid uid, CuffableComponent component, ref BuckleAttemptEvent args)
+        {
+            // one hand cuffed is able to unbuckle
+            if (component.CuffedHandCount == 2)
+            {
+                args.Cancelled = true;
+            }
         }
     }
 }

--- a/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
@@ -13,3 +13,4 @@ handcuff-component-cuff-self-success-message = You cuff yourself.
 handcuff-component-cuff-interrupt-message = You were interrupted while cuffing {$targetName}!
 handcuff-component-cuff-interrupt-other-message = You interrupt {$otherName} while they are cuffing you!
 handcuff-component-cuff-interrupt-self-message = You were interrupted while cuffing yourself.
+handcuff-component-cuff-interrupt-buckled-message = You can't uncuff while buckled!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Fixed behavior when trying to uncuff while buckled: now handcuffs must be first removed, then it's possible to unbuckle.

Fixes this issue: https://github.com/space-wizards/space-station-14/issues/16545

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: It's no longer possible to unbuckle if you are handcuffed
