### PR TITLE
Deathgasp changes for mutes

### DIFF
--- a/Content.Server/Mobs/CritMobActionsSystem.cs
+++ b/Content.Server/Mobs/CritMobActionsSystem.cs
@@ -58,6 +58,7 @@ public sealed class CritMobActionsSystem : EntitySystem
         _quickDialog.OpenDialog(actor.PlayerSession, Loc.GetString("action-name-crit-last-words"), "",
             (string lastWords) =>
             {
+                // Intentionally does not check for muteness
                 if (actor.PlayerSession.AttachedEntity != uid
                     || !_mobState.IsCritical(uid))
                     return;

--- a/Content.Server/Mobs/CritMobActionsSystem.cs
+++ b/Content.Server/Mobs/CritMobActionsSystem.cs
@@ -2,6 +2,9 @@
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking;
 using Content.Server.Mind.Components;
+using Content.Server.Popups;
+using Content.Server.Speech.Muting;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -16,10 +19,12 @@ namespace Content.Server.Mobs;
 /// </summary>
 public sealed class CritMobActionsSystem : EntitySystem
 {
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly DeathgaspSystem _deathgasp = default!;
     [Dependency] private readonly IServerConsoleHost _host = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly QuickDialogSystem _quickDialog = default!;
 
     private const int MaxLastWordsLength = 30;
@@ -46,6 +51,12 @@ public sealed class CritMobActionsSystem : EntitySystem
     {
         if (!_mobState.IsCritical(uid))
             return;
+
+        if (HasComp<MutedComponent>(uid))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("fake-death-muted"), uid, uid);
+            return;
+        }
 
         args.Handled = _deathgasp.Deathgasp(uid);
     }

--- a/Content.Server/Mobs/DeathgaspSystem.cs
+++ b/Content.Server/Mobs/DeathgaspSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.Chat.Systems;
+using Content.Server.Speech.Muting;
 using Content.Shared.Mobs;
 using Robust.Shared.Prototypes;
 
@@ -31,6 +32,9 @@ public sealed class DeathgaspSystem: EntitySystem
     public bool Deathgasp(EntityUid uid, DeathgaspComponent? component = null)
     {
         if (!Resolve(uid, ref component, false))
+            return false;
+
+        if (HasComp<MutedComponent>(uid))
             return false;
 
         _chat.TryEmoteWithChat(uid, component.Prototype, ignoreActionBlocker: true);

--- a/Resources/Locale/en-US/speech/speech-effects.ftl
+++ b/Resources/Locale/en-US/speech/speech-effects.ftl
@@ -1,1 +1,2 @@
 speech-muted = You can't speak right now!
+fake-death-muted = You can't fake your death without a voice!


### PR DESCRIPTION
## About the PR

-Enshrines in stone the CentCom-given right of mute people to say their last words
-Mutes don't deathgasp when they die
-Mutes can't fake death

fixes #19019


**Media**


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Errant
- tweak: Mutes no longer make a sound when they die, and can't fake their death while in crit. They can still summon up their remaining strength to whisper their first-last words.