### PR TITLE
Buff the Cargo Telepad Delay.

### DIFF
--- a/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
+++ b/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
@@ -17,13 +17,13 @@ public sealed class CargoTelepadComponent : Component
     /// The base amount of time it takes to teleport from the telepad
     /// </summary>
     [DataField("baseDelay"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDelay = 45f;
+    public float BaseDelay = 10f;
 
     /// <summary>
     /// The actual amount of time it takes to teleport from the telepad
     /// </summary>
     [DataField("delay"), ViewVariables(VVAccess.ReadWrite)]
-    public float Delay = 45f;
+    public float Delay = 10f;
 
     /// <summary>
     /// The machine part that affects <see cref="Delay"/>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
It's 45 seconds. It is currently faster to send the shuttle and bring it back. This buffs it to 10 seconds so you aren't awkwardly sitting around and waiting for your order. With T4 parts it takes ~4 seconds for an order to come in, so you can get people their stuff right as they ask for it. 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Lank
- tweak: The Cargo Telepad has been significantly improved, teleporting orders over 4x faster.  
