### PR TITLE
ERT role restrictions

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -23,6 +23,18 @@
     - type: GhostRole
       name: ghost-role-information-ert-leader-name
       description: ghost-role-information-ert-leader-description
+      requirements:
+        - !type:OverallPlaytimeRequirement
+          time: 36000 # 10 hrs
+        - !type:DepartmentTimeRequirement
+          department: Security
+          time: 10800 # 3 hrs
+        - !type:DepartmentTimeRequirement
+          department: Command
+          time: 10800 # 3 hrs
+        - !type:DepartmentTimeRequirement
+          department: Engineering
+          time: 10800 # 3 hrs
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTLeaderGear ]
@@ -47,9 +59,6 @@
   id: ERTLeaderEVA
   parent: ERTLeader
   components:
-    - type: GhostRole
-      name: ghost-role-information-ert-leader-name
-      description: ghost-role-information-ert-leader-description
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTLeaderGearEVA ]
@@ -78,6 +87,12 @@
     - type: GhostRole
       name: ghost-role-information-ert-janitor-name
       description: ghost-role-information-ert-janitor-description
+      requirements:
+        - !type:OverallPlaytimeRequirement
+          time: 36000 # 10 hrs
+        - !type:RoleTimeRequirement
+          role: JobJanitor
+          time: 10800 # 3 hrs
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:
@@ -102,9 +117,6 @@
   id: ERTJanitorEVA
   parent: ERTJanitor
   components:
-    - type: GhostRole
-      name: ghost-role-information-ert-janitor-name
-      description: ghost-role-information-ert-janitor-description
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTJanitorGearEVA ]
@@ -133,6 +145,12 @@
     - type: GhostRole
       name: ghost-role-information-ert-engineer-name
       description: ghost-role-information-ert-engineer-description
+      requirements:
+        - !type:OverallPlaytimeRequirement
+          time: 36000 # 10 hrs
+        - !type:DepartmentTimeRequirement
+          department: Engineering
+          time: 10800 # 3 hrs
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:
@@ -157,9 +175,6 @@
   id: ERTEngineerEVA
   parent: ERTEngineer
   components:
-    - type: GhostRole
-      name: ghost-role-information-ert-engineer-name
-      description: ghost-role-information-ert-engineer-description
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTEngineerGearEVA ]
@@ -188,6 +203,12 @@
     - type: GhostRole
       name: ghost-role-information-ert-security-name
       description: ghost-role-information-ert-security-description
+      requirements:
+        - !type:OverallPlaytimeRequirement
+          time: 36000 # 10 hrs
+        - !type:DepartmentTimeRequirement
+          department: Security
+          time: 10800 # 3 hrs
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:
@@ -212,9 +233,6 @@
   id: ERTSecurityEVA
   parent: ERTSecurity
   components:
-    - type: GhostRole
-      name: ghost-role-information-ert-security-name
-      description: ghost-role-information-ert-security-description
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTSecurityGearEVA ]
@@ -243,6 +261,12 @@
     - type: GhostRole
       name: ghost-role-information-ert-medical-name
       description: ghost-role-information-ert-medical-description
+      requirements:
+        - !type:OverallPlaytimeRequirement
+          time: 36000 # 10 hrs
+        - !type:DepartmentTimeRequirement
+          department: Medical
+          time: 10800 # 3 hrs
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:
@@ -267,9 +291,6 @@
   id: ERTMedicalEVA
   parent: ERTMedical
   components:
-    - type: GhostRole
-      name: ghost-role-information-ert-medical-name
-      description: ghost-role-information-ert-medical-description
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTMedicalGearEVA ]
@@ -294,6 +315,12 @@
     - type: GhostRole
       name: ghost-role-information-cburn-agent-name
       description: ghost-role-information-cburn-agent-description
+      requirements:
+        - !type:OverallPlaytimeRequirement
+          time: 36000 # 10h
+        - !type:DepartmentTimeRequirement
+          department: Security
+          time: 18000 # 5 hrs
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Why give the opportunity to play for roles with full access to random assistants who died from the clown at the beginning of the round and were the first to click on the role?
Obviously the engineers have to play enough in the engineering department, the medics in the medical department, the leaders in the command, the cleaners for the cleaners and the security officers in the security.

Depends:
https://github.com/space-wizards/space-station-14/pull/17925

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: VigersRay
- tweak: ERT ghost roles now require a certain amount of time on their respective roles.
