### PR TITLE
Disable reflection on reflective vest

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -97,7 +97,7 @@
 #  - type: Reflect 
 #    reflectProb: 1
 #    reflects:
-#    - energy # definign this doesn't seem to work, the vest just reflects everything, despite showing correctly in VV
+#    - energy # defining this doesn't seem to work, the vest just reflects everything, despite showing correctly in VV
 
 - type: entity
   parent: ClothingOuterBaseLarge

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -94,8 +94,10 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.4 # this technically means it protects against fires pretty well? -heat is just for lasers and stuff, not atmos temperature
-  - type: Reflect
-    reflectProb: 1
+#  - type: Reflect 
+#    reflectProb: 1
+#    reflects:
+#    - energy # definign this doesn't seem to work, the vest just reflects everything, despite showing correctly in VV
 
 - type: entity
   parent: ClothingOuterBaseLarge


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Currently bugged, reflects all forms of projectiles which just causes it to be immune to ranged weapons.
The reflection chance _can_ be lowered but the vest is still not intended to be reflecting nonenergy projectiles-

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: Whisper
- remove: Removed reflection from reflective vest, as there's a reflection bug where projectile types aren't being differentiated.
