### PR TITLE
Revision of power consumption, some machines

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -767,7 +767,7 @@
     - map: ["computerLayerKeys"]
       state: generic_keys
   - type: ApcPowerReceiver
-    powerLoad: 3100 #We want this to fail first so I transferred most of the scanner and pod's power here. (3500 in total)
+    powerLoad: 3100 #We want this to fail first so I transferred most of the scanner and pod's power here. (4000 in total)
   - type: Computer
     board: CloningConsoleComputerCircuitboard
   - type: PointLight

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -228,7 +228,7 @@
   - type: Transform
     anchored: true
   - type: ApcPowerReceiver
-    powerLoad: 1500
+    powerLoad: 3000
   - type: ExtensionCableReceiver
   - type: AmbientSound
     range: 5

--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -40,7 +40,7 @@
     anchored: true
     noRot: false
   - type: ApcPowerReceiver
-    powerLoad: 15000
+    powerLoad: 6000
     needsPower: false #only turns on when scanning
   - type: UpgradePowerDraw
     powerDrawMultiplier: 0.80

--- a/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
@@ -64,7 +64,7 @@
     BoardName: "CloningPod"
     LayoutId: CloningPod
   - type: ApcPowerReceiver
-    powerLoad: 200 #Receives most of its power from the console
+    powerLoad: 450 #Receives most of its power from the console
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -25,7 +25,7 @@
   - type: Transform
     anchored: true
   - type: ApcPowerReceiver
-    powerLoad: 2500
+    powerLoad: 7500
   - type: ExtensionCableReceiver
   - type: Physics
     bodyType: Static

--- a/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
@@ -83,7 +83,7 @@
   - type: Appearance
   - type: Climbable
   - type: ApcPowerReceiver
-    powerLoad: 200 #Receives most of its power from the console
+    powerLoad: 450 #Receives most of its power from the console
   - type: EmptyOnMachineDeconstruct
     containers:
     - scanner-bodyContainer


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Revision of power consumption, some machines
I redid the ones I thought were odd,
It's up to you to decide.

artifact analyzer - 15.000 - 6000 wt
gravity generator - 2.500 - 7.500 wt
anomaly equipment - 1500 - 3000 wt
cloning machine - 200 - 450 wt
medical scanner - 200 - 450 wt

In fact, you can change a lot of things, there is even a chemical dispenser with 5 watts, but I could not find the prototype, where its power consumption is indicated -_-

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Сhanged the power consumption of some machines

