### PR TITLE
Improve implanter descriptions

### DIFF
--- a/Content.Client/Implants/UI/ImplanterStatusControl.cs
+++ b/Content.Client/Implants/UI/ImplanterStatusControl.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Message;
+using Content.Client.Message;
 using Content.Client.Stylesheets;
 using Content.Shared.Implants.Components;
 using Robust.Client.UserInterface;
@@ -16,6 +16,7 @@ public sealed class ImplanterStatusControl : Control
     {
         _parent = parent;
         _label = new RichTextLabel { StyleClasses = { StyleNano.StyleClassItemStatus } };
+        _label.MaxWidth = 350;
         AddChild(_label);
 
         Update();
@@ -41,13 +42,17 @@ public sealed class ImplanterStatusControl : Control
             _ => Loc.GetString("injector-invalid-injector-toggle-mode")
         };
 
-        var entitiesStringLocalized = _parent.ImplanterSlot.HasItem switch
+        var (implantName, implantDescription) = _parent.ImplanterSlot.HasItem switch
         {
-            false => Loc.GetString("implanter-empty-text"),
-            true => Loc.GetString("implanter-implant-text", ("implantName", _parent.ImplantData.Item1), ("implantDescription", _parent.ImplantData.Item2), ("lineBreak", "\n")),
+            false => (Loc.GetString("implanter-empty-text"), ""),
+            true => (_parent.ImplantData.Item1, _parent.ImplantData.Item2),
         };
 
 
-        _label.SetMarkup(Loc.GetString("implanter-label", ("currentEntities", entitiesStringLocalized), ("modeString", modeStringLocalized), ("lineBreak", "\n")));
+        _label.SetMarkup(Loc.GetString("implanter-label",
+                ("implantName", implantName),
+                ("implantDescription", implantDescription),
+                ("modeString", modeStringLocalized),
+                ("lineBreak", "\n")));
     }
 }

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading.Tasks;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -8,7 +7,6 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Implants.Components;
 using Content.Shared.Popups;
 using Robust.Shared.Containers;
-using Robust.Shared.Player;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Implants;

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -1,8 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.DoAfter;
+using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Implants.Components;
 using Content.Shared.Popups;
@@ -25,6 +26,7 @@ public abstract class SharedImplanterSystem : EntitySystem
 
         SubscribeLocalEvent<ImplanterComponent, ComponentInit>(OnImplanterInit);
         SubscribeLocalEvent<ImplanterComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
+        SubscribeLocalEvent<ImplanterComponent, ExaminedEvent>(OnExamine);
     }
 
     private void OnImplanterInit(EntityUid uid, ImplanterComponent component, ComponentInit args)
@@ -41,6 +43,13 @@ public abstract class SharedImplanterSystem : EntitySystem
         component.ImplantData = (implantData.EntityName, implantData.EntityDescription);
     }
 
+    private void OnExamine(EntityUid uid, ImplanterComponent component, ExaminedEvent args)
+    {
+        if (!component.ImplanterSlot.HasItem || !args.IsInDetailsRange)
+            return;
+
+        args.PushMarkup(Loc.GetString("implanter-contained-implant-text", ("desc", component.ImplantData.Item2)));
+    }
 
     //Instantly implant something and add all necessary components and containers.
     //Set to draw mode if not implant only

--- a/Resources/Locale/en-US/implant/implant.ftl
+++ b/Resources/Locale/en-US/implant/implant.ftl
@@ -1,4 +1,4 @@
-﻿## Implanter Attempt Messages
+## Implanter Attempt Messages
 
 implanter-component-implanting-target = {$user} is trying to implant you with something!
 implanter-draw-failed-permanent = The {$implant} in {$target} is fused with them and cannot be removed!
@@ -9,9 +9,10 @@ implanter-draw-text = Draw
 implanter-inject-text = Inject
 
 implanter-empty-text = None
-implanter-implant-text = {$implantName}{$lineBreak}{$implantDescription}
 
