### PR TITLE
Remove erroneous SrEngie spawnpoint in maints

### DIFF
--- a/Resources/Maps/origin.yml
+++ b/Resources/Maps/origin.yml
@@ -21551,7 +21551,7 @@ entities:
     - pos: 10.5,47.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -245486.9
+    - SecondsUntilStateChange: -246248.66
       state: Closing
       type: Door
     - enabled: False
@@ -21568,7 +21568,7 @@ entities:
     - pos: 10.5,49.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -245486.9
+    - SecondsUntilStateChange: -246248.66
       state: Closing
       type: Door
     - enabled: False
@@ -21585,7 +21585,7 @@ entities:
     - pos: 10.5,48.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -245486.9
+    - SecondsUntilStateChange: -246248.66
       state: Closing
       type: Door
     - enabled: False
@@ -21604,7 +21604,7 @@ entities:
     - pos: 18.5,-56.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -310916.3
+    - SecondsUntilStateChange: -311678.06
       state: Closing
       type: Door
     - enabled: False
@@ -21621,7 +21621,7 @@ entities:
     - pos: 47.5,-51.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -180297.11
+    - SecondsUntilStateChange: -181058.86
       state: Closing
       type: Door
     - enabled: False
@@ -21638,7 +21638,7 @@ entities:
     - pos: 47.5,-52.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -180297.11
+    - SecondsUntilStateChange: -181058.86
       state: Closing
       type: Door
     - enabled: False
@@ -21655,7 +21655,7 @@ entities:
     - pos: 47.5,-53.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -180297.11
+    - SecondsUntilStateChange: -181058.86
       state: Closing
       type: Door
     - enabled: False
@@ -21672,7 +21672,7 @@ entities:
     - pos: 47.5,-54.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -180297.11
+    - SecondsUntilStateChange: -181058.86
       state: Closing
       type: Door
     - enabled: False
@@ -21689,7 +21689,7 @@ entities:
     - pos: 52.5,-58.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -180284.78
+    - SecondsUntilStateChange: -181046.53
       state: Closing
       type: Door
     - enabled: False
@@ -21706,7 +21706,7 @@ entities:
     - pos: 50.5,-62.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -180287.31
+    - SecondsUntilStateChange: -181049.06
       state: Closing
       type: Door
     - enabled: False
@@ -21724,7 +21724,7 @@ entities:
       pos: 55.5,-56.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -180235.6
+    - SecondsUntilStateChange: -180997.34
       state: Closing
       type: Door
     - enabled: False
@@ -21742,7 +21742,7 @@ entities:
       pos: 54.5,-56.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -180235.6
+    - SecondsUntilStateChange: -180997.34
       state: Closing
       type: Door
     - enabled: False
@@ -21759,7 +21759,7 @@ entities:
     - pos: -45.5,-34.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -435764.75
+    - SecondsUntilStateChange: -436526.5
       state: Closing
       type: Door
     - enabled: False
@@ -21777,7 +21777,7 @@ entities:
       pos: -40.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -434115.1
+    - SecondsUntilStateChange: -434876.84
       state: Closing
       type: Door
     - enabled: False
@@ -21795,7 +21795,7 @@ entities:
       pos: -39.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -434115.1
+    - SecondsUntilStateChange: -434876.84
       state: Closing
       type: Door
     - enabled: False
@@ -21813,7 +21813,7 @@ entities:
       pos: -38.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -434115.1
+    - SecondsUntilStateChange: -434876.84
       state: Closing
       type: Door
     - enabled: False
@@ -21831,7 +21831,7 @@ entities:
       pos: -37.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -434115.1
+    - SecondsUntilStateChange: -434876.84
       state: Closing
       type: Door
     - enabled: False
@@ -21848,7 +21848,7 @@ entities:
     - pos: -49.5,19.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -314079.47
+    - SecondsUntilStateChange: -314841.22
       state: Closing
       type: Door
     - enabled: False
@@ -21865,7 +21865,7 @@ entities:
     - pos: -49.5,23.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -314079.47
+    - SecondsUntilStateChange: -314841.22
       state: Closing
       type: Door
     - enabled: False
@@ -21882,7 +21882,7 @@ entities:
     - pos: 51.5,44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -21901,7 +21901,7 @@ entities:
     - pos: 54.5,45.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -21919,7 +21919,7 @@ entities:
     - pos: -52.5,34.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -108206.56
