### PR TITLE
Allow fireaxe to pry plating

### DIFF
--- a/Content.Server/Maps/TileSystem.cs
+++ b/Content.Server/Maps/TileSystem.cs
@@ -26,8 +26,13 @@ public sealed class TileSystem : EntitySystem
         var tileRef = grid.GetTileRef(indices);
         return PryTile(tileRef);
     }
+	
+	public bool PryTile(TileRef tileRef)
+    {
+        return PryTile(tileRef, false);
+    }
 
-    public bool PryTile(TileRef tileRef)
+    public bool PryTile(TileRef tileRef, bool pryPlating)
     {
         var tile = tileRef.Tile;
 
@@ -36,7 +41,7 @@ public sealed class TileSystem : EntitySystem
 
         var tileDef = (ContentTileDefinition) _tileDefinitionManager[tile.TypeId];
 
-        if (!tileDef.CanCrowbar)
+        if (!tileDef.CanCrowbar && !(pryPlating && tileDef.CanAxe))
             return false;
 
         return DeconstructTile(tileRef);

--- a/Content.Server/Tools/Components/TilePryingComponent.cs
+++ b/Content.Server/Tools/Components/TilePryingComponent.cs
@@ -12,6 +12,12 @@ namespace Content.Server.Tools.Components
 
         [DataField("qualityNeeded", customTypeSerializer:typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
         public string QualityNeeded = "Prying";
+		
+        /// <summary>
+        /// Whether this tool can pry tiles with CanAxe.
+        /// </summary>
+        [DataField("advanced")]
+        public bool Advanced = false;
 
         [DataField("delay")]
         public float Delay = 1f;

--- a/Content.Server/Tools/ToolSystem.TilePrying.cs
+++ b/Content.Server/Tools/ToolSystem.TilePrying.cs
@@ -51,7 +51,7 @@ public sealed partial class ToolSystem
                 $"{ToPrettyString(args.User):actor} pried {_tileDefinitionManager[tile.Tile.TypeId].Name} at {center}");
         }
 
-        _tile.PryTile(tile);
+        _tile.PryTile(tile, component.Advanced);
     }
 
     private bool TryPryTile(EntityUid toolEntity, EntityUid user, TilePryingComponent component, EntityCoordinates clickLocation)
@@ -71,7 +71,7 @@ public sealed partial class ToolSystem
 
         var tileDef = (ContentTileDefinition)_tileDefinitionManager[tile.Tile.TypeId];
 
-        if (!tileDef.CanCrowbar)
+        if (!tileDef.CanCrowbar && !(tileDef.CanAxe && component.Advanced))
             return false;
 
         var ev = new TilePryingDoAfterEvent(coordinates);

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -37,6 +37,11 @@ namespace Content.Shared.Maps
         public string BaseTurf { get; } = string.Empty;
 
         [DataField("canCrowbar")] public bool CanCrowbar { get; private set; }
+		
+        /// <summary>
+        /// Whether this tile can be pried by an advanced prying tool if not pryable otherwise.
+        /// </summary>
+        [DataField("canAxe")] public bool CanAxe { get; private set; }
 
         [DataField("canWirecutter")] public bool CanWirecutter { get; private set; }
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -37,6 +37,7 @@
     qualities:
       - Prying
   - type: TilePrying
+    advanced: true
 
 - type: entity
   id: FireAxeFlaming

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -4,6 +4,7 @@
   sprite: /Textures/Tiles/plating.png
   baseTurf: Lattice
   isSubfloor: true
+  canAxe: true
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
allows the fireaxe to pry plating
gives atmos an actual reason to have it
overall: when targeting plating, crowbars it normally and refunds the tile, otherwise behaves like a normal crowbar

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/57039557/a1f98479-ae17-44cf-b402-18760ab0a6e4)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: The atmos fireaxe and the syndicate fire axe can now pry plating.