-implanter-label = [color=white]Implant: {$currentEntities}{$lineBreak}Mode: {$modeString}[/color]
+implanter-label = Implant: [color=green]{$implantName}[/color] | [color=white]{$modeString}[/color]{$lineBreak}{$implantDescription}
+
+implanter-contained-implant-text = [color=green]{$desc}[/color]
 
 ## Implanter Actions
 

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -1,8 +1,8 @@
-﻿# Implanters
+# Implanters
 
 - type: entity
   name: implanter
-  description: a syringe fitted to be used exclusively with implants
+  description: A syringe exclusively designed for the injection and extraction of subdermal implants.
   id: BaseImplanter
   parent: BaseItem
   abstract: true
@@ -48,6 +48,7 @@
 - type: entity
   id: Implanter
   parent: BaseImplanter
+  description: A disposable syringe exclusively designed for the injection and extraction of subdermal implants.
   components:
     - type: Tag
       tags:
@@ -56,7 +57,7 @@
 - type: entity
   id: BaseImplantOnlyImplanter
   parent: Implanter
-  description: a single use implanter
+  description: A disposable syringe exclusively designed for the injection of subdermal implants.
   abstract: true
   components:
     - type: Sprite
@@ -78,7 +79,6 @@
 - type: entity
   id: SadTromboneImplanter
   name: sad trombone implanter
-  description: a single use implanter, the implant plays a sad tune on death
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -87,7 +87,6 @@
 - type: entity
   id: LightImplanter
   name: light implanter
-  description: a single use implanter, the implant emits light on activation
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -96,7 +95,6 @@
 - type: entity
   id: BikeHornImplanter
   name: bike horn implanter
-  description: a single use implanter, the implant makes you able to honk anywhere at any time
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -107,7 +105,6 @@
 - type: entity
   id: TrackingImplanter
   name: tracking implanter
-  description: a single use implanter, the implant tracks
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -118,7 +115,6 @@
 - type: entity
   id: StorageImplanter
   name: storage implanter
-  description: a single use implanter, the implant grants hidden storage
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -127,7 +123,6 @@
 - type: entity
   id: FreedomImplanter
   name: freedom implanter
-  description: a single use implanter, the implant lets the user break out of hand restraints three times
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -136,7 +131,6 @@
 - type: entity
   id: UplinkImplanter
   name: uplink implanter
-  description: a single use implanter, the implant lets the user access a syndicate uplink at will
   parent: BaseImplantOnlyImplanter
   components:
   - type: Implanter
@@ -145,7 +139,6 @@
 - type: entity
   id: EmpImplanter
   name: EMP implanter
-  description: a single use implanter, the implant creates an EMP pulse when you activate it.
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -153,8 +146,7 @@
 
 - type: entity
   id: DnaScramblerImplanter
-  name: dna scrambler implanter
-  description: a single use implanter, the implant allows you to randomly change your appearance and name once.
+  name: DNA scrambler implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -166,8 +158,7 @@
 
 - type: entity
   id: MicroBombImplanter
-  name: micro bomb implanter
-  description: a single use implanter, the implant is permanent and blows the user up on death
+  name: micro-bomb implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -175,8 +166,7 @@
 
 - type: entity
   id: MacroBombImplanter
-  name: macro bomb implanter
-  description: a single use implanter, the implant creates a large explosion on death after the alloted time
+  name: macro-bomb implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -184,8 +174,7 @@
 
 - type: entity
   id: DeathRattleImplanter
-  name: Deathrattle implanter
-  description: a single use implanter, the implant will inform anyone with access to the syndicate radio channel of your death.
+  name: death rattle implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   id: BaseSubdermalImplant
   name: implant
-  description: a microscopic chip that's injected under the skin
+  description: A microscopic chip that's injected under the skin.
   abstract: true
   components:
     - type: SubdermalImplant
@@ -17,7 +17,7 @@
   parent: BaseSubdermalImplant
   id: SadTromboneImplant
   name: sad trombone implant
