### PR TITLE
Sawn-off shotgun are now empty when made

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -126,7 +126,7 @@
   - type: BallisticAmmoProvider
     proto: ShellShotgunBeanbag
   - type: Construction
-    graph: ShotgunSawnRubber
+    graph: ShotgunSawn
     node: start
     deconstructionTarget: null
 
@@ -179,15 +179,15 @@
 - type: entity
   name: sawn-off shogun
   parent: WeaponShotgunSawn
-  id: WeaponShotgunSawnRubber
+  id: WeaponShotgunSawnEmpty
   description: Groovy! Uses .50 shotgun shells.
-  suffix: Non-Lethal
+  suffix: Empty
   components:
   - type: BallisticAmmoProvider
-    proto: ShellShotgunBeanbag
+    proto: null
   - type: Construction
-    graph: ShotgunSawnRubber
-    node: shotgunsawnrubber
+    graph: ShotgunSawn
+    node: shotgunsawn
     deconstructionTarget: null
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -125,10 +125,6 @@
   components:
   - type: BallisticAmmoProvider
     proto: ShellShotgunBeanbag
-  - type: Construction
-    graph: ShotgunSawn
-    node: start
-    deconstructionTarget: null
 
 - type: entity
   name: Enforcer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -125,6 +125,10 @@
   components:
   - type: BallisticAmmoProvider
     proto: ShellShotgunBeanbag
+  - type: Construction
+    graph: ShotgunSawnRubber
+    node: start
+    deconstructionTarget: null
 
 - type: entity
   name: Enforcer
@@ -170,6 +174,20 @@
   - type: Construction
     graph: ShotgunSawn
     node: shotgunsawn
+    deconstructionTarget: null
+
+- type: entity
+  name: sawn-off shogun
+  parent: WeaponShotgunSawn
+  id: WeaponShotgunSawnRubber
+  description: Groovy! Uses .50 shotgun shells.
+  suffix: Non-Lethal
+  components:
+  - type: BallisticAmmoProvider
+    proto: ShellShotgunBeanbag
+  - type: Construction
+    graph: ShotgunSawnRubber
+    node: shotgunsawnrubber
     deconstructionTarget: null
 
 - type: entity

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/shotgunsawn.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/shotgunsawn.yml
@@ -10,3 +10,16 @@
               doAfter: 2
     - node: shotgunsawn
       entity: WeaponShotgunSawn
+
+- type: constructionGraph
+  id: ShotgunSawnRubber
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: shotgunsawnrubber
+          steps:
+            - tool: Sawing
+              doAfter: 2
+    - node: shotgunsawnrubber
+      entity: WeaponShotgunSawnRubber

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/shotgunsawn.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/shotgunsawn.yml
@@ -9,17 +9,4 @@
             - tool: Sawing
               doAfter: 2
     - node: shotgunsawn
-      entity: WeaponShotgunSawn
-
-- type: constructionGraph
-  id: ShotgunSawnRubber
-  start: start
-  graph:
-    - node: start
-      edges:
-        - to: shotgunsawnrubber
-          steps:
-            - tool: Sawing
-              doAfter: 2
-    - node: shotgunsawnrubber
-      entity: WeaponShotgunSawnRubber
+      entity: WeaponShotgunSawnEmpty # Makes the sawn-off spawn empty. At max they're losing 2 shells.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes #9762. 
No more barkeeps sawing it off to get lethals. It does technically mean you waste 2 shells, but this can be counteracted by emptying it first and given it's literally 2 shells I don't think it matters (barkeeps get way more shells than they ever use). 
Filled sawnoffs still exist so the nukies can rejoice over their 2 free shells. 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Lank
- tweak: Sawing off a double barrel shotgun no longer fills it with lethal shells. It will instead spawn empty. 
