### PR TITLE
Construct and upgrade mini gravity generator

### DIFF
--- a/Content.Server/Gravity/GravityGeneratorComponent.cs
+++ b/Content.Server/Gravity/GravityGeneratorComponent.cs
@@ -1,4 +1,6 @@
-﻿using Content.Shared.Gravity;
+using Content.Shared.Gravity;
+using Content.Shared.Construction.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Gravity
 {
@@ -29,8 +31,14 @@ namespace Content.Server.Gravity
         [DataField("intact")]
         public bool Intact { get; set; } = true;
 
+        [DataField("maxCharge")]
+        public float MaxCharge { get; set; } = 1;
+
         // 0 -> 1
         [ViewVariables(VVAccess.ReadWrite)] [DataField("charge")] public float Charge { get; set; } = 1;
+
+        [DataField("machinePartMaxChargeMultiplier", customTypeSerializer: typeof(PrototypeIdSerializer<MachinePartPrototype>))]
+        public string MachinePartMaxChargeMultiplier = "Capacitor";
 
         /// <summary>
         /// Is the gravity generator currently "producing" gravity?

--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -259,8 +259,8 @@ namespace Content.Server.Gravity
 
         private void OnRefreshParts(EntityUid uid, GravityGeneratorComponent component, RefreshPartsEvent args)
         {
-            //var maxChargeMultipler = args.PartRatings[component.MachinePartMaxChargeMultiplier];
-            //component.MaxCharge = maxChargeMultipler * 1;
+            var maxChargeMultipler = args.PartRatings[component.MachinePartMaxChargeMultiplier];
+            component.MaxCharge = maxChargeMultipler * 1;
         }
 
         private void MakeBroken(EntityUid uid, GravityGeneratorComponent component, AppearanceComponent? appearance)

--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -27,7 +27,7 @@ namespace Content.Server.Gravity
             SubscribeLocalEvent<GravityGeneratorComponent, ComponentShutdown>(OnComponentShutdown);
             SubscribeLocalEvent<GravityGeneratorComponent, EntParentChangedMessage>(OnParentChanged); // Or just anchor changed?
             SubscribeLocalEvent<GravityGeneratorComponent, InteractHandEvent>(OnInteractHand);
-            //SubscribeLocalEvent<GravityGeneratorComponent, RefreshPartsEvent>(OnRefreshParts);
+            SubscribeLocalEvent<GravityGeneratorComponent, RefreshPartsEvent>(OnRefreshParts);
             SubscribeLocalEvent<GravityGeneratorComponent, SharedGravityGeneratorComponent.SwitchGeneratorMessage>(
                 OnSwitchGenerator);
         }
@@ -257,11 +257,11 @@ namespace Content.Server.Gravity
             }
         }
 
-        /*private void OnRefreshParts(EntityUid uid, GravityGeneratorComponent component, RefreshPartsEvent args)
+        private void OnRefreshParts(EntityUid uid, GravityGeneratorComponent component, RefreshPartsEvent args)
         {
             var maxChargeMultipler = args.PartRatings[component.MachinePartMaxChargeMultiplier];
             component.MaxCharge = maxChargeMultipler * 1;
-        }*/
+        }
 
         private void MakeBroken(EntityUid uid, GravityGeneratorComponent component, AppearanceComponent? appearance)
         {

--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -259,8 +259,8 @@ namespace Content.Server.Gravity
 
         private void OnRefreshParts(EntityUid uid, GravityGeneratorComponent component, RefreshPartsEvent args)
         {
-            var maxChargeMultipler = args.PartRatings[component.MachinePartMaxChargeMultiplier];
-            component.MaxCharge = maxChargeMultipler * 1;
+            //var maxChargeMultipler = args.PartRatings[component.MachinePartMaxChargeMultiplier];
+            //component.MaxCharge = maxChargeMultipler * 1;
         }
 
         private void MakeBroken(EntityUid uid, GravityGeneratorComponent component, AppearanceComponent? appearance)

--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -27,7 +27,7 @@ namespace Content.Server.Gravity
             SubscribeLocalEvent<GravityGeneratorComponent, ComponentShutdown>(OnComponentShutdown);
             SubscribeLocalEvent<GravityGeneratorComponent, EntParentChangedMessage>(OnParentChanged); // Or just anchor changed?
             SubscribeLocalEvent<GravityGeneratorComponent, InteractHandEvent>(OnInteractHand);
-            SubscribeLocalEvent<GravityGeneratorComponent, RefreshPartsEvent>(OnRefreshParts);
+            //SubscribeLocalEvent<GravityGeneratorComponent, RefreshPartsEvent>(OnRefreshParts);
             SubscribeLocalEvent<GravityGeneratorComponent, SharedGravityGeneratorComponent.SwitchGeneratorMessage>(
                 OnSwitchGenerator);
         }
@@ -257,11 +257,11 @@ namespace Content.Server.Gravity
             }
         }
 
