### PR TITLE
fix anomalies spawning on escape pods

### DIFF
--- a/Content.Server/StationEvents/Events/AnomalySpawnRule.cs
+++ b/Content.Server/StationEvents/Events/AnomalySpawnRule.cs
@@ -1,9 +1,7 @@
-﻿using System.Linq;
-using Content.Server.Anomaly;
+﻿using Content.Server.Anomaly;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Station.Components;
 using Content.Server.StationEvents.Components;
-using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -30,13 +28,9 @@ public sealed class AnomalySpawnRule : StationEventSystem<AnomalySpawnRuleCompon
         if (!TryComp<StationDataComponent>(chosenStation, out var stationData))
             return;
 
-        EntityUid? grid = null;
-        foreach (var g in stationData.Grids.Where(HasComp<BecomesStationComponent>))
-        {
-            grid = g;
-        }
+        var grid = StationSystem.GetLargestGrid(stationData);
 
-        if (grid is not { })
+        if (grid is null)
             return;
 
         var amountToSpawn = Math.Max(1, (int) MathF.Round(GetSeverityModifier() / 2));


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
apparently escape pods have the BecomesStationComponent or some shit.
now it just picks the largest station grid (the main one) which is probably what we want.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Midround anomaly spawns no longer have a high chance of spawning in escape pods.
