### PR TITLE
Reduce damage and crit/death thresholds for bats and hamsters

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -57,7 +57,12 @@
     animation: WeaponArcBite
     damage:
       types:
-        Piercing: 5
+        Piercing: 0.5
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      15: Critical
+      30: Dead
   - type: NoSlip
   - type: Puller
     needsHands: true
@@ -2184,8 +2189,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      40: Critical
-      60: Dead
+      15: Critical
+      30: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed : 4
     baseSprintSpeed : 4
@@ -2252,7 +2257,7 @@
     animation: WeaponArcBite
     damage:
       types:
-        Piercing: 2
+        Piercing: 0.4
   - type: InteractionPopup
     successChance: 0.4
     interactSuccessString: petting-success-hamster


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Per title, this drastically reduces both the attack damage and crit/death thresholds for hamsters and bats to reduce the issue posed by players in these roles harassing others. They should now not do enough damage to cause meaningful harm and also will be much easier to kill.

This is an alternative to #18203 as some players (myself included) raised objections that, though not of great significance, there is at least some RP value in letting these animals have a bite, and also that in Hamlet's case he actually needs it to break out of his cage.

With this change, Hamlet would now require about 25 bites just to get a mouse to crit. Remilia needs 20.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Due to animal control complaints, Nanotrasen is no longer supplying genetically enhanced animals for pet requisitions. Hamsters and bats (including Hamlet and Remilia) are now significantly more fragile and have drastically weaker bites.
