### PR TITLE
Gas tank cleanup and fix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -6,7 +6,6 @@
 # 1000 / (Atmospherics.R * temperature / volume)
 # (What the hell is Atmospherics.R ?)
 
-
 # Filling 15 liters at exactly 1000 kpa and 293.15K takes 6.154137219 moles
 # Multiply/divide total moles in proportion to tank size to keep it at 1000 kpa pressure
 
@@ -14,6 +13,10 @@
 # 15 liters tank :   6.154137219 moles
 #  5 liters tank :   6.154137219 / 3 = 2.051379073 moles
 # Yes, you do need all those digits or your pressure wont end up *exactly* 1000
+
+
+# If you change the filling amounts, you can calculate the new gas supply times with:
+# (moles / outputPressure) * 325 = minutes
 
 - type: entity
   id: OxygenTankFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -8,15 +8,15 @@
 
 # Filling 15 liters at exactly 1000 kpa and 293.15K takes 6.154137219 moles
 # Multiply/divide total moles in proportion to tank size to keep it at 1000 kpa pressure
-
-# For practical folk:
-# 15 liters tank :   6.154137219 moles
-#  5 liters tank :   6.154137219 / 3 = 2.051379073 moles
+#
+# More practically:
+# Temperature must be exactly 293.15
+# moles = volume * 0.4102758146
 # Yes, you do need all those digits or your pressure wont end up *exactly* 1000
 
 
 # If you change the filling amounts, you can calculate the new gas supply times with:
-# (moles / outputPressure) * 325 = minutes
+# minutes = (moles / outputPressure) * 325
 
 - type: entity
   id: OxygenTankFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -8,12 +8,12 @@
   suffix: Filled
   components: &oxyTankFill
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 21.3
     air:
-      volume: 15
+      volume: 5
       moles:
         # 1000 / (Atmospherics.R * temperature / volume)
-        - 6.154137219
+        - 2.051379073
       temperature: 293.15
 
 - type: entity
@@ -28,12 +28,12 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 21.27825
+      outputPressure: 21.3
       air:
-        volume: 2
+        volume: 0.66
         moles:
           # 1000 / (Atmospherics.R * temperature / volume)
-          - 0.820551629 # oxygen
+          - 0.270782038 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -42,12 +42,12 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 21.27825
+      outputPressure: 21.3
       air:
-        volume: 6
+        volume: 2
         moles:
           # 1000 / (Atmospherics.R * temperature / volume)
-          - 2.461654887 # oxygen
+          - 0.820551629 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -56,12 +56,12 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 21.27825
+      outputPressure: 21.3
       air:
-        volume: 10
+        volume: 3.33
         moles:
           # 1000 / (Atmospherics.R * temperature / volume)
-          - 4.102725815 # oxygen
+          - 1.366218462 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -70,14 +70,14 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 101.325
+      outputPressure: 101.3
       air:
-        volume: 15
+        volume: 5
         moles:
           # (1000 * .22) / (Atmospherics.R * temperature / volume)
-          - 1.353910188 # oxygen
+          - 0.451303396 # oxygen
           # (1000 * .78) / (Atmospherics.R * temperature / volume)
-          - 4.800227031 # nitrogen
+          - 1.600075677 # nitrogen
         temperature: 293.15
 
 - type: entity
@@ -87,13 +87,13 @@
   name: nitrogen tank
   components:
     - type: GasTank
-      outputPressure: 21.27825
+      outputPressure: 21.3
       air:
-        volume: 15
+        volume: 5
         moles:
           - 0 # oxygen
           # 1000 / (Atmospherics.R * temperature / volume)
-          - 6.154137219 # nitrogen
+          - 2.051379073 # nitrogen
         temperature: 293.15
 
 - type: entity
@@ -108,12 +108,12 @@
       #  * 101.325 | one atmosphere
       # __________
       #    30.3975   optimal output pressure
-      outputPressure: 30.3975
+      outputPressure: 30.4
       air:
