### PR TITLE
empty syringe starts on draw, 15u

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -326,6 +326,9 @@
   parent: BaseSyringe
   id: Syringe
   components:
+  - type: Injector
+    transferAmount: 15
+    toggleState: Draw
   - type: Tag
     tags:
     - Syringe


### PR DESCRIPTION
## About the PR
its extremely tedious setting every single syringe to 15u every time its being used
if its empty theres nothing to inject so being on draw makes sense

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun