### PR TITLE
Add missing CleanReturnAsync() to some tests.

### DIFF
--- a/Content.IntegrationTests/Tests/Body/SaveLoadReparentTest.cs
+++ b/Content.IntegrationTests/Tests/Body/SaveLoadReparentTest.cs
@@ -157,6 +157,8 @@ public sealed class SaveLoadReparentTest
                         Assert.That(component.ParentSlot.Child, Is.EqualTo(id));
                     });
                 }
+
+                maps.DeleteMap(mapId);
             }
         });
 

--- a/Content.IntegrationTests/Tests/Body/SaveLoadReparentTest.cs
+++ b/Content.IntegrationTests/Tests/Body/SaveLoadReparentTest.cs
@@ -159,5 +159,7 @@ public sealed class SaveLoadReparentTest
                 }
             }
         });
+
+        await pairTracker.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/LogErrorTest.cs
+++ b/Content.IntegrationTests/Tests/LogErrorTest.cs
@@ -28,5 +28,7 @@ public sealed class LogErrorTest
         // But errors do
         await server.WaitPost(() => Assert.Throws<AssertionException>(() => logmill.Error("test")));
         await client.WaitPost(() => Assert.Throws<AssertionException>(() => logmill.Error("test")));
+
+        await pairTracker.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Networking/ConnectTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/ConnectTest.cs
@@ -30,6 +30,8 @@ namespace Content.IntegrationTests.Tests.Networking
 
             Assert.That(clEntityManager.GetComponent<TransformComponent>(lastSvEntity).Coordinates,
                 Is.EqualTo(svEntityManager.GetComponent<TransformComponent>(lastSvEntity).Coordinates));
+
+            await pairTracker.CleanReturnAsync();
         }
     }
 }

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -144,12 +144,8 @@ public sealed class BodySystem : SharedBodySystem
 
     public override bool DropPart(EntityUid? partId, BodyPartComponent? part = null)
     {
-        if (partId == null || !Resolve(partId.Value, ref part, false))
-        {
-            if (partId != null)
-                Resolve(partId!.Value, ref part);
+        if (partId == null || !Resolve(partId.Value, ref part))
             return false;
-        }
 
         if (!base.DropPart(partId, part))
             return false;

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -5,7 +5,6 @@ using Content.Server.GameTicking;
 using Content.Server.Humanoid;
 using Content.Server.Kitchen.Components;
 using Content.Server.Mind;
-using Content.Server.Mind.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Prototypes;
@@ -36,9 +35,55 @@ public sealed class BodySystem : SharedBodySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<BodyPartComponent, ComponentStartup>(OnPartStartup);
+        SubscribeLocalEvent<BodyComponent, ComponentStartup>(OnBodyStartup);
         SubscribeLocalEvent<BodyComponent, MoveInputEvent>(OnRelayMoveInput);
         SubscribeLocalEvent<BodyComponent, ApplyMetabolicMultiplierEvent>(OnApplyMetabolicMultiplier);
         SubscribeLocalEvent<BodyComponent, BeingMicrowavedEvent>(OnBeingMicrowaved);
+    }
+
+    private void OnPartStartup(EntityUid uid, BodyPartComponent component, ComponentStartup args)
+    {
+        // This inter-entity relationship makes be deeply uncomfortable because its probably going to re-encounter
+        // all of the networking & startup ordering issues that containers and joints have.
+        // TODO just use containers. Please.
+
+        foreach (var slot in component.Children.Values)
+        {
+            DebugTools.Assert(slot.Parent == uid);
+            if (slot.Child == null)
+                continue;
+
+            if (TryComp(slot.Child, out BodyPartComponent? child))
+            {
+                child.ParentSlot = slot;
+                Dirty(slot.Child.Value);
+                continue;
+            }
+
+            Log.Error($"Body part encountered missing limbs: {ToPrettyString(uid)}. Slot: {slot.Id}");
+            slot.Child = null;
+        }
+    }
+
+    private void OnBodyStartup(EntityUid uid, BodyComponent component, ComponentStartup args)
+    {
+        if (component.Root is not { } slot)
+            return;
+
+        DebugTools.Assert(slot.Parent == uid);
+        if (slot.Child == null)
+            return;
+
+        if (!TryComp(slot.Child, out BodyPartComponent? child))
+        {
+            Log.Error($"Body part encountered missing limbs: {ToPrettyString(uid)}. Slot: {slot.Id}");
+            slot.Child = null;
+            return;
+        }
+
+        child.ParentSlot = slot;
+        Dirty(slot.Child.Value);
     }
 
     private void OnRelayMoveInput(EntityUid uid, BodyComponent component, ref MoveInputEvent args)
