### PR TITLE
Allow Dwarves To Use Human Tattoos/Markings

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -2,7 +2,7 @@
   id: TattooHiveChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human]
+  speciesRestriction: [Human, Dwarf]
   coloring:
     default:
       type:
@@ -16,7 +16,7 @@
   id: TattooNightlingChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human]
+  speciesRestriction: [Human, Dwarf]
   coloring:
     default:
       type:
@@ -30,7 +30,7 @@
   id: TattooSilverburghLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Human]
+  speciesRestriction: [Human, Dwarf]
   coloring:
     default:
       type:
@@ -44,7 +44,7 @@
   id: TattooSilverburghRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Human]
+  speciesRestriction: [Human, Dwarf]
   coloring:
     default:
       type:
@@ -58,7 +58,7 @@
   id: TattooCampbellLeftArm
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Human]
+  speciesRestriction: [Human, Dwarf]
   coloring:
     default:
       type:
@@ -72,7 +72,7 @@
   id: TattooCampbellRightArm
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Human]
+  speciesRestriction: [Human, Dwarf]
   coloring:
     default:
       type:
@@ -86,7 +86,7 @@
   id: TattooCampbellLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Human]
+  speciesRestriction: [Human, Dwarf]
   coloring:
     default:
       type:
@@ -100,7 +100,7 @@
   id: TattooCampbellRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Human]
+  speciesRestriction: [Human, Dwarf]
   coloring:
     default:
       type:
@@ -114,7 +114,7 @@
   id: TattooEyeRight
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf]
   coloring:
     default:
       type:
@@ -128,7 +128,7 @@
   id: TattooEyeLeft
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf]
   coloring:
     default:
       type:


### PR DESCRIPTION
## About the PR
Adds Dwarves to the same markings list as humans.

**Media**
- [X] This PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Dwarves now have access to all the same tattoos that humans do.
