### PR TITLE
Make AGhosts able to interact with bound UIs from any range

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -122,3 +122,4 @@
     stealthy: true
   - type: Stripping
   - type: SolutionScanner
+  - type: IgnoreUIRange


### PR DESCRIPTION
## About the PR
Requires https://github.com/space-wizards/RobustToolbox/pull/4264
Fixes https://github.com/space-wizards/space-station-14/issues/17060

**Media**

[aghostui.webm](https://github.com/space-wizards/space-station-14/assets/10968691/9765dc58-be4a-4dbe-a9f6-a27c4a02568c)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Admin ghosts are now able to interact with user interfaces from any range.