+    - SecondsUntilStateChange: -108968.31
       state: Closing
       type: Door
     - enabled: False
@@ -21936,7 +21936,7 @@ entities:
     - pos: -52.5,30.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -108178.85
+    - SecondsUntilStateChange: -108940.6
       state: Closing
       type: Door
     - enabled: False
@@ -21953,7 +21953,7 @@ entities:
     - pos: -53.5,23.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -108247.5
+    - SecondsUntilStateChange: -109009.25
       state: Closing
       type: Door
     - enabled: False
@@ -21970,7 +21970,7 @@ entities:
     - pos: -53.5,19.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -108247.5
+    - SecondsUntilStateChange: -109009.25
       state: Closing
       type: Door
     - enabled: False
@@ -21987,7 +21987,7 @@ entities:
     - pos: 53.5,46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -274495.66
+    - SecondsUntilStateChange: -275257.4
       state: Closing
       type: Door
     - enabled: False
@@ -22006,7 +22006,7 @@ entities:
     - pos: 55.5,46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276498.03
+    - SecondsUntilStateChange: -277259.78
       state: Closing
       type: Door
     - enabled: False
@@ -22024,7 +22024,7 @@ entities:
     - pos: 50.5,47.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22041,7 +22041,7 @@ entities:
     - pos: 57.5,44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22058,7 +22058,7 @@ entities:
     - pos: 56.5,47.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22080,7 +22080,7 @@ entities:
     - pos: 53.5,48.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -274495.66
+    - SecondsUntilStateChange: -275257.4
       state: Closing
       type: Door
     - enabled: False
@@ -22107,7 +22107,7 @@ entities:
     - pos: 58.5,47.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22124,7 +22124,7 @@ entities:
     - pos: 52.5,45.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276733.44
+    - SecondsUntilStateChange: -277495.2
       state: Closing
       type: Door
     - enabled: False
@@ -22142,7 +22142,7 @@ entities:
     - pos: 53.5,44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -274495.66
+    - SecondsUntilStateChange: -275257.4
       state: Closing
       type: Door
     - enabled: False
@@ -22160,7 +22160,7 @@ entities:
     - pos: 55.5,44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22178,7 +22178,7 @@ entities:
     - pos: 58.5,45.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22195,7 +22195,7 @@ entities:
     - pos: 57.5,46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22219,7 +22219,7 @@ entities:
     - pos: 54.5,47.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22236,7 +22236,7 @@ entities:
     - pos: 52.5,47.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22253,7 +22253,7 @@ entities:
     - pos: 51.5,46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22271,7 +22271,7 @@ entities:
     - pos: 56.5,45.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276592.12
+    - SecondsUntilStateChange: -277353.88
       state: Closing
       type: Door
     - enabled: False
@@ -22289,7 +22289,7 @@ entities:
     - pos: 50.5,45.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -276237.78
+    - SecondsUntilStateChange: -276999.53
       state: Closing
       type: Door
     - enabled: False
@@ -22307,7 +22307,7 @@ entities:
     - pos: -18.5,-96.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -222612.03
+    - SecondsUntilStateChange: -223373.78
       state: Closing
       type: Door
     - enabled: False
@@ -22324,7 +22324,7 @@ entities:
     - pos: -18.5,-98.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -222612.03
+    - SecondsUntilStateChange: -223373.78
       state: Closing
       type: Door
     - enabled: False
@@ -22341,7 +22341,7 @@ entities:
     - pos: -26.5,-96.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -222620.36
+    - SecondsUntilStateChange: -223382.11
       state: Closing
       type: Door
     - enabled: False
@@ -22358,7 +22358,7 @@ entities:
     - pos: -26.5,-98.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -222620.36
+    - SecondsUntilStateChange: -223382.11
       state: Closing
       type: Door
     - enabled: False
@@ -22375,7 +22375,7 @@ entities:
     - pos: 67.5,-39.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -178393.9
+    - SecondsUntilStateChange: -179155.66
       state: Closing
       type: Door
     - enabled: False
@@ -22404,7 +22404,7 @@ entities:
       pos: 24.5,46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22422,7 +22422,7 @@ entities:
       pos: 23.5,46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22440,7 +22440,7 @@ entities:
       pos: 25.5,46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22458,7 +22458,7 @@ entities:
       pos: 26.5,44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22476,7 +22476,7 @@ entities:
       pos: 24.5,44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22494,7 +22494,7 @@ entities:
       pos: 23.5,44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22512,7 +22512,7 @@ entities:
       pos: 25.5,44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22530,7 +22530,7 @@ entities:
       pos: 26.5,46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22548,7 +22548,7 @@ entities:
       pos: 22.5,44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22566,7 +22566,7 @@ entities:
       pos: 22.5,46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -240474.94
+    - SecondsUntilStateChange: -241236.69
       state: Opening
       type: Door
     - enabled: True
@@ -22583,7 +22583,7 @@ entities:
     - pos: -8.5,-91.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -224369.02
+    - SecondsUntilStateChange: -225130.77
       state: Opening
       type: Door
     - enabled: True
@@ -22601,7 +22601,7 @@ entities:
     - pos: -8.5,-92.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -224369.02
+    - SecondsUntilStateChange: -225130.77
       state: Opening
       type: Door
     - enabled: True
@@ -22619,7 +22619,7 @@ entities:
     - pos: -8.5,-93.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -224369.02
+    - SecondsUntilStateChange: -225130.77
       state: Opening
       type: Door
     - enabled: True
@@ -22637,7 +22637,7 @@ entities:
     - pos: -6.5,-91.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -224369.02
+    - SecondsUntilStateChange: -225130.77
       state: Opening
       type: Door
     - enabled: True
@@ -22655,7 +22655,7 @@ entities:
     - pos: -6.5,-90.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -224369.02
+    - SecondsUntilStateChange: -225130.77
       state: Opening
       type: Door
     - enabled: True
@@ -22673,7 +22673,7 @@ entities:
     - pos: -6.5,-92.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -224369.02
+    - SecondsUntilStateChange: -225130.77
       state: Opening
       type: Door
     - enabled: True
@@ -22691,7 +22691,7 @@ entities:
     - pos: -6.5,-93.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -224369.02
+    - SecondsUntilStateChange: -225130.77
       state: Opening
       type: Door
     - enabled: True
@@ -22709,7 +22709,7 @@ entities:
     - pos: -8.5,-90.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -224369.02
+    - SecondsUntilStateChange: -225130.77
       state: Opening
       type: Door
     - enabled: True
@@ -22729,7 +22729,7 @@ entities:
     - pos: -11.5,-11.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -69319.48
+    - SecondsUntilStateChange: -70081.23
       state: Closing
       type: Door
     - enabled: False
@@ -22748,7 +22748,7 @@ entities:
     - pos: -56.5,-11.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -352044.94
+    - SecondsUntilStateChange: -352806.7
       state: Opening
       type: Door
     - enabled: True
@@ -22765,7 +22765,7 @@ entities:
     - pos: -56.5,-12.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -352044.94
+    - SecondsUntilStateChange: -352806.7
       state: Opening
       type: Door
     - enabled: True
@@ -22782,7 +22782,7 @@ entities:
     - pos: -56.5,-13.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -352044.94
+    - SecondsUntilStateChange: -352806.7
       state: Opening
       type: Door
     - enabled: True
@@ -22799,7 +22799,7 @@ entities:
     - pos: -56.5,-14.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -352044.94
+    - SecondsUntilStateChange: -352806.7
       state: Opening
       type: Door
     - enabled: True
@@ -22816,7 +22816,7 @@ entities:
     - pos: -56.5,-15.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -352044.94
+    - SecondsUntilStateChange: -352806.7
       state: Opening
       type: Door
     - enabled: True
@@ -22834,7 +22834,7 @@ entities:
       pos: -64.5,-22.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -121242.55
+    - SecondsUntilStateChange: -122004.3
       state: Opening
       type: Door
     - enabled: True
@@ -22852,7 +22852,7 @@ entities:
       pos: -65.5,-22.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -121242.55
+    - SecondsUntilStateChange: -122004.3
       state: Opening
       type: Door
     - enabled: True
@@ -22870,7 +22870,7 @@ entities:
       pos: -66.5,-22.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -121242.55
+    - SecondsUntilStateChange: -122004.3
       state: Opening
       type: Door
     - enabled: True
@@ -22888,7 +22888,7 @@ entities:
       pos: -67.5,-22.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -121242.55
+    - SecondsUntilStateChange: -122004.3
       state: Opening
       type: Door
     - enabled: True
