### PR TITLE
Explicit Lit Damage values instead of bonuses

### DIFF
--- a/Content.Server/Tools/Components/WelderComponent.cs
+++ b/Content.Server/Tools/Components/WelderComponent.cs
@@ -50,14 +50,10 @@ namespace Content.Server.Tools.Components
         public SoundSpecifier WelderRefill { get; } = new SoundPathSpecifier("/Audio/Effects/refill.ogg");
 
         /// <summary>
-        ///     When the welder is lit, this damage is added to the base melee weapon damage.
+        ///     While the welder is lit this damage REPLACES the base melee weapon damage.
         /// </summary>
-        /// <remarks>
-        ///     If this is a standard welder, this damage bonus should probably subtract the entity's standard melee weapon damage
-        ///     and replace it all with heat damage.
-        /// </remarks>
-        [DataField("litMeleeDamageBonus")]
-        public DamageSpecifier LitMeleeDamageBonus = new();
+        [DataField("litDamage")]
+        public DamageSpecifier LitDamage = new();
 
         /// <summary>
         ///     Whether the item is safe to refill while lit without exploding the tank.

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -18,8 +18,8 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Utility;
 
-namespace Content.Server.Tools
-{
+namespace Content.Server.Tools;
+
     public sealed partial class ToolSystem
     {
         [Dependency] private readonly IEntityManager _entityManager = default!;
@@ -49,7 +49,7 @@ namespace Content.Server.Tools
         private void OnGetMeleeDamage(EntityUid uid, WelderComponent component, ref GetMeleeDamageEvent args)
         {
             if (component.Lit)
-                args.Damage += component.LitMeleeDamageBonus;
+                args.Damage = component.LitDamage;
         }
 
         public (FixedPoint2 fuel, FixedPoint2 capacity) GetWelderFuelAndCapacity(EntityUid uid, WelderComponent? welder = null, SolutionContainerManagerComponent? solutionContainer = null)
@@ -326,4 +326,3 @@ namespace Content.Server.Tools
             WelderOn = welderOn;
         }
     }
-}

--- a/Content.Server/Weapons/Melee/EnergySword/EnergySwordComponent.cs
+++ b/Content.Server/Weapons/Melee/EnergySword/EnergySwordComponent.cs
@@ -48,9 +48,11 @@ internal sealed class EnergySwordComponent : Component
         Color.MediumSpringGreen,
         Color.MediumOrchid
     };
-
-    [DataField("litDamageBonus")]
-    public DamageSpecifier LitDamageBonus = new();
+    /// <summary>
+    ///     While the energy blade is active this damage REPLACES the base melee weapon damage.
+    /// </summary>
+    [DataField("litDamage")]
+    public DamageSpecifier LitDamage = new();
 
     [DataField("litDisarmMalus")]
     public float LitDisarmMalus = 0.6f;

--- a/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
@@ -49,11 +49,8 @@ public sealed class EnergySwordSystem : EntitySystem
 
     private void OnGetMeleeDamage(EntityUid uid, EnergySwordComponent comp, ref GetMeleeDamageEvent args)
     {
-        if (!comp.Activated)
-            return;
-
-        // Adjusts base damage when the energy blade is active, by values set in yaml
-        args.Damage += comp.LitDamageBonus;
+        if (comp.Activated)
+            args.Damage = comp.LitDamage;
     }
 
     private void OnUseInHand(EntityUid uid, EnergySwordComponent comp, UseInHandEvent args)

--- a/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
@@ -131,10 +131,9 @@
   - type: Tool
     speed: 0.05
   - type: Welder
-    litMeleeDamageBonus:
-      types: # When lit, negate standard melee damage and replace with heat
+    litDamage: # While the flame is on, lit damage REPLACES base damage
+      types:
         Heat: 0.5
-        Blunt: -5
 
 - type: entity
   name: milkalyzer

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -61,7 +61,7 @@
   - type: Welder
     fuelConsumption: 0.01
     fuelLitCost: 0.1
-    litMeleeDamageBonus:
+    litDamage: # While the flame is on, lit damage REPLACES base damage
       types:
         Heat: 1
     tankSafe: true

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -48,10 +48,9 @@
       collection: Welder
     qualities: Welding
   - type: Welder
-    litMeleeDamageBonus:
+    litDamage: # While the flame is on, lit damage REPLACES base damage
       types:
         Heat: 8
-        Blunt: -5
   - type: PointLight
     enabled: false
     radius: 1.5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -5,12 +5,11 @@
   description: A very loud & dangerous sword with a beam made of pure, concentrated plasma. Cuts through unarmored targets like butter.
   components:
   - type: EnergySword
-    litDamageBonus:
+    litDamage: # While the blade is active lit damage REPLACES base damage
         types:
             Slash: 15
             Heat: 15
             Structural: 4
-            Blunt: -4.5
     litDisarmMalus: 0.6
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_sword.rsi
@@ -63,11 +62,10 @@
   components:
   - type: EnergySword
     secret: true
-    litDamageBonus:
+    litDamage: # While the blade is active lit damage REPLACES base damage
         types:
             Slash: 9
             Heat: 9
-            Blunt: -1
     litDisarmMalus: 0.4
     activateSound: !type:SoundPathSpecifier
       path: /Audio/Weapons/ebladeon.ogg
@@ -143,11 +141,10 @@
   components:
   - type: EnergySword
     secret: true
-    litDamageBonus:
+    litDamage: # While the blade is active lit damage REPLACES base damage
         types:
             Slash: 7.5
             Heat: 7.5
-            Blunt: -1
     litDisarmMalus: 0.6
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_cutlass.rsi
@@ -171,12 +168,11 @@
   - type: Wieldable
     wieldTime: 0
   - type: EnergySword
-    litDamageBonus:
+    litDamage: # While the blade is active lit damage REPLACES base damage
         types:
             Slash: 9
             Heat: 9
             Structural: 20
-            Blunt: -4.5
     litDisarmMalus: 0.7
   - type: MeleeWeapon
     attackRate: 1.5


### PR DESCRIPTION
## About the PR
This changes the damage logic of active energy swords and welders to use Lit Damage values directly, rather than as modifiers on top of the base melee damage. So the negative blunt damages in the ymls can be cast into the void. 

No player-facing changes
