### PR TITLE
Make some tests use the PoolSettings.InLobby option

### DIFF
--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -376,6 +376,8 @@ public static class PoolManager
         var ticker = pair.Server.ResolveDependency<EntityManager>().System<GameTicker>();
         Assert.That(ticker.DummyTicker, Is.EqualTo(pair.Settings.DummyTicker));
 
+        var cfg = pair.Server.ResolveDependency<IConfigurationManager>();
+        Assert.That(cfg.GetCVar(CCVars.GameLobbyEnabled), Is.EqualTo(pair.Settings.InLobby));
         var status = ticker.PlayerGameStatuses[sPlayer.Sessions.Single().UserId];
         var expected = pair.Settings.InLobby
             ? PlayerGameStatus.NotReadyToPlay

--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -204,16 +204,8 @@ public sealed class AddTests
     [Test]
     public async Task PreRoundAddAndGetSingle()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Dirty = true });
+        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Dirty = true, InLobby = true });
         var server = pairTracker.Pair.Server;
-
-        var configManager = server.ResolveDependency<IConfigurationManager>();
-        await server.WaitPost(() =>
-        {
-            configManager.SetCVar(CCVars.GameLobbyEnabled, true);
-            var command = new RestartRoundNowCommand();
-            command.Execute(null, string.Empty, Array.Empty<string>());
-        });
 
         var sDatabase = server.ResolveDependency<IServerDbManager>();
         var sSystems = server.ResolveDependency<IEntitySystemManager>();


### PR DESCRIPTION
Also adds an assert to check that fast-recycling tests don't change the lobby cvar.