### PR TITLE
send popup message to chat

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -1,4 +1,6 @@
 using System.Linq;
+using Content.Client.Chat.Managers;
+using Content.Shared.Chat;
 using Content.Shared.GameTicking;
 using Content.Shared.Popups;
 using Robust.Client.Graphics;
@@ -19,6 +21,7 @@ namespace Content.Client.Popups
 {
     public sealed class PopupSystem : SharedPopupSystem
     {
+        [Dependency] private readonly IChatManager _chatManager = default!;
         [Dependency] private readonly IConfigurationManager _configManager = default!;
         [Dependency] private readonly IInputManager _inputManager = default!;
         [Dependency] private readonly IOverlayManager _overlay = default!;
@@ -73,6 +76,7 @@ namespace Content.Client.Popups
             };
 
             _aliveWorldLabels.Add(label);
+            _chatManager.SendMessage($"notice {message}", ChatSelectChannel.Console);
         }
 
         #region Abstract Method Implementations

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -498,6 +498,7 @@ public sealed class ChatUIController : UIController
             FilterableChannels |= ChatChannel.Whisper;
             FilterableChannels |= ChatChannel.Radio;
             FilterableChannels |= ChatChannel.Emotes;
+            FilterableChannels |= ChatChannel.Visual;
 
             // Can only send local / radio / emote when attached to a non-ghost entity.
             // TODO: this logic is iffy (checking if controlling something that's NOT a ghost), is there a better way to check this?

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -9,6 +9,12 @@ namespace Content.Client.UserInterface.Systems.Chat.Controls;
 [GenerateTypedNameReferences]
 public sealed partial class ChannelFilterPopup : Popup
 {
+    // Channels that are disabled by default.
+    private static readonly ChatChannel[] ChannelFilterDisabledByDefault =
+    {
+        ChatChannel.Visual
+    };
+
     // order in which the available channel filters show up when available
     private static readonly ChatChannel[] ChannelFilterOrder =
     {
@@ -66,7 +72,7 @@ public sealed partial class ChannelFilterPopup : Popup
                 checkbox = new ChannelFilterCheckbox(channel);
                 _filterStates.Add(channel, checkbox);
                 checkbox.OnPressed += CheckboxPressed;
-                checkbox.Pressed = true;
+                checkbox.Pressed = Array.IndexOf(ChannelFilterDisabledByDefault, channel) == -1;
             }
 
             if ((channels & channel) == 0)

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class ChannelFilterPopup : Popup
         ChatChannel.Local,
         ChatChannel.Whisper,
         ChatChannel.Emotes,
+        ChatChannel.Visual,
         ChatChannel.Radio,
         ChatChannel.LOOC,
         ChatChannel.OOC,

--- a/Content.Server/Chat/Commands/NoticeCommand.cs
+++ b/Content.Server/Chat/Commands/NoticeCommand.cs
@@ -5,40 +5,41 @@ using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;
 
-namespace Content.Server.Chat.Commands
+namespace Content.Server.Chat.Commands;
+
+[AnyCommand]
+internal sealed class NoticeCommand : IConsoleCommand
 {
-    [AnyCommand]
-    internal sealed class NoticeCommand : IConsoleCommand
+    [Dependency] private readonly IChatManager _chatManager = default!;
+
+    public string Command => "notice";
+    public string Description => Loc.GetString("notice-command-description");
+    public string Help => Loc.GetString("notice-command-help", ("command", Command));
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        public string Command => "notice";
-        public string Description => "Send a chat message to self.";
-        public string Help => "notice <text>";
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (shell.Player is not IPlayerSession player)
         {
-            if (shell.Player is not IPlayerSession player)
-            {
-                shell.WriteError("This command cannot be run from the server.");
-                return;
-            }
-
-            if (player.Status != SessionStatus.InGame)
-                return;
-
-            if (player.AttachedEntity is not { } playerEntity)
-            {
-                shell.WriteError("You don't have an entity!");
-                return;
-            }
-
-            if (args.Length < 1)
-                return;
-
-            var message = string.Join(" ", args).Trim();
-            if (string.IsNullOrEmpty(message))
-                return;
-
-            IoCManager.Resolve<IChatManager>().ChatMessageToOne(ChatChannel.Visual, message, message, EntityUid.Invalid, false, player.ConnectedClient, recordReplay: false);
+            shell.WriteError("This command cannot be run from the server.");
+            return;
         }
+
+        if (player.Status != SessionStatus.InGame)
+            return;
+
+        if (player.AttachedEntity is not { })
+        {
+            shell.WriteError("You don't have an entity!");
+            return;
+        }
+
+        if (args.Length < 1)
+            return;
+
+        var message = string.Join(" ", args).Trim();
+        if (string.IsNullOrEmpty(message))
+            return;
+
+        _chatManager.ChatMessageToOne(ChatChannel.Visual, message, message, EntityUid.Invalid, false, player.ConnectedClient, recordReplay: false);
     }
 }

