### PR TITLE
Hide debug coordinates from non-admins

### DIFF
--- a/Content.Client/DebugMon/DebugMonitorSystem.cs
+++ b/Content.Client/DebugMon/DebugMonitorSystem.cs
@@ -1,5 +1,8 @@
 using Content.Client.Administration.Managers;
+using Content.Shared.CCVar;
 using Robust.Client.UserInterface;
+using Robust.Shared.Configuration;
+
 
 namespace Content.Client.DebugMon;
 
@@ -8,14 +11,15 @@ namespace Content.Client.DebugMon;
 /// </summary>
 public sealed class DebugMonitorSystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IClientAdminManager _admin = default!;
     [Dependency] private readonly IUserInterfaceManager _userInterface = default!;
 
     public override void FrameUpdate(float frameTime)
     {
-        if (_admin.IsActive())
-            _userInterface.DebugMonitors.SetMonitor(DebugMonitor.Coords, true);
-        else
+        if (!_admin.IsActive() && _cfg.GetCVar(CCVars.DebugCoordinatesAdminOnly))
             _userInterface.DebugMonitors.SetMonitor(DebugMonitor.Coords, false);
+        else
+            _userInterface.DebugMonitors.SetMonitor(DebugMonitor.Coords, true);
     }
 }

--- a/Content.Client/DebugMon/DebugMonitorSystem.cs
+++ b/Content.Client/DebugMon/DebugMonitorSystem.cs
@@ -1,0 +1,21 @@
+using Content.Client.Administration.Managers;
+using Robust.Client.UserInterface;
+
+namespace Content.Client.DebugMon;
+
+/// <summary>
+/// This handles preventing certain debug monitors from appearing.
+/// </summary>
+public sealed class DebugMonitorSystem : EntitySystem
+{
+    [Dependency] private readonly IClientAdminManager _admin = default!;
+    [Dependency] private readonly IUserInterfaceManager _userInterface = default!;
+
+    public override void FrameUpdate(float frameTime)
+    {
+        if (_admin.IsActive())
+            _userInterface.DebugMonitors.SetMonitor(DebugMonitor.Coords, true);
+        else
+            _userInterface.DebugMonitors.SetMonitor(DebugMonitor.Coords, false);
+    }
+}

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -285,6 +285,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> LocalStatusIconsEnabled =
             CVarDef.Create("game.local_status_icons_enabled", true, CVar.CLIENTONLY);
 
+        /// <summary>
+        /// Whether or not coordinates on the Debug overlay should only be available to admins.
+        /// </summary>
+        public static readonly CVarDef<bool> DebugCoordinatesAdminOnly =
+            CVarDef.Create("game.debug_coordinates_admin_only", false, CVar.SERVER | CVar.REPLICATED);
+
 #if EXCEPTION_TOLERANCE
         /// <summary>
         ///     Amount of times round start must fail before the server is shut down.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Debug now only shows Positioning info if the user is admin
Thank you for the code, moony


No CL, this is a surprise for intrepid space explorers :3



**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/35878406/a8280e33-4d20-437b-9986-24e76999affb)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

<!--
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->