### PR TITLE
RPED fixes

### DIFF
--- a/Content.Server/Construction/Components/PartExchangerComponent.cs
+++ b/Content.Server/Construction/Components/PartExchangerComponent.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Robust.Shared.Audio;
 
 namespace Content.Server.Construction.Components;

--- a/Content.Server/Construction/PartExchangerSystem.cs
+++ b/Content.Server/Construction/PartExchangerSystem.cs
@@ -32,31 +32,36 @@ public sealed class PartExchangerSystem : EntitySystem
 
     private void OnDoAfter(EntityUid uid, PartExchangerComponent component, DoAfterEvent args)
     {
-        component.AudioStream?.Stop();
-        if (args.Cancelled || args.Handled || args.Args.Target == null)
+        if (args.Cancelled)
+        {
+            component.AudioStream?.Stop();
+            return;
+        }
+
+        if (args.Handled || args.Args.Target == null)
             return;
 
         if (!TryComp<ServerStorageComponent>(uid, out var storage) || storage.Storage == null)
             return; //the parts are stored in here
 
         var machinePartQuery = GetEntityQuery<MachinePartComponent>();
-        var machineParts = new List<MachinePartComponent>();
+        var machineParts = new List<(EntityUid, MachinePartComponent)>();
 
         foreach (var item in storage.Storage.ContainedEntities) //get parts in RPED
         {
             if (machinePartQuery.TryGetComponent(item, out var part))
-                machineParts.Add(part);
+                machineParts.Add((item, part));
         }
 
-        TryExchangeMachineParts(args.Args.Target.Value, storage, machineParts);
-        TryConstructMachineParts(args.Args.Target.Value, storage, machineParts);
+        TryExchangeMachineParts(args.Args.Target.Value, uid, machineParts);
+        TryConstructMachineParts(args.Args.Target.Value, uid, machineParts);
 
         args.Handled = true;
     }
 
-    private void TryExchangeMachineParts(EntityUid uid, ServerStorageComponent storage, List<MachinePartComponent> machineParts)
+    private void TryExchangeMachineParts(EntityUid uid, EntityUid storageUid, List<(EntityUid, MachinePartComponent)> machineParts)
     {
-        if (!TryComp<MachineComponent>(uid, out var machine) || storage.Storage == null)
+        if (!TryComp<MachineComponent>(uid, out var machine))
             return;
 
         var machinePartQuery = GetEntityQuery<MachinePartComponent>();
@@ -69,37 +74,36 @@ public sealed class PartExchangerSystem : EntitySystem
         {
             if (machinePartQuery.TryGetComponent(item, out var part))
             {
-                machineParts.Add(part);
+                machineParts.Add((item, part));
                 _container.RemoveEntity(uid, item);
             }
         }
 
-        machineParts.Sort((x, y) => y.Rating.CompareTo(x.Rating));
+        machineParts.Sort((x, y) => y.Item2.Rating.CompareTo(x.Item2.Rating));
 
-        var updatedParts = new List<MachinePartComponent>();
+        var updatedParts = new List<(EntityUid, MachinePartComponent)>();
         foreach (var (type, amount) in macBoardComp.Requirements)
         {
-            var target = machineParts.Where(p => p.PartType == type).Take(amount);
+            var target = machineParts.Where(p => p.Item2.PartType == type).Take(amount);
             updatedParts.AddRange(target);
         }
         foreach (var part in updatedParts)
         {
-            machine.PartContainer.Insert(part.Owner, EntityManager);
+            machine.PartContainer.Insert(part.Item1, EntityManager);
             machineParts.Remove(part);
         }
 
         //put the unused parts back into rped. (this also does the "swapping")
-        foreach (var unused in machineParts)
+        foreach (var (unused, _) in machineParts)
         {
-            storage.Storage.Insert(unused.Owner);
-            _storage.Insert(uid, unused.Owner, null, false);
+            _storage.Insert(storageUid, unused, null, false);
         }
         _construction.RefreshParts(uid, machine);
     }
 
