### PR TITLE
Chat prettification / richtextification

### DIFF
--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -29,7 +29,7 @@ chat-manager-send-ooc-patron-wrap-message = OOC: [bold][color={$patronColor}]{$p
 chat-manager-send-dead-chat-wrap-message = {$deadChannelName}: [bold]{$playerName}:[/bold] {$message}
 chat-manager-send-admin-dead-chat-wrap-message = {$adminChannelName}: [bold]({$userName}):[/bold] {$message}
 chat-manager-send-admin-chat-wrap-message = {$adminChannelName}: [bold]{$playerName}:[/bold] {$message}
-chat-manager-send-admin-announcement-wrap-message = [font size=13][bold]{$adminChannelName}: {$message}[/bold][/font]
+chat-manager-send-admin-announcement-wrap-message = [bold]{$adminChannelName}: {$message}[/bold]
 chat-manager-send-hook-ooc-wrap-message = OOC: [bold](D){$senderName}:[/bold] {$message}
 
 chat-manager-dead-channel-name = DEAD

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -16,21 +16,21 @@ chat-manager-no-headset-on-message = You don't have a headset on!
 chat-manager-no-radio-key = No radio key specified!
 chat-manager-no-such-channel = There is no channel with key '{$key}'!
 chat-manager-whisper-headset-on-message = You can't whisper on the radio!
-chat-manager-server-wrap-message = SERVER: {$message}
-chat-manager-sender-announcement-wrap-message = {$sender} Announcement:
-                                                {$message}
-chat-manager-entity-say-wrap-message = {$entityName} says, "{$message}"
-chat-manager-entity-whisper-wrap-message = {$entityName} whispers, "{$message}"
-chat-manager-entity-whisper-unknown-wrap-message = Someone whispers, "{$message}"
-chat-manager-entity-me-wrap-message = {$entityName} {$message}
-chat-manager-entity-looc-wrap-message = LOOC: {$entityName}: {$message}
-chat-manager-send-ooc-wrap-message = OOC: {$playerName}: {$message}
-chat-manager-send-ooc-patron-wrap-message = OOC: [color={$patronColor}]{$playerName}[/color]: {$message}
-chat-manager-send-dead-chat-wrap-message = {$deadChannelName}: {$playerName}: {$message}
-chat-manager-send-admin-dead-chat-wrap-message = {$adminChannelName}:({$userName}): {$message}
-chat-manager-send-admin-chat-wrap-message = {$adminChannelName}: {$playerName}: {$message}
-chat-manager-send-admin-announcement-wrap-message = {$adminChannelName}: {$message}
-chat-manager-send-hook-ooc-wrap-message = OOC: (D){$senderName}: {$message}
+chat-manager-server-wrap-message = [bold]{$message}[/bold]
+chat-manager-sender-announcement-wrap-message = [font size=14][bold]{$sender} Announcement:[/font][font size=12]
+                                                {$message}[/bold][/font]
+chat-manager-entity-say-wrap-message = [bold]{$entityName}[/bold] [italic]says,[/italic] "{$message}"
+chat-manager-entity-whisper-wrap-message = [font size=11][italic]{$entityName} whispers, "{$message}"[/italic][/font]
+chat-manager-entity-whisper-unknown-wrap-message = [font size=11][italic]Someone whispers, "{$message}"[/italic][/font]
+chat-manager-entity-me-wrap-message = [italic]{$entityName} {$message}[/italic]
+chat-manager-entity-looc-wrap-message = LOOC: [bold]{$entityName}:[/bold] {$message}
+chat-manager-send-ooc-wrap-message = OOC: [bold]{$playerName}:[/bold] {$message}
+chat-manager-send-ooc-patron-wrap-message = OOC: [bold][color={$patronColor}]{$playerName}[/color]:[/bold] {$message}
+chat-manager-send-dead-chat-wrap-message = {$deadChannelName}: [bold]{$playerName}:[/bold] {$message}
+chat-manager-send-admin-dead-chat-wrap-message = {$adminChannelName}: [bold]({$userName}):[/bold] {$message}
+chat-manager-send-admin-chat-wrap-message = {$adminChannelName}: [bold]{$playerName}:[/bold] {$message}
+chat-manager-send-admin-announcement-wrap-message = [font size=13][bold]{$adminChannelName}: {$message}[/bold][/font]
+chat-manager-send-hook-ooc-wrap-message = OOC: [bold](D){$senderName}:[/bold] {$message}
 
 chat-manager-dead-channel-name = DEAD
 chat-manager-admin-channel-name = ADMIN

--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -1,5 +1,5 @@
 # Chat window radio wrap (prefix and postfix)
-chat-radio-message-wrap = [color={$color}]{$channel} {$name} says: "{$message}"[/color]
+chat-radio-message-wrap = [color={$color}]{$channel} [bold]{$name}[/bold] [italic]says,[/italic] "{$message}"[/color]
 
 examine-headset-default-channel = Use {$prefix} for the default channel ([color={$color}]{$channel}[/color]).
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

crediting julian in CL because this is basically all richtext refactor lol

embarrassing that we did not do this sooner after that was merged! looks and feels way better for almost no effort

willing to accept i may have gone overboard with bolding in some cases for most peoples taste, i think its alright though

notable features if ur 2lazy to read code:
- whispered text is smaller
- announcements are larger
- server text is bolded and the `SERVER:` prefix is removed
- admin text is bolded
- names are bolded

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/space-wizards/space-station-14/assets/19853115/69093850-99ab-4426-b580-62801ff685de)

(note that this might kind of feel like color vomit but it wont look like that all the time obviously!! this is just demonstration of every chat type changed)

a more normal distribution of text:
![image](https://github.com/space-wizards/space-station-14/assets/19853115/a12caae8-f795-4f19-99fa-2d9eb9a1e6b5)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: juliangiebel & mirrorcult
- tweak: You may notice that chat text in general has become much prettier and dynamic. Whispered text is smaller, announcements are larger, and names should pop out more.
