### PR TITLE
Cheaper medkit crates

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/medical-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/medical-crates.ftl
@@ -13,22 +13,22 @@ ent-CrateMedicalScrubs = Medical scrubs crate
     .desc = Medical clothings.
 
 ent-CrateEmergencyBurnKit = Emergency burn kit
-    .desc = Crate filled with a burn treatment kits
+    .desc = Crate filled with a burn treatment kit
 
 ent-CrateEmergencyToxinKit = Emergency toxin kit
-    .desc = Crate filled with a toxin treatment kits
+    .desc = Crate filled with a toxin treatment kit
 
 ent-CrateEmergencyO2Kit = Emergency O2 kit
-    .desc = Crate filled with a O2 treatment kits
+    .desc = Crate filled with an O2 treatment kit
 
 ent-CrateEmergencyBruteKit = Emergency brute kit
-    .desc = Crate filled with a brute treatment kits
+    .desc = Crate filled with a brute treatment kit
 
 ent-CrateEmergencyAdvancedKit = Emergency advanced kit
-    .desc = Crate filled with a advanced treatment kits
+    .desc = Crate filled with an advanced treatment kit
 
 ent-CrateEmergencyRadiationKit = Emergency radiation kit
-    .desc = Crate filled with a radiation treatment kits
+    .desc = Crate filled with a radiation treatment kit
 
 ent-CrateBodyBags = Body bags crate
     .desc = Contains ten body bags.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/medical-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/medical-crates.ftl
@@ -13,25 +13,25 @@ ent-CrateMedicalScrubs = Medical scrubs crate
     .desc = Medical clothings.
 
 ent-CrateEmergencyBurnKit = Emergency burn kit
-    .desc = Crate filled with four burn treatment kits 
+    .desc = Crate filled with a burn treatment kits
 
 ent-CrateEmergencyToxinKit = Emergency toxin kit
-    .desc = Crate filled with four toxin treatment kits
+    .desc = Crate filled with a toxin treatment kits
 
 ent-CrateEmergencyO2Kit = Emergency O2 kit
-    .desc = Crate filled with four O2 treatment kits
+    .desc = Crate filled with a O2 treatment kits
 
 ent-CrateEmergencyBruteKit = Emergency brute kit
-    .desc = Crate filled with four brute treatment kits
+    .desc = Crate filled with a brute treatment kits
 
 ent-CrateEmergencyAdvancedKit = Emergency advanced kit
-    .desc = Crate filled with four advanced treatment kits
+    .desc = Crate filled with a advanced treatment kits
 
 ent-CrateEmergencyRadiationKit = Emergency radiation kit
-    .desc = Crate filled with four radiation treatment kits
+    .desc = Crate filled with a radiation treatment kits
 
 ent-CrateBodyBags = Body bags crate
     .desc = Contains ten body bags.
-    
+
 ent-CrateVirologyBiosuit = Virology bio suit crate
     .desc = Contains 2 biohazard suits to ensure that no disease will distract you from treating the crew. Requires Medical access to open.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -24,7 +24,7 @@
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: burnkit
   product: CrateEmergencyBurnKit
-  cost: 2100
+  cost: 600
   category: Medical
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: toxinkit
   product: CrateEmergencyToxinKit
-  cost: 700
+  cost: 600
   category: Medical
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: o2kit
   product: CrateEmergencyO2Kit
-  cost: 1100
+  cost: 600
   category: Medical
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: brutekit
   product: CrateEmergencyBruteKit
-  cost: 3600
+  cost: 600
   category: Medical
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: advkit
   product: CrateEmergencyAdvancedKit
-  cost: 3700
+  cost: 1200
   category: Medical
   group: market
 
@@ -74,7 +74,7 @@
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: radkit
   product: CrateEmergencyRadiationKit
-  cost: 2500
+  cost: 600
   category: Medical
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -63,8 +63,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: MedkitBurnFilled
-        amount: 4
+    - id: MedkitBurnFilled
 
 - type: entity
   id: CrateEmergencyToxinKit
@@ -72,8 +71,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: MedkitToxinFilled
-        amount: 4
+    - id: MedkitToxinFilled
 
 - type: entity
   id: CrateEmergencyO2Kit
@@ -81,8 +79,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: MedkitOxygenFilled
-        amount: 4
+    - id: MedkitOxygenFilled
 
 - type: entity
   id: CrateEmergencyBruteKit
@@ -90,8 +87,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: MedkitBruteFilled
-        amount: 4
+    - id: MedkitBruteFilled
 
 - type: entity
   id: CrateEmergencyAdvancedKit
@@ -99,8 +95,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: MedkitAdvancedFilled
-        amount: 4
+    - id: MedkitAdvancedFilled
 
 - type: entity
   id: CrateEmergencyRadiationKit
@@ -108,8 +103,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: MedkitRadiationFilled
-        amount: 4
+    - id: MedkitRadiationFilled
 
 - type: entity
   id: CrateBodyBags

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -37,7 +37,7 @@
   - type: StorageFill
     contents:
       - id: MedicatedSuture
-        amount: 2
+      - id: Brutepack
       - id: Gauze
       - id: Bloodpack
       - id: SyringeTranexamicAcid


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
most of the crates were like several thousand spesos and gave like 4 kits. I thought it made more sense to make them cheaper but only have one kit per.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This better incentivizes ordering single crates as they're actually at a price range where it'd be reasonable.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
yaml

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: All of the emergency medkit cargo crates now only give a single kit but are cheaper in return.