### PR TITLE
Taxibot fixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -116,8 +116,6 @@
     - state: taxibot
       map: ["enum.VehicleVisualLayers.AutoAnimate"]
     noRot: true
-  - type: Physics
-    bodyType: Dynamic
   - type: IntrinsicRadioReceiver
   - type: ActiveRadio
     channels:
@@ -133,14 +131,14 @@
     friction: 2
     frictionNoInput: 6
     baseWalkSpeed: 3
-    baseSprintSpeed: 10
+    baseSprintSpeed: 6
   - type: Strap
     buckleOffset: "0, 0"
     maxBuckleDistance: 1
   - type: AmbientSound
     sound: "/Audio/Effects/Vehicle/vehicleengineidle.ogg"
     range: 10
-    volume: -5
+    volume: -10
     enabled: true
   - type: Construction
     graph: TaxiBot

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -109,6 +109,7 @@
   name: taxibot
   description: Give a ride?
   components:
+  - type: NoSlip
   - type: Sprite
     drawdepth: Mobs
     sprite: Mobs/Silicon/Bots/taxibot.rsi

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -10,7 +10,7 @@
   - type: AmbientSound
     sound: "/Audio/Effects/Vehicle/vehicleengineidle.ogg"
     range: 10
-    volume: -5
+    volume: -10
     enabled: false
   - type: InputMover
   - type: InteractionOutline


### PR DESCRIPTION
- If someone else makes a mob dynamic on god.
- Reduce ambientsound coz god damn it's loud.
- Reduce the comical faster-than-pvs speed.

:cl:
- fix: Fix taxibots incorrectly pushing entities.
- tweak: Nerf taxibot speed from 10 to 6 and reduce their volume significantly.
