### PR TITLE
Fixes the flash overlay being offset in separated UI mode

### DIFF
--- a/Content.Client/Flash/FlashOverlay.cs
+++ b/Content.Client/Flash/FlashOverlay.cs
@@ -22,7 +22,7 @@ namespace Content.Client.Flash
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
 
-        public override OverlaySpace Space => OverlaySpace.ScreenSpace;
+        public override OverlaySpace Space => OverlaySpace.WorldSpace;
         private readonly ShaderInstance _shader;
         private double _startTime = -1;
         private double _lastsFor = 1;
@@ -61,18 +61,16 @@ namespace Content.Client.Flash
             if (percentComplete >= 1.0f)
                 return;
 
-            var screenSpaceHandle = args.ScreenHandle;
-            screenSpaceHandle.UseShader(_shader);
+            var worldHandle = args.WorldHandle;
+            worldHandle.UseShader(_shader);
             _shader.SetParameter("percentComplete", percentComplete);
-
-            var screenSize = UIBox2.FromDimensions(new Vector2(0, 0), _displayManager.ScreenSize);
 
             if (_screenshotTexture != null)
             {
-                screenSpaceHandle.DrawTextureRect(_screenshotTexture, screenSize);
+                worldHandle.DrawTextureRectRegion(_screenshotTexture, args.WorldBounds);
             }
 
-            screenSpaceHandle.UseShader(null);
+            worldHandle.UseShader(null);
         }
 
         protected override void DisposeBehavior()


### PR DESCRIPTION
## About the PR
This PR does exactly what it says on the tin. It makes it so the flashed overlay is no longer offset towards the actual physical center of your screen while you're in separated UI mode, and coincidentally removes the stretching that occurs with the flash overlay when playing fullscreen on an ultrawide monitor.

This PR fixes that by simply making the flash overlay use worldspace (rendering at the end of the viewport pass) instead of screenspace (which renders right after the viewport is positioned on the screen). Simple.

**Media**

https://github.com/space-wizards/space-station-14/assets/6356337/88e7a6a4-cdfe-4e25-97a1-480eb44786ef


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**


:cl: Bhijn and Myr
- fix: The flash overlay is no longer offset towards the actual physical center of your screen when playing with the separated UI layout. Additionally, ultrawide monitors no longer experience an exceptionally stretched flash overlay.
