### PR TITLE
Make AtmosAlarmThreshold prototypes immutable

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/AlarmThresholdTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AlarmThresholdTest.cs
@@ -30,10 +30,8 @@ namespace Content.IntegrationTests.Tests.Atmos
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
             AtmosAlarmThreshold threshold = default!;
 
-            await server.WaitPost(() =>
-            {
-                threshold = prototypeManager.Index<AtmosAlarmThreshold>("AlarmThresholdTestDummy");
-            });
+            var proto = prototypeManager.Index<AtmosAlarmThresholdPrototype>("AlarmThresholdTestDummy");
+            threshold = new(proto);
 
             await server.WaitAssertion(() =>
             {

--- a/Content.Server/Atmos/Monitor/Components/AtmosMonitorComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AtmosMonitorComponent.cs
@@ -1,7 +1,7 @@
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Monitor;
-using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 
 namespace Content.Server.Atmos.Monitor.Components;
 
@@ -19,19 +19,19 @@ public sealed class AtmosMonitorComponent : Component
     // Note that this cancels every single network
     // event, including ones that may not be
     // related to atmos monitor events.
-    [ViewVariables]
+    [DataField("netEnabled")]
     public bool NetEnabled = true;
 
-    [DataField("temperatureThreshold", customTypeSerializer: (typeof(PrototypeIdSerializer<AtmosAlarmThreshold>)))]
+    [DataField("temperatureThresholdId", customTypeSerializer: (typeof(PrototypeIdSerializer<AtmosAlarmThresholdPrototype>)))]
     public readonly string? TemperatureThresholdId;
 
-    [ViewVariables]
+    [DataField("temperatureThreshold")]
     public AtmosAlarmThreshold? TemperatureThreshold;
 
-    [DataField("pressureThreshold", customTypeSerializer: (typeof(PrototypeIdSerializer<AtmosAlarmThreshold>)))]
+    [DataField("pressureThresholdId", customTypeSerializer: (typeof(PrototypeIdSerializer<AtmosAlarmThresholdPrototype>)))]
     public readonly string? PressureThresholdId;
 
-    [ViewVariables]
+    [DataField("pressureThreshold")]
     public AtmosAlarmThreshold? PressureThreshold;
 
     // monitor fire - much different from temperature
@@ -41,14 +41,11 @@ public sealed class AtmosMonitorComponent : Component
     [DataField("monitorFire")]
     public bool MonitorFire = false;
 
-    // really messy but this is parsed at runtime after
-    // prototypes are initialized, there's no
-    // way without implementing a new
-    // type serializer
-    [DataField("gasThresholds")]
-    public Dictionary<Gas, string>? GasThresholdIds;
+    [DataField("gasThresholdPrototypes",
+        customTypeSerializer:typeof(PrototypeIdValueDictionarySerializer<Gas, AtmosAlarmThresholdPrototype>))]
+    public Dictionary<Gas, string>? GasThresholdPrototypes;
 
-    [ViewVariables]
+    [DataField("gasThresholds")]
     public Dictionary<Gas, AtmosAlarmThreshold>? GasThresholds;
 
     // Stores a reference to the gas on the tile this is on.
@@ -56,14 +53,16 @@ public sealed class AtmosMonitorComponent : Component
     public GasMixture? TileGas;
 
     // Stores the last alarm state of this alarm.
-    [ViewVariables]
+    [DataField("lastAlarmState")]
     public AtmosAlarmType LastAlarmState = AtmosAlarmType.Normal;
 
-    [ViewVariables] public HashSet<AtmosMonitorThresholdType> TrippedThresholds = new();
+    [DataField("trippedThresholds")]
+    public HashSet<AtmosMonitorThresholdType> TrippedThresholds = new();
 
     /// <summary>
     ///     Registered devices in this atmos monitor. Alerts will be sent directly
     ///     to these devices.
     /// </summary>
-    [ViewVariables] public HashSet<string> RegisteredDevices = new();
+    [DataField("registeredDevices")]
+    public HashSet<string> RegisteredDevices = new();
 }

--- a/Content.Shared/Atmos/Monitor/AtmosAlarmThreshold.cs
+++ b/Content.Shared/Atmos/Monitor/AtmosAlarmThreshold.cs
@@ -3,77 +3,91 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Atmos.Monitor;
 
-// mostly based around floats and percentages, no literals
-// except for the range boundaries
+
 [Prototype("alarmThreshold")]
-[Serializable, NetSerializable]
-public sealed class AtmosAlarmThreshold : IPrototype, ISerializationHooks
+public sealed class AtmosAlarmThresholdPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; } = default!;
+
+    [DataField("ignore")]
+    public readonly bool Ignore;
+
+    [DataField("upperBound")]
+    public readonly AlarmThresholdSetting UpperBound = AlarmThresholdSetting.Disabled;
+
+    [DataField("lowerBound")]
+    public readonly AlarmThresholdSetting LowerBound = AlarmThresholdSetting.Disabled;
+
+    [DataField("upperWarnAround")]
+    public readonly AlarmThresholdSetting UpperWarningPercentage = AlarmThresholdSetting.Disabled;
+
+    [DataField("lowerWarnAround")]
+    public readonly AlarmThresholdSetting LowerWarningPercentage = AlarmThresholdSetting.Disabled;
+}
+
+[Serializable, NetSerializable, DataDefinition]
+public sealed class AtmosAlarmThreshold
+{
     [DataField("ignore")]
     public bool Ignore;
 
     [DataField("upperBound")]
-    private AlarmThresholdSetting _UpperBound;
+    private AlarmThresholdSetting _upperBound = AlarmThresholdSetting.Disabled;
 
-    public AlarmThresholdSetting UpperBound { get { return _UpperBound; } private set
+    [DataField("lowerBound")]
+    private AlarmThresholdSetting _lowerBound = AlarmThresholdSetting.Disabled;
+
+    [DataField("upperWarnAround")]
+    public AlarmThresholdSetting UpperWarningPercentage = AlarmThresholdSetting.Disabled;
+
+    [DataField("lowerWarnAround")]
+    public AlarmThresholdSetting LowerWarningPercentage = AlarmThresholdSetting.Disabled;
+
+    public AlarmThresholdSetting UpperBound
+    {
+        get => _upperBound;
+        set
         {
             // Because the warnings are stored as percentages of the bounds,
             // Make a copy of the calculated bounds, so that the real warning amount
             // doesn't change value when user changes the bounds
             var oldWarning = UpperWarningBound;
-            _UpperBound = value;
+            _upperBound = value;
             UpperWarningBound = oldWarning;
         }
     }
 
-    [DataField("lowerBound")]
-    public AlarmThresholdSetting _LowerBound;
-
-    public AlarmThresholdSetting LowerBound { get { return _LowerBound; } private set
+    public AlarmThresholdSetting LowerBound
+    {
+        get => _lowerBound;
+        set
         {
             // Because the warnings are stored as percentages of the bounds,
             // Make a copy of the calculated bounds, so that the real warning amount
             // doesn't change value when user changes the bounds
             var oldWarning = LowerWarningBound;
-            _LowerBound = value;
+            _lowerBound = value;
             LowerWarningBound = oldWarning;
         }
     }
 
-    // upper warning percentage
-    // must always cause UpperWarningBound
-    // to be smaller
-    [DataField("upperWarnAround")]
-    public AlarmThresholdSetting UpperWarningPercentage { get; private set; }
-
-    // lower warning percentage
-    // must always cause LowerWarningBound
-    // to be larger
-    [DataField("lowerWarnAround")]
-    public AlarmThresholdSetting LowerWarningPercentage { get; private set; }
-
     [ViewVariables]
     public AlarmThresholdSetting UpperWarningBound
     {
-        get { return CalculateWarningBound(AtmosMonitorThresholdBound.Upper); }
-        set { UpperWarningPercentage = CalculateWarningPercentage(AtmosMonitorThresholdBound.Upper, value); }
+        get => CalculateWarningBound(AtmosMonitorThresholdBound.Upper);
+        set => UpperWarningPercentage = CalculateWarningPercentage(AtmosMonitorThresholdBound.Upper, value);
     }
 
     [ViewVariables]
     public AlarmThresholdSetting LowerWarningBound
     {
-        get { return CalculateWarningBound(AtmosMonitorThresholdBound.Lower); }
-        set { LowerWarningPercentage = CalculateWarningPercentage(AtmosMonitorThresholdBound.Lower, value); }
+        get => CalculateWarningBound(AtmosMonitorThresholdBound.Lower);
+        set => LowerWarningPercentage = CalculateWarningPercentage(AtmosMonitorThresholdBound.Lower, value);
     }
 
     public AtmosAlarmThreshold()
     {
-        UpperBound = new AlarmThresholdSetting();
-        LowerBound = new AlarmThresholdSetting();
-        UpperWarningPercentage = new AlarmThresholdSetting();
-        LowerWarningPercentage = new AlarmThresholdSetting();
     }
 
     public AtmosAlarmThreshold(AtmosAlarmThreshold other)
@@ -85,12 +99,13 @@ public sealed class AtmosAlarmThreshold : IPrototype, ISerializationHooks
         LowerWarningPercentage = other.LowerWarningPercentage;
     }
 
-    void ISerializationHooks.AfterDeserialization()
+    public AtmosAlarmThreshold(AtmosAlarmThresholdPrototype proto)
     {
-        UpperBound = new AlarmThresholdSetting{ Enabled = UpperBound.Value != 0, Value = UpperBound.Value };
-        LowerBound = new AlarmThresholdSetting{ Enabled = LowerBound.Value != 0, Value = LowerBound.Value };
-        UpperWarningPercentage = new AlarmThresholdSetting{ Enabled = UpperWarningPercentage.Value != 0, Value = UpperWarningPercentage.Value };
-        LowerWarningPercentage = new AlarmThresholdSetting{ Enabled = LowerWarningPercentage.Value != 0, Value = LowerWarningPercentage.Value };
+        Ignore = proto.Ignore;
+        UpperBound = proto.UpperBound;
+        LowerBound = proto.LowerBound;
+        UpperWarningPercentage = proto.UpperWarningPercentage;
+        LowerWarningPercentage = proto.LowerWarningPercentage;
     }
 
     // utility function to check a threshold against some calculated value
@@ -238,38 +253,41 @@ public sealed class AtmosAlarmThreshold : IPrototype, ISerializationHooks
                 break;
         }
     }
