### PR TITLE
air alarm signal ports and other stuff

### DIFF
--- a/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
@@ -1,7 +1,10 @@
+using Content.Server.DeviceLinking.Components;
 using Content.Shared.Atmos.Monitor;
 using Content.Shared.Atmos.Monitor.Components;
 using Content.Shared.Atmos.Piping.Unary.Components;
+using Content.Shared.DeviceLinking;
 using Robust.Shared.Network;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Atmos.Monitor.Components;
 
@@ -24,4 +27,28 @@ public sealed class AirAlarmComponent : Component
     public HashSet<NetUserId> ActivePlayers = new();
 
     public bool CanSync = true;
+
+    /// <summary>
+    /// Previous alarm state for use with output ports.
+    /// </summary>
+    [DataField("state")]
+    public AtmosAlarmType State = AtmosAlarmType.Normal;
+
+    /// <summary>
+    /// The port that gets set to high while the alarm is in the danger state, and low when not.
+    /// </summary>
+    [DataField("dangerPort", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
+    public string DangerPort = "AirDanger";
+
+    /// <summary>
+    /// The port that gets set to high while the alarm is in the warning state, and low when not.
+    /// </summary>
+    [DataField("warningPort", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
+    public string WarningPort = "AirWarning";
+
+    /// <summary>
+    /// The port that gets set to high while the alarm is in the normal state, and low when not.
+    /// </summary>
+    [DataField("normalPort", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
+    public string NormalPort = "AirNormal";
 }

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -166,6 +166,7 @@ public sealed class AirAlarmSystem : EntitySystem
         SubscribeLocalEvent<AirAlarmComponent, DeviceListUpdateEvent>(OnDeviceListUpdate);
         SubscribeLocalEvent<AirAlarmComponent, BoundUIClosedEvent>(OnClose);
         SubscribeLocalEvent<AirAlarmComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<AirAlarmComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<AirAlarmComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<AirAlarmComponent, InteractHandEvent>(OnInteract);
     }
@@ -224,7 +225,10 @@ public sealed class AirAlarmSystem : EntitySystem
     private void OnInit(EntityUid uid, AirAlarmComponent comp, ComponentInit args)
     {
         _deviceLink.EnsureSourcePorts(uid, comp.DangerPort, comp.WarningPort, comp.NormalPort);
+    }
 
+    private void OnMapInit(EntityUid uid, AirAlarmComponent comp, MapInitEvent args)
+    {
         // for mapped linked air alarms, start with high so when it changes for the first time it goes from high to low
         // without this the output would suddenly get sent a low signal after nothing which is bad
         _deviceLink.SendSignal(uid, GetPort(comp), true);

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -41,7 +41,6 @@ public sealed class AirAlarmSystem : EntitySystem
     [Dependency] private readonly DeviceLinkSystem _deviceLink = default!;
     [Dependency] private readonly DeviceListSystem _deviceList = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
-    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
     #region Device Network API
@@ -238,9 +237,6 @@ public sealed class AirAlarmSystem : EntitySystem
 
     private void OnInteract(EntityUid uid, AirAlarmComponent component, InteractHandEvent args)
     {
-        if (!_interaction.InRangeUnobstructed(args.User, args.Target))
-            return;
-
         if (!TryComp<ActorComponent>(args.User, out var actor))
             return;
 

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Atmos.Monitor.Components;
 using Content.Server.Atmos.Piping.Components;
+using Content.Server.DeviceLinking.Systems;
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Components;
 using Content.Server.DeviceNetwork.Systems;
@@ -13,6 +14,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Atmos.Monitor;
 using Content.Shared.Atmos.Monitor.Components;
 using Content.Shared.Atmos.Piping.Unary.Components;
+using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Systems;
 using Content.Shared.Interaction;
@@ -32,14 +34,15 @@ namespace Content.Server.Atmos.Monitor.Systems;
 // response data in its data key.
 public sealed class AirAlarmSystem : EntitySystem
 {
-    [Dependency] private readonly DeviceNetworkSystem _deviceNet = default!;
-    [Dependency] private readonly DeviceListSystem _deviceListSystem = default!;
-    [Dependency] private readonly AtmosDeviceNetworkSystem _atmosDevNetSystem = default!;
+    [Dependency] private readonly AccessReaderSystem _access = default!;
     [Dependency] private readonly AtmosAlarmableSystem _atmosAlarmable = default!;
-    [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
-    [Dependency] private readonly AccessReaderSystem _accessSystem = default!;
+    [Dependency] private readonly AtmosDeviceNetworkSystem _atmosDevNet = default!;
+    [Dependency] private readonly DeviceNetworkSystem _deviceNet = default!;
+    [Dependency] private readonly DeviceLinkSystem _deviceLink = default!;
+    [Dependency] private readonly DeviceListSystem _deviceList = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
-    [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
     #region Device Network API
 
@@ -57,8 +60,8 @@ public sealed class AirAlarmSystem : EntitySystem
     /// <param name="data">The data to send to the device.</param>
     public void SetData(EntityUid uid, string address, IAtmosDeviceData data)
     {
-        _atmosDevNetSystem.SetDeviceState(uid, address, data);
-        _atmosDevNetSystem.Sync(uid, address);
+        _atmosDevNet.SetDeviceState(uid, address, data);
+        _atmosDevNet.Sync(uid, address);
     }
 
     /// <summary>
@@ -66,7 +69,7 @@ public sealed class AirAlarmSystem : EntitySystem
     /// </summary>
     private void SyncAllDevices(EntityUid uid)
     {
-        _atmosDevNetSystem.Sync(uid, null);
+        _atmosDevNet.Sync(uid, null);
     }
 
     /// <summary>
@@ -75,7 +78,7 @@ public sealed class AirAlarmSystem : EntitySystem
     /// <param name="address">The address of the device.</param>
     private void SyncDevice(EntityUid uid, string address)
     {
-        _atmosDevNetSystem.Sync(uid, address);
+        _atmosDevNet.Sync(uid, address);
     }
 
     /// <summary>
@@ -85,8 +88,8 @@ public sealed class AirAlarmSystem : EntitySystem
     /// <param name="uid"></param>
     private void SyncRegisterAllDevices(EntityUid uid)
     {
-        _atmosDevNetSystem.Register(uid, null);
-        _atmosDevNetSystem.Sync(uid, null);
+        _atmosDevNet.Register(uid, null);
+        _atmosDevNet.Sync(uid, null);
     }
 
     /// <summary>
@@ -133,8 +136,7 @@ public sealed class AirAlarmSystem : EntitySystem
     /// <param name="mode">The mode to sync with the rest of the network.</param>
     private void SyncMode(EntityUid uid, AirAlarmMode mode)
     {
-        if (EntityManager.TryGetComponent(uid, out AtmosMonitorComponent? monitor)
-            && !monitor.NetEnabled)
+        if (TryComp<AtmosMonitorComponent>(uid, out var monitor) && !monitor.NetEnabled)
             return;
 
         var payload = new NetworkPayload
@@ -164,6 +166,7 @@ public sealed class AirAlarmSystem : EntitySystem
         SubscribeLocalEvent<AirAlarmComponent, AirAlarmTabSetMessage>(OnTabChange);
         SubscribeLocalEvent<AirAlarmComponent, DeviceListUpdateEvent>(OnDeviceListUpdate);
         SubscribeLocalEvent<AirAlarmComponent, BoundUIClosedEvent>(OnClose);
+        SubscribeLocalEvent<AirAlarmComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<AirAlarmComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<AirAlarmComponent, InteractHandEvent>(OnInteract);
     }
@@ -178,7 +181,7 @@ public sealed class AirAlarmSystem : EntitySystem
                 continue;
             }
 
-            _atmosDevNetSystem.Deregister(uid, deviceNet.Address);
+            _atmosDevNet.Deregister(uid, deviceNet.Address);
         }
 
         component.ScrubberData.Clear();
@@ -219,6 +222,15 @@ public sealed class AirAlarmSystem : EntitySystem
             RemoveActiveInterface(uid);
     }
 
+    private void OnInit(EntityUid uid, AirAlarmComponent comp, ComponentInit args)
+    {
+        _deviceLink.EnsureSourcePorts(uid, comp.DangerPort, comp.WarningPort, comp.NormalPort);
+
+        // for mapped linked air alarms, start with high so when it changes for the first time it goes from high to low
+        // without this the output would suddenly get sent a low signal after nothing which is bad
+        _deviceLink.SendSignal(uid, GetPort(comp), true);
+    }
+
     private void OnShutdown(EntityUid uid, AirAlarmComponent component, ComponentShutdown args)
     {
         _activeUserInterfaces.Remove(uid);
@@ -226,7 +238,7 @@ public sealed class AirAlarmSystem : EntitySystem
 
     private void OnInteract(EntityUid uid, AirAlarmComponent component, InteractHandEvent args)
     {
-        if (!_interactionSystem.InRangeUnobstructed(args.User, args.Target))
+        if (!_interaction.InRangeUnobstructed(args.User, args.Target))
             return;
 
         if (!TryComp<ActorComponent>(args.User, out var actor))
@@ -241,9 +253,9 @@ public sealed class AirAlarmSystem : EntitySystem
         if (!this.IsPowered(uid, EntityManager))
             return;
 
-        var ui = _uiSystem.GetUiOrNull(uid, SharedAirAlarmInterfaceKey.Key);
+        var ui = _ui.GetUiOrNull(uid, SharedAirAlarmInterfaceKey.Key);
         if (ui != null)
-            _uiSystem.OpenUi(ui, actor.PlayerSession);
+            _ui.OpenUi(ui, actor.PlayerSession);
         component.ActivePlayers.Add(actor.PlayerSession.UserId);
         AddActiveInterface(uid);
         SyncAllDevices(uid);
@@ -267,12 +279,20 @@ public sealed class AirAlarmSystem : EntitySystem
 
     private void OnUpdateAlarmMode(EntityUid uid, AirAlarmComponent component, AirAlarmUpdateAlarmModeMessage args)
     {
-        var addr = string.Empty;
-        if (EntityManager.TryGetComponent(uid, out DeviceNetworkComponent? netConn)) addr = netConn.Address;
         if (AccessCheck(uid, args.Session.AttachedEntity, component))
+        {
+            var addr = string.Empty;
+            if (TryComp<DeviceNetworkComponent>(uid, out var netConn))
+            {
+                addr = netConn.Address;
+            }
+
             SetMode(uid, addr, args.Mode, false);
+        }
         else
+        {
             UpdateUI(uid, component);
+        }
     }
 
     private void OnUpdateAutoMode(EntityUid uid, AirAlarmComponent component, AirAlarmUpdateAutoModeMessage args)
@@ -292,7 +312,7 @@ public sealed class AirAlarmSystem : EntitySystem
     private void OnUpdateDeviceData(EntityUid uid, AirAlarmComponent component, AirAlarmUpdateDeviceDataMessage args)
     {
         if (AccessCheck(uid, args.Session.AttachedEntity, component)
-            && _deviceListSystem.ExistsInDeviceList(uid, args.Address))
+            && _deviceList.ExistsInDeviceList(uid, args.Address))
         {
             SetDeviceData(uid, args.Address, args.Data);
         }
@@ -307,10 +327,14 @@ public sealed class AirAlarmSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return false;
 
-        if (!EntityManager.TryGetComponent(uid, out AccessReaderComponent? reader) || user == null)
+        // if it has no access reader behave as if the user has AA
+        if (!TryComp<AccessReaderComponent>(uid, out var reader))
+            return true;
+
+        if (user == null)
             return false;
 
-        if (!_accessSystem.IsAllowed(user.Value, reader))
+        if (!_access.IsAllowed(user.Value, reader))
         {
             _popup.PopupEntity(Loc.GetString("air-alarm-ui-access-denied"), user.Value, user.Value);
             return false;
@@ -327,8 +351,10 @@ public sealed class AirAlarmSystem : EntitySystem
         }
 
         var addr = string.Empty;
-        if (EntityManager.TryGetComponent(uid, out DeviceNetworkComponent? netConn))
+        if (TryComp<DeviceNetworkComponent>(uid, out var netConn))
+        {
             addr = netConn.Address;
+        }
 
         if (component.AutoMode)
         {
@@ -342,7 +368,30 @@ public sealed class AirAlarmSystem : EntitySystem
             }
         }
 
+        if (component.State != args.AlarmType)
+        {
+            TryComp<DeviceLinkSourceComponent>(uid, out var source);
+
+            // send low to old state's port
+            _deviceLink.SendSignal(uid, GetPort(component), false, source);
+
+            // send high to new state's port, along with updating the cached state
+            component.State = args.AlarmType;
+            _deviceLink.SendSignal(uid, GetPort(component), true, source);
+        }
+
         UpdateUI(uid, component);
+    }
+
+    private string GetPort(AirAlarmComponent comp)
+    {
+        if (comp.State == AtmosAlarmType.Danger)
+            return comp.DangerPort;
+
+        if (comp.State == AtmosAlarmType.Warning)
+            return comp.WarningPort;
+
+        return comp.NormalPort;
     }
 
     #endregion
@@ -490,7 +539,7 @@ public sealed class AirAlarmSystem : EntitySystem
     /// </summary>
     private void ForceCloseAllInterfaces(EntityUid uid)
     {
-        _uiSystem.TryCloseAll(uid, SharedAirAlarmInterfaceKey.Key);
+        _ui.TryCloseAll(uid, SharedAirAlarmInterfaceKey.Key);
     }
 
     private void OnAtmosUpdate(EntityUid uid, AirAlarmComponent alarm, AtmosDeviceUpdateEvent args)
@@ -558,7 +607,7 @@ public sealed class AirAlarmSystem : EntitySystem
             highestAlarm = AtmosAlarmType.Normal;
         }
 
-        _uiSystem.TrySetUiState(
+        _ui.TrySetUiState(
             uid,
             SharedAirAlarmInterfaceKey.Key,
             new AirAlarmUIState(devNet.Address, deviceCount, pressure, temperature, dataToSend, alarm.CurrentMode, alarm.CurrentTab, highestAlarm.Value, alarm.AutoMode));

--- a/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
@@ -1,3 +1,4 @@
+﻿using Content.Server.DeviceLinking.Components;
 ﻿using Content.Server.DeviceLinking.Events;
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Components;
@@ -95,9 +96,23 @@ public sealed class DeviceLinkSystem : SharedDeviceLinkSystem
                     }
                 }
 
-                _deviceNetworkSystem.QueuePacket(uid, sinkNetworkComponent.Address, payload, sinkNetworkComponent.ReceiveFrequency);
+                // force using wireless network so things like atmos devices are able to send signals
+                var network = (int) DeviceNetworkComponent.DeviceNetIdDefaults.Wireless;
+                _deviceNetworkSystem.QueuePacket(uid, sinkNetworkComponent.Address, payload, sinkNetworkComponent.ReceiveFrequency, network);
             }
         }
+    }
+
+    /// <summary>
+    /// Helper function that invokes a port with a high/low binary logic signal.
+    /// </summary>
+    public void SendSignal(EntityUid uid, string port, bool signal, DeviceLinkSourceComponent? comp = null)
+    {
+        var data = new NetworkPayload
+        {
+            [DeviceNetworkConstants.LogicState] = signal ? SignalState.High : SignalState.Low
+        };
+        InvokePort(uid, port, data, comp);
     }
 
     /// <summary>

--- a/Content.Server/DeviceLinking/Systems/LogicGateSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/LogicGateSystem.cs
@@ -140,12 +140,7 @@ public sealed class LogicGateSystem : EntitySystem
         {
             comp.LastOutput = output;
 
-            var data = new NetworkPayload
-            {
-                [DeviceNetworkConstants.LogicState] = output ? SignalState.High : SignalState.Low
-            };
-
-            _deviceLink.InvokePort(uid, comp.OutputPort, data);
+            _deviceLink.SendSignal(uid, comp.OutputPort, output);
         }
     }
 }

