### PR TITLE
cow ops 2

### DIFF
--- a/Content.Server/Chemistry/ReactionEffects/CreateEntityReactionEffect.cs
+++ b/Content.Server/Chemistry/ReactionEffects/CreateEntityReactionEffect.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
@@ -28,13 +29,15 @@ public sealed class CreateEntityReactionEffect : ReagentEffect
     public override void Effect(ReagentEffectArgs args)
     {
         var transform = args.EntityManager.GetComponent<TransformComponent>(args.SolutionEntity);
+        var transformSystem = args.EntityManager.System<SharedTransformSystem>();
         var quantity = Number * args.Quantity.Int();
 
         for (var i = 0; i < quantity; i++)
         {
-            args.EntityManager.SpawnEntity(Entity, transform.MapPosition);
+            var uid = args.EntityManager.SpawnEntity(Entity, transform.MapPosition);
+            transformSystem.AttachToGridOrMap(uid);
 
-            // TODO figure out how to spawn inside of containers
+            // TODO figure out how to properly spawn inside of containers
             // e.g. cheese:
             // if the user is holding a bowl milk & enzyme, should drop to floor, not attached to the user.
             // if reaction happens in a backpack, should insert cheese into backpack.

--- a/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
@@ -21,15 +21,16 @@ namespace Content.Server.Nutrition.EntitySystems;
 /// </summary>
 public sealed class AnimalHusbandrySystem : EntitySystem
 {
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly HungerSystem _hunger = default!;
     [Dependency] private readonly IAdminLogManager _adminLog = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
-    [Dependency] private readonly HungerSystem _hunger = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     private readonly HashSet<EntityUid> _failedAttempts = new();
 
@@ -197,6 +198,7 @@ public sealed class AnimalHusbandrySystem : EntitySystem
         foreach (var spawn in spawns)
         {
             var offspring = Spawn(spawn, xform.Coordinates.Offset(_random.NextVector2(0.3f)));
+            _transform.AttachToGridOrMap(offspring);
             if (component.MakeOffspringInfant)
             {
                 var infant = AddComp<InfantComponent>(offspring);

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -8,6 +8,9 @@
   - type: SolutionContainerManager
   - type: Sprite
     state: produce
+  # let cows eat raw produce like wheat and oats
+  - type: Food
+    stomachs: 2
   - type: Produce
   - type: PotencyVisuals
   - type: Appearance

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -984,6 +984,7 @@
     seedId: flyAmanita
   - type: Extractable
     grindableSolutionName: food
+  - type: BadFood
 
 - type: entity
   name: gatfruit

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -10,7 +10,7 @@
     state: produce
   # let cows eat raw produce like wheat and oats
   - type: Food
-    stomachs: 2
+    requiredStomachs: 2
   - type: Produce
   - type: PotencyVisuals
   - type: Appearance

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -83,7 +83,6 @@
           nodeGroupID: Spreader
     - type: Food
       requiredStomachs: 2 # ruminants have 4 stomachs but i dont care to give them literally 4 stomachs. 2 is good
-      # TODO make botany plants edible to ruminants as well ...
       delay: 0.5
     - type: FlavorProfile
       flavors:


### PR DESCRIPTION
## About the PR
sequel to cow ops

- create entity reaction effect now attaches to grid, so cheese will parent properly.
  only bad thing i have seen from this not being done is on frontier i had to nudge shuttle slightly to make cows eat fresh cheese
- animal breeding thing see #18328 same thing, should prevent cows bred inside crates being deleted after crowbaring crate
- animals will eat raw produce like wheat and oats (fly amanita blacklisted)

**Media**
trust me it work...
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- tweak: Animals can now eat raw produce like wheat and oats.