### PR TITLE
nerf dungeon dragon damage

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -102,7 +102,6 @@
     hidden: true
     soundHit:
       path: /Audio/Weapons/Xeno/alien_claw_flesh3.ogg
-  - type: MeleeWeapon
     damage:
       types:
         Piercing: 15

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -102,6 +102,7 @@
     hidden: true
     soundHit:
       path: /Audio/Weapons/Xeno/alien_claw_flesh3.ogg
+  - type: MeleeWeapon
     damage:
       types:
         Piercing: 15
@@ -159,3 +160,10 @@
     spawned:
     - id: FoodMeatDragon
       amount: 1
+  # half damage, spread evenly
+  - type: MeleeWeapon
+    damage:
+      types:
+        Brute: 5
+        Piercing: 5
+        Slash: 5

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -163,7 +163,5 @@
   # half damage, spread evenly
   - type: MeleeWeapon
     damage:
-      types:
+      groups:
         Brute: 5
-        Piercing: 5
-        Slash: 5

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -164,4 +164,4 @@
   - type: MeleeWeapon
     damage:
       groups:
-        Brute: 5
+        Brute: 15


### PR DESCRIPTION
## About the PR
getting 4 shot bad
now does 15 brute, spread across each subtype

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Dragons on expeditions do less damage now.