### PR TITLE
Add some debug messages for random test failures.

### DIFF
--- a/Content.Server/Database/UserDbDataManager.cs
+++ b/Content.Server/Database/UserDbDataManager.cs
@@ -63,7 +63,12 @@ public sealed class UserDbDataManager
 
     public bool IsLoadComplete(IPlayerSession session)
     {
-        return _users[session.UserId].Task.IsCompleted;
+        return GetLoadTask(session).IsCompleted;
+    }
+
+    public Task GetLoadTask(IPlayerSession session)
+    {
+        return _users[session.UserId].Task;
     }
 
     private sealed record UserData(CancellationTokenSource Cancel, Task Task);

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -120,8 +120,27 @@ namespace Content.Server.GameTicking
 
             async void SpawnWaitDb()
             {
+                // Temporary debugging code to fix a random test failures
+                var initialStatus = _userDb.GetLoadTask(session).Status;
+                var prefsLoaded = _prefsManager.HavePreferencesLoaded(session);
+                DebugTools.Assert(session.Status == SessionStatus.InGame);
+
                 await _userDb.WaitLoadComplete(session);
-                SpawnPlayer(session, EntityUid.Invalid);
+
+                try
+                {
+                    SpawnPlayer(session, EntityUid.Invalid);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Caught exception while trying to spawn a player.\n" +
+                              $"Initial DB task status: {initialStatus}\n" +
+                              $"Prefs initially loaded: {prefsLoaded}\n" +
+                              $"DB task status: {_userDb.GetLoadTask(session).Status}\n" +
+                              $"Prefs loaded: {_prefsManager.HavePreferencesLoaded(session)}\n" +
+                              $"Exception: \n{e}");
+                    throw;
+                }
             }
 
             async void SpawnObserverWaitDb()

--- a/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
@@ -17,5 +17,6 @@ namespace Content.Server.Preferences.Managers
         bool TryGetCachedPreferences(NetUserId userId, [NotNullWhen(true)] out PlayerPreferences? playerPreferences);
         PlayerPreferences GetPreferences(NetUserId userId);
         IEnumerable<KeyValuePair<NetUserId, ICharacterProfile>> GetSelectedProfilesForPlayers(List<NetUserId> userIds);
+        bool HavePreferencesLoaded(IPlayerSession session);
     }
 }


### PR DESCRIPTION
Adds some logs to maybe help narrow down what is causing a random test failure. The random failure be seen in #18191 and has logs like:
```
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
  Failed Test [[12](https://github.com/space-wizards/space-station-14/actions/runs/5631889688/job/15259289602#step:10:13)4 ms]
  Error Message:
   System.Collections.Generic.KeyNotFoundException : The given key '76a29b07-0ccd-4fc9-8d70-235f60be376d' was not present in the dictionary.
  Stack Trace:
     at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Content.Server.Preferences.Managers.ServerPreferencesManager.GetPreferences(NetUserId userId) in D:\a\space-station-[14](https://github.com/space-wizards/space-station-14/actions/runs/5631889688/job/15259289602#step:10:15)\space-station-14\Content.Server\Preferences\Managers\ServerPreferencesManager.cs:line 246
   at Content.Server.GameTicking.GameTicker.GetPlayerProfile(IPlayerSession p) in D:\a\space-station-14\space-station-14\Content.Server\GameTicking\GameTicker.Player.cs:line 144
   at Content.Server.GameTicking.GameTicker.SpawnPlayer(IPlayerSession player, EntityUid station, String jobId, Boolean lateJoin) in D:\a\space-station-14\space-station-14\Content.Server\GameTicking\GameTicker.Spawning.cs:line 103
   at Content.Server.GameTicking.GameTicker.<>c__DisplayClass[15](https://github.com/space-wizards/space-station-14/actions/runs/5631889688/job/15259289602#step:10:16)2_0.<<PlayerStatusChanged>g__SpawnWaitDb|0>d.MoveNext() in D:\a\space-station-14\space-station-14\Content.Server\GameTicking\GameTicker.Player.cs:line 124
--- End of stack trace from previous location ---
```