-        volume: 15
+        volume: 5
         moles:
           # (1000 * .7) / (Atmospherics.R * temperature / volume)
-          - 4.307896053 # oxygen
+          - 1.435965351 # oxygen
           - 0 # Nitrogen
           - 0 # CO2
           - 0 # Plasma
@@ -121,7 +121,7 @@
           - 0 # Water vapor
           - 0 # Miasma
           # (1000 * .3) / (Atmospherics.R * temperature / volume)
-          - 1.846241166 # N2O
+          - 0.615413722 # N2O
         temperature: 293.15
 
 - type: entity
@@ -131,13 +131,13 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 101.325
+      outputPressure: 101.3
       air:
-        volume: 15
+        volume: 5
         moles:
           - 0
           - 0
           - 0
           # 1000 / (Atmospherics.R * temperature / volume)
-          - 6.154137219 # plasma
+          - 2.051379073 # plasma
         temperature: 293.15

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -2,6 +2,18 @@
 # MaxReleasePressure for a GasCanister, which is 10 * Atmospherics.OneAtmosphere,
 # rounded down.
 
+# Moles calculation:
+# 1000 / (Atmospherics.R * temperature / volume)
+# (What the hell is Atmospherics.R ?)
+
+
+# Filling 15 liters at exactly 1000 kpa and 293.15K takes 6.154137219 moles
+# Multiply/divide total moles in proportion to tank size to keep it at 1000 kpa pressure
+
+# For simple folk like me:
+# 15 liters tank = 6.154137219 moles
+#  5 liters tank = 1/3 as many
+
 - type: entity
   id: OxygenTankFilled
   parent: OxygenTank
@@ -10,10 +22,10 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      volume: 5
+      # 97 minutes
+      volume: 15
       moles:
-        # 1000 / (Atmospherics.R * temperature / volume)
-        - 2.051379073
+        - 6.154137219 # oxygen
       temperature: 293.15
 
 - type: entity
@@ -30,10 +42,10 @@
     - type: GasTank
       outputPressure: 21.3
       air:
-        volume: 0.66
+        # 13 minutes
+        volume: 2
         moles:
-          # 1000 / (Atmospherics.R * temperature / volume)
-          - 0.270782038 # oxygen
+          - 0.820551629 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -44,10 +56,10 @@
     - type: GasTank
       outputPressure: 21.3
       air:
-        volume: 2
+        # 39 minutes
+        volume: 6
         moles:
-          # 1000 / (Atmospherics.R * temperature / volume)
-          - 0.820551629 # oxygen
+          - 2.461654887 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -58,10 +70,10 @@
     - type: GasTank
       outputPressure: 21.3
       air:
-        volume: 3.33
+        # 65 minutes
+        volume: 10
         moles:
-          # 1000 / (Atmospherics.R * temperature / volume)
-          - 1.366218462 # oxygen
+          - 4.102725815 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -72,12 +84,12 @@
     - type: GasTank
       outputPressure: 101.3
       air:
-        volume: 5
+        # 20 minutes due to output pressure
+        volume: 15
         moles:
-          # (1000 * .22) / (Atmospherics.R * temperature / volume)
-          - 0.451303396 # oxygen
-          # (1000 * .78) / (Atmospherics.R * temperature / volume)
-          - 1.600075677 # nitrogen
+          - 1.353910188 # 22% oxygen
+          - 4.800227031 # 78% nitrogen
+          # 6.154137219       total
         temperature: 293.15
 
 - type: entity
@@ -89,11 +101,11 @@
     - type: GasTank
       outputPressure: 21.3
       air:
-        volume: 5
+        # 97 minutes
+        volume: 15
         moles:
-          - 0 # oxygen
-          # 1000 / (Atmospherics.R * temperature / volume)
-          - 2.051379073 # nitrogen
+          - 0           # oxygen not included
+          - 6.154137219 # nitrogen
         temperature: 293.15
 
 - type: entity
@@ -110,18 +122,18 @@
       #    30.3975   optimal output pressure
       outputPressure: 30.4
       air:
-        volume: 5
+        # only 68 minutes due to pressure
+        volume: 15
         moles:
-          # (1000 * .7) / (Atmospherics.R * temperature / volume)
-          - 1.435965351 # oxygen
-          - 0 # Nitrogen
+          - 4.307896053 #     70% oxygen
+          - 0 # nitrogen
           - 0 # CO2
-          - 0 # Plasma
-          - 0 # Tritium
-          - 0 # Water vapor
-          - 0 # Miasma
-          # (1000 * .3) / (Atmospherics.R * temperature / volume)
-          - 0.615413722 # N2O
+          - 0 # plasma
+          - 0 # tritium
+          - 0 # water vapor
+          - 0 # miasma
+          - 1.846241166 #     30% N2O
+          # 6.154137219       total
         temperature: 293.15
 
 - type: entity
@@ -133,11 +145,11 @@
     - type: GasTank
       outputPressure: 101.3
       air:
-        volume: 5
+        # 20 minutes of agony
+        volume: 15
         moles:
-          - 0
-          - 0
-          - 0
-          # 1000 / (Atmospherics.R * temperature / volume)
-          - 2.051379073 # plasma
+          - 0 # oxygen
+          - 0 # nitrogen
+          - 0 # CO2
+          - 6.154137219 # plasma
         temperature: 293.15

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -10,9 +10,10 @@
 # Filling 15 liters at exactly 1000 kpa and 293.15K takes 6.154137219 moles
 # Multiply/divide total moles in proportion to tank size to keep it at 1000 kpa pressure
 
-# For simple folk like me:
+# For practical folk:
 # 15 liters tank = 6.154137219 moles
-#  5 liters tank = 1/3 as many
+#  5 liters tank = 6.154137219 / 3 = 2.051379073 moles
+# Yes, you do need all those digits
 
 - type: entity
   id: OxygenTankFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -1,21 +1,23 @@
-# The number 1000 used in the rest of this file refers to the default
-# MaxReleasePressure for a GasCanister, which is 10 * Atmospherics.OneAtmosphere,
-# rounded down.
-
-# Moles calculation:
-# 1000 / (Atmospherics.R * temperature / volume)
-# (What the hell is Atmospherics.R ?)
-
-# Filling 15 liters at exactly 1000 kpa and 293.15K takes 6.154137219 moles
-# Multiply/divide total moles in proportion to tank size to keep it at 1000 kpa pressure
+# Moles calculation
 #
-# More practically:
-# Temperature must be exactly 293.15
-# moles = volume * 0.4102758146
-# Yes, you do need all those digits or your pressure wont end up *exactly* 1000
+#   moles = 1000 / (8.31446261 * 293.15 / volume)
+#
+#   More practically:
+#
+#   moles = volume * 0.41027581
+#
+#   Yes, you do need all those digits or your pressure wont end up exactly 1000
+#
+#
+# The number 1000 comes from the default MaxReleasePressure for a GasCanister,
+# which is 10 * Atmospherics.OneAtmosphere, rounded down.
+#
+# 8.31446261 is the universal gas constant
+#
+# 293.15 is our default atmospheric temperature
+#
 
-
-# If you change the filling amounts, you can calculate the new gas supply times with:
+# If you change the mole amounts, you can calculate the new gas supply times with:
 # minutes = (moles / outputPressure) * 325
 
 - type: entity
@@ -29,7 +31,7 @@
       # 94 minutes
       volume: 15
       moles:
-        - 6.154137219 # oxygen
+        - 6.15413721 # oxygen
       temperature: 293.15
 
 - type: entity
@@ -49,7 +51,7 @@
         # 13 minutes
         volume: 2
         moles:
-          - 0.820551629 # oxygen
+          - 0.82055162 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -63,7 +65,7 @@
         # 38 minutes
         volume: 6
         moles:
-          - 2.461654887 # oxygen
+          - 2.46165488 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -77,7 +79,7 @@
         # 63 minutes
         volume: 10
         moles:
-          - 4.102725815 # oxygen
+          - 4.10275814 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -91,9 +93,9 @@
         # 20 minutes due to output pressure
         volume: 15
         moles:
-          - 1.353910188 # 22% oxygen
-          - 4.800227031 # 78% nitrogen
-          # 6.154137219       total
+          - 1.35391018 # 22% oxygen
+          - 4.80022703 # 78% nitrogen
+          # 6.15413721       total
         temperature: 293.15
 
 - type: entity
@@ -108,8 +110,8 @@
         # 94 minutes
         volume: 15
         moles:
-          - 0           # oxygen not included
-          - 6.154137219 # nitrogen
+          - 0          # oxygen not included
+          - 6.15413721 # nitrogen
         temperature: 293.15
 
 - type: entity
@@ -129,15 +131,15 @@
         # only 66 minutes due to pressure
         volume: 15
         moles:
-          - 4.307896053 #     70% oxygen
+          - 4.30789605 # 70% oxygen
           - 0 # nitrogen
           - 0 # CO2
           - 0 # plasma
           - 0 # tritium
           - 0 # water vapor
           - 0 # miasma
-          - 1.846241166 #     30% N2O
-          # 6.154137219       total
+          - 1.84624116 # 30% N2O
+          # 6.15413721       total
         temperature: 293.15
 
 - type: entity
@@ -152,8 +154,8 @@
         # 20 minutes of agony
         volume: 15
         moles:
-          - 0 # oxygen
-          - 0 # nitrogen
-          - 0 # CO2
-          - 6.154137219 # plasma
+          - 0          # oxygen
+          - 0          # nitrogen
+          - 0          # CO2
+          - 6.15413721 # plasma
         temperature: 293.15

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -31,7 +31,7 @@
       # 94 minutes
       volume: 15
       moles:
-        - 6.15413721 # oxygen
+        - 6.154137219 # oxygen
       temperature: 293.15
 
 - type: entity
@@ -51,7 +51,7 @@
         # 13 minutes
         volume: 2
         moles:
-          - 0.82055162 # oxygen
+          - 0.820551629 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -65,7 +65,7 @@
         # 38 minutes
         volume: 6
         moles:
-          - 2.46165488 # oxygen
+          - 2.461654887 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -93,9 +93,9 @@
         # 20 minutes due to output pressure
         volume: 15
         moles:
-          - 1.35391018 # 22% oxygen
-          - 4.80022703 # 78% nitrogen
-          # 6.15413721       total
+          - 1.353910188 # 22% oxygen
+          - 4.800227031 # 78% nitrogen
+          # 6.15413721        total
         temperature: 293.15
 
 - type: entity
@@ -110,8 +110,8 @@
         # 94 minutes
         volume: 15
         moles:
-          - 0          # oxygen not included
-          - 6.15413721 # nitrogen
+          - 0           # oxygen not included
+          - 6.154137219 # nitrogen
         temperature: 293.15
 
 - type: entity
@@ -157,5 +157,5 @@
           - 0          # oxygen
           - 0          # nitrogen
           - 0          # CO2
-          - 6.15413721 # plasma
+          - 6.154137219 # plasma
         temperature: 293.15

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -11,9 +11,9 @@
 # Multiply/divide total moles in proportion to tank size to keep it at 1000 kpa pressure
 
 # For practical folk:
-# 15 liters tank = 6.154137219 moles
-#  5 liters tank = 6.154137219 / 3 = 2.051379073 moles
-# Yes, you do need all those digits
+# 15 liters tank :   6.154137219 moles
+#  5 liters tank :   6.154137219 / 3 = 2.051379073 moles
+# Yes, you do need all those digits or your pressure wont end up *exactly* 1000
 
 - type: entity
   id: OxygenTankFilled
