### PR TITLE
Make faded notes pop in on hover

### DIFF
--- a/Content.Client/Administration/UI/Notes/AdminNotesLinePopup.xaml.cs
+++ b/Content.Client/Administration/UI/Notes/AdminNotesLinePopup.xaml.cs
@@ -53,8 +53,8 @@ public sealed partial class AdminNotesLinePopup : Popup
         DeleteButton.OnPressed += DeletePressed;
     }
 
-    private int NoteId { get; }
-    private NoteType NoteType { get; }
+    public int NoteId { get; }
+    public NoteType NoteType { get; }
     private TimeSpan? DeleteResetOn { get; set; }
 
     private void EditPressed(ButtonEventArgs args)


### PR DESCRIPTION
## About the PR
Fixes https://github.com/space-wizards/space-station-14/issues/18546

**Media**

https://github.com/space-wizards/space-station-14/assets/10968691/e27ff5ca-f5d1-49c8-8e17-f0c21bf7bb44

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Faded admin notes now pop in when hovering over them.
