### PR TITLE
Add API to change the sound of AmbientSoundComponent

### DIFF
--- a/Content.Shared/Audio/AmbientSoundComponent.cs
+++ b/Content.Shared/Audio/AmbientSoundComponent.cs
@@ -50,7 +50,5 @@ public sealed class AmbientSoundComponentState : ComponentState
     public bool Enabled { get; init; }
     public float Range { get; init; }
     public float Volume { get; init; }
-    // Begin Nyano-code: allow changing of SoundSpecifier.
     public SoundSpecifier Sound { get; init; } = default!;
-    // End Nyano-code.
 }

--- a/Content.Shared/Audio/AmbientSoundComponent.cs
+++ b/Content.Shared/Audio/AmbientSoundComponent.cs
@@ -50,4 +50,7 @@ public sealed class AmbientSoundComponentState : ComponentState
     public bool Enabled { get; init; }
     public float Range { get; init; }
     public float Volume { get; init; }
+    // Begin Nyano-code: allow changing of SoundSpecifier.
+    public SoundSpecifier Sound { get; init; } = default!;
+    // End Nyano-code.
 }

--- a/Content.Shared/Audio/SharedAmbientSoundSystem.cs
+++ b/Content.Shared/Audio/SharedAmbientSoundSystem.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Audio;
@@ -45,12 +46,23 @@ public abstract class SharedAmbientSoundSystem : EntitySystem
         Dirty(ambience);
     }
 
+    public virtual void SetSound(EntityUid uid, SoundSpecifier sound, AmbientSoundComponent? ambience = null)
+    {
+        if (!Resolve(uid, ref ambience, false) || ambience.Sound == sound)
+            return;
+
+        ambience.Sound = sound;
+        QueueUpdate(uid, ambience);
+        Dirty(ambience);
+    }
+
     private void HandleCompState(EntityUid uid, AmbientSoundComponent component, ref ComponentHandleState args)
     {
         if (args.Current is not AmbientSoundComponentState state) return;
         SetAmbience(uid, state.Enabled, component);
         SetRange(uid, state.Range, component);
         SetVolume(uid, state.Volume, component);
+        SetSound(uid, state.Sound, component);
     }
 
     private void GetCompState(EntityUid uid, AmbientSoundComponent component, ref ComponentGetState args)
@@ -60,6 +72,7 @@ public abstract class SharedAmbientSoundSystem : EntitySystem
             Enabled = component.Enabled,
             Range = component.Range,
             Volume = component.Volume,
+            Sound = component.Sound,
         };
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Currently, ambient sounds can be turned on and off, but they cannot change the sound they are playing. Some use cases will want multiple states beyond playing and not, so this API allows them to change the sound. To do so without this API involves removing the component and trying to initialize a new one with a new sound, which is quite unclean.

This was originally written by https://github.com/Finket as part of https://github.com/Nyanotrasen/Nyanotrasen/pull/1345/ .

I am upstreaming it to fulfill https://github.com/Nyanotrasen/Nyanotrasen/issues/1631 .

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase