### PR TITLE
Add enum serialization test.

### DIFF
--- a/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
+++ b/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Robust.Shared.Physics;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -22,17 +21,11 @@ public sealed class SerializationTest
         var seriMan = server.ResolveDependency<ISerializationManager>();
         var refMan = server.ResolveDependency<IReflectionManager>();
 
-        Enum value = BodyType.Static;
+        Enum value = TestEnum.Bb;
 
         var node = seriMan.WriteValue(value, notNullableOverride:true);
         var valueNode = node as ValueDataNode;
         Assert.NotNull(valueNode);
-
-        // Workaround to a stupid bug
-        refMan.TryParseEnumReference("enum.BodyType.Static", out _);
-        refMan.TryParseEnumReference("enum.BodyType.Dynamic", out _);
-        refMan.TryParseEnumReference("enum.BodyType.KinematicController", out _);
-        refMan.TryParseEnumReference("enum.BodyType.Kinematic", out _);
 
         var expected = refMan.GetEnumReference(value);
         Assert.That(valueNode!.Value, Is.EqualTo(expected));
@@ -43,8 +36,8 @@ public sealed class SerializationTest
         // Repeat test with enums in a data definitions.
         var data = new TestData
         {
-            Value = BodyType.Dynamic,
-            Sequence = new() {BodyType.KinematicController, BodyType.Kinematic}
+            Value = TestEnum.Cc,
+            Sequence = new() {TestEnum.Dd, TestEnum.Aa}
         };
 
         node = seriMan.WriteValue(data, notNullableOverride:true);
@@ -55,6 +48,8 @@ public sealed class SerializationTest
         Assert.That(deserializedData.Sequence[0], Is.EqualTo(data.Sequence[0]));
         Assert.That(deserializedData.Sequence[1], Is.EqualTo(data.Sequence[1]));
     }
+
+    private enum TestEnum : byte { Aa, Bb, Cc, Dd }
 
     [DataDefinition]
     private sealed class TestData

--- a/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
+++ b/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -30,6 +31,9 @@ public sealed class SerializationTest
         var expected = refMan.GetEnumReference(value);
         Assert.That(valueNode!.Value, Is.EqualTo(expected));
 
+        var errors = seriMan.ValidateNode<Enum>(valueNode).GetErrors();
+        Assert.That(errors.Any(), Is.False);
+
         var deserialized = seriMan.Read<Enum>(node, notNullableOverride:true);
         Assert.That(deserialized, Is.EqualTo(value));
 
@@ -41,12 +45,28 @@ public sealed class SerializationTest
         };
 
         node = seriMan.WriteValue(data, notNullableOverride:true);
+
+        errors = seriMan.ValidateNode<TestData>(node).GetErrors();
+        Assert.That(errors.Any(), Is.False);
+
         var deserializedData = seriMan.Read<TestData>(node, notNullableOverride:false);
 
         Assert.That(deserializedData.Value, Is.EqualTo(data.Value));
         Assert.That(deserializedData.Sequence.Count, Is.EqualTo(data.Sequence.Count));
         Assert.That(deserializedData.Sequence[0], Is.EqualTo(data.Sequence[0]));
         Assert.That(deserializedData.Sequence[1], Is.EqualTo(data.Sequence[1]));
+
+        // Check that Generic & non-generic serializers are incompativle.
+        Enum genericValue = TestEnum.Bb;
+        TestEnum typedValue = TestEnum.Bb;
+
+        var genericNode = seriMan.WriteValue(genericValue, notNullableOverride:true);
+        var typedNode = seriMan.WriteValue(typedValue);
+
+        Assert.That(seriMan.ValidateNode<Enum>(genericNode).GetErrors().Any(), Is.False);
+        Assert.That(seriMan.ValidateNode<TestEnum>(genericNode).GetErrors().Any(), Is.True);
+        Assert.That(seriMan.ValidateNode<Enum>(typedNode).GetErrors().Any(), Is.True);
+        Assert.That(seriMan.ValidateNode<TestEnum>(typedNode).GetErrors().Any(), Is.False);
     }
 
     private enum TestEnum : byte { Aa, Bb, Cc, Dd }

--- a/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
+++ b/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
@@ -67,6 +67,8 @@ public sealed class SerializationTest
         Assert.That(seriMan.ValidateNode<TestEnum>(genericNode).GetErrors().Any(), Is.True);
         Assert.That(seriMan.ValidateNode<Enum>(typedNode).GetErrors().Any(), Is.True);
         Assert.That(seriMan.ValidateNode<TestEnum>(typedNode).GetErrors().Any(), Is.False);
+
+        await pairTracker.CleanReturnAsync();
     }
 
     private enum TestEnum : byte { Aa, Bb, Cc, Dd }

--- a/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
+++ b/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Robust.Shared.Physics;
+using Robust.Shared.Reflection;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Markdown.Value;
+
+namespace Content.IntegrationTests.Tests.Serialization;
+
+[TestFixture]
+public sealed class SerializationTest
+{
+    /// <summary>
+    /// Check that serializing generic enums works as intended. This should really be in engine, but engine
+    /// integrations tests block reflection and I am lazy..
+    /// </summary>
+    [Test]
+    public async Task SerializeGenericEnums()
+    {
+        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true });
+        var server = pairTracker.Pair.Server;
+        var seriMan = server.ResolveDependency<ISerializationManager>();
+        var refMan = server.ResolveDependency<IReflectionManager>();
+
+        Enum value = BodyType.Static;
+
+        var node = seriMan.WriteValue(value, notNullableOverride:true);
+        var valueNode = node as ValueDataNode;
+        Assert.NotNull(valueNode);
+
+        // Workaround to a stupid bug
+        refMan.TryParseEnumReference("enum.BodyType.Static", out _);
+        refMan.TryParseEnumReference("enum.BodyType.Dynamic", out _);
+        refMan.TryParseEnumReference("enum.BodyType.KinematicController", out _);
+        refMan.TryParseEnumReference("enum.BodyType.Kinematic", out _);
+
+        var expected = refMan.GetEnumReference(value);
+        Assert.That(valueNode!.Value, Is.EqualTo(expected));
+
+        var deserialized = seriMan.Read<Enum>(node, notNullableOverride:true);
+        Assert.That(deserialized, Is.EqualTo(value));
+
+        // Repeat test with enums in a data definitions.
+        var data = new TestData
+        {
+            Value = BodyType.Dynamic,
+            Sequence = new() {BodyType.KinematicController, BodyType.Kinematic}
+        };
+
+        node = seriMan.WriteValue(data, notNullableOverride:true);
+        var deserializedData = seriMan.Read<TestData>(node, notNullableOverride:false);
+
+        Assert.That(deserializedData.Value, Is.EqualTo(data.Value));
+        Assert.That(deserializedData.Sequence.Count, Is.EqualTo(data.Sequence.Count));
+        Assert.That(deserializedData.Sequence[0], Is.EqualTo(data.Sequence[0]));
+        Assert.That(deserializedData.Sequence[1], Is.EqualTo(data.Sequence[1]));
+    }
+
+    [DataDefinition]
+    private sealed class TestData
+    {
+        [DataField("value")] public Enum Value = default!;
+        [DataField("sequence")] public List<Enum> Sequence = default!;
+    }
+}


### PR DESCRIPTION
Adds a basic enum serialization test. These tests should probably be in engine, but reflections is currently disabled there and I get confusing errors when trying to enable it.

Requires space-wizards/RobustToolbox/pull/4208