### PR TITLE
Gives the Sec winter jacket armor values.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -310,12 +310,20 @@
 - type: entity
   parent: ClothingOuterWinterCoat
   id: ClothingOuterWinterSec
-  name: security winter coat
+  name: security armored winter coat
+  description: While it doesnt provide as much protection as standard issue armor, it will hopefully reduce Lizard officer fatalities.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/WinterCoats/coatsec.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coatsec.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.85 #slightly less damage resistance than standard armor
+        Heat: 0.70
 
 - type: entity
   parent: ClothingOuterWinterCoat


### PR DESCRIPTION
First PR so don't bonk me too hard.

Changes: 
-Sec winter jacket name changed to Security Armored Winter Jacket
-Given a description of : While it doesn't provide as much protection as standard issue armor, it will hopefully reduce Lizard officer fatalities.
- New modifiers: blunt .75, slash .75, piercing .85

About: I often found that sec lizards died a lot to cold, and warden has a winter armored vest. On top of this, it takes the same slot as armor so I simply modified it to be weaker armor, yet still have the jacket temp resist. 