### PR TITLE
Fix mime wall & turf/tile helper issues.

### DIFF
--- a/Content.Server/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Server/Abilities/Mime/MimePowersSystem.cs
@@ -9,6 +9,8 @@ using Content.Shared.Mobs.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
 using Content.Server.Speech.Muting;
+using Robust.Shared.Containers;
+using Robust.Shared.Map;
 
 namespace Content.Server.Abilities.Mime
 {
@@ -19,7 +21,8 @@ namespace Content.Server.Abilities.Mime
         [Dependency] private readonly AlertsSystem _alertsSystem = default!;
         [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
         [Dependency] private readonly TurfSystem _turf = default!;
-
+        [Dependency] private readonly IMapManager _mapMan = default!;
+        [Dependency] private readonly SharedContainerSystem _container = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
 
         public override void Initialize()
@@ -62,11 +65,14 @@ namespace Content.Server.Abilities.Mime
             if (!component.Enabled)
                 return;
 
+            if (_container.IsEntityOrParentInContainer(uid))
+                return;
+
             var xform = Transform(uid);
             // Get the tile in front of the mime
-            var offsetValue = xform.LocalRotation.ToWorldVec().Normalized;
-            var coords = xform.Coordinates.Offset(offsetValue).SnapToGrid(EntityManager);
-            var tile = coords.GetTileRef();
+            var offsetValue = xform.LocalRotation.ToWorldVec();
+            var coords = xform.Coordinates.Offset(offsetValue).SnapToGrid(EntityManager, _mapMan);
+            var tile = coords.GetTileRef(EntityManager, _mapMan);
             if (tile == null)
                 return;
 
@@ -88,7 +94,7 @@ namespace Content.Server.Abilities.Mime
             }
             _popupSystem.PopupEntity(Loc.GetString("mime-invisible-wall-popup", ("mime", uid)), uid);
             // Make sure we set the invisible wall to despawn properly
-            Spawn(component.WallPrototype, coords);
+            Spawn(component.WallPrototype, _turf.GetTileCenter(tile.Value));
             // Handle args so cooldown works
             args.Handled = true;
         }

--- a/Content.Server/Chemistry/TileReactions/CreateEntityTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/CreateEntityTileReaction.cs
@@ -58,7 +58,8 @@ public sealed class CreateEntityTileReaction : ITileReaction
             var xoffs = random.NextFloat(-RandomOffsetMax, RandomOffsetMax);
             var yoffs = random.NextFloat(-RandomOffsetMax, RandomOffsetMax);
 
-            var pos = tile.GridPosition().Offset(new Vector2(0.5f + xoffs, 0.5f + yoffs));
+            var center = entMan.System<TurfSystem>().GetTileCenter(tile);
+            var pos = center.Offset(new Vector2(xoffs, yoffs));
             entMan.SpawnEntity(Entity, pos);
 
             return Usage;

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
@@ -80,7 +80,7 @@ public sealed partial class ExplosionSystem : EntitySystem
         HashSet<EntityUid> encounteredGrids = new();
         Dictionary<EntityUid, HashSet<Vector2i>>? previousGridJump;
 
-        // variables for transforming between grid and space-coordiantes
+        // variables for transforming between grid and space-coordinates
         var spaceMatrix = Matrix3.Identity;
         var spaceAngle = Angle.Zero;
         if (referenceGrid != null)

