### PR TITLE
Improve server compile diagnostics, make hybrid ACZ default

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Package client
       run: |
-        Tools/package_server_build.py -p win-x64 linux-x64 osx-x64 linux-arm64
+        Tools/package_server_build.py -p win-x64 linux-x64 osx-x64 linux-arm64 --no-hybrid-acz
         Tools/package_client_build.py
 
     - name: Update Build Info

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Package client
         run: |
-          Tools/package_server_build.py -p win-x64 linux-x64 osx-x64 linux-arm64
+          Tools/package_server_build.py -p win-x64 linux-x64 osx-x64 linux-arm64 --no-hybrid-acz
           Tools/package_client_build.py
 
       - name: Update Build Info

--- a/Tools/package_client_build.py
+++ b/Tools/package_client_build.py
@@ -9,7 +9,10 @@ import argparse
 
 from typing import List, Optional
 
+import package_lib
 from package_lib import Fore, Style, SHARED_IGNORED_RESOURCES
+
+package_lib.init("package_client_build")
 
 p = os.path.join
 

--- a/Tools/package_client_build.py
+++ b/Tools/package_client_build.py
@@ -9,31 +9,9 @@ import argparse
 
 from typing import List, Optional
 
-try:
-    from colorama import init, Fore, Style
-    init()
-
-except ImportError:
-    # Just give an empty string for everything, no colored logging.
-    class ColorDummy(object):
-        def __getattr__(self, name):
-            return ""
-
-    Fore = ColorDummy()
-    Style = ColorDummy()
-
+from package_lib import Fore, Style, SHARED_IGNORED_RESOURCES
 
 p = os.path.join
