### PR TITLE
Make guidebooks specify both damage types and groups

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/HealthChange.cs
+++ b/Content.Server/Chemistry/ReagentEffects/HealthChange.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Content.Shared.Localizations;
 using JetBrains.Annotations;
@@ -28,20 +29,63 @@ namespace Content.Server.Chemistry.ReagentEffects
         /// </summary>
         [JsonPropertyName("scaleByQuantity")]
         [DataField("scaleByQuantity")]
-        public bool ScaleByQuantity = false;
+        public bool ScaleByQuantity;
 
         [DataField("ignoreResistances")]
         [JsonPropertyName("ignoreResistances")]
         public bool IgnoreResistances = true;
 
-        protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        protected override string ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         {
             var damages = new List<string>();
             var heals = false;
             var deals = false;
 
-            // TODO: This should be smarter. Namely, not showing a damage type as being in a group unless every damage type in the group is present and equal in value.
-            foreach (var (kind, amount) in Damage.GetDamagePerGroup())
+            var damageSpec = new DamageSpecifier(Damage);
+
+            foreach (var group in prototype.EnumeratePrototypes<DamageGroupPrototype>())
+            {
+                if (!damageSpec.TryGetDamageInGroup(group, out var amount))
+                    continue;
+
+                var relevantTypes = damageSpec.DamageDict
+                    .Where(x => x.Value != FixedPoint2.Zero && group.DamageTypes.Contains(x.Key)).ToList();
+
+                if (relevantTypes.Count != group.DamageTypes.Count)
+                    continue;
+
+                var sum = FixedPoint2.Zero;
+                foreach (var (_, typeAmount) in relevantTypes)
+                {
+                    sum += typeAmount;
+                }
+
+                // if the total sum of all the types equal the damage amount,
+                // assume that they're evenly distributed.
+                if (sum != amount)
+                    continue;
+
+                var sign = MathF.Sign(amount.Float());
+
+                if (sign < 0)
+                    heals = true;
+                if (sign > 0)
+                    deals = true;
+
+                damages.Add(
+                    Loc.GetString("health-change-display",
+                        ("kind", group.ID),
+                        ("amount", MathF.Abs(amount.Float())),
+                        ("deltasign", sign)
+                    ));
+
+                foreach (var type in group.DamageTypes)
+                {
+                    damageSpec.DamageDict.Remove(type);
+                }
+            }
+
+            foreach (var (kind, amount) in damageSpec.DamageDict)
             {
                 var sign = MathF.Sign(amount.Float());
 
@@ -71,7 +115,7 @@ namespace Content.Server.Chemistry.ReagentEffects
             var scale = ScaleByQuantity ? args.Quantity : FixedPoint2.New(1);
             scale *= args.Scale;
 
-            EntitySystem.Get<DamageableSystem>().TryChangeDamage(args.SolutionEntity, Damage * scale, IgnoreResistances);
+            args.EntityManager.System<DamageableSystem>().TryChangeDamage(args.SolutionEntity, Damage * scale, IgnoreResistances);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Makes the guidebook specify damage types when relevant and only damage groups when relevant.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/199f597f-c36c-411e-9e8c-0f50a0bc7454)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: The chemistry guidebook now specifies specific types for damage and only uses groups when damage is evenly distributed across each type of a group.
