### PR TITLE
stunmeta 1984

### DIFF
--- a/Resources/Prototypes/Damage/types.yml
+++ b/Resources/Prototypes/Damage/types.yml
@@ -71,3 +71,10 @@
   id: Structural
   armorCoefficientPrice: 1
   armorFlatPrice: 1
+
+# Damage represents stamina of a mob.
+# Used by certain armor to counter stun weaponry.
+- type: damageType
+  id: Stun
+  armorCoefficientPrice: 5
+  armorFlatPrice: 20

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -94,6 +94,7 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.4 # this technically means it protects against fires pretty well? -heat is just for lasers and stuff, not atmos temperature
+        Stun: 0.8
 
 - type: entity
   parent: ClothingOuterBaseLarge

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -423,6 +423,7 @@
         Heat: 0.4
         Radiation: 0.50
         Caustic: 0.75
+        Stun: 0.4
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: ToggleableClothing
@@ -454,6 +455,7 @@
         Heat: 0.5
         Radiation: 0.25
         Caustic: 0.35
+        Stun: 0.1
   - type: ExplosionResistance
     damageCoefficient: 0.8
   - type: ToggleableClothing
@@ -487,6 +489,7 @@
         Heat: 0.2
         Radiation: 0.25
         Caustic: 0.5
+        Stun: 0.4
   - type: ExplosionResistance
     damageCoefficient: 0.3
   - type: ToggleableClothing
@@ -518,6 +521,7 @@
         Heat: 0.3
         Radiation: 0.25
         Caustic: 0.4
+        Stun: 0.4
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: ToggleableClothing
@@ -549,6 +553,8 @@
         Heat: 0.25
         Radiation: 0.25
         Caustic: 0.75
+        # magic
+        Stun: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: ToggleableClothing
@@ -637,6 +643,7 @@
         Piercing: 0.85
         Heat: 0.4
         Caustic: 0.75
+        Stun: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: ToggleableClothing
@@ -736,6 +743,7 @@
         Heat: 0.2
         Radiation: 0.1
         Caustic: 0.2
+        Stun: 0.2
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: ToggleableClothing

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -455,7 +455,7 @@
         Heat: 0.5
         Radiation: 0.25
         Caustic: 0.35
-        Stun: 0.1
+        Stun: 0.0
   - type: ExplosionResistance
     damageCoefficient: 0.8
   - type: ToggleableClothing

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -357,12 +357,14 @@
           Slash: 0.9
           Piercing: 0.85
           Heat: 0.6
+          Stun: 0.6
       activeBlockModifier:
         coefficients:
           Blunt: 1.2
           Slash: 0.85
           Piercing: 0.5
           Heat: 0.4
+          Stun: 0.4
         flatReductions:
           Heat: 1
           Piercing: 1


### PR DESCRIPTION
## About the PR
blood-red and friends have high stun resistance
jugg has complete stun resistance so its no longer le flukie purchase because slow, youll be expensive to gun down.
minor antags suits like wizard, ling have small stun resistance
reflective vest has some stun resistance since makes sense

e-shield has low-high stun resistance depending on if its planted or not

does not affect licoxide or pies (yet?)

**Media**

Uploading average day in sec.mp4…


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Syndicate R&D has added stun resistance to its defensive options, notably the juggernaut suit which is now completely stunproof. 
