### PR TITLE
radiator overshooting fix

### DIFF
--- a/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
@@ -57,19 +57,14 @@ public sealed class HeatExchangerSystem : EntitySystem
         var dt = args.dt;
         var dP = inlet.Air.Pressure - outlet.Air.Pressure;
 
+        // Approximation of how much the difference in pressure between the gases changes (designated ΔΔP) per mole transferred:
+        // ΔPV = ΔnRT; ΔP/Δn = RT/V; this is for one gas, ΔP being the change in its own pressure.
+        // For 2 gases (designated i and o): ΔΔP/Δn = (ΔPi - ΔPo)/Δn = (ΔnRTo/Vo - (-Δn)RTi/Vi)/Δn = R(To/Vo + Ti/Vi)
+        float dPdivdN = Atmospherics.R * (outlet.Air.Temperature / outlet.Air.Volume + inlet.Air.Temperature / inlet.Air.Volume);
         // What we want is dN/dt = G*dP (first-order constant-coefficient differential equation w.r.t. P).
-        // However, by approximating dN = G*dP*dt using Forward Euler dN can be larger than all of the gas
-        // available for sufficiently large dP. However, we know that dN cannot exceed:
-        //
-        //   dNMax = (n2T2/V2 - n1T1/V1)/(T2/V1 + T2/V2) = Δp/R/T2/(1/V1 + 1/V2)
-        //
-        // Because that is the amount of gas that needs to be transferred to equalize pressures [citation needed].
-        // So we just limit abs(dN) < abs(dNMax).
-        //
-        // Also, by factoring out dP we can avoid taking any abs().
-        // transferLimit below is equal to dNMax/dP
-        var transferLimit = 1/Atmospherics.R/outlet.Air.Temperature/(1/inlet.Air.Volume + 1/outlet.Air.Volume);
-        var dN = dP*Math.Min(comp.G*dt, transferLimit);
+        // This is done here via integrating ΔP' = kΔP, where k = -G * ΔΔP/Δn below.
+        float dP2 = dP * MathF.Exp(-comp.G * dPdivdN * dt);
+        float dN = (dP - dP2) / dPdivdN;
 
         GasMixture xfer;
         if (dN > 0)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- radiators in an environment will no longer void heat, radiated heat is transferred to/from the environment instead
- convection and radiation heat transfer are now properly solved with respect to time
(this means that radiators in an environment will no longer overshoot)
works properly according to several ingame tests

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
this means that radiators will properly try to equalise temperature of the environment and gas flowing through the radiator

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
uses math derived from partially random guesses to be properly able to find temperature in respect to time

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
N/A