### PR TITLE
Fixes GLES2 not booting due to error in outline.swsl

### DIFF
--- a/Resources/Textures/Shaders/outline.swsl
+++ b/Resources/Textures/Shaders/outline.swsl
@@ -72,7 +72,7 @@ void fragment() {
     maxa = max(a, maxa);
     mina = min(a, mina);
 
-	float sampledLight = outline_fullbright ? 1.0 : sqrt(mix(0.0, 1.0, (lightSample.r * 0.34) + (lightSample.g * 0.5) + (lightSample.b * 0.16)) * light_boost);
+	lowp float sampledLight = outline_fullbright ? 1.0 : sqrt(mix(0.0, 1.0, (lightSample.r * 0.34) + (lightSample.g * 0.5) + (lightSample.b * 0.16)) * light_boost);
 	COLOR = mix(col, outline_color * sampledLight, maxa - col.a);
 	lightSample = vec3(1.0);
 }


### PR DESCRIPTION
## About the PR
It turns out GLES2 does not like it if you define a float without specifying the precision.


oops

**Changelog**


:cl: Bhijn and Myr
- fix: The game now boots in GLES2 again. oops.