--- a/Content.Server/Maps/TileSystem.cs
+++ b/Content.Server/Maps/TileSystem.cs
@@ -17,6 +17,7 @@ public sealed class TileSystem : EntitySystem
     [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly DecalSystem _decal = default!;
+    [Dependency] private readonly TurfSystem _turf = default!;
 
     public bool PryTile(Vector2i indices, EntityUid gridId)
     {
@@ -68,7 +69,7 @@ public sealed class TileSystem : EntitySystem
             return false;
 
         var variant = _robustRandom.Pick(replacementTile.PlacementVariants);
-        var decals = _decal.GetDecalsInRange(tileref.GridUid, tileref.GridPosition().SnapToGrid(EntityManager, _mapManager).Position, 0.5f);
+        var decals = _decal.GetDecalsInRange(tileref.GridUid, _turf.GetTileCenter(tileref).Position, 0.5f);
         foreach (var (id, _) in decals)
         {
             _decal.RemoveDecal(tileref.GridUid, id);

--- a/Content.Server/Respawn/SpecialRespawnSystem.cs
+++ b/Content.Server/Respawn/SpecialRespawnSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.Database;
 using Content.Shared.Maps;
+using Content.Shared.Physics;
 using Content.Shared.Respawn;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
@@ -19,7 +20,7 @@ public sealed class SpecialRespawnSystem : SharedSpecialRespawnSystem
     [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly TurfSystem _turf = default!;
     [Dependency] private readonly IChatManager _chat = default!;
 
     public override void Initialize()
@@ -100,10 +101,15 @@ public sealed class SpecialRespawnSystem : SharedSpecialRespawnSystem
 
             foreach (var tile in grid.GetTilesIntersecting(circle))
             {
-                if (tile.IsSpace(_tileDefinitionManager) || tile.IsBlockedTurf(true) || !_atmosphere.IsTileMixtureProbablySafe(entityGridUid, entityMapUid.Value, grid.TileIndicesFor(mapPos)))
+                if (tile.IsSpace(_tileDefinitionManager)
+                    || _turf.IsTileBlocked(tile, CollisionGroup.MobMask)
+                    || !_atmosphere.IsTileMixtureProbablySafe(entityGridUid, entityMapUid.Value,
+                        grid.TileIndicesFor(mapPos)))
+                {
                     continue;
+                }
 
-                pos = tile.GridPosition();
+                pos = _turf.GetTileCenter(tile);
                 found = true;
 
                 if (found)

--- a/Content.Server/Tools/ToolSystem.TilePrying.cs
+++ b/Content.Server/Tools/ToolSystem.TilePrying.cs
@@ -1,17 +1,10 @@
-using System.Threading;
-using Content.Server.Fluids.Components;
 using Content.Server.Tools.Components;
-using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
-using Content.Shared.DoAfter;
 using Content.Shared.Fluids.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Tools.Components;
-using Robust.Shared.Audio;
 using Robust.Shared.Map;
-using Robust.Shared.Player;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Tools;
 
@@ -41,20 +34,21 @@ public sealed partial class ToolSystem
         var gridUid = args.Coordinates.GetGridUid(EntityManager);
         if (!_mapManager.TryGetGrid(gridUid, out var grid))
         {
-            Logger.Error("Attempted to pry from a non-existent grid?");
+            Log.Error("Attempted to pry from a non-existent grid?");
             return;
         }
 
         var tile = grid.GetTileRef(args.Coordinates);
+        var center = _turf.GetTileCenter(tile);
         if (args.Used != null)
         {
             _adminLogger.Add(LogType.Action, LogImpact.Low,
-                $"{ToPrettyString(args.User):actor} used {ToPrettyString(args.Used.Value):tool} to pry {_tileDefinitionManager[tile.Tile.TypeId].Name} at {ToPrettyString(tile.GridUid):grid} {tile.GridPosition()}");
+                $"{ToPrettyString(args.User):actor} used {ToPrettyString(args.Used.Value):tool} to pry {_tileDefinitionManager[tile.Tile.TypeId].Name} at {center}");
         }
         else
         {
             _adminLogger.Add(LogType.Action, LogImpact.Low,
-                $"{ToPrettyString(args.User):actor} pried {_tileDefinitionManager[tile.Tile.TypeId].Name} at {ToPrettyString(tile.GridUid):grid} {tile.GridPosition()}");
+                $"{ToPrettyString(args.User):actor} pried {_tileDefinitionManager[tile.Tile.TypeId].Name} at {center}");
         }
 
         _tile.PryTile(tile);

--- a/Content.Server/Tools/ToolSystem.cs
+++ b/Content.Server/Tools/ToolSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Popups;
 using Content.Server.Tools.Components;
+using Content.Shared.Maps;
 using Content.Shared.Tools;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
@@ -17,6 +18,7 @@ namespace Content.Server.Tools
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly TransformSystem _transformSystem = default!;
+        [Dependency] private readonly TurfSystem _turf = default!;
 
         public override void Initialize()
         {

--- a/Content.Shared/Coordinates/Helpers/SnapgridHelper.cs
+++ b/Content.Shared/Coordinates/Helpers/SnapgridHelper.cs
@@ -9,22 +9,25 @@ namespace Content.Shared.Coordinates.Helpers
         {
             IoCManager.Resolve(ref entMan, ref mapManager);
 
-            var gridIdOpt = coordinates.GetGridUid(entMan);
+            var gridId = coordinates.GetGridUid(entMan);
 
-            var tileSize = 1f;
-
-            if (gridIdOpt is EntityUid gridId && gridId.IsValid())
+            if (gridId == null)
             {
-                var grid = mapManager.GetGrid(gridId);
-                tileSize = grid.TileSize;
+                var xformSys = entMan.System<SharedTransformSystem>();
+                var mapPos = coordinates.ToMap(entMan, xformSys);
+                var mapX = (int)Math.Floor(mapPos.X) + 0.5f;
+                var mapY = (int)Math.Floor(mapPos.Y) + 0.5f;
+                mapPos = new MapCoordinates(new Vector2(mapX, mapY), mapPos.MapId);
+                return EntityCoordinates.FromMap(coordinates.EntityId, mapPos, xformSys);
             }
 
-            var localPos = coordinates.Position;
-
+            var grid = mapManager.GetGrid(gridId.Value);
+            var tileSize = grid.TileSize;
+            var localPos = coordinates.WithEntityId(gridId.Value).Position;
             var x = (int)Math.Floor(localPos.X / tileSize) + tileSize / 2f;
             var y = (int)Math.Floor(localPos.Y / tileSize) + tileSize / 2f;
-
-            return new EntityCoordinates(coordinates.EntityId, x, y);
+            var gridPos = new EntityCoordinates(gridId.Value, new Vector2(x, y));
+            return gridPos.WithEntityId(coordinates.EntityId);
         }
 
         public static EntityCoordinates SnapToGrid(this EntityCoordinates coordinates, MapGridComponent grid)

--- a/Content.Shared/Maps/TurfHelpers.cs
+++ b/Content.Shared/Maps/TurfHelpers.cs
@@ -140,13 +140,6 @@ namespace Content.Shared.Maps
             return IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<TurfSystem>().IsTileBlocked(turf, mask);
         }
 
-        public static EntityCoordinates GridPosition(this TileRef turf, IMapManager? mapManager = null)
-        {
-            mapManager ??= IoCManager.Resolve<IMapManager>();
-
-            return turf.GridIndices.ToEntityCoordinates(turf.GridUid, mapManager);
-        }
-
         /// <summary>
         /// Creates a box the size of a tile, at the same position in the world as the tile.
         /// </summary>

--- a/Content.Shared/Maps/TurfSystem.cs
+++ b/Content.Shared/Maps/TurfSystem.cs
@@ -12,6 +12,7 @@ public sealed class TurfSystem : EntitySystem
 {
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly IMapManager _mapMan = default!;
 
     /// <summary>
     ///     Returns true if a given tile is blocked by physics-enabled entities.
@@ -83,5 +84,15 @@ public sealed class TurfSystem : EntitySystem
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Returns the location of the centre of the tile in grid coordinates.
+    /// </summary>
+    public EntityCoordinates GetTileCenter(TileRef turf)
+    {
+        var grid = _mapMan.GetGrid(turf.GridUid);
+        var center = (turf.GridIndices + new Vector2(0.5f, 0.5f)) * grid.TileSize;
+        return new EntityCoordinates(turf.GridUid, center);
     }
 }


### PR DESCRIPTION
- Mime walls are no longer placeable while inside of a container. They should also always spawn attached to the grid or map, instead of attached to the mime's parent.
- Replaces `TurfHelpers.GridPosition()` with `TurfSystem.GetTileCenter()`. The new method also returns the centre of the tile, rather than the corner.
- `SnapgridHelper.SnapToGrid()` should now actually snap to the grid or map if an entity is not directly parented to a grid. Previously it was just snapping local positions.

Fixes #17634
Fixes #15129

:cl:
- fix: Mimes can no longer create invisible walls while inside of containers or vehicles.
