### PR TITLE
Fixes Romerol & Corpium, Small Zombie Tweaks

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
@@ -12,7 +12,7 @@ public sealed class CauseZombieInfection : ReagentEffect
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("reagent-effect-guidebook-cause-zombie-infection", ("chance", Probability)); 
 
-    // Removes the Zombie Infection Components
+    // Adds the Zombie Infection Components
     public override void Effect(ReagentEffectArgs args)
     {
         var entityManager = args.EntityManager;

--- a/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Prototypes;
+
+using Robust.Shared.Configuration;
+using Content.Server.Zombies;
+
+
+namespace Content.Server.Chemistry.ReagentEffects;
+
+public sealed class CauseZombieInfection : ReagentEffect
+{
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-paralyze"); 
+
+    // Removes the Zombie Infection Components
+    public override void Effect(ReagentEffectArgs args)
+    {
+        var entityManager = args.EntityManager;
+        entityManager.AddComponent<ZombifyOnDeathComponent>(args.SolutionEntity);
+        entityManager.AddComponent<PendingZombieComponent>(args.SolutionEntity);
+    }
+}
+

--- a/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
@@ -10,14 +10,14 @@ namespace Content.Server.Chemistry.ReagentEffects;
 public sealed class CauseZombieInfection : ReagentEffect
 {
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-        => Loc.GetString("reagent-effect-guidebook-cause-zombie-infection"); 
+        => Loc.GetString("reagent-effect-guidebook-cause-zombie-infection", ("chance", Probability)); 
 
     // Removes the Zombie Infection Components
     public override void Effect(ReagentEffectArgs args)
     {
         var entityManager = args.EntityManager;
-        entityManager.AddComponent<ZombifyOnDeathComponent>(args.SolutionEntity);
-        entityManager.AddComponent<PendingZombieComponent>(args.SolutionEntity);
+        entityManager.EnsureComponent<ZombifyOnDeathComponent>(args.SolutionEntity);
+        entityManager.EnsureComponent<PendingZombieComponent>(args.SolutionEntity);
     }
 }
 

--- a/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Chemistry.ReagentEffects;
 public sealed class CauseZombieInfection : ReagentEffect
 {
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-        => Loc.GetString("reagent-effect-guidebook-paralyze"); 
+        => Loc.GetString("reagent-effect-guidebook-cause-zombie-infection"); 
 
     // Removes the Zombie Infection Components
     public override void Effect(ReagentEffectArgs args)

--- a/Content.Server/Chemistry/ReagentEffects/CureZombieInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/CureZombieInfection.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Prototypes;
+
+using Robust.Shared.Configuration;
+using Content.Server.Zombies;
+
+
+namespace Content.Server.Chemistry.ReagentEffects;
+
+public sealed class CureZombieInfection : ReagentEffect
+{
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-paralyze"); 
+
+    // Removes the Zombie Infection Components
+    public override void Effect(ReagentEffectArgs args)
+    {
+        var entityManager = args.EntityManager;
+        entityManager.RemoveComponent<ZombifyOnDeathComponent>(args.SolutionEntity);
+        entityManager.RemoveComponent<PendingZombieComponent>(args.SolutionEntity);
+    }
+}
+

--- a/Content.Server/Chemistry/ReagentEffects/CureZombieInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/CureZombieInfection.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Chemistry.ReagentEffects;
 public sealed class CureZombieInfection : ReagentEffect
 {
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-        => Loc.GetString("reagent-effect-guidebook-paralyze"); 
+        => Loc.GetString("reagent-effect-guidebook-cure-zombie-infection"); 
 
     // Removes the Zombie Infection Components
     public override void Effect(ReagentEffectArgs args)

--- a/Content.Server/Chemistry/ReagentEffects/CureZombieInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/CureZombieInfection.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Chemistry.ReagentEffects;
 public sealed class CureZombieInfection : ReagentEffect
 {
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-        => Loc.GetString("reagent-effect-guidebook-cure-zombie-infection"); 
+        => Loc.GetString("reagent-effect-guidebook-cure-zombie-infection", ("chance", Probability)); 
 
     // Removes the Zombie Infection Components
     public override void Effect(ReagentEffectArgs args)

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -44,14 +44,14 @@ namespace Content.Shared.Zombies
         /// The baseline infection chance you have if you are completely nude
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MaxZombieInfectionChance = 0.30f;
+        public float MaxZombieInfectionChance = 0.50f;
 
         /// <summary>
         /// The minimum infection chance possible. This is simply to prevent
         /// being invincible by bundling up.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MinZombieInfectionChance = 0.05f;
+        public float MinZombieInfectionChance = 0.20f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public float ZombieMovementSpeedDebuff = 0.70f;

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -313,13 +313,13 @@ reagent-effect-guidebook-cure-zombie-infection =
     { $chance ->
         [1] Cures
         *[other] cure
-    } an ongoing zombie infection.
+    } an ongoing zombie infection
 
 reagent-effect-guidebook-cause-zombie-infection =
     { $chance ->
         [1] Gives
         *[other] give
-    } an individual the zombie infection.
+    } an individual the zombie infection
 
 reagent-effect-guidebook-missing =
     { $chance ->

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -309,6 +309,18 @@ reagent-effect-guidebook-wash-cream-pie-reaction =
         *[other] wash
     } off cream pie from one's face
 
+reagent-effect-guidebook-cure-zombie-infection =
+    { $chance ->
+        [1] Cures
+        *[other] cure
+    } an ongoing zombie infection.
+
+reagent-effect-guidebook-cause-zombie-infection =
+    { $chance ->
+        [1] Gives
+        *[other] give
+    } an individual the zombie infection.
+
 reagent-effect-guidebook-missing =
     { $chance ->
         [1] Causes

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -53,7 +53,7 @@ reagent-name-phalanximine = phalanximine
 reagent-desc-phalanximine = Used in the treatment of cancer. Causes moderate radiation poisoning.
 
 reagent-name-romerol = romerol
-reagent-desc-romerol = A difficult to procure chemical used in the reversal of the zombification process. Tastes like death.
+reagent-desc-romerol = A difficult to procure chemical that can remove a zombie infection in living organisms. Cannot save anyone who has already turned. Tastes like death.
 
 reagent-name-pulped-banana-peel = pulped banana peel
 reagent-desc-pulped-banana-peel = Pulped banana peels have some effectiveness against bleeding.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -480,25 +480,25 @@
   categories:
   - UplinkBundles
 
-#- type: listing
-#  id: UplinkZombieBundle
-#  name: uplink-zombie-bundle-name
-#  description: uplink-zombie-bundle-desc
-#  icon: { sprite: /Textures/Structures/Wallmounts/signs.rsi, state: bio }
-#  productEntity: ClothingBackpackDuffelZombieBundle
-#  cost:
-#    Telecrystal: 40
-#  categories:
-#  - UplinkBundles
-#  conditions:
-#  - !type:StoreWhitelistCondition
-#    whitelist:
-#      tags:
-#      - NukeOpsUplink
-#  - !type:BuyerWhitelistCondition
-#    blacklist:
-#      components:
-#      - SurplusBundle
+- type: listing
+  id: UplinkZombieBundle
+  name: uplink-zombie-bundle-name
+  description: uplink-zombie-bundle-desc
+  icon: { sprite: /Textures/Structures/Wallmounts/signs.rsi, state: bio }
+  productEntity: ClothingBackpackDuffelZombieBundle
+  cost:
+    Telecrystal: 40
+  categories:
+  - UplinkBundles
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
 
 - type: listing
   id: UplinkSurplusBundle

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -574,6 +574,9 @@
           types:
             Poison: 0.5
       - !type:CureZombieInfection
+          conditions:
+            - !type:ReagentThreshold
+              min: 10
 
 - type: reagent
   id: PulpedBananaPeel

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -573,6 +573,7 @@
         damage:
           types:
             Poison: 0.5
+      - !type:CureZombieInfection
 
 - type: reagent
   id: PulpedBananaPeel

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -398,6 +398,7 @@
           damage:
             types:
               Cellular: 1
+        - !type:CauseZombieInfection
 
 - type: reagent
   id: UncookedAnimalProteins

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -399,6 +399,9 @@
             types:
               Cellular: 1
         - !type:CauseZombieInfection
+          conditions:
+            - !type:ReagentThreshold
+              min: 5
 
 - type: reagent
   id: UncookedAnimalProteins


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Zombies have been back for about a month and the cure just hasn't worked. That's dumb. I fixed it, and Romerol can now cure ongoing infections (though you won't be immune to any future ones). 
I also subsequently fixed Corpium, and readded the Zombie Bundle since I fixed the reason it was gone. 
Given the simply pathetic zombie infection chance (5% at the lowest), I thought it fitting to try and raise it a bit (though not to as high as it was previously) now that Romerol is working. 

I also just changed the description to not imply it can cure those who are already zombies, which it did before.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/space-wizards/space-station-14/assets/135308300/5bb46a30-d19a-4a47-bff6-ecd8dc5b55aa)
![image](https://github.com/space-wizards/space-station-14/assets/135308300/62e15dcf-69ee-48c0-9cba-437e7e5b6082)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Lank
- add: Nanotrasen has made Romerol properly cure ongoing zombie infections.
- add: In response, the Syndicate has outed their expired stock of Corpium, and it now infects as it should. This means the Zombie Bundle is available for nuclear operatives. 
- tweak: The ongoing biological warfare has made all zombies significantly more infectious. 