### PR TITLE
Light-reactive interaction outlines

### DIFF
--- a/Resources/Prototypes/Shaders/outline.yml
+++ b/Resources/Prototypes/Shaders/outline.yml
@@ -4,6 +4,7 @@
   path: "/Textures/Shaders/outline.swsl"
   params:
     outline_color: "#FF000055"
+    light_boost: 2
 
 - type: shader
   id: SelectionOutlineInrange
@@ -11,3 +12,4 @@
   path: "/Textures/Shaders/outline.swsl"
   params:
     outline_color: "#00FF0055"
+    light_boost: 4

--- a/Resources/Textures/Shaders/outline.swsl
+++ b/Resources/Textures/Shaders/outline.swsl
@@ -27,12 +27,13 @@
 //
 //************************************************************************
 
-light_mode unshaded;
+//light_mode unshaded;
 //shader_type canvas_item;
 uniform highp float outline_width; // = 2.0;
 // TODO: implement that hint_color thingy.
 //uniform vec4 outline_color: hint_color;
 uniform highp vec4 outline_color; // =vec4(1.0,0.0,0.0,0.33);
+uniform highp float light_boost; // = 4.0;
 
 void fragment() {
 	highp vec4 col = zTexture(UV);
@@ -74,5 +75,8 @@ void fragment() {
     maxa = max(a, maxa);
     mina = min(a, mina);
 
-	COLOR = mix(col, outline_color, maxa-col.a);
+	float sampledLight = sqrt(mix(0.0, 1.0, (lightSample.r * 0.34) + (lightSample.g * 0.5) + (lightSample.b * 0.16)) * light_boost);
+	COLOR = mix(col, outline_color * sampledLight, maxa - col.a);
+	lightSample = vec3(1.0);
+	//COLOR = col;
 }

--- a/Resources/Textures/Shaders/outline.swsl
+++ b/Resources/Textures/Shaders/outline.swsl
@@ -29,6 +29,7 @@
 
 uniform highp float outline_width; // = 2.0;
 uniform highp vec4 outline_color; // =vec4(1.0,0.0,0.0,0.33);
+uniform bool outline_fullbright; // =false;
 uniform highp float light_boost; // = 4.0;
 
 void fragment() {
@@ -71,7 +72,7 @@ void fragment() {
     maxa = max(a, maxa);
     mina = min(a, mina);
 
-	float sampledLight = sqrt(mix(0.0, 1.0, (lightSample.r * 0.34) + (lightSample.g * 0.5) + (lightSample.b * 0.16)) * light_boost);
+	float sampledLight = outline_fullbright ? 1.0 : sqrt(mix(0.0, 1.0, (lightSample.r * 0.34) + (lightSample.g * 0.5) + (lightSample.b * 0.16)) * light_boost);
 	COLOR = mix(col, outline_color * sampledLight, maxa - col.a);
 	lightSample = vec3(1.0);
 }

--- a/Resources/Textures/Shaders/outline.swsl
+++ b/Resources/Textures/Shaders/outline.swsl
@@ -27,11 +27,7 @@
 //
 //************************************************************************
 
-//light_mode unshaded;
-//shader_type canvas_item;
 uniform highp float outline_width; // = 2.0;
-// TODO: implement that hint_color thingy.
-//uniform vec4 outline_color: hint_color;
 uniform highp vec4 outline_color; // =vec4(1.0,0.0,0.0,0.33);
 uniform highp float light_boost; // = 4.0;
 
@@ -78,5 +74,4 @@ void fragment() {
 	float sampledLight = sqrt(mix(0.0, 1.0, (lightSample.r * 0.34) + (lightSample.g * 0.5) + (lightSample.b * 0.16)) * light_boost);
 	COLOR = mix(col, outline_color * sampledLight, maxa - col.a);
 	lightSample = vec3(1.0);
-	//COLOR = col;
 }


### PR DESCRIPTION
## About the PR

This PR makes the interaction outlines directly react to lighting. How much a given object reacts to lighting is configurable from the outline prototype. In laymen's terms, this means that using your mouse to scan for objects from a distance in a dark area will end up being much easier said than done, and if there's no light at all, then there simply won't be an interaction outline. Interactions outlines that are in-range are much easier to see in darker areas, meaning it's still entirely plausible to fumble around maintenance if you have a light source of any kind on-hand. While not pictured in the below video, colored lighting does not influence the outline's color at all, meaning green outlines are still visible in emergency lighting.

This PR also does a bit of minor cleanup for the outline shader (mostly just axing commented-out lines)

Additionally, this PR relies on space-wizards/RobustToolbox#4201 . Without it, shader compilation will simply error out.

**Media**

https://github.com/space-wizards/space-station-14/assets/6356337/5dd96882-a318-4940-aaf2-fb73195398b1


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Bhijn and Myr
- add: Interaction outlines now directly react to lighting. You can no longer merely wave your mouse around in the dark to see objects in the distance in maint. Interaction outlines that're in-range are far brighter even in dim conditions, though out-of-range interaction outlines are hard to see in poor light conditions.