@@ -99,8 +144,12 @@ public sealed class BodySystem : SharedBodySystem
 
     public override bool DropPart(EntityUid? partId, BodyPartComponent? part = null)
     {
-        if (partId == null || !Resolve(partId.Value, ref part))
+        if (partId == null || !Resolve(partId.Value, ref part, false))
+        {
+            if (partId != null)
+                Resolve(partId!.Value, ref part);
             return false;
+        }
 
         if (!base.DropPart(partId, part))
             return false;

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Humanoid;
 using Content.Server.Kitchen.Components;
 using Content.Server.Mind;
 using Content.Shared.Body.Components;
+using Content.Shared.Body.Organ;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Prototypes;
 using Content.Shared.Body.Systems;
@@ -62,6 +63,23 @@ public sealed class BodySystem : SharedBodySystem
             }
 
             Log.Error($"Body part encountered missing limbs: {ToPrettyString(uid)}. Slot: {slot.Id}");
+            slot.Child = null;
+        }
+
+        foreach (var slot in component.Organs.Values)
+        {
+            DebugTools.Assert(slot.Parent == uid);
+            if (slot.Child == null)
+                continue;
+
+            if (TryComp(slot.Child, out OrganComponent? child))
+            {
+                child.ParentSlot = slot;
+                Dirty(slot.Child.Value);
+                continue;
+            }
+
+            Log.Error($"Body part encountered missing organ: {ToPrettyString(uid)}. Slot: {slot.Id}");
             slot.Child = null;
         }
     }

--- a/Content.Shared/Body/Organ/OrganComponent.cs
+++ b/Content.Shared/Body/Organ/OrganComponent.cs
@@ -10,6 +10,7 @@ public sealed class OrganComponent : Component
     [DataField("body")]
     public EntityUid? Body;
 
-    [DataField("parent")]
+    // TODO use containers. See comments in BodyPartComponent.
+    // Do not rely on this in client-side code.
     public OrganSlot? ParentSlot;
 }

--- a/Content.Shared/Body/Part/BodyPartComponent.cs
+++ b/Content.Shared/Body/Part/BodyPartComponent.cs
@@ -13,13 +13,16 @@ public sealed class BodyPartComponent : Component
     public EntityUid? Body;
 
     // This inter-entity relationship makes be deeply uncomfortable because its probably going to re-encounter all of the
-    // networking issues that containers and joins have.
+    // networking issues that containers and joints have.
     // TODO just use containers. Please.
+    // Do not use set or get data from this in client-side code.
     public BodyPartSlot? ParentSlot;
 
+    // Do not use set or get data from this in client-side code.
     [DataField("children")]
     public Dictionary<string, BodyPartSlot> Children = new();
 
+    // See all the above ccomments.
     [DataField("organs")]
     public Dictionary<string, OrganSlot> Organs = new();
 

--- a/Content.Shared/Body/Part/BodyPartComponent.cs
+++ b/Content.Shared/Body/Part/BodyPartComponent.cs
@@ -12,7 +12,9 @@ public sealed class BodyPartComponent : Component
     [DataField("body")]
     public EntityUid? Body;
 
-    [DataField("parent")]
+    // This inter-entity relationship makes be deeply uncomfortable because its probably going to re-encounter all of the
+    // networking issues that containers and joins have.
+    // TODO just use containers. Please.
     public BodyPartSlot? ParentSlot;
 
     [DataField("children")]

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -48,7 +48,7 @@ public partial class SharedBodySystem
         if (args.Current is not BodyComponentState state)
             return;
 
-        body.Root = state.Root;
+        body.Root = state.Root; // TODO use containers. This is broken and does not work.
         body.GibSound = state.GibSound;
     }
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -42,8 +42,8 @@ public partial class SharedBodySystem
             return;
 
         part.Body = state.Body;
-        part.ParentSlot = state.ParentSlot;
-        part.Children = state.Children;
+        part.ParentSlot = state.ParentSlot; // TODO use containers. This is broken and does not work.
+        part.Children = state.Children; // TODO use containers. This is broken and does not work.
         part.Organs = state.Organs;
         part.PartType = state.PartType;
         part.IsVital = state.IsVital;

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -44,7 +44,7 @@ public partial class SharedBodySystem
         part.Body = state.Body;
         part.ParentSlot = state.ParentSlot; // TODO use containers. This is broken and does not work.
         part.Children = state.Children; // TODO use containers. This is broken and does not work.
-        part.Organs = state.Organs;
+        part.Organs = state.Organs; // TODO end my suffering.
         part.PartType = state.PartType;
         part.IsVital = state.IsVital;
         part.Symmetry = state.Symmetry;


### PR DESCRIPTION
Also tries to fix the a broken body test, which was silently failing. It doesn't really fix the underlying issue, bodies should really just use container ids.