### PR TITLE
Fix Murdertron 5000 a/k/a Emagged recycler

### DIFF
--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -114,10 +114,10 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
         if (HasComp<MobStateComponent>(item) && !CanGib(uid, item, component)) // whitelist? We be gibbing, boy!
             return false;
 
-        if (component.Whitelist != null && !component.Whitelist.IsValid(item))
+        if (component.Whitelist is {} whitelist && !whitelist.IsValid(item))
             return false;
 
-        if (component.Blacklist != null && component.Blacklist.IsValid(item))
+        if (component.Blacklist is {} blacklist && blacklist.IsValid(item))
             return false;
 
         if (user != null)

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -111,8 +111,10 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
         if (!CanStart(uid, component))
             return false;
 
-        if (component.Whitelist != null && !component.Whitelist.IsValid(item) ||
-            HasComp<MobStateComponent>(item) && !CanGib(uid, item, component)) // whitelist? We be gibbing, boy!
+        if (HasComp<MobStateComponent>(item) && !CanGib(uid, item, component)) // whitelist? We be gibbing, boy!
+            return false;
+
+        if (component.Whitelist != null && !component.Whitelist.IsValid(item))
             return false;
 
         if (component.Blacklist != null && component.Blacklist.IsValid(item))

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -87,7 +87,7 @@
     whitelist:
       components:
       - PhysicalComposition
-      - HumanoidAppearance
+      - MobState
       - SpaceGarbage
       tags:
       - Trash

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -87,6 +87,7 @@
     whitelist:
       components:
       - PhysicalComposition
+      - HumanoidAppearance
       - SpaceGarbage
       tags:
       - Trash

--- a/SpaceStation14.sln
+++ b/SpaceStation14.sln
@@ -120,6 +120,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Project Files", "Project Fi
 		RobustToolbox\README.md = RobustToolbox\README.md
 		RobustToolbox\RELEASE-NOTES.md = RobustToolbox\RELEASE-NOTES.md
 	EndProjectSection
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Content.Replay", "Content.Replay\Content.Replay.csproj", "{A493616C-338D-47B7-8072-A7F14D034D0B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Robust.Shared.CompNetworkGenerator", "RobustToolbox\Robust.Shared.CompNetworkGenerator\Robust.Shared.CompNetworkGenerator.csproj", "{07CA34A1-1D37-4771-A2E3-495A1044AE0B}"

--- a/SpaceStation14.sln
+++ b/SpaceStation14.sln
@@ -120,7 +120,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Project Files", "Project Fi
 		RobustToolbox\README.md = RobustToolbox\README.md
 		RobustToolbox\RELEASE-NOTES.md = RobustToolbox\RELEASE-NOTES.md
 	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Content.Replay", "Content.Replay\Content.Replay.csproj", "{A493616C-338D-47B7-8072-A7F14D034D0B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Robust.Shared.CompNetworkGenerator", "RobustToolbox\Robust.Shared.CompNetworkGenerator\Robust.Shared.CompNetworkGenerator.csproj", "{07CA34A1-1D37-4771-A2E3-495A1044AE0B}"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Due to some mystical reason recycler has a blacklist and a whitelist at the same time which basically limits what can be recycled to things in the whitelist only.
(Human)Appearance component was not in the list.

~~Additionally this kills animals and mobs if they walk into it or are shoved in.~~ Somewhy doesnt work anymore xd

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Emagged recyclers now not only gib people, but other mobs too.