@@ -22906,7 +22906,7 @@ entities:
       pos: -68.5,-22.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -121242.55
+    - SecondsUntilStateChange: -122004.3
       state: Opening
       type: Door
     - enabled: True
@@ -141843,7 +141843,7 @@ entities:
     - pos: 60.5,21.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -513435.47
+    - SecondsUntilStateChange: -514197.22
       state: Opening
       type: Door
   - uid: 20667
@@ -141874,7 +141874,7 @@ entities:
     - pos: 3.5,-62.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -587997.2
+    - SecondsUntilStateChange: -588758.94
       state: Closing
       type: Door
   - uid: 20672
@@ -160566,7 +160566,7 @@ entities:
       type: Occluder
     - canCollide: False
       type: Physics
-    - SecondsUntilStateChange: -123519.7
+    - SecondsUntilStateChange: -124281.45
       state: Closing
       type: Door
     - airBlocked: False
@@ -160584,7 +160584,7 @@ entities:
       type: Occluder
     - canCollide: False
       type: Physics
-    - SecondsUntilStateChange: -123519.7
+    - SecondsUntilStateChange: -124281.45
       state: Closing
       type: Door
     - airBlocked: False
@@ -160618,7 +160618,7 @@ entities:
       pos: 15.5,13.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -104574.79
+    - SecondsUntilStateChange: -105336.54
       state: Opening
       type: Door
     - canCollide: True
@@ -160641,7 +160641,7 @@ entities:
     - pos: -32.5,32.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134133.2
+    - SecondsUntilStateChange: -134894.95
       state: Opening
       type: Door
     - canCollide: True
@@ -160658,7 +160658,7 @@ entities:
     - pos: 37.5,-0.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -42223.055
+    - SecondsUntilStateChange: -42984.8
       state: Opening
       type: Door
     - canCollide: True
@@ -160684,7 +160684,7 @@ entities:
       pos: 15.5,11.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -104574.79
+    - SecondsUntilStateChange: -105336.54
       state: Opening
       type: Door
     - canCollide: True
@@ -160702,7 +160702,7 @@ entities:
       pos: 15.5,10.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -104574.79
+    - SecondsUntilStateChange: -105336.54
       state: Opening
       type: Door
     - canCollide: True
@@ -160720,7 +160720,7 @@ entities:
       pos: -2.5,-5.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -84243.95
+    - SecondsUntilStateChange: -85005.7
       state: Opening
       type: Door
     - canCollide: True
@@ -160737,7 +160737,7 @@ entities:
     - pos: -0.5,-2.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -84243.95
+    - SecondsUntilStateChange: -85005.7
       state: Opening
       type: Door
     - canCollide: True
@@ -160754,7 +160754,7 @@ entities:
     - pos: 18.5,15.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -104574.79
+    - SecondsUntilStateChange: -105336.54
       state: Opening
       type: Door
     - canCollide: True
@@ -160771,7 +160771,7 @@ entities:
     - pos: 17.5,15.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -104574.79
+    - SecondsUntilStateChange: -105336.54
       state: Opening
       type: Door
     - canCollide: True
@@ -160797,7 +160797,7 @@ entities:
       pos: 48.5,6.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39768.883
+    - SecondsUntilStateChange: -40530.63
       state: Opening
       type: Door
     - canCollide: True
@@ -160815,7 +160815,7 @@ entities:
       pos: 35.5,4.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -103662.06
+    - SecondsUntilStateChange: -104423.81
       state: Opening
       type: Door
     - canCollide: True
@@ -160833,7 +160833,7 @@ entities:
       pos: 15.5,12.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -104574.79
+    - SecondsUntilStateChange: -105336.54
       state: Opening
       type: Door
     - canCollide: True
@@ -160850,7 +160850,7 @@ entities:
     - pos: 61.5,-56.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -160868,7 +160868,7 @@ entities:
       pos: 15.5,14.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -104574.79
+    - SecondsUntilStateChange: -105336.54
       state: Opening
       type: Door
     - canCollide: True
@@ -160885,7 +160885,7 @@ entities:
     - pos: 45.5,9.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39768.883
+    - SecondsUntilStateChange: -40530.63
       state: Opening
       type: Door
     - canCollide: True
@@ -160902,7 +160902,7 @@ entities:
     - pos: 43.5,7.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39768.883
