### PR TITLE
Closing bolt no longer removes cartridge

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -198,10 +198,11 @@ public abstract partial class SharedGunSystem
     {
         // Try to put a new round in if possible.
         var magEnt = GetMagazineEntity(uid);
+        var chambered = GetChamberEntity(uid);
 
         // Similar to what takeammo does though that uses an optimised version where
         // multiple bullets may be fired in a single tick.
-        if (magEnt != null)
+        if (magEnt != null && chambered == null)
         {
             var relayedArgs = new TakeAmmoEvent(1,
                 new List<(EntityUid? Entity, IShootable Shootable)>(),


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Closing bolt will no longer feed cartridge from magazine if there's already round in chamber.
It does that, by checking if chamber has round and if so - skip cycling (as if there was no magazine)

This is issue, because when round starts, every gun will spawn a bullet on floor when used as mentioned here https://github.com/space-wizards/space-station-14/issues/19176.
Also there's no scenario where player would want to eject round by closing bolt, and rounds should eject only when bolt opens anyway