### PR TITLE
Cargo crate fixes

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-food.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-food.ftl
@@ -1,6 +1,9 @@
 ent-FoodPizza = { ent-CrateFoodPizza }
     .desc = { ent-CrateFoodPizza.desc }
 
+ent-FoodPizzaLarge = { ent-CrateFoodPizzaLarge }
+    .desc = { ent-CrateFoodPizzaLarge.desc }
+
 ent-FoodMRE = { ent-CrateFoodMRE }
     .desc = { ent-CrateFoodMRE.desc }
 
@@ -12,3 +15,9 @@ ent-FoodDinnerware = { ent-CrateFoodDinnerware }
 
 ent-FoodBarSupply = { ent-CrateFoodBarSupply }
     .desc = { ent-CrateFoodBarSupply.desc }
+
+ent-FoodSoftdrinks = { ent-CrateFoodSoftdrinks }
+    .desc = { ent-CrateFoodSoftdrinks.desc }
+
+ent-FoodSoftdrinksLarge = { ent-CrateFoodSoftdrinksLarge }
+    .desc = { ent-CrateFoodSoftdrinksLarge.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/food-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/food-crates.ftl
@@ -17,7 +17,7 @@ ent-CrateFoodBarSupply = Bartending supplies crate
     .desc = Extra Bar supplies, in case the clown was allowed in the bar unsupervised.
 
 ent-CrateFoodSoftdrinks = Softdrinks crate
-    .desc = A variety of sodas to complement a small party, without having to empty the soda machines.
+    .desc = A variety of sodas to complement a small party, without having to empty the soda machines. Includes 14 sodas.
 
 ent-CrateFoodSoftdrinksLarge = Softdrinks bulk crate
-    .desc = Lots of sodas taken straight out of Centcomm's own vending machines, because you just can't leave your department.
+    .desc = Lots of sodas taken straight out of Centcomm's own vending machines, because you just can't leave your department. Includes 28 sodas.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/food-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/food-crates.ftl
@@ -1,5 +1,8 @@
 ent-CrateFoodPizza = Emergency pizza delivery
-    .desc = Help do your part to end station hunger by distributing pizza to underfunded departments!
+    .desc = Help do your part to end station hunger by distributing pizza to underfunded departments! Includes 4 pizzas.
+
+ent-CrateFoodPizzaLarge = Disaster pizza delivery
+    .desc = In the ultimate event that all else has failed, Find comfort in that more pizza solves everything. Includes 16 pizzas.
 
 ent-CrateFoodMRE = MRE crate
     .desc = A military style meal fit to feed a whole department.
@@ -12,3 +15,9 @@ ent-CrateFoodDinnerware = Kitchen dinnerware crate
 
 ent-CrateFoodBarSupply = Bartending supplies crate
     .desc = Extra Bar supplies, in case the clown was allowed in the bar unsupervised.
+
+ent-CrateFoodSoftdrinks = Softdrinks crate
+    .desc = A variety of sodas to complement a small party, without having to empty the soda machines.
+
+ent-CrateFoodSoftdrinksLarge = Softdrinks bulk crate
+    .desc = Lots of sodas taken straight out of Centcomm's own vending machines, because you just can't leave your department.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -2,7 +2,7 @@
   id: FoodPizza
   icon:
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
-    state: margherita
+    state: margherita-slice
   product: CrateFoodPizza
   cost: 450
   category: Food
@@ -61,7 +61,7 @@
 - type: cargoProduct
   id: FoodSoftdrinks
   icon:
-    sprite: Objects/Consumable/Drinks/beerglass.rsi
+    sprite: Objects/Consumable/Drinks/cola.rsi
     state: icon
   product: CrateFoodSoftdrinks
   cost: 1200
@@ -71,7 +71,7 @@
 - type: cargoProduct
   id: FoodSoftdrinksLarge
   icon:
-    sprite: Objects/Consumable/Drinks/beerglass.rsi
+    sprite: Objects/Consumable/Drinks/colabottle.rsi
     state: icon
   product: CrateFoodSoftdrinksLarge
   cost: 2400

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -14,14 +14,14 @@
   id: CrateFoodPizzaLarge
   parent: CratePlastic
   components:
-    - type: StorageFill
-      contents:
-        - id: FoodBoxPizzaFilled
-          amount: 16
-        - id: KnifePlastic
-          amount: 4
-        - id: LidSalami
-          prob: 0.04
+  - type: StorageFill
+    contents:
+    - id: FoodBoxPizzaFilled
+      amount: 16
+    - id: KnifePlastic
+      amount: 4
+    - id: LidSalami
+      prob: 0.04
 
 - type: entity
   id: CrateFoodMRE
@@ -109,37 +109,37 @@
   id: CrateFoodSoftdrinks
   parent: CratePlastic
   components:
-    - type: StorageFill
-      contents:
-      - id: DrinkColaCan
-        amount: 4
-      - id: DrinkGrapeCan
-        amount: 2
-      - id: DrinkRootBeerCan
-        amount: 2
-      - id: DrinkIcedTeaCan
-        amount: 2
-      - id: DrinkLemonLimeCan
-        amount: 2
-      - id: DrinkFourteenLokoCan
-        amount: 2
+  - type: StorageFill
+    contents:
+    - id: DrinkColaCan
+      amount: 4
+    - id: DrinkGrapeCan
+      amount: 2
+    - id: DrinkRootBeerCan
+      amount: 2
+    - id: DrinkIcedTeaCan
+      amount: 2
+    - id: DrinkLemonLimeCan
+      amount: 2
+    - id: DrinkFourteenLokoCan
+      amount: 2
 
 - type: entity
   id: CrateFoodSoftdrinksLarge
   parent: CratePlastic
   components:
-    - type: StorageFill
-      contents:
-        - id: DrinkColaCan
-          amount: 8
-        - id: DrinkGrapeCan
-          amount: 4
-        - id: DrinkRootBeerCan
-          amount: 4
-        - id: DrinkIcedTeaCan
-          amount: 4
-        - id: DrinkLemonLimeCan
-          amount: 4
-        - id: DrinkFourteenLokoCan
-          amount: 4
+  - type: StorageFill
+    contents:
+      - id: DrinkColaCan
+        amount: 8
+      - id: DrinkGrapeCan
+        amount: 4
+      - id: DrinkRootBeerCan
+        amount: 4
+      - id: DrinkIcedTeaCan
+        amount: 4
+      - id: DrinkLemonLimeCan
+        amount: 4
+      - id: DrinkFourteenLokoCan
+        amount: 4
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added Locale to 3 cargo crates that were missing them (FoodPizzaLarge, FoodSoftdrinks, FoodSoftdrinksLarge).
Added text saying how many contents come in said Pizza and Soda boxes.
Changed Pizza crate icons to differentiate between small and large orders
Changed Softdrink crates to use soda icons instead of beer

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The 3 crates missing Locale were just showing up as "plastic crate" in the cargo list, and had no description. There was only the icon to go on.
Those respective crates (and additionally, the emergency pizza crate) were given content amounts in their description so you know what the actual difference is between smaller and larger orders.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: EnDecc
- fix: Three "plastic crates" in cargo have now been given appropriate labels, after Centcomm forgot to use tape on them. Disaster pizza crate, Softdrinks crate, and Softdrinks bulk crate will now show up in orders appropriately.
