### PR TITLE
add spare checkers pieces

### DIFF
--- a/Content.Server/Tabletop/TabletopCheckerSetup.cs
+++ b/Content.Server/Tabletop/TabletopCheckerSetup.cs
@@ -33,13 +33,28 @@ namespace Content.Server.Tabletop
             // Queens
             for (int i = 1; i < 4; i++)
             {
-                EntityUid tempQualifier = entityManager.SpawnEntity("BlackCheckerQueen", new MapCoordinates(x + 9 * separation + 9f / 32, y - i * separation, mapId));
+                EntityUid tempQualifier = entityManager.SpawnEntity("BlackCheckerQueen", new MapCoordinates(x + 9 * separation + 9f / 32, y - (i - 1) * separation, mapId));
                 session.Entities.Add(tempQualifier);
 
-                EntityUid tempQualifier1 = entityManager.SpawnEntity("WhiteCheckerQueen", new MapCoordinates(x + 8 * separation + 9f / 32, y - i * separation, mapId));
+                EntityUid tempQualifier1 = entityManager.SpawnEntity("WhiteCheckerQueen", new MapCoordinates(x + 8 * separation + 9f / 32, y - (i - 1) * separation, mapId));
                 session.Entities.Add(tempQualifier1);
             }
 
+            var spares = new List<EntityUid>();
+            for (var i = 1; i < 7; i++)
+            {
+                var step = 3 + 0.25f * (i - 1);
+                spares.Add(
+                  entityManager.SpawnEntity("BlackCheckerPiece",
+                  new MapCoordinates(x + 9 * separation + 9f / 32, y - step * separation, mapId)
+                ));
+
+                spares.Add(
+                  entityManager.SpawnEntity("WhiteCheckerPiece",
+                  new MapCoordinates(x + 8 * separation + 9f / 32, y - step * separation, mapId)
+                ));
+            }
+            session.Entities.UnionWith(spares);
         }
 
         private void SpawnPieces(TabletopSession session, IEntityManager entityManager, string color, MapCoordinates left, float separation = 1f)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

add +6 pieces per colour to allow for most variants, f.ex. dama, dameo,…

this PR is purely functional; setup is refactored in #18359 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, ~~**or** this PR does not require an ingame showcase~~

![image](https://github.com/space-wizards/space-station-14/assets/73342011/a3a9a526-12cf-4a94-bdea-12baef95e4d1)
![image](https://github.com/space-wizards/space-station-14/assets/73342011/182ac4bf-ba19-4a17-8bbd-ee66fd1ba03f)
![image](https://github.com/space-wizards/space-station-14/assets/73342011/db9a7e92-21d3-43a1-bc31-76f42c178df8)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Spare pieces have been added to checkerboards allowing for more playable variants.
