### PR TITLE
fix passive vents

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
@@ -36,14 +36,14 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 return;
 
             var inletAir = inlet.Air.RemoveRatio(1f);
-			var envAir = environment.RemoveRatio(1f);
+            var envAir = environment.RemoveRatio(1f);
 
-			var mergeAir = new GasMixture(inletAir.Volume + envAir.Volume);
-			_atmosphereSystem.Merge(mergeAir, inletAir);
-			_atmosphereSystem.Merge(mergeAir, envAir);
+            var mergeAir = new GasMixture(inletAir.Volume + envAir.Volume);
+            _atmosphereSystem.Merge(mergeAir, inletAir);
+            _atmosphereSystem.Merge(mergeAir, envAir);
 
-			_atmosphereSystem.Merge(inlet.Air, mergeAir.RemoveVolume(inletAir.Volume));
-			_atmosphereSystem.Merge(environment, mergeAir);
+            _atmosphereSystem.Merge(inlet.Air, mergeAir.RemoveVolume(inletAir.Volume));
+            _atmosphereSystem.Merge(environment, mergeAir);
         }
     }
 }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
@@ -35,29 +35,15 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (!_nodeContainer.TryGetNode(nodeContainer, vent.InletName, out PipeNode? inlet))
                 return;
 
-            var environmentPressure = environment.Pressure;
-            var pressureDelta = MathF.Abs(environmentPressure - inlet.Air.Pressure);
+            var inletAir = inlet.Air.RemoveRatio(1f);
+			var envAir = environment.RemoveRatio(1f);
 
-            if ((environment.Temperature > 0 || inlet.Air.Temperature > 0) && pressureDelta > 0.5f)
-            {
-                if (environmentPressure < inlet.Air.Pressure)
-                {
-                    var airTemperature = environment.Temperature > 0 ? environment.Temperature : inlet.Air.Temperature;
-                    var transferMoles = pressureDelta * environment.Volume / (airTemperature * Atmospherics.R);
-                    var removed = inlet.Air.Remove(transferMoles);
-                    _atmosphereSystem.Merge(environment, removed);
-                }
-                else
-                {
-                    var airTemperature = inlet.Air.Temperature > 0 ? inlet.Air.Temperature : environment.Temperature;
-                    var outputVolume = inlet.Air.Volume;
-                    var transferMoles = (pressureDelta * outputVolume) / (airTemperature * Atmospherics.R);
-                    transferMoles = MathF.Min(transferMoles, environment.TotalMoles * inlet.Air.Volume / environment.Volume);
-                    var removed = environment.Remove(transferMoles);
-                    _atmosphereSystem.Merge(inlet.Air, removed);
-                }
-            }
+			var mergeAir = new GasMixture(inletAir.Volume + envAir.Volume);
+			_atmosphereSystem.Merge(mergeAir, inletAir);
+			_atmosphereSystem.Merge(mergeAir, envAir);
 
+			_atmosphereSystem.Merge(inlet.Air, mergeAir.RemoveVolume(inletAir.Volume));
+			_atmosphereSystem.Merge(environment, mergeAir);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
makes passive vents properly equalise air between environment and passive vent pipenet
should fix:
- passive vents not properly exchanging temperature
- the volume pump + passive vent infinite pressure bug (no more 1x1 burnchamber abuse) (closes #13748)
- related passive vent bugs

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/57039557/263d7c2f-6758-4ae6-b0b3-3b33be3e265e)
footage of a heater actually working in order to heat air (they were terribly inefficient at it before)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Passive vents now equalize pressure both ways between the pipe and environment.