+}
 
-    [DataDefinition, Serializable]
-    public struct AlarmThresholdSetting
+[DataDefinition, Serializable]
+public readonly struct AlarmThresholdSetting
+{
+    [DataField("enabled")]
+    public bool Enabled { get; init; } = true;
+
+    [DataField("threshold")]
+    public float Value { get; init; } = 1;
+
+    public static AlarmThresholdSetting Disabled = new() {Enabled = false, Value = 0};
+
+    public AlarmThresholdSetting()
     {
-        [DataField("enabled")]
-        public bool Enabled { get; set; } = false;
-        [DataField("threshold")]
-        public float Value { get; set; } = 0;
+    }
 
-        public AlarmThresholdSetting()
-        {
-        }
+    public static bool operator <=(float a, AlarmThresholdSetting b)
+    {
+        return b.Enabled && a <= b.Value;
+    }
 
-        public static bool operator <=(float a, AlarmThresholdSetting b)
-        {
-            return b.Enabled && a <= b.Value;
-        }
+    public static bool operator >=(float a, AlarmThresholdSetting b)
+    {
+        return b.Enabled && a >= b.Value;
+    }
 
-        public static bool operator >=(float a, AlarmThresholdSetting b)
-        {
-            return b.Enabled && a >= b.Value;
-        }
+    public AlarmThresholdSetting WithThreshold(float threshold)
+    {
+        return this with {Value = threshold};
+    }
 
-        public AlarmThresholdSetting WithThreshold(float threshold)
-        {
-            return new AlarmThresholdSetting{ Enabled = Enabled, Value = threshold };
-        }
-
-        public AlarmThresholdSetting WithEnabled(bool enabled)
-        {
-            return new AlarmThresholdSetting{ Enabled = enabled, Value = Value };
-        }
+    public AlarmThresholdSetting WithEnabled(bool enabled)
+    {
+        return this with {Enabled = enabled};
     }
 }
 

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -38,9 +38,9 @@
     - type: DeviceNetworkRequiresPower
     - type: AtmosDevice
     - type: AtmosMonitor
