### PR TITLE
bug with reflection fixed

### DIFF
--- a/Content.Shared/Weapons/Reflect/SharedReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/SharedReflectSystem.cs
@@ -174,6 +174,9 @@ public abstract class SharedReflectSystem : EntitySystem
         if (!TryComp(args.Equipee, out ReflectComponent? reflection))
             return;
 
+        if (args.Slot == "pocket1" || args.Slot == "pocket2")
+            return;
+
         reflection.Enabled = comp.Enabled;
         // reflection probability should be: (1 - old probability) * newly-equipped item probability + old probability
         // example: if entity has .25 reflection and newly-equipped item has .7, entity should have (1 - .25) * .7 + .25 = .775

--- a/Content.Shared/Weapons/Reflect/SharedReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/SharedReflectSystem.cs
@@ -174,8 +174,7 @@ public abstract class SharedReflectSystem : EntitySystem
         if (!TryComp(args.Equipee, out ReflectComponent? reflection))
             return;
 
-        reflection.Enabled = true;
-
+        reflection.Enabled = comp.Enabled;
         // reflection probability should be: (1 - old probability) * newly-equipped item probability + old probability
         // example: if entity has .25 reflection and newly-equipped item has .7, entity should have (1 - .25) * .7 + .25 = .775
         reflection.ReflectProb += (1 - reflection.ReflectProb) * comp.ReflectProb;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Bug with reflection in pocket seems to be fixed.
Closes #18666.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Energy swords don't reflect in pockets anymore.
