### PR TITLE
mech air overhaul

### DIFF
--- a/Content.Server/Mech/Components/MechAirFilterComponent.cs
+++ b/Content.Server/Mech/Components/MechAirFilterComponent.cs
@@ -1,0 +1,32 @@
+﻿using Content.Shared.Atmos;
+
+namespace Content.Server.Mech.Components;
+
+/// <summary>
+/// This is basically a reverse scrubber for MechAir
+/// </summary>
+[RegisterComponent]
+public sealed class MechAirFilterComponent : Component
+{
+    /// <summary>
+    /// Gases that will be filtered out of internal air
+    /// </summary>
+    [DataField("gases")]
+    public HashSet<Gas> Gases = new HashSet<Gas>
+    {
+        Gas.CarbonDioxide,
+        Gas.Plasma,
+        Gas.Tritium,
+        Gas.WaterVapor,
+        Gas.Miasma,
+        Gas.NitrousOxide,
+        Gas.Frezon
+        //Gas.Helium4
+    };
+
+    /// <summary>
+    /// Target volume to transfer every second.
+    /// </summary>
+    [DataField("transferRate")]
+    public float TransferRate = Atmospherics.MaxTransferRate;
+}

--- a/Content.Server/Mech/Components/MechAirFilterComponent.cs
+++ b/Content.Server/Mech/Components/MechAirFilterComponent.cs
@@ -11,18 +11,8 @@ public sealed class MechAirFilterComponent : Component
     /// <summary>
     /// Gases that will be filtered out of internal air
     /// </summary>
-    [DataField("gases")]
-    public HashSet<Gas> Gases = new HashSet<Gas>
-    {
-        Gas.CarbonDioxide,
-        Gas.Plasma,
-        Gas.Tritium,
-        Gas.WaterVapor,
-        Gas.Miasma,
-        Gas.NitrousOxide,
-        Gas.Frezon
-        //Gas.Helium4
-    };
+    [DataField("gases", required: true)]
+    public HashSet<Gas> Gases = new();
 
     /// <summary>
     /// Target volume to transfer every second.

--- a/Content.Server/Mech/Components/MechAirFilterComponent.cs
+++ b/Content.Server/Mech/Components/MechAirFilterComponent.cs
@@ -28,5 +28,5 @@ public sealed class MechAirFilterComponent : Component
     /// Target volume to transfer every second.
     /// </summary>
     [DataField("transferRate")]
-    public float TransferRate = Atmospherics.MaxTransferRate;
+    public float TransferRate = MechAirComponent.GasMixVolume * 0.1f;
 }

--- a/Content.Server/Mech/Components/MechAirIntakeComponent.cs
+++ b/Content.Server/Mech/Components/MechAirIntakeComponent.cs
@@ -1,0 +1,28 @@
+﻿using Content.Shared.Atmos;
+
+namespace Content.Server.Mech.Components;
+
+/// <summary>
+/// This is basically a siphon vent for mech but not using pump vent component because MechAir bad
+/// </summary>
+[RegisterComponent]
+public sealed class MechAirIntakeComponent : Component
+{
+    /// <summary>
+    /// Target pressure change for a single atmos tick
+    /// </summary>
+    [DataField("targetPressureChange")]
+    public float TargetPressureChange = 5f;
+
+    /// <summary>
+    /// How strong the intake pump is, it will be able to replenish air from lower pressure areas.
+    /// </summary>
+    [DataField("pumpPower")]
+    public float PumpPower = 2f;
+
+    /// <summary>
+    /// Pressure to intake gases up to, maintains MechAir pressure.
+    /// </summary>
+    [DataField("pressure")]
+    public float Pressure = Atmospherics.OneAtmosphere;
+}

