### PR TITLE
Nukie rounds are higher quality with more practiced operators, zombie rounds should be rarer due to it being a literal apocalypse

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,6 +1,6 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.15
+    Nukeops: 0.25
     Traitor: 0.70
-    Zombie: 0.15
+    Zombie: 0.05


### PR DESCRIPTION
Right now the nukie winrate is super low, but not because they are not inherently powerful enough. On average >50% of the nukie team is new to being a nukie, which can be fixed by having more nukie rounds. With more people more practiced, more interesting rounds can occur.

Changelog

🆑
tweak: Changed game mode weights to make nukeops more common and zombies less common.