### PR TITLE
Remove multitool from autolathe crafting list

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -225,6 +225,7 @@
       - ClothingBackpackDuffelHolding
       - WelderExperimental
       - JawsOfLife
+      - Multitool
 
 - type: entity
   id: CircuitImprinter

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -86,7 +86,6 @@
       - Welder
       - Wrench
       - Crowbar
-      - Multitool
       - NetworkConfigurator
       - AirlockPainter
       - FlashlightLantern

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -85,6 +85,7 @@
   materials:
     Steel: 200
     Plastic: 200
+    Gold: 25
 
 - type: latheRecipe
   id: NetworkConfigurator

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -185,6 +185,7 @@
     - WelderExperimental
     - PowerDrill
     - JawsOfLife
+    - Multitool
 
 # Tier 3
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
#17244 removed multitool from salvagers roundstart
#14173 removed roundstart full utility belts from youtool to be given away freely
---And some other PR I don't remember was trying to make multitools more rare, since it's only benefit compared to network config is the ability to hack doors and bolt/unbolt without access.---

Update:
- Multitool removed from autolathe roundstart
- Multitool moved to advanced tools tech
- Multitool recipe changed: added a requirement of 25 gold per piece

This PR just removes multitool from roundstart crafting list of autolathe, since it makes all other changes to it's rarity void.

:cl:
- remove: Removed multitool from autolathe's crafting list
- tweak: Multitool is now locked behind Advanced Tools tech
- tweak: Multitool recipe changed, now requires 25 additional gold