### PR TITLE
changes/fixes for singulo

### DIFF
--- a/Content.Shared/Movement/Components/MovementIgnoreInAirComponent.cs
+++ b/Content.Shared/Movement/Components/MovementIgnoreInAirComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Movement.Components;
+
+/// <summary>
+/// Can this entity still move while its BodyStatus is InAir?
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed class MovementIgnoreInAirComponent : Component
+{
+
+}

--- a/Content.Shared/Movement/Events/InAirMoveEvent.cs
+++ b/Content.Shared/Movement/Events/InAirMoveEvent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.Movement.Events;
+
+/// <summary>
+/// Raised on an entity to check if it can move while the BodyStatus is InAir.
+/// </summary>
+[ByRefEvent]
+public record struct CanInAirMoveEvent(EntityUid Uid)
+{
+    public bool CanMove = false;
+}

--- a/Content.Shared/Movement/Systems/MovementIgnoreGravitySystem.cs
+++ b/Content.Shared/Movement/Systems/MovementIgnoreGravitySystem.cs
@@ -11,9 +11,15 @@ public sealed class MovementIgnoreGravitySystem : EntitySystem
         SubscribeLocalEvent<MovementIgnoreGravityComponent, ComponentGetState>(GetState);
         SubscribeLocalEvent<MovementIgnoreGravityComponent, ComponentHandleState>(HandleState);
         SubscribeLocalEvent<MovementAlwaysTouchingComponent, CanWeightlessMoveEvent>(OnWeightless);
+        SubscribeLocalEvent<MovementIgnoreInAirComponent, CanInAirMoveEvent>(OnInAir);
     }
 
     private void OnWeightless(EntityUid uid, MovementAlwaysTouchingComponent component, ref CanWeightlessMoveEvent args)
+    {
+        args.CanMove = true;
+    }
+
+    private void OnInAir(EntityUid uid, MovementIgnoreInAirComponent component, ref CanInAirMoveEvent args)
     {
         args.CanMove = true;
     }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -147,11 +147,21 @@ namespace Content.Shared.Movement.Systems
             LerpRotation(uid, mover, frameTime);
 
             if (!canMove
-                || physicsComponent.BodyStatus != BodyStatus.OnGround
                 || PullableQuery.TryGetComponent(uid, out var pullable) && pullable.BeingPulled)
             {
                 UsedMobMovement[uid] = false;
                 return;
+            }
+            
+            if (physicsComponent.BodyStatus != BodyStatus.OnGround)
+            {
+                var ev = new CanInAirMoveEvent(uid);
+				RaiseLocalEvent(uid, ref ev, true);
+                if (!ev.CanMove)
+                {
+                    UsedMobMovement[uid] = false;
+                    return;
+                }
             }
 
             UsedMobMovement[uid] = true;

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -156,7 +156,7 @@ namespace Content.Shared.Movement.Systems
             if (physicsComponent.BodyStatus != BodyStatus.OnGround)
             {
                 var ev = new CanInAirMoveEvent(uid);
-				RaiseLocalEvent(uid, ref ev, true);
+                RaiseLocalEvent(uid, ref ev, true);
                 if (!ev.CanMove)
                 {
                     UsedMobMovement[uid] = false;

--- a/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
@@ -354,7 +354,6 @@ public abstract class SharedSingularitySystem : EntitySystem
     /// <param name="args">The event arguments.</param>
     private void UpdateBody(EntityUid uid, PhysicsComponent comp, SingularityLevelChangedEvent args)
     {
-        _physics.SetBodyStatus(comp, (args.NewValue > 1) ? BodyStatus.InAir : BodyStatus.OnGround);
         if (args.NewValue <= 1 && args.OldValue > 1) // Apparently keeps singularities from getting stuck in the corners of containment fields.
             _physics.SetLinearVelocity(uid, Vector2.Zero, body: comp); // No idea how stopping the singularities movement keeps it from getting stuck though.
     }

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -11,6 +11,7 @@
       path: /Audio/Effects/singularity.ogg
   - type: Physics
     bodyType: Dynamic
+    bodyStatus: InAir
   - type: EventHorizon # To make the singularity consume things.
     radius: 0.5
     canBreachContainment: false
@@ -86,8 +87,29 @@
           5:
             sprite: Structures/Power/Generation/Singularity/singularity_5.rsi
             state: singularity_5
-            scale: 1.5,1.5
+            scale: 1.1,1.1
           6:
             sprite: Structures/Power/Generation/Singularity/singularity_6.rsi
             state: singularity_6
             scale: .9,.9
+
+- type: entity
+  id: SingularitySentient
+  parent: Singularity
+  suffix: sentient
+  components:
+  - type: MovementAlwaysTouching
+  - type: MovementIgnoreInAir
+  - type: MovementIgnoreGravity
+    gravityState: true
+  - type: InputMover
+  - type: MovementSpeedModifier
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: gravitational singularity
+    description: Praise the lord.
+  - type: GhostTakeoverAvailable
+  - type: Eye
+    zoom: 1.6,1.6


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
changes:
- singularities are now always InAir as opposed to being OnGround if level 1 and InAir otherwise
- rescale level 5 singularity (was too large previously)
- add MovementIgnoreInAirComponent
- add sentient singularity prototype for admemes or future PRs

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
singularity ghost role
![image](https://github.com/space-wizards/space-station-14/assets/57039557/b0a9e1cb-a44e-45e6-8f48-721a04752553)

rescaled level 5 singularity
![image](https://github.com/space-wizards/space-station-14/assets/57039557/ce2dfe30-d0af-467f-95ee-c29b734ee33f)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

changes not player-facing, no CL