### PR TITLE
Localize walls

### DIFF
--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
@@ -45,68 +45,68 @@ ent-WallRockBasalt = { ent-WallRock }
     .desc = { ent-WallRock.desc }
 
 ent-WallRockBasaltGold = { ent-WallRock }
-    .desc = An ore vein rich with gold.
-    .suffix = Gold
+    .desc = { ent-WallRockGold.desc }
+    .suffix = { ent-WallRockGold.suffix }
 
 ent-WallRockBasaltPlasma = { ent-WallRock }
-    .desc = An ore vein rich with plasma.
-    .suffix = Plasma
+    .desc = { ent-WallRockPlasma.desc }
+    .suffix = { ent-WallRockPlasma.suffix }
 
 ent-WallRockBasaltQuartz = { ent-WallRock }
-    .desc = An ore vein rich with quartz.
-    .suffix = Quartz
+    .desc = { ent-WallRockQuartz.desc }
+    .suffix = { ent-WallRockQuartz.suffix }
 
 ent-WallRockBasaltSilver = { ent-WallRock }
-    .desc = An ore vein rich with silver.
-    .suffix = Silver
+    .desc = { ent-WallRockSilver.desc }
+    .suffix = { ent-WallRockSilver.suffix }
 
 ent-WallRockBasaltTin = { ent-WallRock }
-    .desc = An ore vein rich with steel.
-    .suffix = Steel
+    .desc = { ent-WallRockTin.desc }
+    .suffix = { ent-WallRockTin.suffix }
 
 ent-WallRockBasaltUranium = { ent-WallRock }
-    .desc = An ore vein rich with uranium.
-    .suffix = Uranium
+    .desc = { ent-WallRockUranium.desc }
+    .suffix = { ent-WallRockUranium.suffix }
 
 ent-WallRockBasaltBananium = { ent-WallRock }
-    .desc = An ore vein rich with bananium.
-    .suffix = Bananium
+    .desc = { ent-WallRockBananium.desc }
+    .suffix = { ent-WallRockBananium.suffix }
 
 ent-WallRockBasaltArtifactFragment = { ent-WallRock }
-    .desc = A rock wall. What's that sticking out of it?
-    .suffix = Artifact Fragment
+    .desc = { ent-WallRockArtifactFragment.desc }
+    .suffix = { ent-WallRockArtifactFragment.suffix }
 
 ent-WallRockSnow = { ent-WallRock }
     .desc = { ent-WallRock.desc }
 
 ent-WallRockSnowGold = { ent-WallRock }
-    .desc = An ore vein rich with gold.
-    .suffix = Gold
+    .desc = { ent-WallRockGold.desc }
+    .suffix = { ent-WallRockGold.suffix }
 
 ent-WallRockSnowPlasma = { ent-WallRock }
-    .desc = An ore vein rich with plasma.
-    .suffix = Plasma
+    .desc = { ent-WallRockPlasma.desc }
+    .suffix = { ent-WallRockPlasma.suffix }
 
 ent-WallRockSnowQuartz = { ent-WallRock }
-    .desc = An ore vein rich with quartz.
-    .suffix = Quartz
+    .desc = { ent-WallRockQuartz.desc }
+    .suffix = { ent-WallRockQuartz.suffix }
 
 ent-WallRockSnowSilver = { ent-WallRock }
-    .desc = An ore vein rich with silver.
-    .suffix = Silver
+    .desc = { ent-WallRockSilver.desc }
+    .suffix = { ent-WallRockSilver.suffix }
 
 ent-WallRockSnowTin = { ent-WallRock }
-    .desc = An ore vein rich with steel.
-    .suffix = Steel
+    .desc = { ent-WallRockTin.desc }
+    .suffix = { ent-WallRockTin.suffix }
 
 ent-WallRockSnowUranium = { ent-WallRock }
-    .desc = An ore vein rich with uranium.
-    .suffix = Uranium
+    .desc = { ent-WallRockUranium.desc }
+    .suffix = { ent-WallRockUranium.suffix }
 
 ent-WallRockSnowBananium = { ent-WallRock }
