### PR TITLE
Warn on improperly disposed tests.

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -51,7 +51,7 @@ jobs:
       shell: pwsh
       run: |
         $env:DOTNET_gcServer=1
-        dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0
+        dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed
   ci-success:
     name: Build & Test Debug
     needs:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -51,7 +51,7 @@ jobs:
       shell: pwsh
       run: |
         $env:DOTNET_gcServer=1
-        dotnet test --configuration Tools --no-build Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0
+        dotnet test --configuration Tools --no-build Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed
   ci-success:
     name: Build & Test Release
     needs:

--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -947,6 +947,10 @@ public sealed class PairTracker : IAsyncDisposable
         _testOut = testOut;
     }
 
+    // Convenience properties.
+    public RobustIntegrationTest.ServerIntegrationInstance Server => Pair.Server;
+    public RobustIntegrationTest.ClientIntegrationInstance Client => Pair.Client;
+
     private async Task OnDirtyDispose()
     {
         var usageTime = UsageWatch.Elapsed;
@@ -957,6 +961,10 @@ public sealed class PairTracker : IAsyncDisposable
         PoolManager.NoCheckReturn(Pair);
         var disposeTime = dirtyWatch.Elapsed;
         await _testOut.WriteLineAsync($"{nameof(DisposeAsync)}: Disposed pair {Pair.PairId} in {disposeTime.TotalMilliseconds} ms");
+
+        // Test pairs should only dirty dispose if they are failing. If they are not failing, this probably happened
+        // because someone forgot to clean-return the pair.
+        Assert.Warn("Test was dirty-disposed.");
     }
 
     private async Task OnCleanDispose()


### PR DESCRIPTION
Adds a warning, and makes tests with warnings report as failed, in order to ensure that people remember to clean return tests. I use a warning rather than just using `Assert.Fail()` as this seems to preserve exceptions that are thrown inside of the test functions.