### PR TITLE
Normalizes atmos tech traitor tc to 20

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -10,7 +10,6 @@
   startingGear: AtmosphericTechnicianGear
   icon: "AtmosphericTechnician"
   supervisors: job-supervisors-ce
-  antagAdvantage: 10
   access:
   - Maintenance
   - Engineering


### PR DESCRIPTION
## About the PR
From what I've heard, Atmos Techs really don't need the TC penalty and aren't insane enough to warrant it. Some jobs are just naturally better at traitor then others, and that shouldn't change.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Traitorous Atmospheric Technicans no longer have a 10 telecrystal penalty, and now have access to the full 20TC that all other jobs do.