-    .desc = An ore vein rich with bananium.
-    .suffix = Bananium
+    .desc = { ent-WallRockBananium.desc }
+    .suffix = { ent-WallRockBananium.suffix }
 
 ent-WallRockSnowArtifactFragment = { ent-WallRock }
-    .desc = A rock wall. What's that sticking out of it?
-    .suffix = Artifact Fragment
+    .desc = { ent-WallRockArtifactFragment.desc }
+    .suffix = { ent-WallRockArtifactFragment.suffix }

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
@@ -77,6 +77,7 @@ ent-WallRockBasaltArtifactFragment = { ent-WallRock }
     .suffix = Artifact Fragment
 
 ent-WallRockSnow = { ent-WallRock }
+    .desc = { ent-WallRock.desc }
 
 ent-WallRockSnowGold = { ent-WallRock }
     .desc = An ore vein rich with gold.

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
@@ -7,6 +7,7 @@ ent-AsteroidRockMining = asteroid rock
     .suffix = High Ore Yield
 
 ent-WallRock = rock
+    .desc = A rock wall.
 
 ent-WallRockGold = { ent-WallRock }
     .desc = An ore vein rich with gold.
@@ -41,6 +42,7 @@ ent-WallRockArtifactFragment = { ent-WallRock }
     .suffix = Artifact Fragment
 
 ent-WallRockBasalt = { ent-WallRock }
+    .desc = { ent-WallRock.desc }
 
 ent-WallRockBasaltGold = { ent-WallRock }
     .desc = An ore vein rich with gold.

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
@@ -1,0 +1,109 @@
+ent-AsteroidRock = asteroid rock
+    .desc = A rocky asteroid.
+    .suffix = Low Ore Yield
+
+ent-AsteroidRockMining = asteroid rock
+    .desc = An asteroid.
+    .suffix = higher ore yield
+
+ent-WallRock = rock
+
+ent-WallRockGold = { ent-WallRock }
+    .desc = An ore vein rich with gold.
+    .suffix = Gold
+
+ent-WallRockPlasma = { ent-WallRock }
+    .desc = An ore vein rich with plasma.
+    .suffix = Plasma
+
+ent-WallRockQuartz = { ent-WallRock }
+    .desc = An ore vein rich with quartz.
+    .suffix = Quartz
+
+ent-WallRockSilver = { ent-WallRock }
+    .desc = An ore vein rich with silver.
+    .suffix = Silver
+
+ent-WallRockTin = { ent-WallRock }
+    .desc = An ore vein rich with steel.
+    .suffix = Steel
+
+ent-WallRockUranium = { ent-WallRock }
+    .desc = An ore vein rich with uranium.
+    .suffix = Uranium
+
+ent-WallRockBananium = { ent-WallRock }
+    .desc = An ore vein rich with bananium.
+    .suffix = Bananium
+
+ent-WallRockArtifactFragment = { ent-WallRock }
+    .desc = A rock wall. What's that sticking out of it?
+    .suffix = Artifact Fragment
+
+ent-WallRockBasalt = { ent-WallRock }
+
+ent-WallRockBasaltGold = { ent-WallRock }
+    .desc = An ore vein rich with gold.
+    .suffix = Gold
+
+ent-WallRockBasaltPlasma = { ent-WallRock }
+    .desc = An ore vein rich with plasma.
+    .suffix = Plasma
+
+ent-WallRockBasaltQuartz = { ent-WallRock }
+    .desc = An ore vein rich with quartz.
+    .suffix = Quartz
+
+ent-WallRockBasaltSilver = { ent-WallRock }
+    .desc = An ore vein rich with silver.
+    .suffix = Silver
+
+ent-WallRockBasaltTin = { ent-WallRock }
+    .desc = An ore vein rich with steel.
+    .suffix = Steel
+
+ent-WallRockBasaltUranium = { ent-WallRock }
+    .desc = An ore vein rich with uranium.
+    .suffix = Uranium
+
+ent-WallRockBasaltBananium = { ent-WallRock }
+    .desc = An ore vein rich with bananium.
+    .suffix = Bananium
+
+ent-WallRockBasaltArtifactFragment = { ent-WallRock }
+    .desc = A rock wall. What's that sticking out of it?
+    .suffix = Artifact Fragment
+
+ent-WallRockSnow = { ent-WallRock }
+
+ent-WallRockSnowGold = { ent-WallRock }
+    .desc = An ore vein rich with gold.
+    .suffix = Gold
+
+ent-WallRockSnowPlasma = { ent-WallRock }
+    .desc = An ore vein rich with plasma.
+    .suffix = Plasma
+
+ent-WallRockSnowQuartz = { ent-WallRock }
+    .desc = An ore vein rich with quartz.
+    .suffix = Quartz
+
+ent-WallRockSnowSilver = { ent-WallRock }
+    .desc = An ore vein rich with silver.
+    .suffix = Silver
+
+ent-WallRockSnowTin = { ent-WallRock }
+    .desc = An ore vein rich with steel.
+    .suffix = Steel
+
+ent-WallRockSnowUranium = { ent-WallRock }
+    .desc = An ore vein rich with uranium.
+    .suffix = Uranium
+
+ent-WallRockSnowBananium = { ent-WallRock }
+    .desc = An ore vein rich with bananium.
+    .suffix = Bananium
+
+ent-WallRockSnowArtifactFragment = { ent-WallRock }
+    .desc = A rock wall. What's that sticking out of it?
+    .suffix = Artifact Fragment

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
@@ -1,9 +1,9 @@
 ent-AsteroidRock = asteroid rock
