### PR TITLE
UI opacity option

### DIFF
--- a/Content.Client/Gameplay/GameplayState.cs
+++ b/Content.Client/Gameplay/GameplayState.cs
@@ -1,4 +1,5 @@
 using Content.Client.Hands;
+using Content.Client.Options.UI;
 using Content.Client.UserInterface.Controls;
 using Content.Client.UserInterface.Screens;
 using Content.Client.UserInterface.Systems.Gameplay;
@@ -51,6 +52,8 @@ namespace Content.Client.Gameplay
             _fpsCounter.Visible = _configurationManager.GetCVar(CCVars.HudFpsCounterVisible);
             _configurationManager.OnValueChanged(CCVars.HudFpsCounterVisible, (show) => { _fpsCounter.Visible = show; });
             _configurationManager.OnValueChanged(CCVars.UILayout, ReloadMainScreenValueChange);
+            _configurationManager.OnValueChanged(CCVars.UIOpacity, UpdateUIOpacity);
+            _uiManager.WindowRoot.OnChildAdded += (child) => UpdateChildUIOpacity(child, _configurationManager.GetCVar(CCVars.UIOpacity));
         }
 
         protected override void Shutdown()
@@ -64,6 +67,21 @@ namespace Content.Client.Gameplay
             _uiManager.ClearWindows();
             _configurationManager.UnsubValueChanged(CCVars.UILayout, ReloadMainScreenValueChange);
             UnloadMainScreen();
+        }
+
+        private void UpdateChildUIOpacity(Control child, float value)
+        {
+            if (child is OptionsMenu || child is EscapeMenu)
+                return;
+            child.Modulate = child.Modulate.WithAlpha(value / 100f);
+        }
+
+        private void UpdateUIOpacity(float value)
+        {
+            foreach (var child in _uiManager.WindowRoot.Children)
+            {
+                UpdateChildUIOpacity(child, value);
+            }
         }
 
         private void ReloadMainScreenValueChange(string _)

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
@@ -16,6 +16,14 @@
                 <OptionButton Name="UIScaleOption" />
             </BoxContainer>
             <BoxContainer Orientation="Horizontal">
+                <Label Text="{Loc 'ui-options-opacity-label'}" />
+                <Slider Name="UIOpacitySlider"
+                        MinValue="0"
+                        MaxValue="100"
+                        Rounded="False"
+                        MinWidth="200" />
+            </BoxContainer>
+            <BoxContainer Orientation="Horizontal">
                 <Label Text="{Loc 'ui-options-hud-theme'}" />
                 <Control MinSize="4 0" />
                 <OptionButton Name="HudThemeOption" />

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -74,6 +74,11 @@ namespace Content.Client.Options.UI.Tabs
                 id++;
             }
 
