### PR TITLE
Melee rebalancing rebalancing, high damage single-target attacks

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -72,16 +72,17 @@ public sealed class MeleeWeaponComponent : Component
     public FixedPoint2 BluntStaminaDamageFactor = FixedPoint2.New(0.5f);
 
     /// <summary>
-    /// Multiplies damage by this amount for wide attacks.
+    /// Multiplies damage by this amount for single-target attacks.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("heavyDamageModifier")]
     public FixedPoint2 HeavyDamageModifier = FixedPoint2.New(1.25);
 
+    //TODO: Was set to 0 value as of 2023-08-06, might want to delete later if we never go back to this idea
     /// <summary>
     /// How much stamina it costs for a heavy attack.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("heavyStaminaCost")]
-    public float HeavyStaminaCost = 15f;
+    public float HeavyStaminaCost = 0f;
 
     // TODO: Temporarily 1.5 until interactionoutline is adjusted to use melee, then probably drop to 1.2
     /// <summary>

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -452,7 +452,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
     protected virtual void DoLightAttack(EntityUid user, LightAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session)
     {
-        var damage = GetDamage(meleeUid, user, component);
+        // If I do not come back later to fix Light Attacks being Heavy Attacks you can throw me in the spider pit -Errant
+        var damage = GetDamage(meleeUid, user, component) * GetHeavyDamageModifier(meleeUid, user, component);
 
         // For consistency with wide attacks stuff needs damageable.
         if (Deleted(ev.Target) ||
@@ -575,7 +576,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         var direction = targetMap.Position - userPos;
         var distance = Math.Min(component.Range, direction.Length());
 
-        var damage = GetDamage(meleeUid, user, component) * GetHeavyDamageModifier(meleeUid, user, component);
+        var damage = GetDamage(meleeUid, user, component);
         var entities = ev.Entities;
 
         if (entities.Count == 0)

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -68,8 +68,9 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 3
-        Poison: 1
+        # Actually does 3 + 1 damage due to +25% damage bonus on all single target melee attacks
+        Slash: 2.4
+        Poison: 0.8
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -262,7 +262,8 @@
     attackRate: 1
     damage:
       types:
-        Blunt: 5
+        # Actually does 5 damage due to +25% damage bonus on all single target melee attacks
+        Blunt: 4
   - type: Pullable
   - type: DoAfter
   - type: CreamPied

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -42,7 +42,8 @@
     animation: WeaponArcPunch
     damage:
       types:
-        Piercing: 5
+        # Actually does 5 damage due to +25% damage bonus on all single target melee attacks
+        Piercing: 4
   - type: Temperature
     heatDamageThreshold: 400
     coldDamageThreshold: 285


### PR DESCRIPTION
## About the PR
As per the linked Idea, let's try something different. Click-attacks now get the damage bonus instead of area attacks, so players can choose between trying to hunt sprites for the bonus damage, or swing away as previously without windup or stamina cost, but less overall damage output as before (per target)

Roundstart playable species' unarmed attacks were reduced to keep them at their current DPS when trying to claw through barriers, but 

This will make every hostile mob with a melee attack deal +25% damage. NPC monsters will become more dangerous, perhaps noticeably so. Consider if we want to reduce all mob damage values to maintain current DPS output with click-attacks

It will also mean that, to some degree, the displayed weapon damage will be a "lie", but at least it will be an understatement

Resolves #18759

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- tweak: Wide attacks no longer cost stamina, deal weapon damage.
- tweak: Primary/Single-target melee attacks deal +25% damage.
