### PR TITLE
Make thermomachines more thermodynamically sound

### DIFF
--- a/Content.Client/Atmos/UI/GasThermomachineBoundUserInterface.cs
+++ b/Content.Client/Atmos/UI/GasThermomachineBoundUserInterface.cs
@@ -75,11 +75,10 @@ namespace Content.Client.Atmos.UI
 
             _window.SetTemperature(cast.Temperature);
             _window.SetActive(cast.Enabled);
-            _window.Title = cast.Mode switch
+            _window.Title = cast.IsHeater switch
             {
-                ThermoMachineMode.Freezer => Loc.GetString("comp-gas-thermomachine-ui-title-freezer"),
-                ThermoMachineMode.Heater => Loc.GetString("comp-gas-thermomachine-ui-title-heater"),
-                _ => string.Empty
+                false => Loc.GetString("comp-gas-thermomachine-ui-title-freezer"),
+                true => Loc.GetString("comp-gas-thermomachine-ui-title-heater")
             };
         }
 

--- a/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
@@ -41,13 +41,6 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [ViewVariables(VVAccess.ReadOnly)]
         public bool HysteresisState = false;
 
-        public ThermoMachineMode Mode {
-            get
-            {
-                return Cp < 0 ? ThermoMachineMode.Freezer : ThermoMachineMode.Heater;
-            }
-        }
-
         /// <summary>
         ///     Coefficient of performance. Output power / input power.
         ///     Positive for heaters, negative for freezers.

--- a/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         ///     Coefficient of performance. Output power / input power.
         ///     Positive for heaters, negative for freezers.
         /// </summary>
-        [DataField("cp")]
+        [DataField("coefficientOfPerformance")]
         public float Cp = 0.9f; // output power / input power, positive is heat
 
         /// <summary>

--- a/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
@@ -12,9 +12,8 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         public string InletName = "pipe";
 
         /// <summary>
-        ///     Current maximum temperature, calculated from <see cref="BaseHeatCapacity"/> and the quality of matter
-        ///     bins. The heat capacity effectively determines the rate at which the thermo machine can add or remove
-        ///     heat from a pipenet.
+        ///     Current electrical power consumption, in watts. Increasing power increases the ability of the
+        ///     thermomachine to heat or cool air.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         public float HeatCapacity = 10000;
@@ -30,8 +29,31 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [ViewVariables(VVAccess.ReadWrite)]
         public float TargetTemperature = Atmospherics.T20C;
 
-        [DataField("mode")]
-        public ThermoMachineMode Mode = ThermoMachineMode.Freezer;
+        /// <summary>
+        ///     Tolerance for temperature setpoint hysteresis.
+        /// </summary>
+        public float TemperatureTolerance = 2f;
+
+        /// <summary>
+        ///     Implements setpoint hysteresis to prevent heater from rapidly cycling on and off at setpoint.
+        ///     If true, add Sign(Cp)*TemperatureTolerance to the temperature setpoint.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadOnly)]
+        public bool HysteresisState = false;
+
+        public ThermoMachineMode Mode {
+            get
+            {
+                return Cp < 0 ? ThermoMachineMode.Freezer : ThermoMachineMode.Heater;
+            }
+        }
+
+        /// <summary>
+        ///     Coefficient of performance. Output power / input power.
+        ///     Positive for heaters, negative for freezers.
+        /// </summary>
+        [DataField("cp")]
+        public float Cp = 0.9f; // output power / input power, positive is heat
 
         /// <summary>
         ///     Current minimum temperature, calculated from <see cref="InitialMinTemperature"/> and <see

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -71,7 +71,9 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             if (!thermoMachine.HysteresisState) // Hysteresis is the same as "Should this be on?"
             {
-                receiver.Load = 0f;
+                // Turn dynamic load back on when power has been adjusted to not cause lights to
+                // blink every time this heater comes on.
+                //receiver.Load = 0f;
                 return;
             }
 
@@ -90,7 +92,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             }
             float dQActual = dQ * scale;
             _atmosphereSystem.AddHeat(inlet.Air, dQActual);
