### PR TITLE
Flash/Welding protection for syndi mask and engi gogs

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -63,6 +63,7 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/meson.rsi
   - type: EyeProtection
+  - type: FlashImmunity
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -39,7 +39,6 @@
     sprite: Clothing/Mask/gassyndicate.rsi
   - type: FlashImmunity
   - type: EyeProtection
-    protectionTime: 5
 
 - type: entity
   parent: ClothingMaskGas


### PR DESCRIPTION
## About the PR
The welding mask protects against welding AND flashes, so why shouldn't the engi goggles do the same? The syndicate gas mask protects against welding because I feel that anything that can withstand a flash can withstand welding.

**Media**
N/A

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: The syndicate gas mask as well as engineering goggles now protect against both welding and flashes.