### PR TITLE
NPC steering tweaks

### DIFF
--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -48,7 +48,7 @@ public sealed class NPCSteeringComponent : Component
     [DataField("lastSteerDirection")]
     public Vector2 LastSteerDirection = Vector2.Zero;
 
-    public const int SteeringFrequency = 10;
+    public const int SteeringFrequency = 5;
 
     /// <summary>
     /// Last position we considered for being stuck.

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -382,7 +382,7 @@ public sealed partial class NPCSteeringSystem
         TransformComponent xform,
         float[] danger)
     {
-        var objectRadius = 0.15f;
+        var objectRadius = 0.10f;
         var detectionRadius = MathF.Max(0.35f, agentRadius + objectRadius);
 
         foreach (var ent in _lookup.GetEntitiesInRange(uid, detectionRadius, LookupFlags.Static))


### PR DESCRIPTION
- Slightly less twitchy in melee.
- Resteer less.
- More aggressive in pursuing running away targets.

:cl:
- tweak: Tweak NPC steering slightly to make them slightly less twitchy.