### PR TITLE
Add Mystery Figure Crate

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-fun.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-fun.ftl
@@ -21,3 +21,4 @@ ent-FunWaterGuns = { ent-CrateFunWaterGuns }
 
 ent-FunParty = { ent-CrateFunParty }
     .desc = { ent-CrateFunParty.desc }
+

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-fun.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-fun.ftl
@@ -21,4 +21,3 @@ ent-FunWaterGuns = { ent-CrateFunWaterGuns }
 
 ent-FunParty = { ent-CrateFunParty }
     .desc = { ent-CrateFunParty.desc }
-

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/fun-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/fun-crates.ftl
@@ -48,3 +48,6 @@ ent-CrateFunBoxing = Boxing Crate
 
 ent-CrateFunBikeHornImplants = Bike Horn Implants
     .desc = A thousand honks a day keeps security officers away!
+
+ent-CrateFunMysteryFigurines = Mystery Figure Crate
+    .desc = A collection of 10 Mystery Figurine boxes. Duplicates non refundable.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -187,4 +187,3 @@
   cost: 4500
   category: Fun
   group: market
-

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -177,3 +177,14 @@
   cost: 1000
   category: Fun
   group: market
+
+- type: cargoProduct
+  id: FunMysteryFigurines
+  icon:
+    sprite: Objects/Fun/figurines.rsi
+    state: fig_box
+  product: CrateFunMysteryFigurines
+  cost: 4500
+  category: Fun
+  group: market
+

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -184,6 +184,6 @@
     sprite: Objects/Fun/figurines.rsi
     state: fig_box
   product: CrateFunMysteryFigurines
-  cost: 4500
+  cost: 4000
   category: Fun
   group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -285,6 +285,3 @@
     contents:
       - id: MysteryFigureBox
         amount: 10
-  
-
-

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -285,3 +285,6 @@
     contents:
       - id: MysteryFigureBox
         amount: 10
+      - id: MysteryFigureBox
+        amount: 15
+        prob: 0.05

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -276,3 +276,15 @@
     contents:
       - id: BikeHornImplanter
         amount: 3
+
+- type: entity
+  id: CrateFunMysteryFigurines
+  parent: CratePlastic
+  components:
+  - type: StorageFill
+    contents:
+      - id: MysteryFigureBox
+        amount: 10
+  
+
+

--- a/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
@@ -212,7 +212,7 @@
   parent: BaseFigurine
   id: ToyFigurineScientist
   name: scientist figurine
-  description: A figurine depicting a Scienist donning a labcoat.
+  description: A figurine depicting a Scientist donning a labcoat.
   components:
   - type: Sprite
     state: scientist


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added the Mystery Figure Crate for cargo to purchase. It costs $4000 and contains 10 mystery figure boxes. It also has a 5% chance to spawn with 25 figures instead of 10. PR also contains a minor typo edit for a figurine.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ✓] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

🆑 Gotimanga:
- Cargo can now purchase the Mystery Figure Crate, a bulk purchase of 10 mystery spacemen minifigure boxes.

https://github.com/space-wizards/space-station-14/assets/127038462/6e22f179-898f-42b7-b732-38cac260947a

