### PR TITLE
let animals drink things

### DIFF
--- a/Content.Server/NPC/Queries/Considerations/DrinkValueCon.cs
+++ b/Content.Server/NPC/Queries/Considerations/DrinkValueCon.cs
@@ -1,0 +1,6 @@
+namespace Content.Server.NPC.Queries.Considerations;
+
+public sealed class DrinkValueCon : UtilityConsideration
+{
+
+}

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -155,6 +155,10 @@ public sealed class NPCUtilitySystem : EntitySystem
                 if (TryComp<ThirstComponent>(owner, out var thirst) && thirst.CurrentThirstThreshold > ThirstThreshold.Okay)
                     return 0f;
 
+                // no janicow don't drink the blood puddle
+                if (HasComp<BadDrinkComponent>(targetUid))
+                    return 0f;
+
                 // needs to have something that will satiate thirst, mice wont try to drink 100% pure mutagen.
                 var hydration = _drink.TotalHydration(targetUid, drink);
                 if (hydration <= 1.0f)

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -23,12 +23,13 @@ namespace Content.Server.NPC.Systems;
 /// </summary>
 public sealed class NPCUtilitySystem : EntitySystem
 {
-    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly ContainerSystem _container = default!;
+    [Dependency] private readonly DrinkSystem _drink = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly FoodSystem _food = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly PuddleSystem _puddle = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SolutionContainerSystem _solutions = default!;
@@ -135,6 +136,18 @@ public sealed class NPCUtilitySystem : EntitySystem
                 // no mouse don't eat the uranium-235
                 var avoidBadFood = !HasComp<IgnoreBadFoodComponent>(owner);
                 if (avoidBadFood && HasComp<BadFoodComponent>(targetUid))
+                    return 0f;
+
+                return 1f;
+            }
+            case DrinkValueCon:
+            {
+                if (!TryComp<DrinkComponent>(targetUid, out var drink) || !drink.Opened)
+                    return 0f;
+
+                // needs to have something that will satiate thirst, mice wont try to drink 100% pure mutagen.
+                var hydration = _drink.TotalHydration(targetUid, drink);
+                if (hydration <= 1.0f)
                     return 0f;
 
                 return 1f;

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -134,12 +134,13 @@ public sealed class NPCUtilitySystem : EntitySystem
                 if (!_food.IsDigestibleBy(owner, targetUid, food))
                     return 0f;
 
-                // only eat when hungry
-                if (TryComp<HungerComponent>(owner, out var hunger) && hunger.CurrentThreshold > HungerThreshold.Okay)
+                var avoidBadFood = !HasComp<IgnoreBadFoodComponent>(owner);
+
+                // only eat when hungry or if it will eat anything
+                if (TryComp<HungerComponent>(owner, out var hunger) && hunger.CurrentThreshold > HungerThreshold.Okay && avoidBadFood)
                     return 0f;
 
                 // no mouse don't eat the uranium-235
-                var avoidBadFood = !HasComp<IgnoreBadFoodComponent>(owner);
                 if (avoidBadFood && HasComp<BadFoodComponent>(targetUid))
                     return 0f;
 

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -12,6 +12,7 @@ using Content.Server.Storage.Components;
 using Content.Shared.Examine;
 using Content.Shared.Fluids.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Nutrition.Components;
 using Robust.Server.Containers;
 using Robust.Shared.Collections;
 using Robust.Shared.Prototypes;
@@ -133,6 +134,10 @@ public sealed class NPCUtilitySystem : EntitySystem
                 if (!_food.IsDigestibleBy(owner, targetUid, food))
                     return 0f;
 
+                // only eat when hungry
+                if (TryComp<HungerComponent>(owner, out var hunger) && hunger.CurrentThreshold > HungerThreshold.Okay)
+                    return 0f;
+
                 // no mouse don't eat the uranium-235
                 var avoidBadFood = !HasComp<IgnoreBadFoodComponent>(owner);
                 if (avoidBadFood && HasComp<BadFoodComponent>(targetUid))
@@ -143,6 +148,10 @@ public sealed class NPCUtilitySystem : EntitySystem
             case DrinkValueCon:
             {
                 if (!TryComp<DrinkComponent>(targetUid, out var drink) || !drink.Opened)
+                    return 0f;
+
+                // only drink when thirsty
+                if (TryComp<ThirstComponent>(owner, out var thirst) && thirst.CurrentThirstThreshold > ThirstThreshold.Okay)
                     return 0f;
 
                 // needs to have something that will satiate thirst, mice wont try to drink 100% pure mutagen.

--- a/Content.Server/Nutrition/Components/BadDrinkComponent.cs
+++ b/Content.Server/Nutrition/Components/BadDrinkComponent.cs
@@ -1,0 +1,12 @@
+using Content.Server.Nutrition.EntitySystems;
+
+namespace Content.Server.Nutrition.Components;
+
+/// <summary>
+/// This component prevents NPC mobs like mice or cows from wanting to drink something that shouldn't be drank from.
+/// Including but not limited to: puddles
+/// </summary>
+[RegisterComponent, Access(typeof(DrinkSystem))]
+public sealed class BadDrinkComponent : Component
+{
+}

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -31,448 +31,447 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
-namespace Content.Server.Nutrition.EntitySystems
+namespace Content.Server.Nutrition.EntitySystems;
+
+public sealed class DrinkSystem : EntitySystem
 {
-    public sealed class DrinkSystem : EntitySystem
+    [Dependency] private readonly BodySystem _body = default!;
+    [Dependency] private readonly FoodSystem _food = default!;
+    [Dependency] private readonly FlavorProfileSystem _flavorProfile = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly PuddleSystem _puddleSystem = default!;
+    [Dependency] private readonly ReactiveSystem _reaction = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly SolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private readonly StomachSystem _stomach = default!;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly BodySystem _body = default!;
-        [Dependency] private readonly FoodSystem _food = default!;
-        [Dependency] private readonly FlavorProfileSystem _flavorProfile = default!;
-        [Dependency] private readonly IPrototypeManager _proto = default!;
-        [Dependency] private readonly IRobustRandom _random = default!;
-        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
-        [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
-        [Dependency] private readonly PopupSystem _popup = default!;
-        [Dependency] private readonly PuddleSystem _puddleSystem = default!;
-        [Dependency] private readonly ReactiveSystem _reaction = default!;
-        [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-        [Dependency] private readonly SharedAudioSystem _audio = default!;
-        [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
-        [Dependency] private readonly SharedInteractionSystem _interaction = default!;
-        [Dependency] private readonly SolutionContainerSystem _solutionContainer = default!;
-        [Dependency] private readonly StomachSystem _stomach = default!;
+        base.Initialize();
 
-        public override void Initialize()
+        // TODO add InteractNoHandEvent for entities like mice.
+        SubscribeLocalEvent<DrinkComponent, SolutionChangedEvent>(OnSolutionChange);
+        SubscribeLocalEvent<DrinkComponent, ComponentInit>(OnDrinkInit);
+        SubscribeLocalEvent<DrinkComponent, LandEvent>(HandleLand);
+        SubscribeLocalEvent<DrinkComponent, UseInHandEvent>(OnUse);
+        SubscribeLocalEvent<DrinkComponent, AfterInteractEvent>(AfterInteract);
+        SubscribeLocalEvent<DrinkComponent, GetVerbsEvent<AlternativeVerb>>(AddDrinkVerb);
+        SubscribeLocalEvent<DrinkComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<DrinkComponent, SolutionTransferAttemptEvent>(OnTransferAttempt);
+        SubscribeLocalEvent<DrinkComponent, ConsumeDoAfterEvent>(OnDoAfter);
+    }
+
+    private FixedPoint2 DrinkVolume(EntityUid uid, DrinkComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return FixedPoint2.Zero;
+
+        if (!_solutionContainer.TryGetSolution(uid, component.SolutionName, out var sol))
+            return FixedPoint2.Zero;
+
+        return sol.Volume;
+    }
+
+    public bool IsEmpty(EntityUid uid, DrinkComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return true;
+
+        return DrinkVolume(uid, component) <= 0;
+    }
+
+    /// <summary>
+    /// Get the total hydration factor contained in a drink's solution.
+    /// </summary>
+    public float TotalHydration(EntityUid uid, DrinkComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return 0f;
+
+        if (!_solutionContainer.TryGetSolution(uid, comp.SolutionName, out var solution))
+            return 0f;
+
+        var total = 0f;
+        foreach (var quantity in solution.Contents)
         {
-            base.Initialize();
+            var reagent = _proto.Index<ReagentPrototype>(quantity.ReagentId);
+            if (reagent.Metabolisms == null)
+                continue;
 
-            // TODO add InteractNoHandEvent for entities like mice.
-            SubscribeLocalEvent<DrinkComponent, SolutionChangedEvent>(OnSolutionChange);
-            SubscribeLocalEvent<DrinkComponent, ComponentInit>(OnDrinkInit);
-            SubscribeLocalEvent<DrinkComponent, LandEvent>(HandleLand);
-            SubscribeLocalEvent<DrinkComponent, UseInHandEvent>(OnUse);
-            SubscribeLocalEvent<DrinkComponent, AfterInteractEvent>(AfterInteract);
-            SubscribeLocalEvent<DrinkComponent, GetVerbsEvent<AlternativeVerb>>(AddDrinkVerb);
-            SubscribeLocalEvent<DrinkComponent, ExaminedEvent>(OnExamined);
-            SubscribeLocalEvent<DrinkComponent, SolutionTransferAttemptEvent>(OnTransferAttempt);
-            SubscribeLocalEvent<DrinkComponent, ConsumeDoAfterEvent>(OnDoAfter);
-        }
-
-        private FixedPoint2 DrinkVolume(EntityUid uid, DrinkComponent? component = null)
-        {
-            if (!Resolve(uid, ref component))
-                return FixedPoint2.Zero;
-
-            if (!_solutionContainer.TryGetSolution(uid, component.SolutionName, out var sol))
-                return FixedPoint2.Zero;
-
-            return sol.Volume;
-        }
-
-        public bool IsEmpty(EntityUid uid, DrinkComponent? component = null)
-        {
-            if (!Resolve(uid, ref component))
-                return true;
-
-            return DrinkVolume(uid, component) <= 0;
-        }
-
-        /// <summary>
-        /// Get the total hydration factor contained in a drink's solution.
-        /// </summary>
-        public float TotalHydration(EntityUid uid, DrinkComponent? comp = null)
-        {
-            if (!Resolve(uid, ref comp))
-                return 0f;
-
-            if (!_solutionContainer.TryGetSolution(uid, comp.SolutionName, out var solution))
-                return 0f;
-
-            var total = 0f;
-            foreach (var quantity in solution.Contents)
+            foreach ((var _, var entry) in reagent.Metabolisms)
             {
-                var reagent = _proto.Index<ReagentPrototype>(quantity.ReagentId);
-                if (reagent.Metabolisms == null)
-                    continue;
-
-                foreach ((var _, var entry) in reagent.Metabolisms)
+                foreach (var effect in entry.Effects)
                 {
-                    foreach (var effect in entry.Effects)
+                    // ignores any effect conditions, just cares about how much it can hydrate
+                    if (effect is SatiateThirst thirst)
                     {
-                        // ignores any effect conditions, just cares about how much it can hydrate
-                        if (effect is SatiateThirst thirst)
-                        {
-                            total += thirst.HydrationFactor * quantity.Quantity.Float();
-                        }
+                        total += thirst.HydrationFactor * quantity.Quantity.Float();
                     }
                 }
             }
-
-            return total;
         }
 
-        private void OnExamined(EntityUid uid, DrinkComponent component, ExaminedEvent args)
-        {
-            if (!component.Opened || !args.IsInDetailsRange || !component.Examinable)
-                return;
+        return total;
+    }
 
-            var color = IsEmpty(uid, component) ? "gray" : "yellow";
-            var openedText =
-                Loc.GetString(IsEmpty(uid, component) ? "drink-component-on-examine-is-empty" : "drink-component-on-examine-is-opened");
-            args.Message.AddMarkup($"\n{Loc.GetString("drink-component-on-examine-details-text", ("colorName", color), ("text", openedText))}");
-            if (!IsEmpty(uid, component))
+    private void OnExamined(EntityUid uid, DrinkComponent component, ExaminedEvent args)
+    {
+        if (!component.Opened || !args.IsInDetailsRange || !component.Examinable)
+            return;
+
+        var color = IsEmpty(uid, component) ? "gray" : "yellow";
+        var openedText =
+            Loc.GetString(IsEmpty(uid, component) ? "drink-component-on-examine-is-empty" : "drink-component-on-examine-is-opened");
+        args.Message.AddMarkup($"\n{Loc.GetString("drink-component-on-examine-details-text", ("colorName", color), ("text", openedText))}");
+        if (!IsEmpty(uid, component))
+        {
+            if (TryComp<ExaminableSolutionComponent>(uid, out var comp))
             {
-                if (TryComp<ExaminableSolutionComponent>(uid, out var comp))
-                {
-                    //provide exact measurement for beakers
-                    args.Message.AddMarkup($" - {Loc.GetString("drink-component-on-examine-exact-volume", ("amount", DrinkVolume(uid, component)))}");
-                }
-                else
-                {
-                    //general approximation
-                    var remainingString = (int) _solutionContainer.PercentFull(uid) switch
-                    {
-                        100 => "drink-component-on-examine-is-full",
-                        > 66 => "drink-component-on-examine-is-mostly-full",
-                        > 33 => HalfEmptyOrHalfFull(args),
-                        _ => "drink-component-on-examine-is-mostly-empty",
-                    };
-                    args.Message.AddMarkup($" - {Loc.GetString(remainingString)}");
-                }
-            }
-        }
-
-        private void SetOpen(EntityUid uid, bool opened = false, DrinkComponent? component = null)
-        {
-            if(!Resolve(uid, ref component))
-                return;
-
-            if (opened == component.Opened)
-                return;
-
-            component.Opened = opened;
-
-            if (!_solutionContainer.TryGetSolution(uid, component.SolutionName, out _))
-                return;
-
-            if (EntityManager.TryGetComponent<AppearanceComponent>(uid, out var appearance))
-            {
-                _appearance.SetData(uid, DrinkCanStateVisual.Opened, opened, appearance);
-            }
-        }
-
-        private void AfterInteract(EntityUid uid, DrinkComponent component, AfterInteractEvent args)
-        {
-            if (args.Handled || args.Target == null || !args.CanReach)
-                return;
-
-            args.Handled = TryDrink(args.User, args.Target.Value, component, uid);
-        }
-
-        private void OnUse(EntityUid uid, DrinkComponent component, UseInHandEvent args)
-        {
-            if (args.Handled)
-                return;
-
-            if (!component.Opened)
-            {
-                //Do the opening stuff like playing the sounds.
-                _audio.PlayPvs(_audio.GetSound(component.OpenSounds), args.User);
-
-                SetOpen(uid, true, component);
-                return;
-            }
-
-            args.Handled = TryDrink(args.User, args.User, component, uid);
-        }
-
-        private void HandleLand(EntityUid uid, DrinkComponent component, ref LandEvent args)
-        {
-            if (component.Pressurized &&
-                !component.Opened &&
-                _random.Prob(0.25f) &&
-                _solutionContainer.TryGetSolution(uid, component.SolutionName, out var interactions))
-            {
-                component.Opened = true;
-                UpdateAppearance(uid, component);
-
-                var solution = _solutionContainer.SplitSolution(uid, interactions, interactions.Volume);
-                _puddleSystem.TrySpillAt(uid, solution, out _);
-
-                _audio.PlayPvs(_audio.GetSound(component.BurstSound), uid, AudioParams.Default.WithVolume(-4));
-            }
-        }
-
-        private void OnDrinkInit(EntityUid uid, DrinkComponent component, ComponentInit args)
-        {
-            SetOpen(uid, component.DefaultToOpened, component);
-
-            if (EntityManager.TryGetComponent(uid, out DrainableSolutionComponent? existingDrainable))
-            {
-                // Beakers have Drink component but they should use the existing Drainable
-                component.SolutionName = existingDrainable.Solution;
+                //provide exact measurement for beakers
+                args.Message.AddMarkup($" - {Loc.GetString("drink-component-on-examine-exact-volume", ("amount", DrinkVolume(uid, component)))}");
             }
             else
             {
-                _solutionContainer.EnsureSolution(uid, component.SolutionName);
+                //general approximation
+                var remainingString = (int) _solutionContainer.PercentFull(uid) switch
+                {
+                    100 => "drink-component-on-examine-is-full",
+                    > 66 => "drink-component-on-examine-is-mostly-full",
+                    > 33 => HalfEmptyOrHalfFull(args),
+                    _ => "drink-component-on-examine-is-mostly-empty",
+                };
+                args.Message.AddMarkup($" - {Loc.GetString(remainingString)}");
             }
+        }
+    }
 
+    private void SetOpen(EntityUid uid, bool opened = false, DrinkComponent? component = null)
+    {
+        if(!Resolve(uid, ref component))
+            return;
+
+        if (opened == component.Opened)
+            return;
+
+        component.Opened = opened;
+
+        if (!_solutionContainer.TryGetSolution(uid, component.SolutionName, out _))
+            return;
+
+        if (EntityManager.TryGetComponent<AppearanceComponent>(uid, out var appearance))
+        {
+            _appearance.SetData(uid, DrinkCanStateVisual.Opened, opened, appearance);
+        }
+    }
+
+    private void AfterInteract(EntityUid uid, DrinkComponent component, AfterInteractEvent args)
+    {
+        if (args.Handled || args.Target == null || !args.CanReach)
+            return;
+
+        args.Handled = TryDrink(args.User, args.Target.Value, component, uid);
+    }
+
+    private void OnUse(EntityUid uid, DrinkComponent component, UseInHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!component.Opened)
+        {
+            //Do the opening stuff like playing the sounds.
+            _audio.PlayPvs(_audio.GetSound(component.OpenSounds), args.User);
+
+            SetOpen(uid, true, component);
+            return;
+        }
+
+        args.Handled = TryDrink(args.User, args.User, component, uid);
+    }
+
+    private void HandleLand(EntityUid uid, DrinkComponent component, ref LandEvent args)
+    {
+        if (component.Pressurized &&
+            !component.Opened &&
+            _random.Prob(0.25f) &&
+            _solutionContainer.TryGetSolution(uid, component.SolutionName, out var interactions))
+        {
+            component.Opened = true;
             UpdateAppearance(uid, component);
 
-            if (TryComp(uid, out RefillableSolutionComponent? refillComp))
-                refillComp.Solution = component.SolutionName;
+            var solution = _solutionContainer.SplitSolution(uid, interactions, interactions.Volume);
+            _puddleSystem.TrySpillAt(uid, solution, out _);
 
-            if (TryComp(uid, out DrainableSolutionComponent? drainComp))
-                drainComp.Solution = component.SolutionName;
+            _audio.PlayPvs(_audio.GetSound(component.BurstSound), uid, AudioParams.Default.WithVolume(-4));
+        }
+    }
+
+    private void OnDrinkInit(EntityUid uid, DrinkComponent component, ComponentInit args)
+    {
+        SetOpen(uid, component.DefaultToOpened, component);
+
+        if (EntityManager.TryGetComponent(uid, out DrainableSolutionComponent? existingDrainable))
+        {
+            // Beakers have Drink component but they should use the existing Drainable
+            component.SolutionName = existingDrainable.Solution;
+        }
+        else
+        {
+            _solutionContainer.EnsureSolution(uid, component.SolutionName);
         }
 
-        private void OnSolutionChange(EntityUid uid, DrinkComponent component, SolutionChangedEvent args)
+        UpdateAppearance(uid, component);
+
+        if (TryComp(uid, out RefillableSolutionComponent? refillComp))
+            refillComp.Solution = component.SolutionName;
+
+        if (TryComp(uid, out DrainableSolutionComponent? drainComp))
+            drainComp.Solution = component.SolutionName;
+    }
+
+    private void OnSolutionChange(EntityUid uid, DrinkComponent component, SolutionChangedEvent args)
+    {
+        UpdateAppearance(uid, component);
+    }
+
+    public void UpdateAppearance(EntityUid uid, DrinkComponent component)
+    {
+        if (!TryComp<AppearanceComponent>(uid, out var appearance) ||
+            !HasComp<SolutionContainerManagerComponent>(uid))
         {
-            UpdateAppearance(uid, component);
+            return;
         }
 
-        public void UpdateAppearance(EntityUid uid, DrinkComponent component)
-        {
-            if (!TryComp<AppearanceComponent>(uid, out var appearance) ||
-                !HasComp<SolutionContainerManagerComponent>(uid))
-            {
-                return;
-            }
+        var drainAvailable = DrinkVolume(uid, component);
+        _appearance.SetData(uid, FoodVisuals.Visual, drainAvailable.Float(), appearance);
+        _appearance.SetData(uid, DrinkCanStateVisual.Opened, component.Opened, appearance);
+    }
 
-            var drainAvailable = DrinkVolume(uid, component);
-            _appearance.SetData(uid, FoodVisuals.Visual, drainAvailable.Float(), appearance);
-            _appearance.SetData(uid, DrinkCanStateVisual.Opened, component.Opened, appearance);
+    private void OnTransferAttempt(EntityUid uid, DrinkComponent component, SolutionTransferAttemptEvent args)
+    {
+        if (!component.Opened)
+        {
+            args.Cancel(Loc.GetString("drink-component-try-use-drink-not-open", ("owner", uid)));
         }
+    }
 
-        private void OnTransferAttempt(EntityUid uid, DrinkComponent component, SolutionTransferAttemptEvent args)
+    private bool TryDrink(EntityUid user, EntityUid target, DrinkComponent drink, EntityUid item)
+    {
+        if (!EntityManager.HasComponent<BodyComponent>(target))
+            return false;
+
+        if (!drink.Opened)
         {
-            if (!component.Opened)
-            {
-                args.Cancel(Loc.GetString("drink-component-try-use-drink-not-open", ("owner", uid)));
-            }
-        }
-
-        private bool TryDrink(EntityUid user, EntityUid target, DrinkComponent drink, EntityUid item)
-        {
-            if (!EntityManager.HasComponent<BodyComponent>(target))
-                return false;
-
-            if (!drink.Opened)
-            {
-                _popup.PopupEntity(Loc.GetString("drink-component-try-use-drink-not-open",
-                    ("owner", EntityManager.GetComponent<MetaDataComponent>(item).EntityName)), item, user);
-                return true;
-            }
-
-            if (!_solutionContainer.TryGetSolution(item, drink.SolutionName, out var drinkSolution) ||
-                drinkSolution.Volume <= 0)
-            {
-                _popup.PopupEntity(Loc.GetString("drink-component-try-use-drink-is-empty",
-                    ("entity", EntityManager.GetComponent<MetaDataComponent>(item).EntityName)), item, user);
-                return true;
-            }
-
-            if (drinkSolution.Name == null)
-                return false;
-
-            if (_food.IsMouthBlocked(target, user))
-                return true;
-
-            if (!_interaction.InRangeUnobstructed(user, item, popup: true))
-                return true;
-
-            var forceDrink = user != target;
-
-            if (forceDrink)
-            {
-                var userName = Identity.Entity(user, EntityManager);
-
-                _popup.PopupEntity(Loc.GetString("drink-component-force-feed", ("user", userName)),
-                    user, target);
-
-                // logging
-                _adminLogger.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(user):user} is forcing {ToPrettyString(target):target} to drink {ToPrettyString(item):drink} {SolutionContainerSystem.ToPrettyString(drinkSolution)}");
-            }
-            else
-            {
-                // log voluntary drinking
-                _adminLogger.Add(LogType.Ingestion, LogImpact.Low, $"{ToPrettyString(target):target} is drinking {ToPrettyString(item):drink} {SolutionContainerSystem.ToPrettyString(drinkSolution)}");
-            }
-
-            var flavors = _flavorProfile.GetLocalizedFlavorsMessage(user, drinkSolution);
-
-            var doAfterEventArgs = new DoAfterArgs(
-                user,
-                forceDrink ? drink.ForceFeedDelay : drink.Delay,
-                new ConsumeDoAfterEvent(drinkSolution.Name, flavors),
-                eventTarget: item,
-                target: target,
-                used: item)
-            {
-                BreakOnUserMove = forceDrink,
-                BreakOnDamage = true,
-                BreakOnTargetMove = forceDrink,
-                MovementThreshold = 0.01f,
-                DistanceThreshold = 1.0f,
-                // Mice and the like can eat without hands.
-                // TODO maybe set this based on some CanEatWithoutHands event or component?
-                NeedHand = forceDrink,
-            };
-
-            _doAfter.TryStartDoAfter(doAfterEventArgs);
+            _popup.PopupEntity(Loc.GetString("drink-component-try-use-drink-not-open",
+                ("owner", EntityManager.GetComponent<MetaDataComponent>(item).EntityName)), item, user);
             return true;
         }
 
-        /// <summary>
-        ///     Raised directed at a victim when someone has force fed them a drink.
-        /// </summary>
-        private void OnDoAfter(EntityUid uid, DrinkComponent component, ConsumeDoAfterEvent args)
+        if (!_solutionContainer.TryGetSolution(item, drink.SolutionName, out var drinkSolution) ||
+            drinkSolution.Volume <= 0)
         {
-            if (args.Handled || args.Cancelled || component.Deleted)
-                return;
+            _popup.PopupEntity(Loc.GetString("drink-component-try-use-drink-is-empty",
+                ("entity", EntityManager.GetComponent<MetaDataComponent>(item).EntityName)), item, user);
+            return true;
+        }
 
-            if (!TryComp<BodyComponent>(args.Target, out var body))
-                return;
+        if (drinkSolution.Name == null)
+            return false;
 
-            if (!_solutionContainer.TryGetSolution(args.Used, args.Solution, out var solution))
-                return;
+        if (_food.IsMouthBlocked(target, user))
+            return true;
 
-            // TODO this should really be checked every tick.
-            if (_food.IsMouthBlocked(args.Target.Value))
-                return;
+        if (!_interaction.InRangeUnobstructed(user, item, popup: true))
+            return true;
 
-            // TODO this should really be checked every tick.
-            if (!_interaction.InRangeUnobstructed(args.User, args.Target.Value))
-                return;
+        var forceDrink = user != target;
 
-            var transferAmount = FixedPoint2.Min(component.TransferAmount, solution.Volume);
-            var drained = _solutionContainer.SplitSolution(uid, solution, transferAmount);
-            var forceDrink = args.User != args.Target;
+        if (forceDrink)
+        {
+            var userName = Identity.Entity(user, EntityManager);
 
-            args.Handled = true;
-            if (transferAmount <= 0)
-                return;
+            _popup.PopupEntity(Loc.GetString("drink-component-force-feed", ("user", userName)),
+                user, target);
 
-            if (!_body.TryGetBodyOrganComponents<StomachComponent>(args.Target.Value, out var stomachs, body))
+            // logging
+            _adminLogger.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(user):user} is forcing {ToPrettyString(target):target} to drink {ToPrettyString(item):drink} {SolutionContainerSystem.ToPrettyString(drinkSolution)}");
+        }
+        else
+        {
+            // log voluntary drinking
+            _adminLogger.Add(LogType.Ingestion, LogImpact.Low, $"{ToPrettyString(target):target} is drinking {ToPrettyString(item):drink} {SolutionContainerSystem.ToPrettyString(drinkSolution)}");
+        }
+
+        var flavors = _flavorProfile.GetLocalizedFlavorsMessage(user, drinkSolution);
+
+        var doAfterEventArgs = new DoAfterArgs(
+            user,
+            forceDrink ? drink.ForceFeedDelay : drink.Delay,
+            new ConsumeDoAfterEvent(drinkSolution.Name, flavors),
+            eventTarget: item,
+            target: target,
+            used: item)
+        {
+            BreakOnUserMove = forceDrink,
+            BreakOnDamage = true,
+            BreakOnTargetMove = forceDrink,
+            MovementThreshold = 0.01f,
+            DistanceThreshold = 1.0f,
+            // Mice and the like can eat without hands.
+            // TODO maybe set this based on some CanEatWithoutHands event or component?
+            NeedHand = forceDrink,
+        };
+
+        _doAfter.TryStartDoAfter(doAfterEventArgs);
+        return true;
+    }
+
+    /// <summary>
+    ///     Raised directed at a victim when someone has force fed them a drink.
+    /// </summary>
+    private void OnDoAfter(EntityUid uid, DrinkComponent component, ConsumeDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled || component.Deleted)
+            return;
+
+        if (!TryComp<BodyComponent>(args.Target, out var body))
+            return;
+
+        if (!_solutionContainer.TryGetSolution(args.Used, args.Solution, out var solution))
+            return;
+
+        // TODO this should really be checked every tick.
+        if (_food.IsMouthBlocked(args.Target.Value))
+            return;
+
+        // TODO this should really be checked every tick.
+        if (!_interaction.InRangeUnobstructed(args.User, args.Target.Value))
+            return;
+
+        var transferAmount = FixedPoint2.Min(component.TransferAmount, solution.Volume);
+        var drained = _solutionContainer.SplitSolution(uid, solution, transferAmount);
+        var forceDrink = args.User != args.Target;
+
+        args.Handled = true;
+        if (transferAmount <= 0)
+            return;
+
+        if (!_body.TryGetBodyOrganComponents<StomachComponent>(args.Target.Value, out var stomachs, body))
+        {
+            _popup.PopupEntity(forceDrink ? Loc.GetString("drink-component-try-use-drink-cannot-drink-other") : Loc.GetString("drink-component-try-use-drink-had-enough"), args.Target.Value, args.User);
+
+            if (HasComp<RefillableSolutionComponent>(args.Target.Value))
             {
-                _popup.PopupEntity(forceDrink ? Loc.GetString("drink-component-try-use-drink-cannot-drink-other") : Loc.GetString("drink-component-try-use-drink-had-enough"), args.Target.Value, args.User);
-
-                if (HasComp<RefillableSolutionComponent>(args.Target.Value))
-                {
-                    _puddleSystem.TrySpillAt(args.User, drained, out _);
-                    return;
-                }
-
-                _solutionContainer.Refill(args.Target.Value, solution, drained);
+                _puddleSystem.TrySpillAt(args.User, drained, out _);
                 return;
             }
 
-            var firstStomach = stomachs.FirstOrNull(stomach => _stomach.CanTransferSolution(stomach.Comp.Owner, drained));
+            _solutionContainer.Refill(args.Target.Value, solution, drained);
+            return;
+        }
 
-            //All stomachs are full or can't handle whatever solution we have.
-            if (firstStomach == null)
-            {
-                _popup.PopupEntity(Loc.GetString("drink-component-try-use-drink-had-enough"), args.Target.Value, args.Target.Value);
+        var firstStomach = stomachs.FirstOrNull(stomach => _stomach.CanTransferSolution(stomach.Comp.Owner, drained));
 
-                if (forceDrink)
-                {
-                    _popup.PopupEntity(Loc.GetString("drink-component-try-use-drink-had-enough-other"), args.Target.Value, args.User);
-                    _puddleSystem.TrySpillAt(args.Target.Value, drained, out _);
-                }
-                else
-                    _solutionContainer.TryAddSolution(uid, solution, drained);
-
-                return;
-            }
-
-            var flavors = args.FlavorMessage;
+        //All stomachs are full or can't handle whatever solution we have.
+        if (firstStomach == null)
+        {
+            _popup.PopupEntity(Loc.GetString("drink-component-try-use-drink-had-enough"), args.Target.Value, args.Target.Value);
 
             if (forceDrink)
             {
-                var targetName = Identity.Entity(args.Target.Value, EntityManager);
-                var userName = Identity.Entity(args.User, EntityManager);
-
-                _popup.PopupEntity(Loc.GetString("drink-component-force-feed-success", ("user", userName), ("flavors", flavors)), args.Target.Value, args.Target.Value);
-
-                _popup.PopupEntity(
-                    Loc.GetString("drink-component-force-feed-success-user", ("target", targetName)),
-                    args.User, args.User);
-
-                // log successful forced drinking
-                _adminLogger.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(uid):user} forced {ToPrettyString(args.User):target} to drink {ToPrettyString(uid):drink}");
+                _popup.PopupEntity(Loc.GetString("drink-component-try-use-drink-had-enough-other"), args.Target.Value, args.User);
+                _puddleSystem.TrySpillAt(args.Target.Value, drained, out _);
             }
             else
-            {
-                _popup.PopupEntity(
-                    Loc.GetString("drink-component-try-use-drink-success-slurp-taste", ("flavors", flavors)), args.User,
-                    args.User);
-                _popup.PopupEntity(
-                    Loc.GetString("drink-component-try-use-drink-success-slurp"), args.User, Filter.PvsExcept(args.User), true);
+                _solutionContainer.TryAddSolution(uid, solution, drained);
 
-                // log successful voluntary drinking
-                _adminLogger.Add(LogType.Ingestion, LogImpact.Low, $"{ToPrettyString(args.User):target} drank {ToPrettyString(uid):drink}");
-            }
-
-            _audio.PlayPvs(_audio.GetSound(component.UseSound), args.Target.Value, AudioParams.Default.WithVolume(-2f));
-
-            _reaction.DoEntityReaction(args.Target.Value, solution, ReactionMethod.Ingestion);
-            //TODO: Grab the stomach UIDs somehow without using Owner
-            _stomach.TryTransferSolution(firstStomach.Value.Comp.Owner, drained, firstStomach.Value.Comp);
-
-            var comp = EnsureComp<ForensicsComponent>(uid);
-            if (TryComp<DnaComponent>(args.Target, out var dna))
-                comp.DNAs.Add(dna.DNA);
-
-            if (!forceDrink && solution.Volume > 0)
-                args.Repeat = true;
+            return;
         }
 
-        private void AddDrinkVerb(EntityUid uid, DrinkComponent component, GetVerbsEvent<AlternativeVerb> ev)
+        var flavors = args.FlavorMessage;
+
+        if (forceDrink)
         {
-            if (uid == ev.User ||
-                !ev.CanInteract ||
-                !ev.CanAccess ||
-                !EntityManager.TryGetComponent(ev.User, out BodyComponent? body) ||
-                !_body.TryGetBodyOrganComponents<StomachComponent>(ev.User, out var stomachs, body))
-                return;
+            var targetName = Identity.Entity(args.Target.Value, EntityManager);
+            var userName = Identity.Entity(args.User, EntityManager);
 
-            if (EntityManager.TryGetComponent<MobStateComponent>(uid, out var mobState) && _mobStateSystem.IsAlive(uid, mobState))
-                return;
+            _popup.PopupEntity(Loc.GetString("drink-component-force-feed-success", ("user", userName), ("flavors", flavors)), args.Target.Value, args.Target.Value);
 
-            AlternativeVerb verb = new()
-            {
-                Act = () =>
-                {
-                    TryDrink(ev.User, ev.User, component, uid);
-                },
-                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/drink.svg.192dpi.png")),
-                Text = Loc.GetString("drink-system-verb-drink"),
-                Priority = 2
-            };
+            _popup.PopupEntity(
+                Loc.GetString("drink-component-force-feed-success-user", ("target", targetName)),
+                args.User, args.User);
 
-            ev.Verbs.Add(verb);
+            // log successful forced drinking
+            _adminLogger.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(uid):user} forced {ToPrettyString(args.User):target} to drink {ToPrettyString(uid):drink}");
         }
-
-        // some see half empty, and others see half full
-        private string HalfEmptyOrHalfFull(ExaminedEvent args)
+        else
         {
-            string remainingString = "drink-component-on-examine-is-half-full";
+            _popup.PopupEntity(
+                Loc.GetString("drink-component-try-use-drink-success-slurp-taste", ("flavors", flavors)), args.User,
+                args.User);
+            _popup.PopupEntity(
+                Loc.GetString("drink-component-try-use-drink-success-slurp"), args.User, Filter.PvsExcept(args.User), true);
 
-            if (TryComp<MetaDataComponent>(args.Examiner, out var examiner) && examiner.EntityName.Length > 0
-                && string.Compare(examiner.EntityName.Substring(0, 1), "m", StringComparison.InvariantCultureIgnoreCase) > 0)
-                remainingString = "drink-component-on-examine-is-half-empty";
-
-            return remainingString;
+            // log successful voluntary drinking
+            _adminLogger.Add(LogType.Ingestion, LogImpact.Low, $"{ToPrettyString(args.User):target} drank {ToPrettyString(uid):drink}");
         }
+
+        _audio.PlayPvs(_audio.GetSound(component.UseSound), args.Target.Value, AudioParams.Default.WithVolume(-2f));
+
+        _reaction.DoEntityReaction(args.Target.Value, solution, ReactionMethod.Ingestion);
+        //TODO: Grab the stomach UIDs somehow without using Owner
+        _stomach.TryTransferSolution(firstStomach.Value.Comp.Owner, drained, firstStomach.Value.Comp);
+
+        var comp = EnsureComp<ForensicsComponent>(uid);
+        if (TryComp<DnaComponent>(args.Target, out var dna))
+            comp.DNAs.Add(dna.DNA);
+
+        if (!forceDrink && solution.Volume > 0)
+            args.Repeat = true;
+    }
+
+    private void AddDrinkVerb(EntityUid uid, DrinkComponent component, GetVerbsEvent<AlternativeVerb> ev)
+    {
+        if (uid == ev.User ||
+            !ev.CanInteract ||
+            !ev.CanAccess ||
+            !EntityManager.TryGetComponent(ev.User, out BodyComponent? body) ||
+            !_body.TryGetBodyOrganComponents<StomachComponent>(ev.User, out var stomachs, body))
+            return;
+
+        if (EntityManager.TryGetComponent<MobStateComponent>(uid, out var mobState) && _mobStateSystem.IsAlive(uid, mobState))
+            return;
+
+        AlternativeVerb verb = new()
+        {
+            Act = () =>
+            {
+                TryDrink(ev.User, ev.User, component, uid);
+            },
+            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/drink.svg.192dpi.png")),
+            Text = Loc.GetString("drink-system-verb-drink"),
+            Priority = 2
+        };
+
+        ev.Verbs.Add(verb);
+    }
+
+    // some see half empty, and others see half full
+    private string HalfEmptyOrHalfFull(ExaminedEvent args)
+    {
+        string remainingString = "drink-component-on-examine-is-half-full";
+
+        if (TryComp<MetaDataComponent>(args.Examiner, out var examiner) && examiner.EntityName.Length > 0
+            && string.Compare(examiner.EntityName.Substring(0, 1), "m", StringComparison.InvariantCultureIgnoreCase) > 0)
+            remainingString = "drink-component-on-examine-is-half-empty";
+
+        return remainingString;
     }
 }

