### PR TITLE
Fixes senior role traitors not getting their job's traitor specific items.

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -879,6 +879,7 @@
     - !type:BuyerJobCondition
       whitelist:
         - Scientist
+        - SeniorResearcher
 
 - type: listing
   id: uplinkProximityMine
@@ -913,6 +914,7 @@
     whitelist:
     - Zookeeper
     - Scientist
+    - SeniorResearcher      
     - Chef
 
 - type: listing
@@ -930,6 +932,8 @@
         - StationEngineer
         - AtmosphericTechnician
         - Scientist
+        - SeniorEngineer
+        - SeniorResearcher
 
 # Armor
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Edits the uplink catalogue so that Senior Engineer and Senior Researcher share Station Engineer/Atmospheric Technician and Scientist's job specific traitor items in the syndicate uplink as a traitor. Because it's silly the senior roles don't have them and its probably an oversight.


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Added missing job specific items to Senior Researcher and Senior Engineer traitors.
