### PR TITLE
Add required dependencies for CEF to Nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,25 @@ let
     zlib
     glib
     gdk-pixbuf
+    nss
+    nspr
+    at-spi2-atk
+    libdrm
+    expat
+    libxkbcommon
+    xorg.libxcb
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libxshmfence
+    mesa
+    alsa-lib
+    dbus
+    at-spi2-core
+    cups
   ];
 in pkgs.mkShell {
   name = "space-station-14-devshell";


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Now, now... I know what you're thinking: "But Vera, SS14 does *not* use CEF!"
And you're right! However I use this shell for messing with [OpenDream](https://github.com/OpenDreamProject/OpenDream) and frankly I can't be arsed to copy-paste this shell there and PR it.
Maybe I should just add this to the engine and have direnv point towards the cloned submodule, hmm...

Anyway! For now this goes here because I'm the only maintainer who does nix stuff and because I love abusing my power :3