-    private void TryConstructMachineParts(EntityUid uid, ServerStorageComponent storage, List<MachinePartComponent> machineParts)
+    private void TryConstructMachineParts(EntityUid uid, EntityUid storageEnt, List<(EntityUid, MachinePartComponent)> machineParts)
     {
-        if (!TryComp<MachineFrameComponent>(uid, out var machine) || storage.Storage == null)
+        if (!TryComp<MachineFrameComponent>(uid, out var machine))
             return;
 
         var machinePartQuery = GetEntityQuery<MachinePartComponent>();
@@ -112,38 +116,38 @@ public sealed class PartExchangerSystem : EntitySystem
         {
             if (machinePartQuery.TryGetComponent(item, out var part))
             {
-                machineParts.Add(part);
+                machineParts.Add((item, part));
                 _container.RemoveEntity(uid, item);
                 machine.Progress[part.PartType]--;
             }
         }
 
-        machineParts.Sort((x, y) => y.Rating.CompareTo(x.Rating));
+        machineParts.Sort((x, y) => y.Item2.Rating.CompareTo(x.Item2.Rating));
 
-        var updatedParts = new List<MachinePartComponent>();
+        var updatedParts = new List<(EntityUid, MachinePartComponent)>();
         foreach (var (type, amount) in macBoardComp.Requirements)
         {
-            var target = machineParts.Where(p => p.PartType == type).Take(amount);
+            var target = machineParts.Where(p => p.Item2.PartType == type).Take(amount);
             updatedParts.AddRange(target);
         }
-        foreach (var part in updatedParts)
+        foreach (var pair in updatedParts)
         {
+            var part = pair.Item2;
+            var partEnt = pair.Item1;
+
             if (!machine.Requirements.ContainsKey(part.PartType))
                 continue;
 
-            machine.PartContainer.Insert(part.Owner, EntityManager);
+            machine.PartContainer.Insert(partEnt, EntityManager);
             machine.Progress[part.PartType]++;
-            machineParts.Remove(part);
+            machineParts.Remove(pair);
         }
 
         //put the unused parts back into rped. (this also does the "swapping")
-        foreach (var unused in machineParts)
+        foreach (var (unused, _) in machineParts)
         {
-            storage.Storage.Insert(unused.Owner);
-            _storage.Insert(uid, unused.Owner, null, false);
+            _storage.Insert(storageEnt, unused, null, false);
         }
-
-
     }
 
     private void OnAfterInteract(EntityUid uid, PartExchangerComponent component, AfterInteractEvent args)
@@ -172,5 +176,4 @@ public sealed class PartExchangerSystem : EntitySystem
             BreakOnUserMove = true
         });
     }
-
 }

--- a/Content.Server/Construction/PartExchangerSystem.cs
+++ b/Content.Server/Construction/PartExchangerSystem.cs
@@ -59,7 +59,7 @@ public sealed class PartExchangerSystem : EntitySystem
         args.Handled = true;
     }
 
-    private void TryExchangeMachineParts(EntityUid uid, EntityUid storageUid, List<(EntityUid, MachinePartComponent)> machineParts)
+    private void TryExchangeMachineParts(EntityUid uid, EntityUid storageUid, List<(EntityUid part, MachinePartComponent partComp)> machineParts)
     {
         if (!TryComp<MachineComponent>(uid, out var machine))
             return;
@@ -79,17 +79,17 @@ public sealed class PartExchangerSystem : EntitySystem
             }
         }
 
-        machineParts.Sort((x, y) => y.Item2.Rating.CompareTo(x.Item2.Rating));
+        machineParts.Sort((x, y) => y.partComp.Rating.CompareTo(x.partComp.Rating));
 
-        var updatedParts = new List<(EntityUid, MachinePartComponent)>();
+        var updatedParts = new List<(EntityUid part, MachinePartComponent partComp)>();
         foreach (var (type, amount) in macBoardComp.Requirements)
         {
-            var target = machineParts.Where(p => p.Item2.PartType == type).Take(amount);
+            var target = machineParts.Where(p => p.partComp.PartType == type).Take(amount);
             updatedParts.AddRange(target);
         }
         foreach (var part in updatedParts)
         {
-            machine.PartContainer.Insert(part.Item1, EntityManager);
+            machine.PartContainer.Insert(part.part, EntityManager);
             machineParts.Remove(part);
         }
 
@@ -101,7 +101,7 @@ public sealed class PartExchangerSystem : EntitySystem
         _construction.RefreshParts(uid, machine);
     }
 
-    private void TryConstructMachineParts(EntityUid uid, EntityUid storageEnt, List<(EntityUid, MachinePartComponent)> machineParts)
+    private void TryConstructMachineParts(EntityUid uid, EntityUid storageEnt, List<(EntityUid part, MachinePartComponent partComp)> machineParts)
     {
         if (!TryComp<MachineFrameComponent>(uid, out var machine))
             return;
@@ -122,18 +122,18 @@ public sealed class PartExchangerSystem : EntitySystem
             }
         }
 
-        machineParts.Sort((x, y) => y.Item2.Rating.CompareTo(x.Item2.Rating));
+        machineParts.Sort((x, y) => y.partComp.Rating.CompareTo(x.partComp.Rating));
 
-        var updatedParts = new List<(EntityUid, MachinePartComponent)>();
+        var updatedParts = new List<(EntityUid part, MachinePartComponent partComp)>();
         foreach (var (type, amount) in macBoardComp.Requirements)
         {
-            var target = machineParts.Where(p => p.Item2.PartType == type).Take(amount);
+            var target = machineParts.Where(p => p.partComp.PartType == type).Take(amount);
             updatedParts.AddRange(target);
         }
         foreach (var pair in updatedParts)
         {
-            var part = pair.Item2;
-            var partEnt = pair.Item1;
+            var part = pair.partComp;
+            var partEnt = pair.part;
 
             if (!machine.Requirements.ContainsKey(part.PartType))
                 continue;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes #19041
part exchanger system now uses 100% less `.Owner` calls.
the replacing audio now only cuts off if the doafter failed (dorkitos)

it passes around a list of a key value pair which is kinda sloppy but this code is niche and not in a hot loops so perf be damned.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed the RPED sound effect cutting off at the end.
