### PR TITLE
Add EmpReactionEffect

### DIFF
--- a/Content.Server/Chemistry/ReactionEffects/EmpReactionEffect.cs
+++ b/Content.Server/Chemistry/ReactionEffects/EmpReactionEffect.cs
@@ -40,7 +40,7 @@ public sealed class EmpReactionEffect : ReagentEffect
         var transform = args.EntityManager.GetComponent<TransformComponent>(args.SolutionEntity);
         var range = MathF.Min((float) (args.Quantity*EmpRangePerUnit), EmpMaxRange);
 
-        EntitySystem.Get<EmpSystem>().EmpPulse(
+        args.EntityManager.System<EmpSystem>().EmpPulse(
             transform.MapPosition,
             range,
             EnergyConsumption,

--- a/Content.Server/Chemistry/ReactionEffects/EmpReactionEffect.cs
+++ b/Content.Server/Chemistry/ReactionEffects/EmpReactionEffect.cs
@@ -9,10 +9,16 @@ namespace Content.Server.Chemistry.ReactionEffects;
 public sealed class EmpReactionEffect : ReagentEffect
 {
     /// <summary>
-    ///     EMP explosion range
+    ///     Impulse range per unit of reagent
     /// </summary>
-    [DataField("range")]
-    public float EmpRange = 1;
+    [DataField("rangePerUnit")]
+    public float EmpRangePerUnit = 0.5f;
+
+    /// <summary>
+    ///     Maximum impulse range
+    /// </summary>
+    [DataField("maxRange")]
+    public float EmpMaxRange = 10;
 
     /// <summary>
     ///     How much energy will be drain from sources
@@ -32,9 +38,11 @@ public sealed class EmpReactionEffect : ReagentEffect
     public override void Effect(ReagentEffectArgs args)
     {
         var transform = args.EntityManager.GetComponent<TransformComponent>(args.SolutionEntity);
+        var range = MathF.Min((float) (args.Quantity*EmpRangePerUnit), EmpMaxRange);
+
         EntitySystem.Get<EmpSystem>().EmpPulse(
             transform.MapPosition,
-            EmpRange,
+            range,
             EnergyConsumption,
             DisableDuration);
     }

--- a/Content.Server/Chemistry/ReactionEffects/EmpReactionEffect.cs
+++ b/Content.Server/Chemistry/ReactionEffects/EmpReactionEffect.cs
@@ -1,0 +1,41 @@
+using Content.Server.Emp;
+using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Chemistry.ReactionEffects;
+
+
+[DataDefinition]
+public sealed class EmpReactionEffect : ReagentEffect
+{
+    /// <summary>
+    ///     EMP explosion range
+    /// </summary>
+    [DataField("range")]
+    public float EmpRange = 1;
+
+    /// <summary>
+    ///     How much energy will be drain from sources
+    /// </summary>
+    [DataField("energyConsumption")]
+    public float EnergyConsumption = 12500;
+
+    /// <summary>
+    ///     Amount of time entities will be disabled
+    /// </summary>
+    [DataField("duration")]
+    public float DisableDuration = 15;
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+            => Loc.GetString("reagent-effect-guidebook-emp-reaction-effect", ("chance", Probability));
+
+    public override void Effect(ReagentEffectArgs args)
+    {
+        var transform = args.EntityManager.GetComponent<TransformComponent>(args.SolutionEntity);
+        EntitySystem.Get<EmpSystem>().EmpPulse(
+            transform.MapPosition,
+            EmpRange,
+            EnergyConsumption,
+            DisableDuration);
+    }
+}

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -31,6 +31,12 @@ reagent-effect-guidebook-explosion-reaction-effect =
         *[other] cause
     } an explosion
 
+reagent-effect-guidebook-emp-reaction-effect =
+    { $chance ->
+        [1] Causes
+        *[other] cause
+    } an electromagnetic pulse
+
 reagent-effect-guidebook-foam-area-reaction-effect =
     { $chance ->
         [1] Creates

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -190,7 +190,8 @@
       amount: 1
   effects:
     - !type:EmpReactionEffect
-      range: 1
+      rangePerUnit: 0.2
+      maxRange: 6
       energyConsumption: 12500
       duration: 15
 

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -178,6 +178,23 @@
         path: /Audio/Effects/extinguish.ogg
 
 - type: reaction
+  id: UraniumEmpExplosion
+  impact: High
+  priority: 20
+  reactants:
+    Iron:
+      amount: 1
+    Uranium:
+      amount: 1
+    Aluminium:
+      amount: 1
+  effects:
+    - !type:EmpReactionEffect
+      range: 1
+      energyConsumption: 12500
+      duration: 15
+
+- type: reaction
   id: TableSalt
   reactants:
     Chlorine:


### PR DESCRIPTION
EMP is cool. And now all of us can do the cool "oops energy gone" pranks "at home".

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

+ Added EmpReactionEffect.
+ Added new reaction that will cause an electromagnetic pulse to happen. You will need 1 part Aluminium, 1 part Iron and 1 part Uranium. 
Range of pulse depends on amount of used reagents with maximum range at 30 units of each.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/81412348/30fcd72c-48ee-43e1-a93f-f85d0712310f

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: mhamster
- add: Added new chemical reaction between iron, aluminium and uranium that will cause electromagnetic pulse.