@@ -23,7 +23,7 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      # 97 minutes
+      # 94 minutes
       volume: 15
       moles:
         - 6.154137219 # oxygen
@@ -57,7 +57,7 @@
     - type: GasTank
       outputPressure: 21.3
       air:
-        # 39 minutes
+        # 38 minutes
         volume: 6
         moles:
           - 2.461654887 # oxygen
@@ -71,7 +71,7 @@
     - type: GasTank
       outputPressure: 21.3
       air:
-        # 65 minutes
+        # 63 minutes
         volume: 10
         moles:
           - 4.102725815 # oxygen
@@ -102,7 +102,7 @@
     - type: GasTank
       outputPressure: 21.3
       air:
-        # 97 minutes
+        # 94 minutes
         volume: 15
         moles:
           - 0           # oxygen not included
@@ -123,7 +123,7 @@
       #    30.3975   optimal output pressure
       outputPressure: 30.4
       air:
-        # only 68 minutes due to pressure
+        # only 66 minutes due to pressure
         volume: 15
         moles:
           - 4.307896053 #     70% oxygen

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -79,7 +79,7 @@
         # 63 minutes
         volume: 10
         moles:
-          - 4.10275814 # oxygen
+          - 4.102758145 # oxygen
         temperature: 293.15
 
 - type: entity
@@ -95,7 +95,7 @@
         moles:
           - 1.353910188 # 22% oxygen
           - 4.800227031 # 78% nitrogen
-          # 6.15413721        total
+          # 6.154137219       total
         temperature: 293.15
 
 - type: entity
@@ -154,8 +154,8 @@
         # 20 minutes of agony
         volume: 15
         moles:
-          - 0          # oxygen
-          - 0          # nitrogen
-          - 0          # CO2
+          - 0           # oxygen
+          - 0           # nitrogen
+          - 0           # CO2
           - 6.154137219 # plasma
         temperature: 293.15

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -52,7 +52,7 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      volume: 5
+      volume: 15
       temperature: 293.15
     tankLowPressure: 30.0
   - type: Clothing
@@ -100,7 +100,7 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      volume: 0.66
+      volume: 2
       temperature: 293.15
   - type: Item
     size: 10
@@ -129,7 +129,7 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      volume: 2
+      volume: 6
       temperature: 293.15
   - type: Item
     size: 10
@@ -151,7 +151,7 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      volume: 3.33
+      volume: 10
       temperature: 293.15
   - type: Item
     size: 10
@@ -178,7 +178,7 @@
     - type: GasTank
       outputPressure: 101.3
       air:
-        volume: 5
+        volume: 15
         temperature: 293.15
     - type: Clothing
       sprite: Objects/Tanks/generic.rsi
@@ -197,7 +197,7 @@
     - type: GasTank
       outputPressure: 30.4
       air:
-        volume: 5
+        volume: 15
         temperature: 293.15
     - type: Clothing
       sprite: Objects/Tanks/anesthetic.rsi
@@ -216,7 +216,7 @@
     - type: GasTank
       outputPressure: 101.3
       air:
-        volume: 5
+        volume: 15
         temperature: 293.15
     - type: Item
       size: 15

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -45,14 +45,14 @@
   parent: GasTankBase
   id: OxygenTank
   name: oxygen tank
-  description: A tank of oxygen, this one is blue.
+  description: A standard cylindrical gas tank for oxygen.
   components:
   - type: Sprite
     sprite: Objects/Tanks/oxygen.rsi
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 21.3
     air:
-      volume: 15
+      volume: 5
       temperature: 293.15
     tankLowPressure: 30.0
   - type: Clothing
@@ -65,7 +65,7 @@
   parent: OxygenTank
   id: YellowOxygenTank
   name: oxygen tank
-  description: A tank of oxygen. This one is in yellow.
+  description: A standard cylindrical gas tank for oxygen. This one is yellow.
   components:
   - type: Sprite
     sprite: Objects/Tanks/yellow.rsi
