### PR TITLE
Make power grid check event force APCs off

### DIFF
--- a/Content.Server/StationEvents/Components/PowerGridCheckDisabledComponent.cs
+++ b/Content.Server/StationEvents/Components/PowerGridCheckDisabledComponent.cs
@@ -1,0 +1,11 @@
+using Content.Server.StationEvents.Events;
+
+namespace Content.Server.StationEvents.Components;
+
+/// <summary>
+/// Added to APCs to prevent them from turning on until event end
+/// </summary>
+[RegisterComponent, Access(typeof(PowerGridCheckRule))]
+public sealed class PowerGridCheckDisabledComponent : Component
+{
+}

--- a/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
@@ -31,7 +31,7 @@ namespace Content.Server.StationEvents.Events
             if (!TryGetRandomStation(out var chosenStation))
                 return;
 
-            var query = EntityQueryEnumerator<ApcComponent, TransformComponent>();
+            var query = AllEntityQuery<ApcComponent, TransformComponent>();
             while (query.MoveNext(out var target, out var apc, out var transform))
             {
                 if (apc.MainBreakerEnabled && CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == chosenStation)

--- a/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
@@ -17,6 +17,13 @@ namespace Content.Server.StationEvents.Events
     {
         [Dependency] private readonly ApcSystem _apcSystem = default!;
 
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<PowerGridCheckDisabledComponent, ApcToggleMainBreakerAttemptEvent>(OnApcToggleMainBreaker);
+        }
+
         protected override void Started(EntityUid uid, PowerGridCheckRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
         {
             base.Started(uid, component, gameRule, args);
@@ -47,9 +54,10 @@ namespace Content.Server.StationEvents.Events
 
                 if (TryComp(entity, out ApcComponent? apcComponent))
                 {
-                    if(!apcComponent.MainBreakerEnabled)
+                    if (!apcComponent.MainBreakerEnabled)
                         _apcSystem.ApcToggleBreaker(entity, apcComponent);
                 }
+                RemComp<PowerGridCheckDisabledComponent>(entity);
             }
 
             // Can't use the default EndAudio
@@ -87,8 +95,14 @@ namespace Content.Server.StationEvents.Events
                     if (apcComponent.MainBreakerEnabled)
                         _apcSystem.ApcToggleBreaker(selected, apcComponent);
                 }
+                EnsureComp<PowerGridCheckDisabledComponent>(selected);
                 component.Unpowered.Add(selected);
             }
+        }
+
+        private void OnApcToggleMainBreaker(EntityUid uid, PowerGridCheckDisabledComponent component, ref ApcToggleMainBreakerAttemptEvent args)
+        {
+            args.Cancelled = true;
         }
     }
 }

--- a/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
@@ -26,10 +26,11 @@ namespace Content.Server.StationEvents.Events
             if (!TryGetRandomStation(out var chosenStation))
                 return;
 
-            foreach (var (apc, transform) in EntityQuery<ApcComponent, TransformComponent>(true))
+            var query = EntityQueryEnumerator<ApcComponent, TransformComponent>();
+            while (query.MoveNext(out var target, out var apc, out var transform))
             {
                 if (apc.MainBreakerEnabled && CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == chosenStation)
-                    component.Powered.Add(apc.Owner);
+                    component.Powered.Add(target);
             }
 
             RobustRandom.Shuffle(component.Powered);

--- a/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
@@ -6,9 +6,7 @@ using Robust.Shared.Utility;
 using System.Threading;
 using Content.Server.Power.EntitySystems;
 using Timer = Robust.Shared.Timing.Timer;
-using System.Linq;
 using Content.Server.GameTicking.Rules.Components;
-using Robust.Shared.Random;
 using Content.Server.Station.Components;
 using Content.Server.StationEvents.Components;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![Peek 2023-07-10 19-17](https://github.com/space-wizards/space-station-14/assets/40753025/a8b4f4fc-c825-497a-bb09-733ec9e364c2)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: now during power grid check event affected APCs can't be turned back on
