### PR TITLE
vehicles cannot be shot anymore

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -38,7 +38,6 @@
         mask:
         - MobMask
         layer:
-        - MobLayer # can be hit by bullets and lasers
         - TableLayer
   - type: Appearance
   - type: Repairable


### PR DESCRIPTION
## About the PR
1. doesnt make any sense
2. wheelchair/atv/unicycle should never block shots from lasers smgs disablers etc

addresses disabler part of #18874, they can actually hit the rider now

**Media**
they still collide with walls dunno if any other behaviour is required
![11:51:41](https://github.com/space-wizards/space-station-14/assets/39013340/5c7428a2-1fdf-4a8e-85fb-74ba5aa1ddf9)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun