### PR TITLE
Fast recycle more tests

### DIFF
--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -787,7 +787,6 @@ public sealed class PoolSettings
     /// </summary>
     public bool Disconnected { get; init; }
 
-    // TODO add a check to verify that clean InLobby pairs as still in the lobby when returned.
     /// <summary>
     /// Set to true if the given server/client pair should be in the lobby.
     /// If the pair is not in the lobby at the end of the test, this test must be marked as dirty.

--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -9,7 +9,6 @@ using Content.IntegrationTests.Tests;
 using Content.IntegrationTests.Tests.Destructible;
 using Content.IntegrationTests.Tests.DeviceNetwork;
 using Content.IntegrationTests.Tests.Interaction.Click;
-using Content.IntegrationTests.Tests.Networking;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
@@ -110,15 +109,6 @@ public static class PoolManager
         {
             var entSysMan = IoCManager.Resolve<IEntitySystemManager>();
             var compFactory = IoCManager.Resolve<IComponentFactory>();
-            entSysMan.LoadExtraSystemType<AutoPredictReconcileTest.AutoPredictionTestEntitySystem>();
-            compFactory.RegisterClass<AutoPredictionTestComponent>();
-            entSysMan.LoadExtraSystemType<SimplePredictReconcileTest.PredictionTestEntitySystem>();
-            compFactory.RegisterClass<SimplePredictReconcileTest.PredictionTestComponent>();
-            entSysMan.LoadExtraSystemType<SystemPredictReconcileTest.SystemPredictionTestEntitySystem>();
-            compFactory.RegisterClass<SystemPredictReconcileTest.SystemPredictionTestComponent>();
-            IoCManager.Register<ResettingEntitySystemTests.TestRoundRestartCleanupEvent>();
-            IoCManager.Register<InteractionSystemTests.TestInteractionSystem>();
-            IoCManager.Register<DeviceNetworkTestSystem>();
             entSysMan.LoadExtraSystemType<ResettingEntitySystemTests.TestRoundRestartCleanupEvent>();
             entSysMan.LoadExtraSystemType<InteractionSystemTests.TestInteractionSystem>();
             entSysMan.LoadExtraSystemType<DeviceNetworkTestSystem>();
@@ -214,14 +204,8 @@ public static class PoolManager
             {
                 ClientBeforeIoC = () =>
                 {
-                    var entSysMan = IoCManager.Resolve<IEntitySystemManager>();
-                    var compFactory = IoCManager.Resolve<IComponentFactory>();
-                    entSysMan.LoadExtraSystemType<AutoPredictReconcileTest.AutoPredictionTestEntitySystem>();
-                    compFactory.RegisterClass<AutoPredictionTestComponent>();
-                    entSysMan.LoadExtraSystemType<SimplePredictReconcileTest.PredictionTestEntitySystem>();
-                    compFactory.RegisterClass<SimplePredictReconcileTest.PredictionTestComponent>();
-                    entSysMan.LoadExtraSystemType<SystemPredictReconcileTest.SystemPredictionTestEntitySystem>();
-                    compFactory.RegisterClass<SystemPredictReconcileTest.SystemPredictionTestComponent>();
+                    // do not register extra systems or components here -- they will get cleared when the client is
+                    // disconnected. just use reflection.
                     IoCManager.Register<IParallaxManager, DummyParallaxManager>(true);
                     IoCManager.Resolve<ILogManager>().GetSawmill("loc").Level = LogLevel.Error;
                     IoCManager.Resolve<IConfigurationManager>()

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -19,7 +19,10 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SpawnAndDeleteAllEntitiesOnDifferentMaps()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true, Destructive = true });
+            // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
+            // is minimal relative to the rest of the test.
+            var settings = new PoolSettings {NoClient = true, Dirty = true};
+            await using var pairTracker = await PoolManager.GetServerClient(settings);
             var server = pairTracker.Pair.Server;
 
             var entityMan = server.ResolveDependency<IEntityManager>();
@@ -71,7 +74,10 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SpawnAndDeleteAllEntitiesInTheSameSpot()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true, Destructive = true });
+            // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
+            // is minimal relative to the rest of the test.
+            var settings = new PoolSettings {NoClient = true, Dirty = true};
+            await using var pairTracker = await PoolManager.GetServerClient(settings);
             var server = pairTracker.Pair.Server;
             var map = await PoolManager.CreateTestMap(pairTracker);
 
