### PR TITLE
Slightly buffs the E-Pen, makes jetpacks 2tc

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -61,7 +61,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Melee/e_dagger.rsi, state: icon }
   productEntity: EnergyDaggerBox
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkWeapons
 
@@ -286,7 +286,7 @@
   description: uplink-black-jetpack-desc
   productEntity: JetpackBlackFilled
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - UplinkUtility
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -2,7 +2,7 @@
   name: energy sword
   parent: BaseItem
   id: EnergySword
-  description: Very loud and very dangerous energy sword that can reflect shots. Can be stored in pockets when turned off.
+  description: A very loud & dangerous sword with a beam made of pure, concentrated plasma. Cuts through unarmored targets like butter.
   components:
   - type: EnergySword
     litDamageBonus:
@@ -65,8 +65,8 @@
     secret: true
     litDamageBonus:
         types:
-            Slash: 7.5
-            Heat: 7.5
+            Slash: 9
+            Heat: 9
             Blunt: -1
     litDisarmMalus: 0.4
     activateSound: !type:SoundPathSpecifier


### PR DESCRIPTION
## About the PR
What it says on the tin.
The E-Pen is now 2TC and the damage has been buffed to 18 like it is in /tg/. While this feels slightly like an overbuff, it will probably be fine considering there is almost no reason to use the energy pen right now due to its cost & hilariously mediocre damage. Even in /tg/ energy pens were rare to see with these stats, so we'll see how it goes.

Jetpacks have been changed to 2tc because they're an "if-you-need-it" item that can be found on station semi-easy like the syndicate toolbox. 4TC feels silly for such a niche item.


**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Buffed the E-Pen to do 18 damage per hit.
- tweak: The Jetpack & Energy Pen in the syndicate uplink now only cost 2tc.
