### PR TITLE
Restrict Fire-fighting remote from Chief door

### DIFF
--- a/Resources/Prototypes/Access/engineering.yml
+++ b/Resources/Prototypes/Access/engineering.yml
@@ -16,3 +16,8 @@
   - ChiefEngineer
   - Engineering
   - Atmospherics
+
+- type: accessGroup
+  id: FireFight
+  tags:
+    - Engineering

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -104,6 +104,7 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
+      - id: DoorRemoteFirefight
 
 - type: entity
   id: LockerEngineerFilledHardsuit

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -154,7 +154,7 @@
 
     - type: Access
       groups:
-        - Engineering
+        - FireFight
 
 - type: entity
   parent: DoorRemoteDefault


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fire-fighting remote has lost the Atmospherics and ChiefEngineer access (in the group called "Engineering"). So you can't open the chief's door with it.

Also added it to lockers in maps which have seperate atmos hard suit storage.

This is a quick fix to https://github.com/space-wizards/space-station-14/pull/16189#discussion_r1291783936

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: After a flurry of memos, the Atmospheric Technician's remote no longer opens the Chief Engineer's door. So I guess fires in that room are considered "totally normal" by command. To compensate, the remotes are more widely available in more stations. Thanks Wookyskill.
