### PR TITLE
Fix missing device links in maps

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -15422,31 +15422,67 @@ entities:
     - pos: -32.5,-5.5
       parent: 60
       type: Transform
+    - linkedPorts:
+        230:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 1485
     components:
     - pos: -32.5,-8.5
       parent: 60
       type: Transform
+    - linkedPorts:
+        268:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 1486
     components:
     - pos: -32.5,-11.5
       parent: 60
       type: Transform
+    - linkedPorts:
+        243:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 1488
     components:
     - pos: -20.5,-8.5
       parent: 60
       type: Transform
+    - linkedPorts:
+        151:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 6971
     components:
     - pos: -20.5,-5.5
       parent: 60
       type: Transform
+    - linkedPorts:
+        843:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 6972
     components:
     - pos: -20.5,-11.5
       parent: 60
       type: Transform
+    - linkedPorts:
+        72:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
 - proto: BrokenBottle
   entities:
   - uid: 23662
@@ -63999,6 +64035,10 @@ entities:
       pos: -47.5,16.5
       parent: 60
       type: Transform
+    - linkedPorts:
+        9442:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
 - proto: computerBodyScanner
   entities:
   - uid: 627
@@ -114115,6 +114155,9 @@ entities:
     - pos: -50.5,17.5
       parent: 60
       type: Transform
+    - links:
+      - 466
+      type: DeviceLinkSink
 - proto: MachineFrame
   entities:
   - uid: 945
@@ -127482,6 +127525,14 @@ entities:
     - pos: -11.495448,-28.362686
       parent: 60
       type: Transform
+    - linkedPorts:
+        7697:
+        - Pressed: Toggle
+        914:
+        - Pressed: Toggle
+        920:
+        - Pressed: Toggle
+      type: DeviceLinkSource
   - uid: 4898
     components:
     - name: Cell 5 Shutters
@@ -128033,6 +128084,7 @@ entities:
       parent: 60
       type: Transform
     - links:
+      - 3017
       - 1189
       type: DeviceLinkSink
   - uid: 920
@@ -128041,6 +128093,7 @@ entities:
       parent: 60
       type: Transform
     - links:
+      - 3017
       - 1189
       type: DeviceLinkSink
   - uid: 2307
@@ -128081,6 +128134,7 @@ entities:
       parent: 60
       type: Transform
     - links:
+      - 3017
       - 1189
       type: DeviceLinkSink
   - uid: 11253
@@ -156929,36 +156983,54 @@ entities:
       pos: -20.5,-12.5
       parent: 60
       type: Transform
+    - links:
+      - 6972
+      type: DeviceLinkSink
   - uid: 151
     components:
     - rot: 1.5707963267948966 rad
       pos: -20.5,-9.5
       parent: 60
       type: Transform
+    - links:
+      - 1488
+      type: DeviceLinkSink
   - uid: 230
     components:
     - rot: -1.5707963267948966 rad
       pos: -32.5,-6.5
       parent: 60
       type: Transform
+    - links:
+      - 1468
+      type: DeviceLinkSink
   - uid: 243
     components:
     - rot: -1.5707963267948966 rad
       pos: -32.5,-12.5
       parent: 60
       type: Transform
+    - links:
+      - 1486
+      type: DeviceLinkSink
   - uid: 268
     components:
     - rot: -1.5707963267948966 rad
       pos: -32.5,-9.5
       parent: 60
       type: Transform
+    - links:
+      - 1485
+      type: DeviceLinkSink
   - uid: 843
     components:
     - rot: 1.5707963267948966 rad
       pos: -20.5,-6.5
       parent: 60
       type: Transform
+    - links:
+      - 6971
+      type: DeviceLinkSink
   - uid: 4078
     components:
     - rot: 3.141592653589793 rad

--- a/Resources/Maps/barratry.yml
+++ b/Resources/Maps/barratry.yml
@@ -15875,16 +15875,34 @@ entities:
     - pos: -56.5,52.5
       parent: 1
       type: Transform
+    - linkedPorts:
+        7871:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 4986
     components:
     - pos: -53.5,52.5
       parent: 1
       type: Transform
+    - linkedPorts:
+        7872:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 4987
     components:
     - pos: -50.5,52.5
       parent: 1
       type: Transform
+    - linkedPorts:
+        7873:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
 - proto: Brutepack
   entities:
   - uid: 1990
@@ -45203,6 +45221,10 @@ entities:
       pos: 0.5,-11.5
       parent: 1
       type: Transform
+    - linkedPorts:
+        347:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
 - proto: ComputerBroken
   entities:
   - uid: 591
@@ -80550,6 +80572,9 @@ entities:
     - pos: 1.5,-14.5
       parent: 1
       type: Transform
