### PR TITLE
put jugs in chemistry research

### DIFF
--- a/Resources/Prototypes/Research/biochemical.yml
+++ b/Resources/Prototypes/Research/biochemical.yml
@@ -15,6 +15,7 @@
   - HotplateMachineCircuitboard
   - ChemicalPayload
   - ClothingEyesGlassesChemical
+  - Jug
 
 - type: technology
   id: SurgicalTools

--- a/Resources/Prototypes/Research/biochemical.yml
+++ b/Resources/Prototypes/Research/biochemical.yml
@@ -15,7 +15,7 @@
   - HotplateMachineCircuitboard
   - ChemicalPayload
   - ClothingEyesGlassesChemical
-  - Jug
+  - Jug # empty?
 
 - type: technology
   id: SurgicalTools


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
puts jugs in chemistry research. they aren't craftable atm due to an oversight so im making the recipe show up when you research chemistry

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed jugs not being craftable by putting them under the chemistry research module.
