### PR TITLE
Make clumsy entities able to shoot funny weapons

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -74,7 +74,7 @@ public sealed partial class GunSystem : SharedGunSystem
 
         // Try a clumsy roll
         // TODO: Who put this here
-        if (TryComp<ClumsyComponent>(user, out var clumsy))
+        if (TryComp<ClumsyComponent>(user, out var clumsy) && gun.ClumsyProof == false)
         {
             for (var i = 0; i < ammo.Count; i++)
             {

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -142,6 +142,13 @@ public partial class GunComponent : Component
     /// </summary>
     [DataField("showExamineText")]
     public bool ShowExamineText = true;
+
+    /// <summary>
+    /// Whether or not someone with the
+    /// clumsy trait can shoot this
+    /// </summary>
+    [DataField("clumsyProof")]
+    public bool ClumsyProof = false;
 }
 
 [Flags]

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -597,6 +597,7 @@
       - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/revolver.ogg
+    clumsyProof: true
   - type: RevolverAmmoProvider
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
@@ -12,6 +12,7 @@
     sprite: Objects/Weapons/Guns/Pistols/water_pistol.rsi
     size: 10
   - type: Gun
+    clumsyProof: true
     cameraRecoilScalar: 0 #no recoil
     fireRate: 1
     selectedMode: SemiAuto
@@ -73,6 +74,7 @@
   description: With this bad boy, you'll be the cooleste kid at the summer barbecue.
   components:
   - type: Gun
+    clumsyProof: true
     cameraRecoilScalar: 0 #no recoil
     fireRate: 2
     selectedMode: FullAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
@@ -74,7 +74,6 @@
   description: With this bad boy, you'll be the cooleste kid at the summer barbecue.
   components:
   - type: Gun
-    clumsyProof: true
     cameraRecoilScalar: 0 #no recoil
     fireRate: 2
     selectedMode: FullAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -27,6 +27,7 @@
       path: /Audio/Effects/thunk.ogg
     soundEmpty:
       path: /Audio/Items/hiss.ogg
+    clumsyProof: true
   - type: ContainerAmmoProvider
     container: storagebase
   - type: PneumaticCannon
@@ -85,6 +86,7 @@
       path: /Audio/Effects/thunk.ogg
     soundEmpty:
       path: /Audio/Items/hiss.ogg
+    clumsyProof: true
   - type: ContainerAmmoProvider
     container: storagebase
   - type: Item


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Allows clowns and monkeys to shoot funny guns again.
This includes the fake cap gun since currently it's just wasted TC for the clown.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Dygon
- tweak: Water guns, pneumatic cannons and cap guns got extra safety measures, clowns and monkeys will be able to use them again without accidentally blowing them up.
