### PR TITLE
Give poison donut a suffix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
@@ -444,6 +444,7 @@
 - type: entity
   parent: FoodDonutPink
   id: FoodDonutPoison
+  suffix: Poison
   components:
   - type: SolutionContainerManager
     solutions:


### PR DESCRIPTION
## About the PR
This makes it harder for mappers to accidentally put down a poisonous donut using the entity spawn menu.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase