### PR TITLE
Fix scientific notation showing in pressure description.

### DIFF
--- a/Resources/Locale/en-US/_lib.ftl
+++ b/Resources/Locale/en-US/_lib.ftl
@@ -1,7 +1,7 @@
 ### Special messages used by internal localizer stuff.
 
 # Used internally by the PRESSURE() function.
-zzzz-fmt-pressure = { TOSTRING($divided, "G3") } { $places ->
+zzzz-fmt-pressure = { TOSTRING($divided, "G4") } { $places ->
     [0] kPa
     [1] MPa
     [2] GPa

--- a/Resources/Locale/en-US/_lib.ftl
+++ b/Resources/Locale/en-US/_lib.ftl
@@ -11,7 +11,7 @@ zzzz-fmt-pressure = { TOSTRING($divided, "G4") } { $places ->
 }
 
 # Used internally by the POWERWATTS() function.
-zzzz-fmt-power-watts = { TOSTRING($divided, "G3") } { $places ->
+zzzz-fmt-power-watts = { TOSTRING($divided, "G4") } { $places ->
     [0] W
     [1] kW
     [2] MW
@@ -23,7 +23,7 @@ zzzz-fmt-power-watts = { TOSTRING($divided, "G3") } { $places ->
 # Used internally by the POWERJOULES() function.
 # Reminder: 1 joule = 1 watt for 1 second (multiply watts by seconds to get joules).
 # Therefore 1 kilowatt-hour is equal to 3,600,000 joules (3.6MJ)
-zzzz-fmt-power-joules = { TOSTRING($divided, "G3") } { $places ->
+zzzz-fmt-power-joules = { TOSTRING($divided, "G4") } { $places ->
     [0] J
     [1] kJ
     [2] MJ


### PR DESCRIPTION
## About the PR
In situations where the pressure is 4 digits eg: 1000 kPa like the default starting tank amount. The fluent conversion tries to make a 3 digit display and reverts to scientific notation if not able to fit in 3. eg 1E+03E kPa. 
This will allow it to display 4 digits correctly.

**Media**
Default 02 tank pre change:
![image](https://github.com/space-wizards/space-station-14/assets/47093363/6b05e0cb-2678-429b-94aa-3c6cf384d55b)

Default 02 tank post change:
![image](https://github.com/space-wizards/space-station-14/assets/47093363/42c7a97e-1b9c-4e38-89ef-ceb86bbc3023)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Repo
- fix: fixed pressure tanks to not show scientific notation.
