### PR TITLE
Fix shooting from vehicles

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -149,6 +149,14 @@ public partial class GunComponent : Component
     /// </summary>
     [DataField("clumsyProof")]
     public bool ClumsyProof = false;
+
+    /// <summary>
+    /// Offset bullet origin this distance from the center of the firing player.
+    /// This simulates the bullet starting at the end of the barrel and also prevents
+    /// a player shooting from a vehicle from hitting the vehicle.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("barrelLength")]
+    public float BarrelLength = 0.8f;
 }
 
 [Flags]


### PR DESCRIPTION
## About the PR
After https://github.com/space-wizards/space-station-14/pull/18500, shooting from vehicles is broken again. But we shouldn't need to make bullets pass through vehicles!

This change offset shot projectiles by gun barrel length. It adds a new barrel length field to gun components, which determines how far from the center of the player the bullet is spawned.

This offset places laser gun effects offset from the gun as if it came from the end of the barrel, instead of starting the beam right in the middle of the player.

This offset also fixes the problem of players on vehicles shooting themselves, without making vehicles completely transparent to projectiles.

**Media**

https://github.com/space-wizards/space-station-14/assets/3229565/96704e3c-7410-4be3-8e03-1aa43c561a03

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
N/A