### PR TITLE
Fix energy swords healing blunt

### DIFF
--- a/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
@@ -52,7 +52,7 @@ public sealed class EnergySwordSystem : EntitySystem
         if (!comp.Activated)
             return;
 
-        // Overrides basic blunt damage with burn+slash as set in yaml
+        // Adjusts base damage when the energy blade is active, by values set in yaml
         args.Damage += comp.LitDamageBonus;
     }
 

--- a/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
@@ -53,7 +53,7 @@ public sealed class EnergySwordSystem : EntitySystem
             return;
 
         // Overrides basic blunt damage with burn+slash as set in yaml
-        args.Damage = comp.LitDamageBonus;
+        args.Damage += comp.LitDamageBonus;
     }
 
     private void OnUseInHand(EntityUid uid, EnergySwordComponent comp, UseInHandEvent args)


### PR DESCRIPTION
## About the PR
All energy weapons dealt their Bonus damage while activated, instead of adding it to their base blunt damage. 
This resulted in a negative blunt damage while active, causing them to heal pre-existing bruises while the energy damage killed the target. 

This makes no difference against uninjured targets, which is probably why no one ever noticed it, but if the target already has some blunt damage this bug essentially caused a 25% decrease in damage output for eswords until all the blunt was healed

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- fix: Active energy swords no longer heal small amounts of blunt damage on every hit. Cybersun CEO reportedly thrown out an airlock over "Bluntgate" scandal.