-
-SHARED_IGNORED_RESOURCES = {
-    "ss13model.7z",
-    "ResourcePack.zip",
-    "buildResourcePack.py",
-    "CONTENT_GOES_HERE",
-    ".gitignore",
-    ".directory",
-    ".DS_Store"
-}
 
 CLIENT_IGNORED_RESOURCES = {
     "Maps",

--- a/Tools/package_lib.py
+++ b/Tools/package_lib.py
@@ -68,10 +68,6 @@ def init(tool):
     if not _are_we_in_correct_directory():
         print(Fore.RED + "For an unknown reason, Content.Shared/Content.Shared.csproj is missing. Continuing regardless." + Style.RESET_ALL)
     try:
-        os.stat("Content.Shared/Content.Shared.csproj")
-    except FileNotFoundError:
-        print(Fore.RED + "For an unknown reason, Content.Shared/Content.Shared.csproj is missing. Continuing regardless." + Style.RESET_ALL)
-    try:
         os.stat(".git")
     except FileNotFoundError:
         print(Fore.YELLOW + tool + " was executed with a non-Git source tree.")

--- a/Tools/package_lib.py
+++ b/Tools/package_lib.py
@@ -28,9 +28,9 @@ SHARED_IGNORED_RESOURCES = {
 
 def print_pycmd_for_platform(script, args):
     if IS_WINDOWS:
-        print(Fore.GREEN + "E:\\ilo\\space-station-14\\> py -3 " + (" ").join(args) + Style.RESET_ALL)
+        print(Fore.GREEN + "E:\\ilo\\space-station-14\\> py -3 " + script + " " + (" ").join(args) + Style.RESET_ALL)
     else:
-        print(Fore.GREEN + "jan@ilo:~/space-station-14$ python3 " + (" ").join(args) + Style.RESET_ALL)
+        print(Fore.GREEN + "jan@ilo:~/space-station-14$ python3 " + script + " " + (" ").join(args) + Style.RESET_ALL)
 
 def diagnose_installation(tool):
     try:

--- a/Tools/package_lib.py
+++ b/Tools/package_lib.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+try:
+    from colorama import init, Fore, Style
+    init()
+
+except ImportError:
+    # Just give an empty string for everything, no colored logging.
+    class ColorDummy(object):
+        def __getattr__(self, name):
+            return ""
+
+    Fore = ColorDummy()
+    Style = ColorDummy()
+
+IS_WINDOWS = sys.platform in ("win32", "cygwin")
+
+SHARED_IGNORED_RESOURCES = {
+    ".gitignore",
+    ".directory",
+    ".DS_Store"
+}
+
+# Diagnose common mistakes
+
+def print_pycmd_for_platform(script, args):
+    if IS_WINDOWS:
+        print(Fore.GREEN + "E:\\ilo\\space-station-14\\> py -3 " + (" ").join(args) + Style.RESET_ALL)
+    else:
+        print(Fore.GREEN + "jan@ilo:~/space-station-14$ python3 " + (" ").join(args) + Style.RESET_ALL)
+
+def diagnose_installation(tool):
+    try:
+        os.stat("Content.Shared/Content.Shared.csproj")
+    except FileNotFoundError:
+        print(Fore.RED + "This program cannot be executed from this current directory.")
+        print("It must be executed from the space-station-14 directory, for example:" + Style.RESET_ALL)
+        print_pycmd_for_platform("Tools/" + tool + ".py", sys.argv[1:])
+        exit(1) # this is irrecoverable even for advanced users unless we just plain start *guessing*... let's not
+    try:
+        os.stat(".git")
+    except FileNotFoundError:
+        print(Fore.YELLOW + tool + " was executed with a non-Git source tree.")
+        print("Do not use the 'Download ZIP' button on GitHub.")
+        print("Instead, use a Git client. In Git Bash, the command would be:" + Style.RESET_ALL)
+        print(Fore.GREEN + "jan@ilo:~$ git clone https://github.com/space-wizards/space-station-14" + Style.RESET_ALL)
+        print(Fore.YELLOW + "You may add '--depth=1 --recursive' if you wish to reduce clone time/disk space, but beware that this still carries caveats.")
+        print("Be sure to also run the RUN_THIS.py script:" + Style.RESET_ALL)
+        print_pycmd_for_platform("RUN_THIS.py", [])
+        print(Fore.YELLOW + "Continuing regardless..." + Style.RESET_ALL) # user may know what they're doing, in which case blocking them would not be appreciated
+    try:
+        os.stat("RobustToolbox/Robust.Shared/Robust.Shared.csproj")
+    except FileNotFoundError:
+        print(Fore.YELLOW + tool + " did not find Robust.Shared.csproj, which usually means RUN_THIS.py has not been executed:")
+        print_pycmd_for_platform("RUN_THIS.py", [])
+        print(Fore.YELLOW + "Continuing regardless..." + Style.RESET_ALL)
+
+if __name__ == '__main__':
+    diagnose_installation("package_lib")
+    print(Fore.RED + "package_lib.py is a library and not meant to be executed directly." + Style.RESET_ALL)
+    print(Fore.RED + "Instead, execute Tools/package_server_build.py (in most cases) or that and Tools/package_client_build.py (for if you're hosting a server with a separate client build server)." + Style.RESET_ALL)
+    exit(1)
+

--- a/Tools/package_lib.py
+++ b/Tools/package_lib.py
@@ -26,20 +26,51 @@ SHARED_IGNORED_RESOURCES = {
 
 # Diagnose common mistakes
 
-def print_pycmd_for_platform(script, args):
+def _print_pycmd_for_platform(script, args):
+    """
+    Prints a python command from the space-station-14 directory.
+    """
     if IS_WINDOWS:
         print(Fore.GREEN + "E:\\ilo\\space-station-14\\> py -3 " + script + " " + (" ").join(args) + Style.RESET_ALL)
     else:
         print(Fore.GREEN + "jan@ilo:~/space-station-14$ python3 " + script + " " + (" ").join(args) + Style.RESET_ALL)
 
-def diagnose_installation(tool):
+def _are_we_in_correct_directory():
+    """
+    Returns if we're in the right directory.
+    """
     try:
         os.stat("Content.Shared/Content.Shared.csproj")
     except FileNotFoundError:
-        print(Fore.RED + "This program cannot be executed from this current directory.")
-        print("It must be executed from the space-station-14 directory, for example:" + Style.RESET_ALL)
-        print_pycmd_for_platform("Tools/" + tool + ".py", sys.argv[1:])
-        exit(1) # this is irrecoverable even for advanced users unless we just plain start *guessing*... let's not
+        return False
+    return True
+
+def init(tool):
+    """
+    Sets the current directory to be the space-station-14 directory, and does some diagnostics.
+    """
+    # firstly check that we actually need to do this
+    # because the structure we're in could be "weird", so if we don't need to do this we shouldn't!
+    if not _are_we_in_correct_directory():
+        # *then* attempt recovery
+        baseline = os.path.realpath(sys.argv[0])
+        # if we're being called from the terminal for SOME reason:
+        #  == Tools
+        # otherwise
+        #  == something.py
+        # let's just try to be sure...
+        if os.path.basename(baseline) != "Tools":
+            baseline = os.path.dirname(baseline)
+        # ok, now we have the path of Tools, it's whatever is immediately outside that
+        baseline = os.path.dirname(baseline)
+        os.chdir(baseline)
+        # print(Fore.YELLOW + "Automatically changed directory: " + baseline + Style.RESET_ALL)
+    if not _are_we_in_correct_directory():
+        print(Fore.RED + "For an unknown reason, Content.Shared/Content.Shared.csproj is missing. Continuing regardless." + Style.RESET_ALL)
+    try:
+        os.stat("Content.Shared/Content.Shared.csproj")
+    except FileNotFoundError:
+        print(Fore.RED + "For an unknown reason, Content.Shared/Content.Shared.csproj is missing. Continuing regardless." + Style.RESET_ALL)
     try:
         os.stat(".git")
     except FileNotFoundError:
@@ -49,17 +80,17 @@ def diagnose_installation(tool):
         print(Fore.GREEN + "jan@ilo:~$ git clone https://github.com/space-wizards/space-station-14" + Style.RESET_ALL)
         print(Fore.YELLOW + "You may add '--depth=1 --recursive' if you wish to reduce clone time/disk space, but beware that this still carries caveats.")
         print("Be sure to also run the RUN_THIS.py script:" + Style.RESET_ALL)
-        print_pycmd_for_platform("RUN_THIS.py", [])
+        _print_pycmd_for_platform("RUN_THIS.py", [])
         print(Fore.YELLOW + "Continuing regardless..." + Style.RESET_ALL) # user may know what they're doing, in which case blocking them would not be appreciated
     try:
         os.stat("RobustToolbox/Robust.Shared/Robust.Shared.csproj")
     except FileNotFoundError:
         print(Fore.YELLOW + tool + " did not find Robust.Shared.csproj, which usually means RUN_THIS.py has not been executed:")
-        print_pycmd_for_platform("RUN_THIS.py", [])
+        _print_pycmd_for_platform("RUN_THIS.py", [])
         print(Fore.YELLOW + "Continuing regardless..." + Style.RESET_ALL)
 
 if __name__ == '__main__':
-    diagnose_installation("package_lib")
+    init("package_lib")
     print(Fore.RED + "package_lib.py is a library and not meant to be executed directly." + Style.RESET_ALL)
     print(Fore.RED + "Instead, execute Tools/package_server_build.py (in most cases) or that and Tools/package_client_build.py (for if you're hosting a server with a separate client build server)." + Style.RESET_ALL)
     exit(1)

--- a/Tools/package_server_build.py
+++ b/Tools/package_server_build.py
@@ -10,18 +10,7 @@ import argparse
 
 from typing import List, Optional
 
-try:
-    from colorama import init, Fore, Style
-    init()
-
-except ImportError:
-    # Just give an empty string for everything, no colored logging.
-    class ColorDummy(object):
-        def __getattr__(self, name):
-            return ""
-
-    Fore = ColorDummy()
-    Style = ColorDummy()
+from package_lib import Fore, Style, SHARED_IGNORED_RESOURCES
 
 class PlatformReg:
     def __init__(self, rid: str, target_os: str, build_by_default: bool):
@@ -44,12 +33,6 @@ PLATFORMS = [
 
 PLATFORM_RIDS = {x.rid for x in PLATFORMS}
 PLATFORM_RIDS_DEFAULT = {x.rid for x in filter(lambda val: val.build_by_default, PLATFORMS)}
-
-SHARED_IGNORED_RESOURCES = {
-    ".gitignore",
-    ".directory",
-    ".DS_Store"
-}
 
 SERVER_IGNORED_RESOURCES = {
     "Textures",
@@ -110,12 +93,16 @@ def main() -> None:
 
     parser.add_argument("--hybrid-acz",
                         action="store_true",
-                        help="Creates a 'Hybrid ACZ' build that contains an embedded Content.Client.zip the server hosts.")
+                        help="Dummy; Hybrid ACZ builds are default.")
+
+    parser.add_argument("--no-hybrid-acz",
+                        action="store_true",
+                        help="Disables 'Hybrid ACZ' build. Hybrid ACZ builds contain an embedded Content.Client.zip that the server hosts. " + Fore.YELLOW + "You usually want this!" + Style.RESET_ALL)
 
     args = parser.parse_args()
     platforms = args.platform
     skip_build = args.skip_build
-    hybrid_acz = args.hybrid_acz
+    hybrid_acz = not args.no_hybrid_acz
 
     if not platforms:
         platforms = PLATFORM_RIDS_DEFAULT

--- a/Tools/package_server_build.py
+++ b/Tools/package_server_build.py
@@ -10,7 +10,10 @@ import argparse
 
 from typing import List, Optional
 
+import package_lib
 from package_lib import Fore, Style, SHARED_IGNORED_RESOURCES
+
+package_lib.init("package_server_build")
 
 class PlatformReg:
     def __init__(self, rid: str, target_os: str, build_by_default: bool):

--- a/Tools/package_server_build.py
+++ b/Tools/package_server_build.py
@@ -96,11 +96,11 @@ def main() -> None:
 
     parser.add_argument("--hybrid-acz",
                         action="store_true",
-                        help="Dummy; Hybrid ACZ builds are default.")
+                        help="Does nothing; Hybrid ACZ builds are default. Hybrid ACZ builds contain an embedded Content.Client.zip that the server hosts.")
 
     parser.add_argument("--no-hybrid-acz",
                         action="store_true",
-                        help="Disables 'Hybrid ACZ' build. Hybrid ACZ builds contain an embedded Content.Client.zip that the server hosts. " + Fore.YELLOW + "You usually want this!" + Style.RESET_ALL)
+                        help="Disables 'Hybrid ACZ' build. " + Fore.YELLOW + "You shouldn't supply this flag unless you have your own way of shipping the client data, such as a Robust.CDN server." + Style.RESET_ALL)
 
     args = parser.parse_args()
     platforms = args.platform


### PR DESCRIPTION
## About the PR
This PR makes `--hybrid-acz` a default flag. People compiling servers usually want Hybrid ACZ unless they have their own client build shipping infrastructure (unlikely). The workflows were changed accordingly to disable Hybrid ACZ on official builds.

It also adds diagnostics to the build scripts for common mistakes (downloaded source incorrectly, did not perform `RUN_THIS.py`, etc.)

Finally, the scripts will automatically change current directory to the `space-station-14` directory rather than failing.

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

N/A