### PR TITLE
Spiret fix modular receiver and rifle stock

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/improvised_gun_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/improvised_gun_parts.yml
@@ -10,8 +10,7 @@
 #      size: 15
     - type: Sprite
       sprite: Objects/Misc/modular_receiver.rsi
-    - type: Item
-      sprite: Objects/Misc/modular_receiver.rsi
+      state: icon
     - type: Tag
       tags:
       - ModularReceiver
@@ -27,8 +26,7 @@
 #      size: 25
     - type: Sprite
       sprite: Objects/Misc/rifle_stock.rsi
-    - type: Item
-      sprite: Objects/Misc/rifle_stock.rsi
+      state: icon
     - type: Construction
       graph: RifleStockGraph
       node: riflestock


### PR DESCRIPTION
Reupload

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This fix was made by mhamsterr, he was able to understand what the problem of displaying sprites is, now the sprites will be displayed normally both in the inventory and the world, and in the craft menu.

I messed up something and reuploaded the PR

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![1a](https://github.com/space-wizards/space-station-14/assets/129199891/62dddf6c-dddd-4159-9b0f-b2a38c90a0d0)
![1c](https://github.com/space-wizards/space-station-14/assets/129199891/f8b8e2de-0aa6-4dc2-8dcb-cfc1f1e8e7ca)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: fixed spirete modular receiver and rifle stock
