### PR TITLE
Removes Spaceacillin

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -64,9 +64,6 @@ reagent-desc-pulped-banana-peel = Pulped banana peels have some effectiveness ag
 reagent-name-siderlac = siderlac
 reagent-desc-siderlac = A powerful anti-caustic medicine derived from plants.
 
-reagent-name-spaceacillin = spaceacillin
-reagent-desc-spaceacillin = A theta-lactam antibiotic, effective against space diseases. Side-effects may include cancer. Phalanximine is recommended after ingestion.
-
 reagent-name-stellibinin = stellibinin
 reagent-desc-stellibinin = A natual anti-toxin with particular effectiveness against amatoxin.
 

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -317,5 +317,4 @@
         amount: 3
       - id: ClothingHandsGlovesLatex
       - id: SyringeTranexamicAcid
-      - id: SyringeSpaceacillin
       - id: SyringeHyronalin

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -53,8 +53,6 @@
   components:
   - type: StorageFill
     contents:
-      - id: SyringeSpaceacillin
-        amount: 2
       - id: SyringeIpecac
         amount: 2
       - id: AntiPoisonMedipen

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -461,19 +461,6 @@
           Quantity: 15
 
 - type: entity
-  name: spaceacillin syringe
-  parent: BaseSyringe
-  id: SyringeSpaceacillin
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      injector:
-        maxVol: 15
-        reagents:
-        - ReagentId: Spaceacillin
-          Quantity: 15
-
-- type: entity
   name: bicaridine syringe
   parent: BaseSyringe
   id: SyringeBicaridine

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -638,22 +638,6 @@
             Caustic: -5
 
 - type: reagent
-  id: Spaceacillin
-  name: reagent-name-spaceacillin
-  group: Medicine
-  desc: reagent-desc-spaceacillin
-  physicalDesc: reagent-physical-desc-opaque
-  flavor: medicine
-  color: "#9942f5"
-  metabolisms:
-    Medicine:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Cellular: 0.5
-
-- type: reagent
   id: Stellibinin
   name: reagent-name-stellibinin
   group: Medicine

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1515,7 +1515,7 @@
     MaterialCloth1: 1
   reagents:
     TranexamicAcid: 50
-    Spaceacillin: 50
+    Cryptobiolin: 50
 
 - type: microwaveMealRecipe
   id: RecipeRegenerativeMesh

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -360,16 +360,6 @@
     Siderlac: 2
 
 - type: reaction
-  id: Spaceacillin
-  reactants:
-    Cryptobiolin:
-      amount: 1
-    Inaprovaline:
-      amount: 1
-  products:
-    Spaceacillin: 2
-
-- type: reaction
   id: Cognizine
   reactants:
     CarpoToxin:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -161,3 +161,6 @@ MountainRockMining: AsteroidRockMining
 
 # 2023-08-08
 WindowTintedDirectional: WindowFrostedDirectional
+
+# 2023-08-10
+SyringeSpaceacillin: null


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
why does this shitass chem exist

suture crafting recipe uses cryptobiolin since it'd be useless otherwise

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Lank
- remove: As disease has been eradicated, Spaceacillin can no longer be created or found. 
- tweak: Creating medicated suture now required Cryptobiolin in place of Spaceacillin.