--- a/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
@@ -6,171 +6,170 @@ using Content.Shared.Alert;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Rejuvenate;
 
-namespace Content.Server.Nutrition.EntitySystems
+namespace Content.Server.Nutrition.EntitySystems;
+
+[UsedImplicitly]
+public sealed class ThirstSystem : EntitySystem
 {
-    [UsedImplicitly]
-    public sealed class ThirstSystem : EntitySystem
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
+    [Dependency] private readonly SharedJetpackSystem _jetpack = default!;
+
+    private ISawmill _sawmill = default!;
+    private float _accumulatedFrameTime;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly IRobustRandom _random = default!;
-        [Dependency] private readonly AlertsSystem _alerts = default!;
-        [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
-        [Dependency] private readonly SharedJetpackSystem _jetpack = default!;
+        base.Initialize();
 
-        private ISawmill _sawmill = default!;
-        private float _accumulatedFrameTime;
+        _sawmill = Logger.GetSawmill("thirst");
 
-        public override void Initialize()
+        SubscribeLocalEvent<ThirstComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
+        SubscribeLocalEvent<ThirstComponent, ComponentStartup>(OnComponentStartup);
+        SubscribeLocalEvent<ThirstComponent, RejuvenateEvent>(OnRejuvenate);
+    }
+
+    private void OnComponentStartup(EntityUid uid, ThirstComponent component, ComponentStartup args)
+    {
+        // Do not change behavior unless starting value is explicitly defined
+        if (component.CurrentThirst < 0)
         {
-            base.Initialize();
-
-            _sawmill = Logger.GetSawmill("thirst");
-
-            SubscribeLocalEvent<ThirstComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
-            SubscribeLocalEvent<ThirstComponent, ComponentStartup>(OnComponentStartup);
-            SubscribeLocalEvent<ThirstComponent, RejuvenateEvent>(OnRejuvenate);
+            component.CurrentThirst = _random.Next(
+                (int) component.ThirstThresholds[ThirstThreshold.Thirsty] + 10,
+                (int) component.ThirstThresholds[ThirstThreshold.Okay] - 1);
         }
+        component.CurrentThirstThreshold = GetThirstThreshold(component, component.CurrentThirst);
+        component.LastThirstThreshold = ThirstThreshold.Okay; // TODO: Potentially change this -> Used Okay because no effects.
+        // TODO: Check all thresholds make sense and throw if they don't.
+        UpdateEffects(uid, component);
+    }
 
-        private void OnComponentStartup(EntityUid uid, ThirstComponent component, ComponentStartup args)
+    private void OnRefreshMovespeed(EntityUid uid, ThirstComponent component, RefreshMovementSpeedModifiersEvent args)
+    {
+        // TODO: This should really be taken care of somewhere else
+        if (_jetpack.IsUserFlying(uid))
+            return;
+
+        var mod = component.CurrentThirstThreshold <= ThirstThreshold.Parched ? 0.75f : 1.0f;
+        args.ModifySpeed(mod, mod);
+    }
+
+    private void OnRejuvenate(EntityUid uid, ThirstComponent component, RejuvenateEvent args)
+    {
+        ResetThirst(component);
+    }
+
+    private ThirstThreshold GetThirstThreshold(ThirstComponent component, float amount)
+    {
+        ThirstThreshold result = ThirstThreshold.Dead;
+        var value = component.ThirstThresholds[ThirstThreshold.OverHydrated];
+        foreach (var threshold in component.ThirstThresholds)
         {
-            // Do not change behavior unless starting value is explicitly defined
-            if (component.CurrentThirst < 0)
+            if (threshold.Value <= value && threshold.Value >= amount)
             {
-                component.CurrentThirst = _random.Next(
-                    (int) component.ThirstThresholds[ThirstThreshold.Thirsty] + 10,
-                    (int) component.ThirstThresholds[ThirstThreshold.Okay] - 1);
+                result = threshold.Key;
+                value = threshold.Value;
             }
-            component.CurrentThirstThreshold = GetThirstThreshold(component, component.CurrentThirst);
-            component.LastThirstThreshold = ThirstThreshold.Okay; // TODO: Potentially change this -> Used Okay because no effects.
-            // TODO: Check all thresholds make sense and throw if they don't.
-            UpdateEffects(uid, component);
         }
 
-        private void OnRefreshMovespeed(EntityUid uid, ThirstComponent component, RefreshMovementSpeedModifiersEvent args)
+        return result;
+    }
+
+    public void UpdateThirst(ThirstComponent component, float amount)
+    {
+        component.CurrentThirst = Math.Clamp(component.CurrentThirst + amount, component.ThirstThresholds[ThirstThreshold.Dead], component.ThirstThresholds[ThirstThreshold.OverHydrated]);
+    }
+
+    public void ResetThirst(ThirstComponent component)
+    {
+        component.CurrentThirst = component.ThirstThresholds[ThirstThreshold.Okay];
+    }
+
+    private bool IsMovementThreshold(ThirstThreshold threshold)
+    {
+        switch (threshold)
         {
-            // TODO: This should really be taken care of somewhere else
-            if (_jetpack.IsUserFlying(uid))
+            case ThirstThreshold.Dead:
+            case ThirstThreshold.Parched:
+                return true;
+            case ThirstThreshold.Thirsty:
+            case ThirstThreshold.Okay:
+            case ThirstThreshold.OverHydrated:
+                return false;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(threshold), threshold, null);
+        }
+    }
+
+    private void UpdateEffects(EntityUid uid, ThirstComponent component)
+    {
+        if (IsMovementThreshold(component.LastThirstThreshold) != IsMovementThreshold(component.CurrentThirstThreshold) &&
+                TryComp(uid, out MovementSpeedModifierComponent? movementSlowdownComponent))
+        {
+            _movement.RefreshMovementSpeedModifiers(uid, movementSlowdownComponent);
+        }
+
+        // Update UI
+        if (ThirstComponent.ThirstThresholdAlertTypes.TryGetValue(component.CurrentThirstThreshold, out var alertId))
+        {
+            _alerts.ShowAlert(uid, alertId);
+        }
+        else
+        {
+            _alerts.ClearAlertCategory(uid, AlertCategory.Thirst);
+        }
+
+        switch (component.CurrentThirstThreshold)
+        {
+            case ThirstThreshold.OverHydrated:
+                component.LastThirstThreshold = component.CurrentThirstThreshold;
+                component.ActualDecayRate = component.BaseDecayRate * 1.2f;
                 return;
 
-            var mod = component.CurrentThirstThreshold <= ThirstThreshold.Parched ? 0.75f : 1.0f;
-            args.ModifySpeed(mod, mod);
-        }
+            case ThirstThreshold.Okay:
+                component.LastThirstThreshold = component.CurrentThirstThreshold;
+                component.ActualDecayRate = component.BaseDecayRate;
+                return;
 
-        private void OnRejuvenate(EntityUid uid, ThirstComponent component, RejuvenateEvent args)
-        {
-            ResetThirst(component);
-        }
+            case ThirstThreshold.Thirsty:
+                // Same as okay except with UI icon saying drink soon.
+                component.LastThirstThreshold = component.CurrentThirstThreshold;
+                component.ActualDecayRate = component.BaseDecayRate * 0.8f;
+                return;
+            case ThirstThreshold.Parched:
+                _movement.RefreshMovementSpeedModifiers(uid);
+                component.LastThirstThreshold = component.CurrentThirstThreshold;
+                component.ActualDecayRate = component.BaseDecayRate * 0.6f;
+                return;
 
-        private ThirstThreshold GetThirstThreshold(ThirstComponent component, float amount)
+            case ThirstThreshold.Dead:
+                return;
+
+            default:
+                _sawmill.Error($"No thirst threshold found for {component.CurrentThirstThreshold}");
+                throw new ArgumentOutOfRangeException($"No thirst threshold found for {component.CurrentThirstThreshold}");
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        _accumulatedFrameTime += frameTime;
+
+        if (_accumulatedFrameTime > 1)
         {
-            ThirstThreshold result = ThirstThreshold.Dead;
-            var value = component.ThirstThresholds[ThirstThreshold.OverHydrated];
-            foreach (var threshold in component.ThirstThresholds)
+            var query = EntityManager.EntityQueryEnumerator<ThirstComponent>();
+            while (query.MoveNext(out var uid, out var comp))
             {
-                if (threshold.Value <= value && threshold.Value >= amount)
+                UpdateThirst(comp, - comp.ActualDecayRate);
+                var calculatedThirstThreshold = GetThirstThreshold(comp, comp.CurrentThirst);
+                if (calculatedThirstThreshold != comp.CurrentThirstThreshold)
                 {
-                    result = threshold.Key;
-                    value = threshold.Value;
+                    comp.CurrentThirstThreshold = calculatedThirstThreshold;
+                    UpdateEffects(uid, comp);
                 }
             }
-
-            return result;
-        }
-
-        public void UpdateThirst(ThirstComponent component, float amount)
-        {
-            component.CurrentThirst = Math.Clamp(component.CurrentThirst + amount, component.ThirstThresholds[ThirstThreshold.Dead], component.ThirstThresholds[ThirstThreshold.OverHydrated]);
-        }
-
-        public void ResetThirst(ThirstComponent component)
-        {
-            component.CurrentThirst = component.ThirstThresholds[ThirstThreshold.Okay];
-        }
-
-        private bool IsMovementThreshold(ThirstThreshold threshold)
-        {
-            switch (threshold)
-            {
-                case ThirstThreshold.Dead:
-                case ThirstThreshold.Parched:
-                    return true;
-                case ThirstThreshold.Thirsty:
-                case ThirstThreshold.Okay:
-                case ThirstThreshold.OverHydrated:
-                    return false;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(threshold), threshold, null);
-            }
-        }
-
-        private void UpdateEffects(EntityUid uid, ThirstComponent component)
-        {
-            if (IsMovementThreshold(component.LastThirstThreshold) != IsMovementThreshold(component.CurrentThirstThreshold) &&
-                    TryComp(uid, out MovementSpeedModifierComponent? movementSlowdownComponent))
-            {
-                _movement.RefreshMovementSpeedModifiers(uid, movementSlowdownComponent);
-            }
-
-            // Update UI
-            if (ThirstComponent.ThirstThresholdAlertTypes.TryGetValue(component.CurrentThirstThreshold, out var alertId))
-            {
-                _alerts.ShowAlert(uid, alertId);
-            }
-            else
-            {
-                _alerts.ClearAlertCategory(uid, AlertCategory.Thirst);
-            }
-
-            switch (component.CurrentThirstThreshold)
-            {
-                case ThirstThreshold.OverHydrated:
-                    component.LastThirstThreshold = component.CurrentThirstThreshold;
-                    component.ActualDecayRate = component.BaseDecayRate * 1.2f;
-                    return;
-
-                case ThirstThreshold.Okay:
-                    component.LastThirstThreshold = component.CurrentThirstThreshold;
-                    component.ActualDecayRate = component.BaseDecayRate;
-                    return;
-
-                case ThirstThreshold.Thirsty:
-                    // Same as okay except with UI icon saying drink soon.
-                    component.LastThirstThreshold = component.CurrentThirstThreshold;
-                    component.ActualDecayRate = component.BaseDecayRate * 0.8f;
-                    return;
-                case ThirstThreshold.Parched:
-                    _movement.RefreshMovementSpeedModifiers(uid);
-                    component.LastThirstThreshold = component.CurrentThirstThreshold;
-                    component.ActualDecayRate = component.BaseDecayRate * 0.6f;
-                    return;
-
-                case ThirstThreshold.Dead:
-                    return;
-
-                default:
-                    _sawmill.Error($"No thirst threshold found for {component.CurrentThirstThreshold}");
-                    throw new ArgumentOutOfRangeException($"No thirst threshold found for {component.CurrentThirstThreshold}");
-            }
-        }
-
-        public override void Update(float frameTime)
-        {
-            _accumulatedFrameTime += frameTime;
-
-            if (_accumulatedFrameTime > 1)
-            {
-                var query = EntityManager.EntityQueryEnumerator<ThirstComponent>();
-                while (query.MoveNext(out var uid, out var comp))
-                {
-                    UpdateThirst(comp, - comp.ActualDecayRate);
-                    var calculatedThirstThreshold = GetThirstThreshold(comp, comp.CurrentThirst);
-                    if (calculatedThirstThreshold != comp.CurrentThirstThreshold)
-                    {
-                        comp.CurrentThirstThreshold = calculatedThirstThreshold;
-                        UpdateEffects(uid, comp);
-                    }
-                }
-                _accumulatedFrameTime -= 1;
-            }
+            _accumulatedFrameTime -= 1;
         }
     }
 }

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -4,9 +4,9 @@
   parent: Puddle
   abstract: true
   components:
-    - type: Transform
-      anchored: true
-      noRot: false
+  - type: Transform
+    anchored: true
+    noRot: false
 
 - type: entity
   id: PuddleSmear
@@ -16,67 +16,67 @@
   id: PuddleVomit
   parent: PuddleTemporary
   components:
-    - type: SolutionContainerManager
-      solutions:
-        puddle:
-          maxVol: 1000
-          reagents:
-            - ReagentId: Nutriment
-              Quantity: 5
-            - ReagentId: Water
-              Quantity: 5
+  - type: SolutionContainerManager
+    solutions:
+      puddle:
+        maxVol: 1000
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
+        - ReagentId: Water
+          Quantity: 5
 
 - type: entity
   id: PuddleEgg
   parent: PuddleTemporary
   components:
-    - type: SolutionContainerManager
-      solutions:
-        puddle:
-          maxVol: 1000
-          reagents:
-            - ReagentId: Egg
-              Quantity: 6 # same as when cooking
+  - type: SolutionContainerManager
+    solutions:
+      puddle:
+        maxVol: 1000
+        reagents:
+        - ReagentId: Egg
+          Quantity: 6 # same as when cooking
 
 - type: entity
   id: PuddleTomato
   parent: PuddleTemporary
   components:
-    - type: SolutionContainerManager
-      solutions:
-        puddle:
-          maxVol: 1000
-          reagents:
-            - ReagentId: Nutriment
-              Quantity: 5
-            - ReagentId: Water
-              Quantity: 5
+  - type: SolutionContainerManager
+    solutions:
+      puddle:
+        maxVol: 1000
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
+        - ReagentId: Water
+          Quantity: 5
 
 - type: entity
   id: PuddleWatermelon
   parent: PuddleTemporary
   components:
