### PR TITLE
Removes space medipens from survival boxes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -4,13 +4,13 @@
   id: BoxSurvival
   description: It's a box with basic internals inside.
   components:
-  - type: Storage
-    capacity: 20
   - type: StorageFill
     contents:
       - id: ClothingMaskBreath
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: Flare
+      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -18,7 +18,7 @@
 
 - type: entity
   name: extended-capacity survival box
-  parent: BoxSurvival
+  parent: BoxCardboard
   id: BoxSurvivalEngineering
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
   components:
@@ -27,6 +27,8 @@
       - id: ClothingMaskBreath
       - id: ExtendedEmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: Flare
+      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -34,7 +36,7 @@
 
 - type: entity
   name: survival box
-  parent: BoxSurvival
+  parent: BoxCardboard
   id: BoxSurvivalSecurity
   description: It's a box with basic internals inside.
   suffix: Security
@@ -44,6 +46,8 @@
       - id: ClothingMaskGasSecurity
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: Flare
+      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -51,7 +55,7 @@
 
 - type: entity
   name: survival box
-  parent: BoxSurvival
+  parent: BoxCardboard
   id: BoxSurvivalBrigmedic
   description: It's a box with basic internals inside.
   suffix: Medical
@@ -62,6 +66,7 @@
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
       - id: EmergencyMedipen
+      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -69,7 +74,7 @@
 
 - type: entity
   name: survival box
-  parent: BoxSurvival
+  parent: BoxCardboard
   id: BoxSurvivalMedical
   description: It's a box with basic internals inside.
   suffix: Medical
@@ -79,6 +84,8 @@
       - id: ClothingMaskBreathMedical
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: Flare
+      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -86,7 +93,7 @@
 
 - type: entity
   name: box of hugs
-  parent: BoxSurvival
+  parent: BoxCardboard
   id: BoxHug
   description: A special box for sensitive people.
   components:
@@ -101,13 +108,15 @@
       - id: ClothingMaskBreath
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: Flare
+      - id: FoodTinMRE
   - type: Tag
     tags:
       - BoxHug
 
 - type: entity
   name: extended-capacity survival box
-  parent: BoxSurvival
+  parent: BoxCardboard
   id: BoxSurvivalSyndicate
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
   components:
@@ -116,6 +125,8 @@
       - id: ClothingMaskGasSyndicate
       - id: ExtendedEmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: Flare
+      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -4,14 +4,13 @@
   id: BoxSurvival
   description: It's a box with basic internals inside.
   components:
+  - type: Storage
+    capacity: 20
   - type: StorageFill
     contents:
       - id: ClothingMaskBreath
       - id: EmergencyOxygenTankFilled
-      - id: SpaceMedipen
       - id: EmergencyMedipen
-      - id: Flare
-      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -19,7 +18,7 @@
 
 - type: entity
   name: extended-capacity survival box
-  parent: BoxCardboard
+  parent: BoxSurvival
   id: BoxSurvivalEngineering
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
   components:
@@ -27,10 +26,7 @@
     contents:
       - id: ClothingMaskBreath
       - id: ExtendedEmergencyOxygenTankFilled
-      - id: SpaceMedipen
       - id: EmergencyMedipen
-      - id: Flare
-      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -38,7 +34,7 @@
 
 - type: entity
   name: survival box
-  parent: BoxCardboard
+  parent: BoxSurvival
   id: BoxSurvivalSecurity
   description: It's a box with basic internals inside.
   suffix: Security
@@ -47,10 +43,7 @@
     contents:
       - id: ClothingMaskGasSecurity
       - id: EmergencyOxygenTankFilled
-      - id: SpaceMedipen
       - id: EmergencyMedipen
-      - id: Flare
-      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -58,7 +51,7 @@
 
 - type: entity
   name: survival box
-  parent: BoxCardboard
+  parent: BoxSurvival
   id: BoxSurvivalBrigmedic
   description: It's a box with basic internals inside.
   suffix: Medical
@@ -67,10 +60,8 @@
     contents:
       - id: ClothingMaskBreathMedicalSecurity
       - id: EmergencyOxygenTankFilled
-      - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: EmergencyMedipen
-      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -78,7 +69,7 @@
 
 - type: entity
   name: survival box
-  parent: BoxCardboard
+  parent: BoxSurvival
   id: BoxSurvivalMedical
   description: It's a box with basic internals inside.
   suffix: Medical
@@ -87,10 +78,7 @@
     contents:
       - id: ClothingMaskBreathMedical
       - id: EmergencyOxygenTankFilled
-      - id: SpaceMedipen
       - id: EmergencyMedipen
-      - id: Flare
-      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
@@ -98,7 +86,7 @@
 
 - type: entity
   name: box of hugs
-  parent: BoxCardboard
+  parent: BoxSurvival
   id: BoxHug
   description: A special box for sensitive people.
   components:
@@ -112,17 +100,14 @@
     contents:
       - id: ClothingMaskBreath
       - id: EmergencyOxygenTankFilled
-      - id: SpaceMedipen
       - id: EmergencyMedipen
-      - id: Flare
-      - id: FoodTinMRE
   - type: Tag
     tags:
       - BoxHug
 
 - type: entity
   name: extended-capacity survival box
-  parent: BoxCardboard
+  parent: BoxSurvival
   id: BoxSurvivalSyndicate
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
   components:
@@ -130,10 +115,7 @@
     contents:
       - id: ClothingMaskGasSyndicate
       - id: ExtendedEmergencyOxygenTankFilled
-      - id: SpaceMedipen
       - id: EmergencyMedipen
-      - id: Flare
-      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals


### PR DESCRIPTION
## About the PR
What it says on the tin. Space medipens are a relic of the long-bygone era of hyper lethal spacing. Now that space doesn't murder you instantly, they're really not needed and basically just let you ignore spacing entirely for one use, which is pretty dumb and lets you get out of a lot of situations you probably shouldn't be able to.

Without all-access externals, this may suck balls and just lead to completely and utterly unsurvivable situations, but spacing is hilariously weak right now so it's probably at least worth testing. Pods are also of course intended to counter this exact situation - fingers crossed they'll actually be used now.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- remove: Due to budget cuts, the survival box no longer includes the space medipen. Nanotrasen suggests using the escape pods in situations where the departures lounge may now be unreachable.
