### PR TITLE
Role timers update

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -9,10 +9,10 @@
       time: 21600 #6 hrs
     - !type:RoleTimeRequirement
       role: JobSalvageSpecialist
-      time: 21600 #6 hrs
+      time: 10800 #3 hrs
     - !type:DepartmentTimeRequirement
       department: Cargo
-      time: 108000 # 30 hrs
+      time: 36000 #10 hours
   weight: 10
   startingGear: QuartermasterGear
   icon: "QuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -14,7 +14,7 @@
       department: Cargo
       time: 36000 #10 hours
     - !type:OverallPlaytimeRequirement
-      time: 14400 #40 hrs            
+      time: 144000 #40 hrs            
   weight: 10
   startingGear: QuartermasterGear
   icon: "QuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -13,6 +13,8 @@
     - !type:DepartmentTimeRequirement
       department: Cargo
       time: 36000 #10 hours
+    - !type:OverallPlaytimeRequirement
+      time: 14400 #40 hrs            
   weight: 10
   startingGear: QuartermasterGear
   icon: "QuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -4,24 +4,18 @@
   description: job-description-captain
   playTimeTracker: JobCaptain
   requirements:
-    - !type:RoleTimeRequirement
-      role: JobHeadOfPersonnel
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobHeadOfSecurity
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobChiefMedicalOfficer
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobChiefEngineer
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobResearchDirector
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobQuartermaster
-      time: 21600 #6 hrs
+    - !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 54000 # 15 hours
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 54000 # 15 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 54000 # 15 hours
+    - !type:DepartmentTimeRequirement
+      department: Command
+      time: 54000 # 15 hours
   weight: 20
   startingGear: CaptainGear
   icon: "Captain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -6,16 +6,16 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 54000 # 15 hrs
+      time: 36000 # 10 hours
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 54000 # 15 hrs
+      time: 36000 # 10 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 54000 # 15 hrs
+      time: 36000 # 10 hrs
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 72000 # 20 hrs
+      time: 36000 # 10 hours
   weight: 20
   startingGear: HoPGear
   icon: "HeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -14,7 +14,7 @@
       department: Engineering
       time: 36000 #10 hrs
     - !type:OverallPlaytimeRequirement
-      time: 14400 #40 hrs      
+      time: 144000 #40 hrs      
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "ChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -13,6 +13,8 @@
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 36000 #10 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 14400 #40 hrs      
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "ChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -12,7 +12,7 @@
       time: 21600 #6 hrs
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 108000 # 30 hrs
+      time: 36000 #10 hrs
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "ChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -16,7 +16,7 @@
       department: Medical
       time: 36000 #10 hrs
     - !type:OverallPlaytimeRequirement
-      time: 14400 #40 hrs            
+      time: 144000 #40 hrs            
   weight: 10
   startingGear: CMOGear
   icon: "ChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,6 +15,8 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 36000 #10 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 14400 #40 hrs            
   weight: 10
   startingGear: CMOGear
   icon: "ChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -8,13 +8,13 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobChemist
-      time: 21600 #6 hrs
+      time: 10800 #3 hrs
     - !type:RoleTimeRequirement
       role: JobMedicalDoctor
       time: 21600 #6 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 108000 # 30 hrs
+      time: 36000 #10 hrs
   weight: 10
   startingGear: CMOGear
   icon: "ChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -8,7 +8,7 @@
       department: Science
       time: 36000 #10 hrs
     - !type:OverallPlaytimeRequirement
-      time: 14400 #40 hrs            
+      time: 144000 #40 hrs            
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "ResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Science
-      time: 108000 # 30 hrs
+      time: 36000 #10 hrs
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "ResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -7,6 +7,8 @@
     - !type:DepartmentTimeRequirement
       department: Science
       time: 36000 #10 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 14400 #40 hrs            
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "ResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -14,7 +14,7 @@
       department: Security
       time: 108000 # 30 hrs
     - !type:OverallPlaytimeRequirement
-      time: 14400 #40 hrs            
+      time: 144000 #40 hrs            
   weight: 10
   startingGear: HoSGear
   icon: "HeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -6,10 +6,7 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 21600 #6 hrs
-    - !type:RoleTimeRequirement
-      role: JobDetective
-      time: 7200 #2 hrs
+      time: 10800 #3 hrs
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
       time: 36000 #10 hrs

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -13,6 +13,8 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 108000 # 30 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 14400 #40 hrs            
   weight: 10
   startingGear: HoSGear
   icon: "HeadOfSecurity"


### PR DESCRIPTION
the previous roletimers were a little harsh we know, this is what i am proposing. 
-lower most command staffs overalls to 10 hours and specialist roles to 3 hours (exception to ce, hos, cap, and hop)
-hop now requires 10 hours of med,sec,eng and command instead of old values (15 each and 20 hours command)
-captain now requires 15 hours of med,sec,eng and command instead of old values (6 hours of every command)
-hos has dropped the detective requirement and reduced warden from 6 to 3 hours (after 3 hours of warden youll get it) but retains the 30 hour security time.
-CE has dropped the 30 hours of engi requirement to 10 hours but still requires 6 hours of atmotech and station engineer time.

🆑 
- tweak: tweaked role times 