--- a/Content.Server/DeviceLinking/Systems/SignalSwitchSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignalSwitchSystem.cs
@@ -30,15 +30,11 @@ public sealed class SignalSwitchSystem : EntitySystem
 
         comp.State = !comp.State;
         _deviceLink.InvokePort(uid, comp.State ? comp.OnPort : comp.OffPort);
-        var data = new NetworkPayload
-        {
-            [DeviceNetworkConstants.LogicState] = comp.State ? SignalState.High : SignalState.Low
-        };
 
         // only send status if it's a toggle switch and not a button
         if (comp.OnPort != comp.OffPort)
         {
-            _deviceLink.InvokePort(uid, comp.StatusPort, data);
+            _deviceLink.SendSignal(uid, comp.StatusPort, comp.State);
         }
 
         _audio.PlayPvs(comp.ClickSound, uid, AudioParams.Default.WithVariation(0.125f).WithVolume(8f));

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -66,7 +66,7 @@ namespace Content.Server.DeviceNetwork.Systems
         /// <param name="frequency">The frequency to send on</param>
         /// <param name="data">The data to be sent</param>
         /// <returns>Returns true when the packet was successfully enqueued.</returns>
-        public bool QueuePacket(EntityUid uid, string? address, NetworkPayload data, uint? frequency = null, DeviceNetworkComponent? device = null)
+        public bool QueuePacket(EntityUid uid, string? address, NetworkPayload data, uint? frequency = null, int? network = null, DeviceNetworkComponent? device = null)
         {
             if (!Resolve(uid, ref device, false))
                 return false;
@@ -79,7 +79,9 @@ namespace Content.Server.DeviceNetwork.Systems
             if (frequency == null)
                 return false;
 
-            _nextQueue.Enqueue(new DeviceNetworkPacketEvent(device.DeviceNetId, address, frequency.Value, device.Address, uid, data));
+            network ??= device.DeviceNetId;
+
+            _nextQueue.Enqueue(new DeviceNetworkPacketEvent(network.Value, address, frequency.Value, device.Address, uid, data));
             return true;
         }
 