-    .desc = A rocky asteroid.
+    .desc = A rocky asteroid wall.
     .suffix = Low Ore Yield
 
 ent-AsteroidRockMining = asteroid rock
-    .desc = An asteroid.
+    .desc = An asteroid wall.
     .suffix = High Ore Yield
 
 ent-WallRock = rock

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
@@ -2,8 +2,8 @@ ent-AsteroidRock = asteroid rock
     .desc = A rocky asteroid wall.
     .suffix = Low Ore Yield
 
-ent-AsteroidRockMining = asteroid rock
-    .desc = An asteroid wall.
+ent-AsteroidRockMining = { ent-AsteroidRock }
+    .desc = { ent-AsteroidRock.desc }
     .suffix = High Ore Yield
 
 ent-WallRock = rock

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/asteroid.ftl
@@ -4,7 +4,7 @@ ent-AsteroidRock = asteroid rock
 
 ent-AsteroidRockMining = asteroid rock
     .desc = An asteroid.
-    .suffix = higher ore yield
+    .suffix = High Ore Yield
 
 ent-WallRock = rock
 

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/barricades.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/barricades.ftl
@@ -1,0 +1,1 @@
+ent-Barricade = barricade

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/barricades.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/barricades.ftl
@@ -1,1 +1,2 @@
 ent-Barricade = barricade
+    .desc = A patchwork fortification of planks.

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/girders.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/girders.ftl
@@ -1,5 +1,5 @@
 ent-Girder = girder
-    .desc = A large structural assembly made out of metal; It requires a layer of metal before it can be considered a wall.
+    .desc = A large structural assembly made out of metal. It requires a layer of metal before it can be considered a wall.
 
 ent-ReinforcedGirder = reinforced girder
-    .desc = A large structural assembly made out of metal and plasteel; It requires a layer of plasteel before it can be considered a reinforced wall.
+    .desc = A large structural assembly made out of metal and plasteel. It requires a layer of plasteel before it can be considered a reinforced wall.

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/girders.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/girders.ftl
@@ -1,0 +1,5 @@
+ent-Girder = girder
+    .desc = A large structural assembly made out of metal; It requires a layer of metal before it can be considered a wall.
+
+ent-ReinforcedGirder = reinforced girder
+    .desc = A large structural assembly made out of metal and plasteel; It requires a layer of plasteel before it can be considered a reinforced wall.

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/grille.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/grille.ftl
@@ -1,0 +1,5 @@
+ent-Grille = grille
+    .desc = A flimsy framework of iron rods.
+
+ent-GrilleBroken = { ent-Grille }
+    .desc = A flimsy framework of iron rods. It has seen better days.

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/mountain.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/mountain.ftl
@@ -1,0 +1,5 @@
+ent-MountainRock = mountain rock
+    .desc = A craggy mountain wall.
+
+ent-MountainRockMining = { ent-MountainRock }
+    .desc = { ent-MountainRock.desc }

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/mountain.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/mountain.ftl
@@ -1,5 +1,7 @@
 ent-MountainRock = mountain rock
     .desc = A craggy mountain wall.
