### PR TITLE
Revert "add syndies+nukies gamemode"

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops-traitor.ftl
@@ -1,2 +1,0 @@
-nukeops-traitor-title = Traitors and Nuclear Operatives
-nukeops-traitor-description = Both Syndicate agents and Nuclear Operatives have targeted the station. Will they fight or cooperate?

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -72,19 +72,6 @@
   rules:
     - Nukeops
     - BasicStationEventScheduler
-    
-- type: gamePreset
-  id: NukeopsTraitor
-  alias:
-    - nukeopstraitor
-    - syndinukies
-  name: nukeops-traitor-title
-  description: nukeops-traitor-description
-  showInVote: false
-  rules:
-    - Nukeops
-    - Traitor
-    - BasicStationEventScheduler
 
 - type: gamePreset
   id: Zombie

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,8 +1,6 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.15
+    Nukeops: 0.25
     Traitor: 0.65
-    # TODO: remove when dynamic is a thing
-    NukeopsTraitor: 0.10
     Zombie: 0.10


### PR DESCRIPTION
Reverts space-wizards/space-station-14#18991

Few things:
- this is quite literally a shitty workaround for no dynamic
- a good 75% of syndicate objectives are fundamentally incompatible with regular nukies.
- Nukies round-ending behavior naturally spoils syndicate rounds since it prevents the shuttle from arriving.
- the natural interaction between syndies and ops is really shitty and doesn't add anything interesting.

If we want dual antag modes they should just be implemented properly via some game director system.