### PR TITLE
Xeno spitter fixes

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Client.Items;
 using Content.Client.Weapons.Ranged.Components;
 using Content.Shared.Camera;
+using Content.Shared.CombatMode;
 using Content.Shared.Spawners.Components;
 using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
@@ -126,7 +127,7 @@ public sealed partial class GunSystem : SharedGunSystem
 
         var entityNull = _player.LocalPlayer?.ControlledEntity;
 
-        if (entityNull == null)
+        if (entityNull == null || !TryComp<CombatModeComponent>(entityNull, out var combat) || !combat.IsInCombatMode)
         {
             return;
         }

--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -40,6 +40,12 @@ public sealed class NPCSteeringComponent : Component
     #endregion
 
     /// <summary>
+    /// Set to true from other systems if you wish to force the NPC to move closer.
+    /// </summary>
+    [DataField("forceMove")]
+    public bool ForceMove = false;
+
+    /// <summary>
     /// Next time we can change our steering direction.
     /// </summary>
     [DataField("nextSteer", customTypeSerializer:typeof(TimeOffsetSerializer))]

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -1,6 +1,7 @@
 using Content.Server.NPC.Components;
 using Content.Shared.CombatMode;
 using Content.Shared.Interaction;
+using Content.Shared.Physics;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Map;
@@ -132,13 +133,20 @@ public sealed partial class NPCCombatSystem
             if (comp.LOSAccumulator < 0f)
             {
                 comp.LOSAccumulator += UnoccludedCooldown;
-                comp.TargetInLOS = _interaction.InRangeUnobstructed(uid, comp.Target, distance + 0.1f);
+                // For consistency with NPC steering.
+                comp.TargetInLOS = _interaction.InRangeUnobstructed(uid, Transform(comp.Target).Coordinates, distance + 0.1f);
             }
 
             if (!comp.TargetInLOS)
             {
                 comp.ShootAccumulator = 0f;
                 comp.Status = CombatStatus.NotInSight;
+
+                if (TryComp(uid, out steering))
+                {
+                    steering.ForceMove = true;
+                }
+
                 continue;
             }
 
@@ -188,8 +196,13 @@ public sealed partial class NPCCombatSystem
                 targetCordinates = new EntityCoordinates(xform.MapUid!.Value, targetSpot);
             }
 
+            if (gun.NextFire > _timing.CurTime)
+            {
+                comp.Status = CombatStatus.Normal;
+                return;
+            }
+
             _gun.AttemptShoot(uid, gunUid, gun, targetCordinates);
-            comp.Status = CombatStatus.Normal;
         }
     }
 }

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -196,9 +196,10 @@ public sealed partial class NPCCombatSystem
                 targetCordinates = new EntityCoordinates(xform.MapUid!.Value, targetSpot);
             }
 
+            comp.Status = CombatStatus.Normal;
+
             if (gun.NextFire > _timing.CurTime)
             {
-                comp.Status = CombatStatus.Normal;
                 return;
             }
 

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -81,7 +81,7 @@ public sealed partial class NPCSteeringSystem
 
         // Check if we're in LOS if that's required.
         // TODO: Need something uhh better not sure on the interaction between these.
-        if (steering.ArriveOnLineOfSight)
+        if (!steering.ForceMove && steering.ArriveOnLineOfSight)
         {
             // TODO: use vision range
             inLos = _interaction.InRangeUnobstructed(uid, steering.Coordinates, 10f);
@@ -105,6 +105,7 @@ public sealed partial class NPCSteeringSystem
         else
         {
             steering.LineOfSightTimer = 0f;
+            steering.ForceMove = false;
         }
 
         // We've arrived, nothing else matters.

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -126,8 +126,11 @@ public abstract partial class SharedGunSystem : EntitySystem
         var user = args.SenderSession.AttachedEntity;
 
         if (user == null ||
+            !_combatMode.IsInCombatMode(user) ||
             !TryGetGun(user.Value, out var ent, out var gun))
+        {
             return;
+        }
 
         if (ent != msg.Gun)
             return;
@@ -164,9 +167,6 @@ public abstract partial class SharedGunSystem : EntitySystem
     {
         gunEntity = default;
         gunComp = null;
-
-        if (!_combatMode.IsInCombatMode(entity))
-            return false;
 
         if (EntityManager.TryGetComponent(entity, out HandsComponent? hands) &&
             hands.ActiveHandEntity is { } held &&

--- a/Resources/Prototypes/NPCs/Combat/gun.yml
+++ b/Resources/Prototypes/NPCs/Combat/gun.yml
@@ -71,6 +71,7 @@
 
         - !type:HTNPrimitiveTask
           preconditions:
+            - !type:ActiveHandFreePrecondition
             - !type:TargetInRangePrecondition
               targetKey: Target
               rangeKey: InteractRange

--- a/Resources/Prototypes/NPCs/Combat/melee.yml
+++ b/Resources/Prototypes/NPCs/Combat/melee.yml
@@ -38,6 +38,7 @@
 
         - !type:HTNPrimitiveTask
           preconditions:
+            - !type:ActiveHandFreePrecondition
             - !type:TargetInRangePrecondition
               targetKey: Target
               rangeKey: InteractRange


### PR DESCRIPTION
- Require hands for pickup compounds
- Ranged combat can force movement to ignore LOS checks if ranged wants better LOS.

:cl:
- fix: Fix xenos not spittin'.
