### PR TITLE
nitrous oxide causes laughing

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -257,6 +257,22 @@
         visualType: Medium
         messages: [ "effect-sleepy" ]
         probability: 0.1
+      - !type:Emote
+        conditions:
+        - !type:ReagentThreshold
+          reagent: NitrousOxide
+          min: 0.3
+        emote: Laugh
+        showInChat: true
+        probability: 0.1
+      - !type:Emote
+        conditions:
+        - !type:ReagentThreshold
+          reagent: NitrousOxide
+          min: 0.3
+        emote: Scream
+        showInChat: true
+        probability: 0.01
       - !type:MovespeedModifier
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -245,6 +245,22 @@
   metabolisms:
     Gas:
       effects:
+      - !type:Emote
+        conditions:
+        - !type:ReagentThreshold
+          reagent: NitrousOxide
+          min: 0.2
+        emote: Laugh
+        showInChat: true
+        probability: 0.1
+      - !type:Emote
+        conditions:
+        - !type:ReagentThreshold
+          reagent: NitrousOxide
+          min: 0.2
+        emote: Scream
+        showInChat: true
+        probability: 0.01
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold
@@ -257,22 +273,6 @@
         visualType: Medium
         messages: [ "effect-sleepy" ]
         probability: 0.1
-      - !type:Emote
-        conditions:
-        - !type:ReagentThreshold
-          reagent: NitrousOxide
-          min: 0.3
-        emote: Laugh
-        showInChat: true
-        probability: 0.1
-      - !type:Emote
-        conditions:
-        - !type:ReagentThreshold
-          reagent: NitrousOxide
-          min: 0.3
-        emote: Scream
-        showInChat: true
-        probability: 0.01
       - !type:MovespeedModifier
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
## About the PR
:trollface:

Considerable nitrous oxide levels in the air cause laughing, rarely screaming, allegedly due to hallucinations.


**Media**

https://github.com/space-wizards/space-station-14/assets/69696513/83a38e13-b7d2-44e0-bf85-ad9936d33ee5



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl:
- add: Nitrous oxide now causes laughing
