### PR TITLE
addendum to admin relay message

### DIFF
--- a/Resources/Locale/en-US/administration/bwoink.ftl
+++ b/Resources/Locale/en-US/administration/bwoink.ftl
@@ -2,7 +2,7 @@ bwoink-user-title = Admin Message
 
 bwoink-system-starmute-message-no-other-users = *System: Nobody is available to receive your message. Try pinging Game Admins on Discord.
 
-bwoink-system-messages-being-relayed-to-discord = Your messages are being relayed to the admins via Discord.
+bwoink-system-messages-being-relayed-to-discord = Your messages are being relayed to the admins via Discord. Issues may be handled without a response.
 
 bwoink-system-typing-indicator = {$players} {$count ->
 [one] is


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Due to complaints that ahelps aren't resolved despite some being done;

- without written reply from an admin
- in a different round
- with ahelping player disconnected.

"Your messages are being relayed to the admins via Discord. **Issues may be handled without a response**."

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Needs testing w the webhook
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

no cl