### PR TITLE
Fixed cargo's gas canister purchase prices

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -4,7 +4,7 @@
     sprite: Structures/Storage/canister.rsi
     state: grey
   product: AirCanister
-  cost: 2700
+  cost: 1100
   category: Atmospherics
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 2300
+  cost: 1100
   category: Atmospherics
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 3200
+  cost: 1100
   category: Atmospherics
   group: market
 
@@ -34,7 +34,17 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 2600
+  cost: 2200 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
+  category: Atmospherics
+  group: market
+
+- type: cargoProduct
+  id: AtmosphericsStorage
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: yellow
+  product: StorageCanister
+  cost: 1000 # No gases in it so it's cheaper
   category: Atmospherics
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -44,7 +44,7 @@
     sprite: Structures/Storage/canister.rsi
     state: yellow
   product: StorageCanister
-  cost: 1000 # No gases in it so it's cheaper
+  cost: 1010 # No gases in it so it's cheaper
   category: Atmospherics
   group: market
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Gas canister prices were all wonky due to an artifact from a time where the gasses they contained were actually worth something. Before every can was a different price, and they were all like 2k or 3k spesos. Now they are just the price of the can (1000) + 90 spesos for the gas + 10 spesos as a markup. co2 cans are 2200 instead of 1100 since co2 is poisonous. Remember that the sell prices of all these gasses is 0.

Also added an empty storage canister to cargo's catalog, so cargo can save a quick buck if they don't need the rest of the gasses. The empty storage canister is 90 spesos cheaper.

Economically speaking, since the station has a source of infinite gas the effective value of all minable gasses is 0 + shipping (unless atmos withholds supply), so being able to buy gasses for a price of 1 speso per 20 mols (cans contain 1800 mols) shouldn't break anything.

Having a stable source of empty gas canisters also shouldn't hurt since there's never really a deficit of them anyway.

The thing I'm least sure about here is making co2 cans pricier (or even sellable at all) so feel free to convince me that it's a bad idea.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://github.com/space-wizards/space-station-14/assets/113810873/21e7b5aa-9de6-4f03-8e2d-286d219b2559)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/c212bd86-b427-474e-8fb4-64ca41e3ec76)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/e5421af5-729b-45d5-ab80-1be3280191e6)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/379810ec-bf5f-416d-ad30-d1a7a7e0402f)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Centcom will now sell Cargo gas canisters at a vastly reduced (and consistent!) price after realizing the station has infinite gasses anyway.
