### PR TITLE
Botany tweaks vol. 2

### DIFF
--- a/Content.Server/Botany/SeedPrototype.cs
+++ b/Content.Server/Botany/SeedPrototype.cs
@@ -125,7 +125,7 @@ public class SeedData
 
     #region Tolerances
 
-    [DataField("nutrientConsumption")] public float NutrientConsumption = 0.50f;
+    [DataField("nutrientConsumption")] public float NutrientConsumption = 0.70f;
 
     [DataField("waterConsumption")] public float WaterConsumption = 0.5f;
     [DataField("idealHeat")] public float IdealHeat = 293f;

--- a/Content.Server/Botany/SeedPrototype.cs
+++ b/Content.Server/Botany/SeedPrototype.cs
@@ -125,7 +125,7 @@ public class SeedData
 
     #region Tolerances
 
-    [DataField("nutrientConsumption")] public float NutrientConsumption = 0.70f;
+    [DataField("nutrientConsumption")] public float NutrientConsumption = 0.50f;
 
     [DataField("waterConsumption")] public float WaterConsumption = 0.5f;
     [DataField("idealHeat")] public float IdealHeat = 293f;

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -119,6 +119,7 @@ public sealed class MutationSystem : EntitySystem
     {
         // Probability that a bit flip happens for this value.
         float p = mult*bits/totalbits;
+        p = Math.Clamp(p, 0, 1);
         if (!Random(p))
         {
             return;
@@ -150,6 +151,7 @@ public sealed class MutationSystem : EntitySystem
     {
         // Probability that a bit flip happens for this value.
         float p = mult*bits/totalbits;
+        p = Math.Clamp(p, 0, 1);
         if (!Random(p))
         {
             return;
@@ -174,7 +176,8 @@ public sealed class MutationSystem : EntitySystem
     private void MutateBool(ref bool val, bool polarity, int bits, int totalbits, float mult)
     {
         // Probability that a bit flip happens for this value.
-        float p = mult*bits/totalbits;
+        float p = mult * bits / totalbits;
+        p = Math.Clamp(p, 0, 1);
         if (!Random(p))
         {
             return;
@@ -186,6 +189,7 @@ public sealed class MutationSystem : EntitySystem
     private void MutateHarvestType(ref HarvestType val, int bits, int totalbits, float mult)
     {
         float p = mult * bits/totalbits;
+        p = Math.Clamp(p, 0, 1);
         if (!Random(p))
             return;
 

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -344,7 +344,7 @@ namespace Content.Server.Botany.Systems
             }
 
             // Weeds like water and nutrients! They may appear even if there's not a seed planted.
-            if (component.WaterLevel > 10 && component.NutritionLevel > 2)
+            if (component.WaterLevel > 10 && component.NutritionLevel > 5)
             {
                 var chance = 0f;
                 if (component.Seed == null)
@@ -435,7 +435,7 @@ namespace Content.Server.Botany.Systems
             // Make sure the plant is not starving.
             if (_random.Prob(0.35f))
             {
-                if (component.NutritionLevel > 2)
+                if (component.NutritionLevel > 5)
                 {
                     component.Health += healthMod;
                 }
@@ -904,8 +904,8 @@ namespace Content.Server.Botany.Systems
             if (!component.DrawWarnings)
                 return;
 
-            _appearance.SetData(uid, PlantHolderVisuals.WaterLight, component.WaterLevel <= 10, app);
-            _appearance.SetData(uid, PlantHolderVisuals.NutritionLight, component.NutritionLevel <= 2, app);
+            _appearance.SetData(uid, PlantHolderVisuals.WaterLight, component.WaterLevel <= 15, app);
+            _appearance.SetData(uid, PlantHolderVisuals.NutritionLight, component.NutritionLevel <= 8, app);
             _appearance.SetData(uid, PlantHolderVisuals.AlertLight,
                 component.WeedLevel >= 5 || component.PestLevel >= 5 || component.Toxins >= 40 || component.ImproperHeat ||
                 component.ImproperLight || component.ImproperPressure || component.MissingGas > 0, app);

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
@@ -17,4 +17,5 @@
     DiseaseSwab: 20
     #TO DO:
     #plant analyzer
-
+  emaggedInventory:
+    Left4ZedChemistryBottle: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -191,6 +191,23 @@
     - Bottle
 
 - type: entity
+  id: Left4ZedChemistryBottle
+  name: left-4-zed bottle
+  description: This will increase the effectiveness of mutagen.
+  parent: BaseChemistryEmptyBottle
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: Left4Zed
+          Quantity: 30
+  - type: Tag
+    tags:
+    - Bottle
+
+- type: entity
   id: UnstableMutagenChemistryBottle
   name: unstable mutagen bottle
   description: This will cause rapid mutations in your plants.

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -13,7 +13,7 @@
   yield: 3
   potency: 5
   idealLight: 8
-  nutrientConsumption: 0.30
+  nutrientConsumption: 0.40
   chemicals:
     Nutriment:
       Min: 1
@@ -39,7 +39,7 @@
   yield: 3
   potency: 5
   idealLight: 8
-  nutrientConsumption: 0.30
+  nutrientConsumption: 0.40
   chemicals:
     Nutriment:
       Min: 1
@@ -298,7 +298,7 @@
   yield: 2
   potency: 10
   waterConsumption: 0.60
-  nutrientConsumption: 0.30
+  nutrientConsumption: 0.40
   idealLight: 8
   idealHeat: 298
   juicy: true
@@ -873,7 +873,7 @@
   potency: 5
   growthStages: 4
   idealLight: 5
-  nutrientConsumption: 0.30
+  nutrientConsumption: 0.40
   waterConsumption: 0.60
   chemicals:
     Nutriment:
@@ -901,7 +901,7 @@
   yield: 3
   potency: 5
   idealLight: 7
-  nutrientConsumption: 0.30
+  nutrientConsumption: 0.40
   chemicals:
     Nutriment:
       Min: 1

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -8,7 +8,7 @@
   physicalDesc: reagent-physical-desc-thick
   plantMetabolism:
     - !type:PlantAdjustNutrition
-      amount: 1
+      amount: 2
   metabolisms:
     Food:
       effects:
@@ -32,7 +32,7 @@
       amount: -0.5
     - !type:PlantAdjustMutationMod
       prob: 0.3
-      amount: 0.2
+      amount: 0.4
   metabolisms:
     Medicine:
       effects:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This is somewhat of a continuation to my last botany PR #18832 .
After observing what can be considered a full-length round, I saw only a single tray run out of nutrients,3 minutes before shuttle arrived. After a bit of discussion on Discord I've decided to ramp up the nutrient consumption of plants even more, and in return buff the nutrition gain of EZ nutrient in order to make it less tedious to restore nutrient levels. With these changes, a tray will run out of nutrients after 40-50 minutes of continuous use with the default nutrient consumption.
I also buffed left 4 zed a bit because it's really underused, and added it to the Nutrimax's emag inventory for any syndies who might want to use it for mischief.
While not worth mentioning in the changelog, I also made the nutrient and water warning lights appear a bit faster, so there's a bit more of a warning before the plant starts taking damage.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Emagging the NutriMax will give a bottle of left-4-zed, for when you need kudzu ASAP.
- add: Since it got lost in translation last time, the NutriMax also has EZ nutrient to satisfy increased nutrient demand.
- tweak: New and improved formulas have increased the effectiveness of EZ nutrient and Left-4-Zed.