### PR TITLE
clarify execution requirements

### DIFF
--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -90,6 +90,6 @@ Security/Command will be expected to answer for use of lethal force. Security/Co
     - Brig times should generally not exceed 10 minutes unless the crime is permabriggable. Repeat offenders or antagonists may be permabrigged.
     - Security may choose to confiscate dangerous items (weapons, firearms) as well as items used to commission crimes or items that prove problematic in possession of the detainee (tools, insulated gloves, etc.).
     - Detainees that die in your custody must be cloned unless they have been (legally) executed, suicide, or there is strong reason to believe they are an antagonist.
-    - Executions must be for a permabriggable crime and approved by the Captain/Acting Captain, who will answer for approving it alongside Security's chain of command. Those who willingly attempt to damage/destroy or escape from the permabrig may be executed.
+    - Executions must be for a permabriggable crime, used only as a last resort, and approved by the Captain/Acting Captain, who will answer for approving it alongside Security's chain of command. Those who willingly attempt to damage/destroy or escape from the permabrig may be executed.
     - Detainees in the brig have the right to know what they are being charged with, as well as basic medical aid, at least to the point they are no longer at risk of dying.
     As there is no space law, Security/Command acts to maintain the safety of the station and its inhabitants, as well as Nanotrasen assets.


### PR DESCRIPTION
Detailed rules include
> Executions should be a last resort if the prisoner cannot be safely contained, or for particularly destructive or damaging crimes.

The current LRP in-game rules are potentially misleading about execution requirements.