--- a/Content.Server/DeviceNetwork/Systems/WiredNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/WiredNetworkSystem.cs
@@ -17,7 +17,7 @@ namespace Content.Server.DeviceNetwork.Systems
         /// </summary>
         private void OnBeforePacketSent(EntityUid uid, WiredNetworkComponent component, BeforePacketSentEvent args)
         {
-            if (EntityManager.GetComponent<TransformComponent>(uid).GridUid != args.SenderTransform.GridUid)
+            if (Transform(uid).GridUid != args.SenderTransform.GridUid)
             {
                 args.Cancel();
             }

--- a/Content.Server/DeviceNetwork/Systems/WirelessNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/WirelessNetworkSystem.cs
@@ -20,8 +20,11 @@ namespace Content.Server.DeviceNetwork.Systems
             var ownPosition = args.SenderPosition;
             var xform = Transform(uid);
 
+            // not a wireless to wireless connection, just let it happen
+            if (!TryComp<WirelessNetworkComponent>(args.Sender, out var sendingComponent))
+                return;
+
             if (xform.MapID != args.SenderTransform.MapID
-                || !TryComp<WirelessNetworkComponent>(args.Sender, out var sendingComponent)
                 || (ownPosition - xform.WorldPosition).Length() > sendingComponent.Range)
             {
                 args.Cancel();

--- a/Content.Server/Disposal/Mailing/MailingUnitSystem.cs
+++ b/Content.Server/Disposal/Mailing/MailingUnitSystem.cs
@@ -111,7 +111,7 @@ public sealed class MailingUnitSystem : EntitySystem
             [NetTarget] = component.Target
         };
 
-        _deviceNetworkSystem.QueuePacket(uid, null, payload, null, device);
+        _deviceNetworkSystem.QueuePacket(uid, null, payload, null, null, device);
     }
 
     /// <summary>
@@ -129,7 +129,7 @@ public sealed class MailingUnitSystem : EntitySystem
         };
 
         component.TargetList.Clear();
-        _deviceNetworkSystem.QueuePacket(uid, null, payload, null, device);
+        _deviceNetworkSystem.QueuePacket(uid, null, payload, null, null, device);
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/machine-linking/transmitter_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/transmitter_ports.ftl
@@ -8,7 +8,7 @@ signal-port-name-off-transmitter = Off
 signal-port-description-off-transmitter = This port is invoked whenever the transmitter is turned off.
 
 signal-port-name-status-transmitter = Status
-signal-port-description-logic-output = This port is invoked with HIGH or LOW depending on the transmitter status.
+signal-port-description-status-transmitter = This port is invoked with HIGH or LOW depending on the transmitter status.
 
 signal-port-name-left = Left
 signal-port-description-left = This port is invoked whenever the lever is moved to the leftmost position.
@@ -36,3 +36,12 @@ signal-port-description-logic-output-high = This port is invoked whenever the in
 
 signal-port-name-logic-output-low = Low Output
 signal-port-description-logic-output-low = This port is invoked whenever the input has a falling edge.
+
+signal-port-name-air-danger = Danger
+signal-port-description-air-danger = This port is invoked with HIGH when in danger mode and LOW when not.
+
+signal-port-name-air-warning = Warning
+signal-port-description-air-warning = This port is invoked with HIGH when in warning mode and LOW when not.
+
+signal-port-name-air-normal = Normal
+signal-port-description-air-normal = This port is invoked with HIGH when in normal mode and LOW when not.

