### PR TITLE
Double emergency oxygen tanks in Salvage Vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -12,3 +12,4 @@
     WeaponCrusher: 2
     WeaponCrusherDagger: 2
     WeaponProtoKineticAccelerator: 2
+    DoubleEmergencyOxygenTankFilled: 2 # For Arachnids. Remove if they no longer need this

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -12,4 +12,4 @@
     WeaponCrusher: 2
     WeaponCrusherDagger: 2
     WeaponProtoKineticAccelerator: 2
-    DoubleEmergencyOxygenTankFilled: 2 # For Arachnids. Remove if they no longer need this
+    DoubleEmergencyOxygenTankFilled: 2 # For Arachnids. Remove if they no longer need different tanks


### PR DESCRIPTION
## About the PR
Optional QoL feature for up to 2 spiders to be able to stay alive on alien planets without standard gas tanks after the volume reduction on #18288 . So long as they pry the double tanks out of the cold dead hands of whoever took them first

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Errant
- add: A small number of double emergency tanks were made available in the Salvage Vendor, for arachnids joining away teams.