### PR TITLE
Adds Lead & Zinc, nerfs Licoxide.

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/elements.ftl
+++ b/Resources/Locale/en-US/reagents/meta/elements.ftl
@@ -63,3 +63,6 @@ reagent-desc-uranium = A grey metallic chemical element in the actinide series, 
 
 reagent-name-bananium = bananium
 reagent-desc-bananium = A yellow radioactive organic solid.
+
+reagent-name-zinc = zinc
+reagent-desc-zinc = A silvery, brittle metal, often used in batteries to carry charge. 

--- a/Resources/Locale/en-US/reagents/meta/fun.ftl
+++ b/Resources/Locale/en-US/reagents/meta/fun.ftl
@@ -14,4 +14,4 @@ reagent-name-saxoite = Saxoite
 reagent-desc-saxoite = Smells like jazz.
 
 reagent-name-licoxide = Licoxide
-reagent-desc-licoxide = It looks... electrifying.
+reagent-desc-licoxide = A synthetic battery acid. It looks... electrifying.

--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -57,3 +57,6 @@ reagent-desc-pax = A psychiatric drug which prevents the patient from directly h
 
 reagent-name-honk = honk
 reagent-desc-honk = A toxin found in bananium. Causes severe honking and internal bleeding, may also cause the patient to mutate.
+
+reagent-name-lead = lead
+reagent-desc-lead = A slow-acting but incredibly lethal toxin found in steel, albiet in trace amounts. Tasteless. 

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -57,6 +57,18 @@
   - type: FloorTile
     outputs:
     - Plating
+  - type: Extractable
+    grindableSolutionName: steel
+  - type: SolutionContainerManager
+    solutions:
+      steel:
+        reagents:
+        - ReagentId: Iron
+          Quantity: 22
+        - ReagentId: Carbon
+          Quantity: 2.5
+        - ReagentId: Lead
+          Quantity: 0.5
 
 - type: entity
   parent: SheetSteel

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -23,7 +23,7 @@
   - type: Extractable
     juiceSolution:
       reagents:
-        - ReagentId: Licoxide
+        - ReagentId: Zinc
           Quantity: 5
   - type: Tag
     tags:

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -262,3 +262,14 @@
         damage:
           types:
             Radiation: 2
+
+- type: reagent
+  id: Zinc
+  name: reagent-name-zinc
+  group: Elements
+  desc: reagent-desc-zinc
+  physicalDesc: reagent-physical-desc-metallic
+  flavor: metallic
+  color: "#bababa"
+  meltingPoint: 419.5
+  boilingPoint: 907.0

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -268,7 +268,7 @@
   name: reagent-name-zinc
   group: Elements
   desc: reagent-desc-zinc
-  physicalDesc: reagent-physical-desc-metallic
+  physicalDesc: reagent-physical-desc-shiny
   flavor: metallic
   color: "#bababa"
   meltingPoint: 419.5

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -483,3 +483,19 @@
         damage:
           types:
             Poison: 0.06
+
+- type: reagent
+  id: Lead
+  name: reagent-name-lead
+  group: Toxins
+  desc: reagent-desc-lead
+  physicalDesc: reagent-physical-desc-nondescript
+  color: "#5C6274"
+  metabolisms:
+    Poison:
+      metabolismRate: 0.03 # Effectively once every 30 seconds.
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 0.6 # Makes it 20 damage per unit. 

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -490,7 +490,6 @@
   group: Toxins
   desc: reagent-desc-lead
   physicalDesc: reagent-physical-desc-metallic
-  physicalDesc: reagent-physical-desc-nondescript
   color: "#5C6274"
   metabolisms:
     Poison:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -489,6 +489,7 @@
   name: reagent-name-lead
   group: Toxins
   desc: reagent-desc-lead
+  physicalDesc: reagent-physical-desc-metallic
   physicalDesc: reagent-physical-desc-nondescript
   color: "#5C6274"
   metabolisms:

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -81,3 +81,13 @@
       amount: 1
   products:
     SpaceGlue: 2
+
+- type: reaction
+  id: Licoxide
+  reactants:
+    Lead:
+      amount: 1
+    Zinc:
+      amount: 1
+  products:
+    Licoxide: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Adds Lead, a toxin obtained in very small amounts from grinding steel. Has no taste and does 20 damage per unit, but metabolizes at 0.03u/sec, effectively 30 seconds per unit, or 2 1/2 minutes to crit someone. 
Grinding batteries now gives Zinc instead of Licoxide. It's only used for crafting Licoxide alongside Lead at the moment.
Licoxide is now only obtained through combining Zinc and Lead, at a 1:1:1 ratio (1 Zinc + 1 Lead gives 1 Licoxide). 

You get 0.5u of lead per sheet, alongside 22 iron and 2.5 carbon (to prevent people from grinding 30 sheets at once). This should make Lead, and by extension Licoxide, very annoying and suspicious to get as you have to grind large amount of steel for a long while to get any meaningful amount. 


**Media**
![image](https://github.com/space-wizards/space-station-14/assets/135308300/608bdb7a-8ccb-460c-a9ff-10fd5b1792f3)

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Lank
- add: Added Lead, a tasteless, incredibly powerful but slow-acting poison obtained in small amounts by grinding steel.
- tweak: Grinding powercells now gives Zinc instead of Licoxide
- tweak: Licoxide is now obtained through a combination of Zinc and Lead. 
