### PR TITLE
syndi mask tweak

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -39,7 +39,6 @@
     sprite: Clothing/Mask/gassyndicate.rsi
   - type: FlashImmunity
   - type: EyeProtection
-    protectionTime: 5
 
 - type: entity
   parent: ClothingMaskGas


### PR DESCRIPTION
## About the PR
Yesterday I made basically the same change, except I also made the engi goggles flash proof. As people pointed out and in hindsight, that's not the greatest idea for balance and I've closed that PR, so thanks for calling me out on that. I still feel making the syndi mask welder proof is fair.

**Media**
N/A

**Changelog**

:cl:
- tweak: The Syndicate gas mask now protects your eyes from welders.