--- a/Resources/Prototypes/DeviceLinking/source_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/source_ports.yml
@@ -96,3 +96,21 @@
   name: signal-port-name-logic-output-low
   description: signal-port-description-logic-output-low
   defaultLinks: [ Off, Close ]
+
+- type: sourcePort
+  id: AirDanger
+  name: signal-port-name-air-danger
+  description: signal-port-description-air-danger
+  defaultLinks: [ DoorBolt ]
+
+- type: sourcePort
+  id: AirWarning
+  name: signal-port-name-air-warning
+  description: signal-port-description-air-warning
+  defaultLinks: [ DoorBolt ]
+
+- type: sourcePort
+  id: AirNormal
+  name: signal-port-name-air-normal
+  description: signal-port-description-air-normal
+  defaultLinks: [ DoorBolt ]

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -2,6 +2,10 @@
   id: AirAlarm
   name: air alarm
   description: An air alarm. Alarms... air?
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wallmount
   components:
   - type: WallMount
   - type: ApcPowerReceiver
@@ -16,14 +20,22 @@
     prefix: device-address-prefix-air-alarm
     sendBroadcastAttemptEvent: true
   - type: WiredNetworkConnection
+  # for output status ports
+  - type: WirelessNetworkConnection
+    range: 200
   - type: DeviceList
   - type: DeviceNetworkRequiresPower
