### PR TITLE
Fix new players added to admin logs defaulting to selected when not all players are selected

### DIFF
--- a/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
@@ -420,14 +420,18 @@ public sealed partial class AdminLogsControl : Control
     public void SetPlayers(Dictionary<Guid, string> players)
     {
         var buttons = new SortedSet<AdminLogPlayerButton>(_adminLogPlayerButtonComparer);
+        var allSelected = true;
 
         foreach (var control in PlayersContainer.Children.ToArray())
         {
-            if (control is not AdminLogPlayerButton player ||
-                !players.Remove(player.Id))
-            {
+            if (control is not AdminLogPlayerButton player)
                 continue;
-            }
+
+            if (!SelectedPlayers.Contains(player.Id))
+                allSelected = false;
+
+            if (!players.Remove(player.Id))
+                continue;
 
             buttons.Add(player);
         }
@@ -437,10 +441,12 @@ public sealed partial class AdminLogsControl : Control
             var button = new AdminLogPlayerButton(id)
             {
                 Text = name,
-                Pressed = true
+                Pressed = allSelected
             };
 
-            SelectedPlayers.Add(id);
+            if (allSelected)
+                SelectedPlayers.Add(id);
+
             button.OnPressed += PlayerButtonPressed;
 
             buttons.Add(button);


### PR DESCRIPTION
## About the PR
Fixes https://github.com/space-wizards/space-station-14/issues/14171

**Media**

https://github.com/space-wizards/space-station-14/assets/10968691/b31ead86-ee82-40c6-97c5-0cb578a628b4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed new players added to admin logs defaulting to selected, even when not all players are selected.
