### PR TITLE
Revenants no longer cause the object to emag itself

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -320,7 +320,7 @@ public sealed partial class RevenantSystem
 
         foreach (var ent in _lookup.GetEntitiesInRange(uid, component.MalfunctionRadius))
         {
-            _emag.DoEmagEffect(ent, ent); //it emags itself. spooky.
+            _emag.DoEmagEffect(uid, ent); //it does not emag itself. adorable.
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
pretty sure this only affects borgs, no more "you must follow your own orders above all else" jank. now revenants can build an army of loyal followers (assuming their panel is open and you can emag them without anyone noticing) 

![image](https://github.com/space-wizards/space-station-14/assets/135308300/0d098f1f-b3ff-4eaa-b465-9d201a2efae1)
