### PR TITLE
Give captain's sword reflect chance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -15,6 +15,10 @@
         Slash: 17 #cmon, it has to be at least BETTER than the rest.
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: Reflect
+    enabled: true
+    reflectProb: .5
+    spread: 90        
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/captain_sabre.rsi


### PR DESCRIPTION
this will make it more a juicy item to loot/use for captain and traitors, also makes it more viable in combat. ss13 does something similar with this. it has a 50% reflect chance compared to deswords 75% it also reflects less accurately than desword

🆑 
- tweak: Captain's Sabre now has a chance to reflect projectiles.