+    - SecondsUntilStateChange: -40530.63
       state: Opening
       type: Door
     - canCollide: True
@@ -160919,7 +160919,7 @@ entities:
     - pos: 62.5,-56.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -160936,7 +160936,7 @@ entities:
     - pos: 63.5,-56.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -160953,7 +160953,7 @@ entities:
     - pos: 22.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -129138.85
+    - SecondsUntilStateChange: -129900.6
       state: Opening
       type: Door
     - canCollide: True
@@ -160970,7 +160970,7 @@ entities:
     - pos: -30.5,27.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134133.2
+    - SecondsUntilStateChange: -134894.95
       state: Opening
       type: Door
     - canCollide: True
@@ -160987,7 +160987,7 @@ entities:
     - pos: 29.5,9.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -103662.06
+    - SecondsUntilStateChange: -104423.81
       state: Opening
       type: Door
     - canCollide: True
@@ -161004,7 +161004,7 @@ entities:
     - pos: 34.5,9.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -103662.06
+    - SecondsUntilStateChange: -104423.81
       state: Opening
       type: Door
     - canCollide: True
@@ -161021,7 +161021,7 @@ entities:
     - pos: -31.5,27.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134133.2
+    - SecondsUntilStateChange: -134894.95
       state: Opening
       type: Door
     - canCollide: True
@@ -161039,7 +161039,7 @@ entities:
       pos: 35.5,7.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -103662.06
+    - SecondsUntilStateChange: -104423.81
       state: Opening
       type: Door
     - canCollide: True
@@ -161056,7 +161056,7 @@ entities:
     - pos: -33.5,27.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134133.2
+    - SecondsUntilStateChange: -134894.95
       state: Opening
       type: Door
     - canCollide: True
@@ -161073,7 +161073,7 @@ entities:
     - pos: -49.5,13.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -94312
+    - SecondsUntilStateChange: -95073.75
       state: Opening
       type: Door
     - canCollide: True
@@ -161090,7 +161090,7 @@ entities:
     - pos: -48.5,13.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -94312
+    - SecondsUntilStateChange: -95073.75
       state: Opening
       type: Door
     - canCollide: True
@@ -161107,7 +161107,7 @@ entities:
     - pos: -31.5,32.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134133.2
+    - SecondsUntilStateChange: -134894.95
       state: Opening
       type: Door
     - canCollide: True
@@ -161124,7 +161124,7 @@ entities:
     - pos: 32.5,9.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -103662.06
+    - SecondsUntilStateChange: -104423.81
       state: Opening
       type: Door
     - canCollide: True
@@ -161141,7 +161141,7 @@ entities:
     - pos: 39.5,-0.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -42223.055
+    - SecondsUntilStateChange: -42984.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161158,7 +161158,7 @@ entities:
     - pos: -33.5,32.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134133.2
+    - SecondsUntilStateChange: -134894.95
       state: Opening
       type: Door
     - canCollide: True
@@ -161175,7 +161175,7 @@ entities:
     - pos: -46.5,13.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -94312
+    - SecondsUntilStateChange: -95073.75
       state: Opening
       type: Door
     - canCollide: True
@@ -161192,7 +161192,7 @@ entities:
     - pos: -47.5,13.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -94312
+    - SecondsUntilStateChange: -95073.75
       state: Opening
       type: Door
     - canCollide: True
@@ -161209,7 +161209,7 @@ entities:
     - pos: 43.5,5.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39768.883
+    - SecondsUntilStateChange: -40530.63
       state: Opening
       type: Door
     - canCollide: True
@@ -161226,7 +161226,7 @@ entities:
     - pos: 59.5,-54.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -161243,7 +161243,7 @@ entities:
     - pos: 65.5,-54.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -161261,7 +161261,7 @@ entities:
       pos: 66.5,-51.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -161279,7 +161279,7 @@ entities:
       pos: 66.5,-52.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -161297,7 +161297,7 @@ entities:
       pos: 58.5,-51.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -161315,7 +161315,7 @@ entities:
       pos: 58.5,-52.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -161332,7 +161332,7 @@ entities:
     - pos: 61.5,-50.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -161349,7 +161349,7 @@ entities:
     - pos: 63.5,-50.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -134047.47
+    - SecondsUntilStateChange: -134809.22
       state: Opening
       type: Door
     - canCollide: True
