### PR TITLE
Restore Miros player cap and tick rate

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/miros.toml
+++ b/Resources/ConfigPresets/WizardsDen/miros.toml
@@ -2,10 +2,6 @@
 
 [game]
 hostname = "[EN] Wizard's Den Miros [EU West 2]"
-soft_max_players = 50
-
-[net]
-tickrate = 20
 
 [hub]
 tags = "lang:en,region:eu_w,rp:low"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Restores Miros to normal player cap and tick rate.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
New hardware. This will not affect balance because no one plays on the server. No players will be impacted.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
We took Miros and pushed it somewhere else. That somewhere else is a healthier environment for Miros. A place where it can breathe, grow, and thrive. A place where it can accommodate more players, run faster, and be more stable. A place where it can unleash its full potential.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase