### PR TITLE
copy-settings-to-all-similar for scrubbers and vents in air alarms

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmBoundUserInterface.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmBoundUserInterface.cs
@@ -31,6 +31,7 @@ public sealed class AirAlarmBoundUserInterface : BoundUserInterface
 
         _window.OnClose += Close;
         _window.AtmosDeviceDataChanged += OnDeviceDataChanged;
+		_window.AtmosDeviceDataCopied += OnDeviceDataCopied;
         _window.AtmosAlarmThresholdChanged += OnThresholdChanged;
         _window.AirAlarmModeChanged += OnAirAlarmModeChanged;
         _window.AutoModeChanged += OnAutoModeChanged;
@@ -46,6 +47,11 @@ public sealed class AirAlarmBoundUserInterface : BoundUserInterface
     private void OnDeviceDataChanged(string address, IAtmosDeviceData data)
     {
         SendMessage(new AirAlarmUpdateDeviceDataMessage(address, data));
+    }
+	
+	private void OnDeviceDataCopied(IAtmosDeviceData data)
+    {
+        SendMessage(new AirAlarmCopyDeviceDataMessage(data));
     }
 
     private void OnAirAlarmModeChanged(AirAlarmMode mode)

--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -18,6 +18,7 @@ namespace Content.Client.Atmos.Monitor.UI;
 public sealed partial class AirAlarmWindow : FancyWindow
 {
     public event Action<string, IAtmosDeviceData>? AtmosDeviceDataChanged;
+	public event Action<IAtmosDeviceData>? AtmosDeviceDataCopied;
     public event Action<string, AtmosMonitorThresholdType, AtmosAlarmThreshold, Gas?>? AtmosAlarmThresholdChanged;
     public event Action<AirAlarmMode>? AirAlarmModeChanged;
     public event Action<bool>? AutoModeChanged;
@@ -137,6 +138,7 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 {
                     var control= new PumpControl(pump, addr);
                     control.PumpDataChanged += AtmosDeviceDataChanged!.Invoke;
+					control.PumpDataCopied += AtmosDeviceDataCopied!.Invoke;
                     _pumps.Add(addr, control);
                     CVentContainer.AddChild(control);
                 }
@@ -151,6 +153,7 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 {
                     var control = new ScrubberControl(scrubber, addr);
                     control.ScrubberDataChanged += AtmosDeviceDataChanged!.Invoke;
+					control.ScrubberDataCopied += AtmosDeviceDataCopied!.Invoke;
                     _scrubbers.Add(addr, control);
                     CScrubberContainer.AddChild(control);
                 }

--- a/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml
@@ -9,7 +9,7 @@
                 <BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
                     <CheckBox Name="CEnableDevice" Text="{Loc 'air-alarm-ui-widget-enable'}" />
                 </BoxContainer>
-				<BoxContainer Orientation="Horizontal" Margin="0 0 0 2" HorizontalExpand="True">
+                <BoxContainer Orientation="Horizontal" Margin="0 0 0 2" HorizontalExpand="True">
                     <BoxContainer Orientation="Vertical" HorizontalExpand="True">
                         <Label Text="{Loc 'air-alarm-ui-vent-pump-label'}" Margin="0 0 0 1" />
                         <OptionButton Name="CPumpDirection" />

--- a/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml
@@ -31,7 +31,7 @@
                     </BoxContainer>
                 </BoxContainer>
 				<BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
-					<Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" />
+					<Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" ToolTip="{Loc 'air-alarm-ui-widget-copy-tooltip'}" />
                 </BoxContainer>
             </BoxContainer>
         </CollapsibleBody>

--- a/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml
@@ -9,7 +9,7 @@
                 <BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
                     <CheckBox Name="CEnableDevice" Text="{Loc 'air-alarm-ui-widget-enable'}" />
                 </BoxContainer>
-                <BoxContainer Orientation="Horizontal" Margin="0 0 0 2" HorizontalExpand="True">
+				<BoxContainer Orientation="Horizontal" Margin="0 0 0 2" HorizontalExpand="True">
                     <BoxContainer Orientation="Vertical" HorizontalExpand="True">
                         <Label Text="{Loc 'air-alarm-ui-vent-pump-label'}" Margin="0 0 0 1" />
                         <OptionButton Name="CPumpDirection" />
@@ -19,7 +19,7 @@
                         <OptionButton Name="CPressureCheck" />
                     </BoxContainer>
                 </BoxContainer>
-                <!-- Lower row: pressure bounds -->
+                <!-- Lower row: pressure bounds, copy settings -->
                 <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
                     <BoxContainer Orientation="Vertical" HorizontalExpand="True">
                         <Label Text="{Loc 'air-alarm-ui-vent-external-bound-label'}" Margin="0 0 0 1" />
@@ -29,6 +29,9 @@
                         <Label Text="{Loc 'air-alarm-ui-vent-internal-bound-label'}" Margin="0 0 0 1" />
                         <FloatSpinBox Name="CInternalBound" HorizontalExpand="True" />
                     </BoxContainer>
+                </BoxContainer>
+				<BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
+					<Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" />
                 </BoxContainer>
             </BoxContainer>
         </CollapsibleBody>

--- a/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml
@@ -30,8 +30,8 @@
                         <FloatSpinBox Name="CInternalBound" HorizontalExpand="True" />
                     </BoxContainer>
                 </BoxContainer>
-				<BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
-					<Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" ToolTip="{Loc 'air-alarm-ui-widget-copy-tooltip'}" />
+                <BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
+                    <Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" ToolTip="{Loc 'air-alarm-ui-widget-copy-tooltip'}" />
                 </BoxContainer>
             </BoxContainer>
         </CollapsibleBody>

--- a/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml.cs
@@ -17,6 +17,7 @@ public sealed partial class PumpControl : BoxContainer
     private string _address;
 
     public event Action<string, IAtmosDeviceData>? PumpDataChanged;
+	public event Action<IAtmosDeviceData>? PumpDataCopied;
 
     private CheckBox _enabled => CEnableDevice;
     private CollapsibleHeading _addressLabel => CAddress;
@@ -24,6 +25,7 @@ public sealed partial class PumpControl : BoxContainer
     private OptionButton _pressureCheck => CPressureCheck;
     private FloatSpinBox _externalBound => CExternalBound;
     private FloatSpinBox _internalBound => CInternalBound;
+	private Button _copySettings => CCopySettings;
 
     public PumpControl(GasVentPumpData data, string address)
     {
@@ -84,6 +86,11 @@ public sealed partial class PumpControl : BoxContainer
             _data.PressureChecks = (VentPressureBound) args.Id;
             PumpDataChanged?.Invoke(_address, _data);
         };
+		
+		_copySettings.OnPressed += _ =>
+		{
+			PumpDataCopied?.Invoke(_data);
+		};
     }
 
     public void ChangeData(GasVentPumpData data)

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
@@ -22,8 +22,8 @@
                 <BoxContainer>
                     <CheckBox Name="CWideNet" Text="{Loc 'air-alarm-ui-scrubber-wide-net-label'}" />
                 </BoxContainer>
