### PR TITLE
Make the CMO's hypospray unable to go through hardsuits

### DIFF
--- a/Content.Server/Chemistry/Components/HypoProtectionComponent.cs
+++ b/Content.Server/Chemistry/Components/HypoProtectionComponent.cs
@@ -1,0 +1,13 @@
+namespace Content.Server.Chemistry.Components
+{
+/// <summary>
+/// It's a component to make my life easier.
+/// Basically, if its in hardsuits.yml or
+/// hardsuit-helmets.yml, it has this.
+/// </summary>
+[RegisterComponent]
+public sealed class HypoProtectionComponent : Component
+{
+	
+}
+}

--- a/Content.Server/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Server/Chemistry/Components/HyposprayComponent.cs
@@ -21,6 +21,9 @@ namespace Content.Server.Chemistry.Components
         [DataField("injectSound")]
         public SoundSpecifier InjectSound = new SoundPathSpecifier("/Audio/Items/hypospray.ogg");
 
+        [DataField("canPenetrateHardsuits")]
+        public bool CanPenetrateHardsuits = true;
+
         public override ComponentState GetComponentState()
         {
             var solutionSys = _entMan.EntitySysManager.GetEntitySystem<SolutionContainerSystem>();

--- a/Resources/Locale/en-US/chemistry/components/hypospray-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/hypospray-component.ftl
@@ -10,4 +10,5 @@ hypospray-component-inject-self-clumsy-message = Oops! You injected yourself.
 hypospray-component-empty-message = It's empty!
 hypospray-component-feel-prick-message = You feel a tiny prick!
 hypospray-component-transfer-already-full-message = {$owner} is already full!
+hypospray-cant-inject-hardsuit = The hypo can't inject through {$target}'s hardsuit!
 hypospray-cant-inject = Can't inject into {$target}!

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -161,6 +161,7 @@
     - HidesHair
     - WhitelistChameleon
   - type: IdentityBlocker
+  - type: HypoProtection
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -75,6 +75,7 @@
   - type: Tag
     tags:
     - Hardsuit
+  - type: HypoProtection
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -18,6 +18,7 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+    canPenetrateHardsuits: false
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice
@@ -252,3 +253,34 @@
     - id: Hypopen
     sound:
       path: /Audio/Effects/unwrap.ogg
+
+# Debug
+
+- type: entity
+  suffix: DEBUG
+  parent: BaseItem
+  id: DebugHyposprayCanPenetrate
+  components:
+    - type: Sprite
+      sprite: Objects/Specific/Medical/hypospray.rsi
+      state: hypo
+    - type: Item
+      sprite: Objects/Specific/Medical/hypospray.rsi
+    - type: SolutionContainerManager
+      solutions:
+        hypospray:
+          maxVol: 999999
+    - type: RefillableSolution
+      solution: hypospray
+    - type: ExaminableSolution
+      solution: hypospray
+    - type: Hypospray
+    - type: UseDelay
+      delay: 0
+
+- type: entity
+  parent: DebugHyposprayCanPenetrate
+  id: DebugHyposprayCannotPenetrate
+  components:
+    - type: Hypospray
+      canPenetrateHardsuits: false


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Makes the CMO's hypospray unable to inject people that are wearing hardsuits.
This is mostly intended to help with powergaming CMOs that make deathmix for nukies.
If they need to heal someone in space, the person they're healing can afford to take their helmet off for 3 seconds.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://github.com/space-wizards/space-station-14/assets/45953835/895b8ec1-43a1-4266-b817-61643ddd1d6c)![image](https://github.com/space-wizards/space-station-14/assets/45953835/8138cd5d-7e61-401a-920f-7ef380379cb2)![image](https://github.com/space-wizards/space-station-14/assets/45953835/d584354a-39f2-4392-a742-0d22de92185e)![image](https://github.com/space-wizards/space-station-14/assets/45953835/ee90cd2b-635a-40a4-a4be-33fb9580e11c)



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Due to Nanotrasen Budget Cuts (tm), the CMO's hypospray can no longer inject people with the hypospray through hardsuits. Hypopens and Gorlex hyposprays are unaffected.
