### PR TITLE
Damage on forced uncuff

### DIFF
--- a/Content.Shared/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Shared/Cuffs/Components/CuffableComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
@@ -43,8 +44,13 @@ public sealed class CuffableComponent : Component
     /// Damage is applied to someone when they try to uncuff themselves.
     /// </summary>
     [DataField("damageOnResist"), ViewVariables(VVAccess.ReadWrite)]
-    public float DamageOnResist = 3f;
-
+    public DamageSpecifier DamageOnResist = new()
+    {
+        DamageDict = new()
+             {
+                 { "Blunt", 3.0 },
+             }
+    };
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Shared/Cuffs/Components/CuffableComponent.cs
@@ -43,7 +43,7 @@ public sealed class CuffableComponent : Component
     /// Damage is applied to someone when they try to uncuff themselves.
     /// </summary>
     [DataField("damageOnResist"), ViewVariables(VVAccess.ReadWrite)]
-    public float DamageOnResist = 1f;
+    public float DamageOnResist = 3f;
 
 }
 

--- a/Content.Shared/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Shared/Cuffs/Components/CuffableComponent.cs
@@ -38,6 +38,13 @@ public sealed class CuffableComponent : Component
     /// </summary>
     [DataField("canStillInteract"), ViewVariables(VVAccess.ReadWrite)]
     public bool CanStillInteract = true;
+
+    /// <summary>
+    /// Damage is applied to someone when they try to uncuff themselves.
+    /// </summary>
+    [DataField("damageOnResist"), ViewVariables(VVAccess.ReadWrite)]
+    public float DamageOnResist = 1f;
+
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -582,7 +582,7 @@ namespace Content.Shared.Cuffs
 
             if (isOwner)
             {
-                _damageSystem.TryChangeDamage(target, new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Blunt"), cuffable.DamageOnResist), true, false);
+                _damageSystem.TryChangeDamage(target, new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Brute"), cuffable.DamageOnResist), true, false);
             }
 
             if (_net.IsServer)

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -42,6 +42,7 @@ namespace Content.Shared.Cuffs
         [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
         [Dependency] private readonly AlertsSystem _alerts = default!;
+        [Dependency] private readonly DamageableSystem _damageSystem = default!;
         [Dependency] private readonly MobStateSystem _mobState = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedContainerSystem _container = default!;
@@ -51,7 +52,6 @@ namespace Content.Shared.Cuffs
         [Dependency] private readonly SharedInteractionSystem _interaction = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
-        [Dependency] private readonly DamageableSystem _damageSystem = default!;
 
         public override void Initialize()
         {

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -5,6 +5,8 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Cuffs.Components;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands;
@@ -29,6 +31,7 @@ using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Cuffs
@@ -50,6 +53,8 @@ namespace Content.Shared.Cuffs
         [Dependency] private readonly SharedInteractionSystem _interaction = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly DamageableSystem _damageSystem = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
         public override void Initialize()
         {
@@ -572,6 +577,13 @@ namespace Content.Shared.Cuffs
 
             if (!_doAfter.TryStartDoAfter(doAfterEventArgs))
                 return;
+
+            _adminLog.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(user)} is trying to uncuff {ToPrettyString(target)}");
+
+            if (isOwner)
+            {
+                _damageSystem.TryChangeDamage(target, new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Blunt"), cuffable.DamageOnResist), true, false);
+            }
 
             if (_net.IsServer)
             {

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -579,14 +579,7 @@ namespace Content.Shared.Cuffs
 
             if (isOwner)
             {
-                var uncuffDamage = new DamageSpecifier()
-                {
-                    DamageDict = new()
-                    {
-                        { "Blunt", cuffable.DamageOnResist }
-                    }
-                };
-                _damageSystem.TryChangeDamage(target, uncuffDamage, true, false);
+                _damageSystem.TryChangeDamage(target, cuffable.DamageOnResist, true, false);
             }
 
             if (_net.IsServer)

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -582,7 +582,14 @@ namespace Content.Shared.Cuffs
 
             if (isOwner)
             {
-                _damageSystem.TryChangeDamage(target, new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Brute"), cuffable.DamageOnResist), true, false);
+                var uncuffDamage = new DamageSpecifier()
+                {
+                    DamageDict = new()
+                    {
+                        { "Blunt", cuffable.DamageOnResist }
+                    }
+                };
+                _damageSystem.TryChangeDamage(target, uncuffDamage, true, false);
             }
 
             if (_net.IsServer)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR aims to stop people from spam uncuffing - the damage only applies to the person wearing and spamming the uncuff button it does not hurt to take cuffs off someone else.
it also adds a log for uncuffing.
it is 3 blunt damage per uncuff attempt.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Attempting to uncuff yourself damages you slightly
