### PR TITLE
stimulants increase stamina

### DIFF
--- a/Content.Shared/Damage/Components/StaminaModifierComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaModifierComponent.cs
@@ -13,6 +13,6 @@ public sealed partial class StaminaModifierComponent : Component
     /// When added this scales max stamina, but not stamina damags to give you an extra boost of survability.
     /// If you have too much damage when the modifier is removed, you suffer "withdrawl" and instantly stamcrit.
     /// </summary>
-    [DataField("modifier"), AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite), DataField("modifier"), AutoNetworkedField]
     public float Modifier = 2f;
 }

--- a/Content.Shared/Damage/Components/StaminaModifierComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaModifierComponent.cs
@@ -4,6 +4,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Damage.Components;
 
 /// <summary>
+/// Multiplies the entity's <see cref="StaminaComponent.StaminaDamage"/> by the <see cref="Modifier"/>.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(StaminaSystem))]
 public sealed partial class StaminaModifierComponent : Component

--- a/Content.Shared/Damage/Components/StaminaModifierComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaModifierComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Damage.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Damage.Components;
+
+/// <summary>
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(StaminaSystem))]
+public sealed partial class StaminaModifierComponent : Component
+{
+    /// <summary>
+    /// What to multiply max stamina by.
+    /// When added this scales max stamina, but not stamina damags to give you an extra boost of survability.
+    /// If you have too much damage when the modifier is removed, you suffer "withdrawl" and instantly stamcrit.
+    /// </summary>
+    [DataField("modifier"), AutoNetworkedField]
+    public float Modifier = 2f;
+}

--- a/Content.Shared/Damage/Systems/StaminaSystem.Modifier.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.Modifier.cs
@@ -30,19 +30,20 @@ public sealed partial class StaminaSystem
     /// Change the stamina modifier for an entity.
     /// If it has <see cref="StaminaComponent"/> it will also be updated.
     /// </summary>
-    public void SetModifier(EntityUid uid, float modifier, StaminaModifierComponent? comp = null)
+    public void SetModifier(EntityUid uid, float modifier, StaminaComponent? stamina = null, StaminaModifierComponent? comp = null)
     {
         if (!Resolve(uid, ref comp))
             return;
 
         var old = comp.Modifier;
-        if (old == modifier)
+
+        if (old.Equals(modifier))
             return;
 
         comp.Modifier = modifier;
-        Dirty(comp);
+        Dirty(uid, comp);
 
-        if (TryComp<StaminaComponent>(uid, out var stamina))
+        if (Resolve(uid, ref stamina, false))
         {
             // scale to the new threshold, act as if it was removed then added
             stamina.CritThreshold *= modifier / old;

--- a/Content.Shared/Damage/Systems/StaminaSystem.Modifier.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.Modifier.cs
@@ -1,0 +1,51 @@
+using Content.Shared.Damage.Components;
+
+namespace Content.Shared.Damage.Systems;
+
+public sealed partial class StaminaSystem
+{
+    private void InitializeModifier()
+    {
+        SubscribeLocalEvent<StaminaModifierComponent, ComponentStartup>(OnModifierStartup);
+        SubscribeLocalEvent<StaminaModifierComponent, ComponentShutdown>(OnModifierShutdown);
+    }
+
+    private void OnModifierStartup(EntityUid uid, StaminaModifierComponent comp, ComponentStartup args)
+    {
+        if (!TryComp<StaminaComponent>(uid, out var stamina))
+            return;
+
+        stamina.CritThreshold *= comp.Modifier;
+    }
+
+    private void OnModifierShutdown(EntityUid uid, StaminaModifierComponent comp, ComponentShutdown args)
+    {
+        if (!TryComp<StaminaComponent>(uid, out var stamina))
+            return;
+
+        stamina.CritThreshold /= comp.Modifier;
+    }
+
+    /// <summary>
+    /// Change the stamina modifier for an entity.
+    /// If it has <see cref="StaminaComponent"/> it will also be updated.
+    /// </summary>
+    public void SetModifier(EntityUid uid, float modifier, StaminaModifierComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return;
+
+        var old = comp.Modifier;
+        if (old == modifier)
+            return;
+
+        comp.Modifier = modifier;
+        Dirty(comp);
+
+        if (TryComp<StaminaComponent>(uid, out var stamina))
+        {
+            // scale to the new threshold, act as if it was removed then added
+            stamina.CritThreshold *= modifier / old;
+        }
+    }
+}

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -21,7 +21,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Shared.Damage.Systems;
 
-public sealed class StaminaSystem : EntitySystem
+public sealed partial class StaminaSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
@@ -41,6 +41,9 @@ public sealed class StaminaSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
+
+        InitializeModifier();
+
         SubscribeLocalEvent<StaminaComponent, EntityUnpausedEvent>(OnStamUnpaused);
         SubscribeLocalEvent<StaminaComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<StaminaComponent, ComponentShutdown>(OnShutdown);
@@ -48,6 +51,7 @@ public sealed class StaminaSystem : EntitySystem
         SubscribeLocalEvent<StaminaComponent, ComponentHandleState>(OnStamHandleState);
         SubscribeLocalEvent<StaminaComponent, DisarmedEvent>(OnDisarmed);
         SubscribeLocalEvent<StaminaComponent, RejuvenateEvent>(OnRejuvenate);
+
         SubscribeLocalEvent<StaminaDamageOnCollideComponent, StartCollideEvent>(OnCollide);
         SubscribeLocalEvent<StaminaDamageOnHitComponent, MeleeHitEvent>(OnHit);
     }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -194,6 +194,7 @@
       - ForcedSleep
       - TemporaryBlindness
       - Pacified
+      - StaminaModifier
   - type: ThermalRegulator
     metabolismHeat: 800
     radiatedHeat: 100

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -84,6 +84,7 @@
       - ForcedSleep
       - TemporaryBlindness
       - Pacified
+      - StaminaModifier
   - type: Blindable
   # Other
   - type: Inventory

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -124,6 +124,11 @@
         key: KnockedDown
         time: 3
         type: Remove
+      - !type:GenericStatusEffect
+        key: StaminaModifier
+        component: StaminaModifier
+        time: 3
+        type: Add
     Medicine:
       metabolismRate: 1.0
       effects:

--- a/Resources/Prototypes/status_effects.yml
+++ b/Resources/Prototypes/status_effects.yml
@@ -56,3 +56,6 @@
 
 - type: statusEffect
   id: RatvarianLanguage #Praise him
+
+- type: statusEffect
+  id: StaminaModifier


### PR DESCRIPTION
## About the PR
- adds StaminaModifier for modifying CritThreshold
- stims double your stamina when active, meaning you can take twice as much stuns or do twice as many wide swings, making it a more versatile tool. it can now actually prevent you being stunned and dropping your weapon, which usually ends an op immediately. getting up a little bit faster isnt nearly as important compared to that.
- if you have over 100 stamina damage and stims wear off you instantly stamcrit as withdrawl
- excellent for offensive since you can do more damage with wide swings, and less slowdown

meth untouched since it can be mass produced, might be worth for a future pr

**Media**

https://github.com/space-wizards/space-station-14/assets/39013340/12c8b5b2-25ff-4ab5-92e8-f0a8693fdd9d


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Stimulants now double your stamina, making you harder to stun and letting you use more heavy attacks.
