### PR TITLE
Singularity Stability Tweaks (fixed)

### DIFF
--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.Emitter.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.Emitter.cs
@@ -47,8 +47,8 @@ public sealed partial class ParticleAcceleratorSystem
             {
                 ParticleAcceleratorPowerState.Standby => 0,
                 ParticleAcceleratorPowerState.Level0 => 1,
-                ParticleAcceleratorPowerState.Level1 => 3,
-                ParticleAcceleratorPowerState.Level2 => 6,
+                ParticleAcceleratorPowerState.Level1 => 2,
+                ParticleAcceleratorPowerState.Level2 => 3,
                 ParticleAcceleratorPowerState.Level3 => 10,
                 _ => 0,
             } * 10;

--- a/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
@@ -130,9 +130,9 @@ public sealed class SingularitySystem : SharedSingularitySystem
 
         singularity.Energy = value;
         SetLevel(uid, value switch {
-                >= 1500 => 6,
-                >= 1000 => 5,
-                >= 600 => 4,
+                >= 2400 => 6,
+                >= 1600 => 5,
+                >= 900 => 4,
                 >= 300 => 3,
                 >= 200 => 2,
                 > 0 => 1,
@@ -312,8 +312,8 @@ public sealed class SingularitySystem : SharedSingularitySystem
         {
             6 => 20,
             5 => 15,
-            4 => 10,
-            3 => 6,
+            4 => 12,
+            3 => 8,
             2 => 2,
             1 => 1,
             _ => 0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Aims to make the singularity more stable overall, and add slight depth to the different power levels. The singularity was getting loose on its own again, so I spent a few hours looking at different values figuring out what to tweak. Now, level 1 on the PA will keep the singulo at a level 3. Level 2 will increase the singularity to level 4, and will eventually loose it, but you have time to react. Level 3 will loose the singularity but it won't be nearly as instant anymore due to increased energy level requirements between stages.

This allows some level of reaction time to potentially stop sabotage in the form of the PA computer being messed with. Syndis that snip the emitter wires will also loose it, but it shouldn't be nearly as destructive since the singulo will have a much harder time growing, potentially giving more options for sabotage besides just ending the round.

Fixes https://github.com/space-wizards/space-station-14/issues/18825

Changes taken from #18856 and reset back to before it broke.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: liltenhead
- tweak: Changed singularity energy levels to require more energy overall to increase in size.
- tweak: Changed singularity energy drain rates to keep them more stable, and die quicker without food.
- tweak: Changed level 2 and 3 PA to feed less energy, slowing the speed of a singuloose slightly.
