### PR TITLE
Specify drawdepth layers for some objects

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
@@ -5,6 +5,7 @@
   description: Finally, some decent reception around here...
   components:
   - type: Sprite
+    drawdepth: SmallObjects
     layers:
     - map: ["computerLayerBody"]
       state: television

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -13,6 +13,7 @@
   - type: InteractionOutline
   - type: Physics
     canCollide: false
+    drawdepth: SmallObjects
   - type: Sprite
     sprite: Structures/Wallmounts/switch.rsi
     state: on
@@ -50,6 +51,7 @@
   - type: Physics
     canCollide: false
   - type: Sprite
+    drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch.rsi
     state: dead
   - type: UseDelay
@@ -109,6 +111,7 @@
     - type: Transform
       anchored: true
     - type: Sprite
+      drawdepth: SmallObjects
       sprite: Structures/Wallmounts/switch.rsi
       state: on
     - type: Rotatable
@@ -133,6 +136,7 @@
     - type: Clickable
     - type: InteractionOutline
     - type: Sprite
+      drawdepth: FloorObjects
       sprite: Structures/conveyor.rsi
       layers:
         - state: switch-off

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -13,8 +13,8 @@
   - type: InteractionOutline
   - type: Physics
     canCollide: false
-    drawdepth: SmallObjects
   - type: Sprite
+    drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch.rsi
     state: on
   - type: SignalSwitch

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/timer.yml
@@ -14,6 +14,7 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Sprite
+    drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch.rsi
     state: on
   - type: Appearance
@@ -51,6 +52,7 @@
     canEditLabel: true
   - type: TextScreenVisuals
   - type: Sprite
+    drawdepth: WallMountedItems
     sprite: Structures/Wallmounts/textscreen.rsi
     state: textscreen
     noRot: true


### PR DESCRIPTION
TV, buttons, timers, levers.

I made everything higher than a table except the lever which I specifically made a floor object.

Resolves #16333
Resolves #7438