--- a/Content.Server/Mech/Systems/MechSystem.Filtering.cs
+++ b/Content.Server/Mech/Systems/MechSystem.Filtering.cs
@@ -1,0 +1,87 @@
+using Content.Server.Atmos;
+using Content.Server.Atmos.Piping.Components;
+using Content.Server.Mech.Components;
+using Content.Shared.Atmos;
+using Content.Shared.Mech.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.Server.Mech.Systems;
+
+// TODO: this could be reused for gasmask or something if MechAir wasnt a thing
+public sealed partial class MechSystem
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private void InitializeFiltering()
+    {
+        SubscribeLocalEvent<MechAirIntakeComponent, AtmosDeviceUpdateEvent>(OnIntakeUpdate);
+        SubscribeLocalEvent<MechAirFilterComponent, AtmosDeviceUpdateEvent>(OnFilterUpdate);
+    }
+
+    private void OnIntakeUpdate(EntityUid uid, MechAirIntakeComponent intake, AtmosDeviceUpdateEvent args)
+    {
+        if (!TryComp<MechComponent>(uid, out var mech) || !mech.Airtight || !TryComp<MechAirComponent>(uid, out var mechAir))
+            return;
+
+        var xform = Transform(uid);
+        var coordinates = Transform(uid).MapPosition;
+        if (!_map.TryFindGridAt(coordinates, out _, out var grid))
+            return;
+
+        var tile = grid.GetTileRef(coordinates);
+        if (_atmosphere.GetTileMixture(tile.GridUid, null, tile.GridIndices, true) is not { } environment)
+        {
+            return;
+        }
+
+        // if the mech is filled there is nothing to do
+        if (mechAir.Air.Pressure >= intake.Pressure)
+            return;
+
+        // absolute maximum pressure change
+        var pressureDelta = args.dt * intake.TargetPressureChange;
+        pressureDelta = MathF.Min(pressureDelta, intake.Pressure - mechAir.Air.Pressure);
+        if (pressureDelta <= 0)
+            return;
+
+        // how many moles to transfer to change internal pressure by pressureDelta
+        // ignores temperature difference because lazy
+        var transferMoles = pressureDelta * mechAir.Air.Volume / (environment.Temperature * Atmospherics.R);
+        _atmosphere.Merge(mechAir.Air, environment.Remove(transferMoles));
+    }
+
+    private void OnFilterUpdate(EntityUid uid, MechAirFilterComponent filter, AtmosDeviceUpdateEvent args)
+    {
+        if (!TryComp<MechComponent>(uid, out var mech) || !mech.Airtight || !TryComp<MechAirComponent>(uid, out var mechAir))
+            return;
+
+        var ratio = MathF.Min(1f, args.dt * filter.TransferRate / mechAir.Air.Volume);
+        var removed = mechAir.Air.RemoveRatio(ratio);
+        // nothing left to remove from the mech
+        if (MathHelper.CloseToPercent(removed.TotalMoles, 0f))
+            return;
+
+
+        var coordinates = Transform(uid).MapPosition;
+        GasMixture? destination = null;
+        if (_map.TryFindGridAt(coordinates, out _, out var grid))
+        {
+            var tile = grid.GetTileRef(coordinates);
+            destination = _atmosphere.GetTileMixture(tile.GridUid, null, tile.GridIndices, true);
+        }
+
+        if (destination != null)
+        {
+            _atmosphere.ScrubInto(removed, destination, filter.Gases);
+        }
+        else
+        {
+            // filtering into space/planet so just discard them
+            foreach (var gas in filter.Gases)
+            {
+                removed.SetMoles(gas, 0f);
+            }
+        }
+        _atmosphere.Merge(mechAir.Air, removed);
+    }
+}

--- a/Content.Server/Mech/Systems/MechSystem.Filtering.cs
+++ b/Content.Server/Mech/Systems/MechSystem.Filtering.cs
@@ -23,19 +23,13 @@ public sealed partial class MechSystem
         if (!TryComp<MechComponent>(uid, out var mech) || !mech.Airtight || !TryComp<MechAirComponent>(uid, out var mechAir))
             return;
 
-        var xform = Transform(uid);
-        var coordinates = Transform(uid).MapPosition;
-        if (!_map.TryFindGridAt(coordinates, out _, out var grid))
-            return;
-
-        var tile = grid.GetTileRef(coordinates);
-        if (_atmosphere.GetTileMixture(tile.GridUid, null, tile.GridIndices, true) is not { } environment)
-        {
-            return;
-        }
-
         // if the mech is filled there is nothing to do
         if (mechAir.Air.Pressure >= intake.Pressure)
+            return;
+
+        var environment = _atmosphere.GetContainingMixture(uid, true, true);
+        // nothing to intake from
+        if (environment == null)
             return;
 
         // absolute maximum pressure change

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -310,56 +310,6 @@ public sealed partial class MechSystem : SharedMechSystem
         UserInterfaceSystem.SetUiState(ui, state);
     }
 
