### PR TITLE
Fix to allow no severity on note messages and watchlists

### DIFF
--- a/Content.Client/Administration/UI/Notes/NoteEdit.xaml.cs
+++ b/Content.Client/Administration/UI/Notes/NoteEdit.xaml.cs
@@ -239,7 +239,7 @@ public sealed partial class NoteEdit : FancyWindow
             return;
         }
 
-        SubmitButton.Disabled = NoteSeverity == null;
+        SubmitButton.Disabled = (NoteType != NoteType.Watchlist && NoteType != NoteType.Message) && NoteSeverity == null;
     }
 
     private void ResetSubmitButton()


### PR DESCRIPTION
## About the PR
Fixes watchlists and messages to be saved without severity as per previous functionality. 
Small Issue that was from PR #19059
Maybe @DrSmugleaf can review if someone else doesn't?

**Media**
Problem:
![image](https://github.com/space-wizards/space-station-14/assets/47093363/0213b9ce-79b7-40f4-8fec-2ea932b292d0)
Only allows message and watchlist to not have severity.
![image](https://github.com/space-wizards/space-station-14/assets/47093363/245fbe6b-fd7d-408e-ae05-4befe8c7f0b4)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed Admin watchlists and messages.