-  description: plays a sad tune when the user dies
+  description: This implant plays a sad tune when the user dies.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -34,7 +34,7 @@
   parent: BaseSubdermalImplant
   id: LightImplant
   name: light implant
-  description: makes your skin emit a faint light
+  description: This implant emits light from the user's skin on activation.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -62,7 +62,7 @@
   parent: BaseSubdermalImplant
   id: BikeHornImplant
   name: bike horn implant
-  description: Makes you honk
+  description: This implant lets the user honk anywhere at any time.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -83,7 +83,7 @@
   parent: BaseSubdermalImplant
   id: TrackingImplant
   name: tracking implant
-  description: tracks whoever was implanted via the suit sensor network
+  description: This implant has a tracking device attached to the suit sensor network, as well as a condition monitor for the Security radio channel.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -110,7 +110,7 @@
   parent: BaseSubdermalImplant
   id: StorageImplant
   name: storage implant
-  description: made with bluespace technology, allows the user to fit a few items in hidden storage
+  description: This implant grants hidden storage within a person's body using bluespace technology.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -132,7 +132,7 @@
   parent: BaseSubdermalImplant
   id: FreedomImplant
   name: freedom implant
-  description: you can break these cuffs
+  description: This implant lets the user break out of hand restraints up to three times before ceasing to function anymore.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -142,7 +142,7 @@
   parent: BaseSubdermalImplant
   id: UplinkImplant
   name: uplink implant
-  description: allows the user to open a hidden uplink at will
+  description: This implant lets the user access a hidden Syndicate uplink at will.
   noSpawn: true
   components:
   - type: SubdermalImplant
@@ -160,7 +160,7 @@
   parent: BaseSubdermalImplant
   id: EmpImplant
   name: EMP implant
-  description: allows the user to release a small EMP pulse
+  description: This implant creates an electromagnetic pulse when activated.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -175,7 +175,7 @@
   parent: BaseSubdermalImplant
   id: DnaScramblerImplant
   name: DNA scrambler implant
-  description: allows the user to change their appearance and name
+  description: This implant lets the user randomly change their appearance and name once.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -186,8 +186,8 @@
 - type: entity
   parent: BaseSubdermalImplant
   id: MicroBombImplant
-  name: micro bomb implant
-  description: mission failed, user blows up on death to prevent company equipment from being stolen
+  name: micro-bomb implant
+  description: This implant detonates the user upon death.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -216,8 +216,8 @@
 - type: entity
   parent: BaseSubdermalImplant
   id: MacroBombImplant
-  name: macro bomb implant
-  description: a large explosion packed into a small implant, be warned as this could be dangerous for your teammates
+  name: macro-bomb implant
+  description: This implant creates a large explosion on death after a preprogrammed countdown.
   noSpawn: true
   components:
     - type: SubdermalImplant
@@ -250,8 +250,8 @@
 - type: entity
   parent: BaseSubdermalImplant
   id: DeathRattleImplant
-  name: deathrattle implant
-  description: sends a message with your location to the syndicate radio channel when you fall into a critical state or die.
+  name: death rattle implant
+  description: This implant will inform the Syndicate radio channel should the user fall into critical condition or die.
   noSpawn: true
   components:
     - type: SubdermalImplant


### PR DESCRIPTION
- Rewrote all the implant descriptions to be more descriptive and have better grammar.

- Made the in-hand UI look more like the syringe which it resembled.
![image](https://github.com/space-wizards/space-station-14/assets/114301317/d2569673-69fa-4f92-88b0-97a806611f1c)

Syringe for comparison: 
![image](https://github.com/space-wizards/space-station-14/assets/114301317/677cf01c-9fff-43fe-ba8a-72f15ba28658)

What an empty implanter looks like:
![image](https://github.com/space-wizards/space-station-14/assets/114301317/91a7f41d-b151-40ed-9a60-b348fe478988)

- More details are available from the implanter examine, if you're in details range.

![image](https://github.com/space-wizards/space-station-14/assets/114301317/2b09927c-8841-4f08-be4c-982cf7215b3e)
