### PR TITLE
Autocapitalize the word I in IC chat

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -183,9 +183,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         bool shouldCapitalize = (desiredType != InGameICChatType.Emote);
         bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
         // Capitalizing the word I only happens in English, so we check language here
-        var curCulture = CultureInfo.CurrentCulture;
-        bool shouldCapitalizeTheWordI = (!curCulture.IsNeutralCulture && curCulture.Parent.Name == "en")
-            || (curCulture.IsNeutralCulture && curCulture.Name == "en");
+        bool shouldCapitalizeTheWordI = (!CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Parent.Name == "en")
+            || (CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Name == "en");
 
         message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldPunctuate, shouldCapitalizeTheWordI);
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -181,13 +181,13 @@ public sealed partial class ChatSystem : SharedChatSystem
         }
 
         bool shouldCapitalize = (desiredType != InGameICChatType.Emote);
+        bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
         // Capitalizing the word I only happens in English, so we check language here
         var curCulture = CultureInfo.CurrentCulture;
         bool shouldCapitalizeTheWordI = (!curCulture.IsNeutralCulture && curCulture.Parent.Name == "en")
             || (curCulture.IsNeutralCulture && curCulture.Name == "en");
-        bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
 
-        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldCapitalizeTheWordI, shouldPunctuate);
+        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldPunctuate, shouldCapitalizeTheWordI);
 
         // Was there an emote in the message? If so, send it.
         if (player != null && emoteStr != message && emoteStr != null)
@@ -617,7 +617,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     }
 
     // ReSharper disable once InconsistentNaming
-    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool capitalizeTheWordI = true, bool punctuate = false)
+    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false, bool capitalizeTheWordI = true)
     {
         var newMessage = message.Trim();
         if (capitalize)

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -180,9 +180,10 @@ public sealed partial class ChatSystem : SharedChatSystem
         }
 
         bool shouldCapitalize = (desiredType != InGameICChatType.Emote);
+        bool shouldCapitalizeTheWordI = true;
         bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
 
-        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldPunctuate);
+        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldCapitalizeTheWordI, shouldPunctuate);
 
         // Was there an emote in the message? If so, send it.
         if (player != null && emoteStr != message && emoteStr != null)
@@ -612,11 +613,13 @@ public sealed partial class ChatSystem : SharedChatSystem
     }
 
     // ReSharper disable once InconsistentNaming
-    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false)
+    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool capitalizeTheWordI = true, bool punctuate = false)
     {
         var newMessage = message.Trim();
         if (capitalize)
             newMessage = SanitizeMessageCapital(newMessage);
+        if (capitalizeTheWordI)
+            newMessage = SanitizeMessageCapitalizeTheWordI(newMessage, "i");
         if (punctuate)
             newMessage = SanitizeMessagePeriod(newMessage);
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Content.Server.Administration.Logs;
@@ -180,7 +181,10 @@ public sealed partial class ChatSystem : SharedChatSystem
         }
 
         bool shouldCapitalize = (desiredType != InGameICChatType.Emote);
-        bool shouldCapitalizeTheWordI = true;
+        // Capitalizing the word I only happens in English, so we check language here
+        var curCulture = CultureInfo.CurrentCulture;
+        bool shouldCapitalizeTheWordI = (!curCulture.IsNeutralCulture && curCulture.Parent.Name == "en")
+            || (curCulture.IsNeutralCulture && curCulture.Name == "en");
         bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
 
         message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldCapitalizeTheWordI, shouldPunctuate);

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -131,4 +131,33 @@ public abstract class SharedChatSystem : EntitySystem
         message = char.ToUpper(message[0]) + message.Remove(0, 1);
         return message;
     }
+
+    public string SanitizeMessageCapitalizeTheWordI(string message, string theWordI = "i")
+    {
+        if (string.IsNullOrEmpty(message))
+            return message;
+
+        for
+        (
+            var index = message.IndexOf(theWordI);
+            index != -1;
+            index = message.IndexOf(theWordI, index + 1)
+        )
+        {
+            // Stops the code If It's tryIng to capItalIze the letter I In the mIddle of words
+            // Repeating the code twice is the simplest option
+            if (index + 1 < message.Length && char.IsLetter(message[index + 1]))
+                continue;
+            if (index - 1 >= 0 && char.IsLetter(message[index - 1]))
+                continue;
+
+            var beforeTarget = message.Substring(0, index);
+            var target = message.Substring(index, theWordI.Length);
+            var afterTarget = message.Substring(index + theWordI.Length);
+
+            message = beforeTarget + target.ToUpper() + afterTarget;
+        }
+
+        return message;
+    }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Since the beginning of Space Station 14 history, countless users have injured their pinky trying to reach the shift key to capitalize single-letter first person singular pronouns.

Now, if you and me can see i to I here, we'll both notice that this has changed.

At long last, whenever the letter "i" (in lowercase) is contained in a message sent in IC chat, it will be capitalized if the characters before and after the "i" are not "letters".

Obviously signifying this in variable names is kind of tough, so the variable names are a bit lacking in brevity.

For similar reasons I was unable to search for or locate any related PRs or issues, if they exist.

I rather lack experience in the structuring of these things, so if something should be moved somewhere then I'll have very much not noticed.

You may see that this prose sounds rather confident. That is in fact all a ruse as I have no idea what I am doing. I took a beginner's C# course and that's it. At least I avoided regular expressions.

addendum: English is the only language to capitalize the first person nominative singular pronoun of I, which helpfully fixes all of our localization problems for us. Regrettably this PR's function is only useful for capitalization of a single one-letter word, and will be rather useless for other languages' arbitrarily complex capitalization requirements.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
(all screenshot messages were typed in all lowercase)

![image](https://github.com/space-wizards/space-station-14/assets/113810873/548d1234-491f-49e4-aece-c529c5b9d40b)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/a82d07c5-9c10-49a1-b47a-de1b8118832f)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/c36c9a6e-f5b6-4d79-8054-2723cf7317ea)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/662d66ab-94be-4ddf-b39a-ed7deb922119)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/08e91254-b89b-4728-a422-46ed7639d8b0)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/81df0f3c-2878-4805-b14b-04d77d1709fb)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/05345425-6b0b-4bfc-bc3e-adbf0f3cfbf6)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/75b4f641-4fac-4cba-b06c-90862bd11bd3)

Bonus addendum screenshots:
![image](https://github.com/space-wizards/space-station-14/assets/113810873/4a4f36de-9b11-441b-9de5-62b6f34e87f7)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/3b13236c-7412-49c3-b0fa-617109e05cd5)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/bab6377e-13d6-416f-a0c8-b088ea19d6e6)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/ff9a8272-020b-4a9a-bc17-75910472abbe)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/a34f0d3f-3da4-446b-b372-b2ad921da0fe)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/14d7577f-1b07-41b0-9a75-0fea02abe196) "


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: The word "i" is now automatically capitalized in IC chat! Your pinky's structural integrity is now safe!