### PR TITLE
Lowering head closet bloat.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -45,7 +45,7 @@
       - id: PlushieNuke
         prob: 0.1
       - id: CigarGoldCase
-        prob: 0.15
+        prob: 0.25
       - id: ClothingBeltSheathFilled
       - id: DoorRemoteCommand
       - id: ClothingNeckCloakCapFormal

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -7,15 +7,9 @@
     contents:
       - id: ClothingNeckCloakQm
       - id: ClothingHeadsetCargo
-      - id: PlushieLizard
-        prob: 0.1
       - id: ClothingHandsGlovesColorBrown
-      - id: ClothingOuterSuitFire
-        prob: 0.5
       - id: ClothingShoesColorBrown
-        prob: 0.7
       - id: ClothingHeadHatQMsoft
-        prob: 0.8
       - id: CargoRequestComputerCircuitboard
       - id: CargoShuttleComputerCircuitboard
       - id: CargoShuttleConsoleCircuitboard
@@ -51,7 +45,7 @@
       - id: PlushieNuke
         prob: 0.1
       - id: CigarGoldCase
-        prob: 0.25
+        prob: 0.15
       - id: ClothingBeltSheathFilled
       - id: DoorRemoteCommand
       - id: ClothingNeckCloakCapFormal
@@ -112,12 +106,10 @@
       - id: IDComputerCircuitboard
       - id: WeaponDisabler
       - id: ClothingShoesColorBlack
-        prob: 0.7
-      - id: PlushieLizard
-        prob: 0.1
       - id: CigarGoldCase
-        prob: 0.10
+        prob: 0.25
         # Fuck the HoP they don't deserve fucking cigars.
+        # Yes they do fuck you.
       - id: DoorRemoteService
       - id: ClothingNeckGoldmedal
       - id: RubberStampHop
@@ -189,7 +181,6 @@
       - id: ClothingOuterHardsuitMedical
       - id: DiagnoserMachineCircuitboard
       - id: VaccinatorMachineCircuitboard
-        prob: 0.25
       - id: Hypospray
       - id: HandheldCrewMonitor
       - id: DoorRemoteMedical
@@ -217,7 +208,6 @@
       - id: ClothingHeadHatBeretCmo
       - id: DiagnoserMachineCircuitboard
       - id: VaccinatorMachineCircuitboard
-        prob: 0.25
       - id: Hypospray
       - id: HandheldCrewMonitor
       - id: DoorRemoteMedical
@@ -241,8 +231,6 @@
       - id: ClothingHeadsetMedicalScience
       - id: ClothingOuterHardsuitRd
       - id: HandTeleporter
-      - id: PlushieSlime
-        prob: 0.1
       - id: DoorRemoteResearch
       - id: ClothingHeadHatBeretRND
       - id: RubberStampRd
@@ -263,8 +251,6 @@
       - id: ClothingNeckCloakRd
       - id: ClothingHeadsetMedicalScience
       - id: HandTeleporter
-      - id: PlushieSlime
-        prob: 0.1
       - id: DoorRemoteResearch
       - id: ClothingHeadHatBeretRND
       - id: RubberStampRd
@@ -286,28 +272,14 @@
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingUniformJumpskirtHoSAlt
       - id: ClothingUniformJumpsuitHoSAlt
-      - id: ClothingUniformJumpsuitHoSBlue
-        prob: 0.5
-      - id: ClothingUniformJumpsuitHoSGrey
-        prob: 0.5
-      - id: ClothingUniformJumpsuitHoSParadeMale
-        prob: 0.1
-      - id: ClothingUniformJumpskirtHoSParadeMale
-        prob: 0.1
       - id: ClothingOuterHardsuitSecurityRed
       - id: ClothingMaskGasSwat
-      - id: ClothingShoeSlippersDuck
-        prob: 0.2
-      - id: DrinkVacuumFlask
-        prob: 0.8
       - id: ClothingBeltSecurityFilled
       - id: ClothingHeadsetAltSecurity
       - id: ClothingEyesGlassesSecurity
       - id: ClothingShoesBootsJack
       - id: CigarGoldCase
         prob: 0.50
-      - id: PlushieSharkPink
-        prob: 0.1
       - id: DoorRemoteSecurity
       - id: ClothingUniformJumpskirtHosFormal
       - id: ClothingUniformJumpsuitHosFormal
@@ -331,26 +303,12 @@
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingUniformJumpskirtHoSAlt
       - id: ClothingUniformJumpsuitHoSAlt
-      - id: ClothingUniformJumpsuitHoSBlue
-        prob: 0.5
-      - id: ClothingUniformJumpsuitHoSGrey
-        prob: 0.5
-      - id: ClothingUniformJumpsuitHoSParadeMale
-        prob: 0.1
-      - id: ClothingUniformJumpskirtHoSParadeMale
-        prob: 0.1
-      - id: ClothingShoeSlippersDuck
-        prob: 0.2
-      - id: DrinkVacuumFlask
-        prob: 0.8
       - id: ClothingBeltSecurityFilled
       - id: ClothingHeadsetAltSecurity
       - id: ClothingEyesGlassesSecurity
       - id: ClothingShoesBootsJack
       - id: CigarGoldCase
         prob: 0.50
-      - id: PlushieSharkPink
-        prob: 0.1
       - id: DoorRemoteSecurity
       - id: ClothingUniformJumpskirtHosFormal
       - id: ClothingUniformJumpsuitHosFormal


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Changes the contents of most of the head's of staff's lockers to remove a bunch of bloat as mentioned in issue #18491 such as random item spawns, especially in the case of the head of security.

I've kept some things in the HoS' locker mentioned in the issue such as encryption keys and the holobarrier projector, since one is the only source of a decent number of spare encryption keys and the holobarrier is niche equipment that I don't think can be made elsewhere. (I might be wrong on this, but only the HoS and Warden get it, in their lockers.)



QM Locker
-Removed random lizard plushie spawn. 
-Removed random fire suit spawn. (Why, they're all over the station.)
-Made brown shoes guaranteed to spawn.
-Made QM hat guaranteed spawn.

Captain Locker
-No changes (The nukie plush is kinda funny.)

HoP locker
-Made shoes guaranteed.
-Removed random lizard plush spawn.
-Increased cigar spawn chance from 10% to 25% (Fuck you they DO deserve cigars.)

CE locker
-No changes.

CMO locker
-Made vaccinator machine board guaranteed. (It's useless but the diagnoser board was guaranteed so why not, for whenever diseases return.)

RD Locker
-Removed random slime plush spawn.

HoS locker
-Removed all non-guaranteed clothing. (If you want it you can just go to HoP and use the uniform printer. Nerd.)
-Removed the random duck slippers spawn. (Why?)
-Removed the random shark plush spawn. (Also why?)
-Removed the random vacuum flask spawn. (80% chance and if you want one just go to the bar.)


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Adjusted the contents of command staff's lockers to reduce bloat.

