### PR TITLE
Nuke codes paper stamp fix

### DIFF
--- a/Content.Server/Nuke/NukeCodePaperSystem.cs
+++ b/Content.Server/Nuke/NukeCodePaperSystem.cs
@@ -65,7 +65,7 @@ namespace Content.Server.Nuke
                     paperContent,
                     Loc.GetString("nuke-codes-fax-paper-name"),
                     null,
-                    "paper_stamp-cent",
+                    "paper_stamp-centcom",
                     new() { Loc.GetString("stamp-component-stamped-name-centcom") });
                 _faxSystem.Receive(faxEnt, printout, null, fax);
 


### PR DESCRIPTION
Broke down after renaming `paper_stamp-cent` to `paper_stamp-centcom`, the PR changes it.

Before:
![image](https://github.com/space-wizards/space-station-14/assets/46868845/ba2dafb2-0c0f-49a9-a6ba-02998b41a178)

After:
![image](https://github.com/space-wizards/space-station-14/assets/46868845/e6dcbc92-23d1-40ca-9647-43b988bd9cef)
