### PR TITLE
map atmosphere reactions

### DIFF
--- a/Content.Server/Atmos/Components/MapAtmosphereComponent.cs
+++ b/Content.Server/Atmos/Components/MapAtmosphereComponent.cs
@@ -20,4 +20,16 @@ public sealed class MapAtmosphereComponent : SharedMapAtmosphereComponent
     /// </summary>
     [DataField("space"), ViewVariables(VVAccess.ReadWrite)]
     public bool Space = true;
+
+    /// <summary>
+    ///     Whether reactions take place, e.g. plasma fires.
+    /// </summary>
+    [DataField("simulated"), ViewVariables(VVAccess.ReadWrite)]
+    public bool Simulated;
+
+    /// <summary>
+    ///     Seconds since last atmos update.
+    /// </summary>
+    [ViewVariables]
+    public float Timer;
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Map.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Map.cs
@@ -72,10 +72,19 @@ public partial class AtmosphereSystem
 
     public void SetMapSpace(EntityUid uid, bool space, MapAtmosphereComponent? component = null)
     {
-        if (!Resolve(uid, ref component))
+        if (!Resolve(uid, ref component) || component.Space == space)
             return;
 
         component.Space = space;
+        Dirty(component);
+    }
+
+    public void SetMapSimulated(EntityUid uid, bool simulated, MapAtmosphereComponent? component = null)
+    {
+        if (!Resolve(uid, ref component) || component.Simulated == simulated)
+            return;
+
+        component.Simulated = simulated;
         Dirty(component);
     }
 }

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -111,12 +111,14 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
             var moles = new float[Atmospherics.AdjustedNumberOfGases];
             air.Gases.CopyTo(moles, 0);
             var atmos = _entManager.EnsureComponent<MapAtmosphereComponent>(mapUid);
-            _entManager.System<AtmosphereSystem>().SetMapSpace(mapUid, air.Space, atmos);
-            _entManager.System<AtmosphereSystem>().SetMapGasMixture(mapUid, new GasMixture(2500)
+            var atmosphere = _entManager.System<AtmosphereSystem>();
+            atmosphere.SetMapSpace(mapUid, air.Space, atmos);
+            atmosphere.SetMapGasMixture(mapUid, new GasMixture(2500)
             {
                 Temperature = mission.Temperature,
                 Moles = moles,
             }, atmos);
+            atmosphere.SetMapSimulated(mapUid, true, atmos);
 
             if (mission.Color != null)
             {

--- a/Resources/Prototypes/Procedural/salvage_mods.yml
+++ b/Resources/Prototypes/Procedural/salvage_mods.yml
@@ -28,9 +28,6 @@
 #  weather: false
 #  biome: null
 
-# Temperature mods -> not required
-# Also whitelist it
-
 # Weather mods -> not required
 - type: salvageWeatherMod
   id: SnowfallHeavy


### PR DESCRIPTION
## About the PR
adds support for running reactions on planets, fire and maybe in the future fusion if you made a tritium planet
only enabled for exped planets currently since theres no other way to have plasma atmosphere planet

## Why / Balance
volatile atmosphere + high temp being a fire planet makes sense, requires atmosias help or sending in a borg or something to safely do stuff

## Technical details
- bad
- doesnt update the planets gas visuals so you cant actually see that its on fire
- it doesnt light people on fire since thats a tile thing, would probably require copypasting a lot of stuff
- dont know how to query all entities on a map but not on a shuttle grid

## Media

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!