### PR TITLE
Make pardon command test non-destructive

### DIFF
--- a/Content.IntegrationTests/Tests/Commands/PardonCommand.cs
+++ b/Content.IntegrationTests/Tests/Commands/PardonCommand.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Server.Database;
 using Robust.Server.Console;
 using Robust.Server.Player;
+using Robust.Shared.Network;
 
 namespace Content.IntegrationTests.Tests.Commands
 {
@@ -14,126 +15,140 @@ namespace Content.IntegrationTests.Tests.Commands
         [Test]
         public async Task PardonTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new() { Destructive = true });
+            await using var pairTracker = await PoolManager.GetServerClient();
             var server = pairTracker.Pair.Server;
+            var client = pairTracker.Pair.Client;
 
             var sPlayerManager = server.ResolveDependency<IPlayerManager>();
             var sConsole = server.ResolveDependency<IServerConsoleHost>();
             var sDatabase = server.ResolveDependency<IServerDbManager>();
+            var netMan = client.ResolveDependency<IClientNetManager>();
+            var clientSession = sPlayerManager.Sessions.Single();
+            var clientId = clientSession.UserId;
 
-            await server.WaitAssertion(async () =>
+            Assert.That(netMan.IsConnected);
+
+            Assert.That(sPlayerManager.Sessions.Count(), Is.EqualTo(1));
+            // No bans on record
+            Assert.Multiple(async () =>
             {
-                var clientSession = sPlayerManager.Sessions.Single();
-                var clientId = clientSession.UserId;
+                Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Null);
+                Assert.That(await sDatabase.GetServerBanAsync(1), Is.Null);
+                Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Is.Empty);
+            });
 
-                // No bans on record
-                Assert.Multiple(async () =>
-                {
-                    Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Null);
-                    Assert.That(await sDatabase.GetServerBanAsync(1), Is.Null);
-                    Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Is.Empty);
-                });
+            // Try to pardon a ban that does not exist
+            await server.WaitPost(() => sConsole.ExecuteCommand("pardon 1"));
 
-                // Try to pardon a ban that does not exist
-                sConsole.ExecuteCommand("pardon 1");
+            // Still no bans on record
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Null);
+                Assert.That(await sDatabase.GetServerBanAsync(1), Is.Null);
+                Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Is.Empty);
+            });
 
-                // Still no bans on record
-                Assert.Multiple(async () =>
-                {
-                    Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Null);
-                    Assert.That(await sDatabase.GetServerBanAsync(1), Is.Null);
-                    Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Is.Empty);
-                });
+            var banReason = "test";
 
-                var banReason = "test";
+            Assert.That(sPlayerManager.Sessions.Count(), Is.EqualTo(1));
+            // Ban the client for 24 hours
+            await server.WaitPost(() => sConsole.ExecuteCommand($"ban {clientSession.Name} {banReason} 1440"));
 
-                // Ban the client for 24 hours
-                sConsole.ExecuteCommand($"ban {clientSession.Name} {banReason} 1440");
-
-                // Should have one ban on record now
-                Assert.Multiple(async () =>
-                {
-                    Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Not.Null);
-                    Assert.That(await sDatabase.GetServerBanAsync(1), Is.Not.Null);
-                    Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Has.Count.EqualTo(1));
-                });
-
-                // Try to pardon a ban that does not exist
-                sConsole.ExecuteCommand("pardon 2");
-
-                // The existing ban is unaffected
+            // Should have one ban on record now
+            Assert.Multiple(async () =>
+            {
                 Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Not.Null);
+                Assert.That(await sDatabase.GetServerBanAsync(1), Is.Not.Null);
+                Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Has.Count.EqualTo(1));
+            });
 
-                var ban = await sDatabase.GetServerBanAsync(1);
-                Assert.Multiple(async () =>
-                {
-                    Assert.That(ban, Is.Not.Null);
-                    Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Has.Count.EqualTo(1));
+            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            Assert.That(sPlayerManager.Sessions.Count(), Is.EqualTo(0));
+            Assert.That(!netMan.IsConnected);
 
-                    // Check that it matches
-                    Assert.That(ban.Id, Is.EqualTo(1));
-                    Assert.That(ban.UserId, Is.EqualTo(clientId));
-                    Assert.That(ban.BanTime.UtcDateTime - DateTime.UtcNow, Is.LessThanOrEqualTo(MarginOfError));
-                    Assert.That(ban.ExpirationTime, Is.Not.Null);
-                    Assert.That(ban.ExpirationTime.Value.UtcDateTime - DateTime.UtcNow.AddHours(24), Is.LessThanOrEqualTo(MarginOfError));
-                    Assert.That(ban.Reason, Is.EqualTo(banReason));
+            // Try to pardon a ban that does not exist
+            await server.WaitPost(() => sConsole.ExecuteCommand("pardon 2"));
 
-                    // Done through the console
-                    Assert.That(ban.BanningAdmin, Is.Null);
-                    Assert.That(ban.Unban, Is.Null);
-                });
+            // The existing ban is unaffected
+            Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Not.Null);
 
-                // Pardon the actual ban
-                sConsole.ExecuteCommand("pardon 1");
+            var ban = await sDatabase.GetServerBanAsync(1);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(ban, Is.Not.Null);
+                Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Has.Count.EqualTo(1));
 
