### PR TITLE
Buff debug generator

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
@@ -3,6 +3,10 @@
   parent: BaseGenerator
   suffix: DEBUG
   components:
+  - type: PowerSupplier
+    supplyRate: 300000
+    supplyRampRate: 50000
+    supplyRampTolerance: 500
   - type: Tag
     tags:
       - Debug


### PR DESCRIPTION
## About the PR
This makes the debug generator power a reasonable-sized station.

## Why / Balance
No balance changes, because this is a [DEBUG] prototype that should never be mapped. This makes it less annoying for developers testing the non-Dev map, so that they can put down a debug generator and power the station instead of setting up the AME or VV-ing the debug generator.

## Technical details
N/A

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A