### PR TITLE
Fix CentCom official costume issues

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -147,6 +147,7 @@
   id: ClothingBackpackDuffelSyndicateCostumeCentcom
   name: CentCom official costume duffel bag
   description: "Contains a full CentCom Official uniform set, headset and clipboard included. Encryption keys and ID access are not included."
+  suffix: DO NOT MAP
   components:
   - type: Tag
     tags: [] # ignore "WhitelistChameleon" tag

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -146,22 +146,22 @@
   parent: ClothingBackpackDuffel
   id: ClothingBackpackDuffelSyndicateCostumeCentcom
   name: CentCom official costume duffel bag
-  description: "Contains a full CentCom Official uniform set, headset and clipboard included. The headset comes without an encryption key."
+  description: "Contains a full CentCom Official uniform set, headset and clipboard included. Encryption keys and ID access are not included."
   components:
   - type: Tag
     tags: [] # ignore "WhitelistChameleon" tag
   - type: StorageFill
     contents:
-      - id: ClothingHeadHatCaptain
+      - id: ClothingHeadHatCentcom
       - id: ClothingEyesGlassesSunglasses
       - id: ClothingUniformJumpsuitCentcomOfficial
       - id: ClothingShoesBootsJack
       - id: ClothingHandsGlovesColorGray
-      - id: ClothingHeadsetService
+      - id: ClothingHeadsetCentComFake
       - id: ClothingOuterArmorBasic
       - id: Paper
-      - id: Pen
-      - id: CentcomPDA
+      - id: PenCentcom
+      - id: CentcomPDAFake
 
 - type: entity
   parent: ClothingBackpackDuffelClown

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -161,7 +161,7 @@
       - id: ClothingHeadsetAltCentComFake
       - id: ClothingOuterArmorBasic
       - id: Paper
-      - id: PenCentcom
+      - id: Pen
       - id: CentcomPDAFake
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -157,8 +157,8 @@
       - id: ClothingEyesGlassesSunglasses
       - id: ClothingUniformJumpsuitCentcomOfficial
       - id: ClothingShoesBootsJack
-      - id: ClothingHandsGlovesColorGray
-      - id: ClothingHeadsetCentComFake
+      - id: ClothingHandsGlovesColorBlack
+      - id: ClothingHeadsetAltCentComFake
       - id: ClothingOuterArmorBasic
       - id: Paper
       - id: PenCentcom

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -87,6 +87,16 @@
     sprite: Clothing/Ears/Headsets/centcom.rsi
 
 - type: entity
+  parent: ClothingHeadsetCentCom
+  id: ClothingHeadsetCentComFake
+  suffix: Fake
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+
+- type: entity
   parent: ClothingHeadset
   id: ClothingHeadsetCommand
   name: command headset

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -87,16 +87,6 @@
     sprite: Clothing/Ears/Headsets/centcom.rsi
 
 - type: entity
-  parent: ClothingHeadsetCentCom
-  id: ClothingHeadsetCentComFake
-  suffix: Fake
-  components:
-  - type: ContainerFill
-    containers:
-      key_slots:
-      - EncryptionKeyCommon
-
-- type: entity
   parent: ClothingHeadset
   id: ClothingHeadsetCommand
   name: command headset

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -42,6 +42,16 @@
     sprite: Clothing/Ears/Headsets/centcom.rsi
 
 - type: entity
+  parent: ClothingHeadsetAltCentCom
+  id: ClothingHeadsetAltCentComFake
+  suffix: Fake
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+
+- type: entity
   parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltCommand
   name: command over-ear headset


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes an issue where the CentCom official costume had a real AA ID card. Also changes some other items (like headset and hat) to be CentCom themed.
Should I add it to the uplink or would that be a separate PR?

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/44417085/80ebaa73-7abc-4b40-ad76-bd0044a6c2bc)
![image](https://github.com/space-wizards/space-station-14/assets/44417085/5e67169f-19af-45dd-aa46-19ad514e4ac3)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: crazybrain
- fix: CentCom official costume no longer has AA.
- tweak: CentCom official costume items are more CentCom themed.