### PR TITLE
Reduce Nitrogen Tank output pressure

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -70,7 +70,7 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 101.325
+      outputPressure: 21.27825
       air:
         volume: 15
         moles:

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -70,7 +70,7 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 21.27825
+      outputPressure: 101.325
       air:
         volume: 15
         moles:
@@ -87,7 +87,7 @@
   name: nitrogen tank
   components:
     - type: GasTank
-      outputPressure: 101.325
+      outputPressure: 21.27825
       air:
         volume: 15
         moles:


### PR DESCRIPTION
## About the PR
Nitrogen tanks are set to default 101 which is very wasteful when slimes breathe just fine on the standard 21. 
If this is an intentionally imperfect setting for the player to fix before use, then the oxygen tank should also be set to 101 instead

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Errant
- tweak: Nitrogen tank settings have been adjusted to avoid gas wastage