### PR TITLE
Remove UI state enter/exit logic from DamageOverlayUi

### DIFF
--- a/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
+++ b/Content.Client/UserInterface/Systems/DamageOverlays/DamageOverlayUiController.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Client.Alerts;
-using Content.Client.Gameplay;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
@@ -15,7 +14,7 @@ using Robust.Client.UserInterface.Controllers;
 namespace Content.Client.UserInterface.Systems.DamageOverlays;
 
 [UsedImplicitly]
-public sealed class DamageOverlayUiController : UIController, IOnStateChanged<GameplayState>
+public sealed class DamageOverlayUiController : UIController
 {
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -31,16 +30,6 @@ public sealed class DamageOverlayUiController : UIController, IOnStateChanged<Ga
         SubscribeLocalEvent<PlayerDetachedEvent>(OnPlayerDetached);
         SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<MobThresholdChecked>(OnThresholdCheck);
-    }
-
-    public void OnStateEntered(GameplayState state)
-    {
-        _overlayManager.AddOverlay(_overlay);
-    }
-
-    public void OnStateExited(GameplayState state)
-    {
-        _overlayManager.RemoveOverlay(_overlay);
     }
 
     private void OnPlayerAttach(PlayerAttachedEvent args)


### PR DESCRIPTION
Can result in the overlay being added even when it shouldn't be active. The overlay is already only drawn to a viewport that is associated with the eye of the currently controlled entity, so it shouldn't cause issues in other UI states.

:cl:
- fix: Fixed replay playback a bug that could cause the damage overlay to stay permanently active.