--- a/Content.Server/Chat/Commands/NoticeCommand.cs
+++ b/Content.Server/Chat/Commands/NoticeCommand.cs
@@ -1,0 +1,44 @@
+using Content.Server.Chat.Managers;
+using Content.Shared.Administration;
+using Content.Shared.Chat;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Enums;
+
+namespace Content.Server.Chat.Commands
+{
+    [AnyCommand]
+    internal sealed class NoticeCommand : IConsoleCommand
+    {
+        public string Command => "notice";
+        public string Description => "Send a chat message to self.";
+        public string Help => "notice <text>";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (shell.Player is not IPlayerSession player)
+            {
+                shell.WriteError("This command cannot be run from the server.");
+                return;
+            }
+
+            if (player.Status != SessionStatus.InGame)
+                return;
+
+            if (player.AttachedEntity is not { } playerEntity)
+            {
+                shell.WriteError("You don't have an entity!");
+                return;
+            }
+
+            if (args.Length < 1)
+                return;
+
+            var message = string.Join(" ", args).Trim();
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            IoCManager.Resolve<IChatManager>().ChatMessageToOne(ChatChannel.Emotes, message, message, EntityUid.Invalid, false, player.ConnectedClient, recordReplay: false);
+        }
+    }
+}

--- a/Content.Server/Chat/Commands/NoticeCommand.cs
+++ b/Content.Server/Chat/Commands/NoticeCommand.cs
@@ -38,7 +38,7 @@ namespace Content.Server.Chat.Commands
             if (string.IsNullOrEmpty(message))
                 return;
 
-            IoCManager.Resolve<IChatManager>().ChatMessageToOne(ChatChannel.Emotes, message, message, EntityUid.Invalid, false, player.ConnectedClient, recordReplay: false);
+            IoCManager.Resolve<IChatManager>().ChatMessageToOne(ChatChannel.Visual, message, message, EntityUid.Invalid, false, player.ConnectedClient, recordReplay: false);
         }
     }
 }

--- a/Resources/Locale/en-US/administration/commands/notice-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/notice-command.ftl
@@ -1,0 +1,2 @@
+notice-command-description = Send a message to self in the Visual channel
+notice-command-help = Usage: {$command} <message>…


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

display popup messages in the chat

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

in accordance with the information redundancy principle from the accessibility guidelines:
<https://hackmd.io/PIF3dxZkRS27hIyJM58xLw#Text>

the popup itself still provides an animated alert in the play area, but can also be read later or grab the player's attention if they're looking away from the play area, _that is_ at the chat.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

adds a `notice` command that writes a client-side message to the `Visual` ('Actions') channel. `Visual` is filtered out by default.

originally I tried sending this only when the popup target was the player, but this excluded things like _burning your hand_ or _getting injected with a needle_ that seem important. rather than enforce or expect an important popup to always centre on the player character, this assumes that any popup is something intended to be read.

this PR is not concerned with the style or consistency of popup messages; only that they get duplicated to the chat.

yes, I see the deprecation warning on `IConsoleCommand`, but I don't know what to do with that information.
yes, this allows people to talk to themselves in the chat window. I don't know if that's good  or bad.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, ~~**or** this PR does not require an ingame showcase~~

![image](https://github.com/space-wizards/space-station-14/assets/73342011/6ec7e10e-8b76-4f15-b5a7-4f65aaab657a)

<details>
<summary>chat filter</summary>

![image](https://github.com/space-wizards/space-station-14/assets/73342011/3cceabae-8726-4cc3-8435-790b27019526)

</details>

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
n/a

## Changelog
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl?