### PR TITLE
Add chem solution atmos heating and cooling

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -31,7 +31,7 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly TileSystem _tile = default!;
 
-    private const float ExposedUpdateDelay = 1f;
+    public const float ExposedUpdateDelay = 1f;
     private float _exposedTimer = 0f;
 
     public override void Initialize()

--- a/Content.Server/Chemistry/Components/SolutionManager/SolutionGasHeatConductivityComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionManager/SolutionGasHeatConductivityComponent.cs
@@ -1,0 +1,22 @@
+namespace Content.Server.Chemistry.Components.SolutionManager;
+
+/// <summary>
+/// Lets the solution conduct heat to/from atmos gases.
+/// </summary>
+[RegisterComponent]
+public sealed class SolutionGasHeatConductivityComponent : Component
+{
+    /// <summary>
+    /// Solution that conducts heat.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("solution")]
+    public string Solution { get; set; } = "default";
+
+    /// <summary>
+    /// The heat conductivity between the gas and solution.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("wattsPerKelvin")]
+    public float WattsPerKelvin = 1;
+}

--- a/Content.Server/Chemistry/EntitySystems/SolutionGasHeatConductivitySystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionGasHeatConductivitySystem.cs
@@ -1,0 +1,45 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Chemistry.Components.SolutionManager;
+using Robust.Server.GameObjects;
+
+namespace Content.Server.Chemistry.EntitySystems;
+
+public sealed class SolutionGasHeatConductivitySystem : EntitySystem
+{
+    [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
+    [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
+    [Dependency] private readonly TransformSystem _transformSystem = default!;
+
+    /// <inheritdoc/>
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<SolutionContainerManagerComponent, SolutionGasHeatConductivityComponent>();
+        while (query.MoveNext(out var uid, out var solutionContainer, out var solutionGasHeatConductivity))
+        {
+            if (!_solutionContainerSystem.TryGetSolution(uid, solutionGasHeatConductivity.Solution, out var solution) || solution.Volume == 0)
+                continue;
+
+            var tf = Transform(uid);
+            var grid = tf.GridUid;
+            var map = tf.MapUid;
+            var indices = _transformSystem.GetGridOrMapTilePosition(uid, tf);
+            var mixture = _atmosphereSystem.GetTileMixture(grid, map, indices);
+
+            if (mixture is null)
+                continue;
+
+            var heatDifferentialKelvin = mixture.Temperature - solution.Temperature;
+            if (Math.Abs(heatDifferentialKelvin) < 0.5)
+                continue; // close enough
+
+            var thermalEnergyTransferWatts = heatDifferentialKelvin * solutionGasHeatConductivity.WattsPerKelvin;
+            var thermalEnergyTransferJoules = thermalEnergyTransferWatts * frameTime;
+
+            _solutionContainerSystem.AddThermalEnergy(uid, solution, thermalEnergyTransferJoules);
+            var gasHeatCapacity = _atmosphereSystem.GetHeatCapacity(mixture);
+            mixture.Temperature += gasHeatCapacity == 0 ? 0 : -thermalEnergyTransferJoules / gasHeatCapacity;
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -142,6 +142,9 @@
     - type: SolutionContainerManager
       solutions:
         puddle: { maxVol: 1000 }
+    - type: AtmosExposed
+    - type: SolutionGasHeatConductivity
+      solution: puddle
     - type: Puddle
     - type: Appearance
     - type: EdgeSpreader

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -30,6 +30,8 @@
     solution: drink
   - type: DrainableSolution
     solution: drink
+  - type: SolutionGasHeatConductivity
+    solution: drink
   - type: UserInterface
     interfaces:
     - key: enum.TransferAmountUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -30,6 +30,7 @@
     solution: drink
   - type: DrainableSolution
     solution: drink
+  - type: AtmosExposed
   - type: SolutionGasHeatConductivity
     solution: drink
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -34,6 +34,8 @@
     solution: drink
   - type: DrainableSolution
     solution: drink
+  - type: SolutionGasHeatConductivity
+    solution: drink
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -34,6 +34,7 @@
     solution: drink
   - type: DrainableSolution
     solution: drink
+  - type: AtmosExposed
   - type: SolutionGasHeatConductivity
     solution: drink
   - type: Appearance

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -21,6 +21,8 @@
   - type: SolutionTransfer
     canChangeTransferAmount: true
     maxTransferAmount: 10
+  - type: SolutionGasHeatConductivity
+    solution: drink
   - type: UserInterface
     interfaces:
     - key: enum.TransferAmountUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -21,6 +21,7 @@
   - type: SolutionTransfer
     canChangeTransferAmount: true
     maxTransferAmount: 10
+  - type: AtmosExposed
   - type: SolutionGasHeatConductivity
     solution: drink
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
@@ -22,6 +22,8 @@
     canChangeTransferAmount: true
   - type: Spillable
     solution: drink
+  - type: SolutionGasHeatConductivity
+    solution: drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/shaker.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
@@ -22,6 +22,7 @@
     canChangeTransferAmount: true
   - type: Spillable
     solution: drink
+  - type: AtmosExposed
   - type: SolutionGasHeatConductivity
     solution: drink
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -33,6 +33,7 @@
     solution: drink
   - type: DrainableSolution
     solution: drink
+  - type: AtmosExposed
   - type: SolutionGasHeatConductivity
     solution: drink
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -33,6 +33,8 @@
     solution: drink
   - type: DrainableSolution
     solution: drink
+  - type: SolutionGasHeatConductivity
+    solution: drink
   - type: UserInterface
     interfaces:
     - key: enum.TransferAmountUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -40,6 +40,7 @@
     solution: beaker
   - type: SolutionTransfer
     canChangeTransferAmount: true
+  - type: AtmosExposed
   - type: SolutionGasHeatConductivity
     solution: beaker
   - type: UserInterface
@@ -133,6 +134,7 @@
     solution: beaker
   - type: SolutionTransfer
     canChangeTransferAmount: true
+  - type: AtmosExposed
   - type: SolutionGasHeatConductivity
     solution: beaker
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -40,6 +40,8 @@
     solution: beaker
   - type: SolutionTransfer
     canChangeTransferAmount: true
+  - type: SolutionGasHeatConductivity
+    solution: beaker
   - type: UserInterface
     interfaces:
     - key: enum.TransferAmountUiKey.Key
@@ -131,6 +133,8 @@
     solution: beaker
   - type: SolutionTransfer
     canChangeTransferAmount: true
+  - type: SolutionGasHeatConductivity
+    solution: beaker
   - type: UserInterface
     interfaces:
     - key: enum.TransferAmountUiKey.Key


### PR DESCRIPTION
Chem solutions now conduct heat between atmos gases.

## About the PR
- Adds `SolutionGasHeatConductivityComponent`/`System`. Every container with `FitsInDispenserComponent` has this component.
- Follows first law of thermodynamics. When solution is heated, gas mix will lose the same amount of thermal energy that the solution gains, and vice versa.
- ~~Puddles don't have this yet, because I'm not sure if it will lag due to large amount of puddle entities.~~ Puddles now also have it since now it only updates every second.

**Media**
https://github.com/space-wizards/space-station-14/assets/48867431/3e425a9a-9c84-49eb-bbb8-2662e7b2112d

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Thermal conductivity between chemistry solutions and atmos gases has been implemented.
