### PR TITLE
Attacking a powered light now shocks an unarmed attacker

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration.Logs;
+using Content.Server.Light.Components;
 using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.NodeGroups;
@@ -76,6 +77,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
         SubscribeLocalEvent<ElectrifiedComponent, InteractHandEvent>(OnElectrifiedHandInteract);
         SubscribeLocalEvent<ElectrifiedComponent, InteractUsingEvent>(OnElectrifiedInteractUsing);
         SubscribeLocalEvent<RandomInsulationComponent, MapInitEvent>(OnRandomInsulationMapInit);
+        SubscribeLocalEvent<PoweredLightComponent, AttackedEvent>(OnLightAttacked);
 
         UpdatesAfter.Add(typeof(PowerNetSystem));
     }
@@ -159,21 +161,37 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             TryDoElectrifiedAct(uid, args.OtherEntity, 1, electrified);
     }
 
-        private void OnElectrifiedAttacked(EntityUid uid, ElectrifiedComponent electrified, AttackedEvent args)
-        {
-            if (!electrified.OnAttacked)
-                return;
+    private void OnElectrifiedAttacked(EntityUid uid, ElectrifiedComponent electrified, AttackedEvent args)
+    {
+        if (!electrified.OnAttacked)
+            return;
 
-            if (_meleeWeapon.GetDamage(args.Used, args.User).Total == 0)
-                return;
+        if (_meleeWeapon.GetDamage(args.Used, args.User).Total == 0)
+            return;
 
-            TryDoElectrifiedAct(uid, args.User, 1, electrified);
+        TryDoElectrifiedAct(uid, args.User, 1, electrified);
     }
 
     private void OnElectrifiedHandInteract(EntityUid uid, ElectrifiedComponent electrified, InteractHandEvent args)
     {
         if (electrified.OnHandInteract)
             TryDoElectrifiedAct(uid, args.User, 1, electrified);
+    }
+
+    private void OnLightAttacked(EntityUid uid, PoweredLightComponent component, AttackedEvent args)
+    {
+
+        if (_meleeWeapon.GetDamage(args.Used, args.User).Total == 0)
+            return;
+
+        if (args.Used != args.User)
+            return;
+
+        if (component.CurrentLit == false)
+            return;
+
+        DoCommonElectrocution(args.User, uid, component.UnarmedHitShock, component.UnarmedHitStun, false, 1);
+
     }
 
     private void OnElectrifiedInteractUsing(EntityUid uid, ElectrifiedComponent electrified, InteractUsingEvent args)

--- a/Content.Server/Light/Components/PoweredLightComponent.cs
+++ b/Content.Server/Light/Components/PoweredLightComponent.cs
@@ -68,5 +68,17 @@ namespace Content.Server.Light.Components
         /// </summary>
         [DataField("ejectBulbDelay")]
         public float EjectBulbDelay = 2;
+
+        /// <summary>
+        /// Shock damage done to a mob that hits the light with an unarmed attack
+        /// </summary>
+        [DataField("unarmedHitShock")]
+        public int UnarmedHitShock = 20;
+
+        /// <summary>
+        /// Stun duration applied to a mob that hits the light with an unarmed attack
+        /// </summary>
+        [DataField("unarmedHitStun")]
+        public TimeSpan UnarmedHitStun = TimeSpan.FromSeconds(5);
     }
 }


### PR DESCRIPTION
## About the PR

As proposed on #18203, attacking a light/led unarmed will shock the player, causing damage and stun (default: 20 Shock damage, 5 sec stun). This will crit a bat on the 3rd attack, zombie on the 4th.
The attack will still damage and likely destroy the light, and there is no shock if the light was off due to no power.

The 5 second stun should get the idea across immediately, and will hopefully make it unpleasent enough for the player to stop trying even if the damage is not huge compared to max hp (for example tarantula only crits on the 8th light). Carp is for some reason not affected by the stun despite shaking from the shock. This is probably a carp thing

This should not annoy players accidentally, since crewmembers will be using a weapon while wide-swinging, and monsters currently can't wideswing.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Errant
- add: Unarmed attacks on powered lights now cause electric shock.