### PR TITLE
Add More Fluff To Maintenance Spawners

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -160,6 +160,7 @@
         - Crowbar
         - NetworkConfigurator
         - trayScanner
+        - GasAnalyzer
         - AirlockPainter
         - AppraisalTool
         - Flare

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -37,6 +37,21 @@
         - CluwneHorn
         - ClothingMaskRat
         - MysteryFigureBox
+        - ClothingHandsGlovesMercFingerless
+        - ClothingHandsGlovesNitrile
+        - ClothingHandsGlovesPowerglove
+        - ClothingHeadHatAnimalHeadslime
+        - ClothingHeadHatBeretMerc
+        - ClothingHeadHatOutlawHat
+        - ClothingHeadHatUshanka
+        - ClothingHeadHatBunny
+        - ClothingMaskNeckGaiter
+        - ClothingNeckScarfStripedZebra
+        - ClothingOuterRobesCult
+        - ClothingOuterGhostSheet
+        - ClothingShoesCult
+        - ClothingUniformJumpsuitAncient
+        - ClothingUniformJumpsuitPirate
       rareChance: 0.01
       prototypes:
         - Lighter
@@ -60,6 +75,37 @@
         - ClothingMaskRaven
         - ClothingMaskJackal
         - ClothingMaskBat
+        - ClothingBeltSuspenders
+        - ClothingEyesEyepatch
+        - ClothingEyesGlasses
+        - ClothingHandsGlovesLatex
+        - ClothingHandsGlovesFingerless
+        - ClothingHandsGlovesColorBlack
+        - ClothingHeadHatBeret
+        - ClothingHeadHatBowlerHat
+        - ClothingHeadHatFedoraBrown
+        - ClothingHeadHatFedoraGrey
+        - ClothingHeadHatFez
+        - ClothingHeadHatPaper
+        - ClothingHeadHatPirate
+        - ClothingHeadHatPirateTricord
+        - ClothingHeadHatTophat
+        - ClothingMaskSterile
+        - ClothingNeckHeadphones
+        - ClothingNeckTieRed
+        - ClothingOuterCoatGentle
+        - ClothingOuterCoatJensen
+        - ClothingOuterCoatLab
+        - ClothingOuterCoatPirate
+        - ClothingOuterHoodieBlack
+        - ClothingOuterHoodieGrey
+        - ClothingOuterVestHazard
+        - ClothingShoesBootsJack
+        - ClothingShoesBootsLaceup
+        - ClothingShoesLeather
+        - ClothingShoesBootsSalvage
+        - ClothingShoesBootsWork
+        - ClothingShoesTourist
       chance: 0.6
       offset: 0.0
 
@@ -80,22 +126,58 @@
         - LanternFlash
         - PowerCellHigh
         - NetProbeCartridge
+        - WelderIndustrial
+        - SheetPlasteel10
+        - ClothingMaskGasExplorer
       rareChance: 0.08
       prototypes:
         - FlashlightLantern
         - YellowOxygenTankFilled
         - DoubleEmergencyOxygenTankFilled
         - ToolboxEmergencyFilled
+        - NitrogenTankFilled
         - ToolboxElectricalFilled
         - ToolboxMechanicalFilled
-        - ClothingBeltUtilityFilled
+        - ClothingBeltUtility
         - Shovel
         - Welder
         - WeaponFlareGun
-        - SheetSteel
-        - SheetPlastic
+        - SheetSteel10
+        - SheetPlastic10
+        - SheetGlass10
+        - PartRodMetal10
+        - MaterialCardboard10
+        - MaterialCloth10
+        - MaterialWoodPlank10
         - ResearchDisk
         - Plunger
+        - TechnologyDisk
+        - PowerCellMedium
+        - PowerCellSmall
+        - Wirecutter
+        - Screwdriver
+        - Wrench
+        - Crowbar
+        - NetworkConfigurator
+        - trayScanner
+        - AirlockPainter
+        - AppraisalTool
+        - Flare
+        - HandheldGPSBasic
+        - HandLabeler
+        - GlowstickBase
+        - Bucket
+        - RadioHandheld
+        - GeigerCounter
+        - Beaker
+        - ClothingMaskGas
+        - ClothingMaskBreath
+        - DoorElectronics
+        - APCElectronics
+        - InflatableWallStack5
+        - CableHVStack10
+        - CableMVStack10
+        - CableApcStack10
       chance: 0.6
       offset: 0.0
 
@@ -115,6 +197,10 @@
         - Machete
         - BaseBallBat
         - CombatKnife
+        - Spear
+        - RifleStock
+        - ModularReceiver
+        - HydroponicsToolScythe
       rareChance: 0.05
       prototypes:
         - FlashlightLantern
@@ -126,9 +212,22 @@
         - Shovel
         - Welder
         - WeaponFlareGun
-        - Spear
         - LidSalami
         - ClothingEyesBlindfold
+        - ClothingMaskMuzzle
+        - ClothingMaskGasSecurity
+        - ShardGlass
+        - Syringe
+        - Mousetrap
+        - Brutepack1
+        - Ointment1
+        - Gauze1
+        - Bola
+        - SurvivalKnife
+        - ScalpelShiv
+        - Shiv
+        - SawImprov
+        - HydroponicsToolMiniHoe
       chance: 0.6
       offset: 0.0
 

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -76,6 +76,19 @@
 
 - type: entity
   parent: SheetGlass
+  id: SheetGlass10
+  suffix: 10
+  components:
+  - type: Sprite
+    state: glass
+  - type: Stack
+    stackType: Glass
+    count: 10
+  - type: Item
+    size: 10
+
+- type: entity
+  parent: SheetGlass
   id: SheetGlass1
   suffix: Single
   components:

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -72,6 +72,20 @@
 
 - type: entity
   parent: SheetSteel
+  id: SheetSteel10
+  name: steel
+  suffix: 10
+  components:
+  - type: Item
+    size: 10
+  - type: Sprite
+    state: steel
+  - type: Stack
+    stackType: Steel
+    count: 10
+
+- type: entity
+  parent: SheetSteel
   id: SheetSteel1
   name: steel
   suffix: Single
@@ -109,6 +123,20 @@
   - type: Item
     heldPrefix: plasteel
   - type: Appearance
+
+- type: entity
+  parent: SheetPlasteel
+  id: SheetPlasteel10
+  name: plasteel
+  suffix: 10
+  components:
+  - type: Sprite
+    state: plasteel
+  - type: Stack
+    stackType: Plasteel
+    count: 10
+  - type: Item
+    size: 10
 
 - type: entity
   parent: SheetPlasteel

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -144,6 +144,19 @@
 
 - type: entity
   parent: SheetPlastic
+  id: SheetPlastic10
+  name: plastic
+  suffix: 10
+  components:
+  - type: Sprite
+    state: plastic
+  - type: Item
+    size: 10
+  - type: Stack
+    count: 10
+
+- type: entity
+  parent: SheetPlastic
   id: SheetPlastic1
   name: plastic
   suffix: Single

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -53,6 +53,18 @@
 
 - type: entity
   parent: MaterialCardboard
+  id: MaterialCardboard10
+  suffix: 10
+  components:
+  - type: Sprite
+    state: cardboard
+  - type: Stack
+    count: 10
+  - type: Item
+    size: 10
+
+- type: entity
+  parent: MaterialCardboard
   id: MaterialCardboard1
   suffix: Single
   components:
@@ -120,7 +132,18 @@
       - DroneUsable
       - Gauze
       - RawMaterial
-      
+
+- type: entity
+  parent: MaterialCloth
+  id: MaterialCloth10
+  suffix: 10
+  components:
+  - type: Sprite
+    state: cloth
+  - type: Stack
+    count: 10
+  - type: Item
+    size: 10
 
 - type: entity
   parent: MaterialCloth
@@ -212,6 +235,16 @@
   - type: Appearance
   - type: Item
     heldPrefix: wood
+
+- type: entity
+  parent: MaterialWoodPlank
+  id: MaterialWoodPlank10
+  suffix: 10
+  components:
+  - type: Stack
+    count: 10
+  - type: Item
+    size: 10
 
 - type: entity
   parent: MaterialWoodPlank

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -62,6 +62,23 @@
 
 - type: entity
   parent: PartRodMetal
+  id: PartRodMetal10
+  name: metal rod
+  suffix: 10
+  components:
+  - type: Tag
+    tags:
+    - RodMetal1
+    - DroneUsable
+  - type: Sprite
+    state: rods
+  - type: Stack
+    count: 10
+  - type: Item
+    size: 10
+
+- type: entity
+  parent: PartRodMetal
   id: PartRodMetal1
   name: metal rod
   suffix: Single

--- a/Resources/Prototypes/Entities/Objects/Tools/inflatable_wall.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/inflatable_wall.yml
@@ -52,6 +52,18 @@
 
 - type: entity
   parent: InflatableWallStack
+  id: InflatableWallStack5
+  suffix: 5
+  components:
+    - type: Sprite
+      state: item_wall
+    - type: Item
+      size: 5
+    - type: Stack
+      count: 5
+
+- type: entity
+  parent: InflatableWallStack
   id: InflatableWallStack1
   suffix: 1
   components:


### PR DESCRIPTION
## About the PR
Adds more stuff to the "Fluff+Clothes", "Tools+Cells+Mats", and "Scrap+Weapons" maintenance spawners to hopefully diversify maint a little more.
Fairly open to feedback on this because it changes up the availability of a good deal of items.
(Also adds 10 stack prototypes for steel, glass, plastic, plastseel, rods, cloth, wood, and cardboard, alongside a 5 stack for inflatable walls. Because I wanted to lessen mat stacks in maint.)

**Media**
A raw list here won't really do any good, so images instead. (All items shown are new to the spawners. Red outlined objects mean rare, black crossed out items have been replaced with a counterpart)

Fluff+Clothes
![image](https://github.com/space-wizards/space-station-14/assets/110078045/722641c3-015a-4fda-b44c-8476e2591f37)

Tools+Cells+Mats (Mats are in stacks of ten, five for inflatable wall. Also there's supposed to be a gas analyzer here.)
![image](https://github.com/space-wizards/space-station-14/assets/110078045/7338d7f4-fb44-413e-8be8-80e62daea29f)

Scrap+Weapons (Spear moved from non-rare to rare. All medical items are single items of one.)
![image](https://github.com/space-wizards/space-station-14/assets/110078045/298d88f7-24ce-4872-9c03-f0bab4e1f10a)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl:
- tweak: Changed random maintenance loot spawns to be more diverse.