### PR TITLE
Damage other on hit player feedback

### DIFF
--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Damage.Systems
 
             RaiseNetworkEvent(new ColorFlashEffectEvent(Color.Red, new List<EntityUid> { args.Target }), Filter.Pvs(args.Target, entityManager: EntityManager));
             _guns.PlayImpactSound(args.Target, dmg, null, false);
-            if (TryComp<PhysicsComponent>(uid, out var body))
+            if (TryComp<PhysicsComponent>(uid, out var body) && body.LinearVelocity.LengthSquared() > 0f)
             {
                 var direction = body.LinearVelocity.Normalized();
                 _sharedCameraRecoil.KickCamera(args.Target, direction);

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Damage.Systems
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly GunSystem _guns = default!;
         [Dependency] private readonly SharedCameraRecoilSystem _sharedCameraRecoil = default!;
+        [Dependency] private readonly ThrownItemSystem _thrownItem = default!;
 
         public override void Initialize()
         {
@@ -39,6 +40,8 @@ namespace Content.Server.Damage.Systems
                 var direction = body.LinearVelocity.Normalized();
                 _sharedCameraRecoil.KickCamera(args.Target, direction);
             }
+
+            _thrownItem.LandComponent(args.Thrown, args.Component, playSound: false);
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Damage.Systems
 
         private void OnDoHit(EntityUid uid, DamageOtherOnHitComponent component, ThrowDoHitEvent args)
         {
-            var dmg = _damageableSystem.TryChangeDamage(args.Target, component.Damage, component.IgnoreResistances, origin: args.User);
+            var dmg = _damageableSystem.TryChangeDamage(args.Target, component.Damage, component.IgnoreResistances, origin: args.Component.Thrower);
 
             // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
             if (dmg != null && HasComp<MobStateComponent>(args.Target))

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -1,16 +1,23 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Damage.Components;
+using Content.Server.Weapons.Ranged.Systems;
+using Content.Shared.Camera;
 using Content.Shared.Damage;
 using Content.Shared.Database;
+using Content.Shared.Effects;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Throwing;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Player;
 
 namespace Content.Server.Damage.Systems
 {
     public sealed class DamageOtherOnHitSystem : EntitySystem
     {
         [Dependency] private readonly DamageableSystem _damageableSystem = default!;
-        [Dependency] private readonly IAdminLogManager _adminLogger= default!;
+        [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly GunSystem _guns = default!;
+        [Dependency] private readonly SharedCameraRecoilSystem _sharedCameraRecoil = default!;
 
         public override void Initialize()
         {
@@ -24,6 +31,14 @@ namespace Content.Server.Damage.Systems
             // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
             if (dmg != null && HasComp<MobStateComponent>(args.Target))
                 _adminLogger.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total:damage} damage from collision");
+
+            RaiseNetworkEvent(new ColorFlashEffectEvent(Color.Red, new List<EntityUid> { args.Target }), Filter.Pvs(args.Target, entityManager: EntityManager));
+            _guns.PlayImpactSound(args.Target, dmg, null, false);
+            if (TryComp<PhysicsComponent>(uid, out var body))
+            {
+                var direction = body.LinearVelocity.Normalized();
+                _sharedCameraRecoil.KickCamera(args.Target, direction);
+            }
         }
     }
 }

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -309,8 +309,8 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
             return;
         }
 
-        if (args.User != null)
-            _adminLogger.Add(LogType.Landed, LogImpact.Low, $"{ToPrettyString(args.Thrown)} thrown by {ToPrettyString(args.User.Value):player} landed in {ToPrettyString(uid)}");
+        if (args.Component.Thrower != null)
+            _adminLogger.Add(LogType.Landed, LogImpact.Low, $"{ToPrettyString(args.Thrown)} thrown by {ToPrettyString(args.Component.Thrower.Value):player} landed in {ToPrettyString(uid)}");
 
         AfterInsert(uid, component, args.Thrown);
     }