+  - type: DeviceLinkSource
+    ports:
+    - AirDanger
+    - AirWarning
+    - AirNormal
   - type: AtmosAlarmable
     syncWith:
-      - AirAlarm
-      - AirSensor
-      - GasVent
-      - GasScrubber
+    - AirAlarm
+    - AirSensor
+    - GasVent
+    - GasScrubber
   - type: AtmosAlarmableVisuals
     layerMap: "airAlarmBase"
     alarmStates:
@@ -85,15 +97,15 @@
           - !type:PlaySoundBehavior
             sound:
               path: /Audio/Effects/metalbreak.ogg
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wallmount
 
 - type: entity
   id: AirAlarmAssembly
   name: air alarm assembly
   description: An air alarm. Doesn't look like it'll be alarming air any time soon.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wallmount
   components:
   - type: WallMount
   - type: Clickable
@@ -115,7 +127,3 @@
     node: assembly
   - type: Transform
     anchored: true
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wallmount


### PR DESCRIPTION
## About the PR
- adds output ports to air alarm for each state, set to high when in it and low when not
- light air alarm refactoring
- hopefully made air alarm support working without AccessReader
- added support for sending packets to not normal networks, made device link InvokePort force all packets onto the Wireless network since obviously air alarm shouldnt send logic stuff to scrubbers and stuff, doesnt affect operation otherwise
- stuff

**Media**

an airlock controller that prevents the loss of air
air alarm is set to be at danger above 10kPa, warning at 100Pa, so normal when its completely empty
normal output -> not gate -> bolt input


https://github.com/space-wizards/space-station-14/assets/39013340/4362b432-d1f6-4d8e-8a89-9422d9435484


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Air alarms now have output signal ports for each state.
