### PR TITLE
Make anchoring nukes require enough nearby floor

### DIFF
--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -175,5 +175,12 @@ namespace Content.Server.Nuke
         public bool PlayedAlertSound = false;
 
         public IPlayingAudioStream? AlertAudioStream = default;
+
+        /// <summary>
+        ///     The radius from the nuke for which there must be floor tiles for it to be anchorable.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("requiredFloorRadius")]
+        public float RequiredFloorRadius = 7;
     }
 }

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -9,10 +9,12 @@ using Content.Shared.Construction.Components;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.DoAfter;
+using Content.Shared.Maps;
 using Content.Shared.Nuke;
 using Content.Shared.Popups;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
+using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 
@@ -23,7 +25,9 @@ public sealed class NukeSystem : EntitySystem
     [Dependency] private readonly AlertLevelSystem _alertLevel = default!;
     [Dependency] private readonly ChatSystem _chatSystem = default!;
     [Dependency] private readonly ExplosionSystem _explosions = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly ITileDefinitionManager _tileDefManager = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
     [Dependency] private readonly PopupSystem _popups = default!;
     [Dependency] private readonly ServerGlobalSoundSystem _sound = default!;
@@ -186,6 +190,22 @@ public sealed class NukeSystem : EntitySystem
         }
         else
         {
+            if (!_mapManager.TryGetGrid(xform.GridUid, out var grid))
+                return;
+
+            var worldPos = _transform.GetWorldPosition(xform);
+
+            foreach (var tile in grid.GetTilesIntersecting(new Circle(worldPos, component.RequiredFloorRadius), false))
+            {
+                if (!tile.IsSpace(_tileDefManager))
+                    continue;
+
+                var msg = Loc.GetString("nuke-component-cant-anchor-floor");
+                _popups.PopupEntity(msg, uid, args.Session, PopupType.MediumCaution);
+
+                return;
+            }
+
             _transform.SetCoordinates(uid, xform, xform.Coordinates.SnapToGrid());
             _transform.AnchorEntity(uid, xform);
         }

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -5,7 +5,6 @@ using Content.Server.Explosion.EntitySystems;
 using Content.Server.Popups;
 using Content.Server.Station.Systems;
 using Content.Shared.Audio;
-using Content.Shared.Construction.Components;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.DoAfter;
@@ -57,9 +56,6 @@ public sealed class NukeSystem : EntitySystem
         SubscribeLocalEvent<NukeComponent, EntInsertedIntoContainerMessage>(OnItemSlotChanged);
         SubscribeLocalEvent<NukeComponent, EntRemovedFromContainerMessage>(OnItemSlotChanged);
 
-        // anchoring logic
-        SubscribeLocalEvent<NukeComponent, AnchorAttemptEvent>(OnAnchorAttempt);
-        SubscribeLocalEvent<NukeComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
         // Shouldn't need re-anchoring.
         SubscribeLocalEvent<NukeComponent, AnchorStateChangedEvent>(OnAnchorChanged);
 
@@ -136,28 +132,6 @@ public sealed class NukeSystem : EntitySystem
     }
 
     #region Anchor
-
-    private void OnAnchorAttempt(EntityUid uid, NukeComponent component, AnchorAttemptEvent args)
-    {
-        CheckAnchorAttempt(uid, component, args);
-    }
-
-    private void OnUnanchorAttempt(EntityUid uid, NukeComponent component, UnanchorAttemptEvent args)
-    {
-        CheckAnchorAttempt(uid, component, args);
-    }
-
-    private void CheckAnchorAttempt(EntityUid uid, NukeComponent component, BaseAnchoredAttemptEvent args)
-    {
-        // cancel any anchor attempt if armed
-        if (component.Status == NukeStatus.ARMED)
-        {
-            var msg = Loc.GetString("nuke-component-cant-anchor");
-            _popups.PopupEntity(msg, uid, args.User);
-
-            args.Cancel();
-        }
-    }
 
     private void OnAnchorChanged(EntityUid uid, NukeComponent component, ref AnchorStateChangedEvent args)
     {

--- a/Resources/Locale/en-US/nuke/nuke-component.ftl
+++ b/Resources/Locale/en-US/nuke/nuke-component.ftl
@@ -1,4 +1,3 @@
-nuke-component-cant-anchor = The bolts seems to be blocked without disk!
 nuke-component-cant-anchor-floor = The anchoring bolts fail to lock into the floor!
 nuke-component-announcement-sender = Nuclear Fission Explosive
 nuke-component-announcement-armed = Attention! The station's self-destruct mechanism has been engaged at global coordinates {$position}. {$time} seconds until detonation. If this was made in error, the mechanism may still be disarmed.

--- a/Resources/Locale/en-US/nuke/nuke-component.ftl
+++ b/Resources/Locale/en-US/nuke/nuke-component.ftl
@@ -1,4 +1,5 @@
 nuke-component-cant-anchor = The bolts seems to be blocked without disk!
+nuke-component-cant-anchor-floor = The anchoring bolts fail to lock into the floor!
 nuke-component-announcement-sender = Nuclear Fission Explosive
 nuke-component-announcement-armed = Attention! The station's self-destruct mechanism has been engaged at global coordinates {$position}. {$time} seconds until detonation. If this was made in error, the mechanism may still be disarmed.
 nuke-component-announcement-unarmed = The station's self-destruct was deactivated! Have a nice day!


### PR DESCRIPTION
Open to suggestions on radius.

[nuke-bolts.webm](https://github.com/space-wizards/space-station-14/assets/114301317/816df4ff-9abf-41d3-911d-34a74462c6e7)

Resolves #15026

:cl: 
- tweak: Nuclear fission devices need enough floor around them to anchor now.
