### PR TITLE
Fix tooltips for non-disabled verbs

### DIFF
--- a/Content.Server/Access/Systems/IdExaminableSystem.cs
+++ b/Content.Server/Access/Systems/IdExaminableSystem.cs
@@ -34,7 +34,7 @@ public sealed class IdExaminableSystem : EntitySystem
             Text = Loc.GetString("id-examinable-component-verb-text"),
             Category = VerbCategory.Examine,
             Disabled = !detailsRange,
-            Message = Loc.GetString("id-examinable-component-verb-disabled"),
+            Message = detailsRange ? null : Loc.GetString("id-examinable-component-verb-disabled"),
             Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/character.svg.192dpi.png"))
         };
 

--- a/Content.Server/DetailExaminable/DetailExaminableystem.cs
+++ b/Content.Server/DetailExaminable/DetailExaminableystem.cs
@@ -31,7 +31,7 @@ namespace Content.Server.DetailExaminable
                 Text = Loc.GetString("detail-examinable-verb-text"),
                 Category = VerbCategory.Examine,
                 Disabled = !detailsRange,
-                Message = Loc.GetString("detail-examinable-verb-disabled"),
+                Message = detailsRange ? null : Loc.GetString("detail-examinable-verb-disabled"),
                 Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/examine.svg.192dpi.png"))
             };
 

--- a/Content.Server/DeviceLinking/Systems/TwoWayLeverSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/TwoWayLeverSystem.cs
@@ -50,6 +50,7 @@ namespace Content.Server.DeviceLinking.Systems
             if (!args.CanAccess || !args.CanInteract || (args.Hands == null))
                 return;
 
+            var disabled = component.State == TwoWayLeverState.Left;
             InteractionVerb verbLeft = new()
             {
                 Act = () =>
@@ -63,14 +64,15 @@ namespace Content.Server.DeviceLinking.Systems
                     StateChanged(uid, component);
                 },
                 Category = VerbCategory.Lever,
-                Message = Loc.GetString("two-way-lever-cant"),
-                Disabled = component.State == TwoWayLeverState.Left,
+                Message = disabled ? Loc.GetString("two-way-lever-cant") : null,
+                Disabled = disabled,
                 Icon = new SpriteSpecifier.Texture(new ($"/Textures/Interface/VerbIcons/{_leftToggleImage}")),
                 Text = Loc.GetString("two-way-lever-left"),
             };
 
             args.Verbs.Add(verbLeft);
 
+            disabled = component.State == TwoWayLeverState.Right;
             InteractionVerb verbRight = new()
             {
                 Act = () =>
@@ -84,8 +86,8 @@ namespace Content.Server.DeviceLinking.Systems
                     StateChanged(uid, component);
                 },
                 Category = VerbCategory.Lever,
-                Message = Loc.GetString("two-way-lever-cant"),
-                Disabled = component.State == TwoWayLeverState.Right,
+                Message = disabled ? Loc.GetString("two-way-lever-cant") : null,
+                Disabled = disabled,
                 Icon = new SpriteSpecifier.Texture(new ($"/Textures/Interface/VerbIcons/{_rightToggleImage}")),
                 Text = Loc.GetString("two-way-lever-right"),
             };

--- a/Content.Server/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Server/HealthExaminable/HealthExaminableSystem.cs
@@ -35,7 +35,7 @@ public sealed class HealthExaminableSystem : EntitySystem
             Text = Loc.GetString("health-examinable-verb-text"),
             Category = VerbCategory.Examine,
             Disabled = !detailsRange,
-            Message = Loc.GetString("health-examinable-verb-disabled"),
+            Message = detailsRange ? null : Loc.GetString("health-examinable-verb-disabled"),
             Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/rejuvenate.svg.192dpi.png"))
         };
 

--- a/Content.Server/Storage/EntitySystems/PickRandomSystem.cs
+++ b/Content.Server/Storage/EntitySystems/PickRandomSystem.cs
@@ -29,6 +29,10 @@ public sealed class PickRandomSystem : EntitySystem
 
         var user = args.User;
 
+        var enabled = false;
+        if (storage.StoredEntities != null)
+            enabled = storage.StoredEntities.Any(item => comp.Whitelist?.IsValid(item, EntityManager) ?? true);
+
         // alt-click / alt-z to pick an item
         args.Verbs.Add(new AlternativeVerb
         {
@@ -37,8 +41,8 @@ public sealed class PickRandomSystem : EntitySystem
             }),
             Impact = LogImpact.Low,
             Text = Loc.GetString(comp.VerbText),
-            Disabled = !(storage.StoredEntities?.Any(item => comp.Whitelist?.IsValid(item, EntityManager) ?? true) ?? false),
-            Message = Loc.GetString(comp.EmptyText, ("storage", uid))
+            Disabled = !enabled,
+            Message = enabled ? null : Loc.GetString(comp.EmptyText, ("storage", uid))
         });
     }
 


### PR DESCRIPTION
A bunch of verbs were showing tooltips about why they were disabled even while they were allowed.