### PR TITLE
Rename Faction to NpcFaction

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -109,7 +109,7 @@ namespace Content.Client.Entry
             _prototypeManager.RegisterIgnore("htnPrimitive");
             _prototypeManager.RegisterIgnore("gameMap");
             _prototypeManager.RegisterIgnore("gameMapPool");
-            _prototypeManager.RegisterIgnore("faction");
+            _prototypeManager.RegisterIgnore("npcFaction");
             _prototypeManager.RegisterIgnore("lobbyBackground");
             _prototypeManager.RegisterIgnore("advertisementsPack");
             _prototypeManager.RegisterIgnore("metabolizerType");

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -119,7 +119,7 @@ public sealed class NukeopsRuleComponent : Component
     [DataField("operativePlayers")]
     public readonly Dictionary<string, IPlayerSession> OperativePlayers = new();
 
-    [DataField("faction", customTypeSerializer: typeof(PrototypeIdSerializer<FactionPrototype>), required: true)]
+    [DataField("faction", customTypeSerializer: typeof(PrototypeIdSerializer<NpcFactionPrototype>), required: true)]
     public string Faction = default!;
 }
 

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -49,7 +49,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IPlayerManager _playerSystem = default!;
     [Dependency] private readonly EmergencyShuttleSystem _emergency = default!;
-    [Dependency] private readonly FactionSystem _faction = default!;
+    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidSystem = default!;
     [Dependency] private readonly StationSpawningSystem _stationSpawningSystem = default!;
     [Dependency] private readonly StationSystem _stationSystem = default!;
@@ -181,9 +181,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         // we can only currently guarantee that NT stations are the only station to
         // exist in the base game.
 
-        var eligible = EntityQuery<StationEventEligibleComponent, FactionComponent>()
+        var eligible = EntityQuery<StationEventEligibleComponent, NpcFactionMemberComponent>()
             .Where(x =>
-                _faction.IsFactionHostile(component.Faction, x.Item2.Owner, x.Item2))
+                _npcFaction.IsFactionHostile(component.Faction, x.Item2.Owner, x.Item2))
             .Select(x => x.Item1.Owner)
             .ToList();
 
@@ -712,8 +712,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         if (component.StartingGearPrototypes.TryGetValue(gear, out var gearPrototype))
             _stationSpawningSystem.EquipStartingGear(mob, gearPrototype, profile);
 
-        _faction.RemoveFaction(mob, "NanoTrasen", false);
-        _faction.AddFaction(mob, "Syndicate");
+        _npcFaction.RemoveFaction(mob, "NanoTrasen", false);
+        _npcFaction.AddFaction(mob, "Syndicate");
     }
 
     private void SpawnOperatives(int spawnCount, List<IPlayerSession> sessions, bool addSpawnPoints, NukeopsRuleComponent component)

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -31,7 +31,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
     [Dependency] private readonly IObjectivesManager _objectivesManager = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
-    [Dependency] private readonly FactionSystem _faction = default!;
+    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly UplinkSystem _uplink = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
@@ -263,8 +263,8 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         }
 
         // Change the faction
-        _faction.RemoveFaction(entity, "NanoTrasen", false);
-        _faction.AddFaction(entity, "Syndicate");
+        _npcFaction.RemoveFaction(entity, "NanoTrasen", false);
+        _npcFaction.AddFaction(entity, "Syndicate");
 
         // Give traitors their objectives
         var maxDifficulty = _cfg.GetCVar(CCVars.TraitorMaxDifficulty);

--- a/Content.Server/NPC/Components/NpcFactionMemberComponent.cs
+++ b/Content.Server/NPC/Components/NpcFactionMemberComponent.cs
@@ -4,14 +4,14 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.NPC.Components
 {
     [RegisterComponent]
-    [Access(typeof(FactionSystem))]
-    public sealed class FactionComponent : Component
+    [Access(typeof(NpcFactionSystem))]
+    public sealed class NpcFactionMemberComponent : Component
     {
         /// <summary>
         /// Factions this entity is a part of.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite),
-         DataField("factions", customTypeSerializer:typeof(PrototypeIdHashSetSerializer<FactionPrototype>))]
+         DataField("factions", customTypeSerializer:typeof(PrototypeIdHashSetSerializer<NpcFactionPrototype>))]
         public HashSet<string> Factions = new();
 
         /// <summary>

--- a/Content.Server/NPC/Components/NpcFactionPrototype.cs
+++ b/Content.Server/NPC/Components/NpcFactionPrototype.cs
@@ -1,23 +1,22 @@
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 
 namespace Content.Server.NPC.Components
 {
     /// <summary>
     /// Contains data about this faction's relations with other factions.
     /// </summary>
-    [Prototype("faction")]
-    public sealed class FactionPrototype : IPrototype
+    [Prototype("npcFaction")]
+    public sealed class NpcFactionPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]
         public string ID { get; } = default!;
 
