### PR TITLE
Add song name support

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -1,4 +1,3 @@
-using Content.Client.Chat.Managers;
 using Content.Client.GameTicking.Managers;
 using Content.Client.LateJoin;
 using Content.Client.Lobby.UI;
@@ -9,15 +8,12 @@ using Content.Client.UserInterface.Systems.Chat;
 using Content.Client.Voting;
 using Robust.Client;
 using Robust.Client.Console;
-using Robust.Client.Input;
-using Robust.Client.Player;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
-using Content.Client.UserInterface.Systems.EscapeMenu;
 
 
 namespace Content.Client.Lobby

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -2,6 +2,7 @@ using Content.Client.Chat.Managers;
 using Content.Client.GameTicking.Managers;
 using Content.Client.LateJoin;
 using Content.Client.Lobby.UI;
+using Content.Client.Message;
 using Content.Client.Preferences;
 using Content.Client.Preferences.UI;
 using Content.Client.UserInterface.Systems.Chat;
@@ -198,6 +199,29 @@ namespace Content.Client.Lobby
             if (_gameTicker.ServerInfoBlob != null)
             {
                 _lobby!.ServerInfo.SetInfoBlob(_gameTicker.ServerInfoBlob);
+            }
+
+            if (_gameTicker.LobbySong == null)
+            {
+                _lobby!.LobbySong.SetMarkup(Loc.GetString("lobby-state-song-no-song-text"));
+            }
+            else if (_resourceCache.TryGetResource<AudioResource>(_gameTicker.LobbySong, out var lobbySongResource))
+            {
+                var lobbyStream = lobbySongResource.AudioStream;
+
+                var title = string.IsNullOrEmpty(lobbyStream.Title) ?
+                    Loc.GetString("lobby-state-song-unknown-title") :
+                    lobbyStream.Title;
+
+                var artist = string.IsNullOrEmpty(lobbyStream.Artist) ?
+                    Loc.GetString("lobby-state-song-unknown-artist") :
+                    lobbyStream.Artist;
+
+                var markup = Loc.GetString("lobby-state-song-text",
+                    ("songTitle", title),
+                    ("songArtist", artist));
+
+                _lobby!.LobbySong.SetMarkup(markup);
             }
         }
 

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -40,8 +40,11 @@
                     <!-- Vertical Padding-->
                     <Control VerticalExpand="True"/>
                     <!-- Left Bot Panel -->
-                    <BoxContainer Orientation="Vertical" HorizontalAlignment="Left" VerticalAlignment="Bottom" MaxWidth="620">
+                    <BoxContainer Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom">
                         <info:DevInfoBanner Name="DevInfoBanner" VerticalExpand="false" Margin="3 3 3 3"/>
+                        <PanelContainer StyleClasses="AngleRect">
+                            <RichTextLabel Name="LobbySong" Access="Public" HorizontalAlignment="Center" />
+                        </PanelContainer>
                     </BoxContainer>
                 </Control>
                 <!-- Character setup state -->

--- a/Resources/Locale/en-US/lobby/lobby-state.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-state.ftl
@@ -10,3 +10,7 @@ lobby-state-player-status-ready = Ready
 lobby-state-player-status-observer = Observer
 lobby-state-player-status-round-not-started = The round hasn't started yet
 lobby-state-player-status-round-time =  The round time is: {$hours} hours and {$minutes} minutes
+lobby-state-song-text = Playing: [color=white]{$songTitle}[/color] by [color=white]{$songArtist}[/color]
+lobby-state-song-no-song-text = No lobby song playing.
+lobby-state-song-unknown-title = [color=dimgray]Unknown title[/color]
+lobby-state-song-unknown-artist = [color=dimgray]Unknown artist[/color]


### PR DESCRIPTION
![image](https://github.com/space-wizards/space-station-14/assets/114301317/c35d23af-dc17-4926-b248-5bfef80968eb)

This depends on the Vorbis tags being set correctly, which most of the default songs have set, otherwise you'll end up with this:

![image](https://github.com/space-wizards/space-station-14/assets/114301317/94ebde05-4e22-44ec-b648-079bfab9544e)

Resolves https://github.com/space-wizards/space-station-14/issues/15947

Requires https://github.com/space-wizards/RobustToolbox/pull/4207

Supported by https://github.com/space-wizards/space-station-14/pull/18432