### PR TITLE
Remove or fix broken Dirty() calls.

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -58,7 +58,7 @@ public sealed class BodySystem : SharedBodySystem
             if (TryComp(slot.Child, out BodyPartComponent? child))
             {
                 child.ParentSlot = slot;
-                Dirty(slot.Child.Value);
+                Dirty(slot.Child.Value, child);
                 continue;
             }
 
@@ -75,7 +75,7 @@ public sealed class BodySystem : SharedBodySystem
             if (TryComp(slot.Child, out OrganComponent? child))
             {
                 child.ParentSlot = slot;
-                Dirty(slot.Child.Value);
+                Dirty(slot.Child.Value, child);
                 continue;
             }
 
@@ -101,7 +101,7 @@ public sealed class BodySystem : SharedBodySystem
         }
 
         child.ParentSlot = slot;
-        Dirty(slot.Child.Value);
+        Dirty(slot.Child.Value, child);
     }
 
     private void OnRelayMoveInput(EntityUid uid, BodyComponent component, ref MoveInputEvent args)

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.Map.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.Map.cs
@@ -34,8 +34,6 @@ namespace Content.Server.Polymorph.Systems
             var newmap = _mapManager.CreateMap();
             _mapManager.SetMapPaused(newmap, true);
             PausedMap = _mapManager.GetMapEntityId(newmap);
-
-            Dirty(PausedMap.Value);
         }
     }
 }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
@@ -70,8 +70,8 @@ public partial class SharedBodySystem
         organ.ParentSlot = slot;
         organ.Body = CompOrNull<BodyPartComponent>(slot.Parent)?.Body;
 
-        Dirty(slot.Parent);
-        Dirty(organId.Value);
+        DirtyAllComponents(slot.Parent);
+        Dirty(organId.Value, organ);
 
         if (organ.Body == null)
         {
@@ -84,6 +84,20 @@ public partial class SharedBodySystem
 
         return true;
     }
+
+    public void DirtyAllComponents(EntityUid uid)
+    {
+        // TODO just use containers. Please
+        if (TryComp(uid, out BodyPartComponent? part))
+            Dirty(uid, part);
+
+        if (TryComp(uid, out OrganComponent? organ))
+            Dirty(uid, organ);
+
+        if (TryComp(uid, out BodyComponent? body))
+            Dirty(uid, body);
+    }
+
 
     public bool AddOrganToFirstValidSlot(
         EntityUid? childId,

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -55,7 +55,7 @@ public partial class SharedBodySystem
         if (part.ParentSlot is { } slot)
         {
             slot.Child = null;
-            Dirty(slot.Parent);
+            DirtyAllComponents(slot.Parent);
         }
 
         foreach (var childSlot in part.Children.Values.ToArray())
@@ -207,8 +207,8 @@ public partial class SharedBodySystem
             part.Body = null;
         }
 
-        Dirty(slot.Parent);
-        Dirty(partId.Value);
+        DirtyAllComponents(slot.Parent);
+        DirtyAllComponents(partId.Value);
 
         if (part.Body is { } newBody)
         {
@@ -226,7 +226,7 @@ public partial class SharedBodySystem
                 RaiseLocalEvent(organ.Id, new AddedToBodyEvent(newBody), true);
             }
 
-            Dirty(newBody);
+            DirtyAllComponents(newBody);
         }
 
         return true;
@@ -281,8 +281,8 @@ public partial class SharedBodySystem
             }
         }
 
-        Dirty(slot.Parent);
-        Dirty(partId.Value);
+        DirtyAllComponents(slot.Parent);
+        DirtyAllComponents(partId.Value);
 
         return true;
     }

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -322,10 +322,12 @@ public sealed class MobThresholdSystem : EntitySystem
         }
 
         if (mobState.CurrentState != MobState.Dead || thresholds.AllowRevives)
+        {
             thresholds.CurrentThresholdState = newState;
-        _mobStateSystem.UpdateMobState(target, mobState);
+            Dirty(target, thresholds);
+        }
 
-        Dirty(target);
+        _mobStateSystem.UpdateMobState(target, mobState);
     }
 
     private void UpdateAlerts(EntityUid target, MobState currentMobState, MobThresholdsComponent? threshold = null,


### PR DESCRIPTION
Some systems were unnecessarily dirtying entities, presumably because they were trying to dirty some components.
In the case of body system I largely just fixed this by dirtying all relevant components because the code needs changing anyways and I couldn't be bothered trying to figure out what component they were trying to dirty.

Required for an engine PR