### PR TITLE
Nerf bed and medical bed healing potency for groups

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -6,11 +6,9 @@
   components:
   - type: HealOnBuckle
     damage:
-      groups:
-        Brute: -0.2 ## 0.1 per
-        Burn: -0.2
       types:
         Poison: -0.1
+        Blunt: -0.1
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -70,11 +68,10 @@
     state: bed-MED
   - type: HealOnBuckle
     damage:
-      groups:
-        Brute: -0.4 ## 0.2 per
-        Burn: -0.4
       types:
         Poison: -0.2
+        Cold: -0.4
+        Blunt: -0.2
   - type: Construction
     graph: bed
     node: medicalbed


### PR DESCRIPTION
beds currently healed all brute and burn which i thought didnt make much sense. this just makes it so they only heal blunt and cold instead of their parent groups. this change will make them less of a catch all and more of a recovery for basic injuries common around the station. also reduces the efficacy of medical bed spam. Medical beds healing cold will also make them more efficient for starvation dmg.

🆑 
- tweak: Beds and medical beds now heal blunt and cold specifically instead of brute and burn groups.