### PR TITLE
Make jugs label deletable

### DIFF
--- a/Content.Server/Labels/Label/Components/LabelComponent.cs
+++ b/Content.Server/Labels/Label/Components/LabelComponent.cs
@@ -1,12 +1,21 @@
 namespace Content.Server.Labels.Components
 {
+    /// <summary>
+    /// Gives opportunity to add labels by entities with the <see cref="HandLabelerComponent"/>
+    /// </summary>
     [RegisterComponent]
     public sealed class LabelComponent : Component
     {
+        /// <summary>
+        /// Label text. If you using that field in your prototype, you must set originalName field too, and set name of entity like it with label
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("currentLabel")]
         public string? CurrentLabel { get; set; }
 
+        /// <summary>
+        /// Name of entity without label
+        /// </summary>
         [DataField("originalName")]
         public string? OriginalName { get; set; }
     }

--- a/Content.Server/Labels/Label/Components/LabelComponent.cs
+++ b/Content.Server/Labels/Label/Components/LabelComponent.cs
@@ -7,6 +7,7 @@ namespace Content.Server.Labels.Components
         [DataField("currentLabel")]
         public string? CurrentLabel { get; set; }
 
+        [DataField("originalName")]
         public string? OriginalName { get; set; }
     }
 }

--- a/Content.Server/Labels/Label/Components/LabelComponent.cs
+++ b/Content.Server/Labels/Label/Components/LabelComponent.cs
@@ -1,21 +1,18 @@
 namespace Content.Server.Labels.Components
 {
     /// <summary>
-    /// Gives opportunity to add labels by entities with the <see cref="HandLabelerComponent"/>
+    /// Makes entities have a label in their name. Labels are normally given by <see cref="HandLabelerComponent"/>
     /// </summary>
     [RegisterComponent]
     public sealed class LabelComponent : Component
     {
         /// <summary>
-        /// Label text. If you using that field in your prototype, you must set originalName field too, and set name of entity like it with label
+        /// The actual text in the label
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("currentLabel")]
         public string? CurrentLabel { get; set; }
 
-        /// <summary>
-        /// Name of entity without label
-        /// </summary>
         [DataField("originalName")]
         public string? OriginalName { get; set; }
     }

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -46,6 +46,8 @@
       fillBaseName: jug
     - type: StaticPrice
       price: 80
+    - type: Label
+      originalName: jug
 
 - type: entity
   parent: Jug

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -51,7 +51,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (carbon)
+  name: jug (Carbon)
   id: JugCarbon
   noSpawn: true
   components:
@@ -66,7 +66,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (iodine)
+  name: jug (Iodine)
   id: JugIodine
   noSpawn: true
   components:
@@ -81,7 +81,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (fluorine)
+  name: jug (Fluorine)
   id: JugFluorine
   noSpawn: true
   components:
@@ -96,7 +96,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (chlorine)
+  name: jug (Chlorine)
   id: JugChlorine
   noSpawn: true
   components:
@@ -111,7 +111,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (aluminium)
+  name: jug (Aluminium)
   id: JugAluminium
   noSpawn: true
   components:
@@ -126,7 +126,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (phosphorus)
+  name: jug (Phosphorus)
   id: JugPhosphorus
   noSpawn: true
   components:
@@ -141,7 +141,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (sulfur)
+  name: jug (Sulfur)
   id: JugSulfur
   noSpawn: true
   components:
@@ -156,7 +156,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (silicon)
+  name: jug (Silicon)
   id: JugSilicon
   noSpawn: true
   components:
@@ -171,7 +171,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (hydrogen)
+  name: jug (Hydrogen)
   id: JugHydrogen
   noSpawn: true
   components:
@@ -186,7 +186,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (lithium)
+  name: jug (Lithium)
   id: JugLithium
   noSpawn: true
   components:
@@ -201,7 +201,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (sodium)
+  name: jug (Sodium)
   id: JugSodium
   noSpawn: true
   components:
@@ -216,7 +216,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (potassium)
+  name: jug (Potassium)
   id: JugPotassium
   noSpawn: true
   components:
@@ -231,7 +231,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (radium)
+  name: jug (Radium)
   id: JugRadium
   noSpawn: true
   components:
@@ -246,7 +246,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (iron)
+  name: jug (Iron)
   id: JugIron
   noSpawn: true
   components:
@@ -261,7 +261,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (copper)
+  name: jug (Copper)
   id: JugCopper
   noSpawn: true
   components:
@@ -276,7 +276,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (gold)
+  name: jug (Gold)
   id: JugGold
   noSpawn: true
   components:
@@ -291,7 +291,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (mercury)
+  name: jug (Mercury)
   id: JugMercury
   noSpawn: true
   components:
@@ -306,7 +306,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (silver)
+  name: jug (Silver)
   id: JugSilver
   noSpawn: true
   components:
@@ -321,7 +321,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (ethanol)
+  name: jug (Ethanol)
   id: JugEthanol
   noSpawn: true
   components:
@@ -336,7 +336,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (sugar)
+  name: jug (Sugar)
   id: JugSugar
   noSpawn: true
   components:
@@ -351,7 +351,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (nitrogen)
+  name: jug (Nitrogen)
   id: JugNitrogen
   noSpawn: true
   components:
