### PR TITLE
Fix bugs when updating paper UI

### DIFF
--- a/Content.Client/Paper/UI/PaperWindow.xaml.cs
+++ b/Content.Client/Paper/UI/PaperWindow.xaml.cs
@@ -178,14 +178,22 @@ namespace Content.Client.Paper.UI
         public void Populate(SharedPaperComponent.PaperBoundUserInterfaceState state)
         {
             bool isEditing = state.Mode == SharedPaperComponent.PaperAction.Write;
+            bool wasEditing = InputContainer.Visible;
             InputContainer.Visible = isEditing;
 
             var msg = new FormattedMessage();
             msg.AddMarkupPermissive(state.Text);
 
-            Input.TextRope = Rope.Leaf.Empty;
-            Input.CursorPosition = new TextEdit.CursorPos();
-            Input.InsertAtCursor(msg.ToString());
+            if (!wasEditing)
+            {
+                // We can get repeated messages with state.Mode == Write if another
+                // player opens the UI for reading. In this case, don't update the
+                // text input, as this player is currently writing new text and we
+                // don't want to lose any text they already input.
+                Input.TextRope = Rope.Leaf.Empty;
+                Input.CursorPosition = new TextEdit.CursorPos();
+                Input.InsertAtCursor(msg.ToString());
+            }
 
             for (var i = 0; i <= state.StampedBy.Count * 3 + 1; i++)
             {


### PR DESCRIPTION
Paper UI update events were being broadcast to all players. This led to some bugs:

If player A is writing a paper and player B reads it, player A's editing interface disappears and they lose the text they input so far.

If player A is reading a paper and player B starts writing it, player A will get an editing interface and be able to write paper without a pen.

Now, the editing interface is available only to players who actually started writing a paper, and the editing interface is only updated when the text changes -- this removes the possibility of losing partially-input text in all but one (rare) case:

If player A starts writing a paper but player B starts (and finishes) writing the same paper, then player A's in-progress text is lost. Both players will see player B's updated text.

Short of implementing a realtime, collaborative document or changing how text is input, I think we'll have to live with it.

Bonus: Removes usage of some obsolete methods in PaperSystem.cs

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

no cl no fun
