### PR TITLE
Minor botany tweaks

### DIFF
--- a/Content.Server/Botany/SeedPrototype.cs
+++ b/Content.Server/Botany/SeedPrototype.cs
@@ -125,7 +125,7 @@ public class SeedData
 
     #region Tolerances
 
-    [DataField("nutrientConsumption")] public float NutrientConsumption = 0.45f;
+    [DataField("nutrientConsumption")] public float NutrientConsumption = 0.50f;
 
     [DataField("waterConsumption")] public float WaterConsumption = 0.5f;
     [DataField("idealHeat")] public float IdealHeat = 293f;

--- a/Content.Server/Botany/SeedPrototype.cs
+++ b/Content.Server/Botany/SeedPrototype.cs
@@ -125,9 +125,9 @@ public class SeedData
 
     #region Tolerances
 
-    [DataField("nutrientConsumption")] public float NutrientConsumption = 0.25f;
+    [DataField("nutrientConsumption")] public float NutrientConsumption = 0.45f;
 
-    [DataField("waterConsumption")] public float WaterConsumption = 3f;
+    [DataField("waterConsumption")] public float WaterConsumption = 0.5f;
     [DataField("idealHeat")] public float IdealHeat = 293f;
     [DataField("heatTolerance")] public float HeatTolerance = 10f;
     [DataField("idealLight")] public float IdealLight = 7f;

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Botany.Systems
         [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
 
         public const float HydroponicsSpeedMultiplier = 1f;
-        public const float HydroponicsConsumptionMultiplier = 4f;
+        public const float HydroponicsConsumptionMultiplier = 2f;
 
         public override void Initialize()
         {
@@ -412,7 +412,7 @@ namespace Content.Server.Botany.Systems
             if (component.Seed.WaterConsumption > 0 && component.WaterLevel > 0 && _random.Prob(0.75f))
             {
                 component.WaterLevel -= MathF.Max(0f,
-                    component.Seed.NutrientConsumption * HydroponicsConsumptionMultiplier * HydroponicsSpeedMultiplier);
+                    component.Seed.WaterConsumption * HydroponicsConsumptionMultiplier * HydroponicsSpeedMultiplier);
                 if (component.DrawWarnings)
                     component.UpdateSpriteAfterUpdate = true;
             }

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -288,11 +288,17 @@ namespace Content.Server.Botany.Systems
 
                 if (_solutionSystem.TryGetSolution(args.Used, produce.SolutionName, out var solution2))
                 {
-                    // This deliberately discards overfill.
-                    _solutionSystem.TryAddSolution(args.Used, solution2,
-                        _solutionSystem.SplitSolution(args.Used, solution2, solution2.Volume));
+                    if (_solutionSystem.TryGetSolution(uid, component.SoilSolutionName, out var solution1))
+                    {
+                        // We try to fit as much of the composted plant's contained solution into the hydroponics tray as we can,
+                        // since the plant will be consumed anyway.
 
-                    ForceUpdateByExternalCause(uid, component);
+                        var fillAmount = FixedPoint2.Min(solution2.Volume, solution1.AvailableVolume);
+                        _solutionSystem.TryAddSolution(uid, solution1,
+                            _solutionSystem.SplitSolution(args.Used, solution2, fillAmount));
+
+                        ForceUpdateByExternalCause(uid, component);
+                    }
                 }
 
                 EntityManager.QueueDeleteEntity(args.Used);

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
@@ -12,6 +12,7 @@
     PestSpray: 20
     Syringe: 5
     RobustHarvestChemistryBottle: 3
+    EZNutrientChemistryBottle: 3
     Bucket: 3
     DiseaseSwab: 20
     #TO DO:

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -174,6 +174,23 @@
     - Bottle
 
 - type: entity
+  id: EZNutrientChemistryBottle
+  name: ez nutrient bottle
+  description: This will provide some nutrition to your plants.
+  parent: BaseChemistryEmptyBottle
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: EZNutrient
+          Quantity: 30
+  - type: Tag
+    tags:
+    - Bottle
+
+- type: entity
   id: UnstableMutagenChemistryBottle
   name: unstable mutagen bottle
   description: This will cause rapid mutations in your plants.

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -13,7 +13,7 @@
   yield: 3
   potency: 5
   idealLight: 8
-  nutrientConsumption: 0.15
+  nutrientConsumption: 0.30
   chemicals:
     Nutriment:
       Min: 1
@@ -39,7 +39,7 @@
   yield: 3
   potency: 5
   idealLight: 8
-  nutrientConsumption: 0.15
+  nutrientConsumption: 0.30
   chemicals:
     Nutriment:
       Min: 1
@@ -65,7 +65,7 @@
   production: 6
   yield: 2
   idealLight: 9
-  waterConsumption: 6
+  waterConsumption: 0.60
   idealHeat: 298
   chemicals:
     Vitamin:
@@ -92,7 +92,7 @@
   yield: 3
   potency: 10
   growthStages: 3
-  waterConsumption: 6
+  waterConsumption: 0.60
   chemicals:
     JuiceCarrot:
       Min: 1
@@ -227,7 +227,7 @@
   yield: 3
   potency: 10
   growthStages: 4
-  waterConsumption: 6
+  waterConsumption: 0.60
   chemicals:
     Nutriment:
       Min: 1
@@ -277,9 +277,10 @@
   yield: 5
   potency: 1
   growthStages: 3
-  waterConsumption: 6
+  waterConsumption: 0.60
+  nutrientConsumption: 0.50
   lightTolerance: 6
-  idealLight: 288
+  idealHeat: 288
 
 - type: seed
   id: tomato
@@ -296,8 +297,8 @@
   production: 6
   yield: 2
   potency: 10
-  waterConsumption: 6
-  nutrientConsumption: 0.25
+  waterConsumption: 0.60
+  nutrientConsumption: 0.30
   idealLight: 8
   idealHeat: 298
   juicy: true
@@ -435,7 +436,7 @@
   potency: 20
   growthStages: 3
   idealLight: 8
-  waterConsumption: 6
+  waterConsumption: 0.60
   idealHeat: 298
   chemicals:
     Nutriment:
@@ -463,7 +464,7 @@
   potency: 20
   growthStages: 3
   idealLight: 8
-  waterConsumption: 6
+  waterConsumption: 0.60
   idealHeat: 298
   chemicals:
     Nutriment:
@@ -495,7 +496,7 @@
   potency: 20
   growthStages: 3
   idealLight: 8
-  waterConsumption: 6
+  waterConsumption: 0.60
   idealHeat: 298
   chemicals:
     Nutriment:
@@ -527,7 +528,8 @@
   potency: 1
   growthStages: 3
   lightTolerance: 6
-  waterConsumption: 6
+  waterConsumption: 0.60
+  nutrientConsumption: 0.50
   idealHeat: 288
   chemicals:
     Nutriment:
@@ -550,6 +552,7 @@
   production: 12
   yield: 2
   potency: 20
+  nutrientConsumption: 0.50
   idealLight: 9
   idealHeat: 298
   chemicals:
@@ -574,6 +577,7 @@
   yield: 2
   potency: 20
   growthStages: 3
+  waterConsumption: 0.40
   idealLight: 9
   idealHeat: 298
   chemicals:
@@ -598,6 +602,7 @@
   yield: 2
   potency: 20
   growthStages: 3
+  waterConsumption: 0.40
   idealLight: 9
   idealHeat: 298
   chemicals:
@@ -622,7 +627,7 @@
   potency: 20
   growthStages: 5
   idealLight: 8
-  waterConsumption: 6
+  waterConsumption: 0.60
   idealHeat: 298
   chemicals:
     Histamine:
@@ -676,7 +681,7 @@
   yield: 3
   potency: 10
   growthStages: 3
-  waterConsumption: 6
+  waterConsumption: 0.60
   chemicals:
     Nutriment:
       Min: 1
@@ -702,7 +707,7 @@
   yield: 3
   potency: 10
   growthStages: 5
-  waterConsumption: 6
+  waterConsumption: 0.60
   chemicals:
     Aloe:
       Min: 1
@@ -728,7 +733,7 @@
   yield: 3
   potency: 10
   growthStages: 3
-  waterConsumption: 6
+  waterConsumption: 0.60
   chemicals:
     Ultravasculine:
       Min: 1
@@ -754,7 +759,7 @@
   yield: 3
   potency: 10
   growthStages: 6
-  waterConsumption: 6
+  waterConsumption: 0.60
   chemicals:
     Nutriment:
       Min: 1
@@ -792,7 +797,7 @@
   yield: 3
   potency: 10
   growthStages: 3
-  waterConsumption: 6
+  waterConsumption: 0.60
   chemicals:
     Stellibinin:
       Min: 1
@@ -814,7 +819,8 @@
   yield: 3
   potency: 10
   growthStages: 2
-  waterConsumption: 6
+  waterConsumption: 0.60
+  nutrientConsumption: 0.50
   chemicals:
     Amatoxin:
       Min: 1
@@ -867,7 +873,8 @@
   potency: 5
   growthStages: 4
   idealLight: 5
-  nutrientConsumption: 0.15
+  nutrientConsumption: 0.30
+  waterConsumption: 0.60
   chemicals:
     Nutriment:
       Min: 1
@@ -894,7 +901,7 @@
   yield: 3
   potency: 5
   idealLight: 7
-  nutrientConsumption: 0.15
+  nutrientConsumption: 0.30
   chemicals:
     Nutriment:
       Min: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
I don't think I've ever seen the nutrient light appear on a hydroponics tray under normal conditions, so I decided to try and make plants eat up their nutrient reserves twice as fast, I'm not sure if the increase is too much (or not enough) since I have yet to see it play out in an actual round.
Added EZ Nutrient bottle and made the nutrimax come with 3, in case nothing else is available.

This also includes a couple fixes to PlantHolderSystem, which had some pretty questionable code:
- Changed water consumption to actually use the seed prototype's water consumption field instead of using the nutrient one again.
- Made composting work properly, or at least better than it did before. (With the old code, no reagents would actually be transferred to the tray at all.)

**Media**

https://github.com/space-wizards/space-station-14/assets/75124791/6a02f333-6595-4598-b57d-1d14670f0ce8

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Due to Nanotrasen choosing a new seed supplier, most plants consume nutrients much faster.
- new: To help offset this, the NutriMax vendor comes stocked with EZ nutrient bottles.
- fix: Composting produce into trays actually works now.
