### PR TITLE
Fix scrubs crate to have scrubs hats instead of bandanas

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -51,9 +51,9 @@
       - id: UniformScrubsColorGreen
       - id: UniformScrubsColorPurple
       - id: UniformScrubsColorBlue
-      - id: ClothingHeadBandBlue
-      - id: ClothingHeadBandRed
-      - id: ClothingHeadBandGreen
+      - id: ClothingHeadHatSurgcapBlue
+      - id: ClothingHeadHatSurgcapPurple
+      - id: ClothingHeadHatSurgcapGreen
       - id: ClothingMaskSterile
         amount: 3
 


### PR DESCRIPTION
## About the PR
Fix for this issue: #19089 Medical Scrub crates were being filled with bandanas instead of scrubs.

**Media** 
Previous items:
![image](https://github.com/space-wizards/space-station-14/assets/47093363/e20f2e95-c603-43aa-86da-812404cf44f6)

With proper scrubs:
![image](https://github.com/space-wizards/space-station-14/assets/47093363/0042944c-b122-4829-94bb-de33b968553c)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Repo
- fix: Nanotrasen no longer provides imitation head scrubs in the medical scrub crate.
