### PR TITLE
Add linter-friendly WeightedRandom prototypes

### DIFF
--- a/Content.Server/Mining/MiningSystem.cs
+++ b/Content.Server/Mining/MiningSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Mining.Components;
+using Content.Server.Mining.Components;
 using Content.Shared.Destructible;
 using Content.Shared.Mining;
 using Content.Shared.Random;
@@ -47,6 +47,6 @@ public sealed class MiningSystem : EntitySystem
         if (component.CurrentOre != null || component.OreRarityPrototypeId == null || !_random.Prob(component.OreChance))
             return;
 
-        component.CurrentOre = _proto.Index<WeightedRandomPrototype>(component.OreRarityPrototypeId).Pick(_random);
+        component.CurrentOre = _proto.Index<WeightedRandomOrePrototype>(component.OreRarityPrototypeId).Pick(_random);
     }
 }

--- a/Content.Server/Salvage/SalvageMagnetComponent.cs
+++ b/Content.Server/Salvage/SalvageMagnetComponent.cs
@@ -108,7 +108,7 @@ namespace Content.Server.Salvage
         /// A weighted random prototype corresponding to
         /// what asteroid entities will be generated.
         /// </summary>
-        [DataField("asteroidPool", customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomPrototype>)), ViewVariables(VVAccess.ReadWrite)]
+        [DataField("asteroidPool", customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomEntityPrototype>)), ViewVariables(VVAccess.ReadWrite)]
         public string AsteroidPool = "RandomAsteroidPool";
     }
 

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -347,7 +347,7 @@ namespace Content.Server.Salvage
             EntityUid? salvageEnt;
             if (_random.Prob(component.AsteroidChance))
             {
-                var asteroidProto = _prototypeManager.Index<WeightedRandomPrototype>(component.AsteroidPool).Pick(_random);
+                var asteroidProto = _prototypeManager.Index<WeightedRandomEntityPrototype>(component.AsteroidPool).Pick(_random);
                 salvageEnt = Spawn(asteroidProto, new MapCoordinates(0, 0, salvMap));
             }
             else

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -115,7 +115,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
         if (_randomizeCharacters)
         {
             var weightId = _configurationManager.GetCVar(CCVars.ICRandomSpeciesWeights);
-            var weights = _prototypeManager.Index<WeightedRandomPrototype>(weightId);
+            var weights = _prototypeManager.Index<WeightedRandomSpeciesPrototype>(weightId);
             speciesId = weights.Pick(_random);
         }
         else if (profile != null)

--- a/Content.Shared/Mining/Components/OreVeinComponent.cs
+++ b/Content.Shared/Mining/Components/OreVeinComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Mining;
+using Content.Shared.Mining;
 using Content.Shared.Random;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
@@ -20,7 +20,7 @@ public sealed class OreVeinComponent : Component
     /// <summary>
     /// The weighted random prototype used for determining what ore will be dropped.
     /// </summary>
-    [DataField("oreRarityPrototypeId", customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomPrototype>))]
+    [DataField("oreRarityPrototypeId", customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomOrePrototype>))]
     public string? OreRarityPrototypeId;
 
     /// <summary>

--- a/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
+++ b/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Shared.Dataset;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Random;
@@ -12,7 +12,7 @@ namespace Content.Shared.Random.Helpers
             return random.Pick(prototype.Values);
         }
 
-        public static string Pick(this WeightedRandomPrototype prototype, System.Random random)
+        public static string Pick(this IWeightedRandomPrototype prototype, System.Random random)
         {
             var picks = prototype.Weights;
             var sum = picks.Values.Sum();
@@ -34,7 +34,7 @@ namespace Content.Shared.Random.Helpers
             throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
         }
 
-        public static string Pick(this WeightedRandomPrototype prototype, IRobustRandom? random = null)
+        public static string Pick(this IWeightedRandomPrototype prototype, IRobustRandom? random = null)
         {
             IoCManager.Resolve(ref random);
             var picks = prototype.Weights;

--- a/Content.Shared/Random/IWeightedRandom.cs
+++ b/Content.Shared/Random/IWeightedRandom.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Random;
+
+/// <summary>
+/// IWeightedRandomPrototype implements a dictionary of strings to float weights
+/// to be used with <see cref="Helpers.SharedRandomExtensions.Pick(IWeightedRandomPrototype, Robust.Shared.Random.IRobustRandom)" />.
+/// </summary>
+public interface IWeightedRandomPrototype : IPrototype
+{
+    [ViewVariables]
+    public Dictionary<string, float> Weights { get; }
+}

--- a/Content.Shared/Random/WeightedRandomEntityPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomEntityPrototype.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+
+namespace Content.Shared.Random;
+
+/// <summary>
+/// Linter-friendly version of weightedRandom for Entity prototypes.
+/// </summary>
+[Prototype("weightedRandomEntity")]
+public sealed class WeightedRandomEntityPrototype : IWeightedRandomPrototype
+{
+    [IdDataField]
+    public string ID { get; } = default!;
+
+    [DataField("weights", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<float, EntityPrototype>))]
+    public Dictionary<string, float> Weights { get; } = new();
+}

--- a/Content.Shared/Random/WeightedRandomOrePrototype.cs
+++ b/Content.Shared/Random/WeightedRandomOrePrototype.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Mining;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+
+namespace Content.Shared.Random;
+
+/// <summary>
+/// Linter-friendly version of weightedRandom for Ore prototypes.
+/// </summary>
+[Prototype("weightedRandomOre")]
+public sealed class WeightedRandomOrePrototype : IWeightedRandomPrototype
+{
+    [IdDataField]
+    public string ID { get; } = default!;
+
+    [DataField("weights", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<float, OrePrototype>))]
+    public Dictionary<string, float> Weights { get; } = new();
+}

--- a/Content.Shared/Random/WeightedRandomPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomPrototype.cs
@@ -6,10 +6,11 @@ namespace Content.Shared.Random;
 /// Generic random weighting dataset to use.
 /// </summary>
 [Prototype("weightedRandom")]
-public sealed class WeightedRandomPrototype : IPrototype
+public sealed class WeightedRandomPrototype : IWeightedRandomPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField]
+    public string ID { get; } = default!;
 
     [DataField("weights")]
-    public Dictionary<string, float> Weights = new();
+    public Dictionary<string, float> Weights { get; } = new();
 }

--- a/Content.Shared/Random/WeightedRandomSpeciesPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomSpeciesPrototype.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Humanoid.Prototypes;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+
+namespace Content.Shared.Random;
+
+/// <summary>
+/// Linter-friendly version of weightedRandom for Species prototypes.
+/// </summary>
+[Prototype("weightedRandomSpecies")]
+public sealed class WeightedRandomSpeciesPrototype : IWeightedRandomPrototype
+{
+    [IdDataField]
+    public string ID { get; } = default!;
+
+    [DataField("weights", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<float, SpeciesPrototype>))]
+    public Dictionary<string, float> Weights { get; } = new();
+}

--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -179,7 +179,7 @@ public abstract class SharedSalvageSystem : EntitySystem
         foreach (var id in ids)
         {
             // pick a random reward to give
-            var weights = _proto.Index<WeightedRandomPrototype>(id);
+            var weights = _proto.Index<WeightedRandomEntityPrototype>(id);
             rewards.Add(weights.Pick(rand));
         }
 
@@ -187,7 +187,7 @@ public abstract class SharedSalvageSystem : EntitySystem
     }
 
     /// <summary>
-    /// Get a list of WeightedRandomPrototype IDs with the rewards for a certain difficulty.
+    /// Get a list of WeightedRandomEntityPrototype IDs with the rewards for a certain difficulty.
     /// </summary>
     private string[] RewardsForDifficulty(DifficultyRating rating)
     {

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -75,7 +75,7 @@
   - type: ApcPowerReceiver
     powerLoad: 1000
 
-- type: weightedRandom
+- type: weightedRandomEntity
   id: RandomAsteroidPool
   weights:
     AsteroidSalvageSmall: 3

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -1,4 +1,4 @@
-- type: weightedRandom
+- type: weightedRandomEntity
   id: SalvageRewardCommon
   weights:
     # basic materials
@@ -20,7 +20,7 @@
     SpaceCash500: 0.5
     SpaceCash1000: 0.25
 
-- type: weightedRandom
+- type: weightedRandomEntity
   id: SalvageRewardRare
   weights:
     # rare materials
@@ -52,7 +52,7 @@
     SpaceCash1000: 0.75
     SpaceCash2500: 0.5
 
-- type: weightedRandom
+- type: weightedRandomEntity
   id: SalvageRewardEpic
   weights:
     # rare machinery

--- a/Resources/Prototypes/Species/species_weights.yml
+++ b/Resources/Prototypes/Species/species_weights.yml
@@ -1,5 +1,5 @@
 #default species weights used for randomly selected species
-- type: weightedRandom
+- type: weightedRandomSpecies
   id: SpeciesWeights
   weights:
     Human: 5

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -42,7 +42,7 @@
   minOreYield: 2
   maxOreYield: 4
 
-- type: weightedRandom
+- type: weightedRandomOre
   id: RandomOreDistributionStandard
   weights:
     OreSteel: 10


### PR DESCRIPTION
I left out ObjectivePrototype for now pending some advice on whether or not it would be a good idea to move it and everything it's connected to into Shared or if there's some better way of dealing with that.