+    .suffix = Low Ore Yield
 
 ent-MountainRockMining = { ent-MountainRock }
     .desc = { ent-MountainRock.desc }
+    .suffix = High Ore Yield

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/railing.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/railing.ftl
@@ -1,0 +1,8 @@
+ent-Railing = railing
+    .desc = Basic railing meant to protect idiots like you from falling.
+
+ent-RailingCorner = { ent-Railing }
+    .desc = { ent-Railing.desc }
+
+ent-RailingCornerSmall = { ent-Railing }
+    .desc = { ent-Railing.desc }

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/walls.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/walls.ftl
@@ -93,3 +93,4 @@ ent-WallVaultSandstone = sandstone vault wall
 ent-WallInvisible = invisible wall
 
 ent-WallForce = force wall
+    .desc = A magical forcefield.

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/walls.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/walls.ftl
@@ -1,4 +1,4 @@
-ent-BaseWall = basewall
+ent-BaseWall = wall
     .desc = Keeps the air in and the greytide out.
 
 ent-WallBrick = brick wall

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/walls.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/walls.ftl
@@ -17,6 +17,7 @@ ent-WallCult = cult wall
     .desc = { ent-BaseWall.desc }
 
 ent-WallDebug = debug wall
+    .desc = A wall for debugging IconSmooth.
     .suffix = DEBUG
 
 ent-WallDiamond = diamond wall

--- a/Resources/Locale/en-US/prototypes/entities/structures/walls/walls.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/walls/walls.ftl
@@ -1,0 +1,95 @@
+ent-BaseWall = basewall
+    .desc = Keeps the air in and the greytide out.
+
+ent-WallBrick = brick wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallClock = clock wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallClown = bananium wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallMeat = meat wall
+    .desc = Sticky.
+
+ent-WallCult = cult wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallDebug = debug wall
+    .suffix = DEBUG
+
+ent-WallDiamond = diamond wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallGold = gold wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallIce = ice wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallPlasma = plasma wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallPlastic = plastic wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallPlastitaniumIndestructible = plastitanium wall
+    .desc = { ent-BaseWall.desc }
+    .suffix = indestructible
+
+ent-WallPlastitanium = plastitanium wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallPlastitaniumDiagonal = plastitanium wall
+    .desc = { ent-BaseWall.desc }
+    .suffix = diagonal
+
+ent-WallReinforced = reinforced wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallRiveted = riveted wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallSandstone = sandstone wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallSilver = silver wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallShuttleDiagonal = shuttle wall
+    .desc = { ent-BaseWall.desc }
+    .suffix = diagonal
+
+ent-WallShuttle = shuttle wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallSolid = solid wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallSolidDiagonal = solid wall
+    .desc = { ent-BaseWall.desc }
+    .suffix = diagonal
+
+ent-WallSolidRust = solid wall
+    .desc = { ent-BaseWall.desc }
+    .suffix = rusted
+
+ent-WallUranium = uranium wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallWood = wood wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallVaultAlien = alien vault wall
+    .desc = A mysterious ornate looking wall. There may be ancient dangers inside.
+
+ent-WallVaultRock = rock vault wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallVaultSandstone = sandstone vault wall
+    .desc = { ent-BaseWall.desc }
+
+ent-WallInvisible = invisible wall
+
+ent-WallForce = force wall

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -1,9 +1,6 @@
 - type: entity
   id: AsteroidRock
   parent: BaseStructure
-  name: asteroid rock
-  suffix: Low Ore Yield
-  description: A rocky asteroid.
   components:
   - type: Gatherable
     whitelist:
