### PR TITLE
Extends the emergency shuttle timer to 20m green / 10m on blue

### DIFF
--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -5,11 +5,12 @@
     green:
       announcement: alert-level-green-announcement
       color: Green
-      shuttleTime: 600
+      shuttleTime: 1200
     blue:
       announcement: alert-level-blue-announcement
       sound: /Audio/Misc/bluealert.ogg
       color: DodgerBlue
+      shuttleTime: 600
     violet:
       announcement: alert-level-violet-announcement
       sound: /Audio/Misc/notice1.ogg
@@ -21,11 +22,12 @@
       sound: /Audio/Misc/notice1.ogg
       color: Yellow
       emergencyLightColor: Goldenrod
-      shuttleTime: 400
+      shuttleTime: 600
     red:
       announcement: alert-level-red-announcement
       sound: /Audio/Misc/redalert.ogg
       color: Red
+      shuttleTime: 600 #No reduction in time as we don't have swiping for red alert like in /tg/. Shuttle times are intended to create friction, so having a way to brainlessly bypass that would be dumb.
     gamma:
       announcement: alert-level-gamma-announcement
       selectable: false


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
What it says on the blue - extends the emergency shuttle timer to be 20 minutes on green alert, and 10 minutes on everything above it.

The 5 minute shuttle timer as it is right now is hilariously lame, and lets the crew bail out of any bad situation instantly.

10 minutes has been battletested in SS13 and should help increase friction for both antags and crew - forcing them to survive longer, and giving antags that feeling of the last-minute-sprint they need to do to complete their objectives before they leave.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The Emergency Shuttle will now take 20 minutes to arrive on green alert, and 10 minutes to arrive on blue alert.
- tweak: Alert levels above blue no longer decrease the amount of time it takes to leave.
