### PR TITLE
Adds ExaminableSolution to jani trolley

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -290,6 +290,8 @@
       solution: bucket
     - type: RefillableSolution
       solution: bucket
+    - type: ExaminableSolution
+      solution: bucket
     - type: Tag
       tags:
         - Wringer


### PR DESCRIPTION
## About the PR
1 more small QoL tweak for the jani trolley. Adds the examinable solution comp to bring it in-line with the bucket and other open-top liquid containers.


**Media**
Before:
![image](https://github.com/space-wizards/space-station-14/assets/107660393/21a80440-f9bf-45b5-b9c7-8aa7696f8565)
After:
![image](https://github.com/space-wizards/space-station-14/assets/107660393/0134c126-4200-4145-829c-29054cf52d6c)


- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

**Changelog**

:cl: Velcroboy
- add: After an anomalous event swept through NT stations throughout the galaxy, NT workers have gained the sudden ability to see the contents inside of the custodial trolley reservoirs. 
