### PR TITLE
Nukes role restrictions

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -4,6 +4,15 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-objective
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 90000 # 25h
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 18000 # 5h
+  - !type:DepartmentTimeRequirement
+    department: Command
+    time: 18000 # 5h
 
 - type: antag
   id: NukeopsMedic
@@ -11,6 +20,12 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-agent-objective
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 90000 # 25h
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 18000 # 5h
 
 - type: antag
   id: NukeopsCommander
@@ -18,3 +33,9 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-commander-objective
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 90000 # 25h
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 18000 # 5h


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
If you don't know how to turn on the harm mod, you don't play nukers.
The leader must play 5 hours in command and sec department, he must be able to lead and fight. 
Medic must play 5 hours in the medical department, he must be able to heal.
A standard nuker should also play 5 hours in sec department. 
And to know the general aspects of the game, all hes need to play 25 hours.

Depends:
https://github.com/space-wizards/space-station-14/pull/17928

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: VigersRay
- tweak: The syndicate began to recruit more experienced people into the ranks of nuclear operatives.