### PR TITLE
Xeno salvage tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/xeno.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/xeno.yml
@@ -15,6 +15,8 @@
       Heat:
         collection:
           MeatLaserImpact
+  - type: Transform
+    anchored: true
   - type: Clickable
   - type: InteractionOutline
   - type: Sprite

--- a/Resources/Prototypes/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/Procedural/salvage_factions.yml
@@ -18,6 +18,10 @@
       maxAmount: 2
     prob: 0.25
   - entries:
+    - id: WeaponTurretXeno
+      amount: 3
+    prob: 0.25
+  - entries:
     - id: MobXenoRavager
       amount: 1
     prob: 0.1


### PR DESCRIPTION
- Add turret spawns.
- Mark warding tower as anchored.

:cl:
- add: Added xeno turrets to salvage dungeons.
