### PR TITLE
Make jugs printable and bigger

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -17,7 +17,7 @@
           map: [ "enum.SolutionContainerLayers.Fill" ]
           visible: false
     - type: Item
-      size: 15
+      size: 25
       sprite: Objects/Specific/Chemistry/jug.rsi
     - type: RefillableSolution
       solution: beaker

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -17,7 +17,7 @@
           map: [ "enum.SolutionContainerLayers.Fill" ]
           visible: false
     - type: Item
-      size: 25
+      size: 20
       sprite: Objects/Specific/Chemistry/jug.rsi
     - type: RefillableSolution
       solution: beaker

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -17,7 +17,7 @@
           map: [ "enum.SolutionContainerLayers.Fill" ]
           visible: false
     - type: Item
-      size: 10
+      size: 15
       sprite: Objects/Specific/Chemistry/jug.rsi
     - type: RefillableSolution
       solution: beaker

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -204,4 +204,4 @@
   name: jug
   completetime: 4
   materials:
-    Plastic: 1500
+    Plastic: 700

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -197,3 +197,11 @@
   completetime: 2
   materials:
     Plastic: 100
+
+- type: latheRecipe
+  id: Jug
+  result: Jug
+  name: jug
+  completetime: 4
+  materials:
+    Plastic: 1500

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -201,7 +201,6 @@
 - type: latheRecipe
   id: Jug
   result: Jug
-  name: jug
   completetime: 4
   materials:
     Plastic: 700


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Makes jugs printable for 7 plastic sheets and makes them size 20 instead of 10 since they hold 200u.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Added jugs to the medical fabricator.
- tweak: Jugs now take up more space in bags.

