### PR TITLE
Fixes airlock deconstruction issues

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -77,6 +77,15 @@
       - material: ReinforcedGlass
         amount: 1
         doAfter: 2
+    - to: wired
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:EmptyAllContainers {}
+      steps:
+      - tool: Prying
+        doAfter: 5
+
 
   - node: airlock
     entity: Airlock
@@ -112,6 +121,9 @@
       - !type:EntityAnchored {}
       completed:
       - !type:EmptyAllContainers {}
+      - !type:SpawnPrototype
+        prototype: SheetRGlass1
+        amount: 1
       steps:
       - tool: Prying
         doAfter: 5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
-Probably a rare construction move, but it is now possible to go back to Wired from Electronics to remove the door electronics without being forced to finish construction first then start a deconstruction
-Going back to Wired from Glass Electronics now returns 1 sheet of reinforced glass. So you no longer need to have an extra reinforced glass with you to be able to rebuild a glass airlock you just disassembled.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/35878406/f7113753-a4ff-4d1d-a561-2788aaa1ecda)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Errant
- fix: Due to improvements in Glass Airlock quality control, half the glass will no longer be lost on disassembly.
