### PR TITLE
Pyroclastic Anomaly Supercrit Buff

### DIFF
--- a/Content.Server/Anomaly/Components/GasProducerAnomalyComponent.cs
+++ b/Content.Server/Anomaly/Components/GasProducerAnomalyComponent.cs
@@ -53,6 +53,6 @@ public sealed class GasProducerAnomalyComponent : Component
     /// <summary>
     /// The the amount the tempurature should be modified by (negative for decreasing temp)
     /// </summary>
-    [DataField("tempSet")]
-    public float tempSet = 0;
+    [DataField("tempChange")]
+    public float tempChange = 0;
 }

--- a/Content.Server/Anomaly/Components/GasProducerAnomalyComponent.cs
+++ b/Content.Server/Anomaly/Components/GasProducerAnomalyComponent.cs
@@ -3,7 +3,7 @@ using Content.Shared.Atmos;
 namespace Content.Server.Anomaly.Components;
 
 /// <summary>
-/// This component is used for handling gas producing anomalies
+/// This component is used for handling gas producing anomalies. Will always spawn one on the tile with the anomaly, and in a random radius around it.
 /// </summary>
 [RegisterComponent]
 public sealed class GasProducerAnomalyComponent : Component
@@ -37,4 +37,22 @@ public sealed class GasProducerAnomalyComponent : Component
     /// </summary>
     [DataField("passiveMoleAmount")]
     public float PassiveMoleAmount = 1f;
+
+    /// <summary>
+    /// The radius of random gas spawns.
+    /// </summary>
+    [DataField("spawnRadius", required: true)]
+    public float spawnRadius = 3;
+
+    /// <summary>
+    /// The number of tiles which will be modified. 
+    /// </summary>
+    [DataField("tileCount")]
+    public int tileCount = 1;
+    
+    /// <summary>
+    /// The the amount the tempurature should be modified by (negative for decreasing temp)
+    /// </summary>
+    [DataField("tempSet")]
+    public float tempSet = 0;
 }

--- a/Content.Server/Anomaly/Components/GasProducerAnomalyComponent.cs
+++ b/Content.Server/Anomaly/Components/GasProducerAnomalyComponent.cs
@@ -3,7 +3,7 @@ using Content.Shared.Atmos;
 namespace Content.Server.Anomaly.Components;
 
 /// <summary>
-/// This component is used for handling gas producing anomalies. Will always spawn one on the tile with the anomaly, and in a random radius around it.
+/// This component is used for handling gas producing anomalies
 /// </summary>
 [RegisterComponent]
 public sealed class GasProducerAnomalyComponent : Component
@@ -37,22 +37,4 @@ public sealed class GasProducerAnomalyComponent : Component
     /// </summary>
     [DataField("passiveMoleAmount")]
     public float PassiveMoleAmount = 1f;
-
-    /// <summary>
-    /// The radius of random gas spawns.
-    /// </summary>
-    [DataField("spawnRadius", required: true)]
-    public float spawnRadius = 3;
-
-    /// <summary>
-    /// The number of tiles which will be modified. 
-    /// </summary>
-    [DataField("tileCount")]
-    public int tileCount = 1;
-    
-    /// <summary>
-    /// The the amount the tempurature should be modified by (negative for decreasing temp)
-    /// </summary>
-    [DataField("tempSet")]
-    public float tempSet = 0;
 }

--- a/Content.Server/Anomaly/Effects/GasProducerAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/GasProducerAnomalySystem.cs
@@ -3,6 +3,9 @@ using Content.Server.Anomaly.Components;
 using Content.Shared.Anomaly.Components;
 using Content.Shared.Atmos;
 using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+using System.Linq;
 
 namespace Content.Server.Anomaly.Effects;
 
@@ -13,6 +16,8 @@ public sealed class GasProducerAnomalySystem : EntitySystem
 {
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly TransformSystem _xform = default!;
+    [Dependency] private readonly IMapManager _map = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -25,7 +30,7 @@ public sealed class GasProducerAnomalySystem : EntitySystem
         if (!component.ReleaseOnMaxSeverity)
             return;
 
-        ReleaseGas(uid, component.ReleasedGas, component.SuperCriticalMoleAmount);
+        ReleaseGas(uid, component.ReleasedGas, component.SuperCriticalMoleAmount, component.spawnRadius, component.tileCount, component.tempSet);
     }
 
     public override void Update(float frameTime)
@@ -41,35 +46,49 @@ public sealed class GasProducerAnomalySystem : EntitySystem
             // Yes this is unused code since there are no anomalies that
             // release gas passively *yet*, but since I'm here I figured
             // I'd save someone some time and just add it for the future
-            ReleaseGas(ent, comp.ReleasedGas, comp.PassiveMoleAmount * frameTime);
+            ReleaseGas(ent, comp.ReleasedGas, comp.PassiveMoleAmount * frameTime, comp.spawnRadius, comp.tileCount, comp.tempSet);
         }
     }
 
