### PR TITLE
meat rotting hotfix

### DIFF
--- a/Content.Server/Atmos/Miasma/RottingSystem.cs
+++ b/Content.Server/Atmos/Miasma/RottingSystem.cs
@@ -29,7 +29,7 @@ public sealed class RottingSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<PerishableComponent, ComponentStartup>(OnPerishableStartup);
+        SubscribeLocalEvent<PerishableComponent, MapInitEvent>(OnPerishableMapInit);
         SubscribeLocalEvent<PerishableComponent, EntityUnpausedEvent>(OnPerishableUnpaused);
         SubscribeLocalEvent<PerishableComponent, MobStateChangedEvent>(OnMobStateChanged);
 
@@ -43,7 +43,7 @@ public sealed class RottingSystem : EntitySystem
         SubscribeLocalEvent<TemperatureComponent, IsRottingEvent>(OnTempIsRotting);
     }
 
-    private void OnPerishableStartup(EntityUid uid, PerishableComponent component, ComponentStartup args)
+    private void OnPerishableMapInit(EntityUid uid, PerishableComponent component, MapInitEvent args)
     {
         component.NextPerishUpdate = _timing.CurTime + component.PerishUpdateRate;
     }

--- a/Content.Server/Atmos/Miasma/RottingSystem.cs
+++ b/Content.Server/Atmos/Miasma/RottingSystem.cs
@@ -29,6 +29,7 @@ public sealed class RottingSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<PerishableComponent, ComponentStartup>(OnPerishableStartup);
         SubscribeLocalEvent<PerishableComponent, EntityUnpausedEvent>(OnPerishableUnpaused);
         SubscribeLocalEvent<PerishableComponent, MobStateChangedEvent>(OnMobStateChanged);
 
@@ -40,6 +41,11 @@ public sealed class RottingSystem : EntitySystem
         SubscribeLocalEvent<RottingComponent, RejuvenateEvent>(OnRejuvenate);
 
         SubscribeLocalEvent<TemperatureComponent, IsRottingEvent>(OnTempIsRotting);
+    }
+
+    private void OnPerishableStartup(EntityUid uid, PerishableComponent component, ComponentStartup args)
+    {
+        component.NextPerishUpdate = _timing.CurTime + component.PerishUpdateRate;
     }
 
     private void OnPerishableUnpaused(EntityUid uid, PerishableComponent component, ref EntityUnpausedEvent args)

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -26,6 +26,8 @@
           Quantity: 5
   - type: Item
     size: 5
+  # let air cook and freeze meat for cooking and preservation
+  - type: AtmosExposed
   - type: Temperature
     currentTemperature: 290
   - type: Material


### PR DESCRIPTION
## About the PR
being in a cold room didnt actually stop it from rotting because didnt have AtmosExposed
now it does so that works and you can cook steak in a plasma fire epic style

fixes perishable bug where it only sets next update at start for mobs

**Media**
cooking steak in plasma fire :trollface:
freezing in cold environment actually works now :trollface:
![11:59:07](https://github.com/space-wizards/space-station-14/assets/39013340/b72ef5ee-0912-49da-bd80-101097ab58ec)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun