### PR TITLE
More PA fixes

### DIFF
--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -40,6 +40,12 @@ public sealed class ParticleAcceleratorControlBoxComponent : Component
     public bool Firing = false;
 
     /// <summary>
+    /// Block re-entrant rescanning.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public bool CurrentlyRescanning = false;
+
+    /// <summary>
     /// Whether the PA is currently firing or charging to fire.
     /// Bounded by <see cref="ParticleAcceleratorPowerState.Standby"/> and <see cref="MaxStrength"/>.
     /// Modified by <see cref="ParticleAcceleratorStrengthWireAction"/>.


### PR DESCRIPTION
If the PA Control Box isn't rotated to match the Fuel Chamber, it actually rotates itself to match.

This rotation triggered a rotation event, which in turn caused RescanParts() to run again, re-entrantly. This broke everything.

Fixed by adding a boolean to just guard against this.

:cl:
- fix: Fixed the PA even more for real this time pinky promise I swear.
