### PR TITLE
make pyroclastic anomaly ignition ignore line of sight checks

### DIFF
--- a/Content.Server/Anomaly/Effects/PyroclasticAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/PyroclasticAnomalySystem.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
-using Content.Server.Interaction;
 using Content.Shared.Anomaly.Components;
 using Content.Shared.Anomaly.Effects.Components;
 using Robust.Shared.Map;
@@ -14,7 +13,6 @@ public sealed class PyroclasticAnomalySystem : EntitySystem
 {
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly FlammableSystem _flammable = default!;
-    [Dependency] private readonly InteractionSystem _interaction = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -41,10 +39,7 @@ public sealed class PyroclasticAnomalySystem : EntitySystem
         foreach (var flammable in _lookup.GetComponentsInRange<FlammableComponent>(coordinates, radius))
         {
             var ent = flammable.Owner;
-            if (!_interaction.InRangeUnobstructed(coordinates.ToMap(EntityManager), ent, -1))
-                continue;
-
-            var stackAmount = 1 + (int) (severity / 0.25f);
+            var stackAmount = 1 + (int) (severity / 0.15f);
             _flammable.AdjustFireStacks(ent, stackAmount, flammable);
             _flammable.Ignite(ent, flammable);
         }

--- a/Content.Shared/Anomaly/Effects/Components/PyroclasticAnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Effects/Components/PyroclasticAnomalyComponent.cs
@@ -1,38 +1,11 @@
-﻿using Content.Shared.Atmos;
-
-namespace Content.Shared.Anomaly.Effects.Components;
+﻿namespace Content.Shared.Anomaly.Effects.Components;
 
 [RegisterComponent]
 public sealed class PyroclasticAnomalyComponent : Component
 {
-
     /// <summary>
     /// The maximum distance from which you can be ignited by the anomaly.
     /// </summary>
     [DataField("maximumIgnitionRadius")]
-    public float MaximumIgnitionRadius = 8f;
-
-    /// <summary>
-    /// The temperature of the hotspot where the anomaly is
-    /// </summary>
-    [DataField("hotspotExposeTemperature")]
-    public float HotspotExposeTemperature = 1000;
-
-    /// <summary>
-    /// The volume of the hotspot where the anomaly is.
-    /// </summary>
-    [DataField("hotspotExposeVolume")]
-    public float HotspotExposeVolume = 50;
-
-    /// <summary>
-    /// Gas released when the anomaly goes supercritical.
-    /// </summary>
-    [DataField("supercriticalGas")]
-    public Gas SupercriticalGas = Gas.Plasma;
-
-    /// <summary>
-    /// The amount of gas released when the anomaly goes supercritical
-    /// </summary>
-    [DataField("supercriticalMoleAmount")]
-    public float SupercriticalMoleAmount = 75f;
+    public float MaximumIgnitionRadius = 5f;
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
i'm pretty sure 99% of people don't even know this effect exists because you have to be incredibly dumb to be affected by it.
now it ignores line of sight so you can't just hide behind a thindow.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: The pyroclastic anomaly's ignition has gained otherworldly properties and now permeates through solid structures.
