### PR TITLE
Expedition balance pass

### DIFF
--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTimeMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTimeMod.cs
@@ -13,11 +13,11 @@ public sealed class SalvageTimeMod : IPrototype, ISalvageMod
     /// Cost for difficulty modifiers.
     /// </summary>
     [DataField("cost")]
-    public float Cost { get; } = 0f;
+    public float Cost { get; }
 
     [DataField("minDuration")]
-    public int MinDuration = 900;
+    public int MinDuration = 630;
 
     [DataField("maxDuration")]
-    public int MaxDuration = 900;
+    public int MaxDuration = 570;
 }

--- a/Content.Shared/Salvage/Expeditions/SalvageExpeditions.cs
+++ b/Content.Shared/Salvage/Expeditions/SalvageExpeditions.cs
@@ -72,7 +72,7 @@ public sealed class SalvageExpeditionDataComponent : Component
 }
 
 [Serializable, NetSerializable]
-public sealed record SalvageMissionParams
+public sealed record SalvageMissionParams : IComparable<SalvageMissionParams>
 {
     [ViewVariables]
     public ushort Index;
@@ -86,6 +86,14 @@ public sealed record SalvageMissionParams
     /// Base difficulty for this mission.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)] public DifficultyRating Difficulty;
+
+    public int CompareTo(SalvageMissionParams? other)
+    {
+        if (other == null)
+            return -1;
+
+        return Difficulty.CompareTo(other.Difficulty);
+    }
 }
 
 /// <summary>

--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -121,7 +121,7 @@ public abstract class SharedSalvageSystem : EntitySystem
 
         var time = GetMod<SalvageTimeMod>(rand, ref rating);
         // Round the duration to nearest 15 seconds.
-        var exactDuration = time.MinDuration + (time.MaxDuration - time.MinDuration) * rand.NextFloat();
+        var exactDuration = MathHelper.Lerp(time.MinDuration, time.MaxDuration, rand.NextFloat());
         exactDuration = MathF.Round(exactDuration / 15f) * 15f;
         var duration = TimeSpan.FromSeconds(exactDuration);
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
@@ -56,3 +56,13 @@
   - type: TechnologyDisk
   - type: StaticPrice
     price: 50
+
+- type: entity
+  parent: TechnologyDisk
+  id: TechnologyDiskRare
+  name: technology disk
+  suffix: rare.
+  description: A disk for the R&D server containing research technology.
+  components:
+  - type: TechnologyDisk
+    tierWeightPrototype: RareTechDiskTierWeights

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
@@ -60,9 +60,7 @@
 - type: entity
   parent: TechnologyDisk
   id: TechnologyDiskRare
-  name: technology disk
   suffix: rare.
-  description: A disk for the R&D server containing research technology.
   components:
   - type: TechnologyDisk
     tierWeightPrototype: RareTechDiskTierWeights

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
@@ -37,3 +37,9 @@
     1: 25
     2: 10
     3: 1
+
+- type: weightedRandom
+  id: RareTechDiskTierWeights
+  weights:
+    2: 19
+    3: 1

--- a/Resources/Prototypes/Procedural/salvage_mods.yml
+++ b/Resources/Prototypes/Procedural/salvage_mods.yml
@@ -75,8 +75,8 @@
 - type: salvageTimeMod
   id: RushTime
   desc: Rush
-  minDuration: 720
-  maxDuration: 780
+  minDuration: 420
+  maxDuration: 465
   cost: 1
 
 # Misc mods

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -30,19 +30,22 @@
     SheetUranium: 1.0
     CratePartsT3: 1.0
     CratePartsT3T4: 0.5
+    TechnologyDiskRare: 0.5
     # cloning boards
     CloningPodMachineCircuitboard: 0.5
     MedicalScannerMachineCircuitboard: 0.5
     CloningConsoleComputerCircuitboard: 0.5
     BiomassReclaimerMachineCircuitboard: 0.5
     # basic weapons
-    CrateArmorySMG: 0.25
-    CrateArmoryLaser: 0.25
-    WeaponMakeshiftLaser: 0.25
+    Katana: 0.25
+    KukriKnife: 0.25
+    WeaponLaserGun: 0.25
+    MakeshiftShield: 0.25
     # rare armor
-    ClothingHeadHelmetSwat: 0.1
+    ClothingHeadHelmetSwat: 0.25
+    ClothingOuterArmorBasicSlim: 0.25
     # rare weapons
-    WeaponSubMachineGunC20r: 0.1
+    WeaponMakeshiftLaser: 0.1
     # money
     SpaceCash500: 1.0
     SpaceCash1000: 0.75
@@ -55,11 +58,12 @@
     ResearchAndDevelopmentServerMachineCircuitboard: 1.0
     CratePartsT4: 1.0
     PowerCellAntiqueProto: 0.25
-    # rare weapons
-    WeaponAdvancedLaser: 1.0
-    WeaponLaserCannon: 1.0
-    WeaponXrayCannon: 1.0
-    WeaponSniperHristov: 1.0
+    # basic weapons
+    CrateArmorySMG: 1.0
+    CrateArmoryLaser: 1.0
+    CrateArmoryShotgun: 1.0
+    # rare armor
+    ClothingOuterArmorRiot: 1.0
     # rare chemicals
     CognizineChemistryBottle: 1.0
     OmnizineChemistryBottle: 1.0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
people bitch out the ass about these all the time, how about they actually try to do some balancing.
a bunch of misc changes to expeditions to hopefully remove some of the more offensive balance aspects.

the changes:
- only 3 missions are available at a time (although each mission is a unique difficulty, so you can't get 3 extreme missions)
- missions are now shorter (around 10 minutes)
- "rush" missions are even shorter (7:00 to 7:45)
- the raw weapons have been removed outright from the lootpool
- weapon crates moved up into epic (since they sell pretty well and are generally really strong)
- rare rewards changed to remove ballistics in exchange for shields and melees.

I doubt that this is the end-all-be-all of expedition balance, but i think this will help with some of the most blatant issues.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Fewer expeditions are offered to the station at a time.
- tweak: Salvage expeditions are now generally shorter.
- tweak: Adjusted some of the rewards for expeditions.
