### PR TITLE
Fix high UI scale chat box layout.

### DIFF
--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
@@ -29,7 +29,7 @@
 
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" SeparationOverride="10" Margin="10">
                 <menuBar:GameTopMenuBar Name="TopBar" HorizontalExpand="True" Access="Protected" />
-                <chat:ChatBox VerticalExpand="True" HorizontalExpand="True" Name="Chat" Access="Protected" />
+                <chat:ChatBox VerticalExpand="True" HorizontalExpand="True" Name="Chat" Access="Protected" MinSize="0 0"/>
             </BoxContainer>
         </PanelContainer>
     </controls:RecordedSplitContainer>


### PR DESCRIPTION
Make high UI scale chat slightly better when the window is too small. The rest of the UI is still scuffed when the window is too small, it just makes it slightly better.

Before:
![Content Client_Fyuz3F2orQ](https://github.com/space-wizards/space-station-14/assets/60421075/5e05f3e6-2be6-4fd4-85ee-002d494f45d9)

After:
![Content Client_K4eSZrS9lz](https://github.com/space-wizards/space-station-14/assets/60421075/92cc3a5c-31b9-407b-9823-a6c45aca720e)
