### PR TITLE
Reduces subdepartment time for senior roles

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
@@ -6,10 +6,10 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobAtmosphericTechnician
-      time: 43200 #12 hrs
+      time: 21600 #6 hrs
     - !type:RoleTimeRequirement
       role: JobStationEngineer
-      time: 43200 #12 hrs
+      time: 21600 #6 hrs
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 216000 # 60 hrs

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -6,10 +6,10 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobChemist
-      time: 43200 #12 hrs
+      time: 21600 #6 hrs
     - !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 43200 #12 hrs
+      time: 21600 #6 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 216000 # 60 hrs

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -6,13 +6,13 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 43200 #12 hrs
+      time: 21600 #6 hrs
     - !type:RoleTimeRequirement
       role: JobDetective
-      time: 14400 #4 hrs
+      time: 7200 #2 hrs
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 72000 #20 hrs
+      time: 21600 #6 hrs
     - !type:DepartmentTimeRequirement
       department: Security
       time: 216000 # 60 hrs


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Instead of requiring 12 hours in each subdepartment, it requires 6 (the same amount as a head). If someone has enough to play a head role, in addition to 30 more hours in a department, they should be trusted to teach people. 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Lank
- tweak: Senior roles now require less playtime in specific roles. 
