### PR TITLE
fix attack stamina cost check

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CombatMode;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
@@ -566,7 +567,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (targetMap.MapId != userXform.MapID)
             return false;
 
-        if (!_stamina.TryTakeStamina(user, component.HeavyStaminaCost))
+        if (!_stamina.TryTakeStamina(user, component.HeavyStaminaCost)
+        && HasComp<StaminaComponent>(user))
         {
             PopupSystem.PopupClient(Loc.GetString("melee-stamina"), user, user);
             return false;


### PR DESCRIPTION
## About the PR
Mobs without a StaminaComponent failed the stamina cost check (even though the cost is currently 0) on wide swings. Now they just skip the check.

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- fix: Admin ghosts, robots, and other soulless monsters that never tire can now perform wide melee attacks again.
