### PR TITLE
Restructure cannabis

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
@@ -24,10 +24,10 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 30
         reagents:
           - ReagentId: THC
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: Blunt
@@ -55,7 +55,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 30
         reagents:
           - ReagentId: THC
-            Quantity: 10
+            Quantity: 20

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
@@ -16,7 +16,7 @@
       food:
         reagents:
         - ReagentId: THC
-          Quantity: 5
+          Quantity: 15
 
 - type: entity
   name: dried cannabis leaves
@@ -32,7 +32,7 @@
       food:
         reagents:
         - ReagentId: THC
-          Quantity: 2
+          Quantity: 12
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/tobacco.rsi
     state: dried
@@ -51,7 +51,7 @@
       food:
         reagents:
         - ReagentId: THC
-          Quantity: 10
+          Quantity: 20
   - type: Sprite
     sprite: Objects/Misc/reagent_fillings.rsi
     state: powderpile


### PR DESCRIPTION
## About the PR
The point of this PR is to create gradual degradation and more consistent values when crafting joints/blunts/(and other items I will add if this goes through). 

Initially the process is kinda odd with, 
>leaf raw=5
>leaf dried=2(40% loss)
>(2xld)=leaf ground = 10(250% gain)
>(1lg) ground=joint/10(0% loss/gain overall)

You go from 1 item that has 5thc, to another that has 2thc, and then somehow jumps to 10, all to end up with a 1:1 ratio at the end of 2 leaves=1 joint with 10thc....hmm???

This change makes it so
>leaf raw=15
leaf dried=12(20% loss)
(2xld)=leaf ground=20(~17% loss)
(1lg)=Joint=20
(33% overall loss)
 

**Media**

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

**Changelog**

:cl: Velcroboy
- tweak: Restructured cannabis!
