### PR TITLE
Pump action and bolt action guns now need to be cycled after firing again

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -26,7 +26,7 @@ public sealed partial class GunSystem
             return;
 
         //if the gun isn't cycled (so it being cycled right now) then don't bother ejecting ammo
-        if (!component.Cycled)
+        if (!component.IsCycled)
             return;
 
         EntityUid? ent = null;

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -25,6 +25,10 @@ public sealed partial class GunSystem
         if (!Timing.IsFirstTimePredicted)
             return;
 
+        //if the gun isn't cycled (so it being cycled right now) then don't bother ejecting ammo
+        if (!component.Cycled)
+            return;
+
         EntityUid? ent = null;
 
         // TODO: Combine with TakeAmmo

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -11,7 +11,7 @@ public sealed partial class GunSystem
         EntityUid? ent = null;
 
         //if the gun isn't cycled (so it being cycled right now) then don't bother ejecting ammo
-        if (!component.Cycled)
+        if (!component.IsCycled)
             return;
 
         // TODO: Combine with TakeAmmo

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -10,6 +10,10 @@ public sealed partial class GunSystem
     {
         EntityUid? ent = null;
 
+        //if the gun isn't cycled (so it being cycled right now) then don't bother ejecting ammo
+        if (!component.Cycled)
+            return;
+
         // TODO: Combine with TakeAmmo
         if (component.Entities.Count > 0)
         {

--- a/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
@@ -49,6 +49,22 @@ public sealed partial class BallisticAmmoProviderComponent : Component
     public bool Cycleable = true;
 
     /// <summary>
+    /// Is the firearm currently cycled?
+    /// It cannot fire if is it not cycled.
+    /// Must be manually cycled if it is not cycled.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("cycled")]
+    [AutoNetworkedField]
+    public bool Cycled = true;
+
+    /// <summary>
+    /// Automatically cycles the firearm after firing a round
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("autoCycle")]
+    [AutoNetworkedField]
+    public bool AutoCycle = true;
+
+    /// <summary>
     /// Is it okay for this entity to directly transfer its valid ammunition into another provider?
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("mayTransfer")]

--- a/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
@@ -55,7 +55,9 @@ public sealed partial class BallisticAmmoProviderComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("cycled")]
     [AutoNetworkedField]
-    public bool Cycled = true;
+    public bool? Cycled = true;
+
+    public bool IsCycled => Cycled == true || Cycled == null;
 
     /// <summary>
     /// Automatically cycles the firearm after firing a round

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -211,7 +211,7 @@ public abstract partial class SharedGunSystem
     private void OnBallisticTakeAmmo(EntityUid uid, BallisticAmmoProviderComponent component, TakeAmmoEvent args)
     {
         //give up loading if the gun isn't cycled
-        if (!component.Cycled)
+        if (!component.IsCycled)
             return;
 
         for (var i = 0; i < args.Shots; i++)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -172,6 +172,8 @@ public abstract partial class SharedGunSystem
         var shots = GetBallisticShots(component);
         Cycle(uid, component, coordinates);
 
+        component.Cycled = true;
+
         var text = Loc.GetString(shots == 0 ? "gun-ballistic-cycled-empty" : "gun-ballistic-cycled");
 
         Popup(text, uid, user);
@@ -208,6 +210,10 @@ public abstract partial class SharedGunSystem
 
     private void OnBallisticTakeAmmo(EntityUid uid, BallisticAmmoProviderComponent component, TakeAmmoEvent args)
     {
+        //give up loading if the gun isn't cycled
+        if (!component.Cycled)
+            return;
+
         for (var i = 0; i < args.Shots; i++)
         {
             EntityUid entity;
@@ -227,6 +233,10 @@ public abstract partial class SharedGunSystem
                 args.Ammo.Add((entity, EnsureComp<AmmoComponent>(entity)));
             }
         }
+
+        //un-cycle the firearm
+        if (!component.AutoCycle)
+            component.Cycled = false;
 
         UpdateBallisticAppearance(uid, component);
         Dirty(uid, component);

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -45,6 +45,7 @@
     whitelist:
       tags:
         - Grenade
+    autoCycle: false
     capacity: 3
     proto: GrenadeFrag
     soundInsert:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -32,6 +32,7 @@
     whitelist:
       tags:
       - ShellShotgun
+    autoCycle: false
     capacity: 7
     proto: ShellShotgun
     soundInsert:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -112,6 +112,7 @@
     fireRate: 2
   - type: BallisticAmmoProvider
     capacity: 2
+    autoCycle: true
   - type: Construction
     graph: ShotgunSawn
     node: start
@@ -125,6 +126,7 @@
   suffix: Non-Lethal
   components:
   - type: BallisticAmmoProvider
+    autoCycle: true
     proto: ShellShotgunBeanbag
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -25,6 +25,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
   - type: BallisticAmmoProvider
+    autoCycle: false
     capacity: 10
     proto: CartridgeLightRifle
     whitelist:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixes issue #19250, where certain guns that should need to be cycled after firing do not need to be. This has occurred as a result of #17219, which removed the Cycled and AutoCycle from BallisticAmmoProviderComponent.cs, and the accompanying code in the relevant systems. This pr adds them back, and sets the correct values in the yaml.

## Why / Balance
These guns are intended to be cycled, and a bug prevented that from being the case.

## Technical details
* Added Cycled and AutoCycle fields to the BallisticsAmmoProviderComponent.cs.
* Altered OnBallisticTakeAmmo method from SharedGunSystem.Ballistic.cs to return early if the BallisticsAmmoProviderComponent is not cycled. This makes it so you cannot fire the gun if it is not cycled.
* Altered OnBallisticTakeAmmo method from SharedGunSystem.Ballistic.cs to set Cycled to false when the gun is fired if AutoCycle is false. This makes it so that pump action or bolt action guns will not be cycled after firing, and will have to be cycled manually to fire (the whole point of this pr).
* Made it so ammo is not ejected from the gun if a manual cycle has cycled the gun. Otherwise you would fire a shotgun, then cycle it so you can fire again, and (unexpectedly) eject ammo from the gun.
This functionality mimics what existed before #17219. 

### Guns Altered ###
* The China Lake
* Kardashev-Mosin
* Hristov
* Musket
* Flintlock Pistol
* ~~Double-Barrelled Shotgun~~ (reverted, can now fire both shots without needing to be cycled)
* Enforcer
* Kammerer
* Sawn-Off Shotgun
* Handmade Pistol
* Blunderbuss
* Improvised Shotgun

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Certain guns (shotguns, launchers, snipers) now need to be cycled after firing again.
