### PR TITLE
Add Destructible SpawnGasBehavior

### DIFF
--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Administration.Logs;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Systems;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Construction;
@@ -26,6 +27,7 @@ namespace Content.Server.Destructible
         [Dependency] public readonly IRobustRandom Random = default!;
         public new IEntityManager EntityManager => base.EntityManager;
 
+        [Dependency] public readonly AtmosphereSystem AtmosphereSystem = default!;
         [Dependency] public readonly AudioSystem AudioSystem = default!;
         [Dependency] public readonly BodySystem BodySystem = default!;
         [Dependency] public readonly ConstructionSystem ConstructionSystem = default!;

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnGasBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnGasBehavior.cs
@@ -1,0 +1,20 @@
+using Content.Server.Atmos;
+using JetBrains.Annotations;
+
+namespace Content.Server.Destructible.Thresholds.Behaviors;
+
+[UsedImplicitly]
+[DataDefinition]
+public sealed class SpawnGasBehavior : IThresholdBehavior
+{
+    [DataField("gasMixture", required: true)]
+    public GasMixture Gas = new();
+
+    public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
+    {
+        var air = system.AtmosphereSystem.GetContainingMixture(owner, false, true);
+
+        if (air != null)
+            system.AtmosphereSystem.Merge(air, Gas);
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -67,11 +67,19 @@
         sound:
           path: /Audio/Effects/metalbreak.ogg
       - !type:ExplodeBehavior
-      - !type:SpawnEntitiesBehavior # in future should also emit a cloud of hot gas
+      - !type:SpawnEntitiesBehavior
         spawn:
           MachineFrameDestroyed:
             min: 1
             max: 1
+      - !type:SpawnGasBehavior
+        gasMixture:
+          volume: 1000
+          moles:
+            - 0 # oxygen
+            - 0 # nitrogen
+            - 340.5701689 # carbon dioxide
+          temperature: 373.15
   - type: Explosive
     explosionType: Default
     maxIntensity: 100


### PR DESCRIPTION
[spawngasbehavior.webm](https://github.com/space-wizards/space-station-14/assets/114301317/c71deae2-4f16-45d1-aa7f-79411e4f32f1)

Resolves #8375

:cl:
- tweak: Substations produce hot CO2 when destroyed now.