### PR TITLE
Undo migration.yml trimming.

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -6,6 +6,94 @@
 # Window: WallSolid
 # WallSolid: Window
 # Table: null
+#
+chem_dispenser: ChemDispenser
+KvassTankFull: null
+DrinkKvassGlass: null
+KvassTank: null
+
+# 2023-05-03
+SpawnPointBrigmedic: null
+ClothingHeadsetBrigmedic: null
+ClothingHeadHatBeretBrigmedic: null
+ClothingHeadHelmetHardsuitBrigmedic: null
+ClothingOuterHardsuitBrigmedic: null
+ClothingOuterCoatAMG: null
+ClothingBackpackBrigmedic: null
+ClothingBackpackBrigmedicFilled: null
+ClothingBackpackSatchelBrigmedic: null
+ClothingBackpackSatchelBrigmedicFilled: null
+ClothingBackpackDuffelBrigmedic: null
+ClothingBackpackDuffelBrigmedicFilled: null
+BrigmedicIDCard: null
+BrigmedicPDA: null
+BoxSurvivalBrigmedic: null
+LockerBrigmedic: null
+LockerBrigmedicFilled: null
+BedsheetBrigmedic: null
+
+# 2023-05-04
+BoxMagazineMagnumSubMachineGun: BoxMagazinePistolSubMachineGun
+BoxMagazineMagnumSubMachineGunPractice: BoxMagazinePistolSubMachineGunPractice
+BoxMagazineMagnumSubMachineGunRubber: BoxMagazinePistolSubMachineGunRubber
+
+MagazineMagnumSubMachineGun: MagazinePistolSubMachineGun
+MagazineMagnumSubMachineGunHighVelocity: MagazinePistolSubMachineGunHighVelocity
+MagazineMagnumSubMachineGunPractice: MagazinePistolSubMachineGunPractice
+MagazineMagnumSubMachineGunRubber: MagazinePistolSubMachineGunRubber
+WeaponSubMachineGunVector: WeaponSubMachineGunDrozd
+WeaponSubMachineGunVectorRubber: WeaponSubMachineGunDrozdRubber
+
+MagazineBoxAntiMaterial: MagazineBoxAntiMateriel
+CartridgeAntiMaterial: CartridgeAntiMateriel
+BulletAntiMaterial: BulletAntiMateriel
+
+# 2023-05-10
+FoodCondimentBottleSmallHotsauce: FoodCondimentBottleHotsauce
+FoodBakedCookieFortune: FoodSnackCookieFortune
+GunSafeSubMachineGunVector: GunSafeSubMachineGunDrozd
+
+# 2023-05-24
+AMEController: AmeController
+AMEJar: AmeJar
+AMEPart: AmePart
+AMEShielding: AmeShielding
+
+# 2023-05-29
+OrGate: null
+
+# 2023-05-31
+IHSVoidsuit: null
+ClothingHeadHelmetIHSVoidHelm: null
+ClothingHandsGlovesIhscombat: null
+
+# 2023-06-02
+# Yes, this is right. They were, in fact, reversed because the default orientation of the particle accelerator was _down_ relative to the screen.
+# This resulted in the parts being named assuming that the person building the accelerator treated it like a rocket with the particles coming out the _back_.
+# As this was confusing they were converted to nautical orientation with forward being towards the emitters.
+MachineParticleAcceleratorEmitterCenterCircuitboard: MachineParticleAcceleratorEmitterForeCircuitboard
+MachineParticleAcceleratorEmitterLeftCircuitboard: MachineParticleAcceleratorEmitterStarboardCircuitboard
+MachineParticleAcceleratorEmitterRightCircuitboard: MachineParticleAcceleratorEmitterPortCircuitboard
+ParticleAcceleratorEmitterCenter: ParticleAcceleratorEmitterFore
+ParticleAcceleratorEmitterCenterUnfinished: ParticleAcceleratorEmitterForeUnfinished
+ParticleAcceleratorEmitterLeft: ParticleAcceleratorEmitterStarboard
+ParticleAcceleratorEmitterLeftUnfinished: ParticleAcceleratorEmitterStarboardUnfinished
+ParticleAcceleratorEmitterRight: ParticleAcceleratorEmitterPort
+ParticleAcceleratorEmitterRightUnfinished: ParticleAcceleratorEmitterPortUnfinished
+
+# 2023-06-21
+WindoorArmoryLocked: WindoorSecureArmoryLocked
+WindoorBrigLocked: WindoorSecureBrigLocked
+WindoorChemistryLocked: WindoorSecureChemistryLocked
+WindoorCommandLocked: WindoorSecureCommandLocked
+WindoorEngineeringLocked: WindoorSecureEngineeringLocked
+WindoorExternalLocked: WindoorSecureExternalLocked
+WindoorMedicalLocked: WindoorSecureMedicalLocked
+WindoorSecurityLocked: WindoorSecureSecurityLocked
+WindoorScienceLocked: WindoorSecureScienceLocked
+WindoorHeadOfPersonnelLocked: WindoorSecureHeadOfPersonnelLocked
+WindoorAtmosphericsLocked: WindoorSecureAtmosphericsLocked
+WindoorParamedicLocked: WindoorSecureParamedicLocked
 
 # 2023-07-03
 ClothingHeadHelmetHelmet: ClothingHeadHelmetBasic


### PR DESCRIPTION
This PR reverts some the changes made in #18243. The reason for this is just to make it easier for forks/downstreams to checkout a single commit and resave their maps, the trimming of migration.yml should have just been done in a separate PR.