### PR TITLE
Add BlastDoors DrawDepth

### DIFF
--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -79,21 +79,26 @@ namespace Content.Shared.DrawDepth
         Doors = DrawDepthTag.Default + 5,
 
         /// <summary>
+        /// Blast doors and shutters which go over the usual doors.
+        /// </summary>
+        BlastDoors = DrawDepthTag.Default + 6,
+
+        /// <summary>
         /// Stuff that needs to draw over most things, but not effects, like Kudzu.
         /// </summary>
-        Overdoors = DrawDepthTag.Default + 6,
+        Overdoors = DrawDepthTag.Default + 7,
 
         /// <summary>
         ///     Explosions, fire, melee swings. Whatever.
         /// </summary>
-        Effects = DrawDepthTag.Default + 7,
+        Effects = DrawDepthTag.Default + 8,
 
-        Ghosts = DrawDepthTag.Default + 8,
+        Ghosts = DrawDepthTag.Default + 9,
 
         /// <summary>
         ///    Use this selectively if it absolutely needs to be drawn above (almost) everything else. Examples include
         ///    the pointing arrow, the drag & drop ghost-entity, and some debug tools.
         /// </summary>
-        Overlays = DrawDepthTag.Default + 9,
+        Overlays = DrawDepthTag.Default + 10,
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: BaseShutter
   parent: BaseStructure
   name: shutter
@@ -9,7 +9,7 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Shutters/shutters.rsi
-    drawdepth: Overdoors
+    drawdepth: BlastDoors
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
@@ -33,6 +33,8 @@
     containers:
       board: !type:Container
   - type: Door
+    openDrawDepth: BlastDoors
+    closedDrawDepth: BlastDoors
     bumpOpen: false
     clickOpen: false
     closeTimeOne: 0.2


### PR DESCRIPTION
Named `BlastDoors` because that's a far more unique string than `Shutters` in the codebase.

Resolves #9531