--- a/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
@@ -82,7 +82,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
         protected override void CreamedEntity(EntityUid uid, CreamPiedComponent creamPied, ThrowHitByEvent args)
         {
-            _popup.PopupEntity(Loc.GetString("cream-pied-component-on-hit-by-message",("thrower", args.Thrown)), uid, args.Target);
+            _popup.PopupEntity(Loc.GetString("cream-pied-component-on-hit-by-message", ("thrower", args.Thrown)), uid, args.Target);
             var otherPlayers = Filter.Empty().AddPlayersByPvs(uid);
             if (TryComp<ActorComponent>(args.Target, out var actor))
             {

--- a/Content.Shared/Throwing/ThrowEvents.cs
+++ b/Content.Shared/Throwing/ThrowEvents.cs
@@ -5,26 +5,15 @@ namespace Content.Shared.Throwing
     /// </summary>
     public abstract class ThrowEvent : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     The entity that threw <see cref="Thrown"/>.
-        /// </summary>
-        public EntityUid? User { get; }
+        public readonly EntityUid Thrown;
+        public readonly EntityUid Target;
+        public ThrownItemComponent Component;
 
-        /// <summary>
-        ///     The entity thrown by <see cref="User"/> that hit <see cref="Target"/>
-        /// </summary>
-        public EntityUid Thrown { get; }
-
-        /// <summary>
-        ///     The entity hit with <see cref="Thrown"/> by <see cref="User"/>
-        /// </summary>
-        public EntityUid Target { get; }
-
-        public ThrowEvent(EntityUid? user, EntityUid thrown, EntityUid target)
+        public ThrowEvent(EntityUid thrown, EntityUid target, ThrownItemComponent component)
         {
-            User = user;
             Thrown = thrown;
             Target = target;
+            Component = component;
         }
     }
 
@@ -33,7 +22,7 @@ namespace Content.Shared.Throwing
     /// </summary>
     public sealed class ThrowHitByEvent : ThrowEvent
     {
-        public ThrowHitByEvent(EntityUid? user, EntityUid thrown, EntityUid target) : base(user, thrown, target)
+        public ThrowHitByEvent(EntityUid thrown, EntityUid target, ThrownItemComponent component) : base(thrown, target, component)
         {
         }
     }
@@ -43,7 +32,7 @@ namespace Content.Shared.Throwing
     /// </summary>
     public sealed class ThrowDoHitEvent : ThrowEvent
     {
-        public ThrowDoHitEvent(EntityUid? user, EntityUid thrown, EntityUid target) : base(user, thrown, target)
+        public ThrowDoHitEvent(EntityUid thrown, EntityUid target, ThrownItemComponent component) : base(thrown, target, component)
         {
         }
     }

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -73,11 +73,10 @@ namespace Content.Shared.Throwing
             if (args.OtherFixture.Hard == false)
                 return;
 
-            var thrower = component.Thrower;
-            if (args.OtherEntity == thrower)
+            if (args.OtherEntity == component.Thrower)
                 return;
 
-            ThrowCollideInteraction(thrower, args.OurEntity, args.OtherEntity);
+            ThrowCollideInteraction(component, args.OurEntity, args.OtherEntity);
         }
 
         private void PreventCollision(EntityUid uid, ThrownItemComponent component, ref PreventCollideEvent args)
@@ -145,14 +144,14 @@ namespace Content.Shared.Throwing
         /// <summary>
         ///     Raises collision events on the thrown and target entities.
         /// </summary>
-        public void ThrowCollideInteraction(EntityUid? user, EntityUid thrown, EntityUid target)
+        public void ThrowCollideInteraction(ThrownItemComponent component, EntityUid thrown, EntityUid target)
         {
-            if (user is not null)
+            if (component.Thrower is not null)
                 _adminLogger.Add(LogType.ThrowHit, LogImpact.Low,
-                    $"{ToPrettyString(thrown):thrown} thrown by {ToPrettyString(user.Value):thrower} hit {ToPrettyString(target):target}.");
+                    $"{ToPrettyString(thrown):thrown} thrown by {ToPrettyString(component.Thrower.Value):thrower} hit {ToPrettyString(target):target}.");
 
