### PR TITLE
make "no access" popups appear again.

### DIFF
--- a/Content.Shared/Lock/LockComponent.cs
+++ b/Content.Shared/Lock/LockComponent.cs
@@ -9,18 +9,21 @@ namespace Content.Shared.Lock;
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(LockSystem))]
-public sealed class LockComponent : Component
+[AutoGenerateComponentState]
+public sealed partial class LockComponent : Component
 {
     /// <summary>
     /// Whether or not the lock is locked.
     /// </summary>
     [DataField("locked"), ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField]
     public bool Locked  = true;
 
     /// <summary>
     /// Whether or not the lock is toggled by simply clicking.
     /// </summary>
     [DataField("lockOnClick"), ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField]
     public bool LockOnClick;
 
     /// <summary>
@@ -39,25 +42,19 @@ public sealed class LockComponent : Component
     /// Whether or not an emag disables it.
     /// </summary>
     [DataField("breakOnEmag")]
+    [AutoNetworkedField]
     public bool BreakOnEmag = true;
 }
 
-[Serializable, NetSerializable]
-public sealed class LockComponentState : ComponentState
-{
-    public bool Locked;
-
-    public bool LockOnClick;
-
-    public LockComponentState(bool locked, bool lockOnClick)
-    {
-        Locked = locked;
-        LockOnClick = lockOnClick;
-    }
-}
-
+/// <summary>
+/// Event raised on the lock when a toggle is attempted.
+/// Can be cancelled to prevent it.
+/// </summary>
 [ByRefEvent]
 public record struct LockToggleAttemptEvent(EntityUid User, bool Silent = false, bool Cancelled = false);
 
+/// <summary>
+/// Event raised on a lock after it has been toggled.
+/// </summary>
 [ByRefEvent]
 public readonly record struct LockToggledEvent(bool Locked);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Filter.Local() is a fuck: what the hell!

also update network state handling

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Lockers now once again inform you if you cannot access them.
