### PR TITLE
Make the .60 Antimateriel rifle overpowered

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -7,5 +7,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 49
+        Piercing: 60
         Structural: 30
+    ignoreResistances: true
+  - type: StaminaDamageOnCollide
+    damage: 100

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -18,7 +18,7 @@
     - Back
   - type: AmmoCounter
   - type: Gun
-    fireRate: 1
+    fireRate: 0.3 # ~5 second cooldown between shots
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->
The .60 gun damage is laughably bad at this point in time (49 piercing that is reduced by armor). In this PR i will try to change that.

Since the damage is buffed, i thought it would be sensible to reduce Hristov's firerate to make it feel more like a sniper rifle.
The gun will not one-shot targets, instead it will first stun them, forcing allies to drag the target to safety in the 5 seconds while the sniper reloads. If they fail to do so, the second shot will crit the target.

Ideally the Hristov would require two hands to use but the way it works is very janky with bolt action rifles (#18201) and i dont have the expertise to change that.

#18250 might need rebalancing if this is merged, as it makes the Hristov an actually viable weapon and not a meme.

**Changelog**
.60 bullet damage increased to 60 piercing (because its .60) and it now ignores armor resistances (because its a big bullet).
.60 bullet stuns (100 stamina damage) on hit now. - Inspired by TG's .50 sniper rifle.
Hristov firerate decreased to 0.2 (1 shot in 5 seconds).

:cl:
- tweak: The Hristov's sniper rifle cartridges have been refactored. It is now a way more dangerous weapon, at the cost of decreased firerate. It now stuns on a hit, so drag your allies to safety if they got shot with one!
