### PR TITLE
Fix assert when arming the nuke.

### DIFF
--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -455,7 +455,12 @@ public sealed class NukeSystem : EntitySystem
         _sound.PlayGlobalOnStation(uid, _audio.GetSound(component.ArmSound));
 
         _itemSlots.SetLock(uid, component.DiskSlot, true);
-        _transform.AnchorEntity(uid, nukeXform);
+        if (!nukeXform.Anchored)
+        {
+            // Admin command shenanigans, just make sure.
+            _transform.AnchorEntity(uid, nukeXform);
+        }
+
         component.Status = NukeStatus.ARMED;
         UpdateUserInterface(uid, component);
     }


### PR DESCRIPTION
Apparently trying to anchor an entity twice throws an assert!

Note: this PR will conflict with #18869. Idk which one we wanna merge first.