### PR TITLE
Add machine frame completion feedback

### DIFF
--- a/Content.Server/Construction/MachineFrameSystem.cs
+++ b/Content.Server/Construction/MachineFrameSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Stacks;
 using Content.Shared.Tag;
+using Content.Shared.Popups;
 using Robust.Shared.Containers;
 
 namespace Content.Server.Construction;
@@ -16,6 +17,7 @@ public sealed class MachineFrameSystem : EntitySystem
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly StackSystem _stack = default!;
     [Dependency] private readonly ConstructionSystem _construction = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
 
     public override void Initialize()
     {
@@ -75,11 +77,10 @@ public sealed class MachineFrameSystem : EntitySystem
                 {
                     component.Progress[machinePart.PartType]++;
                     args.Handled = true;
-                    return;
                 }
             }
 
-            if (TryComp<StackComponent?>(args.Used, out var stack))
+            if (!args.Handled && TryComp<StackComponent?>(args.Used, out var stack))
             {
                 var type = stack.StackTypeId;
                 if (type == null)
@@ -114,6 +115,13 @@ public sealed class MachineFrameSystem : EntitySystem
 
                 component.MaterialProgress[type] += needed;
                 args.Handled = true;
+            }
+
+            if (args.Handled)
+            {
+                if (IsComplete(component)) {
+                    _popupSystem.PopupEntity(Loc.GetString("machine-frame-component-on-complete"), uid);
+                }
                 return;
             }
 

--- a/Resources/Locale/en-US/construction/components/machine-frame-component.ftl
+++ b/Resources/Locale/en-US/construction/components/machine-frame-component.ftl
@@ -1,1 +1,2 @@
 machine-frame-component-on-examine-label = [color=white]Current machine board:[/color] [color=cyan]{$board}[/color]
+machine-frame-component-on-complete = Construction completed


### PR DESCRIPTION
## About the PR

This closes #17355

Makes machine frame inform the player that it is completed.

It would also be nice to add sound on completion, but I think it should be in a different PR.

**Media**

https://github.com/space-wizards/space-station-14/assets/38111072/3ae1873b-4190-484f-98a0-4d94173fdaa6

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: kseandi
- add: Added machine frame completion popup.
