### PR TITLE
Fix some machine construction bugs.

### DIFF
--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -50,14 +50,14 @@ namespace Content.Server.Stack
             if (!Resolve(uid, ref stack))
                 return null;
 
+            // Try to remove the amount of things we want to split from the original stack...
+            if (!Use(uid, amount, stack))
+                return null;
+
             // Get a prototype ID to spawn the new entity. Null is also valid, although it should rarely be picked...
             var prototype = _prototypeManager.TryIndex<StackPrototype>(stack.StackTypeId, out var stackType)
                 ? stackType.Spawn
                 : Prototype(uid)?.ID;
-
-            // Try to remove the amount of things we want to split from the original stack...
-            if (!Use(uid, amount, stack))
-                return null;
 
             // Set the output parameter in the event instance to the newly split stack.
             var entity = Spawn(prototype, spawnPosition);

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -167,6 +167,7 @@ namespace Content.Shared.Stacks
             amount = Math.Min(amount, GetMaxCount(component));
             amount = Math.Max(amount, 0);
 
+            // Server-side override deletes the entity if count == 0
             component.Count = amount;
             Dirty(component);
 

--- a/Content.Shared/Stacks/StackComponent.cs
+++ b/Content.Shared/Stacks/StackComponent.cs
@@ -28,6 +28,7 @@ namespace Content.Shared.Stacks
 
         /// <summary>
         ///     Set to true to not reduce the count when used.
+        ///     Note that <see cref="Count"/> still limits the amount that can be used at any one time.
         /// </summary>
         [DataField("unlimited")]
         [ViewVariables(VVAccess.ReadOnly)]


### PR DESCRIPTION
This fixes two bugs in machine construction code. Firstly, `RegenerateProgress()` was ignoring stack counts and just always incrementing by one.

Secondly the progress logic in `RegenerateProgress()` and `OnInteractUsing()` was inconsistent. In one case an entity could satisfy multiple different tag/component requirements and in the other it could only satisfy one. This PR changes the behaviour so that it is consistently the former. This avoids potential issues where the order in which entities get inserted or stored can matter.

This PR also tries to make `OnInteractUsing()` more readable by splitting off parts into separate functions (`TryInsertBoard()`, `TryInsertPart()`, and  `TryInsertStack()`).

:cl:
- fix: Fixed a bug causing some machine construction requirements to not work properly.