### PR TITLE
make puddles not appear on space tiles

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -27,6 +27,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Maps;
 
 namespace Content.Server.Fluids.EntitySystems;
 
@@ -50,6 +51,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
     [Dependency] private readonly TileFrictionController _tile = default!;
     [Dependency] private readonly SlowContactsSystem _slowContacts = default!;
+    [Dependency] private readonly ITileDefinitionManager _tileDefMan = default!;
 
     public static float PuddleVolume = 1000;
 
@@ -562,7 +564,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         }
 
         // If space return early, let that spill go out into the void
-        if (tileRef.Tile.IsEmpty)
+        if (tileRef.Tile.IsEmpty || tileRef.IsSpace(_tileDefMan))
         {
             puddleUid = EntityUid.Invalid;
             return false;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![Peek 2023-07-04 19-46](https://github.com/space-wizards/space-station-14/assets/40753025/4b6d86a5-28b7-48be-82fe-44a32f5c73ee)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: puddles can no longer appear on space tiles (lattice)
