### PR TITLE
Adds occluder to bookshelves

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
@@ -44,6 +44,7 @@
     bodyType: Static
   - type: Anchorable
   - type: Pullable
+  - type: Occluder
   - type: Storage
     capacity: 200
     whitelist:


### PR DESCRIPTION
## About the PR
 As the title says, makes bookshelves occlude vision through them allowing libraries to have little nooks and corners to hide in.
 
**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase
Before:
![image](https://github.com/space-wizards/space-station-14/assets/107660393/42286a9d-e382-4ad0-a61f-0bb7df26dd9e)
After:
![image](https://github.com/space-wizards/space-station-14/assets/107660393/332b2ed2-7c0f-4d1e-8b1f-6e7a482427c5)


**Changelog**

:cl: Velcroboy
- tweak: Changed bookshelves to block vision.
