### PR TITLE
add test for salvage map loading

### DIFF
--- a/Content.IntegrationTests/Tests/SalvageTest.cs
+++ b/Content.IntegrationTests/Tests/SalvageTest.cs
@@ -8,57 +8,56 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 
-namespace Content.IntegrationTests.Tests
+namespace Content.IntegrationTests.Tests;
+
+[TestFixture]
+public sealed class SalvageTest
 {
-    [TestFixture]
-    public sealed class SalvageTest
+    /// <summary>
+    /// Asserts that all salvage maps have been saved as grids and are loadable.
+    /// </summary>
+    [Test]
+    public async Task AllSalvageMapsLoadableTest()
     {
-        /// <summary>
-        /// Asserts that all salvage maps have been saved as grids and are loadable.
-        /// </summary>
-        [Test]
-        public async Task AllSalvageMapsLoadableTest()
+        await using var pairTracker = await PoolManager.GetServerClient();
+        var server = pairTracker.Pair.Server;
+
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapLoader = entManager.System<MapLoaderSystem>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var prototypeManager = server.ResolveDependency<IPrototypeManager>();
+        var cfg = server.ResolveDependency<IConfigurationManager>();
+        Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
+
+        await server.WaitPost(() =>
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
-
-            var entManager = server.ResolveDependency<IEntityManager>();
-            var mapLoader = entManager.System<MapLoaderSystem>();
-            var mapManager = server.ResolveDependency<IMapManager>();
-            var prototypeManager = server.ResolveDependency<IPrototypeManager>();
-            var cfg = server.ResolveDependency<IConfigurationManager>();
-            Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
-
-            await server.WaitPost(() =>
+            foreach (var salvage in prototypeManager.EnumeratePrototypes<SalvageMapPrototype>())
             {
-                foreach (var salvage in prototypeManager.EnumeratePrototypes<SalvageMapPrototype>())
+                var mapFile = salvage.MapPath;
+
+                var mapId = mapManager.CreateMap();
+                try
                 {
-                    var mapFile = salvage.MapPath;
-
-                    var mapId = mapManager.CreateMap();
-                    try
-                    {
-                        Assert.That(mapLoader.TryLoad(mapId, mapFile.ToString(), out var roots));
-                        Assert.That(roots.Where(uid => entManager.HasComponent<MapGridComponent>(uid)), Is.Not.Empty);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new Exception($"Failed to load salvage map {salvage.ID}, was it saved as a map instead of a grid?", ex);
-                    }
-
-                    try
-                    {
-                        mapManager.DeleteMap(mapId);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new Exception($"Failed to delete salvage map {salvage.ID}", ex);
-                    }
+                    Assert.That(mapLoader.TryLoad(mapId, mapFile.ToString(), out var roots));
+                    Assert.That(roots.Where(uid => entManager.HasComponent<MapGridComponent>(uid)), Is.Not.Empty);
                 }
-            });
-            await server.WaitRunTicks(1);
+                catch (Exception ex)
+                {
+                    throw new Exception($"Failed to load salvage map {salvage.ID}, was it saved as a map instead of a grid?", ex);
+                }
 
-            await pairTracker.CleanReturnAsync();
-        }
+                try
+                {
+                    mapManager.DeleteMap(mapId);
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"Failed to delete salvage map {salvage.ID}", ex);
+                }
+            }
+        });
+        await server.WaitRunTicks(1);
+
+        await pairTracker.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/SalvageTest.cs
+++ b/Content.IntegrationTests/Tests/SalvageTest.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using Content.Server.Salvage;
+using Content.Shared.CCVar;
+using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests
+{
+    [TestFixture]
+    public sealed class SalvageTest
+    {
+        /// <summary>
+        /// Asserts that all salvage maps have been saved as grids and are loadable.
+        /// </summary>
+        [Test]
+        public async Task AllSalvageMapsLoadableTest()
+        {
+            await using var pairTracker = await PoolManager.GetServerClient();
+            var server = pairTracker.Pair.Server;
+
+            var entManager = server.ResolveDependency<IEntityManager>();
+            var mapLoader = entManager.System<MapLoaderSystem>();
+            var mapManager = server.ResolveDependency<IMapManager>();
+            var prototypeManager = server.ResolveDependency<IPrototypeManager>();
+            var cfg = server.ResolveDependency<IConfigurationManager>();
+            Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
+
+            await server.WaitPost(() =>
+            {
+                foreach (var salvage in prototypeManager.EnumeratePrototypes<SalvageMapPrototype>())
+                {
+                    var mapFile = salvage.MapPath;
+
+                    var mapId = mapManager.CreateMap();
+                    try
+                    {
+                        Assert.That(mapLoader.TryLoad(mapId, mapFile.ToString(), out var roots));
+                        Assert.That(roots.Where(uid => entManager.HasComponent<MapGridComponent>(uid)), Is.Not.Empty);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception($"Failed to load salvage map {salvage.ID}, was it saved as a map instead of a grid?", ex);
+                    }
+
+                    try
+                    {
+                        mapManager.DeleteMap(mapId);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception($"Failed to delete salvage map {salvage.ID}", ex);
+                    }
+                }
+            });
+            await server.WaitRunTicks(1);
+
+            await pairTracker.CleanReturnAsync();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
apparently we never test this?? how has this not broken before

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
no cl no fun
