### PR TITLE
Change how popups are displayed

### DIFF
--- a/Content.Client/Popups/PopupOverlay.cs
+++ b/Content.Client/Popups/PopupOverlay.cs
@@ -1,8 +1,5 @@
 using System.Numerics;
-using Content.Client.Examine;
-using Content.Shared.CCVar;
 using Content.Shared.Examine;
-using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Robust.Client.Graphics;
 using Robust.Client.Player;

--- a/Content.Client/Popups/PopupOverlay.cs
+++ b/Content.Client/Popups/PopupOverlay.cs
@@ -110,6 +110,30 @@ public sealed class PopupOverlay : Overlay
         }
     }
 
+    public float GetPopupHeight(PopupType type)
+    {
+        var font = _smallFont;
+        switch (type)
+        {
+            case PopupType.SmallCaution:
+                break;
+            case PopupType.Medium:
+                font = _mediumFont;
+                break;
+            case PopupType.MediumCaution:
+                font = _mediumFont;
+                break;
+            case PopupType.Large:
+                font = _largeFont;
+                break;
+            case PopupType.LargeCaution:
+                font = _largeFont;
+                break;
+        }
+
+        return font.GetHeight(_uiManager.DefaultUIScale);
+    }
+
     private void DrawPopup(PopupSystem.PopupLabel popup, DrawingHandleScreen handle, Vector2 position, float scale)
     {
         var lifetime = PopupSystem.GetPopupLifetime(popup);
@@ -117,7 +141,11 @@ public sealed class PopupOverlay : Overlay
         // Keep alpha at 1 until TotalTime passes half its lifetime, then gradually decrease to 0.
         var alpha = MathF.Min(1f, 1f - MathF.Max(0f, popup.TotalTime - lifetime / 2) * 2 / lifetime);
 
-        var updatedPosition = position - new Vector2(0f, MathF.Min(8f, 12f * (popup.TotalTime * popup.TotalTime + popup.TotalTime)));
+        // Move the popup over time.
+        // Re-use alpha here so it stays in place until it's begun to fade.
+        var travel = new Vector2((1f - alpha) * PopupSystem.MaximumPopupTravel, 0);
+
+        var updatedPosition = position - travel - popup.OffsetPos;
         var font = _smallFont;
         var color = Color.White.WithAlpha(alpha);
 


### PR DESCRIPTION
Draft, so I can get some feedback and later do some cleanup.

[popup-anim2.webm](https://github.com/space-wizards/space-station-14/assets/114301317/25dd8f81-1186-428c-b82a-716e01713a53)

I decided to try visually stacking the popups instead of the random offset suggested by @metalgearsloth hoping for better legibility. The horizontal travel might be too much, or unnecessary entirely, but I like the stacking.

I can look into the suggestion by @EmoGarbage404 of putting the popup over the top of an entity, though that may not work for all situations.

I haven't tinkered with the game options panel before, but I could look into that too, in order to implement the suggestion by @dmnct for a control slider on how long popups stay around.

I think the legibility could be further improved by giving the engine the ability to draw text with solid outlines, but I haven't looked into how that would work yet.

Resolves #18851