@@ -46,9 +43,6 @@
 - type: entity
   id: AsteroidRockMining
   parent: AsteroidRock
-  name: asteroid rock
-  suffix: higher ore yield
-  description: An asteroid.
   components:
   - type: Gatherable
     whitelist:
@@ -62,7 +56,6 @@
 - type: entity
   id: WallRock
   parent: BaseStructure
-  name: rock
   components:
     - type: Gatherable
       whitelist:
@@ -113,8 +106,6 @@
 - type: entity
   id: WallRockGold
   parent: WallRock
-  description: An ore vein rich with gold.
-  suffix: Gold
   components:
     - type: OreVein
       oreChance: 1.0
@@ -135,8 +126,6 @@
 - type: entity
   id: WallRockPlasma
   parent: WallRock
-  description: An ore vein rich with plasma.
-  suffix: Plasma
   components:
     - type: OreVein
       oreChance: 1.0
@@ -157,8 +146,6 @@
 - type: entity
   id: WallRockQuartz
   parent: WallRock
-  description: An ore vein rich with quartz.
-  suffix: Quartz
   components:
     - type: OreVein
       oreChance: 1.0
@@ -179,8 +166,6 @@
 - type: entity
   id: WallRockSilver
   parent: WallRock
-  description: An ore vein rich with silver.
-  suffix: Silver
   components:
     - type: OreVein
       oreChance: 1.0
@@ -202,8 +187,6 @@
 - type: entity
   id: WallRockTin
   parent: WallRock
-  description: An ore vein rich with steel.
-  suffix: Steel
   components:
     - type: OreVein
       oreChance: 1.0
@@ -224,8 +207,6 @@
 - type: entity
   id: WallRockUranium
   parent: WallRock
-  description: An ore vein rich with uranium.
-  suffix: Uranium
   components:
     - type: OreVein
       oreChance: 1.0
@@ -247,8 +228,6 @@
 - type: entity
   id: WallRockBananium
   parent: WallRock
-  description: An ore vein rich with bananium.
-  suffix: Bananium
   components:
     - type: OreVein
       oreChance: 1.0
@@ -269,8 +248,6 @@
 - type: entity
   id: WallRockArtifactFragment
   parent: WallRock
-  description: A rock wall. What's that sticking out of it?
-  suffix: Artifact Fragment
   components:
     - type: OreVein
       oreChance: 1.0
@@ -309,8 +286,6 @@
 - type: entity
   id: WallRockBasaltGold
   parent: WallRockBasalt
-  description: An ore vein rich with gold.
-  suffix: Gold
   components:
     - type: OreVein
       oreChance: 1.0
@@ -331,8 +306,6 @@
 - type: entity
   id: WallRockBasaltPlasma
   parent: WallRockBasalt
-  description: An ore vein rich with plasma.
-  suffix: Plasma
   components:
     - type: OreVein
       oreChance: 1.0
@@ -353,8 +326,6 @@
 - type: entity
   id: WallRockBasaltQuartz
   parent: WallRockBasalt
-  description: An ore vein rich with quartz.
-  suffix: Quartz
   components:
     - type: OreVein
       oreChance: 1.0
@@ -375,8 +346,6 @@
 - type: entity
   id: WallRockBasaltSilver
   parent: WallRockBasalt
-  description: An ore vein rich with silver.
-  suffix: Silver
   components:
     - type: OreVein
       oreChance: 1.0
@@ -397,8 +366,6 @@
 - type: entity
   id: WallRockBasaltTin
   parent: WallRockBasalt
-  description: An ore vein rich with steel.
-  suffix: Steel
   components:
     - type: OreVein
       oreChance: 1.0
@@ -419,8 +386,6 @@
 - type: entity
   id: WallRockBasaltUranium
   parent: WallRockBasalt
-  description: An ore vein rich with uranium.
-  suffix: Uranium
   components:
     - type: OreVein
       oreChance: 1.0
@@ -442,8 +407,6 @@
 - type: entity
   id: WallRockBasaltBananium
   parent: WallRockBasalt