+    - links:
+      - 341
+      type: DeviceLinkSink
 - proto: MachineFrame
   entities:
   - uid: 253
@@ -111138,18 +111163,27 @@ entities:
       pos: -57.5,52.5
       parent: 1
       type: Transform
+    - links:
+      - 4985
+      type: DeviceLinkSink
   - uid: 7872
     components:
     - rot: 3.141592653589793 rad
       pos: -54.5,52.5
       parent: 1
       type: Transform
+    - links:
+      - 4986
+      type: DeviceLinkSink
   - uid: 7873
     components:
     - rot: 3.141592653589793 rad
       pos: -51.5,52.5
       parent: 1
       type: Transform
+    - links:
+      - 4987
+      type: DeviceLinkSink
   - uid: 13318
     components:
     - rot: 3.141592653589793 rad

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -15529,16 +15529,31 @@ entities:
     - pos: -3.5,25.5
       parent: 8364
       type: Transform
+    - linkedPorts:
+        8624:
+        - Start: Close
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 25829
     components:
     - pos: -7.5,25.5
       parent: 8364
       type: Transform
+    - linkedPorts:
+        8625:
+        - Start: Close
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 26575
     components:
     - pos: -11.5,25.5
       parent: 8364
       type: Transform
+    - linkedPorts:
+        8626:
+        - Start: Close
+        - Timer: Open
+      type: DeviceLinkSource
 - proto: Bucket
   entities:
   - uid: 10718
@@ -77033,6 +77048,10 @@ entities:
     - pos: 71.5,-43.5
       parent: 8364
       type: Transform
+    - linkedPorts:
+        21199:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
 - proto: computerBodyScanner
   entities:
   - uid: 19054
@@ -132027,6 +132046,9 @@ entities:
     - pos: 71.5,-40.5
       parent: 8364
       type: Transform
+    - links:
+      - 17552
+      type: DeviceLinkSink
 - proto: MachineFrame
   entities:
   - uid: 17860
@@ -179007,6 +179029,9 @@ entities:
     - pos: -1.5,25.5
       parent: 8364
       type: Transform
+    - links:
+      - 8743
+      type: DeviceLinkSink
   - uid: 8625
     components:
     - name: Cell 2
@@ -179014,6 +179039,9 @@ entities:
     - pos: -5.5,25.5
       parent: 8364
       type: Transform
+    - links:
+      - 25829
+      type: DeviceLinkSink
   - uid: 8626
     components:
     - name: Cell 1
@@ -179021,6 +179049,9 @@ entities:
     - pos: -9.5,25.5
       parent: 8364
       type: Transform
+    - links:
+      - 26575
+      type: DeviceLinkSink
   - uid: 8973
     components:
     - pos: -4.5,40.5

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -19219,6 +19219,8 @@ entities:
       parent: 1668
       type: Transform
     - linkedPorts:
+        723:
+        - MedicalScannerSender: MedicalScannerReceiver
         722:
         - CloningPodSender: CloningPodReceiver
       type: DeviceLinkSource
@@ -26761,6 +26763,9 @@ entities:
     - pos: 9.5,-14.5
       parent: 1668
       type: Transform
+    - links:
+      - 575
+      type: DeviceLinkSink
 - proto: MedicalTechFab
   entities:
   - uid: 616

--- a/Resources/Maps/cluster.yml
+++ b/Resources/Maps/cluster.yml
@@ -8517,18 +8517,36 @@ entities:
       pos: 11.5,7.5
       parent: 1
       type: Transform
+    - linkedPorts:
+        5535:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 12486
     components:
     - rot: 3.141592653589793 rad
       pos: 14.5,7.5
       parent: 1
       type: Transform
+    - linkedPorts:
+        5536:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 12487
     components:
     - rot: 3.141592653589793 rad
       pos: 17.5,7.5
       parent: 1
       type: Transform
+    - linkedPorts:
+        5537:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
 - proto: Brutepack
   entities:
   - uid: 9629
@@ -82944,16 +82962,25 @@ entities:
     - pos: 12.5,7.5
       parent: 1
       type: Transform
+    - links:
+      - 12485
+      type: DeviceLinkSink
   - uid: 5536
     components:
     - pos: 15.5,7.5
       parent: 1
       type: Transform
+    - links:
+      - 12486
+      type: DeviceLinkSink
   - uid: 5537
     components:
     - pos: 18.5,7.5
       parent: 1
       type: Transform
+    - links:
+      - 12487
+      type: DeviceLinkSink
   - uid: 12003
     components:
     - pos: 36.5,13.5

--- a/Resources/Maps/kettle.yml
+++ b/Resources/Maps/kettle.yml
@@ -71623,6 +71623,10 @@ entities:
     - pos: 30.5,75.5
       parent: 82
       type: Transform
