### PR TITLE
Remove atmos device dependency on game timer

### DIFF
--- a/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
@@ -12,7 +12,6 @@ using Content.Shared.CCVar;
 using Content.Shared.Interaction;
 using JetBrains.Annotations;
 using Robust.Shared.Configuration;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.EntitySystems;
 
@@ -21,7 +20,6 @@ public sealed class HeatExchangerSystem : EntitySystem
     [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
-    [Dependency] private IGameTiming _gameTiming = default!;
 
     float tileLoss;
 
@@ -56,7 +54,7 @@ public sealed class HeatExchangerSystem : EntitySystem
         }
 
         // Positive dN flows from inlet to outlet
-        var dt = (float)(_gameTiming.CurTime - device.LastProcess).TotalSeconds;
+        var dt = args.dt;
         var dP = inlet.Air.Pressure - outlet.Air.Pressure;
         var dN = comp.G*dP*dt;
 

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -14,14 +14,12 @@ using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.Piping.Binary.EntitySystems
 {
     [UsedImplicitly]
     public sealed class GasVolumePumpSystem : EntitySystem
     {
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly TransformSystem _transformSystem = default!;
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
@@ -85,7 +83,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 return;
 
             // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.
-            var removed = inlet.Air.RemoveVolume((float)(pump.TransferRate * (_gameTiming.CurTime - device.LastProcess).TotalSeconds));
+            var removed = inlet.Air.RemoveVolume((float)(pump.TransferRate * args.dt));
 
             // Some of the gas from the mixture leaks when overclocked.
             if (pump.Overclocked)

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
@@ -15,14 +15,12 @@ using Content.Shared.Popups;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
 {
     [UsedImplicitly]
     public sealed class GasFilterSystem : EntitySystem
     {
-        [Dependency] private IGameTiming _gameTiming = default!;
         [Dependency] private UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
@@ -67,7 +65,7 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
             }
 
             // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.
-            var transferVol = (float)(filter.TransferRate * (_gameTiming.CurTime - device.LastProcess).TotalSeconds);
+            var transferVol = (float)(filter.TransferRate * args.dt);
 
             if (transferVol <= 0)
             {

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/PressureControlledValveSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/PressureControlledValveSystem.cs
@@ -8,14 +8,12 @@ using Content.Shared.Atmos.Piping;
 using Content.Shared.Audio;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
 {
     [UsedImplicitly]
     public sealed class PressureControlledValveSystem : EntitySystem
     {
-        [Dependency] private IGameTiming _gameTiming = default!;
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
         [Dependency] private readonly SharedAmbientSoundSystem _ambientSoundSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
@@ -70,7 +68,7 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
             UpdateAppearance(uid, comp);
 
             // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.
-            var transferVolume = (float)(transferRate * (_gameTiming.CurTime - device.LastProcess).TotalSeconds);
+            var transferVolume = (float)(transferRate * args.dt);
             if (transferVolume <= 0)
             {
                 _ambientSoundSystem.SetAmbience(comp.Owner, false);

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasOutletInjectorSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasOutletInjectorSystem.cs
@@ -8,7 +8,6 @@ using Content.Shared.Atmos.Piping;
 using Content.Shared.Interaction;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 {
@@ -16,7 +15,6 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
     public sealed class GasOutletInjectorSystem : EntitySystem
     {
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
 
@@ -73,7 +71,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (environment.Pressure > injector.MaxPressure)
                 return;
 
-            var timeDelta = (float) (_gameTiming.CurTime - device.LastProcess).TotalSeconds;
+            var timeDelta = args.dt;
 
             // TODO adjust ratio so that environment does not go above MaxPressure?
             var ratio = MathF.Min(1f, timeDelta * injector.TransferRate / inlet.Air.Volume);

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -19,7 +19,6 @@ using Content.Shared.Audio;
 using Content.Shared.Examine;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 {
@@ -29,7 +28,6 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
         [Dependency] private readonly DeviceNetworkSystem _deviceNetSystem = default!;
         [Dependency] private readonly DeviceLinkSystem _signalSystem = default!;
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly SharedAmbientSoundSystem _ambientSoundSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
@@ -81,7 +79,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 return;
             }
 
-            var timeDelta =  (_gameTiming.CurTime - device.LastProcess).TotalSeconds;
+            var timeDelta =  args.dt;
             var pressureDelta = (float) timeDelta * vent.TargetPressureChange;
 
             if (vent.PumpDirection == VentPumpDirection.Releasing && pipe.Air.Pressure > 0)

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -17,14 +17,12 @@ using Content.Shared.Atmos.Piping.Unary.Components;
 using Content.Shared.Audio;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 {
     [UsedImplicitly]
     public sealed class GasVentScrubberSystem : EntitySystem
     {
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
         [Dependency] private readonly DeviceNetworkSystem _deviceNetSystem = default!;
         [Dependency] private readonly SharedAmbientSoundSystem _ambientSoundSystem = default!;
@@ -54,7 +52,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (!TryComp(uid, out AtmosDeviceComponent? device))
                 return;
 
-            var timeDelta = (float) (_gameTiming.CurTime - device.LastProcess).TotalSeconds;
+            var timeDelta = args.dt;
 
             if (!scrubber.Enabled
             || !EntityManager.TryGetComponent(uid, out NodeContainerComponent? nodeContainer)

--- a/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
@@ -7,7 +7,6 @@ using Content.Server.Atmos.Piping.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Power.Components;
 using Content.Server.NodeContainer;
-using Robust.Shared.Timing;
 using Robust.Server.GameObjects;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.NodeContainer.NodeGroups;
@@ -25,7 +24,6 @@ namespace Content.Server.Atmos.Portable
         [Dependency] private readonly GasCanisterSystem _canisterSystem = default!;
         [Dependency] private readonly GasPortableSystem _gasPortableSystem = default!;
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly TransformSystem _transformSystem = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly AmbientSoundSystem _ambientSound = default!;
@@ -55,7 +53,7 @@ namespace Content.Server.Atmos.Portable
             if (!TryComp(uid, out AtmosDeviceComponent? device))
                 return;
 
-            var timeDelta = (float) (_gameTiming.CurTime - device.LastProcess).TotalSeconds;
+            var timeDelta = args.dt;
 
             if (!component.Enabled)
                 return;

--- a/Content.Server/Power/Generator/GasPowerReceiverSystem.cs
+++ b/Content.Server/Power/Generator/GasPowerReceiverSystem.cs
@@ -5,7 +5,6 @@ using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Power.Components;
 using Content.Shared.Atmos;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Power.Generator;
 
@@ -14,26 +13,18 @@ namespace Content.Server.Power.Generator;
 /// </summary>
 public sealed class GasPowerReceiverSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
     [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
     {
-        SubscribeLocalEvent<GasPowerReceiverComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<GasPowerReceiverComponent, AtmosDeviceUpdateEvent>(OnDeviceUpdated);
-    }
-
-    private void OnMapInit(EntityUid uid, GasPowerReceiverComponent component, MapInitEvent args)
-    {
-        component.LastProcess = _gameTiming.CurTime;
     }
 
     private void OnDeviceUpdated(EntityUid uid, GasPowerReceiverComponent component, AtmosDeviceUpdateEvent args)
     {
-        var timeDelta =  (float)(_gameTiming.CurTime - component.LastProcess).TotalSeconds;
-        component.LastProcess = _gameTiming.CurTime;
+        var timeDelta = args.dt;
 
         if (!HasComp<AtmosDeviceComponent>(uid)
             || !TryComp<NodeContainerComponent>(uid, out var nodeContainer)


### PR DESCRIPTION
## About the PR
This PR removes game timer dependencies from atmos device systems who used game timer solely to determine the correct update time. The correct update time is now passed in in the event thanks to https://github.com/space-wizards/space-station-14/pull/18781.

Basically, replace all `(float)(_gameTiming.CurTime - device.LastProcess).TotalSeconds` with `args.dt` and remove the IGameTimer dependency.

Atmos device systems that do not depend on GameTimer, or that scale with tick rate, will be fixed in a separate pass and are not touched by this commit.

This change is almost user-invisible. All touched devices will have a small 10% increase in transfer rate because the old game timer subtraction method systematically under-calculates the correct transfer rate by not accounting for the duration of the current tick.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
N/A