-  description: An ore vein rich with bananium.
-  suffix: Bananium
   components:
     - type: OreVein
       oreChance: 1.0
@@ -464,8 +427,6 @@
 - type: entity
   id: WallRockBasaltArtifactFragment
   parent: WallRockBasalt
-  description: A rock wall. What's that sticking out of it?
-  suffix: Artifact Fragment
   components:
     - type: OreVein
       oreChance: 1.0
@@ -504,8 +465,6 @@
 - type: entity
   id: WallRockSnowGold
   parent: WallRockSnow
-  description: An ore vein rich with gold.
-  suffix: Gold
   components:
     - type: OreVein
       oreChance: 1.0
@@ -526,8 +485,6 @@
 - type: entity
   id: WallRockSnowPlasma
   parent: WallRockSnow
-  description: An ore vein rich with plasma.
-  suffix: Plasma
   components:
     - type: OreVein
       oreChance: 1.0
@@ -548,8 +505,6 @@
 - type: entity
   id: WallRockSnowQuartz
   parent: WallRockSnow
-  description: An ore vein rich with quartz.
-  suffix: Quartz
   components:
     - type: OreVein
       oreChance: 1.0
@@ -570,8 +525,6 @@
 - type: entity
   id: WallRockSnowSilver
   parent: WallRockSnow
-  description: An ore vein rich with silver.
-  suffix: Silver
   components:
     - type: OreVein
       oreChance: 1.0
@@ -592,8 +545,6 @@
 - type: entity
   id: WallRockSnowTin
   parent: WallRockSnow
-  description: An ore vein rich with steel.
-  suffix: Steel
   components:
     - type: OreVein
       oreChance: 1.0
@@ -614,8 +565,6 @@
 - type: entity
   id: WallRockSnowUranium
   parent: WallRockSnow
-  description: An ore vein rich with uranium.
-  suffix: Uranium
   components:
     - type: OreVein
       oreChance: 1.0
@@ -637,8 +586,6 @@
 - type: entity
   id: WallRockSnowBananium
   parent: WallRockSnow
-  description: An ore vein rich with bananium.
-  suffix: Bananium
   components:
     - type: OreVein
       oreChance: 1.0
@@ -659,8 +606,6 @@
 - type: entity
   id: WallRockSnowArtifactFragment
   parent: WallRockSnow
-  description: A rock wall. What's that sticking out of it?
-  suffix: Artifact Fragment
   components:
     - type: OreVein
       oreChance: 1.0

--- a/Resources/Prototypes/Entities/Structures/Walls/barricades.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/barricades.yml
@@ -1,7 +1,6 @@
 - type: entity
   id: Barricade
   parent: BaseStructure
-  name: barricade
   components:
   - type: InteractionOutline
   - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Walls/girders.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/girders.yml
@@ -1,8 +1,6 @@
 - type: entity
   id: Girder
   parent: BaseStructureDynamic
-  name: girder
-  description: A large structural assembly made out of metal; It requires a layer of metal before it can be considered a wall.
   components:
   - type: Transform
     anchored: true
@@ -55,8 +53,6 @@
 - type: entity
   id: ReinforcedGirder
   parent: Girder
-  name: reinforced girder
-  description: A large structural assembly made out of metal and plasteel; It requires a layer of plasteel before it can be considered a reinforced wall.
   components:
     - type: Sprite
       sprite: Structures/Walls/solid.rsi

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -1,8 +1,6 @@
 - type: entity
   id: Grille
   parent: BaseStructure
-  name: grille
-  description: A flimsy framework of iron rods.
   components:
     - type: MeleeSound
       soundGroups:
@@ -90,8 +88,6 @@
 - type: entity
   id: GrilleBroken
   parent: BaseStructure
-  name: grille
-  description: A flimsy framework of iron rods. It has seen better days.
   components:
     - type: Sprite
       drawdepth: Walls

--- a/Resources/Prototypes/Entities/Structures/Walls/mountain.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/mountain.yml
@@ -1,8 +1,6 @@
 - type: entity
   id: MountainRock
   parent: AsteroidRock
