### PR TITLE
make pickaxe cost 5x more (and make it bigger)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -25,7 +25,7 @@
         Piercing: 5
         Structural: 15
   - type: Item
-    size: 24
+    size: 80
     sprite: Objects/Weapons/Melee/pickaxe.rsi
 
 - type: entity

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -65,10 +65,10 @@
 - type: latheRecipe
   id: Pickaxe
   result: Pickaxe
-  completetime: 2
+  completetime: 4
   materials:
-    Steel: 200
-    Wood: 100
+    Steel: 1000
+    Wood: 500
 
 - type: latheRecipe
   id: Shovel


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Makes pickaxes cost 5x as much to create, and makes them 80 size.

Resolves #19006 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Pickaxes are now 80 size and take more wood and steel to manufacture.