-    private void ReleaseGas(EntityUid uid, Gas gas, float amount)
+    private void ReleaseGas(EntityUid uid, Gas gas, float mols, float radius, int count, float temp) 
     {
         var xform = Transform(uid);
-        var grid = xform.GridUid;
-        var map = xform.MapUid;
 
-        var indices = _xform.GetGridOrMapTilePosition(uid, xform);
-        var mixture = _atmosphere.GetTileMixture(grid, map, indices, true);
-
-        if (mixture == null)
+        if (!_map.TryGetGrid(xform.GridUid, out var grid))
             return;
 
-        mixture.AdjustMoles(gas, amount);
+        var localpos = xform.Coordinates.Position;
+        var tilerefs = grid.GetLocalTilesIntersecting(
+            new Box2(localpos + (-radius, -radius), localpos + (radius, radius))).ToArray();
 
-        if (grid is { })
+        if (tilerefs.Length == 0)
+            return;
+
+        var mixture = _atmosphere.GetTileMixture(xform.GridUid, xform.MapUid, _xform.GetGridOrMapTilePosition(uid, xform), true);
+        if (mixture != null) 
         {
-            foreach (var ind in _atmosphere.GetAdjacentTiles(grid.Value, indices))
-            {
-                var mix = _atmosphere.GetTileMixture(grid, map, ind, true);
+            mixture.AdjustMoles(gas, mols);
+            mixture.Temperature = temp;
+        }
+            
+        if (count == 0) 
+            return;
 
-                if (mix is not { })
-                    continue;
+        _random.Shuffle(tilerefs);
+        var amountCounter = 0;
+        foreach (var tileref in tilerefs)
+        {
+            var mix = _atmosphere.GetTileMixture(xform.GridUid, xform.MapUid, tileref.GridIndices, true);
+            amountCounter++;
+            if (mix is not { })
+                continue;
 
-                mix.AdjustMoles(gas, amount);
-            }
+            mix.AdjustMoles(gas, mols);
+            mix.Temperature = temp;
+
+            if (amountCounter >= count)
+                return;
         }
     }
 }
+

--- a/Content.Server/Anomaly/Effects/GasProducerAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/GasProducerAnomalySystem.cs
@@ -3,6 +3,9 @@ using Content.Server.Anomaly.Components;
 using Content.Shared.Anomaly.Components;
 using Content.Shared.Atmos;
 using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+using System.Linq;
 
 namespace Content.Server.Anomaly.Effects;
 
@@ -13,6 +16,8 @@ public sealed class GasProducerAnomalySystem : EntitySystem
 {
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly TransformSystem _xform = default!;
+    [Dependency] private readonly IMapManager _map = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -25,7 +30,7 @@ public sealed class GasProducerAnomalySystem : EntitySystem
         if (!component.ReleaseOnMaxSeverity)
             return;
 
-        ReleaseGas(uid, component.ReleasedGas, component.SuperCriticalMoleAmount);
+        ReleaseGas(uid, component.ReleasedGas, component.SuperCriticalMoleAmount, component.spawnRadius, component.tileCount, component.tempSet);
     }
 
     public override void Update(float frameTime)
@@ -41,35 +46,48 @@ public sealed class GasProducerAnomalySystem : EntitySystem
             // Yes this is unused code since there are no anomalies that
             // release gas passively *yet*, but since I'm here I figured
             // I'd save someone some time and just add it for the future
-            ReleaseGas(ent, comp.ReleasedGas, comp.PassiveMoleAmount * frameTime);
+            ReleaseGas(ent, comp.ReleasedGas, comp.PassiveMoleAmount * frameTime, comp.spawnRadius, comp.tileCount, comp.tempSet);
         }
     }
 
-    private void ReleaseGas(EntityUid uid, Gas gas, float amount)
+    private void ReleaseGas(EntityUid uid, Gas gas, float mols, float radius, int count, float temp) 
     {
         var xform = Transform(uid);
-        var grid = xform.GridUid;
-        var map = xform.MapUid;
 
-        var indices = _xform.GetGridOrMapTilePosition(uid, xform);
-        var mixture = _atmosphere.GetTileMixture(grid, map, indices, true);
-
-        if (mixture == null)
+        if (!_map.TryGetGrid(xform.GridUid, out var grid))
             return;
 
-        mixture.AdjustMoles(gas, amount);
+        var localpos = xform.Coordinates.Position;
+        var tilerefs = grid.GetLocalTilesIntersecting(
+            new Box2(localpos + (-radius, -radius), localpos + (radius, radius))).ToArray();
 
-        if (grid is { })
+        if (tilerefs.Length == 0)
+            return;
+
+        var mixture = _atmosphere.GetTileMixture(xform.GridUid, xform.MapUid, _xform.GetGridOrMapTilePosition(uid, xform), true);
+        if (mixture != null) 
         {
-            foreach (var ind in _atmosphere.GetAdjacentTiles(grid.Value, indices))
-            {
-                var mix = _atmosphere.GetTileMixture(grid, map, ind, true);
+            mixture.AdjustMoles(gas, mols);
+            mixture.Temperature = temp;
+        }
+            
+        if (count == 0) 
+            return;
 
-                if (mix is not { })
-                    continue;
+        _random.Shuffle(tilerefs);
+        var amountCounter = 0;
+        foreach (var tileref in tilerefs)
+        {
+            var mix = _atmosphere.GetTileMixture(xform.GridUid, xform.MapUid, tileref.GridIndices, true);
+            amountCounter++;
+            if (mix is not { })
+                continue;
 
-                mix.AdjustMoles(gas, amount);
-            }
+            mix.AdjustMoles(gas, mols);
+            mix.Temperature = temp;
+
+            if (amountCounter >= count)
+                return;
         }
     }
 }