-        [ViewVariables(VVAccess.ReadWrite), DataField("friendly", customTypeSerializer:typeof(PrototypeIdListSerializer<FactionPrototype>))]
+        [ViewVariables(VVAccess.ReadWrite), DataField("friendly", customTypeSerializer:typeof(PrototypeIdListSerializer<NpcFactionPrototype>))]
         public List<string> Friendly = new();
 
-        [ViewVariables(VVAccess.ReadWrite), DataField("hostile", customTypeSerializer:typeof(PrototypeIdListSerializer<FactionPrototype>))]
+        [ViewVariables(VVAccess.ReadWrite), DataField("hostile", customTypeSerializer:typeof(PrototypeIdListSerializer<NpcFactionPrototype>))]
         public List<string> Hostile = new();
     }
 }

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -483,7 +483,7 @@ public sealed partial class NPCSteeringSystem
         var objectRadius = 0.25f;
         var detectionRadius = MathF.Max(0.35f, agentRadius + objectRadius);
         var ourVelocity = body.LinearVelocity;
-        var factionQuery = GetEntityQuery<FactionComponent>();
+        var factionQuery = GetEntityQuery<NpcFactionMemberComponent>();
         factionQuery.TryGetComponent(uid, out var ourFaction);
 
         foreach (var ent in _lookup.GetEntitiesInRange(uid, detectionRadius, LookupFlags.Dynamic))
@@ -496,7 +496,7 @@ public sealed partial class NPCSteeringSystem
                 (mask & otherBody.CollisionLayer) == 0x0 &&
                 (layer & otherBody.CollisionMask) == 0x0 ||
                 !factionQuery.TryGetComponent(ent, out var otherFaction) ||
