### PR TITLE
Disables wheelchair trait

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -50,10 +50,10 @@
   components:
     - type: Uncloneable
 
-# - type: trait
-  # id: WheelchairBound
-  # name: trait-wheelchair-bound-name
-  # description: trait-wheelchair-bound-desc
-  # components:
-    # - type: WheelchairBound
-    # - type: LegsParalyzed
+#- type: trait
+#  id: WheelchairBound
+#  name: trait-wheelchair-bound-name
+#  description: trait-wheelchair-bound-desc
+#  components:
+#    - type: WheelchairBound
+#    - type: LegsParalyzed

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -50,10 +50,10 @@
   components:
     - type: Uncloneable
 
-- type: trait
-  id: WheelchairBound
-  name: trait-wheelchair-bound-name
-  description: trait-wheelchair-bound-desc
-  components:
-    - type: WheelchairBound
-    - type: LegsParalyzed
+# - type: trait
+  # id: WheelchairBound
+  # name: trait-wheelchair-bound-name
+  # description: trait-wheelchair-bound-desc
+  # components:
+    # - type: WheelchairBound
+    # - type: LegsParalyzed


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Unfortunately the trait is currently being exploited to allow easy access to a bug that allows the player to bypass all movement impairing effects.

Why can't we have nice things!

Not a revert PR, I'd love to see this come back when not being used for malicious reasons.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

🆑 Whisper

- tweak: Temporarily disable the Wheelchair Bound trait until its vehicle code is fixed.