-    - type: SolutionContainerManager
-      solutions:
-        puddle:
-          maxVol: 1000
-          reagents:
-            - ReagentId: Nutriment
-              Quantity: 15
-            - ReagentId: Water
-              Quantity: 15
+  - type: SolutionContainerManager
+    solutions:
+      puddle:
+        maxVol: 1000
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 15
+        - ReagentId: Water
+          Quantity: 15
 
 - type: entity
   id: PuddleFlour
   parent: PuddleTemporary
   components:
-    - type: SolutionContainerManager
-      solutions:
-        puddle:
-          maxVol: 1000
-          reagents:
-            - ReagentId: Flour
-              Quantity: 15
+  - type: SolutionContainerManager
+    solutions:
+      puddle:
+        maxVol: 1000
+        reagents:
+        - ReagentId: Flour
+          Quantity: 15
 
 - type: entity
   id: PuddleSparkle
@@ -105,57 +105,58 @@
   placement:
     mode: SnapgridCenter
   components:
-    - type: Clickable
-    - type: FootstepModifier
-      footstepSoundCollection:
-        collection: FootstepWater
-        params:
-          volume: 6
-    - type: Slippery
-      launchForwardsMultiplier: 2.0
-    - type: Transform
-      noRot: true
-      anchored: true
-    - type: Sprite
-      layers:
-        - sprite: Fluids/puddle.rsi
-          state: splat0
-      drawdepth: FloorObjects
-      color: "#FFFFFF80"
-    - type: Physics
-      bodyType: Static
-    - type: Fixtures
-      fixtures:
-        slipFixture:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "-0.4,-0.4,0.4,0.4"
-          mask:
-            - ItemMask
-          layer:
-            - SlipLayer
-          hard: false
-    - type: IconSmooth
-      key: puddles
-      base: splat
-      mode: CardinalFlags
-    - type: SolutionContainerManager
-      solutions:
-        puddle: { maxVol: 1000 }
-    - type: Puddle
-    - type: Appearance
-    - type: EdgeSpreader
-    - type: StepTrigger
-    - type: NodeContainer
-      nodes:
-        puddle:
-          !type:SpreaderNode
-          nodeGroupID: Spreader
-    - type: Drink
-      isOpen: true
-      delay: 3
-      transferAmount: 1
-      solution: puddle
-      examinable: false
-    - type: ExaminableSolution
-      solution: puddle
+  - type: Clickable
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: FootstepWater
+      params:
+        volume: 6
+  - type: Slippery
+    launchForwardsMultiplier: 2.0
+  - type: Transform
+    noRot: true
+    anchored: true
+  - type: Sprite
+    layers:
+    - sprite: Fluids/puddle.rsi
+      state: splat0
+    drawdepth: FloorObjects
+    color: "#FFFFFF80"
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      slipFixture:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.4,0.4,0.4"
+        mask:
+        - ItemMask
+        layer:
+        - SlipLayer
+        hard: false
+  - type: IconSmooth
+    key: puddles
+    base: splat
+    mode: CardinalFlags
+  - type: SolutionContainerManager
+    solutions:
+      puddle: { maxVol: 1000 }
+  - type: Puddle
+  - type: Appearance
+  - type: EdgeSpreader
+  - type: StepTrigger
+  - type: NodeContainer
+    nodes:
+      puddle:
+        !type:SpreaderNode
+        nodeGroupID: Spreader
+  - type: Drink
+    isOpen: true
+    delay: 3
+    transferAmount: 1
+    solution: puddle
+    examinable: false
+  - type: ExaminableSolution
+    solution: puddle
+  - type: BadDrink

