### PR TITLE
Remove preprocessor flags for NPC logs

### DIFF
--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -95,12 +95,6 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
         _xformQuery = GetEntityQuery<TransformComponent>();
 
-#if DEBUG
-        Log.Level = LogLevel.Warning;
-#else
-        Log.Level = LogLevel.Debug;
-#endif
-
         for (var i = 0; i < InterestDirections; i++)
         {
             Directions[i] = new Angle(InterestRadians * i).ToVec();


### PR DESCRIPTION
AKA remove the debug spam when they try pathfind out of crates.