### PR TITLE
rotting meat

### DIFF
--- a/Content.Server/Atmos/Miasma/RottingSystem.cs
+++ b/Content.Server/Atmos/Miasma/RottingSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Temperature.Components;
 using Content.Shared.Atmos.Miasma;
 using Content.Shared.Examine;
 using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Rejuvenate;
 using Robust.Server.Containers;
@@ -81,8 +82,8 @@ public sealed class RottingSystem : EntitySystem
         if (!Resolve(uid, ref perishable, false))
             return false;
 
-        // only dead things perish
-        if (!_mobState.IsDead(uid))
+        // only dead things or inanimate objects can rot
+        if (TryComp<MobStateComponent>(uid, out var mobState) && !_mobState.IsDead(uid, mobState))
             return false;
 
         if (_container.TryGetOuterContainer(uid, Transform(uid), out var container) &&
@@ -119,10 +120,7 @@ public sealed class RottingSystem : EntitySystem
 
     private void OnExamined(EntityUid uid, RottingComponent component, ExaminedEvent args)
     {
-        if (!TryComp<PerishableComponent>(uid, out var perishable))
-            return;
-
-        var stage = (int) (component.TotalRotTime.TotalSeconds / perishable.RotAfter.TotalSeconds);
+        var stage = RotStage(uid, component);
         var description = stage switch
         {
             >= 2 => "miasma-extremely-bloated",
@@ -130,6 +128,17 @@ public sealed class RottingSystem : EntitySystem
                _ => "miasma-rotting"
         };
         args.PushMarkup(Loc.GetString(description));
+    }
+
+    /// <summary>
+    /// Return the rot stage, usually from 0 to 2 inclusive.
+    /// </summary>
+    public int RotStage(EntityUid uid, RottingComponent? comp = null, PerishableComponent? perishable = null)
+    {
+        if (!Resolve(uid, ref comp, ref perishable))
+            return 0;
+
+        return (int) (comp.TotalRotTime.TotalSeconds / perishable.RotAfter.TotalSeconds);
     }
 
     private void OnRejuvenate(EntityUid uid, RottingComponent component, RejuvenateEvent args)
@@ -181,6 +190,17 @@ public sealed class RottingSystem : EntitySystem
             {
                 var damage = rotting.Damage * rotting.RotUpdateRate.TotalSeconds;
                 _damageable.TryChangeDamage(uid, damage, true, false);
+            }
+
+            if (TryComp<RotIntoComponent>(uid, out var rotInto))
+            {
+                var stage = RotStage(uid, rotting, perishable);
+                if (stage >= rotInto.Stage)
+                {
+                    Spawn(rotInto.Entity, xform.Coordinates);
+                    QueueDel(uid);
+                    continue;
+                }
             }
 
             if (!TryComp<PhysicsComponent>(uid, out var physics))

--- a/Content.Shared/Atmos/Miasma/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Miasma/PerishableComponent.cs
@@ -29,7 +29,7 @@ public sealed class PerishableComponent : Component
 
     /// <summary>
     /// How often the rotting ticks.
-    /// Feel free to weak this if there are perf concerns.
+    /// Feel free to tweak this if there are perf concerns.
     /// </summary>
     [DataField("perishUpdateRate"), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan PerishUpdateRate = TimeSpan.FromSeconds(5);

--- a/Content.Shared/Atmos/Miasma/RotIntoComponent.cs
+++ b/Content.Shared/Atmos/Miasma/RotIntoComponent.cs
@@ -18,7 +18,7 @@ public sealed class RotIntoComponent : Component
     public string Entity = string.Empty;
 
     /// <summary>
-    /// Rotting stage to turn at.
+    /// Rotting stage to turn at, this is a multiplier of the total rot time.
     /// 0 = rotting, 1 = bloated, 2 = extremely bloated
     /// </summary>
     [DataField("stage"), ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Atmos/Miasma/RotIntoComponent.cs
+++ b/Content.Shared/Atmos/Miasma/RotIntoComponent.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Shared.Atmos.Miasma;
+
+/// <summary>
+/// Lets an entity rot into another entity.
+/// Used by raw meat to turn into rotten meat.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed class RotIntoComponent : Component
+{
+    /// <summary>
+    /// Entity to rot into.
+    /// </summary>
+    [DataField("entity", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>)), ViewVariables(VVAccess.ReadWrite)]
+    public string Entity = string.Empty;
+
+    /// <summary>
+    /// Rotting stage to turn at.
+    /// 0 = rotting, 1 = bloated, 2 = extremely bloated
+    /// </summary>
+    [DataField("stage"), ViewVariables(VVAccess.ReadWrite)]
+    public int Stage;
+}

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -42,8 +42,8 @@
     tags:
     - Raw
   - type: Perishable
-    # raw meat rots in just a minute, get it into the freezer fast
-    rotAfter: 60
+    # raw meat rots in 5 minutes, get it into the freezer fast
+    rotAfter: 300
     # don't want meat giving off miasma only bodies
     molsPerSecondPerUnitMass: 0
   - type: RotInto

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -33,6 +33,25 @@
     materialComposition:
       Meaterial: 300
 
+- type: entity
+  parent: FoodMeatBase
+  id: FoodMeatRawBase
+  abstract: true
+  components:
+  - type: Tag
+    tags:
+    - Raw
+  - type: Perishable
+    # raw meat rots in just a minute, get it into the freezer fast
+    rotAfter: 60
+    # don't want meat giving off miasma only bodies
+    molsPerSecondPerUnitMass: 0
+  - type: RotInto
+    entity: FoodMeatRotten
+    # once it would say bloated, turn into the rotten prototype
+    stage: 1
+
+# bruh
 - type: Tag
   id: Raw
 
@@ -46,13 +65,10 @@
 
 - type: entity
   name: raw meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeat
   description: A slab of raw meat.
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: plain
   - type: SolutionContainerManager
@@ -73,13 +89,10 @@
 
 - type: entity
   name: raw human meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatHuman
   description: Gross.
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: plain
   - type: SolutionContainerManager
@@ -121,6 +134,7 @@
 
 - type: entity
   name: raw bacon
+  # bacon is cured so not raw = cant rot
   parent: FoodMeatBase
   id: FoodMeatBacon
   description: A raw piece of bacon.
@@ -141,13 +155,10 @@
 
 - type: entity
   name: raw bear meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatBear
   description: A very manly slab of raw bear meat.
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: bear
   - type: SolutionContainerManager
@@ -168,13 +179,10 @@
 
 - type: entity
   name: raw penguin meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatPenguin
   description: A slab of raw penguin meat. Can be used as a substitute for fish in recipes.
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: bird
   - type: SolutionContainerManager
@@ -195,13 +203,10 @@
 
 - type: entity
   name: raw chicken meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatChicken
   description: A slab of raw chicken. Remember to wash your hands!
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: bird
   - type: SolutionContainerManager
@@ -222,13 +227,10 @@
 
 - type: entity
   name: raw duck meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatDuck
   description: A slab of raw duck. Remember to wash your hands!
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: bird
   - type: SolutionContainerManager
@@ -249,6 +251,7 @@
 
 - type: entity
   name: prime-cut corgi meat
+  # can't rot since that would be very bad for syndies
   parent: FoodMeatBase
   id: FoodMeatCorgi
   description: The tainted gift of an evil crime. The meat may be delicious, but at what cost?
@@ -270,16 +273,13 @@
 
 - type: entity
   name: raw crab meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatCrab
   description: A pile of raw crab meat.
   components:
   - type: FlavorProfile
     flavors:
       - crabby
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: crab
   - type: SolutionContainerManager
@@ -297,13 +297,10 @@
 
 - type: entity
   name: raw goliath meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatGoliath
   description: A slab of goliath meat. It's not very edible now, but it cooks great in lava.
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: goliath
   - type: SolutionContainerManager
@@ -347,13 +344,10 @@
 
 - type: entity
   name: raw rat meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatRat
   description: Prime meat from maintenance!
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: plain
   - type: SolutionContainerManager
@@ -367,13 +361,10 @@
 
 - type: entity
   name: raw lizard meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatLizard
   description: Delicious dino damage.
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: lizard
   - type: SolutionContainerManager
@@ -417,17 +408,18 @@
       food:
         reagents:
         - ReagentId: UncookedAnimalProteins
-          Quantity: 20
+          Quantity: 5
+        - ReagentId: Toxin
+          Quantity: 4
+        - ReagentId: Fat
+          Quantity: 4
 
 - type: entity
   name: raw spider meat
-  parent: FoodMeatBase
+  parent: FoodMeatRawBase
   id: FoodMeatSpider
   description: A slab of spider meat. That's so Kafkaesque.
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: spider
   - type: SolutionContainerManager
@@ -448,9 +440,6 @@
   id: FoodMeatSpiderLeg
   description: A still twitching leg of a giant spider... you don't really want to eat this, do you?
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: spiderleg
   - type: SolutionContainerManager
@@ -468,9 +457,6 @@
   id: FoodMeatWheat
   description: This doesn't look like meat, but your standards aren't that high to begin with.
   components:
-  - type: Tag
-    tags:
-    - Raw
   - type: Sprite
     state: clump
   - type: SolutionContainerManager
@@ -482,6 +468,7 @@
 
 - type: entity
   name: raw xeno meat
+  # not raw since acid kills bacteria or something, same as xeno
   parent: FoodMeatBase
   id: FoodMeatXeno
   description: A slab of xeno meat, dripping with acid.
@@ -581,7 +568,7 @@
 - type: entity
   parent: BaseItem
   id: MaterialSmileExtract
-  name: extract smile
+  name: smile extract
   description: It's a real panacea. But at what cost?
   components:
   - type: Food


### PR DESCRIPTION
## About the PR
- most raw meat can now rot:
  - 5 mins it will say rotting in examine
  - 10 mins it will turn into rotten meat
- rotten meat is now actually bad (less proteins, has toxin so its evil)
- putting raw meat in a freezer or cold place/space will prevent/slow rotting
- rotting meat wont produce miasma since thats bad
- cutlets are immune because cbf to make rotten cutlet sprite and ig its cured or something
- xeno meat doesnt rot because le acid lore
- ian meat doesnt rot because that would be incredibly shitty
- raw bacon doesnt rot because its cured

- added RotIntoComponent and FoodMeatRawBase
- rotting dead check only applies if the perishable thing has MobState in the first place to let non-mobs rot

rotting times and the component name ***subject to bikeshedding*** but overall this will make chef gameplay more engaging and realistic

**Media**
1 min in: (will be 5 now)
![063513](https://github.com/space-wizards/space-station-14/assets/39013340/5c8ee374-962d-4de8-bbe4-53c9c38ba3ed)

2 mins in: (will be 10 now)
![063611](https://github.com/space-wizards/space-station-14/assets/39013340/63e095d3-0b3d-4491-bb04-95911450009b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Most raw meat will now rot outside of a freezer. Please don't eat rotten meat.