### PR TITLE
Make Shovel Item size 90

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -475,6 +475,7 @@
       types:
         Blunt: 14
   - type: Item
+    size: 90
     sprite: Objects/Tools/shovel.rsi
   - type: PhysicalComposition
     materialComposition:


### PR DESCRIPTION
It was size 5. Currently spears are 95, baseball bats are 80.