### PR TITLE
Return of the bulletproof vest to the bartender

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -5,7 +5,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterVest
+      - id: ClothingOuterArmorBasicSlim
       - id: WeaponShotgunDoubleBarreledRubber
       - id: DrinkShaker
       - id: ClothingEyesGlassesBeer

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
@@ -10,6 +10,7 @@
     ClothingUniformJumpskirtBartender: 2
     ClothingUniformJumpsuitBartenderPurple: 2
     ClothingShoesColorBlack: 2
+    ClothingOuterArmorBasicSlim: 2
     ClothingOuterVest: 2
     ClothingBeltBandolier: 2
     ClothingEyesGlassesSunglasses: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR fixes the issue that came from PR #17825

I don’t know, maybe for some there’s nothing bad in this, but for me there was a problem after the bartender’s body armor was taken away. The broblem is as follows:

1. In a regular vest, there is no way to put an item in the item slot that body armor has, which is why I noticed how bartenders began to take warm jackets that have this slot

2. The reason why the bartender had a body armor was to be able to protect himself from whoever he and his visitors are attacking, so that the bartender does not fall into crit and does not give the opportunity to pick up his gun, there are many dangers that threaten the bar: violent visitors, spiders, slimes, SPIDERS CLOWNS, syndicate agents who want to kill the bartender and who want to get him with a gun.

In general, this PR returns the body armor to the bartender's vending machine and his closet, the bartender still starts with a regular vest, but in his bar he can change it to a body armor.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Returned body armor to the bartender's vending machine and bartender's closet
