### PR TITLE
Laser namechange and some buffs

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
@@ -8,7 +8,7 @@ ent-CrateTrackingImplants = Tracking implants
     .desc = Contains a handful of tracking implanters. Good for prisoners you'd like to release but still keep track of.
 
 ent-CrateArmoryLaser = lasers crate
-    .desc = Contains three lethal, high-energy laser guns. Requires Armory access to open.
+    .desc = Contains three standard-issue laser rifles. Requires Armory access to open.
 
 ent-CrateArmoryPistols = pistols crate
     .desc = Contains two standard NT pistols with four mags. Requires Armory access to open.

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -35,7 +35,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: WeaponLaserGun
+      - id: WeaponLaserCarbine
         amount: 3
 
 - type: entity

--- a/Resources/Prototypes/Datasets/tips.yml
+++ b/Resources/Prototypes/Datasets/tips.yml
@@ -63,7 +63,7 @@
   - "As an Engineer, you can repair windows by using a welding tool on them while not in combat mode."
   - "As an Engineer, you can electrify grilles by placing powered cables beneath them."
   - "As an Engineer, you can use plasma glass to reinforce an area and prevent radiation. Uranium glass can also be used to prevent radiation."
-  - "As the Captain, you are one of the highest priority targets on the station. Everything from revolutions, to nuclear operatives, to traitors that need to rob you of your unique laser gun or your life are things to worry about."
+  - "As the Captain, you are one of the highest priority targets on the station. Everything from revolutions, to nuclear operatives, to traitors that need to rob you of your unique laser pistol or your life are things to worry about."
   - "As the Captain, always take the nuclear disk and pinpointer with you every shift. It's a good idea to give one of these to another head you can trust with keeping it safe."
   - "As the Captain, you have absolute access and control over the station, but this does not mean that being a horrible person won't result in mutiny."
   - "As the Captain, try to be active and patrol the station. Staying in the bridge might be tempting, but you'll just end up putting a bigger target on your back!"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -45,7 +45,7 @@
     - Belt
 
 - type: entity
-  name: retro laser gun
+  name: retro laser blaster
   parent: BaseWeaponBatterySmall
   id: WeaponLaserGun
   description: A weapon using light amplified by the stimulated emission of radiation.
@@ -68,7 +68,7 @@
   - type: Appearance
 
 - type: entity
-  name: makeshift laser gun
+  name: makeshift laser pistol
   parent: BaseWeaponBatterySmall
   id: WeaponMakeshiftLaser
   description: Better pray it won't burn your hands off.
@@ -91,7 +91,7 @@
     startingCharge: 500
 
 - type: entity
-  name: laser gun
+  name: laser rifle
   parent: BaseWeaponBattery
   id: WeaponLaserCarbine
   description: Favoured by Nanotrasen Security for being cheap and easy to use.
@@ -115,10 +115,10 @@
     fireCost: 62.5
 
 - type: entity
-  name: practice laser gun
+  name: practice laser rifle
   parent: WeaponLaserCarbine
   id: WeaponLaserCarbinePractice
-  description: A modified version of the basic laser gun, this one fires less concentrated energy bolts designed for target practice.
+  description: This modified laser rifle fires harmless beams in the 40-watt range, for target practice.
   components:
   - type: HitscanBatteryAmmoProvider
     proto: RedLaserPractice
@@ -357,7 +357,7 @@
   - type: Appearance
 
 - type: entity
-  name: antique laser gun
+  name: antique laser pistol
   parent: BaseWeaponBatterySmall
   id: WeaponAntiqueLaser
   description: This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy.
@@ -395,10 +395,10 @@
     price: 750
 
 - type: entity
-  name: advanced laser gun
+  name: advanced laser pistol
   parent: BaseWeaponBatterySmall
   id: WeaponAdvancedLaser
-  description: An experimental laser gun with a self charging nuclear powered battery.
+  description: An experimental high-energy laser with a self-charging nuclear battery.
   components:
   - type: Item
     size: 30

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -59,7 +59,7 @@
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
   - type: HitscanBatteryAmmoProvider
-    proto: RedLaser
+    proto: RedMediumLaser
     fireCost: 62.5
   - type: MagazineVisuals
     magState: mag
@@ -360,10 +360,8 @@
   name: antique laser pistol
   parent: BaseWeaponBatterySmall
   id: WeaponAntiqueLaser
-  description: This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy.
+  description: This is an antique laser pistol. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy.
   components:
-  - type: Item
-    size: 30
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi
     layers:
@@ -398,10 +396,10 @@
   name: advanced laser pistol
   parent: BaseWeaponBatterySmall
   id: WeaponAdvancedLaser
-  description: An experimental high-energy laser with a self-charging nuclear battery.
+  description: An experimental high-energy laser pistol with a self-charging nuclear battery.
   components:
   - type: Item
-    size: 30
+    size: 30  # Intentionally larger than other pistols
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
     layers:
@@ -436,8 +434,6 @@
   id: WeaponBehonkerLaser
   description: The eye of a behonker, it fires a laser when squeezed.
   components:
-  - type: Item
-    size: 30
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/behonker_eye.rsi
     layers:

--- a/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
@@ -44,9 +44,9 @@
   <Box>
     <GuideEntityEmbed Entity="CaptainIDCard" Caption="Captain's ID Card"/>
   </Box>
-  - Steal the Captain's [color=#a4885c]Antique Laser Gun[/color].
+  - Steal the Captain's [color=#a4885c]Antique Laser Pistol[/color].
   <Box>
-    <GuideEntityEmbed Entity="WeaponAntiqueLaser" Caption="Captain's Antique Laser Gun"/>
+    <GuideEntityEmbed Entity="WeaponAntiqueLaser" Caption="Captain's Antique Laser Pistol"/>
   </Box>
   - Steal the Captain's [color=#a4885c]Jetpack[/color].
   <Box>


### PR DESCRIPTION
## About the PR
Renamed all laser "guns" to make it easier to tell what they actually are
We now have laser pistols and rifles (and the "retro laser blaster" which is technically a sidearm/pistol too but blaster just sounded more on-brand for retro)

Changed the practice laser gun/rifle description because terminator reference, and the advanced laser gun/pistol's description to hint that it does higher damage than the common laser weapons

No ids were changed

Captain's pistol and Behonker Eye were reduced to size 10 as other pistols

Laser Crate now contains standard lasers instead of retro lasers

Retro lasers were buffed to the slightly higher damage of premium lasers due to their new rarity and so they are no longer exactly the same as normal laser rifles

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- tweak: The various laser guns are now called rifles or pistols.
- tweak: Retro laser blasters now deal 20% more damage. 
- tweak: Laser deliveries now contain 3 laser rifles instead of 3 retro laser blasters.