### PR TITLE
Remove Hamlet ghost role

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -448,13 +448,6 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: hamster-0
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-hamlet-name
-    description: ghost-role-information-hamlet-description
-  - type: GhostTakeoverAvailable
   - type: InteractionPopup
     successChance: 1
   - type: Butcherable


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
can't wait for the hate.

Hamlet being a ghost role is weird and makes no sense:
- no other station pet is a ghost role by default
- hamlet players frequently engage in shittery
- hamlet players always just go fuck off in random parts of the station and are generally extremely intrusive, by nature of having AA.

it's just weird and inconsistent. Ian has a similar level of popularity and doesn't get to be a ghost role. it also devalues cognizine.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- remove: Hamlet is no longer a ghost role.