### PR TITLE
Adds power draw to small lights

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -89,6 +89,7 @@
     lightEnergy: 1.0
     lightRadius: 6
     lightSoftness: 1.1
+    PowerUse: 15
 
 - type: entity
   parent: BaseLightTube


### PR DESCRIPTION
## About the PR
Adds power use to small lights as it seems to be missing.


**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

**Changelog**

:cl: Velcroboy
- fix: After NT officials determined the magic, energy-free light bulbs they were using were the cause of several mass-delusion outbreaks, they have switched to the ancient technology of incandescent in an overabundance of caution. Expect energy bills to rise accordingly.  
