### PR TITLE
Communicate self-uncuff damage a bit more prominently

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.Pulling.Events;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Stunnable;
 using Content.Shared.Verbs;
+using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
@@ -591,6 +592,7 @@ namespace Content.Shared.Cuffs
 
                 if (target == user)
                 {
+                    RaiseNetworkEvent(new DamageEffectEvent(Color.Red, new List<EntityUid>() { user }));
                     _popup.PopupEntity(Loc.GetString("cuffable-component-start-uncuffing-self"), user, user);
                 }
                 else

--- a/Resources/Locale/en-US/cuffs/components/cuffable-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/cuffable-component.ftl
@@ -1,7 +1,7 @@
 cuffable-component-cannot-interact-message = You can't do that!
 cuffable-component-cannot-remove-cuffs-too-far-message = You are too far away to remove the cuffs.
 
-cuffable-component-start-uncuffing-self = You start uncuffing yourself.
+cuffable-component-start-uncuffing-self = You start to painfully wriggle out of your cuffs.
 cuffable-component-start-uncuffing-observer = {$user} starts uncuffing {$target}!
 cuffable-component-start-uncuffing-target-message = You start uncuffing {$targetName}.
 cuffable-component-start-uncuffing-by-other-message = {$otherName} starts uncuffing you!


### PR DESCRIPTION
## About the PR
Self-Uncuffing message shown to the user is now less neutral, and there is a single damage flash on their sprite. It is still possible for someone going full feral to uncuff-spam themselves to crit in moments, if they are so inclined

One concern, this might cause inexperienced players to cancel their uncuff attempt (if they even know how), thinking it will cause further damage if left to continue? The intent is not to _mislead_ players

**Media**

![image](https://github.com/space-wizards/space-station-14/assets/35878406/6b3654e3-b18e-4998-b770-f90b80ff8642)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.
You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.
For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->
:cl: Errant
- tweak: Made it more apparent to the player that starting to remove their handcuffs damaged them.