--- a/Resources/Prototypes/NPCs/nutrition.yml
+++ b/Resources/Prototypes/NPCs/nutrition.yml
@@ -1,11 +1,16 @@
 - type: htnCompound
   id: FoodCompound
   branches:
-    - tasks:
-        - id: PickFoodTargetPrimitive
-        - id: MoveToCombatTargetPrimitive
-        - id: EatPrimitive
-        - id: WaitIdleTimePrimitive
+  - tasks:
+    - id: PickFoodTargetPrimitive
+    - id: MoveToCombatTargetPrimitive
+    - id: EatPrimitive
+    - id: WaitIdleTimePrimitive
+  - tasks:
+    - id: PickDrinkTargetPrimitive
+    - id: MoveToCombatTargetPrimitive
+    - id: EatPrimitive
+    - id: WaitIdleTimePrimitive
 
 
 - type: htnPrimitive
@@ -14,8 +19,13 @@
     proto: NearbyFood
 
 - type: htnPrimitive
+  id: PickDrinkTargetPrimitive
+  operator: !type:UtilityOperator
+    proto: NearbyDrink
+
+- type: htnPrimitive
   id: EatPrimitive
   preconditions:
-    - !type:KeyExistsPrecondition
-      key: CombatTarget
+  - !type:KeyExistsPrecondition
+    key: CombatTarget
   operator: !type:AltInteractOperator

