### PR TITLE
Buckle sound fix

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -485,7 +485,8 @@ public abstract partial class SharedBuckleSystem
         }
 
         AppearanceSystem.SetData(strapUid, StrapVisuals.State, strapComp.BuckledEntities.Count != 0);
-        _audioSystem.PlayPredicted(strapComp.UnbuckleSound, strapUid, strapUid);
+        var audioSourceUid = userUid != buckleUid ? userUid : strapUid;
+        _audioSystem.PlayPredicted(strapComp.UnbuckleSound, strapUid, audioSourceUid);
 
         var ev = new BuckleChangeEvent(strapUid, buckleUid, false);
         RaiseLocalEvent(buckleUid, ref ev);

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Content.Shared.Alert;
 using Content.Shared.Bed.Sleep;
@@ -357,7 +357,8 @@ public abstract partial class SharedBuckleSystem
        ReAttach(buckleUid, strapUid, buckleComp, strapComp);
        SetBuckledTo(buckleUid,strapUid, strapComp, buckleComp);
        // TODO user is currently set to null because if it isn't the sound fails to play in some situations, fix that
-       _audioSystem.PlayPredicted(strapComp.BuckleSound, strapUid, null);
+       var audioSourceUid = userUid == buckleUid ? userUid : strapUid;
+       _audioSystem.PlayPredicted(strapComp.BuckleSound, strapUid, audioSourceUid);
 
        var ev = new BuckleChangeEvent(strapUid, buckleUid, true);
        RaiseLocalEvent(ev.BuckledEntity, ref ev);
@@ -457,6 +458,7 @@ public abstract partial class SharedBuckleSystem
                 buckleXform.Coordinates = oldBuckledXform.Coordinates.Offset(strapComp.UnbuckleOffset);
         }
 
+
         if (TryComp(buckleUid, out AppearanceComponent? appearance))
             AppearanceSystem.SetData(buckleUid, BuckleVisuals.Buckled, false, appearance);
 
@@ -483,7 +485,7 @@ public abstract partial class SharedBuckleSystem
         }
 
         AppearanceSystem.SetData(strapUid, StrapVisuals.State, strapComp.BuckledEntities.Count != 0);
-        _audioSystem.PlayPredicted(strapComp.UnbuckleSound, strapUid, null);
+        _audioSystem.PlayPredicted(strapComp.UnbuckleSound, strapUid, strapUid);
 
         var ev = new BuckleChangeEvent(strapUid, buckleUid, false);
         RaiseLocalEvent(buckleUid, ref ev);

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -458,7 +458,6 @@ public abstract partial class SharedBuckleSystem
                 buckleXform.Coordinates = oldBuckledXform.Coordinates.Offset(strapComp.UnbuckleOffset);
         }
 
-
         if (TryComp(buckleUid, out AppearanceComponent? appearance))
             AppearanceSystem.SetData(buckleUid, BuckleVisuals.Buckled, false, appearance);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Resolves #16751
Buckling and unbuckling sounds only play once.
Resolved by passing non-null values to `PlayPredicted` as user.

This PR seems more like a bandaid than an actual fix but hey it works.

If cases are there because in some cases passing `strapUid` instead of `userUid` will cause the audio to play twice or not at all.

*Second PR (I still am clueless :sob:)*

**Additional Notes**
`audioSourcesUid` is a horrible name but I couldn't come up with anything better.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

*Requires two clients to showcase, which I can barely run. I don't even wanna imagine what it'll be like with me recording it. Yet, I'll try and get a manageable recording tomorrow. I doubt that I'll success. Regardless... Must sleep first.*

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: People wont hear buckling and unbuckling sounds twice anymore. 
