### PR TITLE
Add CVar for customizing round restart time

### DIFF
--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -34,10 +34,10 @@ namespace Content.IntegrationTests.Tests
                 config.SetCVar(CCVars.GameLobbyEnabled, true);
                 config.SetCVar(CCVars.EmergencyShuttleMinTransitTime, 1f);
                 config.SetCVar(CCVars.EmergencyShuttleDockTime, 1f);
+                config.SetCVar(CCVars.EmergencyShuttleRoundRestartTime, 1f);
 
                 roundEndSystem.DefaultCooldownDuration = TimeSpan.FromMilliseconds(100);
                 roundEndSystem.DefaultCountdownDuration = TimeSpan.FromMilliseconds(300);
-                roundEndSystem.DefaultRestartRoundDuration = TimeSpan.FromMilliseconds(100);
             });
 
             await server.WaitAssertion(() =>
@@ -131,10 +131,10 @@ namespace Content.IntegrationTests.Tests
                 config.SetCVar(CCVars.GameLobbyEnabled, false);
                 config.SetCVar(CCVars.EmergencyShuttleMinTransitTime, CCVars.EmergencyShuttleMinTransitTime.DefaultValue);
                 config.SetCVar(CCVars.EmergencyShuttleDockTime, CCVars.EmergencyShuttleDockTime.DefaultValue);
+                config.SetCVar(CCVars.EmergencyShuttleRoundRestartTime, CCVars.EmergencyShuttleRoundRestartTime.DefaultValue);
 
                 roundEndSystem.DefaultCooldownDuration = TimeSpan.FromSeconds(30);
                 roundEndSystem.DefaultCountdownDuration = TimeSpan.FromMinutes(4);
-                roundEndSystem.DefaultRestartRoundDuration = TimeSpan.FromMinutes(1);
                 ticker.RestartRound();
             });
             await PoolManager.ReallyBeIdle(pairTracker.Pair, 10);

--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -34,7 +34,7 @@ namespace Content.IntegrationTests.Tests
                 config.SetCVar(CCVars.GameLobbyEnabled, true);
                 config.SetCVar(CCVars.EmergencyShuttleMinTransitTime, 1f);
                 config.SetCVar(CCVars.EmergencyShuttleDockTime, 1f);
-                config.SetCVar(CCVars.EmergencyShuttleRoundRestartTime, 1f);
+                config.SetCVar(CCVars.RoundRestartTime, 1f);
 
                 roundEndSystem.DefaultCooldownDuration = TimeSpan.FromMilliseconds(100);
                 roundEndSystem.DefaultCountdownDuration = TimeSpan.FromMilliseconds(300);
@@ -131,7 +131,7 @@ namespace Content.IntegrationTests.Tests
                 config.SetCVar(CCVars.GameLobbyEnabled, false);
                 config.SetCVar(CCVars.EmergencyShuttleMinTransitTime, CCVars.EmergencyShuttleMinTransitTime.DefaultValue);
                 config.SetCVar(CCVars.EmergencyShuttleDockTime, CCVars.EmergencyShuttleDockTime.DefaultValue);
-                config.SetCVar(CCVars.EmergencyShuttleRoundRestartTime, CCVars.EmergencyShuttleRoundRestartTime.DefaultValue);
+                config.SetCVar(CCVars.RoundRestartTime, CCVars.RoundRestartTime.DefaultValue);
 
                 roundEndSystem.DefaultCooldownDuration = TimeSpan.FromSeconds(30);
                 roundEndSystem.DefaultCountdownDuration = TimeSpan.FromMinutes(4);

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -41,7 +41,6 @@ namespace Content.Server.RoundEnd
         /// Countdown to use where there is no station alert countdown to be found.
         /// </summary>
         public TimeSpan DefaultCountdownDuration { get; set; } = TimeSpan.FromMinutes(10);
-        public TimeSpan DefaultRestartRoundDuration { get; set; } = TimeSpan.FromMinutes(2);
 
         private CancellationTokenSource? _countdownTokenSource = null;
         private CancellationTokenSource? _cooldownTokenSource = null;
@@ -211,8 +210,26 @@ namespace Content.Server.RoundEnd
             _gameTicker.EndRound();
             _countdownTokenSource?.Cancel();
             _countdownTokenSource = new();
-            _chatManager.DispatchServerAnnouncement(Loc.GetString("round-end-system-round-restart-eta-announcement", ("minutes", DefaultRestartRoundDuration.Minutes)));
-            Timer.Spawn(DefaultRestartRoundDuration, AfterEndRoundRestart, _countdownTokenSource.Token);
+
+            var countdownTime = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.EmergencyShuttleRoundRestartTime));
+            int time;
+            string unitsLocString;
+            if (countdownTime.TotalSeconds < 60)
+            {
+                time = countdownTime.Seconds;
+                unitsLocString = "eta-units-seconds";
+            }
+            else
+            {
+                time = countdownTime.Minutes;
+                unitsLocString = "eta-units-minutes";
+            }
+            _chatManager.DispatchServerAnnouncement(
+                Loc.GetString(
+                    "round-end-system-round-restart-eta-announcement",
+                    ("time", time),
+                    ("units", Loc.GetString(unitsLocString))));
+            Timer.Spawn(countdownTime, AfterEndRoundRestart, _countdownTokenSource.Token);
         }
 
         private void AfterEndRoundRestart()

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -211,7 +211,7 @@ namespace Content.Server.RoundEnd
             _countdownTokenSource?.Cancel();
             _countdownTokenSource = new();
 
-            var countdownTime = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.EmergencyShuttleRoundRestartTime));
+            var countdownTime = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.RoundRestartTime));
             int time;
             string unitsLocString;
             if (countdownTime.TotalSeconds < 60)

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1245,6 +1245,13 @@ namespace Content.Shared.CCVar
             CVarDef.Create("shuttle.emergency_transit_time_max", 180f, CVar.SERVERONLY);
 
         /// <summary>
+        /// The time in seconds that the server should wait after the shuttle arrives at centcomm to restart the round.
+        /// Defaults to 2 minutes.
+        /// </summary>
+        public static readonly CVarDef<float> EmergencyShuttleRoundRestartTime =
+            CVarDef.Create("shuttle.round_restart_time", 120f, CVar.SERVERONLY);
+
+        /// <summary>
         /// Whether the emergency shuttle is enabled or should the round just end.
         /// </summary>
         public static readonly CVarDef<bool> EmergencyShuttleEnabled =

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -312,6 +312,13 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<float> ArtifactRoundEndTimer = CVarDef.Create("game.artifact_round_end_timer", 0.5f, CVar.NOTIFY | CVar.REPLICATED);
 
+        /// <summary>
+        /// The time in seconds that the server should wait before restarting the round.
+        /// Defaults to 2 minutes.
+        /// </summary>
+        public static readonly CVarDef<float> RoundRestartTime =
+            CVarDef.Create("game.round_restart_time", 120f, CVar.SERVERONLY);
+
         /*
          * Discord
          */
@@ -1243,13 +1250,6 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<float> EmergencyShuttleMaxTransitTime =
             CVarDef.Create("shuttle.emergency_transit_time_max", 180f, CVar.SERVERONLY);
-
-        /// <summary>
-        /// The time in seconds that the server should wait after the shuttle arrives at centcomm to restart the round.
-        /// Defaults to 2 minutes.
-        /// </summary>
-        public static readonly CVarDef<float> EmergencyShuttleRoundRestartTime =
-            CVarDef.Create("shuttle.round_restart_time", 120f, CVar.SERVERONLY);
 
         /// <summary>
         /// Whether the emergency shuttle is enabled or should the round just end.

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -3,7 +3,7 @@
 round-end-system-shuttle-called-announcement = An emergency shuttle has been sent. ETA: {$time} {$units}.
 round-end-system-shuttle-auto-called-announcement = An automatic crew shift change shuttle has been sent. ETA: {$time} {$units}. Recall the shuttle to extend the shift.
 round-end-system-shuttle-recalled-announcement = The emergency shuttle has been recalled.
-round-end-system-round-restart-eta-announcement = Restarting the round in {$minutes} minutes...
+round-end-system-round-restart-eta-announcement = Restarting the round in {$time} {$units}...
 
 eta-units-minutes = minutes
 eta-units-seconds = seconds


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
You can now customize the round restart timeout. In other words, you can spend more or less time in the post-game. The default remains at 2 minutes.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

With `game.round_restart_time = 240`:  
![image](https://github.com/space-wizards/space-station-14/assets/30327355/90c1d3de-8a1e-4eea-bc35-29e875ab66c3)

With `game.round_restart_time = 10`:  
![image](https://github.com/space-wizards/space-station-14/assets/30327355/709c2923-dcaf-4fb9-883d-7850c75adf02)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->
N/A