### PR TITLE
RichTextLabelExt update

### DIFF
--- a/Content.Client/Message/RichTextLabelExt.cs
+++ b/Content.Client/Message/RichTextLabelExt.cs
@@ -1,13 +1,13 @@
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Utility;
 
-namespace Content.Client.Message
+namespace Content.Client.Message;
+
+public static class RichTextLabelExt
 {
-    public static class RichTextLabelExt
-    {
-        public static void SetMarkup(this RichTextLabel label, string markup)
-        {
-            label.SetMessage(FormattedMessage.FromMarkup(markup));
-        }
-    }
+	public static RichTextLabel SetMarkup(this RichTextLabel label, string markup)
+	{
+		label.SetMessage(FormattedMessage.FromMarkup(markup));
+		return label;
+	}
 }

--- a/Content.Client/Message/RichTextLabelExt.cs
+++ b/Content.Client/Message/RichTextLabelExt.cs
@@ -5,9 +5,9 @@ namespace Content.Client.Message;
 
 public static class RichTextLabelExt
 {
-	public static RichTextLabel SetMarkup(this RichTextLabel label, string markup)
-	{
-		label.SetMessage(FormattedMessage.FromMarkup(markup));
-		return label;
+    public static RichTextLabel SetMarkup(this RichTextLabel label, string markup)
+    {
+        label.SetMessage(FormattedMessage.FromMarkup(markup));
+        return label;
 	}
 }

--- a/Content.Client/Message/RichTextLabelExt.cs
+++ b/Content.Client/Message/RichTextLabelExt.cs
@@ -9,5 +9,5 @@ public static class RichTextLabelExt
     {
         label.SetMessage(FormattedMessage.FromMarkup(markup));
         return label;
-	}
+    }
 }


### PR DESCRIPTION
Small updates to `RichTextLabelExt`
- The file uses a file scoped namespace
- `SetMarkup` is a chain method now