@@ -123,7 +129,10 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SpawnAndDirtyAllEntities()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = false, Destructive = true });
+            // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
+            // is minimal relative to the rest of the test.
+            var settings = new PoolSettings {NoClient = false, Dirty = true};
+            await using var pairTracker = await PoolManager.GetServerClient(settings);
             var server = pairTracker.Pair.Server;
             var client = pairTracker.Pair.Client;
 
@@ -211,11 +220,7 @@ namespace Content.IntegrationTests.Tests
                 "BiomeSelection", // Whaddya know, requires config.
             };
 
-            var testEntity = @"
-- type: entity
-  id: AllComponentsOneToOneDeleteTestEntity";
-
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true, ExtraPrototypes = testEntity });
+            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true });
             var server = pairTracker.Pair.Server;
 
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -263,7 +268,7 @@ namespace Content.IntegrationTests.Tests
                             continue;
                         }
 
-                        var entity = entityManager.SpawnEntity("AllComponentsOneToOneDeleteTestEntity", testLocation);
+                        var entity = entityManager.SpawnEntity(null, testLocation);
 
                         Assert.That(entityManager.GetComponent<MetaDataComponent>(entity).EntityInitialized);
 
@@ -312,11 +317,7 @@ namespace Content.IntegrationTests.Tests
                 "BiomeSelection", // Whaddya know, requires config.
             };
 