-    public override bool TryInsert(EntityUid uid, EntityUid? toInsert, MechComponent? component = null)
-    {
-        if (!Resolve(uid, ref component))
-            return false;
-
-        if (!base.TryInsert(uid, toInsert, component))
-            return false;
-
-        if (component.Airtight && TryComp(uid, out MechAirComponent? mechAir))
-        {
-            var coordinates = Transform(uid).MapPosition;
-            if (_map.TryFindGridAt(coordinates, out _, out var grid))
-            {
-                var tile = grid.GetTileRef(coordinates);
-
-                if (_atmosphere.GetTileMixture(tile.GridUid, null, tile.GridIndices, true) is { } environment)
-                {
-                    _atmosphere.Merge(mechAir.Air, environment.RemoveVolume(MechAirComponent.GasMixVolume));
-                }
-            }
-        }
-        return true;
-    }
-
-    public override bool TryEject(EntityUid uid, MechComponent? component = null)
-    {
-        if (!Resolve(uid, ref component))
-            return false;
-
-        if (!base.TryEject(uid, component))
-            return false;
-
-        if (component.Airtight && TryComp(uid, out MechAirComponent? mechAir))
-        {
-            var coordinates = Transform(uid).MapPosition;
-            if (_map.TryFindGridAt(coordinates, out _, out var grid))
-            {
-                var tile = grid.GetTileRef(coordinates);
-
-                if (_atmosphere.GetTileMixture(tile.GridUid, null, tile.GridIndices, true) is { } environment)
-                {
-                    _atmosphere.Merge(environment, mechAir.Air);
-                    mechAir.Air.Clear();
-                }
-            }
-        }
-
-        return true;
-    }
-
     public override void BreakMech(EntityUid uid, MechComponent? component = null)
     {
         base.BreakMech(uid, component);

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -26,15 +26,15 @@ namespace Content.Server.Mech.Systems;
 /// <inheritdoc/>
 public sealed partial class MechSystem : SharedMechSystem
 {
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
+    [Dependency] private readonly BatterySystem _battery = default!;
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly IMapManager _map = default!;
-    [Dependency] private readonly UserInterfaceSystem _ui = default!;
-    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly BatterySystem _battery = default!;
+    [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
     private ISawmill _sawmill = default!;
 

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -406,7 +406,7 @@ public abstract class SharedMechSystem : EntitySystem
     /// <param name="toInsert"></param>
     /// <param name="component"></param>
     /// <returns>Whether or not the entity was inserted</returns>
-    public virtual bool TryInsert(EntityUid uid, EntityUid? toInsert, MechComponent? component = null)
+    public bool TryInsert(EntityUid uid, EntityUid? toInsert, MechComponent? component = null)
     {
         if (!Resolve(uid, ref component))
             return false;
@@ -429,7 +429,7 @@ public abstract class SharedMechSystem : EntitySystem
     /// <param name="uid"></param>
     /// <param name="component"></param>
     /// <returns>Whether or not the pilot was ejected.</returns>
-    public virtual bool TryEject(EntityUid uid, MechComponent? component = null)
+    public bool TryEject(EntityUid uid, MechComponent? component = null)
     {
         if (!Resolve(uid, ref component))
             return false;

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -7,6 +7,16 @@
   - type: Mech
   - type: MechAir
   - type: MechAirFilter
+    # everything except oxygen and nitrogen
+    gases:
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    #- 9 TODO: fusion
   - type: MechAirIntake
   # for intake and filter to work
   - type: AtmosDevice

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -6,6 +6,12 @@
   - type: MobMover
   - type: Mech
   - type: MechAir
+  - type: MechAirFilter
+  - type: MechAirIntake
+  # for intake and filter to work
+  - type: AtmosDevice
+    requireAnchored: false
+    joinSystem: true
   - type: DoAfter
   - type: Repairable
     fuelCost: 25


### PR DESCRIPTION
## About the PR
instead of just taking in air when entering and dumping when exiting, airtight mechs will now intake air from the surrounding atmosphere and scrub waste gases, fixes #19116
this means that oxygen will automatically replenish and you cant get co2 poisoning anymore
however they dont have gas mix when built so you have to give it a few seconds to build pressure before getting in

doesnt ripley or honk in any way

unfortunately codewise this is largely a copypaste of pump vent + scrubber, not sure what could be done to reuse them

filtering is slow enough that if an empty vim is in a room with 1mpa of plasma, it will slowly fill up with plasma until its in an area where it can be dumped out, which is a very extreme case. if a vim is already filled with air then there is little danger from a room full of plasma.

**Media**
trust
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The HAMTR and Vim now have builtin scrubbers to remove the risk of carbon dioxide poisoning.
