### PR TITLE
Make lights dim under low power

### DIFF
--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Ghost;
 using Content.Server.Light.Components;
 using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
 using Content.Server.Temperature.Components;
 using Content.Shared.Audio;
 using Content.Shared.Damage;
@@ -42,6 +43,7 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly PowerReceiverSystem _power = default!;
 
         private static readonly TimeSpan ThunkDelay = TimeSpan.FromSeconds(2);
         public const string LightBulbContainer = "light_bulb";
@@ -265,9 +267,10 @@ namespace Content.Server.Light.EntitySystems
             switch (lightBulb.State)
             {
                 case LightBulbState.Normal:
-                    if (powerReceiver.Powered && light.On)
+                    float factor = _power.SupplyFactor(uid, powerReceiver);
+                    if (factor > 0.3 && light.On)
                     {
-                        SetLight(uid, true, lightBulb.Color, light, lightBulb.LightRadius, lightBulb.LightEnergy, lightBulb.LightSoftness);
+                        SetLight(uid, true, lightBulb.Color, light, lightBulb.LightRadius*factor, lightBulb.LightEnergy*factor, lightBulb.LightSoftness);
                         _appearance.SetData(uid, PoweredLightVisuals.BulbState, PoweredLightState.On, appearance);
                         var time = _gameTiming.CurTime;
                         if (time > light.LastThunk + ThunkDelay)

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -51,6 +51,7 @@ namespace Content.Server.Power.Components
         }
 
         public bool? PoweredLastUpdate;
+        public float LastPowerReceived;
 
         [ViewVariables]
         public PowerState.Load NetworkLoad { get; } = new PowerState.Load

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -297,13 +297,14 @@ namespace Content.Server.Power.EntitySystems
             while (enumerator.MoveNext(out var uid, out var apcReceiver))
             {
                 var powered = apcReceiver.Powered;
-                if (powered == apcReceiver.PoweredLastUpdate)
+                if (apcReceiver.LastPowerReceived == apcReceiver.NetworkLoad.ReceivingPower)
                     continue;
 
                 if (metaQuery.GetComponent(uid).EntityPaused)
                     continue;
 
                 apcReceiver.PoweredLastUpdate = powered;
+                apcReceiver.LastPowerReceived = apcReceiver.NetworkLoad.ReceivingPower;
                 var ev = new PowerChangedEvent(apcReceiver.Powered, apcReceiver.NetworkLoad.ReceivingPower);
 
                 RaiseLocalEvent(apcReceiver.Owner, ref ev);

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -157,6 +157,25 @@ namespace Content.Server.Power.EntitySystems
         }
 
         /// <summary>
+        /// Return the fraction of the load power that is actually supplied to this receiver, e.g. 1
+        /// if full power and 0 if no power. Better at handling brownouts compared to IsPowered().
+        /// Handles always-powered devices correctly.
+        /// </summary>
+        public float SupplyFactor(EntityUid uid, ApcPowerReceiverComponent? receiver = null)
+        {
+            if (!Resolve(uid, ref receiver, false))
+                return 1f;
+
+            if (receiver.PowerDisabled)
+                return 0f;
+
+            if (!receiver.NeedsPower)
+                return 1f;
+
+            return receiver.NetworkLoad.ReceivingPower / receiver.Load;
+        }
+
+        /// <summary>
         /// Turn this machine on or off.
         /// Returns true if we turned it on, false if we turned it off.
         /// </summary>


### PR DESCRIPTION
## About the PR
Lights now dim instead of completely going dark in brown-out conditions.

## Why / Balance
- Pow3r (nominally) supports giving devices less power than they request, so we might as well teach some devices how to use it
- Prevents lights from going from 100% to 0% repeatedly in low-power conditions
- "it would just look way cooler": https://discord.com/channels/310555209753690112/310555209753690112/1142573292293718066

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Adds a `SupplyFactor()` method to PowerReceiverSystem which returns a number between 0-1 representing the fraction of the desired load that the receiver is actually receiving. Correctly handles devices that do not receive power.
- Changes the PoweredLightSystem to use this new factor in computing the light output.

Currently, a PowerChangedEvent is only raised when the powered state changes. In other words, if the power arriving at a device changes, but that would not make it "Powered" (i.e. supply enough power to meet 100% of the demand), no new event is raised. This breaks lights, because despite it being under-powered there should still be a change in light intensity if the power supply changes. This PR also changes the event to be fired if the actual supply changes.

## Media

https://github.com/space-wizards/space-station-14/assets/3229565/ef976c5e-8e2d-439e-9fe1-fac0bc126815

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
N/A