### PR TITLE
Salvagers get extended capacity survival kits

### DIFF
--- a/Resources/Maps/Shuttles/emergency_box.yml
+++ b/Resources/Maps/Shuttles/emergency_box.yml
@@ -1028,7 +1028,7 @@ entities:
     - links:
       - 555
       type: DeviceLinkSink
-- proto: BoxSurvivalEngineering
+- proto: BoxSurvivalExtended
   entities:
   - uid: 600
     components:

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -316,7 +316,7 @@
   components:
     - type: StorageFill
       contents:
-        - id: BoxSurvival
+        - id: BoxSurvivalEngineering
 
 - type: entity
   parent: ClothingBackpackSatchelLeather

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -56,7 +56,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxSurvivalEngineering
+      - id: BoxSurvivalExtended
       - id: Flash
       #- id: TelescopicBaton
 
@@ -122,7 +122,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxSurvivalEngineering
+      - id: BoxSurvivalExtended
 
 - type: entity
   noSpawn: true
@@ -131,7 +131,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxSurvivalEngineering
+      - id: BoxSurvivalExtended
 
 - type: entity
   noSpawn: true
@@ -316,7 +316,7 @@
   components:
     - type: StorageFill
       contents:
-        - id: BoxSurvivalEngineering
+        - id: BoxSurvivalExtended
 
 - type: entity
   parent: ClothingBackpackSatchelLeather

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
@@ -241,4 +241,4 @@
   components:
     - type: StorageFill
       contents:
-        - id: BoxSurvival
+        - id: BoxSurvivalEngineering

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
@@ -65,7 +65,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxSurvivalEngineering
+      - id: BoxSurvivalExtended
       - id: Flash
       #- id: TelescopicBaton
 
@@ -131,7 +131,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxSurvivalEngineering
+      - id: BoxSurvivalExtended
 
 - type: entity
   noSpawn: true
@@ -140,7 +140,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxSurvivalEngineering
+      - id: BoxSurvivalExtended
 
 
 - type: entity
@@ -241,4 +241,4 @@
   components:
     - type: StorageFill
       contents:
-        - id: BoxSurvivalEngineering
+        - id: BoxSurvivalExtended

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
@@ -65,7 +65,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxSurvivalEngineering
+      - id: BoxSurvivalExtended
       - id: Flash
       #- id: TelescopicBaton
 
@@ -131,7 +131,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxSurvivalEngineering
+      - id: BoxSurvivalExtended
 
 - type: entity
   noSpawn: true
@@ -140,7 +140,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxSurvivalEngineering
+      - id: BoxSurvivalExtended
 
 - type: entity
   noSpawn: true
@@ -230,7 +230,7 @@
   components:
     - type: StorageFill
       contents:
-        - id: BoxSurvivalEngineering
+        - id: BoxSurvivalExtended
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
@@ -230,7 +230,7 @@
   components:
     - type: StorageFill
       contents:
-        - id: BoxSurvival
+        - id: BoxSurvivalEngineering
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -20,7 +20,7 @@
 - type: entity
   name: extended-capacity survival box
   parent: BoxCardboard
-  id: BoxSurvivalEngineering
+  id: BoxSurvivalExtended
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
   components:
   - type: StorageFill


### PR DESCRIPTION
## About the PR
QoL change for #18288
Since their job involves vac work away from the station, Salvagers will now spawn with the same survival boxes Engineers get, with the Extended Capacity Emergency tank. 

Changed the itemid to BoxSurvivalExtended

Or should I make this a separate prototype in case the two survival boxes might diverge in the future?

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- tweak: Nanotrasen has allocated funds from the Incident Compensation Budget to issue extended capacity survival kits to all Salvage Specialists.