-        private void OnRefreshParts(EntityUid uid, GravityGeneratorComponent component, RefreshPartsEvent args)
+        /*private void OnRefreshParts(EntityUid uid, GravityGeneratorComponent component, RefreshPartsEvent args)
         {
             var maxChargeMultipler = args.PartRatings[component.MachinePartMaxChargeMultiplier];
             component.MaxCharge = maxChargeMultipler * 1;
-        }
+        }*/
 
         private void MakeBroken(EntityUid uid, GravityGeneratorComponent component, AppearanceComponent? appearance)
         {

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -919,3 +919,19 @@
       Steel: 5
       CableHV: 5
       Cable: 2
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  id: MiniGravityGeneratorCircuitboard
+  name: mini gravity generator machine board
+  description: A machine printed circuit board for a mini gravity generator.
+  components:
+  - type: MachineBoard
+    prototype: GravityGeneratorMini
+    requirements:
+      Capacitor: 4
+      MatterBin: 3
+    materialRequirements:
+      Steel: 5
+      CableHV: 5
+      Uranium: 2

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -132,7 +132,5 @@
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
-    #switchedOn: false   
-    #charge: 0
   - type: StaticPrice
     price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -132,7 +132,7 @@
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
-    #switchedOn: false   
-    #charge: 0
+    switchedOn: false   
+    charge: 0
   - type: StaticPrice
     price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -132,7 +132,7 @@
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
-    switchedOn: false   
-    charge: 0
+    #switchedOn: false   
+    #charge: 0
   - type: StaticPrice
     price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -125,14 +125,14 @@
     LayoutId: MiniGravityGenerator        
   - type: Machine
     board: MiniGravityGeneratorCircuitboard
-  - type: ApcPowerReceiver
-    powerLoad: 500
   - type: GravityGenerator
     idlePower: 15
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
-    #switchedOn: false   
+    switchedOn: false   
     charge: 0
+  - type: ApcPowerReceiver
+    powerLoad: 500
   - type: StaticPrice
     price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -125,14 +125,14 @@
     LayoutId: MiniGravityGenerator        
   - type: Machine
     board: MiniGravityGeneratorCircuitboard
+  - type: ApcPowerReceiver
+    powerLoad: 500
   - type: GravityGenerator
     idlePower: 15
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
-    switchedOn: false   
+    #switchedOn: false   
     charge: 0
-  - type: ApcPowerReceiver
-    powerLoad: 500
   - type: StaticPrice
     price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -132,7 +132,7 @@
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
-    switchedOn: false   
+    #switchedOn: false   
     charge: 0
   - type: StaticPrice
     price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -76,7 +76,7 @@
 
 - type: entity
   id: GravityGeneratorMini
-  parent: [ GravityGenerator, ConstructibleMachine ]
+  parent: GravityGenerator
   name: mini gravity generator
   description: It's what keeps you to the floor, now in fun size.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -132,7 +132,7 @@
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
-    #switchedOn: false   
+    switchedOn: false   
     charge: 0
   - type: StaticPrice
     price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -12,7 +12,6 @@
     range: 7
     sound:
       path: /Audio/Ambience/Objects/gravity_gen_hum.ogg
-
   - type: Sprite
     sprite: Structures/Machines/gravity_generator.rsi
     layers:
@@ -77,7 +76,7 @@
 
 - type: entity
   id: GravityGeneratorMini
-  parent: GravityGenerator
+  parent: [ GravityGenerator, ConstructibleMachine ]
   name: mini gravity generator
   description: It's what keeps you to the floor, now in fun size.
   components:
@@ -104,6 +103,28 @@
         - LargeMobMask
         layer:
         - WallLayer
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 500
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/metalbreak.ogg
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MachineFrameDestroyed:
+            min: 1
+            max: 1  
+  - type: WiresPanel
+  - type: Wires
+    BoardName: "MiniGravityGenerator"
+    LayoutId: MiniGravityGenerator        
+  - type: Machine
+    board: MiniGravityGeneratorCircuitboard
   - type: ApcPowerReceiver
     powerLoad: 500
   - type: GravityGenerator
@@ -111,5 +132,7 @@
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
+    switchedOn: false   
+    charge: 0
   - type: StaticPrice
     price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -76,7 +76,7 @@
 
 - type: entity
   id: GravityGeneratorMini
-  parent: GravityGenerator
+  parent: [ GravityGenerator, ConstructibleMachine ]
   name: mini gravity generator
   description: It's what keeps you to the floor, now in fun size.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -306,6 +306,7 @@
       - EmitterCircuitboard
       - ThrusterMachineCircuitboard
       - GyroscopeMachineCircuitboard
+      - MiniGravityGeneratorCircuitboard
       - GasRecyclerMachineCircuitboard
       - SeedExtractorMachineCircuitboard
       - AnalysisComputerCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -653,3 +653,12 @@
   materials:
      Steel: 100
      Glass: 900
+
+- type: latheRecipe
+  id: MiniGravityGeneratorCircuitboard
+  result: MiniGravityGeneratorCircuitboard
+  completetime: 6
+  materials:
+     Steel: 100
+     Glass: 900
+     Gold: 100     

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -125,6 +125,7 @@
   - RadarConsoleCircuitboard
   - ThrusterMachineCircuitboard
   - GyroscopeMachineCircuitboard
+  - MiniGravityGeneratorCircuitboard
 
 - type: technology
   id: RipleyAPLU


### PR DESCRIPTION
## About the PR

Now the mini gravity generator can be assembled/disassembled, the necessary machine board has been added to ShuttleCraft technology. Now it is possible to destroy the mini gravity generator and improve its components, thereby increasing the maximum charge of the generator.


**Media**
1)https://drive.google.com/file/d/199woi4hv5eIy8C-B9otiFboMLGpCScH4/view?usp=drive_link     - construct, upgrade and charging test.
2)https://drive.google.com/file/d/1P4-uIg1x6vsFdAmgf_oKm82p5SE-hdQn/view?usp=drive_link    - deconstruct test.
3)https://drive.google.com/file/d/1lziqvET_6L2MUR19T6P5KrjfsplaW8_-/view?usp=drive_link      - destruct test.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Just_Art
- add: Now a mini gravity generator can be constructed using a machine board and deconstructed.
- add: The mini gravity generator can be improved by replacing capacitors, which will increase the maximum charge of the generator.
- tweak: The amount of damage required to destroy the mini gravity generator has been changed, and now it is completely destroyed, but it can still be restored by welding.