-  name: mountain rock
-  description: A craggy mountain wall.
   components:
   - type: Sprite
     sprite: Structures/Walls/mountain_rock.rsi
@@ -11,8 +9,6 @@
 - type: entity
   id: MountainRockMining
   parent: AsteroidRockMining
-  name: mountain rock
-  description: A craggy mountain wall.
   components:
   - type: Sprite
     sprite: Structures/Walls/mountain_rock.rsi

--- a/Resources/Prototypes/Entities/Structures/Walls/railing.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/railing.yml
@@ -1,8 +1,6 @@
 - type: entity
   parent: BaseStructure
   id: Railing
-  name: railing
-  description: Basic railing meant to protect idiots like you from falling.
   components:
   - type: Sprite
     drawdepth: WallTops
@@ -59,8 +57,6 @@
 - type: entity
   parent: BaseStructure
   id: RailingCorner
-  name: railing
-  description: Basic railing meant to protect idiots like you from falling.
   components:
   - type: Sprite
     drawdepth: WallTops
@@ -126,8 +122,6 @@
 - type: entity
   parent: BaseStructure
   id: RailingCornerSmall
-  name: railing
-  description: Basic railing meant to protect idiots like you from falling.
   components:
   - type: Sprite
     drawdepth: WallTops

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -2,8 +2,6 @@
   abstract: true
   parent: BaseStructure
   id: BaseWall
-  name: basewall
-  description: Keeps the air in and the greytide out.
   placement:
     mode: SnapgridCenter
     snap:
@@ -53,7 +51,6 @@
 - type: entity
   parent: BaseWall
   id: WallBrick
-  name: brick wall
   components:
   - type: Tag
     tags:
@@ -84,7 +81,6 @@
 - type: entity
   parent: BaseWall
   id: WallClock
-  name: clock wall
   components:
   - type: Tag
     tags:
@@ -114,7 +110,6 @@
 - type: entity
   parent: BaseWall
   id: WallClown
-  name: bananium wall
   components:
   - type: Tag
     tags:
@@ -147,8 +142,6 @@
 - type: entity
   parent: BaseWall
   id: WallMeat
-  name: meat wall
-  description: Sticky.
   components:
   - type: Tag
     tags:
@@ -182,7 +175,6 @@
 - type: entity
   parent: BaseWall
   id: WallCult
-  name: cult wall
   components:
   - type: Tag
     tags:
@@ -212,8 +204,6 @@
 - type: entity
   parent: BaseWall
   id: WallDebug
-  name: debug wall
-  suffix: DEBUG
   components:
   - type: Tag
     tags:
@@ -244,7 +234,6 @@
 - type: entity
   parent: BaseWall
   id: WallDiamond
-  name: diamond wall
   components:
   - type: Tag
     tags:
@@ -274,7 +263,6 @@
 - type: entity
   parent: BaseWall
   id: WallGold
-  name: gold wall
   components:
   - type: Tag
     tags:
@@ -315,7 +303,6 @@
 - type: entity
   parent: BaseWall
   id: WallIce
-  name: ice wall
   components:
   - type: Tag
     tags:
@@ -345,7 +332,6 @@
 - type: entity
   parent: BaseWall
   id: WallPlasma
-  name: plasma wall
   components:
   - type: Tag
     tags:
@@ -386,7 +372,6 @@
 - type: entity
   parent: BaseWall
   id: WallPlastic
-  name: plastic wall
   components:
   - type: Tag
     tags:
@@ -427,8 +412,6 @@
 - type: entity
   parent: BaseWall
   id: WallPlastitaniumIndestructible
-  name: plastitanium wall
-  suffix: indestructible
   components:
     - type: Tag
       tags:
@@ -444,8 +427,6 @@
 - type: entity
   parent: WallPlastitaniumIndestructible
   id: WallPlastitanium
-  name: plastitanium wall
-  suffix: ""
   components:
     - type: Tag
       tags:
@@ -468,8 +449,6 @@
 - type: entity
   parent: WallShuttleDiagonal
   id: WallPlastitaniumDiagonal