+    - linkedPorts:
+        25797:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
 - proto: computerBodyScanner
   entities:
   - uid: 2917
@@ -124913,6 +124917,9 @@ entities:
     - pos: 30.5,78.5
       parent: 82
       type: Transform
+    - links:
+      - 25808
+      type: DeviceLinkSink
 - proto: MachineFrame
   entities:
   - uid: 9499

--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -16353,18 +16353,36 @@ entities:
       pos: -45.5,41.5
       parent: 30
       type: Transform
+    - linkedPorts:
+        1761:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 1982
     components:
     - rot: -1.5707963267948966 rad
       pos: -41.5,41.5
       parent: 30
       type: Transform
+    - linkedPorts:
+        1759:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 1993
     components:
     - rot: -1.5707963267948966 rad
       pos: -37.5,41.5
       parent: 30
       type: Transform
+    - linkedPorts:
+        1760:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
 - proto: Bucket
   entities:
   - uid: 318
@@ -148065,16 +148083,25 @@ entities:
     - pos: -43.5,41.5
       parent: 30
       type: Transform
+    - links:
+      - 1982
+      type: DeviceLinkSink
   - uid: 1760
     components:
     - pos: -39.5,41.5
       parent: 30
       type: Transform
+    - links:
+      - 1993
+      type: DeviceLinkSink
   - uid: 1761
     components:
     - pos: -47.5,41.5
       parent: 30
       type: Transform
+    - links:
+      - 1981
+      type: DeviceLinkSink
   - uid: 2230
     components:
     - rot: 1.5707963267948966 rad

--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -14993,18 +14993,36 @@ entities:
       pos: -5.5,29.5
       parent: 5350
       type: Transform
+    - linkedPorts:
+        8057:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 5347
     components:
     - rot: 1.5707963267948966 rad
       pos: -8.5,29.5
       parent: 5350
       type: Transform
+    - linkedPorts:
+        8058:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 5348
     components:
     - rot: 1.5707963267948966 rad
       pos: -11.5,29.5
       parent: 5350
       type: Transform
+    - linkedPorts:
+        8059:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
 - proto: Brutepack
   entities:
   - uid: 16234
@@ -66589,12 +66607,20 @@ entities:
       pos: 13.5,-51.5
       parent: 5350
       type: Transform
+    - linkedPorts:
+        19358:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
   - uid: 19453
     components:
     - rot: -1.5707963267948966 rad
       pos: 22.5,-30.5
       parent: 5350
       type: Transform
+    - linkedPorts:
+        19357:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
 - proto: computerBodyScanner
   entities:
   - uid: 7173
@@ -125591,11 +125617,17 @@ entities:
       pos: 24.5,-30.5
       parent: 5350
       type: Transform
+    - links:
+      - 19453
+      type: DeviceLinkSink
   - uid: 19358
     components:
     - pos: 14.5,-54.5
       parent: 5350
       type: Transform
+    - links:
+      - 19352
+      type: DeviceLinkSink
 - proto: MachineFrame
   entities:
   - uid: 10387
@@ -170832,16 +170864,25 @@ entities:
     - pos: -6.5,29.5
       parent: 5350
       type: Transform
+    - links:
+      - 5344
+      type: DeviceLinkSink
   - uid: 8058
     components:
     - pos: -9.5,29.5
       parent: 5350
       type: Transform
+    - links:
+      - 5347
+      type: DeviceLinkSink
   - uid: 8059
     components:
     - pos: -12.5,29.5
       parent: 5350
       type: Transform
+    - links:
+      - 5348
+      type: DeviceLinkSink
   - uid: 9993
     components:
     - rot: 3.141592653589793 rad

--- a/Resources/Maps/omega.yml
+++ b/Resources/Maps/omega.yml
@@ -10421,11 +10421,23 @@ entities:
     - pos: -27.5,18.5
       parent: 4812
       type: Transform
+    - linkedPorts:
+        7786:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 4811
     components:
     - pos: -27.5,15.5
       parent: 4812
       type: Transform
+    - linkedPorts:
+        7785:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
 - proto: Bucket
   entities:
   - uid: 1477
@@ -33629,6 +33641,10 @@ entities:
       pos: 22.5,-26.5
       parent: 4812
       type: Transform
+    - linkedPorts:
+        6319:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
 - proto: computerBodyScanner
   entities:
   - uid: 4921
@@ -60706,6 +60722,9 @@ entities:
     - pos: 22.5,-29.5
       parent: 4812
       type: Transform
+    - links:
+      - 6313
+      type: DeviceLinkSink
 - proto: MachineFrame
   entities:
   - uid: 3952
@@ -83544,12 +83563,18 @@ entities:
       pos: -27.5,16.5
       parent: 4812
       type: Transform
