### PR TITLE
Adding Scrubs to the MediDrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
@@ -20,3 +20,4 @@
     ClothingOuterHospitalGown: 5
     UniformScrubsColorGreen: 4
     UniformScrubsColorBlue: 4
+    UniformScrubsColorPurple: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
@@ -18,3 +18,5 @@
     ClothingHeadHelmetVoidParamed: 1
     ClothingOuterHardsuitVoidParamed: 1
     ClothingOuterHospitalGown: 5
+    UniformScrubsColorGreen: 4
+    UniformScrubsColorBlue: 4


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR adds the blue, green, and purple scrubs to the MediDrobe.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- Management has realized they forgot to supply station medical staff with scrubs. Scrubs can now be obtained from Medidrobe vendors