@@ -161366,7 +161366,7 @@ entities:
     - pos: -20.5,-58.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -133988.27
+    - SecondsUntilStateChange: -134750.02
       state: Opening
       type: Door
     - canCollide: True
@@ -161383,7 +161383,7 @@ entities:
     - pos: -18.5,-58.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -133988.27
+    - SecondsUntilStateChange: -134750.02
       state: Opening
       type: Door
     - canCollide: True
@@ -161400,7 +161400,7 @@ entities:
     - pos: -37.5,-14.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -84201.1
+    - SecondsUntilStateChange: -84962.85
       state: Opening
       type: Door
     - canCollide: True
@@ -161418,7 +161418,7 @@ entities:
       pos: -33.5,-15.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -84201.1
+    - SecondsUntilStateChange: -84962.85
       state: Opening
       type: Door
     - canCollide: True
@@ -161436,7 +161436,7 @@ entities:
       pos: -33.5,-17.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -84201.1
+    - SecondsUntilStateChange: -84962.85
       state: Opening
       type: Door
     - canCollide: True
@@ -161453,7 +161453,7 @@ entities:
     - pos: 0.5,-2.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -84243.95
+    - SecondsUntilStateChange: -85005.7
       state: Opening
       type: Door
     - canCollide: True
@@ -161470,7 +161470,7 @@ entities:
     - pos: 1.5,-2.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -84243.95
+    - SecondsUntilStateChange: -85005.7
       state: Opening
       type: Door
     - canCollide: True
@@ -161488,7 +161488,7 @@ entities:
       pos: 7.5,9.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -73397.05
+    - SecondsUntilStateChange: -74158.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161506,7 +161506,7 @@ entities:
       pos: 7.5,8.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -73397.05
+    - SecondsUntilStateChange: -74158.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161524,7 +161524,7 @@ entities:
       pos: 7.5,7.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -73397.05
+    - SecondsUntilStateChange: -74158.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161541,7 +161541,7 @@ entities:
     - pos: 2.5,4.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -73397.05
+    - SecondsUntilStateChange: -74158.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161566,7 +161566,7 @@ entities:
     - pos: 0.5,4.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -73397.05
+    - SecondsUntilStateChange: -74158.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161583,7 +161583,7 @@ entities:
     - pos: 5.5,11.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -73397.05
+    - SecondsUntilStateChange: -74158.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161600,7 +161600,7 @@ entities:
     - pos: 4.5,11.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -73397.05
+    - SecondsUntilStateChange: -74158.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161617,7 +161617,7 @@ entities:
     - pos: 23.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -129138.85
+    - SecondsUntilStateChange: -129900.6
       state: Opening
       type: Door
     - canCollide: True
@@ -161634,7 +161634,7 @@ entities:
     - pos: 24.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -129138.85
+    - SecondsUntilStateChange: -129900.6
       state: Opening
       type: Door
     - canCollide: True
@@ -161651,7 +161651,7 @@ entities:
     - pos: 25.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -129138.85
+    - SecondsUntilStateChange: -129900.6
       state: Opening
       type: Door
     - canCollide: True
@@ -161668,7 +161668,7 @@ entities:
     - pos: 26.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -129138.85
+    - SecondsUntilStateChange: -129900.6
       state: Opening
       type: Door
     - canCollide: True
@@ -161685,7 +161685,7 @@ entities:
     - pos: 27.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -129138.85
+    - SecondsUntilStateChange: -129900.6
       state: Opening
       type: Door
     - canCollide: True
@@ -161702,7 +161702,7 @@ entities:
     - pos: 28.5,-40.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -129138.85
+    - SecondsUntilStateChange: -129900.6
       state: Opening
       type: Door
     - canCollide: True
@@ -161720,7 +161720,7 @@ entities:
       pos: -2.5,-4.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -84243.95
+    - SecondsUntilStateChange: -85005.7
       state: Opening
       type: Door
     - canCollide: True
@@ -161738,7 +161738,7 @@ entities:
       pos: 1.5,-46.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39638.64
+    - SecondsUntilStateChange: -40400.387
       state: Opening
       type: Door
     - canCollide: True
@@ -161755,7 +161755,7 @@ entities:
     - pos: 34.5,18.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -102157.66
+    - SecondsUntilStateChange: -102919.41
       state: Opening
       type: Door
     - canCollide: True
