### PR TITLE
add 4 empty jugs to chem vend

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -82,7 +82,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockChemVendFilled
-  cost: 3500
+  cost: 3820
   category: Medical
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -1,6 +1,7 @@
 - type: vendingMachineInventory
   id: ChemVendInventory
   startingInventory:
+    Jug: 4
     JugAluminium: 2
     JugCarbon: 2
     JugChlorine: 2


### PR DESCRIPTION
## About the PR
people just empty out jugs for med storage anyway, may as well have them so when dispensers aren't infinite people aren't dumping chemicals 

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added 4 empty jugs to the chemvend. Janitors remind chemists not to dump dangerous chemicals in drains!