--- a/Resources/Prototypes/NPCs/utility_queries.yml
+++ b/Resources/Prototypes/NPCs/utility_queries.yml
@@ -3,7 +3,7 @@
   query:
     - !type:ComponentQuery
       components:
-        - type: Food
+      - type: Food
   considerations:
     - !type:TargetIsAliveCon
       curve: !type:InverseBoolCurve
@@ -16,6 +16,25 @@
         exponent: 0.4
     - !type:TargetAccessibleCon
       curve: !type:BoolCurve
+
+- type: utilityQuery
+  id: NearbyDrink
+  query:
+  - !type:ComponentQuery
+    components:
+    - type: Drink
+  considerations:
+  - !type:TargetIsAliveCon
+    curve: !type:InverseBoolCurve
+  - !type:TargetDistanceCon
+    curve: !type:PresetCurve
+      preset: TargetDistance
+  - !type:DrinkValueCon
+    curve: !type:QuadraticCurve
+      slope: 1.0
+      exponent: 0.4
+  - !type:TargetAccessibleCon
+    curve: !type:BoolCurve
 
 - type: utilityQuery
   id: NearbyMeleeTargets


### PR DESCRIPTION
## About the PR
- minor thirst + drink systems refactoring
- add TotalHydration api to DrinkSystem used by npc utility query
- animals will now drink things that satiate thirst
- animals ignore all puddles
- animals wont eat or drink when not hungry or thirsty (except for admeme mice which will always eat)

started on this because having to manually pour water down cows throats in a ranch is awful
they can already eat food on their own, why not let them drink?

also lets funny mouse ai raid the bar, more enemies have been made

**Media**
cow drinks opened drink
![14:39:04](https://github.com/space-wizards/space-station-14/assets/39013340/9c0fa925-8a55-4386-a392-8adcd494fb61)

cow is not a janitor he does not do it for free
![11:36:13](https://github.com/space-wizards/space-station-14/assets/39013340/ed9ab2c6-45dc-48a3-a33e-bf4203216718)

cow wont drink things that have no or negative thirst satiating (salt is negative)
![14:41:53](https://github.com/space-wizards/space-station-14/assets/39013340/707909f4-2eab-4e2b-bf35-66fd13152495)

pouring when closed loc thing refactor that just gives it the entity id works
![14:40:48](https://github.com/space-wizards/space-station-14/assets/39013340/ae89126f-20ae-4bf8-be99-585caeb43547)

cow wont drink when no longer thirsty
![16:02:37](https://github.com/space-wizards/space-station-14/assets/39013340/88e81171-9ce0-435c-8626-1a34c3cbdb57)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Animals can now drink satiating liquids like water or beer when thirsty.
- tweak: Animals no longer eat with a full belly.
