### PR TITLE
Fix inventory UI not marking inputs as handled

### DIFF
--- a/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
@@ -220,6 +220,7 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
         if (args.Function == EngineKeyFunctions.UIClick)
         {
             _inventorySystem.UIInventoryActivate(control.SlotName);
+            args.Handle();
             return;
         }
 
@@ -244,6 +245,12 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
         {
             _inventorySystem.UIInventoryAltActivateItem(slot, _playerUid.Value);
         }
+        else
+        {
+            return;
+        }
+
+        args.Handle();
     }
 
     private void StoragePressed(GUIBoundKeyEventArgs args, SlotControl control)


### PR DESCRIPTION
Fixes #19095

:cl:
- fix: Fixed a bug causing inventory slots to sometimes ignore interactions (e.g., not opening the context menu).