### PR TITLE
Adds the TEG

### DIFF
--- a/Content.Server/ThermoelectricGenerator/ThermoelectricGeneratorComponent.cs
+++ b/Content.Server/ThermoelectricGenerator/ThermoelectricGeneratorComponent.cs
@@ -1,0 +1,22 @@
+namespace Content.Server.ThermoelectricGenerator;
+
+[RegisterComponent]
+public sealed class ThermoelectricGeneratorComponent : Component
+{
+    /// <summary>
+    /// Name of the cold loop
+    /// </summary>
+    [DataField("coldLoopName")] public string ColdLoopName = "cold";
+    /// <summary>
+    /// Name of the hotloop
+    /// </summary>
+    [DataField("hotLoopName")] public string HotLoopName = "hot";
+    /// <summary>
+    /// Lerp multiply value
+    /// </summary>
+    [DataField("transferRate")]public float TransferRate = 0.5f;
+    /// <summary>
+    /// Power multiplier
+    /// </summary>
+    [DataField("powerOutput")] public float PowerOutput = 1f;
+}

--- a/Content.Server/ThermoelectricGenerator/ThermoelectricGeneratorSystem.cs
+++ b/Content.Server/ThermoelectricGenerator/ThermoelectricGeneratorSystem.cs
@@ -1,0 +1,50 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Atmos.Piping.Components;
+using Content.Server.NodeContainer;
+using Content.Server.NodeContainer.Nodes;
+using Content.Server.Power.Components;
+using Robust.Shared.Timing;
+
+namespace Content.Server.ThermoelectricGenerator;
+
+public sealed class ThermoelectricGeneratorSystem : EntitySystem
+{
+    [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ThermoelectricGeneratorComponent, AtmosDeviceUpdateEvent>(OnGeneratorUpdated);
+    }
+
+    private void OnGeneratorUpdated(EntityUid uid, ThermoelectricGeneratorComponent component, AtmosDeviceUpdateEvent args)
+    {
+        if (!TryComp(uid, out NodeContainerComponent? nodeContainer)
+            || !TryComp(uid, out AtmosDeviceComponent? device)
+            || !nodeContainer.TryGetNode(component.ColdLoopName, out PipeNode? cold)
+            || !nodeContainer.TryGetNode(component.HotLoopName, out PipeNode? hot))
+        {
+            return;
+        }
+
+        // thank you ilya very cool
+        var hotTransferred = hot.Air.RemoveVolume((float)(component.TransferRate * (_gameTiming.CurTime - device.LastProcess).TotalSeconds));
+        var coldTransferred = cold.Air.RemoveVolume((float)(component.TransferRate * (_gameTiming.CurTime - device.LastProcess).TotalSeconds));
+        // code copied from volumetric pump, assuming it'd be pretty easy to make it work
+        // also yeah add TransferRate to the component, maybe set it to like 1000 by default
+        var hotTemp = hotTransferred.Temperature;
+        var coldTemp = coldTransferred.Temperature;
+        var hotCapacity = _atmosphereSystem.GetHeatCapacity(hotTransferred);
+        var coldCapacity = _atmosphereSystem.GetHeatCapacity(coldTransferred);
+        var finalTemp = (hotTemp * hotCapacity + coldTemp * coldCapacity) / (hotCapacity + coldCapacity);
+        var heatTransferred = (finalTemp - coldTemp) * coldCapacity;
+        hotTransferred.Temperature = finalTemp;
+        coldTransferred.Temperature = finalTemp;
+        _atmosphereSystem.Merge(hot.Air, hotTransferred);
+        _atmosphereSystem.Merge(cold.Air, coldTransferred);
+
+        if (TryComp<PowerSupplierComponent>(uid, out var powerSupplierComponent))
+            powerSupplierComponent.MaxSupply = heatTransferred * component.PowerOutput; // also add PowerOutput to the component
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -315,3 +315,69 @@
             max: 5
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+
+# TEG
+
+- type: entity
+  parent: BaseGenerator
+  id: GeneratorTEG
+  name: thermoelectric generator
+  description: A thermoelectric Generator for long term power. I don't know either.
+  components:
+    - type: ThermoelectricGenerator
+    - type: PowerSupplier
+      supplyRate: 0
+    - type: Sprite
+      sprite: Structures/Piping/Atmospherics/thermomachine.rsi
+      granularLayersRendering: true
+      layers:
+        - state: freezerOff
+          map: [ "enum.PowerDeviceVisualLayers.Powered" ]
+        - state: freezerPanelOpen
+          map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
+        - state: pipe
+          map: [ "enum.PipeVisualLayers.Pipe" ]
+          renderingStrategy: Default
+    - type: GenericVisualizer
+      visuals:
+        enum.PowerDeviceVisuals.Powered:
+          enum.PowerDeviceVisualLayers.Powered:
+            True: { state: freezerOn }
+            False: { state: freezerOff }
+    - type: AmbientSound
+      range: 5
+      sound:
+        path: /Audio/Ambience/Objects/buzzing.ogg
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 600
+          behaviors:
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+        - trigger:
+            !type:DamageTrigger
+            damage: 300
+          behaviors:
+            - !type:PlaySoundBehavior
+              sound:
+                path: /Audio/Effects/metalbreak.ogg
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+    - type: NodeContainer
+      examinable: true
+      nodes:
+        output:
+          !type:CableDeviceNode
+          nodeGroupID: HVPower
+        cold:
+          !type:PipeNode
+          nodeGroupID: Pipe
+          pipeDirection: South
+          volume: 100
+        hot:
+          !type:PipeNode
+          nodeGroupID: Pipe
+          pipeDirection: South
+          volume: 100


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG I LOVE THE TEG and other insane ramblings of not knowing what the fuck any of this does.

It adds the TEG. Probably exploitable, but hey, it's better than the piece of shit AME

TODO:
- [ ] Need sprites
- [ ] Circulators? Do we really need circulators???
- [ ] I dunno anymore whatever the atmos techs yell at me about
- [x] Sobbing

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: eclips_e
- add: The TEG is here. All hail breaking reality.
