### PR TITLE
Speed up observers

### DIFF
--- a/Content.Client/Replay/Spectator/ReplaySpectatorSystem.Spectate.cs
+++ b/Content.Client/Replay/Spectator/ReplaySpectatorSystem.Spectate.cs
@@ -64,7 +64,7 @@ public sealed partial class ReplaySpectatorSystem
 
         var old = _player.LocalPlayer.ControlledEntity;
 
-        var ent = Spawn("MobObserver", coords);
+        var ent = Spawn("ReplayObserver", coords);
         _eye.SetMaxZoom(ent, Vector2.One * 5);
         EnsureComp<ReplaySpectatorComponent>(ent);
 

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -22,9 +22,6 @@
   - type: CombatMode
   - type: Actions
   - type: InputMover
-  - type: MovementSpeedModifier
-    baseSprintSpeed: 12
-    baseWalkSpeed: 8
   - type: Physics
     ignorePaused: true
     bodyType: Kinematic

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -56,8 +56,8 @@
       - state: animated
         shader: unshaded
   - type: MovementSpeedModifier
-    baseSprintSpeed: 8
-    baseWalkSpeed: 5
+    baseSprintSpeed: 12
+    baseWalkSpeed: 8
   - type: MovementIgnoreGravity
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Mobs/Player/replay_observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/replay_observer.yml
@@ -1,0 +1,9 @@
+﻿- type: entity
+  parent: MobObserver
+  id: ReplayObserver
+  noSpawn: true
+  save: false
+  components:
+  - type: MovementSpeedModifier
+    baseSprintSpeed: 24
+    baseWalkSpeed: 16


### PR DESCRIPTION
Yeah I know ideally we'd have a speed selector but whatever.
Regular observers go adminghost speed (50% faster). Replay observer goes 3x faster (due to the way replays work, the speed values end up slower).

:cl:
- tweak: Observers move faster now.
