### PR TITLE
Significantly improve NPC steering

### DIFF
--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -45,6 +45,9 @@ public sealed class NPCSteeringComponent : Component
     [DataField("nextSteer", customTypeSerializer:typeof(TimeOffsetSerializer))]
     public TimeSpan NextSteer = TimeSpan.Zero;
 
+    [DataField("lastSteerIndex")]
+    public int LastSteerIndex = -1;
+
     [DataField("lastSteerDirection")]
     public Vector2 LastSteerDirection = Vector2.Zero;
 

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -146,7 +146,7 @@ public sealed class MoveToOperator : HTNOperator
                 _steering.PrunePath(uid, mapCoords, targetCoordinates.ToMapPos(_entManager, _transform) - mapCoords.Position, result.Path);
             }
 
-            comp.CurrentPath = result.Path;
+            comp.CurrentPath = new Queue<PathPoly>(result.Path);
         }
     }
 

--- a/Content.Server/NPC/Pathfinding/PathRequest.cs
+++ b/Content.Server/NPC/Pathfinding/PathRequest.cs
@@ -17,7 +17,7 @@ public abstract class PathRequest
     public Task<PathResult> Task => Tcs.Task;
     public readonly TaskCompletionSource<PathResult> Tcs;
 
-    public Queue<PathPoly> Polys = new();
+    public List<PathPoly> Polys = new();
 
     public bool Started = false;
 
@@ -103,9 +103,9 @@ public sealed class BFSPathRequest : PathRequest
 public sealed class PathResultEvent
 {
     public PathResult Result;
-    public readonly Queue<PathPoly> Path;
+    public readonly List<PathPoly> Path;
 
-    public PathResultEvent(PathResult result, Queue<PathPoly> path)
+    public PathResultEvent(PathResult result, List<PathPoly> path)
     {
         Result = result;
         Path = path;

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Common.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Common.cs
@@ -24,7 +24,7 @@ public sealed partial class PathfindingSystem
 
     private static readonly PathComparer PathPolyComparer = new();
 
-    private Queue<PathPoly> ReconstructPath(Dictionary<PathPoly, PathPoly> path, PathPoly currentNodeRef)
+    private List<PathPoly> ReconstructPath(Dictionary<PathPoly, PathPoly> path, PathPoly currentNodeRef)
     {
         var running = new List<PathPoly> { currentNodeRef };
         while (path.ContainsKey(currentNodeRef))
@@ -35,10 +35,8 @@ public sealed partial class PathfindingSystem
             running.Add(currentNodeRef);
         }
 
-        running = Simplify(running);
         running.Reverse();
-        var result = new Queue<PathPoly>(running);
-        return result;
+        return running;
     }
 
     private float GetTileCost(PathRequest request, PathPoly start, PathPoly end)

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -238,7 +238,7 @@ namespace Content.Server.NPC.Pathfinding
             PathFlags flags = PathFlags.None)
         {
             if (!TryComp<TransformComponent>(entity, out var start))
-                return new PathResultEvent(PathResult.NoPath, new Queue<PathPoly>());
+                return new PathResultEvent(PathResult.NoPath, new List<PathPoly>());
 
             var layer = 0;
             var mask = 0;
@@ -252,7 +252,7 @@ namespace Content.Server.NPC.Pathfinding
             var path = await GetPath(request);
 
             if (path.Result != PathResult.Path)
-                return new PathResultEvent(PathResult.NoPath, new Queue<PathPoly>());
+                return new PathResultEvent(PathResult.NoPath, new List<PathPoly>());
 
             return new PathResultEvent(PathResult.Path, path.Path);
         }
@@ -280,14 +280,13 @@ namespace Content.Server.NPC.Pathfinding
                 return 0f;
 
             var distance = 0f;
-            var node = path.Path.Dequeue();
-            var lastNode = node;
+            var lastNode = path.Path[0];
 
-            do
+            for (var i = 1; i < path.Path.Count; i++)
             {
+                var node = path.Path[i];
                 distance += GetTileCost(request, lastNode, node);
-                lastNode = node;
-            } while (path.Path.TryDequeue(out node));
+            }
 
             return distance;
         }
@@ -301,7 +300,7 @@ namespace Content.Server.NPC.Pathfinding
         {
             if (!TryComp<TransformComponent>(entity, out var xform) ||
                 !TryComp<TransformComponent>(target, out var targetXform))
-                return new PathResultEvent(PathResult.NoPath, new Queue<PathPoly>());
+                return new PathResultEvent(PathResult.NoPath, new List<PathPoly>());
 
             var request = GetRequest(entity, xform.Coordinates, targetXform.Coordinates, range, cancelToken, flags);
             return await GetPath(request);
@@ -471,7 +470,7 @@ namespace Content.Server.NPC.Pathfinding
 
             if (!request.Task.IsCompletedSuccessfully)
             {
-                return new PathResultEvent(PathResult.NoPath, new Queue<PathPoly>());
+                return new PathResultEvent(PathResult.NoPath, new List<PathPoly>());
             }
 
             // Same context as do_after and not synchronously blocking soooo

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -368,6 +368,12 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
 
         Separation(uid, offsetRot, worldPos, agentRadius, layer, mask, body, xform, danger);
 
+        // Prioritise whichever direction we went last tick if it's a tie-breaker.
+        if (steering.LastSteerIndex != -1)
+        {
+            interest[steering.LastSteerIndex] *= 1.1f;
+        }
+
         // Remove the danger map from the interest map.
         var desiredDirection = -1;
         var desiredValue = 0f;
@@ -392,6 +398,7 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
 
         steering.NextSteer = curTime + TimeSpan.FromSeconds(1f / NPCSteeringComponent.SteeringFrequency);
         steering.LastSteerDirection = resultDirection;
+        steering.LastSteerIndex = desiredDirection;
         DebugTools.Assert(!float.IsNaN(resultDirection.X));
         SetDirection(mover, steering, resultDirection, false);
     }
@@ -425,14 +432,6 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
             _interaction.InRangeUnobstructed(uid, steering.Coordinates.EntityId, range: 30f, (CollisionGroup) physics.CollisionMask))
         {
             steering.CurrentPath.Clear();
-            // Enqueue our poly as it will be pruned later.
-            var ourPoly = _pathfindingSystem.GetPoly(xform.Coordinates);
-
-            if (ourPoly != null)
-            {
-                steering.CurrentPath.Enqueue(ourPoly);
-            }
-
             steering.CurrentPath.Enqueue(targetPoly);
             return;
         }
@@ -468,7 +467,7 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
         var ourPos = xform.MapPosition;
 
         PrunePath(uid, ourPos, targetPos.Position - ourPos.Position, result.Path);
-        steering.CurrentPath = result.Path;
+        steering.CurrentPath = new Queue<PathPoly>(result.Path);
     }
 
     // TODO: Move these to movercontroller


### PR DESCRIPTION
- NPCs should backtrack significantly less as we get the full path and pass that into PrunePath to get the exact poly we're on. Also made the direct steering less stringent.
- NPCs won't flicker between 2 directions back and forth as much as it will slightly weight towards their last tick direction.
- NPCs should flicker less going around corners due to adjusted weight on CollisionAvoidance.

When we get octile distances + diagonal pathfinding should help with diagonals a lot.

:cl:
- fix: Numerous NPC steering improvements so they flicker a lot less.