@@ -161772,7 +161772,7 @@ entities:
     - pos: 35.5,18.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -102157.66
+    - SecondsUntilStateChange: -102919.41
       state: Opening
       type: Door
     - canCollide: True
@@ -161789,7 +161789,7 @@ entities:
     - pos: 36.5,18.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -102157.66
+    - SecondsUntilStateChange: -102919.41
       state: Opening
       type: Door
     - canCollide: True
@@ -161815,7 +161815,7 @@ entities:
       pos: 48.5,7.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39768.883
+    - SecondsUntilStateChange: -40530.63
       state: Opening
       type: Door
     - canCollide: True
@@ -161832,7 +161832,7 @@ entities:
     - pos: 46.5,9.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39768.883
+    - SecondsUntilStateChange: -40530.63
       state: Opening
       type: Door
     - canCollide: True
@@ -161850,7 +161850,7 @@ entities:
       pos: 35.5,-1.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -42223.055
+    - SecondsUntilStateChange: -42984.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161868,7 +161868,7 @@ entities:
       pos: 35.5,-2.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -42223.055
+    - SecondsUntilStateChange: -42984.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161886,7 +161886,7 @@ entities:
       pos: 35.5,-4.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -42223.055
+    - SecondsUntilStateChange: -42984.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161904,7 +161904,7 @@ entities:
       pos: 35.5,-5.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -42223.055
+    - SecondsUntilStateChange: -42984.8
       state: Opening
       type: Door
     - canCollide: True
@@ -161921,7 +161921,7 @@ entities:
     - pos: 41.5,-0.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -42218.555
+    - SecondsUntilStateChange: -42980.3
       state: Opening
       type: Door
     - canCollide: True
@@ -161938,7 +161938,7 @@ entities:
     - pos: 42.5,-0.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -42218.555
+    - SecondsUntilStateChange: -42980.3
       state: Opening
       type: Door
     - canCollide: True
@@ -161955,7 +161955,7 @@ entities:
     - pos: 43.5,-0.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -42218.555
+    - SecondsUntilStateChange: -42980.3
       state: Opening
       type: Door
     - canCollide: True
@@ -161972,7 +161972,7 @@ entities:
     - pos: 46.5,3.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39768.883
+    - SecondsUntilStateChange: -40530.63
       state: Opening
       type: Door
     - canCollide: True
@@ -161990,7 +161990,7 @@ entities:
       pos: 1.5,-47.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39638.64
+    - SecondsUntilStateChange: -40400.387
       state: Opening
       type: Door
     - canCollide: True
@@ -162008,7 +162008,7 @@ entities:
       pos: 1.5,-48.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39638.64
+    - SecondsUntilStateChange: -40400.387
       state: Opening
       type: Door
     - canCollide: True
@@ -162025,7 +162025,7 @@ entities:
     - pos: 3.5,-44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39638.64
+    - SecondsUntilStateChange: -40400.387
       state: Opening
       type: Door
     - canCollide: True
@@ -162042,7 +162042,7 @@ entities:
     - pos: 4.5,-44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39638.64
+    - SecondsUntilStateChange: -40400.387
       state: Opening
       type: Door
     - canCollide: True
@@ -162059,7 +162059,7 @@ entities:
     - pos: 5.5,-44.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39638.64
+    - SecondsUntilStateChange: -40400.387
       state: Opening
       type: Door
     - canCollide: True
@@ -162076,7 +162076,7 @@ entities:
     - pos: 3.5,-51.5
       parent: 2
       type: Transform
-    - SecondsUntilStateChange: -39638.64
+    - SecondsUntilStateChange: -40400.387
       state: Opening
       type: Door
     - canCollide: True
@@ -166659,11 +166659,6 @@ entities:
   - uid: 24193
     components:
     - pos: -38.5,-8.5
-      parent: 2
-      type: Transform
-  - uid: 24194
-    components:
-    - pos: -38.5,-21.5
       parent: 2
       type: Transform
 - proto: SpawnPointSeniorOfficer


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR removes an erroneously placed spawnpoint for the Senior Engineer role on origin station.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Shown here is the original, the spawnpoint seen at the bottom of the image is removed by this PR:
![image](https://github.com/space-wizards/space-station-14/assets/19798667/56cb087d-6e8f-449d-ad9f-a757cefe6524)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

Not necessary. Change is too minor.
