### PR TITLE
Nerf pickaxe + drill slightly

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -14,16 +14,16 @@
   - type: MeleeWeapon
     damage:
       types:
-        Piercing: 5
-        Blunt: 5
-        Structural: 15
+        Blunt: 2.5
+        Piercing: 2.5
+        Structural: 10
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
         Blunt: 5
         Piercing: 5
-        Structural: 15
+        Structural: 10
   - type: Item
     size: 80
     sprite: Objects/Weapons/Melee/pickaxe.rsi
@@ -47,4 +47,4 @@
       types:
         Blunt: 5
         Piercing: 5
-        Structural: 15
+        Structural: 10


### PR DESCRIPTION
I already nerfed its damage from before (at least non-structural) but this nerfs it slightly more.

I'm happy with where the PKA and crusher are at (pending a potential PKA range nerf) I think.

:cl:
- tweak: Nerf pickaxe raw damage slightly.
- tweak: Nerf pickaxe and drill structural damage.