-      temperatureThreshold: stationTemperature
-      pressureThreshold: stationPressure
-      gasThresholds:
+      temperatureThresholdId: stationTemperature
+      pressureThresholdId: stationPressure
+      gasThresholdPrototypes:
         Oxygen: stationOxygen
         Nitrogen: ignore
         CarbonDioxide: stationCO2
@@ -127,9 +127,9 @@
       examinableAddress: true
     - type: DeviceNetworkRequiresPower
     - type: AtmosMonitor
-      temperatureThreshold: stationTemperature
-      pressureThreshold: stationPressure
-      gasThresholds:
+      temperatureThresholdId: stationTemperature
+      pressureThresholdId: stationPressure
+      gasThresholdPrototypes:
         Oxygen: stationOxygen
         Nitrogen: ignore
         CarbonDioxide: stationCO2

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -46,9 +46,9 @@
     - type: DeviceNetworkRequiresPower
     - type: AtmosDevice
     - type: AtmosMonitor
-      temperatureThreshold: stationTemperature
-      pressureThreshold: stationPressure
-      gasThresholds:
+      temperatureThresholdId: stationTemperature
+      pressureThresholdId: stationPressure
+      gasThresholdPrototypes:
         Oxygen: stationOxygen
         Nitrogen: ignore
         CarbonDioxide: stationCO2


### PR DESCRIPTION
Atmos alarms were apparently occasionally modifying prototypes. This just makes the threshold prototypes a separate class.