@@ -79,7 +79,7 @@
   parent: OxygenTank
   id: NitrogenTank
   name: nitrogen tank
-  description: A tank of nitrogen.
+  description: A standard cylindrical gas tank for nitrogen.
   components:
   - type: Sprite
     sprite: Objects/Tanks/red.rsi
@@ -93,14 +93,14 @@
   parent: OxygenTank
   id: EmergencyOxygenTank
   name: emergency oxygen tank
-  description: Used for emergencies. Contains very little oxygen, so try to conserve it until you actually need it.
+  description: An easily portable tank for emergencies. Contains very little oxygen, rated for survival use only.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency.rsi
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 21.3
     air:
-      volume: 3
+      volume: 0.66
       temperature: 293.15
   - type: Item
     size: 10
@@ -122,14 +122,14 @@
   parent: EmergencyOxygenTank
   id: ExtendedEmergencyOxygenTank
   name: extended-capacity emergency oxygen tank
-  description: Used for emergencies. Contains little oxygen, so try to conserve it until you actually need it.
+  description: An emergency tank with extended capacity. Technically rated for prolonged use.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_yellow.rsi
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 21.3
     air:
-      volume: 6
+      volume: 2
       temperature: 293.15
   - type: Item
     size: 10
@@ -144,13 +144,14 @@
   parent: ExtendedEmergencyOxygenTank
   id: DoubleEmergencyOxygenTank
   name: double emergency oxygen tank
+  description: A high-grade dual-tank emergency life support container. It holds a decent amount of oxygen for it's small size.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_double.rsi
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 21.3
     air:
-      volume: 12
+      volume: 3.33
       temperature: 293.15
   - type: Item
     size: 10
@@ -175,9 +176,9 @@
     - type: Sprite
       sprite: Objects/Tanks/generic.rsi
     - type: GasTank
-      outputPressure: 101.325
+      outputPressure: 101.3
       air:
-        volume: 15
+        volume: 5
         temperature: 293.15
     - type: Clothing
       sprite: Objects/Tanks/generic.rsi
@@ -194,9 +195,9 @@
     - type: Sprite
       sprite: Objects/Tanks/anesthetic.rsi
     - type: GasTank
-      outputPressure: 30.3975
+      outputPressure: 30.4
       air:
-        volume: 15
+        volume: 5
         temperature: 293.15
     - type: Clothing
       sprite: Objects/Tanks/anesthetic.rsi
@@ -213,12 +214,12 @@
     - type: Sprite
       sprite: Objects/Tanks/plasma.rsi
     - type: GasTank
-      outputPressure: 101.325
+      outputPressure: 101.3
       air:
-        volume: 15
+        volume: 5
         temperature: 293.15
     - type: Item
-      size: 10
+      size: 15
     - type: Clothing
       sprite: Objects/Tanks/plasma.rsi
       slots:


### PR DESCRIPTION
## About the PR

1. Apparently for a long while, empty Emergency Oxygen Tanks and Double Oxygen Tanks had a different volume than filled ones. I have adjusted the empty ones to match the filled ones in both cases. This should not be very noticeable to players, only Box has an empty one mapped (I wonder if that was an accident?) and I'm not sure if they can be made

2. Plasma tanks for some reason had a smaller external size than standard tanks despite having the same volume. I have increased their size to match

3. I have rounded every tank's default Release Pressure to only include a single fractional digit. Numbers in player-interactive UIs should not be formatted like 21.27825 when it makes no practical difference in supply time compared to 21.3

4. Cleanup and comment changes in the yaml

5. Changed some item descriptions so the difference between emergency, extended and double tanks is more clear

6.  Added gas supply duration legend to all filled tanks, which reveals that **all tanks are still absurdly large** even after the nerf, as noted on #17106. I intend to address that too, but I kept the gas tank nerf to a different PR for logistic reasons, I wanted to fix this first


**Media**

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- fix: Emergency and Double oxygen tanks that spawn empty now have the same internal volume as filled ones.
