### PR TITLE
Fix marking color bands

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -303,7 +303,9 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
 
         for (var j = 0; j < markingPrototype.Sprites.Count; j++)
         {
-            if (markingPrototype.Sprites[j] is not SpriteSpecifier.Rsi rsi)
+            var markingSprite = markingPrototype.Sprites[j];
+
+            if (markingSprite is not SpriteSpecifier.Rsi rsi)
             {
                 continue;
             }
@@ -312,7 +314,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
 
             if (!sprite.LayerMapTryGet(layerId, out _))
             {
-                var layer = sprite.AddLayer(markingPrototype.Sprites[j], targetLayer + j + 1);
+                var layer = sprite.AddLayer(markingSprite, targetLayer + j + 1);
                 sprite.LayerMapSet(layerId, layer);
                 sprite.LayerSetSprite(layerId, rsi);
             }
@@ -324,7 +326,10 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
                 continue;
             }
 
-            if (colors != null)
+            // Okay so if the marking prototype is modified but we load old marking data this may no longer be valid
+            // and we need to check the index is correct.
+            // So if that happens just default to white?
+            if (colors != null && j < colors.Count)
             {
                 sprite.LayerSetColor(layerId, colors[j]);
             }


### PR DESCRIPTION
I'm not entirely sure what happens, I know it's markings being loaded from DB with the same ID as a prototype that was modified don't jive, but I'm not entirely sure if it's the best fix.

Started after https://github.com/space-wizards/space-station-14/pull/18929 but can't confirm this fixes as I don't have old markings saved in my local db.

:cl:
- fix: Potentially fix invalid moth markings leading to issues spawning.
