### PR TITLE
Fix debug error when opening the ahelp ui before joining a game

### DIFF
--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -45,7 +45,6 @@ public sealed class AHelpUIController: UIController, IOnStateChanged<GameplaySta
 
     public void OnStateEntered(GameplayState state)
     {
-        DebugTools.Assert(UIHelper == null);
         _adminManager.AdminStatusUpdated += OnAdminStatusUpdated;
 
         CommandBinds.Builder


### PR DESCRIPTION
## About the PR
There's an ahelp button in the lobby now that lets you open it before the game starts.
If you join the game with it open in debug, it trips an assert.

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase