### PR TITLE
Adds Directional Switches

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -14,7 +14,6 @@
   - type: Physics
     canCollide: false
   - type: Sprite
-    drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch.rsi
     state: on
   - type: SignalSwitch
@@ -51,7 +50,6 @@
   - type: Physics
     canCollide: false
   - type: Sprite
-    drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch.rsi
     state: dead
   - type: UseDelay
@@ -111,7 +109,6 @@
     - type: Transform
       anchored: true
     - type: Sprite
-      drawdepth: SmallObjects
       sprite: Structures/Wallmounts/switch.rsi
       state: on
     - type: Rotatable
@@ -124,7 +121,6 @@
     - type: Construction
       graph: LightSwitchGraph
       node: LightSwitchNode
-    - type: Fixtures
 
 - type: entity
   id: TwoWayLever
@@ -136,7 +132,6 @@
     - type: Clickable
     - type: InteractionOutline
     - type: Sprite
-      drawdepth: FloorObjects
       sprite: Structures/conveyor.rsi
       layers:
         - state: switch-off
@@ -175,3 +170,47 @@
         - Left
         - Right
         - Middle
+
+#directional
+
+- type: entity
+  id: SignalSwitchDirectional
+  name: signal switch
+  suffix: directional
+  parent: SignalSwitch
+  components:
+  - type: WallMount
+    arc: 180
+  - type: Sprite
+    offset: 0,-0.25
+  - type: Construction
+    graph: SignalSwitchDirectionalGraph
+    node: SignalSwitchDirectionalNode
+
+- type: entity
+  id: SignalButtonDirectional
+  name: signal button
+  suffix: directional
+  parent: SignalButton
+  components:
+  - type: WallMount
+    arc: 180
+  - type: Sprite
+    offset: 0,-0.25
+  - type: Construction
+    graph: SignalButtonDirectionalGraph
+    node: SignalButtonDirectionalNode
+
+- type: entity
+  id: ApcNetSwitchDirectional
+  name: apc net switch
+  suffix: directional
+  parent: ApcNetSwitch
+  components:
+  - type: WallMount
+    arc: 180
+  - type: Sprite
+    offset: 0,-0.25
+  - type: Construction
+    graph: LightSwitchDirectionalGraph
+    node: LightSwitchDirectionalNode

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -14,6 +14,7 @@
   - type: Physics
     canCollide: false
   - type: Sprite
+    drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch.rsi
     state: on
   - type: SignalSwitch
@@ -50,6 +51,7 @@
   - type: Physics
     canCollide: false
   - type: Sprite
+    drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch.rsi
     state: dead
   - type: UseDelay
@@ -109,6 +111,7 @@
     - type: Transform
       anchored: true
     - type: Sprite
+      drawdepth: SmallObjects
       sprite: Structures/Wallmounts/switch.rsi
       state: on
     - type: Rotatable
@@ -121,6 +124,7 @@
     - type: Construction
       graph: LightSwitchGraph
       node: LightSwitchNode
+    - type: Fixtures
 
 - type: entity
   id: TwoWayLever
@@ -132,6 +136,7 @@
     - type: Clickable
     - type: InteractionOutline
     - type: Sprite
+      drawdepth: FloorObjects
       sprite: Structures/conveyor.rsi
       layers:
         - state: switch-off

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
@@ -17,6 +17,8 @@
           - material: Steel
             amount: 2
             doAfter: 1
+          - material: Cable
+            amount: 1
   - node: LeverNode
     entity: TwoWayLever
     edges:
@@ -37,6 +39,8 @@
             - material: Steel
               amount: 1
               doAfter: 2.0
+            - material: Cable
+              amount: 1
     - node: LightSwitchNode
       entity: ApcNetSwitch
       edges:
@@ -61,6 +65,8 @@
             - material: Steel
               amount: 1
               doAfter: 2.0
+            - material: Cable
+              amount: 1
     - node: SignalSwitchNode
       entity: SignalSwitch
       edges:
@@ -73,7 +79,7 @@
               prototype: SheetSteel1
               amount: 1
             - !type:DeleteEntity {}
-            
+
 - type: constructionGraph
   id: SignalButtonGraph
   start: start
@@ -85,8 +91,88 @@
             - material: Steel
               amount: 1
               doAfter: 2.0
+            - material: Cable
+              amount: 1
     - node: SignalButtonNode
       entity: SignalButton
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+
+- type: constructionGraph
+  id: LightSwitchDirectionalGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: LightSwitchDirectionalNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+            - material: Cable
+              amount: 1
+    - node: LightSwitchDirectionalNode
+      entity: ApcNetSwitchDirectional
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+
+- type: constructionGraph
+  id: SignalSwitchDirectionalGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: SignalSwitchDirectionalNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+            - material: Cable
+              amount: 1
+    - node: SignalSwitchDirectionalNode
+      entity: SignalSwitchDirectional
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+
+- type: constructionGraph
+  id: SignalButtonDirectionalGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: SignalButtonDirectionalNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+            - material: Cable
+              amount: 1
+    - node: SignalButtonDirectionalNode
+      entity: SignalButtonDirectional
       edges:
         - to: start
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
@@ -8,6 +8,9 @@
       - !type:SpawnPrototype
         prototype: SheetSteel1
         amount: 2
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 1
       - !type:DeleteEntity {}
     edges:
       - to: LeverNode
@@ -52,6 +55,9 @@
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 1
+            - !type:SpawnPrototype
+              prototype: CableApcStack1
+              amount: 1
             - !type:DeleteEntity {}
 
 - type: constructionGraph
@@ -77,6 +83,9 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
+              amount: 1
+            - !type:SpawnPrototype
+              prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}
 
@@ -104,6 +113,9 @@
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 1
+            - !type:SpawnPrototype
+              prototype: CableApcStack1
+              amount: 1
             - !type:DeleteEntity {}
 
 - type: constructionGraph
@@ -129,6 +141,9 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
+              amount: 1
+            - !type:SpawnPrototype
+              prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}
 
@@ -156,6 +171,9 @@
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 1
+            - !type:SpawnPrototype
+              prototype: CableApcStack1
+              amount: 1
             - !type:DeleteEntity {}
 
 - type: constructionGraph
@@ -181,5 +199,8 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
+              amount: 1
+            - !type:SpawnPrototype
+              prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}

--- a/Resources/Prototypes/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Recipes/Construction/machines.yml
@@ -96,3 +96,57 @@
   canBuildInImpassable: true
   conditions:
     - !type:WallmountCondition
+
+- type: construction
+  name: directional light switch
+  id: LightSwitchDirectionalRecipe
+  graph: LightSwitchDirectionalGraph
+  startNode: start
+  targetNode: LightSwitchDirectionalNode
+  category: construction-category-machines
+  description: A switch for toggling lights that are connected to the same apc.
+  icon:
+    sprite: Structures/Wallmounts/switch.rsi
+    state: on
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  name: directional signal switch
+  id: SignalSwitchDirectionalRecipe
+  graph: SignalSwitchDirectionalGraph
+  startNode: start
+  targetNode: SignalSwitchDirectionalNode
+  category: construction-category-machines
+  description: It's a switch for toggling power to things.
+  icon:
+    sprite: Structures/Wallmounts/switch.rsi
+    state: on
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  name: directional signal button
+  id: SignalButtonDirectionalRecipe
+  graph: SignalButtonDirectionalGraph
+  startNode: start
+  targetNode: SignalButtonDirectionalNode
+  category: construction-category-machines
+  description: It's a button for activating something.
+  icon:
+    sprite: Structures/Wallmounts/switch.rsi
+    state: on
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition


### PR DESCRIPTION
## About the PR
Adds directional switches that can only be accessed from one side of a wall. This makes them more versatile for mapping and player interactions. 


**Media**
![image](https://github.com/space-wizards/space-station-14/assets/107660393/04342be4-b67e-45ca-b580-cfdfb0c2a59e)
![image](https://github.com/space-wizards/space-station-14/assets/107660393/52542fd7-a69f-4f75-b15f-4b4b5a83bb78)

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

**Changelog**

:cl: Velcroboy
- add: Added directional switches