-  name: plastitanium wall
-  suffix: diagonal
   placement:
     mode: SnapgridCenter
     snap:
@@ -490,7 +469,6 @@
 - type: entity
   parent: BaseWall
   id: WallReinforced
-  name: reinforced wall
   components:
   - type: Sprite
     sprite: Structures/Walls/solid.rsi
@@ -540,7 +518,6 @@
 - type: entity
   parent: BaseWall
   id: WallRiveted
-  name: riveted wall
   components:
   - type: Tag
     tags:
@@ -572,7 +549,6 @@
 - type: entity
   parent: BaseWall
   id: WallSandstone
-  name: sandstone wall
   components:
   - type: Tag
     tags:
@@ -602,7 +578,6 @@
 - type: entity
   parent: BaseWall
   id: WallSilver
-  name: silver wall
   components:
   - type: Tag
     tags:
@@ -642,9 +617,6 @@
 
 - type: entity
   id: WallShuttleDiagonal
-  name: shuttle wall
-  suffix: diagonal
-  description: Keeps the air in and the greytide out.
   placement:
     mode: SnapgridCenter
     snap:
@@ -716,7 +688,6 @@
 - type: entity
   parent: BaseWall
   id: WallShuttle
-  name: shuttle wall
   components:
   - type: Tag
     tags:
@@ -754,7 +725,6 @@
 - type: entity
   parent: BaseWall
   id: WallSolid
-  name: solid wall
   components:
   - type: Tag
     tags:
@@ -795,8 +765,6 @@
 - type: entity
   parent: WallShuttleDiagonal
   id: WallSolidDiagonal
-  name: solid wall
-  suffix: diagonal
   placement:
     mode: SnapgridCenter
     snap:
@@ -817,8 +785,6 @@
 - type: entity
   parent: BaseWall
   id: WallSolidRust
-  name: solid wall
-  suffix: rusted
   components:
   - type: Sprite
     sprite: Structures/Walls/solidrust.rsi
@@ -856,7 +822,6 @@
 - type: entity
   parent: BaseWall
   id: WallUranium
-  name: uranium wall
   components:
   - type: Sprite
     sprite: Structures/Walls/uranium.rsi
@@ -893,7 +858,6 @@
 - type: entity
   parent: BaseWall
   id: WallWood
-  name: wood wall
   components:
   - type: Sprite
     sprite: Structures/Walls/wood.rsi
@@ -933,8 +897,6 @@
 - type: entity
   parent: BaseWall
   id: WallVaultAlien
-  name: alien vault wall
-  description: A mysterious ornate looking wall. There may be ancient dangers inside.
   components:
   - type: Sprite
     sprite: Structures/Walls/vault.rsi
@@ -954,7 +916,6 @@
 - type: entity
   parent: WallVaultAlien
   id: WallVaultRock
-  name: rock vault wall
   components:
   - type: Sprite
     sprite: Structures/Walls/vault.rsi
@@ -966,7 +927,6 @@
 - type: entity
   parent: WallVaultAlien
   id: WallVaultSandstone
-  name: sandstone vault wall
   components:
   - type: Sprite
     sprite: Structures/Walls/vault.rsi
@@ -980,7 +940,6 @@
 
 - type: entity
   id: WallInvisible
-  name: Invisible Wall
   components:
   - type: TimedDespawn
     lifetime: 30
@@ -1003,7 +962,6 @@
 
 - type: entity
   id: WallForce
-  name: Force Wall
   components:
     - type: TimedDespawn
       lifetime: 20


### PR DESCRIPTION
- Lower-cased the two magic walls `Force Wall` to `force wall`, `Invisible Wall` to `invisible wall`
- Localized names/descs are not inherited hence the repetition of things like:
`= { ent-WallRock }`
`.desc = { ent-BaseWall.desc }`
- Localization entries follow same order as entities in respective YML.
- `higher ore yield` to `High Ore Yield` to be consistent with `Low Ore Yield`.
- Added suffixes to MountainRock similar to AsteroidRock.
- Some additional cleanup.