-				<BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
-					<Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" ToolTip="{Loc 'air-alarm-ui-widget-copy-tooltip'}" />
+                <BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
+                    <Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" ToolTip="{Loc 'air-alarm-ui-widget-copy-tooltip'}" />
                 </BoxContainer>
                 <!-- Lower row: every single gas -->
                 <Collapsible Orientation="Vertical" Margin="2 2 2 2">

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
@@ -8,7 +8,7 @@
                 <BoxContainer Orientation="Horizontal" Margin="0 0 0 2">
                     <CheckBox Name="CEnableDevice" Text="{Loc 'air-alarm-ui-widget-enable'}" />
                 </BoxContainer>
-                <!-- Upper row: toggle, direction, volume rate, widenet -->
+                <!-- Upper row: toggle, direction, volume rate, widenet, copy settings -->
                 <BoxContainer Orientation="Horizontal" Margin="0 0 0 2" HorizontalExpand="True">
                     <BoxContainer Orientation="Vertical" HorizontalExpand="True">
                         <Label Text="{Loc 'air-alarm-ui-scrubber-pump-direction-label'}" Margin="0 0 0 1"/>
@@ -21,6 +21,9 @@
                 </BoxContainer>
                 <BoxContainer>
                     <CheckBox Name="CWideNet" Text="{Loc 'air-alarm-ui-scrubber-wide-net-label'}" />
+                </BoxContainer>
+				<BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
+					<Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" />
                 </BoxContainer>
                 <!-- Lower row: every single gas -->
                 <Collapsible Orientation="Vertical" Margin="2 2 2 2">

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
@@ -23,7 +23,7 @@
                     <CheckBox Name="CWideNet" Text="{Loc 'air-alarm-ui-scrubber-wide-net-label'}" />
                 </BoxContainer>
 				<BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
-					<Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" />
+					<Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" ToolTip="{Loc 'air-alarm-ui-widget-copy-tooltip'}" />
                 </BoxContainer>
                 <!-- Lower row: every single gas -->
                 <Collapsible Orientation="Vertical" Margin="2 2 2 2">

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
@@ -20,12 +20,14 @@ public sealed partial class ScrubberControl : BoxContainer
     private string _address;
 
     public event Action<string, IAtmosDeviceData>? ScrubberDataChanged;
+	public event Action<IAtmosDeviceData>? ScrubberDataCopied;
 
     private CheckBox _enabled => CEnableDevice;
     private CollapsibleHeading _addressLabel => CAddress;
     private OptionButton _pumpDirection => CPumpDirection;
     private FloatSpinBox _volumeRate => CVolumeRate;
     private CheckBox _wideNet => CWideNet;
+	private Button _copySettings => CCopySettings;
 
     private GridContainer _gases => CGasContainer;
     private Dictionary<Gas, Button> _gasControls = new();
@@ -75,6 +77,11 @@ public sealed partial class ScrubberControl : BoxContainer
             _data.PumpDirection = (ScrubberPumpDirection) args.Id;
             ScrubberDataChanged?.Invoke(_address, _data);
         };
+		
+		_copySettings.OnPressed += _ =>
+		{
+			ScrubberDataCopied?.Invoke(_data);
+		};
 
         foreach (var value in Enum.GetValues<Gas>())
         {

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -305,27 +305,29 @@ public sealed class AirAlarmSystem : EntitySystem
 	
 	private void OnCopyDeviceData(EntityUid uid, AirAlarmComponent component, AirAlarmCopyDeviceDataMessage args)
     {
-        if (AccessCheck(uid, args.Session.AttachedEntity, component))
+        if (!AccessCheck(uid, args.Session.AttachedEntity, component))
         {
-			switch (args.Data)
-			{
-				case GasVentPumpData ventData:
-					foreach (string addr in component.VentData.Keys)
-					{
-						SetData(uid, addr, args.Data);
-					}
-					break;
-				case GasVentScrubberData scrubberData:
-					foreach (string addr in component.ScrubberData.Keys)
-					{
-						SetData(uid, addr, args.Data);
-					}
-					break;
-			}
-			
+           UpdateUI(uid, component);
+        	return;       
+        }
+
+		switch (args.Data)
+		{
+			case GasVentPumpData ventData:
+				foreach (string addr in component.VentData.Keys)
+				{
+					SetData(uid, addr, args.Data);
+				}
+				break;
+				
+			case GasVentScrubberData scrubberData:
+				foreach (string addr in component.ScrubberData.Keys)
+				{
+					SetData(uid, addr, args.Data);
+				}
+				break;
 		}
-        else
-            UpdateUI(uid, component);
+	}
     }
 
     private bool AccessCheck(EntityUid uid, EntityUid? user, AirAlarmComponent? component = null)

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -161,6 +161,7 @@ public sealed class AirAlarmSystem : EntitySystem
         SubscribeLocalEvent<AirAlarmComponent, AirAlarmUpdateAutoModeMessage>(OnUpdateAutoMode);
         SubscribeLocalEvent<AirAlarmComponent, AirAlarmUpdateAlarmThresholdMessage>(OnUpdateThreshold);
         SubscribeLocalEvent<AirAlarmComponent, AirAlarmUpdateDeviceDataMessage>(OnUpdateDeviceData);
+		SubscribeLocalEvent<AirAlarmComponent, AirAlarmCopyDeviceDataMessage>(OnCopyDeviceData);
         SubscribeLocalEvent<AirAlarmComponent, AirAlarmTabSetMessage>(OnTabChange);
         SubscribeLocalEvent<AirAlarmComponent, DeviceListUpdateEvent>(OnDeviceListUpdate);
         SubscribeLocalEvent<AirAlarmComponent, BoundUIClosedEvent>(OnClose);
@@ -300,6 +301,31 @@ public sealed class AirAlarmSystem : EntitySystem
         {
             UpdateUI(uid, component);
         }
+    }
+	
+	private void OnCopyDeviceData(EntityUid uid, AirAlarmComponent component, AirAlarmCopyDeviceDataMessage args)
+    {
+        if (AccessCheck(uid, args.Session.AttachedEntity, component))
+        {
+			switch (args.Data)
+			{
+				case GasVentPumpData ventData:
+					foreach (string addr in component.VentData.Keys)
+					{
+						SetData(uid, addr, args.Data);
+					}
+					break;
+				case GasVentScrubberData scrubberData:
+					foreach (string addr in component.ScrubberData.Keys)
+					{
+						SetData(uid, addr, args.Data);
+					}
+					break;
+			}
+			
+		}
+        else
+            UpdateUI(uid, component);
     }
 
     private bool AccessCheck(EntityUid uid, EntityUid? user, AirAlarmComponent? component = null)

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -161,7 +161,7 @@ public sealed class AirAlarmSystem : EntitySystem
         SubscribeLocalEvent<AirAlarmComponent, AirAlarmUpdateAutoModeMessage>(OnUpdateAutoMode);
         SubscribeLocalEvent<AirAlarmComponent, AirAlarmUpdateAlarmThresholdMessage>(OnUpdateThreshold);
         SubscribeLocalEvent<AirAlarmComponent, AirAlarmUpdateDeviceDataMessage>(OnUpdateDeviceData);