-            var testEntity = @"
-- type: entity
-  id: AllComponentsOneEntityDeleteTestEntity";
-
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true, ExtraPrototypes = testEntity });
+            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true });
             var server = pairTracker.Pair.Server;
 
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -385,7 +386,7 @@ namespace Content.IntegrationTests.Tests
                     foreach (var (components, _) in distinctComponents)
                     {
                         var testLocation = grid.ToCoordinates();
-                        var entity = entityManager.SpawnEntity("AllComponentsOneEntityDeleteTestEntity", testLocation);
+                        var entity = entityManager.SpawnEntity(null, testLocation);
 
                         Assert.That(entityManager.GetComponent<MetaDataComponent>(entity).EntityInitialized);
 

--- a/Content.IntegrationTests/Tests/Networking/AutoPredictReconcileTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/AutoPredictReconcileTest.cs
@@ -11,9 +11,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Map;
-using Robust.Shared.Reflection;
 using Robust.Shared.Timing;
 
 namespace Content.IntegrationTests.Tests.Networking
@@ -35,6 +33,8 @@ namespace Content.IntegrationTests.Tests.Networking
         [Test]
         public async Task Test()
         {
+            // TODO remove fresh=true.
+            // Instead, offset the all the explicit tick checks by some initial tick number.
             await using var pairTracker = await PoolManager.GetServerClient(new() { Fresh = true, DummyTicker = true });
             var server = pairTracker.Pair.Server;
             var client = pairTracker.Pair.Client;
@@ -390,7 +390,6 @@ namespace Content.IntegrationTests.Tests.Networking
             await pairTracker.CleanReturnAsync();
         }
 
-        [Reflect(false)]
         public sealed class AutoPredictionTestEntitySystem : EntitySystem
         {
             public bool Allow { get; set; } = true;
@@ -446,6 +445,7 @@ namespace Content.IntegrationTests.Tests.Networking
     [NetworkedComponent()]
     [AutoGenerateComponentState]
     [Access(typeof(AutoPredictReconcileTest.AutoPredictionTestEntitySystem))]
+    [RegisterComponent]
     public sealed partial class AutoPredictionTestComponent : Component
     {
         [AutoNetworkedField]

--- a/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
@@ -12,7 +12,6 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
-using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
@@ -36,6 +35,8 @@ namespace Content.IntegrationTests.Tests.Networking
         [Test]
         public async Task Test()
         {
+            // TODO remove fresh=true.
+            // Instead, offset the all the explicit tick checks by some initial tick number.
             await using var pairTracker = await PoolManager.GetServerClient(new() { Fresh = true, DummyTicker = true });
             var server = pairTracker.Pair.Server;
             var client = pairTracker.Pair.Client;
@@ -393,12 +394,12 @@ namespace Content.IntegrationTests.Tests.Networking
 
         [NetworkedComponent()]
         [Access(typeof(PredictionTestEntitySystem))]
+        [RegisterComponent]
         public sealed class PredictionTestComponent : Component
         {
             public bool Foo;
         }
 
-        [Reflect(false)]
         public sealed class PredictionTestEntitySystem : EntitySystem
         {
             [Serializable, NetSerializable]

--- a/Content.IntegrationTests/Tests/Networking/SystemPredictReconcileTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/SystemPredictReconcileTest.cs
@@ -12,7 +12,6 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
-using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
@@ -35,6 +34,8 @@ namespace Content.IntegrationTests.Tests.Networking
         [Test]
         public async Task Test()
         {
+            // TODO remove fresh=true.
+            // Instead, offset the all the explicit tick checks by some initial tick number.
             await using var pairTracker = await PoolManager.GetServerClient(new() { Fresh = true, DummyTicker = true });
             var server = pairTracker.Pair.Server;
             var client = pairTracker.Pair.Client;
@@ -392,12 +393,12 @@ namespace Content.IntegrationTests.Tests.Networking
 
         [NetworkedComponent()]
         [Access(typeof(SystemPredictionTestEntitySystem))]
+        [RegisterComponent]
         public sealed class SystemPredictionTestComponent : Component
         {
             public bool Foo;
         }
 
-        [Reflect(false)]
         public sealed class SystemPredictionTestEntitySystem : EntitySystem
         {
             public bool Allow { get; set; } = true;

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -150,7 +150,7 @@ namespace Content.IntegrationTests.Tests
                     var mapNames = new List<string>();
                     var naughty = new HashSet<string>()
                     {
-                        "Empty",
+                        PoolManager.TestMap,
                         "Infiltrator",
                         "Pirate",
                     };

--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -41,7 +41,7 @@ public sealed class PrototypeSaveTest
     public async Task UninitializedSaveTest()
     {
         // Apparently SpawnTest fails to clean  up properly. Due to the similarities, I'll assume this also fails.
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true, Dirty = true, Destructive = true });
+        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true });
         var server = pairTracker.Pair.Server;
 
         var mapManager = server.ResolveDependency<IMapManager>();

--- a/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
@@ -13,7 +13,7 @@ using Robust.Shared.Utility;
 namespace Content.IntegrationTests.Tests
 {
     /// <summary>
-    ///     Tests that the
+    ///     Tests that a map's yaml does not change when saved consecutively.
     /// </summary>
     [TestFixture]
     public sealed class SaveLoadSaveTest
@@ -21,7 +21,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SaveLoadSave()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Fresh = true, Disconnected = true });
+            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true });
             var server = pairTracker.Pair.Server;
             var entManager = server.ResolveDependency<IEntityManager>();
             var mapLoader = entManager.System<MapLoaderSystem>();


### PR DESCRIPTION
Makes some changes to test pooling to try make tests slightly faster and prevent some inter-test bugs. Locally tests go from taking 4m 30s to 3m 50s.

- Changes `CanFastRecycle()`, `MustNotBeReused`, and `MustBeNew` so that more server/client pairs can be recycled.
- Changes some tests from "Destructive" to "Dirty"
- Removes some unnecessary test prototypes
- Added some code to validate that a fast-recyclable pair is in a valid state
- Recycled connected server/client pairs now ensure that they are on the same tick.
- Removes `LoadExtraSystemType()` uses from the client, which can cause issues when the client gets disconnected.