### PR TITLE
Fix bullets passing through vehicles

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -38,6 +38,7 @@
         mask:
         - MobMask
         layer:
+        - MobLayer # can be hit by bullets and lasers
         - TableLayer
   - type: Appearance
   - type: Repairable


### PR DESCRIPTION
## About the PR
Adjust BaseVehicle layers so that bullets and lasers do not pass through them.

Tested to check that vehicles still exhibit correct collision while passing through mobs.

**Media**

https://github.com/space-wizards/space-station-14/assets/3229565/a1e661ae-61eb-4d83-b074-d036a706c567

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: notafet
- fix: Bullets, lasers, and disabler bolts now hit vehicles and their occupants.
