### PR TITLE
Janitor trolley bandaid

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -235,14 +235,15 @@
           visible: false
     - type: Rotatable
     - type: InteractionOutline
-    - type: Storage
-      popup: false
-      capacity: 80
-      blacklist: # there is exclusive item slots for that
-        tags:
-          - Mop
-          - TrashBag
-          - Bucket
+    # Removing storage until OnInteractUsing logic resolved
+    #- type: Storage
+    #  popup: false
+    #  capacity: 80
+    #  blacklist: # there is exclusive item slots for that
+    #    tags:
+    #      - Mop
+    #      - TrashBag
+    #      - Bucket
     - type: ItemSlots
       slots:
         mop_slot:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Removed the storage component from janitor trolley to allow its other functions to work.
Item slots for mop/bucket/trash bag will work, along with the mop bucket itself.

Currently it is broken due to #17011 auto-handling any failed insertions, even blacklisted items. The comment makes it clear this should be the case.  The solution transfer seems to use AfterInteractEvent as well, so 'after' designations for subscriptions probably wouldn't work either.

This is just meant to get trolleys mostly functional again until that logic/design can be sorted out. 

Related to issue #17113

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Janitor trolley is functional again. Its storage is temporarily removed.
