### PR TITLE
Saline

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -56,7 +56,7 @@ reagent-name-ambuzol = ambuzol
 reagent-desc-ambuzol = A highly engineered substance able to halt the progression of a zombie infection.
 
 reagent-name-ambuzol-plus = ambuzol plus
-reagent-desc-ambuzol-plus = Further engineered with the blood of the infected, inoculates the living against the infection. 
+reagent-desc-ambuzol-plus = Further engineered with the blood of the infected, inoculates the living against the infection.
 
 reagent-name-pulped-banana-peel = pulped banana peel
 reagent-desc-pulped-banana-peel = Pulped banana peels have some effectiveness against bleeding.
@@ -105,3 +105,6 @@ reagent-desc-diphenylmethylamine = A more stable medicine than ethyloxyephedrine
 
 reagent-name-sigynate = sigynate
 reagent-desc-sigynate = A thick pink syrup useful for neutralizing acids and soothing trauma caused by acids.  Tastes sweet!
+
+reagent-name-saline = saline
+reagent-desc-saline = "A mixture of salt and water. Commonly used to treat dehydration or low fluid presence in blood."

--- a/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
@@ -142,7 +142,5 @@
     Food:
       effects:
       # eating salt on its own kinda sucks, kids
-      - !type:SatiateHunger
-        factor: 0.5
       - !type:SatiateThirst
         factor: -0.5

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -606,6 +606,22 @@
         amount: -0.5
 
 - type: reagent
+  id: Saline
+  name: reagent-name-saline
+  group: Medicine
+  desc: reagent-desc-saline
+  physicalDesc: reagent-physical-desc-salty
+  flavor: salty
+  color: "#0064C8"
+  metabolisms:
+    Drink:
+      effects:
+        - !type:SatiateThirst
+          factor: 6
+        - !type:ModifyBloodLevel
+          amount: 6
+
+- type: reagent
   id: Siderlac
   name: reagent-name-siderlac
   group: Medicine

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -402,7 +402,9 @@
 - type: reaction
   id: Saline
   reactants:
-    Water: 4
-    TableSalt: 1
+    Water:
+      amount: 4
+    TableSalt:
+      amount: 1
   products:
     Saline: 5

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -398,3 +398,11 @@
       amount: 1
   products:
     Sigynate: 4
+
+- type: reaction
+  id: Saline
+  reactants:
+    Water: 4
+    TableSalt: 1
+  products:
+    Saline: 5


### PR DESCRIPTION
saline is used to treat dehydration and fluidloss (bloodloss) in people. it can be made with water and salt. i removed salt satiating hunger because thats a lil dumb

🆑 Emisse
- add: Saline can now be made with water and salt, it can treat dehydration and bloodloss. Salt now makes you dehydrated and no longer fills your belly. Just flavor!