### PR TITLE
stealth clothing

### DIFF
--- a/Content.Shared/Actions/ActionEvents.cs
+++ b/Content.Shared/Actions/ActionEvents.cs
@@ -21,6 +21,11 @@ public sealed class GetItemActionsEvent : EntityEventArgs
     public SortedSet<ActionType> Actions = new();
 
     /// <summary>
+    /// User equipping the item.
+    /// </summary>
+    public EntityUid User;
+
+    /// <summary>
     ///     Slot flags for the inventory slot that this item got equipped to. Null if not in a slot (i.e., if equipped to hands).
     /// </summary>
     public SlotFlags? SlotFlags;
@@ -30,8 +35,9 @@ public sealed class GetItemActionsEvent : EntityEventArgs
     /// </summary>
     public bool InHands => SlotFlags == null;
 
-    public GetItemActionsEvent(SlotFlags? slotFlags = null)
+    public GetItemActionsEvent(EntityUid user, SlotFlags? slotFlags = null)
     {
+        User = user;
         SlotFlags = slotFlags;
     }
 }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -410,7 +410,7 @@ public abstract class SharedActionsSystem : EntitySystem
     #region EquipHandlers
     private void OnDidEquip(EntityUid uid, ActionsComponent component, DidEquipEvent args)
     {
-        var ev = new GetItemActionsEvent(args.SlotFlags);
+        var ev = new GetItemActionsEvent(args.Equipee, args.SlotFlags);
         RaiseLocalEvent(args.Equipment, ev);
 
         if (ev.Actions.Count == 0)
@@ -421,7 +421,7 @@ public abstract class SharedActionsSystem : EntitySystem
 
     private void OnHandEquipped(EntityUid uid, ActionsComponent component, DidEquipHandEvent args)
     {
-        var ev = new GetItemActionsEvent();
+        var ev = new GetItemActionsEvent(args.User);
         RaiseLocalEvent(args.Equipped, ev);
 
         if (ev.Actions.Count == 0)

--- a/Content.Shared/Clothing/Components/StealthClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/StealthClothingComponent.cs
@@ -38,6 +38,6 @@ public sealed partial class StealthClothingComponent : Component
 /// When it is disabled, raises <see cref="AttemptStealthEvent"/> before enabling.
 /// Put any checks in a handler for that event to cancel it.
 /// </summary>
-public sealed class ToggleStealthEvent : InstantActionEvent
+public sealed partial class ToggleStealthEvent : InstantActionEvent
 {
 }

--- a/Content.Shared/Clothing/Components/StealthClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/StealthClothingComponent.cs
@@ -1,0 +1,43 @@
+using Content.Shared.Actions;
+using Content.Shared.Actions.ActionTypes;
+using Content.Shared.Clothing.EntitySystems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing.Components;
+
+/// <summary>
+/// Adds StealthComponent to the user when enabled, either by an action or the system's SetEnabled method.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), Access(typeof(StealthClothingSystem))]
+public sealed partial class StealthClothingComponent : Component
+{
+    /// <summary>
+    /// Whether stealth effect is enabled.
+    /// </summary>
+    [ViewVariables, AutoNetworkedField]
+    public bool Enabled;
+
+    /// <summary>
+    /// Number added to MinVisibility when stealthed, to make the user not fully invisible.
+    /// </summary>
+    [DataField("visibility"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public float Visibility;
+
+    /// <summary>
+    /// The action for enabling and disabling stealth.
+    /// </summary>
+    [DataField("toggleAction")]
+    public InstantAction ToggleAction = new()
+    {
+        Event = new ToggleStealthEvent()
+    };
+}
+
+/// <summary>
+/// When stealth is enabled, disables it.
+/// When it is disabled, raises <see cref="EnableStealthEvent"/> before enabling.
+/// Put any checks in a handler for that event to cancel it.
+/// </summary>
+public sealed class ToggleStealthEvent : InstantActionEvent
+{
+}

--- a/Content.Shared/Clothing/Components/StealthClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/StealthClothingComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class StealthClothingComponent : Component
     /// <summary>
     /// Whether stealth effect is enabled.
     /// </summary>
-    [ViewVariables, AutoNetworkedField]
+    [DataField("enabled"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public bool Enabled;
 
     /// <summary>

--- a/Content.Shared/Clothing/Components/StealthClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/StealthClothingComponent.cs
@@ -35,7 +35,7 @@ public sealed partial class StealthClothingComponent : Component
 
 /// <summary>
 /// When stealth is enabled, disables it.
-/// When it is disabled, raises <see cref="EnableStealthEvent"/> before enabling.
+/// When it is disabled, raises <see cref="AttemptStealthEvent"/> before enabling.
 /// Put any checks in a handler for that event to cancel it.
 /// </summary>
 public sealed class ToggleStealthEvent : InstantActionEvent

--- a/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
@@ -33,6 +33,7 @@ public sealed class StealthClothingSystem : EntitySystem
         if (!Resolve(uid, ref comp) || comp.Enabled == enabled)
             return false;
 
+        // TODO remove this when clothing unequip on delete is less sus
         // prevent debug assert when ending round and its disabled
         if (MetaData(user).EntityLifeStage >= EntityLifeStage.Terminating)
             return false;

--- a/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
@@ -62,7 +62,7 @@ public sealed class StealthClothingSystem : EntitySystem
     }
 
     /// <summary>
-    /// Raises <see cref="EnableStealthEvent"/> if enabling.
+    /// Raises <see cref="AttemptStealthEvent"/> if enabling.
     /// </summary>
     private void OnToggleStealth(EntityUid uid, StealthClothingComponent comp, ToggleStealthEvent args)
     {
@@ -74,7 +74,7 @@ public sealed class StealthClothingSystem : EntitySystem
             return;
         }
 
-        var ev = new EnableStealthEvent(user);
+        var ev = new AttemptStealthEvent(user);
         RaiseLocalEvent(uid, ev);
         if (ev.Cancelled)
             return;
@@ -122,14 +122,14 @@ public class AddStealthActionEvent : CancellableEntityEventArgs
 /// <summary>
 /// Raised on the stealth clothing when the user is attemping to enable it.
 /// </summary>
-public class EnableStealthEvent : CancellableEntityEventArgs
+public class AttemptStealthEvent : CancellableEntityEventArgs
 {
     /// <summary>
     /// User that is attempting to enable the stealth clothing.
     /// </summary>
     public EntityUid User;
 
-    public EnableStealthEvent(EntityUid user)
+    public AttemptStealthEvent(EntityUid user)
     {
         User = user;
     }

--- a/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
@@ -1,0 +1,136 @@
+using Content.Shared.Actions;
+using Content.Shared.Clothing.Components;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Stealth;
+using Content.Shared.Stealth.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing.EntitySystems;
+
+/// <summary>
+/// Handles the toggle action and disables stealth when clothing is unequipped.
+/// </summary>
+public sealed class StealthClothingSystem : EntitySystem
+{
+    [Dependency] private readonly SharedStealthSystem _stealth = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StealthClothingComponent, GetItemActionsEvent>(OnGetItemActions);
+        SubscribeLocalEvent<StealthClothingComponent, ToggleStealthEvent>(OnToggleStealth);
+        SubscribeLocalEvent<StealthClothingComponent, AfterAutoHandleStateEvent>(OnHandleState);
+        SubscribeLocalEvent<StealthClothingComponent, GotUnequippedEvent>(OnUnequipped);
+    }
+
+    /// <summary>
+    /// Sets the clothing's stealth effect for the user.
+    /// </summary>
+    /// <returns>True if it was changed, false otherwise</returns>
+    public bool SetEnabled(EntityUid uid, EntityUid user, bool enabled, StealthClothingComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp) || comp.Enabled == enabled)
+            return false;
+
+        // prevent debug assert when ending round and its disabled
+        if (MetaData(user).EntityLifeStage >= EntityLifeStage.Terminating)
+            return false;
+
+        comp.Enabled = enabled;
+        Dirty(comp);
+
+        var stealth = EnsureComp<StealthComponent>(user);
+        // slightly visible, but doesn't change when moving so it's ok
+        var visibility = enabled ? stealth.MinVisibility + comp.Visibility : stealth.MaxVisibility;
+        _stealth.SetVisibility(user, visibility, stealth);
+        _stealth.SetEnabled(user, enabled, stealth);
+        return true;
+    }
+
+    /// <summary>
+    /// Raise <see cref="AddStealthActionEvent"/> then add the toggle action if it was not cancelled.
+    /// </summary>
+    private void OnGetItemActions(EntityUid uid, StealthClothingComponent comp, GetItemActionsEvent args)
+    {
+        var ev = new AddStealthActionEvent(args.User);
+        RaiseLocalEvent(uid, ev);
+        if (ev.Cancelled)
+            return;
+
+        args.Actions.Add(comp.ToggleAction);
+    }
+
+    /// <summary>
+    /// Raises <see cref="EnableStealthEvent"/> if enabling.
+    /// </summary>
+    private void OnToggleStealth(EntityUid uid, StealthClothingComponent comp, ToggleStealthEvent args)
+    {
+        args.Handled = true;
+        var user = args.Performer;
+        if (comp.Enabled)
+        {
+            SetEnabled(uid, user, false, comp);
+            return;
+        }
+
+        var ev = new EnableStealthEvent(user);
+        RaiseLocalEvent(uid, ev);
+        if (ev.Cancelled)
+            return;
+
+        SetEnabled(uid, user, true, comp);
+    }
+
+    /// <summary>
+    /// Calls <see cref="SetEnabled"/> when server sends new state.
+    /// </summary>
+    private void OnHandleState(EntityUid uid, StealthClothingComponent comp, ref AfterAutoHandleStateEvent args)
+    {
+        // SetEnabled checks if it is the same, so change it to before state was received from the server
+        var enabled = comp.Enabled;
+        comp.Enabled = !enabled;
+        var user = Transform(uid).ParentUid;
+        SetEnabled(uid, user, enabled, comp);
+    }
+
+    /// <summary>
+    /// Force unstealths the user, doesnt remove StealthComponent since other things might use it
+    /// </summary>
+    private void OnUnequipped(EntityUid uid, StealthClothingComponent comp, GotUnequippedEvent args)
+    {
+        SetEnabled(uid, args.Equipee, false, comp);
+    }
+}
+
+/// <summary>
+/// Raised on the stealth clothing when attempting to add an action.
+/// </summary>
+public class AddStealthActionEvent : CancellableEntityEventArgs
+{
+    /// <summary>
+    /// User that equipped the stealth clothing.
+    /// </summary>
+    public EntityUid User;
+
+    public AddStealthActionEvent(EntityUid user)
+    {
+        User = user;
+    }
+}
+
+/// <summary>
+/// Raised on the stealth clothing when the user is attemping to enable it.
+/// </summary>
+public class EnableStealthEvent : CancellableEntityEventArgs
+{
+    /// <summary>
+    /// User that is attempting to enable the stealth clothing.
+    /// </summary>
+    public EntityUid User;
+
+    public EnableStealthEvent(EntityUid user)
+    {
+        User = user;
+    }
+}

--- a/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
@@ -38,7 +38,7 @@ public sealed class StealthClothingSystem : EntitySystem
             return false;
 
         comp.Enabled = enabled;
-        Dirty(comp);
+        Dirty(uid, comp);
 
         var stealth = EnsureComp<StealthComponent>(user);
         // slightly visible, but doesn't change when moving so it's ok

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -106,7 +106,7 @@
     toggleAction:
       # have to plan (un)cloaking ahead of time
       useDelay: 5
-      displayName: action-name-toggle-phase-cloak
+      name: action-name-toggle-phase-cloak
       description: action-desc-toggle-phase-cloak
       priority: -9
       event: !type:ToggleStealthEvent

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -101,6 +101,20 @@
     sprite: Clothing/OuterClothing/Suits/spaceninja.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/spaceninja.rsi
+  - type: StealthClothing
+    visibility: 0.3
+    toggleAction:
+      # have to plan (un)cloaking ahead of time
+      useDelay: 5
+      displayName: action-name-toggle-phase-cloak
+      description: action-desc-toggle-phase-cloak
+      priority: -9
+      event: !type:ToggleStealthEvent
+  - type: PressureProtection
+    highPressureMultiplier: 0.6
+    lowPressureMultiplier: 1000
+  - type: TemperatureProtection
+    coefficient: 0.01
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
## About the PR
adds very basic version of phase cloak to ninja suit (which is currently admeme only)
anyone can enable it with the action, in ninja pr it is limited to ninja only as expected
stealthclothing handles everything except revealing when the user is attacked, which is handled by ninja
also added space/cold resistance to the suit since why not and it somehow conflicted

## Why / Balance
part of ninja refactoring

## Technical details
- adds `StealthClothing{Component,System}`
- events can be cancelled using `AddStealthActionEvent` and `EnableStealthEvent`, in ninjas case having NinjaComponent and having a seconds worth of suit power respectively
- added User field to GetItemActionsEvent to allow that

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/d048098c-900c-433c-9879-96f028d65579


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun