### PR TITLE
Check Deleted instead of null for HandTeleporter

### DIFF
--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -78,7 +78,7 @@ public sealed class HandTeleporterSystem : EntitySystem
         var xform = Transform(user);
 
         // Create the first portal.
-        if (component.FirstPortal == null && component.SecondPortal == null)
+        if (Deleted(component.FirstPortal) && Deleted(component.SecondPortal))
         {
             // don't portal
             if (xform.ParentUid != xform.GridUid)
@@ -90,7 +90,7 @@ public sealed class HandTeleporterSystem : EntitySystem
             _adminLogger.Add(LogType.EntitySpawn, LogImpact.Low, $"{ToPrettyString(user):player} opened {ToPrettyString(component.FirstPortal.Value)} at {Transform(component.FirstPortal.Value).Coordinates} using {ToPrettyString(uid)}");
             _audio.PlayPvs(component.NewPortalSound, uid);
         }
-        else if (component.SecondPortal == null)
+        else if (Deleted(component.SecondPortal))
         {
             var timeout = EnsureComp<PortalTimeoutComponent>(user);
             timeout.EnteredPortal = null;


### PR DESCRIPTION
This can prevent issues where the hand teleporter ceases working if a portal is deleted during the doAfter.