### PR TITLE
Remove extraneous debug log from PickRule

### DIFF
--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -38,7 +38,6 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
         var rules = _prototypeManager.Index<GamePresetPrototype>(preset).Rules;
         foreach (var rule in rules)
         {
-            Logger.Debug($"what the fuck, {rule}");
             GameTicker.StartGameRule(rule, out var ruleEnt);
             component.AdditionalGameRules.Add(ruleEnt);
         }


### PR DESCRIPTION
I kept seeing this in my logs, and I don't know what it's for, therefore: wtf @EmoGarbage404 