### PR TITLE
Fix various IC states not counting as dead

### DIFF
--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -650,6 +650,15 @@ public sealed class MindSystem : EntitySystem
     /// </summary>
     public bool IsCharacterDeadIc(Mind mind)
     {
+        if (mind.OwnedEntity is { } owned)
+        {
+            var ev = new GetCharactedDeadIcEvent(null);
+            RaiseLocalEvent(owned, ref ev);
+
+            if (ev.Dead != null)
+                return ev.Dead.Value;
+        }
+
         return IsCharacterDeadPhysically(mind);
     }
 
@@ -665,3 +674,11 @@ public sealed class MindSystem : EntitySystem
         return "(originally " + mind.OriginalOwnerUserId + ")";
     }
 }
+
+/// <summary>
+/// Raised on an entity to determine whether or not they are "dead" in IC-logic.
+/// If not handled, then it will simply check if they are dead physically.
+/// </summary>
+/// <param name="Dead"></param>
+[ByRefEvent]
+public record struct GetCharactedDeadIcEvent(bool? Dead);

--- a/Content.Server/Objectives/Conditions/KillPersonCondition.cs
+++ b/Content.Server/Objectives/Conditions/KillPersonCondition.cs
@@ -30,9 +30,6 @@ namespace Content.Server.Objectives.Conditions
                 if (Target == null)
                     return Loc.GetString("objective-condition-kill-person-title", ("targetName", targetName), ("job", jobName));
 
-                //if (Target.OwnedEntity is {Valid: true} owned)
-                //    targetName = EntityManager.GetComponent<MetaDataComponent>(owned).EntityName;
-
                 return Loc.GetString("objective-condition-kill-person-title", ("targetName", targetName), ("job", jobName));
             }
         }

--- a/Content.Server/Objectives/Conditions/KillPersonCondition.cs
+++ b/Content.Server/Objectives/Conditions/KillPersonCondition.cs
@@ -24,14 +24,14 @@ namespace Content.Server.Objectives.Conditions
         {
             get
             {
-                var targetName = string.Empty;
+                var targetName = Target?.CharacterName ?? "Unknown";
                 var jobName = Target?.CurrentJob?.Name ?? "Unknown";
 
                 if (Target == null)
                     return Loc.GetString("objective-condition-kill-person-title", ("targetName", targetName), ("job", jobName));
 
-                if (Target.OwnedEntity is {Valid: true} owned)
-                    targetName = EntityManager.GetComponent<MetaDataComponent>(owned).EntityName;
+                //if (Target.OwnedEntity is {Valid: true} owned)
+                //    targetName = EntityManager.GetComponent<MetaDataComponent>(owned).EntityName;
 
                 return Loc.GetString("objective-condition-kill-person-title", ("targetName", targetName), ("job", jobName));
             }

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -55,6 +55,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
         SubscribeLocalEvent<BorgChassisComponent, PowerCellChangedEvent>(OnPowerCellChanged);
         SubscribeLocalEvent<BorgChassisComponent, PowerCellSlotEmptyEvent>(OnPowerCellSlotEmpty);
         SubscribeLocalEvent<BorgChassisComponent, ActivatableUIOpenAttemptEvent>(OnUIOpenAttempt);
+        SubscribeLocalEvent<BorgChassisComponent, GetCharactedDeadIcEvent>(OnGetDeadIC);
 
         SubscribeLocalEvent<BorgBrainComponent, MindAddedMessage>(OnBrainMindAdded);
 
@@ -198,6 +199,11 @@ public sealed partial class BorgSystem : SharedBorgSystem
         // borgs can't view their own ui
         if (args.User == uid)
             args.Cancel();
+    }
+
+    private void OnGetDeadIC(EntityUid uid, BorgChassisComponent component, ref GetCharactedDeadIcEvent args)
+    {
+        args.Dead = true;
     }
 
     private void OnBrainMindAdded(EntityUid uid, BorgBrainComponent component, MindAddedMessage args)

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Drone.Components;
 using Content.Server.Inventory;
 using Content.Shared.Bed.Sleep;
 using Content.Server.Emoting.Systems;
+using Content.Server.Mind;
 using Content.Server.Speech.EntitySystems;
 using Content.Shared.Damage;
 using Content.Shared.Inventory;
@@ -49,6 +50,7 @@ namespace Content.Server.Zombies
             SubscribeLocalEvent<ZombieComponent, MobStateChangedEvent>(OnMobState);
             SubscribeLocalEvent<ZombieComponent, CloningEvent>(OnZombieCloning);
             SubscribeLocalEvent<ZombieComponent, TryingToSleepEvent>(OnSleepAttempt);
+            SubscribeLocalEvent<ZombieComponent, GetCharactedDeadIcEvent>(OnGetCharacterDeadIC);
 
             SubscribeLocalEvent<PendingZombieComponent, MapInitEvent>(OnPendingMapInit);
 
@@ -114,6 +116,11 @@ namespace Content.Server.Zombies
         private void OnSleepAttempt(EntityUid uid, ZombieComponent component, ref TryingToSleepEvent args)
         {
             args.Cancelled = true;
+        }
+
+        private void OnGetCharacterDeadIC(EntityUid uid, ZombieComponent component, ref GetCharactedDeadIcEvent args)
+        {
+            args.Dead = true;
         }
 
         private void OnStartup(EntityUid uid, ZombieComponent component, ComponentStartup args)

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -34,9 +34,6 @@
     proto: robot
   - type: Speech
     speechSounds: Pai
-  - type: MobState
-    allowedStates:
-    - Alive
   - type: ItemSlots
     slots:
       brain_slot:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes multiple instances where players could be "dead IC" but remain alive in terms of the kill objective.
Adds some new code to handle this.

also fixes an issue where kill objective would use the actual entity name instead of the mind's character name.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Being turned into a cyborg or zombie now counts as a being dead for survival and kill objectives.
- fix: Kill objectives no longer reveal a character's true name at all times.
