### PR TITLE
Remove the gloves and carapace from captain's round-start loadout.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -40,8 +40,6 @@
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatCaptain
     eyes: ClothingEyesGlassesSunglasses
-    gloves: ClothingHandsGlovesCaptain
-    outerClothing: ClothingOuterArmorCaptainCarapace
     id: CaptainPDA
     ears: ClothingHeadsetAltCommand
   innerclothingskirt: ClothingUniformJumpskirtCaptain


### PR DESCRIPTION
## About the PR
Doesn't suit the rest of the loadouts.
Prevents the same metagamey issues we had when CE had two belts, just this time with HoP's getting captain's spare gloves and armor.

**Media**
- [X] This PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Changed captain's starting loadout not to have their gloves and carapace.