@@ -366,7 +366,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (oxygen)
+  name: jug (Oxygen)
   id: JugOxygen
   noSpawn: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -51,7 +51,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Carbon)
+  name: jug (carbon)
   id: JugCarbon
   noSpawn: true
   components:
@@ -66,7 +66,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Iodine)
+  name: jug (iodine)
   id: JugIodine
   noSpawn: true
   components:
@@ -81,7 +81,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Fluorine)
+  name: jug (fluorine)
   id: JugFluorine
   noSpawn: true
   components:
@@ -96,7 +96,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Chlorine)
+  name: jug (chlorine)
   id: JugChlorine
   noSpawn: true
   components:
@@ -111,7 +111,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Aluminium)
+  name: jug (aluminium)
   id: JugAluminium
   noSpawn: true
   components:
@@ -126,7 +126,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Phosphorus)
+  name: jug (phosphorus)
   id: JugPhosphorus
   noSpawn: true
   components:
@@ -141,7 +141,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Sulfur)
+  name: jug (sulfur)
   id: JugSulfur
   noSpawn: true
   components:
@@ -156,7 +156,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Silicon)
+  name: jug (silicon)
   id: JugSilicon
   noSpawn: true
   components:
@@ -171,7 +171,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Hydrogen)
+  name: jug (hydrogen)
   id: JugHydrogen
   noSpawn: true
   components:
@@ -186,7 +186,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Lithium)
+  name: jug (lithium)
   id: JugLithium
   noSpawn: true
   components:
@@ -201,7 +201,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Sodium)
+  name: jug (sodium)
   id: JugSodium
   noSpawn: true
   components:
@@ -216,7 +216,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Potassium)
+  name: jug (potassium)
   id: JugPotassium
   noSpawn: true
   components:
@@ -231,7 +231,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Radium)
+  name: jug (radium)
   id: JugRadium
   noSpawn: true
   components:
@@ -246,7 +246,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Iron)
+  name: jug (iron)
   id: JugIron
   noSpawn: true
   components:
@@ -261,7 +261,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Copper)
+  name: jug (copper)
   id: JugCopper
   noSpawn: true
   components:
@@ -276,7 +276,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Gold)
+  name: jug (gold)
   id: JugGold
   noSpawn: true
   components:
@@ -291,7 +291,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Mercury)
+  name: jug (mercury)
   id: JugMercury
   noSpawn: true
   components:
@@ -306,7 +306,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Silver)
+  name: jug (silver)
   id: JugSilver
   noSpawn: true
   components:
@@ -321,7 +321,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Ethanol)
+  name: jug (ethanol)
   id: JugEthanol
   noSpawn: true
   components:
@@ -336,7 +336,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Sugar)
+  name: jug (sugar)
   id: JugSugar
   noSpawn: true
   components:
@@ -351,7 +351,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Nitrogen)
+  name: jug (nitrogen)
   id: JugNitrogen
   noSpawn: true
   components:
@@ -366,7 +366,7 @@
 
 - type: entity
   parent: Jug
-  name: jug (Oxygen)
+  name: jug (oxygen)
   id: JugOxygen
   noSpawn: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -56,7 +56,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Carbon
+      currentLabel: carbon
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -71,7 +71,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Iodine
+      currentLabel: iodine
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -86,7 +86,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Fluorine
+      currentLabel: fluorine
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -101,7 +101,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Chlorine
+      currentLabel: chlorine
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -116,7 +116,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Aluminium
+      currentLabel: aluminium
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -131,7 +131,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Phosphorus
+      currentLabel: phosphorus
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -146,7 +146,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Sulfur
+      currentLabel: sulfur
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -161,7 +161,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Silicon
+      currentLabel: silicon
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -176,7 +176,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Hydrogen
+      currentLabel: hydrogen
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -191,7 +191,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Lithium
+      currentLabel: lithium
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -206,7 +206,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Sodium
+      currentLabel: sodium
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -221,7 +221,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Potassium
+      currentLabel: potassium
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -236,7 +236,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Radium
+      currentLabel: radium
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -251,7 +251,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Iron
+      currentLabel: iron
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -266,7 +266,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Copper
+      currentLabel: copper
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -281,7 +281,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Gold
+      currentLabel: gold
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -296,7 +296,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Mercury
+      currentLabel: mercury
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -311,7 +311,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Silver
+      currentLabel: silver
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -326,7 +326,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Ethanol
+      currentLabel: ethanol
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -341,7 +341,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Sugar
+      currentLabel: sugar
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -356,7 +356,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Nitrogen
+      currentLabel: nitrogen
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -371,7 +371,7 @@
   noSpawn: true
   components:
     - type: Label
-      currentLabel: Oxygen
+      currentLabel: oxygen
     - type: SolutionContainerManager
       solutions:
         beaker:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Now labels from chemVend jugs can be deleted/rewriten
Synchronized jugs label text 
Documented LabelComponent
I know, it's bad that to add to entity prototype label with text you must allow some rules, but not just type some text into required field of yaml, but i think it's hard now, because chemVend use name field (not sure), that means if name be normal, then in vend UI it also be normal. 

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Nanotrasen Department of Economics has reduced glue expenses in jug production lines. Now labels from jugs can be deleted.
