### PR TITLE
Revert "Add pathfinding for dynamic bodies"

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -45,7 +45,6 @@ namespace Content.Server.NPC.Pathfinding
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly DestructibleSystem _destructible = default!;
-        [Dependency] private readonly EntityLookupSystem _lookup = default!;
         [Dependency] private readonly FixtureSystem _fixtures = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 


### PR DESCRIPTION
Reverts space-wizards/space-station-14#17416

EntityLookup doesn't quite handle the tileref so debug asserts are tripped and I thought the test was erroneous.

Will look at it again on the weekend at some point.