### PR TITLE
Syndicate sponge nerf to 7 tc

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -927,15 +927,15 @@
       - SurplusBundle
 
 - type: listing
- id: UplinkSyndicateSpongeBox
- name: uplink-syndicate-sponge-box-name
- description: uplink-syndicate-sponge-box-desc
- icon: { sprite:  Objects/Misc/monkeycube.rsi, state: box}
- productEntity: SyndicateSpongeBox
- cost:
-   Telecrystal: 7
- categories:
- - UplinkMisc
+  id: UplinkSyndicateSpongeBox
+  name: uplink-syndicate-sponge-box-name
+  description: uplink-syndicate-sponge-box-desc
+  icon: { sprite:  Objects/Misc/monkeycube.rsi, state: box}
+  productEntity: SyndicateSpongeBox
+  cost:
+    Telecrystal: 7
+  categories:
+  - UplinkMisc
 
  # Pointless
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -722,6 +722,23 @@
       components:
       - SurplusBundle
 
+- type: listing
+  id: UplinkSyndicateSpongeBox
+  name: uplink-syndicate-sponge-box-name
+  description: uplink-syndicate-sponge-box-desc
+  icon: { sprite:  Objects/Misc/monkeycube.rsi, state: box}
+  productEntity: SyndicateSpongeBox
+  cost:
+    Telecrystal: 7
+  categories:
+  - UplinkJob
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist:
+    - Zookeeper
+    - Scientist
+    - Chef
+
 # Armor
 
 - type: listing
@@ -925,17 +942,6 @@
     blacklist:
       components:
       - SurplusBundle
-
-- type: listing
-  id: UplinkSyndicateSpongeBox
-  name: uplink-syndicate-sponge-box-name
-  description: uplink-syndicate-sponge-box-desc
-  icon: { sprite:  Objects/Misc/monkeycube.rsi, state: box}
-  productEntity: SyndicateSpongeBox
-  cost:
-    Telecrystal: 7
-  categories:
-  - UplinkMisc
 
  # Pointless
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -926,16 +926,16 @@
       components:
       - SurplusBundle
 
-#- type: listing
-#  id: UplinkSyndicateSpongeBox
-#  name: uplink-syndicate-sponge-box-name
-#  description: uplink-syndicate-sponge-box-desc
-#  icon: { sprite:  Objects/Misc/monkeycube.rsi, state: box}
-#  productEntity: SyndicateSpongeBox
-#  cost:
-#    Telecrystal: 6
-#  categories:
-#  - UplinkMisc
+- type: listing
+ id: UplinkSyndicateSpongeBox
+ name: uplink-syndicate-sponge-box-name
+ description: uplink-syndicate-sponge-box-desc
+ icon: { sprite:  Objects/Misc/monkeycube.rsi, state: box}
+ productEntity: SyndicateSpongeBox
+ cost:
+   Telecrystal: 7
+ categories:
+ - UplinkMisc
 
  # Pointless
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR makes the syndicate sponge box 7 tc instead of 6, making people only able to purchase 2 boxes(12 animals) by themselves.
It also makes it so only zookeepers, scientists and chef's can purchase the box.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Dygon
- tweak:  Syndicate sponge boxes now cost 7 tc to purchase