-		SubscribeLocalEvent<AirAlarmComponent, AirAlarmCopyDeviceDataMessage>(OnCopyDeviceData);
+        SubscribeLocalEvent<AirAlarmComponent, AirAlarmCopyDeviceDataMessage>(OnCopyDeviceData);
         SubscribeLocalEvent<AirAlarmComponent, AirAlarmTabSetMessage>(OnTabChange);
         SubscribeLocalEvent<AirAlarmComponent, DeviceListUpdateEvent>(OnDeviceListUpdate);
         SubscribeLocalEvent<AirAlarmComponent, BoundUIClosedEvent>(OnClose);
@@ -302,32 +302,32 @@ public sealed class AirAlarmSystem : EntitySystem
             UpdateUI(uid, component);
         }
     }
-	
-	private void OnCopyDeviceData(EntityUid uid, AirAlarmComponent component, AirAlarmCopyDeviceDataMessage args)
+    
+    private void OnCopyDeviceData(EntityUid uid, AirAlarmComponent component, AirAlarmCopyDeviceDataMessage args)
     {
         if (!AccessCheck(uid, args.Session.AttachedEntity, component))
         {
            UpdateUI(uid, component);
-        	return;       
+            return;       
         }
 
-		switch (args.Data)
-		{
-			case GasVentPumpData ventData:
-				foreach (string addr in component.VentData.Keys)
-				{
-					SetData(uid, addr, args.Data);
-				}
-				break;
-				
-			case GasVentScrubberData scrubberData:
-				foreach (string addr in component.ScrubberData.Keys)
-				{
-					SetData(uid, addr, args.Data);
-				}
-				break;
-		}
-	}
+        switch (args.Data)
+        {
+            case GasVentPumpData ventData:
+                foreach (string addr in component.VentData.Keys)
+                {
+                    SetData(uid, addr, args.Data);
+                }
+                break;
+                
+            case GasVentScrubberData scrubberData:
+                foreach (string addr in component.ScrubberData.Keys)
+                {
+                    SetData(uid, addr, args.Data);
+                }
+                break;
+        }
+    }
     }
 
     private bool AccessCheck(EntityUid uid, EntityUid? user, AirAlarmComponent? component = null)

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -328,7 +328,6 @@ public sealed class AirAlarmSystem : EntitySystem
                 break;
         }
     }
-    }
 
     private bool AccessCheck(EntityUid uid, EntityUid? user, AirAlarmComponent? component = null)
     {

--- a/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
+++ b/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
@@ -118,6 +118,17 @@ public sealed class AirAlarmUpdateDeviceDataMessage : BoundUserInterfaceMessage
 }
 
 [Serializable, NetSerializable]
+public sealed class AirAlarmCopyDeviceDataMessage : BoundUserInterfaceMessage
+{
+    public IAtmosDeviceData Data { get; }
+
+    public AirAlarmCopyDeviceDataMessage(IAtmosDeviceData data)
+    {
+        Data = data;
+    }
+}
+
+[Serializable, NetSerializable]
 public sealed class AirAlarmUpdateAlarmThresholdMessage : BoundUserInterfaceMessage
 {
     public string Address { get; }

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -41,6 +41,7 @@ air-alarm-ui-mode-none = None
 
 air-alarm-ui-widget-enable = Enabled
 air-alarm-ui-widget-copy = Copy settings to similar devices
+air-alarm-ui-widget-copy-tooltip = Copies the settings of this device to all devices in this air alarm tab.
 air-alarm-ui-widget-ignore = Ignore
 air-alarm-ui-atmos-net-device-label = Address: {$address}
 

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -40,6 +40,7 @@ air-alarm-ui-mode-none = None
 ### General
 
 air-alarm-ui-widget-enable = Enabled
+air-alarm-ui-widget-copy = Copy settings to similar devices
 air-alarm-ui-widget-ignore = Ignore
 air-alarm-ui-atmos-net-device-label = Address: {$address}
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
adds a button into scrubber and vent air alarm UI that copies the settings of this scrubber/vent to all devices of a similar type

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/57039557/ac48be3c-b840-4cb6-bacf-0fa57a871715)
(not shown: 2 more scrubbers with successfully copied settings)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: The air alarm UI now allows copying settings of one device to all similar devices.
