### PR TITLE
Expand PVS entities to all players at round end

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -52,7 +52,7 @@ namespace Content.Server.GameTicking
         /// and sent to far-away players.
         /// </summary>
         [ViewVariables]
-        private List<EntityUid> _expandPvsPlayers = new();
+        private HashSet<EntityUid> _expandPvsPlayers = new();
 
         /// <summary>
         /// This is the list of the children entities that should be sent to

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -346,6 +346,10 @@ namespace Content.Server.GameTicking
             //Get the timespan of the round.
             var roundDuration = RoundDuration();
 
+            // Should already be empty, but just in case.
+            _expandPvsEntities.Clear();
+            _expandPvsPlayers.Clear();
+
             //Generate a list of basic player info to display in the end round summary.
             var listOfPlayerInfo = new List<RoundEndMessageEvent.RoundEndPlayerInfo>();
             // Grab the great big book of all the Minds, we'll need them for this.
@@ -406,8 +410,10 @@ namespace Content.Server.GameTicking
                 _expandPvsEntities.AddRange(entities);
 
                 foreach (var entity in entities)
+                {
                     if (TryComp<TransformComponent>(entity, out var xform))
                         RecursePvsEntities(xform.ChildEntities);
+                }
             }
 
             RecursePvsEntities(_expandPvsPlayers);

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -70,6 +70,7 @@ namespace Content.Server.GameTicking
                 "Overflow role does not have the correct name!");
             InitializeGameRules();
             InitializeReplays();
+            InitializeRoundFlow();
             _initialized = true;
         }
 


### PR DESCRIPTION
[expand-pvs-crew.webm](https://github.com/space-wizards/space-station-14/assets/114301317/2758ce7d-4c4d-42cb-b4a4-59ddcd96cf23)

First usage of `ExpandPvsEvent`?

Resolves #11983


:cl:
- fix: Player icons in the end-of-round summary window should now display properly.