-                !_faction.IsEntityFriendly(uid, ent, ourFaction, otherFaction) ||
+                !_npcFaction.IsEntityFriendly(uid, ent, ourFaction, otherFaction) ||
                 // Use <= 0 so we ignore stationary friends in case.
                 Vector2.Dot(otherBody.LinearVelocity, ourVelocity) <= 0f)
             {

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -53,7 +53,7 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly DoorSystem _doors = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly FactionSystem _faction = default!;
+    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly PathfindingSystem _pathfindingSystem = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedMeleeWeaponSystem _melee = default!;

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -26,7 +26,7 @@ public sealed class NPCUtilitySystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly FactionSystem _faction = default!;
+    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly FoodSystem _food = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly PuddleSystem _puddle = default!;
@@ -264,7 +264,7 @@ public sealed class NPCUtilitySystem : EntitySystem
 
                 break;
             case NearbyHostilesQuery:
-                foreach (var ent in _faction.GetNearbyHostiles(owner, vision))
+                foreach (var ent in _npcFaction.GetNearbyHostiles(owner, vision))
                 {
                     entities.Add(ent);
                 }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -134,7 +134,7 @@
   - type: MobMover
   - type: HTN
     rootTask: SimpleHostileCompound
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
   - type: Bloodstream
@@ -207,7 +207,7 @@
     flavorKind: station-event-random-sentience-flavor-organic
   - type: Puller
     needsHands: true
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Passive
 
@@ -290,7 +290,7 @@
     accent: duck
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-organic
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Passive
 
@@ -464,7 +464,7 @@
       path: /Audio/Animals/cow_moo.ogg
   - type: Perishable
     molsPerSecondPerUnitMass: 0.0015
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Passive
   - type: Body
@@ -582,7 +582,7 @@
     interactFailureString: petting-failure-goat
     interactSuccessSound:
       path: /Audio/Animals/goat_bah.ogg
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Passive
   - type: Body
@@ -633,7 +633,7 @@
   - type: Bloodstream
     bloodMaxVolume: 100
   - type: Puller
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Passive
 
@@ -764,7 +764,7 @@
     prototypes: [ BoxingKangarooGear ]
   - type: HTN
     rootTask: SimpleHostileCompound
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
 
@@ -844,7 +844,7 @@
   - type: MonkeyAccent
   - type: Puller
   - type: CanHostGuardian
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Passive
   - type: GhostRole
@@ -902,7 +902,7 @@
     equippedPrefix: 0
     slots:
     - HEAD
-  - type: Faction
+  - type: NpcFactionMember
     factions:
       - Mouse
   - type: HTN
@@ -1270,7 +1270,7 @@
     interactFailureString: petting-failure-generic
     interactSuccessSound:
       path: /Audio/Animals/penguin_squawk.ogg
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Passive
 
@@ -1287,7 +1287,7 @@
   - type: MobMover
   - type: HTN
     rootTask: SimpleHostileCompound
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Syndicate
   - type: Sprite
@@ -1465,7 +1465,7 @@
   id: MobGiantSpiderAngry
   suffix: Angry
   components:
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - Xeno
     - type: InputMover
@@ -1776,7 +1776,7 @@
   - type: MobMover
   - type: HTN
     rootTask: SimpleHostileCompound
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
   - type: InteractionPopup
@@ -2241,6 +2241,6 @@
     accent: pig
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-organic
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Passive

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -13,7 +13,7 @@
     - type: GhostTakeoverAvailable
     - type: HTN
       rootTask: SimpleHostileCompound
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - SimpleHostile
     - type: Speech

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -12,7 +12,7 @@
       blackboard:
         NavSmash: !type:Bool
           true
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - SimpleHostile
     - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/flesh.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/flesh.yml
@@ -10,7 +10,7 @@
     blackboard:
       NavSmash: !type:Bool
         true
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
   - type: Tag

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -8,7 +8,7 @@
   - type: MobMover
   - type: Loadout
     prototypes: [PassengerGear]
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - NanoTrasen
 
@@ -18,7 +18,7 @@
   id: MobSpirate
   description: Yarr!
   components:
-  - type: Faction
+  - type: NpcFactionMember
     factions:
       - Syndicate
   - type: InputMover

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -9,7 +9,7 @@
     - FootstepSound
   - type: InputMover
   - type: MobMover
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
   - type: Hands

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -86,7 +86,7 @@
   id: MobCatRuntime
   description: Professional mouse hunter. Escape artist.
   components:
-  - type: Faction
+  - type: NpcFactionMember
     factions:
       - PetsNT
   - type: HTN
@@ -104,7 +104,7 @@
   parent: MobCatCalico
   description: Ask nicely, and maybe they'll give you one of their spare lives.
   components:
-  - type: Faction
+  - type: NpcFactionMember
     factions:
       - PetsNT
   - type: Grammar
@@ -477,7 +477,7 @@
   id: MobSpiderShiva
   description: The first defender of the station.
   components:
-  - type: Faction
+  - type: NpcFactionMember
     factions:
       - PetsNT
   - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -16,7 +16,7 @@
     groups:
       Flammable: [Touch]
       Extinguish: [Touch]
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
   - type: Sprite
@@ -181,7 +181,7 @@
     groups:
       Flammable: [Touch]
       Extinguish: [Touch]
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
   - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -38,7 +38,7 @@
   - type: Sprite
     noRot: true
     drawdepth: Mobs
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleNeutral
   - type: HealthExaminable

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -19,7 +19,7 @@
     rootTask: IdleCompound
   - type: Input
     context: "human"
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleNeutral
   - type: MovementSpeedModifier

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -5,7 +5,7 @@
   abstract: true
   description: It looks so much like jelly. I wonder what it tastes like?
   components:
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleNeutral
   - type: HTN
@@ -135,7 +135,7 @@
   id: MobAdultSlimesBlueAngry
   suffix: Angry
   components:
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - SimpleHostile
     - type: GhostRole
@@ -170,7 +170,7 @@
   id: MobAdultSlimesGreenAngry
   suffix: Angry
   components:
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - SimpleHostile
     - type: GhostRole
@@ -205,7 +205,7 @@
   id: MobAdultSlimesYellowAngry
   suffix: Angry
   components:
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - SimpleHostile
     - type: GhostRole

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -7,7 +7,7 @@
   components:
   - type: HTN
     rootTask: SimpleHostileCompound
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
   - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -8,7 +8,7 @@
   - type: MobMover
   - type: HTN
     rootTask: SimpleHostileCompound
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
   - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -28,7 +28,7 @@
     groups:
       Flammable: [Touch]
       Extinguish: [Touch]
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Xeno
   - type: Hands
@@ -375,7 +375,7 @@
   - type: MobMover
   - type: HTN
     rootTask: SimpleHostileCompound
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Xeno
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Mobs/Player/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/arachnid.yml
@@ -30,6 +30,6 @@
   - type: CameraRecoil
   - type: Examiner
   - type: CanHostGuardian
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - NanoTrasen

--- a/Resources/Prototypes/Entities/Mobs/Player/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/diona.yml
@@ -29,6 +29,6 @@
     - type: CameraRecoil
     - type: Examiner
     - type: CanHostGuardian
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - NanoTrasen

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -22,7 +22,7 @@
         true
       NavSmash: !type:Bool
         true
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - Dragon
   - type: Speech

--- a/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
@@ -22,6 +22,6 @@
     - type: CameraRecoil
     - type: Examiner
     - type: CanHostGuardian
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - NanoTrasen

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -24,7 +24,7 @@
     - Chapel
   - type: MindContainer
     showExamineInfo: true
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - PetsNT
   - type: Alerts
@@ -54,7 +54,7 @@
         Slash: 7
   - type: InputMover
   - type: MobMover
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleNeutral
   - type: InteractionPopup

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -29,7 +29,7 @@
   - type: CameraRecoil
   - type: Examiner
   - type: CanHostGuardian
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - NanoTrasen
 
@@ -44,7 +44,7 @@
       prototypes: [SyndicateOperativeGearExtremelyBasic]
     - type: RandomMetadata
       nameSegments: [names_death_commando]
-    - type: Faction
+    - type: NpcFactionMember
       factions:
       - Syndicate
 
@@ -74,6 +74,6 @@
       nameSegments:
       - SyndicateNamesPrefix
       - SyndicateNamesNormal
-    - type: Faction
+    - type: NpcFactionMember
       factions:
       - Syndicate

--- a/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
@@ -21,7 +21,7 @@
     - type: CameraRecoil
     - type: Examiner
     - type: CanHostGuardian
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - NanoTrasen
     - type: Respirator

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -20,7 +20,7 @@
     - type: CameraRecoil
     - type: Examiner
     - type: CanHostGuardian
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - NanoTrasen
 

--- a/Resources/Prototypes/Entities/Mobs/Player/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/slime.yml
@@ -21,6 +21,6 @@
     - type: CameraRecoil
     - type: Examiner
     - type: CanHostGuardian
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - NanoTrasen

--- a/Resources/Prototypes/Entities/Mobs/Player/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/vox.yml
@@ -21,7 +21,7 @@
     - type: CameraRecoil
     - type: Examiner
     - type: CanHostGuardian
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - NanoTrasen
     - type: Respirator

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -93,7 +93,7 @@
         layer:
         - LowImpassable
   # pet fish before rehydrating and he will be nice to you
-  - type: FactionException
+  - type: NpcFactionMemberException
   - type: PettableFriend
     successString: petting-success-dehydrated-carp
     failureString: petting-failure-dehydrated-carp

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -93,7 +93,7 @@
         layer:
         - LowImpassable
   # pet fish before rehydrating and he will be nice to you
-  - type: NpcFactionMemberException
+  - type: FactionException
   - type: PettableFriend
     successString: petting-success-dehydrated-carp
     failureString: petting-failure-dehydrated-carp

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -116,7 +116,7 @@
   id: WeaponTurretSyndicate
   suffix: Syndicate
   components:
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - Syndicate
 
@@ -126,7 +126,7 @@
   id: WeaponTurretSyndicateDisposable
   suffix: Syndicate, Disposable
   components:
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - Syndicate
     - type: Destructible
@@ -166,7 +166,7 @@
   id: WeaponTurretNanoTrasen
   suffix: NanoTrasen
   components:
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - NanoTrasen
 
@@ -175,7 +175,7 @@
   id: WeaponTurretHostile
   suffix: Hostile
   components:
-  - type: Faction
+  - type: NpcFactionMember
     factions:
     - SimpleHostile
 
@@ -186,7 +186,7 @@
   id: WeaponTurretXeno
   suffix: Xeno
   components:
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - Xeno
     - type: Sprite

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -2,7 +2,7 @@
   abstract: true
   id: BaseStationNanotrasen
   components:
-    - type: Faction
+    - type: NpcFactionMember
       factions:
         - NanoTrasen
 

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -1,4 +1,4 @@
-- type: faction
+- type: npcFaction
   id: Dragon
   hostile:
     - NanoTrasen
@@ -6,29 +6,29 @@
     - Xeno
     - PetsNT
 
-- type: faction
+- type: npcFaction
   id: NanoTrasen
   hostile:
   - SimpleHostile
   - Syndicate
   - Xeno
 
-- type: faction
+- type: npcFaction
   id: Mouse
   hostile:
     - PetsNT
 
-- type: faction
+- type: npcFaction
   id: Passive
 
-- type: faction
+- type: npcFaction
   id: PetsNT
   hostile:
   - Mouse
   - SimpleHostile
   - Xeno
 
-- type: faction
+- type: npcFaction
   id: SimpleHostile
   hostile:
   - NanoTrasen
@@ -36,10 +36,10 @@
   - Passive
   - PetsNT
 
-- type: faction
+- type: npcFaction
   id: SimpleNeutral
 
-- type: faction
+- type: npcFaction
   id: Syndicate
   hostile:
   - NanoTrasen
@@ -47,7 +47,7 @@
   - Xeno
   - PetsNT
 
-- type: faction
+- type: npcFaction
   id: Xeno
   hostile:
   - NanoTrasen


### PR DESCRIPTION
Renames the `Faction` prototype to `NpcFaction` and the `FactionComponent` to `NpcFactionMemberComponent`. Main motivation for this change is that I want to add "faction" related code that has nothing to do with NPC targeting/hostile logic. Eventually they might be combinable, but for now its easier to just add the NPC prefix. 