+                // Check that it matches
+                Assert.That(ban.Id, Is.EqualTo(1));
+                Assert.That(ban.UserId, Is.EqualTo(clientId));
+                Assert.That(ban.BanTime.UtcDateTime - DateTime.UtcNow, Is.LessThanOrEqualTo(MarginOfError));
+                Assert.That(ban.ExpirationTime, Is.Not.Null);
+                Assert.That(ban.ExpirationTime.Value.UtcDateTime - DateTime.UtcNow.AddHours(24), Is.LessThanOrEqualTo(MarginOfError));
+                Assert.That(ban.Reason, Is.EqualTo(banReason));
+
+                // Done through the console
+                Assert.That(ban.BanningAdmin, Is.Null);
+                Assert.That(ban.Unban, Is.Null);
+            });
+
+            // Pardon the actual ban
+            await server.WaitPost(() => sConsole.ExecuteCommand("pardon 1"));
+
+            // No bans should be returned
+            Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Null);
+
+            // Direct id lookup returns a pardoned ban
+            var pardonedBan = await sDatabase.GetServerBanAsync(1);
+            Assert.Multiple(async () =>
+            {
+                // Check that it matches
+                Assert.That(pardonedBan, Is.Not.Null);
+
+                // The list is still returned since that ignores pardons
+                Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Has.Count.EqualTo(1));
+
+                Assert.That(pardonedBan.Id, Is.EqualTo(1));
+                Assert.That(pardonedBan.UserId, Is.EqualTo(clientId));
+                Assert.That(pardonedBan.BanTime.UtcDateTime - DateTime.UtcNow, Is.LessThanOrEqualTo(MarginOfError));
+                Assert.That(pardonedBan.ExpirationTime, Is.Not.Null);
+                Assert.That(pardonedBan.ExpirationTime.Value.UtcDateTime - DateTime.UtcNow.AddHours(24), Is.LessThanOrEqualTo(MarginOfError));
+                Assert.That(pardonedBan.Reason, Is.EqualTo(banReason));
+
+                // Done through the console
+                Assert.That(pardonedBan.BanningAdmin, Is.Null);
+
+                Assert.That(pardonedBan.Unban, Is.Not.Null);
+                Assert.That(pardonedBan.Unban.BanId, Is.EqualTo(1));
+
+                // Done through the console
+                Assert.That(pardonedBan.Unban.UnbanningAdmin, Is.Null);
+
+                Assert.That(pardonedBan.Unban.UnbanTime.UtcDateTime - DateTime.UtcNow, Is.LessThanOrEqualTo(MarginOfError));
+            });
+
+            // Try to pardon it again
+            await server.WaitPost(() => sConsole.ExecuteCommand("pardon 1"));
+
+            // Nothing changes
+            Assert.Multiple(async () =>
+            {
                 // No bans should be returned
                 Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Null);
 
                 // Direct id lookup returns a pardoned ban
-                var pardonedBan = await sDatabase.GetServerBanAsync(1);
-                Assert.Multiple(async () =>
-                {
-                    // Check that it matches
-                    Assert.That(pardonedBan, Is.Not.Null);
+                Assert.That(await sDatabase.GetServerBanAsync(1), Is.Not.Null);
 
-                    // The list is still returned since that ignores pardons
-                    Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Has.Count.EqualTo(1));
-
-                    Assert.That(pardonedBan.Id, Is.EqualTo(1));
-                    Assert.That(pardonedBan.UserId, Is.EqualTo(clientId));
-                    Assert.That(pardonedBan.BanTime.UtcDateTime - DateTime.UtcNow, Is.LessThanOrEqualTo(MarginOfError));
-                    Assert.That(pardonedBan.ExpirationTime, Is.Not.Null);
-                    Assert.That(pardonedBan.ExpirationTime.Value.UtcDateTime - DateTime.UtcNow.AddHours(24), Is.LessThanOrEqualTo(MarginOfError));
-                    Assert.That(pardonedBan.Reason, Is.EqualTo(banReason));
-
-                    // Done through the console
-                    Assert.That(pardonedBan.BanningAdmin, Is.Null);
-
-                    Assert.That(pardonedBan.Unban, Is.Not.Null);
-                    Assert.That(pardonedBan.Unban.BanId, Is.EqualTo(1));
-
-                    // Done through the console
-                    Assert.That(pardonedBan.Unban.UnbanningAdmin, Is.Null);
-
-                    Assert.That(pardonedBan.Unban.UnbanTime.UtcDateTime - DateTime.UtcNow, Is.LessThanOrEqualTo(MarginOfError));
-                });
-
-                // Try to pardon it again
-                sConsole.ExecuteCommand("pardon 1");
-
-                // Nothing changes
-                Assert.Multiple(async () =>
-                {
-                    // No bans should be returned
-                    Assert.That(await sDatabase.GetServerBanAsync(null, clientId, null), Is.Null);
-
-                    // Direct id lookup returns a pardoned ban
-                    Assert.That(await sDatabase.GetServerBanAsync(1), Is.Not.Null);
-
-                    // The list is still returned since that ignores pardons
-                    Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Has.Count.EqualTo(1));
-                });
+                // The list is still returned since that ignores pardons
+                Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Has.Count.EqualTo(1));
             });
+
+            // Reconnect client. Slightly faster than dirtying the pair.
+            Assert.That(sPlayerManager.Sessions.Count(), Is.EqualTo(0));
+            client.SetConnectTarget(server);
+            await client.WaitPost(() => netMan.ClientConnect(null!, 0, null!));
+            await PoolManager.ReallyBeIdle(pairTracker.Pair);
+            Assert.That(sPlayerManager.Sessions.Count(), Is.EqualTo(1));
+
             await pairTracker.CleanReturnAsync();
         }
     }


### PR DESCRIPTION
This PR is easier to review when hiding whitespace changes.
Requires https://github.com/space-wizards/RobustToolbox/pull/4217 to fix the bug that was causing this test to be "destructive".