### PR TITLE
(Probably) fix random integration test failures.

### DIFF
--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -12,6 +12,7 @@ using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Reflection;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Administration.Logs;
 
@@ -196,10 +197,7 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
         PreRoundQueue.Set(0);
 
         // ship the logs to Azkaban
-        var task = Task.Run(async () =>
-        {
-            await _db.AddAdminLogs(copy);
-        });
+        var task = _db.AddAdminLogs(copy);
 
         _sawmill.Debug($"Saving {copy.Count} admin logs.");
 

--- a/Content.Server/Database/ServerDbSqlite.cs
+++ b/Content.Server/Database/ServerDbSqlite.cs
@@ -20,16 +20,15 @@ namespace Content.Server.Database
     {
         private readonly Func<DbContextOptions<SqliteServerDbContext>> _options;
 
-        private readonly SemaphoreSlim _prefsSemaphore;
+        private readonly ConcurrencySemaphore _prefsSemaphore;
 
         private readonly Task _dbReadyTask;
 
         private int _msDelay;
 
-        public ServerDbSqlite(
-            Func<DbContextOptions<SqliteServerDbContext>> options,
+        public ServerDbSqlite(Func<DbContextOptions<SqliteServerDbContext>> options,
             bool inMemory,
-            IConfigurationManager cfg)
+            IConfigurationManager cfg, bool synchronous)
         {
             _options = options;
 
@@ -37,7 +36,7 @@ namespace Content.Server.Database
 
             // When inMemory we re-use the same connection, so we can't have any concurrency.
             var concurrency = inMemory ? 1 : cfg.GetCVar(CCVars.DatabaseSqliteConcurrency);
-            _prefsSemaphore = new SemaphoreSlim(concurrency, concurrency);
+            _prefsSemaphore = new ConcurrencySemaphore(concurrency, synchronous);
 
             if (cfg.GetCVar(CCVars.DatabaseSynchronous))
             {
@@ -562,6 +561,69 @@ namespace Content.Server.Database
             {
                 await _ctx.DisposeAsync();
                 _db._prefsSemaphore.Release();
+            }
+        }
+
+        private sealed class ConcurrencySemaphore
+        {
+            private readonly bool _synchronous;
+            private readonly SemaphoreSlim _semaphore;
+            private Thread? _holdingThread;
+
+            public ConcurrencySemaphore(int maxCount, bool synchronous)
+            {
+                if (synchronous && maxCount != 1)
+                    throw new ArgumentException("If synchronous, max concurrency must be 1");
+
+                _synchronous = synchronous;
+                _semaphore = new SemaphoreSlim(maxCount, maxCount);
+            }
+
+            public Task WaitAsync()
+            {
+                var task = _semaphore.WaitAsync();
+
+                if (_synchronous)
+                {
+                    if (!task.IsCompleted)
+                    {
+                        if (Thread.CurrentThread == _holdingThread)
+                        {
+                            throw new InvalidOperationException(
+                                "Multiple database requests from same thread on synchronous database!");
+                        }
+
+                        throw new InvalidOperationException(
+                            $"Different threads trying to access the database at once! " +
+                            $"Holding thread: {DiagThread(_holdingThread)}, " +
+                            $"current thread: {DiagThread(Thread.CurrentThread)}");
+                    }
+
+                    _holdingThread = Thread.CurrentThread;
+                }
+
+                return task;
+            }
+
+            public void Release()
+            {
+                if (_synchronous)
+                {
+                    if (Thread.CurrentThread != _holdingThread)
+                        throw new InvalidOperationException("Released on different thread than took lock???");
+
+                    _holdingThread = null;
+                }
+
+                _semaphore.Release();
+            }
+
+            private static string DiagThread(Thread? thread)
+            {
+                if (thread != null)
+                    return $"{thread.Name} ({thread.ManagedThreadId})";
+
+                return "<null thread>";
             }
         }
     }

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -120,27 +120,9 @@ namespace Content.Server.GameTicking
 
             async void SpawnWaitDb()
             {
-                // Temporary debugging code to fix a random test failures
-                var initialStatus = _userDb.GetLoadTask(session).Status;
-                var prefsLoaded = _prefsManager.HavePreferencesLoaded(session);
-                DebugTools.Assert(session.Status == SessionStatus.InGame);
-
                 await _userDb.WaitLoadComplete(session);
 
-                try
-                {
-                    SpawnPlayer(session, EntityUid.Invalid);
-                }
-                catch (Exception e)
-                {
-                    Log.Error($"Caught exception while trying to spawn a player.\n" +
-                              $"Initial DB task status: {initialStatus}\n" +
-                              $"Prefs initially loaded: {prefsLoaded}\n" +
-                              $"DB task status: {_userDb.GetLoadTask(session).Status}\n" +
-                              $"Prefs loaded: {_prefsManager.HavePreferencesLoaded(session)}\n" +
-                              $"Exception: \n{e}");
-                    throw;
-                }
+                SpawnPlayer(session, EntityUid.Invalid);
             }
 
             async void SpawnObserverWaitDb()

--- a/Content.Tests/Server/Preferences/ServerDbSqliteTests.cs
+++ b/Content.Tests/Server/Preferences/ServerDbSqliteTests.cs
@@ -75,7 +75,7 @@ namespace Content.Tests.Server.Preferences
             var conn = new SqliteConnection("Data Source=:memory:");
             conn.Open();
             builder.UseSqlite(conn);
-            return new ServerDbSqlite(() => builder.Options, true, IoCManager.Resolve<IConfigurationManager>());
+            return new ServerDbSqlite(() => builder.Options, true, IoCManager.Resolve<IConfigurationManager>(), true);
         }
 
         [Test]


### PR DESCRIPTION
I noticed that the sporadic test failures all involved RobustSynchronizationContext. This should in and of itself be impossible: integration tests are *supposed* to be configured with the database running fully synchronous.

The actual source of the bug is the admin log manager deferring writes via Task.Run(). This caused multiple requests to hit the concurrency semaphore at the same time, which caused the main integration testing logic to wait on the rest of the thread pool, introducing divergence. From there on it's no telling what goes wrong with the integration testing system, everything's timed wrong and the database is potentially written to across instances.

The funny thing is, that Task.Run() in admin logs isn't even necessary anymore. Nowadays, the DB manager itself forces a Task.Run() regardless (except during integration tests). The simplest fix is to just remove it from admin logs entirely.

The rest of the commit is just a ton of guard code around the database that I used to debug this. It also serves to make sure this never happens again, enforcing that database queries are always returned synchronously during integration tests. This bug became remarkably easy to reproduce as soon as basic .IsCompleted checks were in place to spot the concurrency issues.

I also chased a bit of a red herring wrt admin logs' usage of IAsyncEnumerable<T>. I forced it to not load the query results incrementally (so it's checked synchronous), figuring tests wouldn't have data sizes for this to matter. I realize now while writing this commit message that such a change may mask potential deadlock bugs otherwise caught by integration tests, so I will try to remember to revise this with a more thorough fix later.