### PR TITLE
bola buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -39,7 +39,7 @@
   - type: DamageOnLand
     damage:
       types:
-        Blunt: 5
+        Blunt: 3
   - type: Ensnaring
     freeTime: 2.0
     breakoutTime: 3.5 #all bola should generally be fast to remove

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/bola.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/bola.yml
@@ -6,12 +6,9 @@
       edges:
         - to: bola
           steps:
-            - tag: Handcuffs
-              icon:
-                sprite: Objects/Misc/cablecuffs.rsi
-                state: cuff
-                color: red
-              name: cuffs
+            - material: Cable
+              amount: 5
+              doAfter: 2
             - material: Steel
               amount: 6
               doAfter: 2


### PR DESCRIPTION
## About the PR
No one uses bolas so let's make them more available, maybe then people will give it a shot.

Price changed from 6 metal and a Cablecuff to 6 metal and 5 LV wires. Now an electric toolbox has enough cables for 2 bolas instead of 0.66
They also break on the 5th miss instead of the 3rd

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Errant
- tweak: Bolas are now easier to make and more durable.