### PR TITLE
add syndies+nukies gamemode

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops-traitor.ftl
@@ -1,0 +1,2 @@
+nukeops-traitor-title = Traitors and Nuclear Operatives
+nukeops-traitor-description = Both Syndicate agents and Nuclear Operatives have targeted the station. Will they fight or cooperate?

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -72,6 +72,19 @@
   rules:
     - Nukeops
     - BasicStationEventScheduler
+    
+- type: gamePreset
+  id: NukeopsTraitor
+  alias:
+    - nukeopstraitor
+    - syndinukies
+  name: nukeops-traitor-title
+  description: nukeops-traitor-description
+  showInVote: false
+  rules:
+    - Nukeops
+    - Traitor
+    - BasicStationEventScheduler
 
 - type: gamePreset
   id: Zombie

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,6 +1,7 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.25
-    Traitor: 0.65
+    Nukeops: 0.2
+    Traitor: 0.6
+    NukeopsTraitor: 0.10
     Zombie: 0.10

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,6 +2,7 @@
   id: Secret
   weights:
     Nukeops: 0.2
-    Traitor: 0.6
+    Traitor: 0.65
+    # TODO: remove when dynamic is a thing
     NukeopsTraitor: 0.10
     Zombie: 0.10

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,7 +1,7 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.2
+    Nukeops: 0.15
     Traitor: 0.65
     # TODO: remove when dynamic is a thing
     NukeopsTraitor: 0.10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
adds a gamemode with both syndies and nukies and puts it into secret
weights altered so that the frequency of zombie rounds is unaltered, otherwise makes rounds with traitors and rounds with nukies both more common
probably should be replaced with a better solution regarding combining gamemodes later

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Traitors can now exist along with nuclear operatives.
