### PR TITLE
Fix air alarm not checking if device is in device list before sending atmos device settings

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -33,6 +33,7 @@ namespace Content.Server.Atmos.Monitor.Systems;
 public sealed class AirAlarmSystem : EntitySystem
 {
     [Dependency] private readonly DeviceNetworkSystem _deviceNet = default!;
+    [Dependency] private readonly DeviceListSystem _deviceListSystem = default!;
     [Dependency] private readonly AtmosDeviceNetworkSystem _atmosDevNetSystem = default!;
     [Dependency] private readonly AtmosAlarmableSystem _atmosAlarmable = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
@@ -290,10 +291,15 @@ public sealed class AirAlarmSystem : EntitySystem
 
     private void OnUpdateDeviceData(EntityUid uid, AirAlarmComponent component, AirAlarmUpdateDeviceDataMessage args)
     {
-        if (AccessCheck(uid, args.Session.AttachedEntity, component))
+        if (AccessCheck(uid, args.Session.AttachedEntity, component)
+            && _deviceListSystem.ExistsInDeviceList(uid, args.Address))
+        {
             SetDeviceData(uid, args.Address, args.Data);
+        }
         else
+        {
             UpdateUI(uid, component);
+        }
     }
 
     private bool AccessCheck(EntityUid uid, EntityUid? user, AirAlarmComponent? component = null)

--- a/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
@@ -61,6 +61,19 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
         return devices;
     }
 
+    /// <summary>
+    /// Checks if the given address is present in a device list
+    /// </summary>
+    /// <param name="uid">The entity uid that has the device list that should be checked for the address</param>
+    /// <param name="address">The address to check for</param>
+    /// <param name="deviceList">The device list component</param>
+    /// <returns>True if the address is present. False if not</returns>
+    public bool ExistsInDeviceList(EntityUid uid, string address, DeviceListComponent? deviceList = null)
+    {
+        var addresses = GetDeviceList(uid).Keys;
+        return addresses.Contains(address);
+    }
+
     protected override void UpdateShutdownSubscription(EntityUid uid, List<EntityUid> newDevices, List<EntityUid> oldDevices)
     {
         foreach (var device in newDevices)


### PR DESCRIPTION
Malicious clients could make air alarms update settings on devices not in their device list by sending the address of any atmos device not in the list.