### PR TITLE
'Stealthy' Syndie fireaxe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -40,14 +40,14 @@
 
 - type: entity
   id: FireAxeFlaming
-  name: fire axe
+  name: fireaxe
   parent: FireAxe
   description: Why fight fire with an axe when you can fight with fire and axe?
   components:
   - type: IgniteOnMeleeHit
     fireStacks: 1
   - type: Sprite
-    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
+    sprite: Objects/Weapons/Melee/fireaxe.rsi
     state: icon
   - type: Clothing
     sprite: Objects/Weapons/Melee/fireaxeflaming.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
The syndie 'fire axe' already has a lot of drawbacks and is relatively hard to use stealthily, but on the rare occasions you are say an Atmo tech or engi, it should be vaguely possible. This change makes the sprite and name the same as the regular fireaxe, but lets the examine description remain different. 

Blame the sweaty nerds who memorize pixels for making this necessary.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Syndie Fireaxe now less obvious.

