### PR TITLE
Center reagent grinders

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -27,7 +27,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.08,-0.35,0.15,0.25"
+          bounds: "-0.17,0,0.20,0.4"
         mask:
         - TabletopMachineMask
         layer:
@@ -36,6 +36,7 @@
     sprite: Structures/Machines/juicer.rsi
     drawdepth: SmallObjects
     snapCardinals: true
+    offset: "0.0,0.4"
     layers:
     - map: [ "grinder" ]
       state: "juicer0"


### PR DESCRIPTION
## About the PR
Fixes the horrible positioning of reagent grinders.

## Why / Balance
Because it's much much better now.

## Technical details
n/a

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase
**Before**
![228649507-c9d6dcdc-5d81-4750-b455-fcbc282da781](https://github.com/space-wizards/space-station-14/assets/107660393/dcb67f30-15f4-4dda-aa4c-f790104fbba7)
**After**
![228649581-461eeb57-607a-4994-aa20-d08fcca7db97](https://github.com/space-wizards/space-station-14/assets/107660393/2acd313b-9788-4b7c-b17b-7bd275213f57)
![228649655-c7482123-e9a8-4d3d-92af-40bffd01fdba](https://github.com/space-wizards/space-station-14/assets/107660393/23d9e1cd-b9e9-4732-a9c1-48e9cddee97e)

## Breaking changes
n/a

**Changelog**
n/a