### PR TITLE
Make containment field generator non-rotatable

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
@@ -4,14 +4,12 @@
   name: containment field generator
   description: A machine that generates a containment field when powered by an emitter. Keeps the Singularity docile.
   components:
-  - type: Transform
-    noRot: true
   - type: Fixtures
     fixtures:
       fix1:
         shape:
-          !type:PhysShapeAabb
-          bounds: "-0.30,-0.45,0.30,0.45"
+          !type:PhysShapeCircle
+          radius: 0.4
         density: 190
         mask:
         - FullTileMask

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
@@ -4,12 +4,14 @@
   name: containment field generator
   description: A machine that generates a containment field when powered by an emitter. Keeps the Singularity docile.
   components:
+  - type: Transform
+    noRot: true
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.45,-0.45,0.45,0.45"
+          bounds: "-0.30,-0.45,0.30,0.45"
         density: 190
         mask:
         - FullTileMask


### PR DESCRIPTION

## Make containment field generator non-rotatable

The title speaks for itself. Generators can get stuck in small corridors due to the fact that their shape has been rotated. This PR fixes this and also makes them smaller so that their shape matches the sprite.

**Media**

https://github.com/space-wizards/space-station-14/assets/38111072/8ad6f405-ebd5-4c3c-a6a6-01644a43a7ad

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: kseandi
- fix: NanoTrasen has created more compact singularity field generators that will no longer get stuck in airlocks.