### PR TITLE
Fix for Mopped chems not transfering

### DIFF
--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -140,7 +140,7 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
         // Remove water on target
         // Then do the transfer.
         var nonWater = absorberSoln.SplitSolutionWithout(component.PickupAmount, PuddleSystem.EvaporationReagent);
-        _solutionContainerSystem.UpdateChemicals(used, absorberSoln);
+        _solutionContainerSystem.UpdateChemicals(used, absorberSoln, true);
 
         if (nonWater.Volume == FixedPoint2.Zero && absorberSoln.AvailableVolume == FixedPoint2.Zero)
         {
@@ -168,22 +168,44 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
             _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", used)), used, user);
         }
 
-        //Transfer full amount of nonWater solution
-        if (nonWater.Volume > 0 && _solutionContainerSystem.TryAddSolution(target, refillableSolution, nonWater))
+        // Attempt to transfer the full nonWater solution to the bucket.
+        if (nonWater.Volume > 0)
         {
-            absorberSoln.AddSolution(nonWater, _prototype);
+            bool fullTransferSuccess = _solutionContainerSystem.TryAddSolution(target, refillableSolution, nonWater);
+
+            // If full transfer was unsuccessful, try a partial transfer.
+            if (!fullTransferSuccess)
+            {
+                var partiallyTransferSolution = nonWater.SplitSolution(refillableSolution.AvailableVolume);
+
+                // Try to transfer the split solution to the bucket.
+                if (_solutionContainerSystem.TryAddSolution(target, refillableSolution, partiallyTransferSolution))
+                {
+                    // The transfer was successful. nonWater now contains the amount that wasn't transferred.
+                    // If there's any leftover nonWater solution, add it back to the mop.
+                    if (nonWater.Volume > 0)
+                    {
+                        absorberSoln.AddSolution(nonWater, _prototype);
+                        _solutionContainerSystem.UpdateChemicals(used, absorberSoln);
+                    }
+                }
+                else
+                {
+                    // If the transfer was unsuccessful, combine both solutions and return them to the mop.
+                    nonWater.AddSolution(partiallyTransferSolution, _prototype);
+                    absorberSoln.AddSolution(nonWater, _prototype);
+                    _solutionContainerSystem.UpdateChemicals(used, absorberSoln);
+                }
+            }
+        }
+        else
+        {
             _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", target)), user, user);
         }
 
-        //transfer partial amount of nonWater solution
-        var partiallyTransferSolution = nonWater.SplitSolution(refillableSolution.AvailableVolume);
-
-        if (nonWater.Volume > 0 && _solutionContainerSystem.TryAddSolution(target, refillableSolution, partiallyTransferSolution))
-        {
-            absorberSoln.AddSolution(partiallyTransferSolution, _prototype);
-            _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", target)), user, user);
-        }
-        _solutionContainerSystem.UpdateChemicals(used, absorberSoln, true);
+        _audio.PlayPvs(component.TransferSound, target);
+        _useDelay.BeginDelay(used);
+        return true;
         _audio.PlayPvs(component.TransferSound, target);
         _useDelay.BeginDelay(used);
         return true;

--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -168,11 +168,22 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
             _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", used)), used, user);
         }
 
-        if (nonWater.Volume > 0 && !_solutionContainerSystem.TryAddSolution(target, refillableSolution, nonWater))
+        //Transfer full amount of nonWater solution
+        if (nonWater.Volume > 0 && _solutionContainerSystem.TryAddSolution(target, refillableSolution, nonWater))
         {
             absorberSoln.AddSolution(nonWater, _prototype);
             _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", target)), user, user);
         }
+
+        //transfer partial amount of nonWater solution
+        var partiallyTransferSolution = nonWater.SplitSolution(refillableSolution.AvailableVolume);
+
+        if (nonWater.Volume > 0 && _solutionContainerSystem.TryAddSolution(target, refillableSolution, partiallyTransferSolution))
+        {
+            absorberSoln.AddSolution(partiallyTransferSolution, _prototype);
+            _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", target)), user, user);
+        }
+        _solutionContainerSystem.UpdateChemicals(used, absorberSoln, true);
         _audio.PlayPvs(component.TransferSound, target);
         _useDelay.BeginDelay(used);
         return true;

--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -168,14 +168,11 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
             _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", used)), used, user);
         }
 
-        var toTransferSolution = nonWater.SplitSolution(refillableSolution.AvailableVolume);
-
-        if (nonWater.Volume > 0 && !_solutionContainerSystem.TryAddSolution(target, refillableSolution, toTransferSolution))
+        if (nonWater.Volume > 0 && !_solutionContainerSystem.TryAddSolution(target, refillableSolution, nonWater))
         {
+            absorberSoln.AddSolution(nonWater, _prototype);
             _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", target)), user, user);
         }
-
-        _solutionContainerSystem.TryAddSolution(used, absorberSoln, nonWater);
         _audio.PlayPvs(component.TransferSound, target);
         _useDelay.BeginDelay(used);
         return true;


### PR DESCRIPTION
## About the PR
A recent PR (#18758) from @Fahasor fixing several mopping and transfer issues has cause the transfer of solutions to stop working.
This fix builds on that PR to solve all the issues listed below:
- #19156 - Nonwater solutions not transferring to solution container.
- #18756 - Solution Visual not updating on bucket.
- #18755 - Solution Visual not updating on Mop.
- #17036 - Partial solution transfers and full transfers

**Media**
Video shows the following tests which covers the above issues, I've speed it up so you don't have to suffer this Jani gameplay loop for long..:
- Full transfer Test with water(10 water bucket, 10 weldFuel mop):
- Full transfer Test without water(30 weldFuel bucket, 10 weldFuel mop):
- Partial transfer Test with water(240 weldFuel bucket, 10 water bucket, 25 water mop, 25 weldFuel mop):
- Partial transfer Test without water(240 weldFuel bucket, 25 water mop, 25 weldFuel mop):
- Visual on mop update
- Visual on bucket update

https://github.com/space-wizards/space-station-14/assets/47093363/bb9e8bdc-6169-4af0-b307-b1e2d9e85508

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Repo
- fix: Janitors have remembered how to wring a mop, mops can transfer chemicals back to buckets etc again.
