### PR TITLE
Particle Accelerator power changed admin chat warning

### DIFF
--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -6,6 +6,7 @@ using Robust.Server.Player;
 using Robust.Server.GameObjects;
 using Robust.Shared.Utility;
 using System.Diagnostics;
+using Content.Shared.CCVar;
 
 namespace Content.Server.ParticleAccelerator.EntitySystems;
 
@@ -159,6 +160,12 @@ public sealed partial class ParticleAcceleratorSystem
             };
 
             _adminLogger.Add(LogType.Action, impact, $"{ToPrettyString(player):player} has set the strength of {ToPrettyString(uid)} to {strength}");
+
+
+            var pos = Transform(uid);
+            ParticleAcceleratorPowerState alertMinPowerState = (ParticleAcceleratorPowerState)_cfg.GetCVar(CCVars.AdminAlertParticleAcceleratorMinPowerState);
+            if (strength >= alertMinPowerState)
+                _chat.SendAdminAlert(player, $"changed PA power of {ToPrettyString(uid)} to {strength} at {pos.Coordinates:coordinates}");
         }
 
         comp.SelectedStrength = strength;

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -162,13 +162,15 @@ public sealed partial class ParticleAcceleratorSystem
             _adminLogger.Add(LogType.Action, impact, $"{ToPrettyString(player):player} has set the strength of {ToPrettyString(uid)} to {strength}");
 
 
-            var pos = Transform(uid);
-            ParticleAcceleratorPowerState alertMinPowerState = (ParticleAcceleratorPowerState)_cfg.GetCVar(CCVars.AdminAlertParticleAcceleratorMinPowerState);
+            var alertMinPowerState = (ParticleAcceleratorPowerState)_cfg.GetCVar(CCVars.AdminAlertParticleAcceleratorMinPowerState);
             if (strength >= alertMinPowerState)
+            {
+                var pos = Transform(uid);
                 _chat.SendAdminAlert(player, Loc.GetString("particle-accelerator-admin-power-strength-warning",
-                        ("machine", ToPrettyString(uid)),
-                        ("powerState", strength),
-                        ("coordinates", pos.Coordinates)));
+                    ("machine", ToPrettyString(uid)),
+                    ("powerState", strength),
+                    ("coordinates", pos.Coordinates)));
+            }
         }
 
         comp.SelectedStrength = strength;

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -165,7 +165,10 @@ public sealed partial class ParticleAcceleratorSystem
             var pos = Transform(uid);
             ParticleAcceleratorPowerState alertMinPowerState = (ParticleAcceleratorPowerState)_cfg.GetCVar(CCVars.AdminAlertParticleAcceleratorMinPowerState);
             if (strength >= alertMinPowerState)
-                _chat.SendAdminAlert(player, $"changed PA power of {ToPrettyString(uid)} to {strength} at {pos.Coordinates:coordinates}");
+                _chat.SendAdminAlert(player, Loc.GetString("particle-accelerator-admin-power-strength-warning",
+                        ("machine", ToPrettyString(uid)),
+                        ("powerState", strength),
+                        ("coordinates", pos.Coordinates)));
         }
 
         comp.SelectedStrength = strength;

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.cs
@@ -1,9 +1,11 @@
 using Content.Server.Administration.Logs;
+using Content.Server.Chat.Managers;
 using Content.Server.Projectiles;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
 
 namespace Content.Server.ParticleAccelerator.EntitySystems;
 
@@ -12,6 +14,8 @@ public sealed partial class ParticleAcceleratorSystem : EntitySystem
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly ProjectileSystem _projectileSystem = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -699,6 +699,11 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> AdminAlertExplosionMinIntensity =
             CVarDef.Create("admin.alert.explosion_min_intensity", 60, CVar.SERVERONLY);
 
+        /// <summary>
+        ///     Minimum particle accelerator strength to create an admin alert message.
+        /// </summary>
+        public static readonly CVarDef<int> AdminAlertParticleAcceleratorMinPowerState =
+            CVarDef.Create("admin.alert.particle_accelerator_min_power_state", 3, CVar.SERVERONLY);
 
         /// <summary>
         ///     Should the ban details in admin channel include PII? (IP, HWID, etc)
@@ -711,12 +716,6 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<bool> AdminDeadminOnJoin =
             CVarDef.Create("admin.deadmin_on_join", false, CVar.SERVERONLY);
-
-        /// <summary>
-        ///     Minimum explosion intensity to create an admin alert message. -1 to disable the alert.
-        /// </summary>
-        public static readonly CVarDef<int> AdminAlertParticleAcceleratorMinPowerState =
-            CVarDef.Create("admin.alert.particle_accelerator_min_power_state", 3, CVar.SERVERONLY);
 
         /*
          * Explosions

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -712,6 +712,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> AdminDeadminOnJoin =
             CVarDef.Create("admin.deadmin_on_join", false, CVar.SERVERONLY);
 
+        /// <summary>
+        ///     Minimum explosion intensity to create an admin alert message. -1 to disable the alert.
+        /// </summary>
+        public static readonly CVarDef<int> AdminAlertParticleAcceleratorMinPowerState =
+            CVarDef.Create("admin.alert.particle_accelerator_min_power_state", 3, CVar.SERVERONLY);
+
         /*
          * Explosions
          */

--- a/Resources/Locale/en-US/particle-accelerator/particle-accelerator-admin.ftl
+++ b/Resources/Locale/en-US/particle-accelerator/particle-accelerator-admin.ftl
@@ -1,0 +1,1 @@
+﻿particle-accelerator-admin-power-strength-warning = changed PA power of {$machine} to {$powerState} at {$coordinates:coordinates}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Added a warning in admin chat when someone modifies the particle accelerator projectile strength.
Added a cvar that determines the minimum power level for the warning to trigger. Default is set to 3 (level2)(3 on the UI)

The ParticleAcceleratorPowerState enum values are `Standby, Level0, Level1, Level2, Level3`, so power levels are one less than on the machine UI. `Standby` is 0 on UI and `level3` is the emagged power level.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/10494922/3cc13f36-c10b-4380-b3d7-4660e0a7fcf3