+    - links:
+      - 4811
+      type: DeviceLinkSink
   - uid: 7786
     components:
     - rot: 1.5707963267948966 rad
       pos: -27.5,19.5
       parent: 4812
       type: Transform
+    - links:
+      - 4810
+      type: DeviceLinkSink
 - proto: WindoorTheatreLocked
   entities:
   - uid: 896

--- a/Resources/Maps/origin.yml
+++ b/Resources/Maps/origin.yml
@@ -24277,6 +24277,12 @@ entities:
       pos: 36.5,13.5
       parent: 2
       type: Transform
+    - linkedPorts:
+        30428:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 2252
     components:
     - name: cell 1 brig timer
@@ -24285,6 +24291,12 @@ entities:
       pos: 30.5,13.5
       parent: 2
       type: Transform
+    - linkedPorts:
+        30420:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 2253
     components:
     - name: cell 2 brig timer
@@ -24293,6 +24305,12 @@ entities:
       pos: 33.5,13.5
       parent: 2
       type: Transform
+    - linkedPorts:
+        30425:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 2254
     components:
     - name: cell 4 brig timer
@@ -24301,6 +24319,12 @@ entities:
       pos: 39.5,9.5
       parent: 2
       type: Transform
+    - linkedPorts:
+        30421:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
   - uid: 2255
     components:
     - name: cell 5 brig timer
@@ -24309,6 +24333,12 @@ entities:
       pos: 39.5,6.5
       parent: 2
       type: Transform
+    - linkedPorts:
+        30426:
+        - Start: Close
+        - Timer: AutoClose
+        - Timer: Open
+      type: DeviceLinkSource
 - proto: BrigTimerElectronics
   entities:
   - uid: 2256
@@ -80820,7 +80850,7 @@ entities:
     - pos: -57.484028,-27.38782
       parent: 2
       type: Transform
-- proto: ClothingEyesHudBeer
+- proto: ClothingEyesGlassesBeer
   entities:
   - uid: 12174
     components:
@@ -82349,6 +82379,10 @@ entities:
     - pos: 73.5,-31.5
       parent: 2
       type: Transform
+    - linkedPorts:
+        20936:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
 - proto: computerBodyScanner
   entities:
   - uid: 12409
@@ -144361,6 +144395,9 @@ entities:
       pos: 72.5,-28.5
       parent: 2
       type: Transform
+    - links:
+      - 12408
+      type: DeviceLinkSink
 - proto: MachineFrame
   entities:
   - uid: 20937
@@ -201639,12 +201676,18 @@ entities:
       pos: 29.5,13.5
       parent: 2
       type: Transform
+    - links:
+      - 2252
+      type: DeviceLinkSink
   - uid: 30421
     components:
     - rot: 1.5707963267948966 rad
       pos: 39.5,7.5
       parent: 2
       type: Transform
+    - links:
+      - 2254
+      type: DeviceLinkSink
   - uid: 30422
     components:
     - rot: 3.141592653589793 rad
@@ -201669,12 +201712,18 @@ entities:
       pos: 32.5,13.5
       parent: 2
       type: Transform
+    - links:
+      - 2253
+      type: DeviceLinkSink
   - uid: 30426
     components:
     - rot: 1.5707963267948966 rad
       pos: 39.5,4.5
       parent: 2
       type: Transform
+    - links:
+      - 2255
+      type: DeviceLinkSink
   - uid: 30427
     components:
     - rot: 3.141592653589793 rad
@@ -201687,6 +201736,9 @@ entities:
       pos: 35.5,13.5
       parent: 2
       type: Transform
+    - links:
+      - 2251
+      type: DeviceLinkSink
   - uid: 30429
     components:
     - rot: 3.141592653589793 rad

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -25277,6 +25277,10 @@ entities:
       pos: -15.5,-22.5
       parent: 31
       type: Transform
+    - linkedPorts:
+        8320:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
 - proto: ComputerCargoBounty
   entities:
   - uid: 7126
@@ -46198,6 +46202,9 @@ entities:
     - pos: -14.5,-25.5
       parent: 31
       type: Transform
+    - links:
+      - 8321
+      type: DeviceLinkSink
 - proto: MachineFrame
   entities:
   - uid: 1319

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -111,3 +111,6 @@ ToyAssistant: ToyFigurinePassenger
 
 # 2023-07-20
 ForensicGloves: ClothingHandsGlovesForensic
+
+# 2023-07-24
+ClothingEyesGlassesBeer: ClothingEyesHudBeer


### PR DESCRIPTION
The machine -> device linking migration had a bug where some links would get lost depending on the order in which entities appear in the map file. I fixed this by just removing the link range check. People that need to fix maps can either just ping me or use the changes in https://github.com/ElectroJr/space-station-14/tree/fix-map-resave to resave maps.