### PR TITLE
Trim migration.yml

### DIFF
--- a/Content.Server/Maps/MapMigrationSystem.cs
+++ b/Content.Server/Maps/MapMigrationSystem.cs
@@ -32,11 +32,12 @@ public sealed class MapMigrationSystem : EntitySystem
         if (!TryReadFile(out var mappings))
             return;
 
+        // Verify that all of the entries map to valid entity prototypes.
         foreach (var node in mappings.Values)
         {
             var newId = ((ValueDataNode) node).Value;
             if (!string.IsNullOrEmpty(newId) && newId != "null")
-                DebugTools.Assert(_protoMan.HasIndex<EntityPrototype>(newId));
+                DebugTools.Assert(_protoMan.HasIndex<EntityPrototype>(newId), $"{newId} is not an entity prototype.");
         }
 #endif
     }

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1,98 +1,12 @@
-# basic dictionary that maps old entity ids to new entity ids.
-# an empty or "null" string results in the entity getting deleted.
+# This is a basic dictionary that maps old entity prototype ids to new ids. This only works for entity prototypes, and
+# is intended to allow maps to load without having to manually edit them. An empty or "null" string results in the
+# entity getting deleted.
 
 # e.g., you can swap all walls with windows and delete all tables by adding lines like:
 #
 # Window: WallSolid
 # WallSolid: Window
 # Table: null
-#
-chem_dispenser: ChemDispenser
-KvassTankFull: null
-DrinkKvassGlass: null
-KvassTank: null
-
-# 2023-05-03
-SpawnPointBrigmedic: null
-ClothingHeadsetBrigmedic: null
-ClothingHeadHatBeretBrigmedic: null
-ClothingHeadHelmetHardsuitBrigmedic: null
-ClothingOuterHardsuitBrigmedic: null
-ClothingOuterCoatAMG: null
-ClothingBackpackBrigmedic: null
-ClothingBackpackBrigmedicFilled: null
-ClothingBackpackSatchelBrigmedic: null
-ClothingBackpackSatchelBrigmedicFilled: null
-ClothingBackpackDuffelBrigmedic: null
-ClothingBackpackDuffelBrigmedicFilled: null
-BrigmedicIDCard: null
-BrigmedicPDA: null
-BoxSurvivalBrigmedic: null
-LockerBrigmedic: null
-LockerBrigmedicFilled: null
-BedsheetBrigmedic: null
-
-# 2023-05-04
-BoxMagazineMagnumSubMachineGun: BoxMagazinePistolSubMachineGun
-BoxMagazineMagnumSubMachineGunPractice: BoxMagazinePistolSubMachineGunPractice
-BoxMagazineMagnumSubMachineGunRubber: BoxMagazinePistolSubMachineGunRubber
-
-MagazineMagnumSubMachineGun: MagazinePistolSubMachineGun
-MagazineMagnumSubMachineGunPractice: MagazinePistolSubMachineGunPractice
-MagazineMagnumSubMachineGunRubber: MagazinePistolSubMachineGunRubber
-WeaponSubMachineGunVector: WeaponSubMachineGunDrozd
-WeaponSubMachineGunVectorRubber: WeaponSubMachineGunDrozdRubber
-
-MagazineBoxAntiMaterial: MagazineBoxAntiMateriel
-CartridgeAntiMaterial: CartridgeAntiMateriel
-BulletAntiMaterial: BulletAntiMateriel
-
-# 2023-05-10
-FoodCondimentBottleSmallHotsauce: FoodCondimentBottleHotsauce
-FoodBakedCookieFortune: FoodSnackCookieFortune
-GunSafeSubMachineGunVector: GunSafeSubMachineGunDrozd
-
-# 2023-05-24
-AMEController: AmeController
-AMEJar: AmeJar
-AMEPart: AmePart
-AMEShielding: AmeShielding
-
-# 2023-05-29
-OrGate: null
-
-# 2023-05-31
-IHSVoidsuit: null
-ClothingHeadHelmetIHSVoidHelm: null
-ClothingHandsGlovesIhscombat: null
-
-# 2023-06-02
-# Yes, this is right. They were, in fact, reversed because the default orientation of the particle accelerator was _down_ relative to the screen.
-# This resulted in the parts being named assuming that the person building the accelerator treated it like a rocket with the particles coming out the _back_.
-# As this was confusing they were converted to nautical orientation with forward being towards the emitters.
-MachineParticleAcceleratorEmitterCenterCircuitboard: MachineParticleAcceleratorEmitterForeCircuitboard
-MachineParticleAcceleratorEmitterLeftCircuitboard: MachineParticleAcceleratorEmitterStarboardCircuitboard
-MachineParticleAcceleratorEmitterRightCircuitboard: MachineParticleAcceleratorEmitterPortCircuitboard
-ParticleAcceleratorEmitterCenter: ParticleAcceleratorEmitterFore
-ParticleAcceleratorEmitterCenterUnfinished: ParticleAcceleratorEmitterForeUnfinished
-ParticleAcceleratorEmitterLeft: ParticleAcceleratorEmitterStarboard
-ParticleAcceleratorEmitterLeftUnfinished: ParticleAcceleratorEmitterStarboardUnfinished
-ParticleAcceleratorEmitterRight: ParticleAcceleratorEmitterPort
-ParticleAcceleratorEmitterRightUnfinished: ParticleAcceleratorEmitterPortUnfinished
-
-# 2023-06-21
-WindoorArmoryLocked: WindoorSecureArmoryLocked
-WindoorBrigLocked: WindoorSecureBrigLocked
-WindoorChemistryLocked: WindoorSecureChemistryLocked
-WindoorCommandLocked: WindoorSecureCommandLocked
-WindoorEngineeringLocked: WindoorSecureEngineeringLocked
-WindoorExternalLocked: WindoorSecureExternalLocked
-WindoorMedicalLocked: WindoorSecureMedicalLocked
-WindoorSecurityLocked: WindoorSecureSecurityLocked
-WindoorScienceLocked: WindoorSecureScienceLocked
-WindoorHeadOfPersonnelLocked: WindoorSecureHeadOfPersonnelLocked
-WindoorAtmosphericsLocked: WindoorSecureAtmosphericsLocked
-WindoorParamedicLocked: WindoorSecureParamedicLocked
 
 # 2023-07-03
 ClothingHeadHelmetHelmet: ClothingHeadHelmetBasic
@@ -163,5 +77,4 @@ MountainRockMining: AsteroidRockMining
 WindowTintedDirectional: WindowFrostedDirectional
 
 # 2023-08-10
-# RedMediumLaserWeak: RedLightLaser # TODO migrations for non-entity prototypes
 SyringeSpaceacillin: null


### PR DESCRIPTION
Removes old migrations and adds a debug assert message.

This will not make migrating old maps any harder than it already is, because migrating the old device links already requires checking out old commits and resaving maps (see #18243 and the related discord announcements). All of our maps have already been resaved and these migrations are all older than that PR.