### PR TITLE
remove id computer board objective

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -14,7 +14,6 @@
     CMOHyposprayStealObjective: 1
     RDHardsuitStealObjective: 1
     NukeDiskStealObjective: 1
-    IDComputerBoardStealObjective: 1
     MagbootsStealObjective: 1
     CorgiMeatStealObjective: 1
     CaptainGunStealObjective: 0.5

--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -155,22 +155,6 @@
       prototype: NukeDisk
       owner: objective-condition-steal-station
 
-
-- type: objective
-  id: IDComputerBoardStealObjective
-  issuer: syndicate
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: HeadOfPersonnel
-  conditions:
-    - !type:StealCondition
-      prototype: IDComputerCircuitboard
-      owner: job-name-hop
-
 - type: objective
   id: MagbootsStealObjective
   issuer: syndicate


### PR DESCRIPTION
## About the PR
- theres 3-4 of it on every station
- id computer doesnt give aa so its not useful for syndies anymore
- agent id exists so its a 2 tc equivalent
- its very hard to fail it

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- remove: The Syndicate has stopped requesting ID card computer boards.