-            receiver.Load = thermoMachine.HeatCapacity * scale;
+            receiver.Load = thermoMachine.HeatCapacity;// * scale; // we're not ready for dynamic load yet, see note above
         }
 
         private bool IsHeater(GasThermoMachineComponent comp)

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -50,8 +50,8 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
         private void OnThermoMachineUpdated(EntityUid uid, GasThermoMachineComponent thermoMachine, AtmosDeviceUpdateEvent args)
         {
 
-            if (!(_power.IsPowered(uid) && TryComp(uid, out ApcPowerReceiverComponent? receiver))
-                || !TryComp(uid, out NodeContainerComponent? nodeContainer)
+            if (!(_power.IsPowered(uid) && TryComp<ApcPowerReceiverComponent>(uid, out var receiver))
+                || !TryComp<NodeContainerComponent>(uid, out var nodeContainer)
                 || !_nodeContainer.TryGetNode(nodeContainer, thermoMachine.InletName, out PipeNode? inlet))
             {
                 return;
@@ -84,7 +84,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
         {
             var heatCapacityPartRating = args.PartRatings[thermoMachine.MachinePartHeatCapacity];
             thermoMachine.HeatCapacity = thermoMachine.BaseHeatCapacity * MathF.Pow(heatCapacityPartRating, 2);
-            if (TryComp(uid, out ApcPowerReceiverComponent? receiver))
+            if (TryComp<ApcPowerReceiverComponent>(uid, out var receiver))
             {
                 receiver.Load = thermoMachine.HeatCapacity;
             }

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedGasThermomachineComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedGasThermomachineComponent.cs
@@ -14,14 +14,6 @@ public enum ThermomachineUiKey
 
 [Serializable]
 [NetSerializable]
-public enum ThermoMachineMode : byte
-{
-    Freezer = 0,
-    Heater = 1,
-}
-
-[Serializable]
-[NetSerializable]
 public sealed class GasThermomachineToggleMessage : BoundUserInterfaceMessage
 {
 }
@@ -46,14 +38,14 @@ public sealed class GasThermomachineBoundUserInterfaceState : BoundUserInterface
     public float MaxTemperature { get; }
     public float Temperature { get; }
     public bool Enabled { get; }
-    public ThermoMachineMode Mode { get; }
+    public bool IsHeater { get; }
 
-    public GasThermomachineBoundUserInterfaceState(float minTemperature, float maxTemperature, float temperature, bool enabled, ThermoMachineMode mode)
+    public GasThermomachineBoundUserInterfaceState(float minTemperature, float maxTemperature, float temperature, bool enabled, bool isHeater)
     {
         MinTemperature = minTemperature;
         MaxTemperature = maxTemperature;
         Temperature = temperature;
         Enabled = enabled;
-        Mode = mode;
+        IsHeater = isHeater;
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -284,7 +284,7 @@
             True: { state: freezerOn }
             False: { state: freezerOff }
     - type: GasThermoMachine
-      mode: Freezer
+      cp: -3.9
     - type: ApcPowerReceiver
       powerDisabled: true #starts off
     - type: Machine
@@ -327,7 +327,7 @@
             True: { state: heaterOn }
             False: { state: heaterOff }
     - type: GasThermoMachine
-      mode: Heater
+      cp: 0.95
     - type: ApcPowerReceiver
       powerDisabled: true #starts off
     - type: Machine

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -284,7 +284,7 @@
             True: { state: freezerOn }
             False: { state: freezerOff }
     - type: GasThermoMachine
-      cp: -3.9
+      coefficientOfPerformance: -3.9
     - type: ApcPowerReceiver
       powerDisabled: true #starts off
     - type: Machine
@@ -327,7 +327,7 @@
             True: { state: heaterOn }
             False: { state: heaterOff }
     - type: GasThermoMachine
-      cp: 0.95
+      coefficientOfPerformance: 0.95
     - type: ApcPowerReceiver
       powerDisabled: true #starts off
     - type: Machine


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Also known as *heater and freezer 1984*.

### Why?
Somebody is trying to add TEG's: https://github.com/space-wizards/space-station-14/pull/18840 As it stands, building a heater and freezer and sticking them on the hot and cold ends would allow you to produce infinite power, since the heater produces more heat than it consumes.

### How?
Instead of magically adjusting the temperature of the target gas mixture, this adds energy. The amount of energy that is added depends on the power load of the thermomachine and a new *coefficient of performance* (*CP*) specified in the component. A positive *CP* represents heating, while a negative *CP* represents cooling. Keeping *CP* < 1 prevents free energy generation.

However, now we have to add a way to control the temperature. We use the following patented algorithm:

- If it's too cold, heat up
- If it's too hot, cool down

However, this patented algorithm suffers from oscillating around the setpoint. Therefore, we also implement a simple [hysteresis controller](https://en.wikipedia.org/wiki/Hysteresis).

# ~~Why is this a draft?~~ This is now ready for review

~~1. We need to give engineers one day of free energy because that would be funny.
2. I haven't re-implemented heat capacity machine upgrades, but I'm about to go on vacation and so I was hoping @EmoGarbage404 will go do it. If @EmoGarbage404 does decide to look, this is how you should implement it to avoid free energy generation: scale the APC load with HeatCapacity, i.e. increasing HeatCapacity automatically increases the APC load, which due to how this is implemented automatically gives you a beefier heater/freezer.~~

**Media**

https://github.com/space-wizards/space-station-14/assets/3229565/82418ab1-aa98-4a09-8348-4bac77527788

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

fixes #19300