### PR TITLE
Dump stored items in crafting reagents

### DIFF
--- a/Content.Client/Commands/ActionsCommands.cs
+++ b/Content.Client/Commands/ActionsCommands.cs
@@ -1,4 +1,4 @@
-using Content.Client.Actions;
+﻿using Content.Client.Actions;
 using Content.Client.Mapping;
 using Content.Shared.Administration;
 using Robust.Shared.Console;

--- a/Content.Client/Commands/ActionsCommands.cs
+++ b/Content.Client/Commands/ActionsCommands.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Actions;
+using Content.Client.Actions;
 using Content.Client.Mapping;
 using Content.Shared.Administration;
 using Robust.Shared.Console;

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -16,10 +16,8 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Storage;
-using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Players;
-using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Construction
@@ -32,10 +30,7 @@ namespace Content.Server.Construction
         [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
         [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
-        [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
-        [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly StorageSystem _storageSystem = default!;
-        [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
 
         // --- WARNING! LEGACY CODE AHEAD! ---
         // This entire file contains the legacy code for initial construction.

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Content.Server.Construction.Components;
 using Content.Server.Storage.Components;
+using Content.Server.Storage.EntitySystems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Construction;
 using Content.Shared.Construction.Prototypes;
@@ -15,6 +16,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Storage;
+using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Players;
 using Robust.Shared.Random;
@@ -32,6 +34,8 @@ namespace Content.Server.Construction
         [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
+        [Dependency] private readonly StorageSystem _storageSystem = default!;
+        [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
 
         // --- WARNING! LEGACY CODE AHEAD! ---
         // This entire file contains the legacy code for initial construction.
@@ -208,15 +212,15 @@ namespace Content.Server.Construction
                                 continue;
 
                             // Dump out any stored entities in used entity
-                            if (TryComp<SharedStorageComponent>(entity, out var storage) && storage.StoredEntities != null)
+                            if (TryComp<ServerStorageComponent>(entity, out var storage) && storage.StoredEntities != null)
                             {
                                 foreach (var storedEntity in storage.StoredEntities.ToList())
                                 {
+                                    _storageSystem.RemoveAndDrop(entity, storedEntity, storage);
+
                                     var transform = Transform(storedEntity);
                                     _container.AttachParentToContainerOrGrid(transform);
-                                    _transformSystem.SetLocalPositionRotation(transform, transform.LocalPosition + _random.NextVector2Box() / 2, _random.NextAngle());
-
-                                    storage.Remove(storedEntity);
+                                    _transformSystem.SetLocalPositionRotation(transform, transform.LocalPosition + _random.NextVector2Box() / 4, _random.NextAngle());
                                 }
                             }
 

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -1,8 +1,6 @@
-using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Content.Server.Chemistry.ReagentEffects;
 using Content.Server.Construction.Components;
 using Content.Server.Storage.Components;
 using Content.Shared.ActionBlocker;

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -217,10 +217,6 @@ namespace Content.Server.Construction
                                 foreach (var storedEntity in storage.StoredEntities.ToList())
                                 {
                                     _storageSystem.RemoveAndDrop(entity, storedEntity, storage);
-
-                                    var transform = Transform(storedEntity);
-                                    _container.AttachParentToContainerOrGrid(transform);
-                                    _transformSystem.SetLocalPositionRotation(transform, transform.LocalPosition + _random.NextVector2Box() / 4, _random.NextAngle());
                                 }
                             }
 
@@ -229,13 +225,11 @@ namespace Content.Server.Construction
                                 if (!container.Insert(entity))
                                     continue;
                             }
-
                             else if (!GetContainer(arbitraryStep.Store).Insert(entity))
                                 continue;
 
                             handled = true;
                             used.Add(entity);
-
                             break;
                         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

This PR attempts to resolve issue #10852. When a storage container is used as a reagent for crafting, the items stored inside of it are dumped on the ground.

Attempting to craft a medibot with a full medkit (sans health analyzer)
![medibot-crafting1](https://github.com/space-wizards/space-station-14/assets/50505512/978e00f2-9f57-48fb-9fef-d20f851eef55)

All contents of the medkit are dumped the ground when crafting starts
![medibot-crafting2](https://github.com/space-wizards/space-station-14/assets/50505512/66b16b2a-30cd-4957-a74b-f510dbd62347)

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Containers used in recipes now drop their contents when crafted.