--- a/Content.Server/Anomaly/Effects/GasProducerAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/GasProducerAnomalySystem.cs
@@ -30,7 +30,7 @@ public sealed class GasProducerAnomalySystem : EntitySystem
         if (!component.ReleaseOnMaxSeverity)
             return;
 
-        ReleaseGas(uid, component.ReleasedGas, component.SuperCriticalMoleAmount, component.spawnRadius, component.tileCount, component.tempSet);
+        ReleaseGas(uid, component.ReleasedGas, component.SuperCriticalMoleAmount, component.spawnRadius, component.tileCount, component.tempChange);
     }
 
     public override void Update(float frameTime)
@@ -46,7 +46,7 @@ public sealed class GasProducerAnomalySystem : EntitySystem
             // Yes this is unused code since there are no anomalies that
             // release gas passively *yet*, but since I'm here I figured
             // I'd save someone some time and just add it for the future
-            ReleaseGas(ent, comp.ReleasedGas, comp.PassiveMoleAmount * frameTime, comp.spawnRadius, comp.tileCount, comp.tempSet);
+            ReleaseGas(ent, comp.ReleasedGas, comp.PassiveMoleAmount * frameTime, comp.spawnRadius, comp.tileCount, comp.tempChange);
         }
     }
 
@@ -68,7 +68,7 @@ public sealed class GasProducerAnomalySystem : EntitySystem
         if (mixture != null) 
         {
             mixture.AdjustMoles(gas, mols);
-            mixture.Temperature = temp;
+            mixture.Temperature += temp;
         }
             
         if (count == 0) 
@@ -84,7 +84,7 @@ public sealed class GasProducerAnomalySystem : EntitySystem
                 continue;
 
             mix.AdjustMoles(gas, mols);
-            mix.Temperature = temp;
+            mix.Temperature += temp;
 
             if (amountCounter >= count)
                 return;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -111,6 +111,7 @@
     - type: GasProducerAnomaly
       releasedGas: 3
       releaseOnMaxSeverity: true
+      spawnRadius: 0
 
 - type: entity
   name: behonker
@@ -153,3 +154,4 @@
   - type: GasProducerAnomaly
     releasedGas: 8 # Frezon. Please replace if there is a better way to specify this
     releaseOnMaxSeverity: true
+    spawnRadius: 0

--- a/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
@@ -72,9 +72,6 @@
   - type: GasProducerAnomaly
     releasedGas: 3
     releaseOnMaxSeverity: true
-    spawnRadius: 3
-    tileCount: 5
-    tempSet: 550
 
 - type: entity
   id: AnomalyGravity
@@ -230,5 +227,3 @@
   - type: GasProducerAnomaly
     releasedGas: 8 # Frezon. Please replace if there is a better way to specify this
     releaseOnMaxSeverity: true
-    spawnRadius: 0 # Should disable the random spawning, as it was before. 
-

--- a/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
@@ -74,7 +74,7 @@
     releaseOnMaxSeverity: true
     spawnRadius: 3
     tileCount: 5
-    tempSet: 550
+    tempChange: 550
 
 - type: entity
   id: AnomalyGravity

--- a/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
@@ -72,6 +72,9 @@
   - type: GasProducerAnomaly
     releasedGas: 3
     releaseOnMaxSeverity: true
+    spawnRadius: 3
+    tileCount: 5
+    tempSet: 550
 
 - type: entity
   id: AnomalyGravity
@@ -227,3 +230,5 @@
   - type: GasProducerAnomaly
     releasedGas: 8 # Frezon. Please replace if there is a better way to specify this
     releaseOnMaxSeverity: true
+    spawnRadius: 0 # Should disable the random spawning, as it was before. 
+

--- a/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
@@ -72,6 +72,9 @@
   - type: GasProducerAnomaly
     releasedGas: 3
     releaseOnMaxSeverity: true
+    spawnRadius: 3
+    tileCount: 5
+    tempSet: 550
 
 - type: entity
   id: AnomalyGravity
@@ -227,3 +230,4 @@
   - type: GasProducerAnomaly
     releasedGas: 8 # Frezon. Please replace if there is a better way to specify this
     releaseOnMaxSeverity: true
+    spawnRadius: 0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Pyro anomalies now also spawns (and ignites) plasma in random tiles around it in addition to the tile it's on. This is done by making GasProducerAnomaly component place gas in a random radius around them (akin to Meatzu), and changing the temperature of that gas by enough to ignite it and keep it burning. Both of these are disabled for ice anomalies so that works as it did before. 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/135308300/13c3d804-4296-45aa-916d-bcfc81feee9b


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Lank
- tweak: The pyroclastic anomaly's supercritical gas now ignores structures. 