### PR TITLE
Sechud

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -115,13 +115,14 @@
   parent: ClothingEyesBase
   id: ClothingEyesGlassesSecurity
   name: security sunglasses
-  description: Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes. Often worn by budget security officers.
+  description: Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes. Often worn by budget security officers. Installed with security hud technology
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/secglasses.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/secglasses.rsi
   - type: FlashImmunity
+  - type: ShowSecurityIcons
   - type: EyeProtection
     protectionTime: 5
   - type: Tag

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/sechudglasses.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/sechudglasses.yml
@@ -1,0 +1,23 @@
+- type: constructionGraph
+  id: Sechudglasses
+  start: start
+  graph:
+    - node: start
+      edges:
+      - to: Sechudglasses
+        steps:
+      - tag: ClothingEyesGlassesSunglasses
+        icon:
+          sprite: Clothing/Eyes/Glasses/sunglasses.rsi
+          state: icon
+        name: Sun glasses
+      - tag: Sechud
+        icon:
+          sprite: Clothing/Eyes/Hud/Sec.rsi
+          state: icon
+        name: Sechud
+        - material: Cable
+          amount: 2
+          doAfter: 5
+    - node: Sechudglasses
+      entity: ClothingEyesGlassesSecurity

--- a/Resources/Prototypes/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/Recipes/Crafting/improvised.yml
@@ -151,3 +151,16 @@
   icon:
     sprite: Objects/Misc/rifle_stock.rsi
     state: icon
+
+- type: construction
+  name: Security HUD glasses
+  id: Sechudglasses
+  graph: SechudglassesGraph
+  startNode: start
+  targetNode: Sechudglasses
+  category: construction-category-clothing
+  objectType: Item
+  description: sunglasses installed with security hud technology
+  icon:
+    sprite: Clothing/Eyes/Glasses/secglasses.rsi
+    state: icon


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
security glasses now have sechud (like every ss13 server ever) and can be crafted with sunglasses, sechud, and 2 lv cables

im probably missing a few things so feel free to point them out and help
**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: JoeHammad
- tweak: Sec glasses now have hud installed.
- add: sec glasses can now be crafted with sechud, sun glasses and 2 low voltage cables.

