### PR TITLE
reformatted syndicate objectives for readability

### DIFF
--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -94,29 +94,6 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
     private void DeactivateButton() => CharacterButton!.Pressed = false;
     private void ActivateButton() => CharacterButton!.Pressed = true;
 
-    private const int MaxObjectiveLineLength = 38;
-    private string WordWrap(string inputText, int lineLength)
-    {
-        if (inputText.Length <= lineLength)
-            return inputText;
-
-        string[] stringSplit = inputText.Split(' ');
-        int charCounter = 0;
-        string finalString = "";
-
-        for (int i = 0; i < stringSplit.Length; i++)
-        {
-           finalString += stringSplit[i] + " ";
-           charCounter += stringSplit[i].Length;
-
-            if (charCounter > lineLength){
-                finalString += "\n";
-                charCounter = 0;
-            }
-        }
-        return finalString;
-    }
-
     private void CharacterUpdated(CharacterData data)
     {
         if (_window == null)
@@ -148,8 +125,13 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
                 var conditionControl = new ObjectiveConditionsControl();
                 conditionControl.ProgressTexture.Texture = condition.SpriteSpecifier.Frame0();
                 conditionControl.ProgressTexture.Progress = condition.Progress;
+                var titleMessage = new FormattedMessage();
+                var descriptionMessage = new FormattedMessage();
+                titleMessage.AddText(condition.Title);
+                descriptionMessage.AddText(condition.Description);
 
-                conditionControl.Title.Text = WordWrap(condition.Title + " " + condition.Description, MaxObjectiveLineLength) + "\n";
+                conditionControl.Title.SetMessage(titleMessage);
+                conditionControl.Description.SetMessage(descriptionMessage);
 
                 objectiveControl.AddChild(conditionControl);
             }

--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.CharacterInfo;
+using Content.Client.CharacterInfo;
 using Content.Client.Gameplay;
 using Content.Client.UserInterface.Controls;
 using Content.Client.UserInterface.Systems.Character.Controls;
@@ -94,6 +94,29 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
     private void DeactivateButton() => CharacterButton!.Pressed = false;
     private void ActivateButton() => CharacterButton!.Pressed = true;
 
+    private const int MaxObjectiveLineLength = 38;
+    private string WordWrap(string inputText, int lineLength)
+    {
+        if (inputText.Length <= lineLength)
+            return inputText;
+
+        string[] stringSplit = inputText.Split(' ');
+        int charCounter = 0;
+        string finalString = "";
+
+        for (int i = 0; i < stringSplit.Length; i++)
+        {
+           finalString += stringSplit[i] + " ";
+           charCounter += stringSplit[i].Length;
+
+            if (charCounter > lineLength){
+                finalString += "\n";
+                charCounter = 0;
+            }
+        }
+        return finalString;
+    }
+
     private void CharacterUpdated(CharacterData data)
     {
         if (_window == null)
@@ -126,8 +149,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
                 conditionControl.ProgressTexture.Texture = condition.SpriteSpecifier.Frame0();
                 conditionControl.ProgressTexture.Progress = condition.Progress;
 
-                conditionControl.Title.Text = condition.Title;
-                conditionControl.Description.Text = condition.Description;
+                conditionControl.Title.Text = WordWrap(condition.Title + " " + condition.Description, MaxObjectiveLineLength) + "\n";
 
                 objectiveControl.AddChild(conditionControl);
             }

--- a/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
@@ -1,9 +1,9 @@
-﻿<windows:CharacterWindow
+<windows:CharacterWindow
     xmlns="https://spacestation14.io"
     xmlns:cc="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:windows="clr-namespace:Content.Client.UserInterface.Systems.Character.Windows"
     Title="{Loc 'character-info-title'}"
-    MinWidth="400"
+    MinWidth="500"
     MinHeight="545">
     <ScrollContainer>
         <BoxContainer Orientation="Vertical">

--- a/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
@@ -3,7 +3,7 @@
     xmlns:cc="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:windows="clr-namespace:Content.Client.UserInterface.Systems.Character.Windows"
     Title="{Loc 'character-info-title'}"
-    MinWidth="500"
+    MinWidth="400"
     MinHeight="545">
     <ScrollContainer>
         <BoxContainer Orientation="Vertical">

--- a/Content.Client/UserInterface/Systems/Objectives/Controls/ObjectiveConditionsControl.xaml
+++ b/Content.Client/UserInterface/Systems/Objectives/Controls/ObjectiveConditionsControl.xaml
@@ -6,6 +6,7 @@
     <cc:ProgressTextureRect Name="ProgressTexture" VerticalAlignment="Top" Access="Public" Margin="0 8 0 0"/>
     <Control MinSize="10 0"/>
     <BoxContainer Orientation="Vertical">
-        <Label Name="Title" Access="Public"/>
+        <RichTextLabel Name="Title" Access="Public" SetWidth="325" HorizontalAlignment="Left"/>
+        <RichTextLabel Name="Description" Access="Public" SetWidth="325" HorizontalAlignment="Left"/>
     </BoxContainer>
 </controls:ObjectiveConditionsControl>

--- a/Content.Client/UserInterface/Systems/Objectives/Controls/ObjectiveConditionsControl.xaml
+++ b/Content.Client/UserInterface/Systems/Objectives/Controls/ObjectiveConditionsControl.xaml
@@ -1,12 +1,11 @@
-﻿<controls:ObjectiveConditionsControl
+<controls:ObjectiveConditionsControl
     xmlns="https://spacestation14.io"
     xmlns:cc="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Systems.Objectives.Controls"
     Orientation="Horizontal">
-    <cc:ProgressTextureRect Name="ProgressTexture" VerticalAlignment="Center" Access="Public"/>
+    <cc:ProgressTextureRect Name="ProgressTexture" VerticalAlignment="Top" Access="Public" Margin="0 8 0 0"/>
     <Control MinSize="10 0"/>
     <BoxContainer Orientation="Vertical">
         <Label Name="Title" Access="Public"/>
-        <Label Name="Description" Access="Public"/>
     </BoxContainer>
 </controls:ObjectiveConditionsControl>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Added some word wrapping logic to the syndicate objectives so it doesn't require resizing the window. Also made the character window slightly wider.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![obj3](https://github.com/space-wizards/space-station-14/assets/8183999/cccc4498-e184-4295-a957-2ab2cb4a5958)
![obj2](https://github.com/space-wizards/space-station-14/assets/8183999/563d8e00-bb0e-4609-ad45-a4c5c577e345)
![obj1](https://github.com/space-wizards/space-station-14/assets/8183999/62d06e2d-d8dc-44bf-bfe2-619b136ba9c5)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Syndicate objectives are more readable