+            UIOpacitySlider.OnValueChanged += _ =>
+            {
+                UpdateApplyButton();
+            };
+
             HudLayoutOption.OnItemSelected += args =>
             {
                 HudLayoutOption.SelectId(args.Id);
@@ -109,6 +114,7 @@ namespace Content.Client.Options.UI.Tabs
             FullscreenCheckBox.Pressed = ConfigIsFullscreen;
             LightingPresetOption.SelectId(GetConfigLightingQuality());
             UIScaleOption.SelectId(GetConfigUIScalePreset(ConfigUIScale));
+            UIOpacitySlider.Value = _cfg.GetCVar(CCVars.UIOpacity);
             HudThemeOption.SelectId(_cfg.GetCVar(CCVars.HudTheme));
             ViewportScaleSlider.Value = _cfg.GetCVar(CCVars.ViewportFixedScaleFactor);
             ViewportStretchCheckBox.Pressed = _cfg.GetCVar(CCVars.ViewportStretch);
@@ -153,6 +159,7 @@ namespace Content.Client.Options.UI.Tabs
             _cfg.SetCVar(CVars.DisplayWindowMode,
                          (int) (FullscreenCheckBox.Pressed ? WindowMode.Fullscreen : WindowMode.Windowed));
             _cfg.SetCVar(CVars.DisplayUIScale, UIScaleOptions[UIScaleOption.SelectedId]);
+            _cfg.SetCVar(CCVars.UIOpacity, UIOpacitySlider.Value);
             _cfg.SetCVar(CCVars.ViewportStretch, ViewportStretchCheckBox.Pressed);
             _cfg.SetCVar(CCVars.ViewportFixedScaleFactor, (int) ViewportScaleSlider.Value);
             _cfg.SetCVar(CCVars.ViewportSnapToleranceMargin,
@@ -191,6 +198,7 @@ namespace Content.Client.Options.UI.Tabs
             var isLightingQualitySame = LightingPresetOption.SelectedId == GetConfigLightingQuality();
             var isHudThemeSame = HudThemeOption.SelectedId == _cfg.GetCVar(CCVars.HudTheme);
             var isUIScaleSame = MathHelper.CloseToPercent(UIScaleOptions[UIScaleOption.SelectedId], ConfigUIScale);
+            var isUIOpacitySame = MathHelper.CloseToPercent(UIOpacitySlider.Value, _cfg.GetCVar(CCVars.UIOpacity));
             var isVPStretchSame = ViewportStretchCheckBox.Pressed == _cfg.GetCVar(CCVars.ViewportStretch);
             var isVPScaleSame = (int) ViewportScaleSlider.Value == _cfg.GetCVar(CCVars.ViewportFixedScaleFactor);
             var isIntegerScalingSame = IntegerScalingCheckBox.Pressed == (_cfg.GetCVar(CCVars.ViewportSnapToleranceMargin) != 0);
@@ -206,6 +214,7 @@ namespace Content.Client.Options.UI.Tabs
                                    isFullscreenSame &&
                                    isLightingQualitySame &&
                                    isUIScaleSame &&
+                                   isUIOpacitySame &&
                                    isVPStretchSame &&
                                    isVPScaleSame &&
                                    isIntegerScalingSame &&

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1364,6 +1364,9 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> SeparatedScreenChatSize =
             CVarDef.Create("ui.separated_chat_size", "0.6,0", CVar.CLIENTONLY | CVar.ARCHIVE);
 
+        public static readonly CVarDef<float> UIOpacity =
+            CVarDef.Create("ui.ui_opacity", 100f, CVar.CLIENTONLY | CVar.ARCHIVE);
+
 
         /*
          * CHAT

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1365,7 +1365,7 @@ namespace Content.Shared.CCVar
             CVarDef.Create("ui.separated_chat_size", "0.6,0", CVar.CLIENTONLY | CVar.ARCHIVE);
 
         public static readonly CVarDef<float> UIOpacity =
-            CVarDef.Create("ui.ui_opacity", 100f, CVar.CLIENTONLY | CVar.ARCHIVE);
+            CVarDef.Create("ui.opacity", 100f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
 
         /*

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -37,6 +37,7 @@ ui-options-lighting-low = Low
 ui-options-lighting-medium = Medium
 ui-options-lighting-high = High
 ui-options-scale-label = UI Scale:
+ui-options-opacity-label = UI opacity:
 ui-options-scale-auto = Automatic ({ TOSTRING($scale, "P0") })
 ui-options-scale-75 = 75%
 ui-options-scale-100 = 100%


### PR DESCRIPTION
## About the PR

I think right now the user interface takes up a lot of space on the screen with lots of windows, menus, etc. It would be nice to be able to make them more transparent.

Some suggested making only some elements transparent, but, as I understood, this would require using stylesheets, which, as I also understood, are currently "abandoned":

`// STLYE SHEETS WERE A MISTAKE. KILL ALL OF THIS WITH FIRE`

**Media**

https://github.com/space-wizards/space-station-14/assets/38111072/4f0df269-ae65-4585-99e9-893f22b0035d

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: kseandi
- add: Now you can change the UI opacity in the settings!
