### PR TITLE
Add station anchors

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -44,5 +44,14 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         [ViewVariables]
         public DirectionFlag ThrustDirections = DirectionFlag.None;
+
+        /// <summary>
+        /// Damping applied to the shuttle's physics component when not in FTL.
+        /// </summary>
+        [DataField("linearDamping"), ViewVariables(VVAccess.ReadWrite)]
+        public float LinearDamping = 0.05f;
+
+        [DataField("angularDamping"), ViewVariables(VVAccess.ReadWrite)]
+        public float AngularDamping = 0.05f;
     }
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -236,6 +236,7 @@ public sealed partial class ShuttleSystem
             var xform = Transform(uid);
             PhysicsComponent? body;
             ShuttleComponent? shuttle;
+            TryComp(uid, out shuttle);
 
             switch (comp.State)
             {
@@ -256,7 +257,8 @@ public sealed partial class ShuttleSystem
 
                     if (TryComp(uid, out body))
                     {
-                        Enable(uid, body);
+                        if (shuttle != null)
+                            Enable(uid, body, shuttle);
                         _physics.SetLinearVelocity(uid, new Vector2(0f, 20f), body: body);
                         _physics.SetAngularVelocity(uid, 0f, body: body);
                         _physics.SetLinearDamping(body, 0f);
@@ -283,7 +285,7 @@ public sealed partial class ShuttleSystem
                     // TODO: Arrival effects
                     // For now we'll just use the ss13 bubbles but we can do fancier.
 
-                    if (TryComp(uid, out shuttle))
+                    if (shuttle != null)
                     {
                         _thruster.DisableLinearThrusters(shuttle);
                         _thruster.EnableLinearThrustDirection(shuttle, DirectionFlag.South);
@@ -301,11 +303,13 @@ public sealed partial class ShuttleSystem
                     {
                         _physics.SetLinearVelocity(uid, Vector2.Zero, body: body);
                         _physics.SetAngularVelocity(uid, 0f, body: body);
-                        _physics.SetLinearDamping(body, ShuttleLinearDamping);
-                        _physics.SetAngularDamping(body, ShuttleAngularDamping);
+                        if (shuttle != null)
+                        {
+                            _physics.SetLinearDamping(body, shuttle.LinearDamping);
+                            _physics.SetAngularDamping(body, shuttle.AngularDamping);
+                        }
                     }
 
-                    TryComp(uid, out shuttle);
                     MapId mapId;
 
                     if (comp.TargetUid != null && shuttle != null)
@@ -347,9 +351,9 @@ public sealed partial class ShuttleSystem
                         {
                             Disable(uid, body);
                         }
-                        else
+                        else if (shuttle != null)
                         {
-                            Enable(uid, body);
+                            Enable(uid, body, shuttle);
                         }
                     }
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -44,9 +44,6 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
 
     public const float TileMassMultiplier = 0.5f;
 
-    public const float ShuttleLinearDamping = 0.05f;
-    public const float ShuttleAngularDamping = 0.05f;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -125,7 +122,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
 
         if (component.Enabled)
         {
-            Enable(uid, physicsComponent);
+            Enable(uid, physicsComponent, component);
         }
     }
 
@@ -138,7 +135,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
 
         if (component.Enabled)
         {
-            Enable(uid, physicsComponent);
+            Enable(uid, physicsComponent, component);
         }
         else
         {
@@ -146,15 +143,15 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
         }
     }
 
-    private void Enable(EntityUid uid, PhysicsComponent component)
+    private void Enable(EntityUid uid, PhysicsComponent component, ShuttleComponent shuttle)
     {
         FixturesComponent? manager = null;
 
         _physics.SetBodyType(uid, BodyType.Dynamic, manager: manager, body: component);
         _physics.SetBodyStatus(component, BodyStatus.InAir);
         _physics.SetFixedRotation(uid, false, manager: manager, body: component);
-        _physics.SetLinearDamping(component, ShuttleLinearDamping);
-        _physics.SetAngularDamping(component, ShuttleAngularDamping);
+        _physics.SetLinearDamping(component, shuttle.LinearDamping);
+        _physics.SetAngularDamping(component, shuttle.AngularDamping);
     }
 
     private void Disable(EntityUid uid, PhysicsComponent component)


### PR DESCRIPTION
## About the PR
This modifies the hard-coded shuttle linear and angular damping coefficient to be a data field on the shuttle component. This allows a shuttle to override the grid's linear and angular damping. If you set this to a sufficiently large number, these behave like station anchors.

Since the default shuttle damping is the old hard-coded value, this change does not affect any existing maps. Mappers must update their maps to enable station anchors.

**Media**
N/A

**Changelog**
N/A since this doesn't actually change anything. Maps can bring in anchors if they want to.