### PR TITLE
Allow everyone to turn on APC

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -33,17 +33,7 @@ namespace Content.Client.Power.APC.UI
 
             if (BreakerButton != null)
             {
-                if(castState.HasAccess == false)
-                {
-                    BreakerButton.Disabled = true;
-                    BreakerButton.ToolTip = Loc.GetString("apc-component-insufficient-access");
-                }
-                else
-                {
-                    BreakerButton.Disabled = false;
-                    BreakerButton.ToolTip = null;
-                    BreakerButton.Pressed = castState.MainBreaker;
-                }
+                BreakerButton.Pressed = castState.MainBreaker;
             }
 
             if (PowerLabel != null)

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -31,7 +31,6 @@ namespace Content.Server.Power.EntitySystems
 
             UpdatesAfter.Add(typeof(PowerNetSystem));
 
-            SubscribeLocalEvent<ApcComponent, BoundUIOpenedEvent>(OnBoundUiOpen);
             SubscribeLocalEvent<ApcComponent, MapInitEvent>(OnApcInit);
             SubscribeLocalEvent<ApcComponent, ChargeChangedEvent>(OnBatteryChargeChanged);
             SubscribeLocalEvent<ApcComponent, ApcToggleMainBreakerMessage>(OnToggleMainBreaker);
@@ -50,14 +49,7 @@ namespace Content.Server.Power.EntitySystems
         {
             UpdateApcState(uid, component);
         }
-        //Update the HasAccess var for UI to read
-        private void OnBoundUiOpen(EntityUid uid, ApcComponent component, BoundUIOpenedEvent args)
-        {
-            if (args.Session.AttachedEntity == null)
-                return;
-            component.HasAccess = HasAccess(uid, component, args.Session.AttachedEntity.Value);
-            UpdateApcState(uid, component);
-        }
+
         private void OnToggleMainBreaker(EntityUid uid, ApcComponent component, ApcToggleMainBreakerMessage args)
         {
             var attemptEv = new ApcToggleMainBreakerAttemptEvent();
@@ -146,7 +138,7 @@ namespace Content.Server.Power.EntitySystems
 
             var battery = netBat.NetworkBattery;
 
-            var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled, apc.HasAccess,
+            var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled,
                 (int) MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
                 battery.CurrentStorage / battery.Capacity);
 

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -178,15 +178,13 @@ namespace Content.Shared.APC
     public sealed class ApcBoundInterfaceState : BoundUserInterfaceState
     {
         public readonly bool MainBreaker;
-        public readonly bool HasAccess;
         public readonly int Power;
         public readonly ApcExternalPowerState ApcExternalPower;
         public readonly float Charge;
 
-        public ApcBoundInterfaceState(bool mainBreaker, bool hasAccess, int power, ApcExternalPowerState apcExternalPower, float charge)
+        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge)
         {
             MainBreaker = mainBreaker;
-            HasAccess = hasAccess;
             Power = power;
             ApcExternalPower = apcExternalPower;
             Charge = charge;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
you don't need engi access to turn APC on (but you still need it turn it off for a reason)

also closes #15563 ~~by removing the field~~
(we would need same behaviour for comms console and vending machines I think)

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![Peek 2023-07-10 18-42](https://github.com/space-wizards/space-station-14/assets/40753025/67180e9f-06e6-4eaf-85d5-04848e3e140d)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: turning APC on doesn't require any access
