### PR TITLE
Vehicle stun/sleep immunity fix

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -131,6 +131,16 @@ public abstract partial class SharedBuckleSystem
 
     private void OnBuckleStandAttempt(EntityUid uid, BuckleComponent component, StandAttemptEvent args)
     {
+        //Let entities stand back up while on vehicles so that they can be knocked down when slept/stunned
+        //This prevents an exploit that allowed people to become partially invulnerable to stuns
+        //while on vehicles
+
+        if (component.BuckledTo != null)
+        {
+            var buckle = component.BuckledTo;
+            if (TryComp<VehicleComponent>(buckle, out var vehicle))
+                return;
+        }
         if (component.Buckled)
             args.Cancel();
     }

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -138,7 +138,7 @@ public abstract partial class SharedBuckleSystem
         if (component.BuckledTo != null)
         {
             var buckle = component.BuckledTo;
-            if (TryComp<VehicleComponent>(buckle, out var vehicle))
+            if (TryComp<VehicleComponent>(buckle, out _))
                 return;
         }
         if (component.Buckled)

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -20,6 +20,7 @@ using System.Numerics;
 using Content.Shared.Mobs.Systems;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Content.Shared.Bed.Sleep;
 
 namespace Content.Shared.Movement.Systems
 {
@@ -123,6 +124,7 @@ namespace Content.Shared.Movement.Systems
             if (RelayTargetQuery.TryGetComponent(uid, out var relayTarget))
             {
                 if (_mobState.IsIncapacitated(relayTarget.Source) ||
+                    TryComp<SleepingComponent>(relayTarget.Source, out _) ||
                     !MoverQuery.TryGetComponent(relayTarget.Source, out var relayedMover))
                 {
                     canMove = false;

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -374,7 +374,6 @@
   description: It only has one wheel!
   components:
   - type: Vehicle
-    useHand: false
     northOver: true
     southOver: true
     northOverride: -0.15


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Resolves #18874
This should fix the vehicle stun immunity bug. This is how it worked:
If you got buckled onto a vehicle while not standing (which, for wheelchair users, happens to be all the time), then any attempts to stand again would be canceled due to being buckled. This prevented you from being knocked down once on the vehicle, effectively preventing you from unwillingly dropping its virtual item and being ejected from it.
With this fix, you can stand back up while buckled to something that is considered a vehicle, in order to prevent this exploit.
The unicycle now has a virtual item like all other vehicles to prevent instances of excessive tomfoolery.
Sleeping entities can no longer relay their movement to other entities, because they're supposed to be unconscious so it makes no sense. (This fixes being able to control a vehicle if you're buckled to it while asleep.)

**Media**

https://github.com/space-wizards/space-station-14/assets/75124791/484c5b0e-1f0c-4326-940f-bfacbf2598a5


<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Wheelchairs, unicycles and similar vehicles no longer act as a magical barrier against stuns.
- fix: Driving while asleep is no longer possible.