### PR TITLE
Disposable turret balance changes

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
@@ -52,6 +52,13 @@ public sealed partial class BallisticAmmoProviderComponent : Component
     public bool Cycled = true;
 
     /// <summary>
+    /// Is the gun allowed to be cycled
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("cycleable")]
+    [AutoNetworkedField]
+    public bool Cycleable = true;
+
+    /// <summary>
     /// Is it okay for this entity to directly transfer its valid ammunition into another provider?
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("mayTransfer")]

--- a/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
@@ -52,7 +52,7 @@ public sealed partial class BallisticAmmoProviderComponent : Component
     public bool Cycled = true;
 
     /// <summary>
-    /// Is the gun allowed to be cycled
+    /// Is the magazine allowed to be cycled
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("cycleable")]
     [AutoNetworkedField]

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -132,13 +132,13 @@ public abstract partial class SharedGunSystem
     {
         if (!args.CanAccess || !args.CanInteract || args.Hands == null)
             return;
-
-        args.Verbs.Add(new Verb()
-        {
-            Text = Loc.GetString("gun-ballistic-cycle"),
-            Disabled = GetBallisticShots(component) == 0,
-            Act = () => ManualCycle(uid, component, Transform(uid).MapPosition, args.User),
-        });
+        if (component.Cycleable == true)
+            args.Verbs.Add(new Verb()
+            {
+                Text = Loc.GetString("gun-ballistic-cycle"),
+                Disabled = GetBallisticShots(component) == 0,
+                Act = () => ManualCycle(uid, component, Transform(uid).MapPosition, args.User),
+            });
     }
 
     private void OnBallisticExamine(EntityUid uid, BallisticAmmoProviderComponent component, ExaminedEvent args)

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -805,7 +805,7 @@
   description: uplink-disposable-turret-desc
   productEntity: ToolboxElectricalTurretFilled
   cost:
-    Telecrystal: 12
+    Telecrystal: 8
   categories:
   - UplinkJob
   conditions:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -8,7 +8,7 @@
     - type: InteractionOutline
     - type: Sprite
       sprite: Objects/Weapons/Guns/Turrets/turrets.rsi
-      drawdepth: WallMountedItems
+      drawdepth: Mobs
       layers:
         - state: syndie_broken
     - type: Damageable
@@ -55,7 +55,7 @@
         ballistic-ammo: !type:Container
     - type: Sprite
       sprite: Objects/Weapons/Guns/Turrets/turrets.rsi
-      drawdepth: WallMountedItems
+      drawdepth: Mobs
       layers:
         - state: syndie_lethal
     - type: InteractionPopup
@@ -152,14 +152,22 @@
                   min: 1
                   max: 1
     - type: Gun
-      fireRate: 2.5
+      fireRate: 2
       selectedMode: FullAuto
       availableModes:
         - FullAuto
       soundGunshot: /Audio/Weapons/Guns/Gunshots/gun_sentry.ogg
     - type: BallisticAmmoProvider
       proto: CartridgePistol
-      capacity: 125
+      capacity: 50
+      cycleable: false
+    - type: Construction
+      deconstructionTarget: null
+      graph: WeaponTurretSyndicateDisposable
+      node: disposableTurret
+    - type: Repairable
+      qualityNeeded: "Anchoring"
+      doAfterDelay: 3
 
 - type: entity
   parent: BaseWeaponTurret

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/disposable_turret.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/disposable_turret.yml
@@ -1,0 +1,16 @@
+- type: constructionGraph
+  id: WeaponTurretSyndicateDisposable
+  start: disposableTurret
+  graph:
+  - node: disposableTurret
+    entity: WeaponTurretSyndicateDisposable
+    edges:
+    - to: disposableTurret
+      completed:
+      - !type:SpawnPrototype
+            prototype: ToolboxElectricalTurret
+            amount: 1
+      - !type:DeleteEntity {}
+      steps:
+        - tool: Screwing
+          doAfter: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR adds the following changes to the disposable turret:

- Price lowered to 8tc:
General consensus was that it was too expensive for a "disposable" turret
- Rate of fire lowered by 20% to 2/s:
Now that it's cheaper it's DPS should be a bit lower, two sentries together still have quite a bit more DPS than the original 12 tc one.
- Made repairable and deconstructable:
The turret can now be deconstructed back into a toolbox using a screwdriver, this has a 10 second doafter. 
It can now be repaired using a wrench, this has a 3 second doafter.
Deconstructing the turret and placing it again replenishes all it's ammo and health
- max ammo lowered to 50 since it's cheaper and ammo can be replenished by redeploying it.
- It can't be cycled anymore to prevent people getting infinite bullets from it.
- drawdepth set to Mobs so it will appear in front of dropped items.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/137322659/cdad632a-e3ae-4089-8ffc-ffc40fb97a09


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Dygon
- tweak: Disposable turret price lowered to 8 tc and rate of fire lowered by 20%.
- tweak: Disposable turrets can now be turned back into a toolbox using a screwdriver and repaired using a wrench.