-            RaiseLocalEvent(target, new ThrowHitByEvent(user, thrown, target), true);
-            RaiseLocalEvent(thrown, new ThrowDoHitEvent(user, thrown, target), true);
+            RaiseLocalEvent(target, new ThrowHitByEvent(thrown, target, component), true);
+            RaiseLocalEvent(thrown, new ThrowDoHitEvent(thrown, target, component), true);
         }
     }
 }

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -115,8 +115,13 @@ namespace Content.Shared.Throwing
             EntityManager.RemoveComponent<ThrownItemComponent>(uid);
         }
 
-        public void LandComponent(EntityUid uid, ThrownItemComponent thrownItem, PhysicsComponent physics, bool playSound)
+        public void LandComponent(EntityUid uid, ThrownItemComponent thrownItem, PhysicsComponent? physics = null, bool playSound = true)
         {
+            if (!Resolve(uid, ref physics))
+            {
+                return;
+            }
+
             _physics.SetBodyStatus(physics, BodyStatus.OnGround);
 
             if (thrownItem.Deleted || Deleted(uid) || _containerSystem.IsEntityInContainer(uid))

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -45,7 +45,7 @@ namespace Content.Shared.Throwing
 
         private void OnHandleState(EntityUid uid, ThrownItemComponent component, ref ComponentHandleState args)
         {
-            if (args.Current is not ThrownItemComponentState {Thrower: not null } state ||
+            if (args.Current is not ThrownItemComponentState { Thrower: not null } state ||
                 !state.Thrower.Value.IsValid())
             {
                 return;
@@ -77,7 +77,7 @@ namespace Content.Shared.Throwing
             if (args.OtherEntity == thrower)
                 return;
 
-            ThrowCollideInteraction(thrower, args.OurBody, args.OtherBody);
+            ThrowCollideInteraction(thrower, args.OurEntity, args.OtherEntity);
         }
 
         private void PreventCollision(EntityUid uid, ThrownItemComponent component, ref PreventCollideEvent args)
@@ -145,14 +145,14 @@ namespace Content.Shared.Throwing
         /// <summary>
         ///     Raises collision events on the thrown and target entities.
         /// </summary>
-        public void ThrowCollideInteraction(EntityUid? user, PhysicsComponent thrown, PhysicsComponent target)
+        public void ThrowCollideInteraction(EntityUid? user, EntityUid thrown, EntityUid target)
         {
             if (user is not null)
                 _adminLogger.Add(LogType.ThrowHit, LogImpact.Low,
-                    $"{ToPrettyString(thrown.Owner):thrown} thrown by {ToPrettyString(user.Value):thrower} hit {ToPrettyString(target.Owner):target}.");
-            // TODO: Just pass in the bodies directly
-            RaiseLocalEvent(target.Owner, new ThrowHitByEvent(user, thrown.Owner, target.Owner), true);
-            RaiseLocalEvent(thrown.Owner, new ThrowDoHitEvent(user, thrown.Owner, target.Owner), true);
+                    $"{ToPrettyString(thrown):thrown} thrown by {ToPrettyString(user.Value):thrower} hit {ToPrettyString(target):target}.");
+
+            RaiseLocalEvent(target, new ThrowHitByEvent(user, thrown, target), true);
+            RaiseLocalEvent(thrown, new ThrowDoHitEvent(user, thrown, target), true);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![Peek 2023-08-01 22-05](https://github.com/space-wizards/space-station-14/assets/40753025/744f307b-105b-43e2-8ed2-42a7957e953d)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Hitting entities with thrown items that deal damage now provide more feedback (sound and visual effect).
- tweak: Thrown items that damage other entities now land after first hit.
