### PR TITLE
Made Artifact EORG a server config

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -10,6 +10,8 @@ using Content.Shared.Xenoarchaeology.XenoArtifacts;
 using JetBrains.Annotations;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Robust.Shared.Configuration;
+using Content.Shared.CCVar;
 
 namespace Content.Server.Xenoarchaeology.XenoArtifacts;
 
@@ -18,6 +20,7 @@ public sealed partial class ArtifactSystem : EntitySystem
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
     private ISawmill _sawmill = default!;
 
@@ -301,12 +304,15 @@ public sealed partial class ArtifactSystem : EntitySystem
     /// </summary>
     private void OnRoundEnd(RoundEndTextAppendEvent ev)
     {
-        var query = EntityQueryEnumerator<ArtifactComponent>();
-        while (query.MoveNext(out var ent, out var artifactComp))
+        if (_configurationManager.GetCVar(CCVars.ArtifactRoundEndGrief) == true)
         {
-            artifactComp.CooldownTime = TimeSpan.Zero;
-            var timerTrigger = EnsureComp<ArtifactTimerTriggerComponent>(ent);
-            timerTrigger.ActivationRate = TimeSpan.FromSeconds(0.5); //HAHAHAHAHAHAHAHAHAH -emo
+            var query = EntityQueryEnumerator<ArtifactComponent>();
+            while (query.MoveNext(out var ent, out var artifactComp))
+            {
+                artifactComp.CooldownTime = TimeSpan.Zero;
+                var timerTrigger = EnsureComp<ArtifactTimerTriggerComponent>(ent);
+                timerTrigger.ActivationRate = TimeSpan.FromSeconds(0.5); //HAHAHAHAHAHAHAHAHAH -emo
+            }
         }
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -306,6 +306,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> GameAlertLevelChangeDelay =
             CVarDef.Create("game.alert_level_change_delay", 30, CVar.SERVERONLY);
 
+        /// <summary>
+        /// True: Artifacts will grief on round end.
+        /// False: They won't.
+        /// </summary>
+        public static readonly CVarDef<bool> ArtifactRoundEndGrief = CVarDef.Create("game.artifact_round_end_grief", true, CVar.NOTIFY | CVar.REPLICATED);
+
         /*
          * Discord
          */

--- a/Resources/ConfigPresets/WizardsDen/salamander.toml
+++ b/Resources/ConfigPresets/WizardsDen/salamander.toml
@@ -3,6 +3,7 @@
 [game]
 desc = "Official English Space Station 14 servers. Roleplay required, you must be whitelisted through Discord to play if there are more than 15 online players."
 hostname = "[EN] Wizard's Den Salamander [US West RP]"
+artifact_round_end_grief = false
 
 [server]
 rules_file = "RP_Rules.txt"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
The config is set to true by default. This mostly exists for servers where eorg is banned, such as sala (where I've turned it off). 
While #18160 exists and I agree to a point, given everyone griefs at the end of the round on LRP anyways I don't see a huge problem with having artifacts do it (and I think it's kind of fun, I've certainly had fun with it). 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Lank
- tweak: Artifacts going insane at round-end can now be disabled per-server. 
