### PR TITLE
No unbuckling while cuffed

### DIFF
--- a/Content.Shared/Buckle/Components/BuckleComponent.cs
+++ b/Content.Shared/Buckle/Components/BuckleComponent.cs
@@ -94,7 +94,7 @@ public sealed class BuckleComponentState : ComponentState
 }
 
 [ByRefEvent]
-public record struct BuckleAttemptEvent(EntityUid StrapEntity, EntityUid BuckledEntity, bool Buckling, bool Cancelled = false);
+public record struct BuckleAttemptEvent(EntityUid StrapEntity, EntityUid BuckledEntity, EntityUid UserEntity, bool Buckling, bool Cancelled = false);
 
 [ByRefEvent]
 public readonly record struct BuckleChangeEvent(EntityUid StrapEntity, EntityUid BuckledEntity, bool Buckling);

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -11,6 +11,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Components;
+using Content.Shared.Pulling.Events;
 using Content.Shared.Standing;
 using Content.Shared.Storage.Components;
 using Content.Shared.Stunnable;
@@ -312,6 +313,12 @@ public abstract partial class SharedBuckleSystem
             return false;
         }
 
+        var attemptEvent = new BuckleAttemptEvent(strapUid, buckleUid, userUid, true);
+        RaiseLocalEvent(attemptEvent.BuckledEntity, ref attemptEvent);
+        RaiseLocalEvent(attemptEvent.StrapEntity, ref attemptEvent);
+        if (attemptEvent.Cancelled)
+            return false;
+
         return true;
     }
 
@@ -331,12 +338,6 @@ public abstract partial class SharedBuckleSystem
             return false;
 
        if (!CanBuckle(buckleUid, userUid, strapUid, out var strapComp, buckleComp))
-           return false;
-
-       var attemptEvent = new BuckleAttemptEvent(strapUid, buckleUid, true);
-       RaiseLocalEvent(attemptEvent.BuckledEntity, ref attemptEvent);
-       RaiseLocalEvent(attemptEvent.StrapEntity, ref attemptEvent);
-       if (attemptEvent.Cancelled)
            return false;
 
        if (!StrapTryAdd(strapUid, buckleUid, buckleComp, false, strapComp))
@@ -407,14 +408,14 @@ public abstract partial class SharedBuckleSystem
             buckleComp.BuckledTo is not { } strapUid)
             return false;
 
-        var attemptEvent = new BuckleAttemptEvent(strapUid, buckleUid, false);
-        RaiseLocalEvent(attemptEvent.BuckledEntity, ref attemptEvent);
-        RaiseLocalEvent(attemptEvent.StrapEntity, ref attemptEvent);
-        if (attemptEvent.Cancelled)
-            return false;
-
         if (!force)
         {
+            var attemptEvent = new BuckleAttemptEvent(strapUid, buckleUid, userUid, false);
+            RaiseLocalEvent(attemptEvent.BuckledEntity, ref attemptEvent);
+            RaiseLocalEvent(attemptEvent.StrapEntity, ref attemptEvent);
+            if (attemptEvent.Cancelled)
+                return false;
+
             if (_gameTiming.CurTime < buckleComp.BuckleTime + buckleComp.UnbuckleDelay)
                 return false;
 

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
+using Content.Shared.Buckle.Components;
 using Content.Shared.Cuffs.Components;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
@@ -66,6 +67,7 @@ namespace Content.Shared.Cuffs
             SubscribeLocalEvent<CuffableComponent, IsEquippingAttemptEvent>(OnEquipAttempt);
             SubscribeLocalEvent<CuffableComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
             SubscribeLocalEvent<CuffableComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt);
+            SubscribeLocalEvent<CuffableComponent, BuckleAttemptEvent>(OnBuckleAttemptEvent);
             SubscribeLocalEvent<CuffableComponent, GetVerbsEvent<Verb>>(AddUncuffVerb);
             SubscribeLocalEvent<CuffableComponent, UnCuffDoAfterEvent>(OnCuffableDoAfter);
             SubscribeLocalEvent<CuffableComponent, PullStartedMessage>(OnPull);
@@ -79,7 +81,6 @@ namespace Content.Shared.Cuffs
             SubscribeLocalEvent<HandcuffComponent, AfterInteractEvent>(OnCuffAfterInteract);
             SubscribeLocalEvent<HandcuffComponent, MeleeHitEvent>(OnCuffMeleeHit);
             SubscribeLocalEvent<HandcuffComponent, AddCuffDoAfterEvent>(OnAddCuffDoAfter);
-
         }
 
         private void OnUncuffAttempt(ref UncuffAttemptEvent args)
@@ -176,6 +177,21 @@ namespace Content.Shared.Cuffs
 
             if (pullable.Puller != null && !component.CanStillInteract) // If we are being pulled already and cuffed, we can't get pulled again.
                 args.Cancel();
+        }
+
+        private void OnBuckleAttemptEvent(EntityUid uid, CuffableComponent component, ref BuckleAttemptEvent args)
+        {
+            // if someone else is doing it, let it pass.
+            if (args.UserEntity != uid)
+                return;
+
+            if (!TryComp<HandsComponent>(uid, out var hands) || component.CuffedHandCount != hands.Count)
+                return;
+
+            args.Cancelled = true;
+            var message = Loc.GetString("handcuff-component-cuff-interrupt-buckled-message");
+            if (_net.IsServer)
+                _popup.PopupEntity(message, uid, args.UserEntity);
         }
 
         private void OnPull(EntityUid uid, CuffableComponent component, PullMessage args)

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -189,7 +189,9 @@ namespace Content.Shared.Cuffs
                 return;
 
             args.Cancelled = true;
-            var message = Loc.GetString("handcuff-component-cuff-interrupt-buckled-message");
+            var message = args.Buckling
+                ? Loc.GetString("handcuff-component-cuff-interrupt-buckled-message")
+                : Loc.GetString("handcuff-component-cuff-interrupt-unbuckled-message");
             if (_net.IsServer)
                 _popup.PopupEntity(message, uid, args.UserEntity);
         }

--- a/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
@@ -13,3 +13,4 @@ handcuff-component-cuff-self-success-message = You cuff yourself.
 handcuff-component-cuff-interrupt-message = You were interrupted while cuffing {$targetName}!
 handcuff-component-cuff-interrupt-other-message = You interrupt {$otherName} while they are cuffing you!
 handcuff-component-cuff-interrupt-self-message = You were interrupted while cuffing yourself.
+handcuff-component-cuff-interrupt-buckled-message = You can't uncuff while buckled!

--- a/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
@@ -13,4 +13,5 @@ handcuff-component-cuff-self-success-message = You cuff yourself.
 handcuff-component-cuff-interrupt-message = You were interrupted while cuffing {$targetName}!
 handcuff-component-cuff-interrupt-other-message = You interrupt {$otherName} while they are cuffing you!
 handcuff-component-cuff-interrupt-self-message = You were interrupted while cuffing yourself.
-handcuff-component-cuff-interrupt-buckled-message = You can't uncuff while buckled!
+handcuff-component-cuff-interrupt-buckled-message = You can't buckle while cuffed!
+handcuff-component-cuff-interrupt-unbuckled-message = You can't unbuckle while cuffed!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
implements proper checks:
- while cuffed, you can't buckle or unbuckle yourself
- anyone can unbuckle you at will.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: You can no longer unbuckle yourself while cuffed.
