### PR TITLE
Hot Fix of Gravity Grenades

### DIFF
--- a/Content.Server/Explosion/Components/OnTrigger/TwoStageTriggerComponent.cs
+++ b/Content.Server/Explosion/Components/OnTrigger/TwoStageTriggerComponent.cs
@@ -26,5 +26,10 @@ public sealed class TwoStageTriggerComponent : Component
     [DataField("nextTriggerTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? NextTriggerTime;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("triggered")] public bool Triggered = false;
+
+    [DataField("triggered")]
+    public bool Triggered = false;
+
+    [DataField("ComponentsIsLoaded")]
+    public bool ComponentsIsLoaded = false;
 }

--- a/Content.Server/Explosion/Components/OnTrigger/TwoStageTriggerComponent.cs
+++ b/Content.Server/Explosion/Components/OnTrigger/TwoStageTriggerComponent.cs
@@ -19,13 +19,11 @@ public sealed class TwoStageTriggerComponent : Component
     /// <summary>
     /// This list of components that will be added for the second trigger.
     /// </summary>
-    [ViewVariables(VVAccess.ReadOnly)]
     [DataField("components", required: true)]
     public ComponentRegistry SecondStageComponents = new();
 
     [DataField("nextTriggerTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? NextTriggerTime;
-
 
     [DataField("triggered")]
     public bool Triggered = false;

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -107,7 +107,7 @@ namespace Content.Server.Explosion.EntitySystems
 
             _transformSystem.AnchorEntity(uid, xform);
 
-            if(component.RemoveOnTrigger)
+            if (component.RemoveOnTrigger)
                 RemCompDeferred<AnchorOnTriggerComponent>(uid);
         }
 

--- a/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
@@ -64,7 +64,6 @@ public sealed class TwoStageTriggerSystem : EntitySystem
             if (component.Triggered && !component.ComponentsIsLoaded)
                 LoadComponents(uid, component);
 
-            Console.WriteLine(_timing.CurTime.ToString() + " " + component.NextTriggerTime.ToString());
             if (_timing.CurTime < component.NextTriggerTime)
                 continue;
 

--- a/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
@@ -30,12 +30,10 @@ public sealed class TwoStageTriggerSystem : EntitySystem
             return;
 
         component.Triggered = true;
-        if (!component.ComponentsIsLoaded)
-            LoadComponents(uid, component);
         component.NextTriggerTime = _timing.CurTime + component.TriggerDelay;
     }
 
-    public void LoadComponents(EntityUid uid, TwoStageTriggerComponent component)
+    private void LoadComponents(EntityUid uid, TwoStageTriggerComponent component)
     {
         foreach (var (name, entry) in component.SecondStageComponents)
         {
@@ -59,8 +57,11 @@ public sealed class TwoStageTriggerSystem : EntitySystem
         var enumerator = EntityQueryEnumerator<TwoStageTriggerComponent>();
         while (enumerator.MoveNext(out var uid, out var component))
         {
-            if (component.NextTriggerTime == null)
+            if (!component.Triggered)
                 continue;
+
+            if (!component.ComponentsIsLoaded)
+                LoadComponents(uid, component);
 
             if (_timing.CurTime < component.NextTriggerTime)
                 continue;

--- a/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
@@ -1,6 +1,8 @@
 using Robust.Shared.Timing;
 using Robust.Shared.Serialization.Manager;
 using Content.Server.Explosion.Components.OnTrigger;
+using Content.Shared.Popups;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Content.Server.Explosion.EntitySystems;
 
@@ -47,6 +49,7 @@ public sealed class TwoStageTriggerSystem : EntitySystem
             _serializationManager.CopyTo(entry.Component, ref temp);
             EntityManager.AddComponent(uid, comp);
         }
+        component.ComponentsIsLoaded = true;
     }
 
     public override void Update(float frameTime)
@@ -60,11 +63,14 @@ public sealed class TwoStageTriggerSystem : EntitySystem
             if (component.NextTriggerTime == null)
                 continue;
 
+            if (component.Triggered && !component.ComponentsIsLoaded)
+                LoadComponents(uid, component);
+
+            Console.WriteLine(_timing.CurTime.ToString() + " " + component.NextTriggerTime.ToString());
             if (_timing.CurTime < component.NextTriggerTime)
                 continue;
 
             component.NextTriggerTime = null;
-            LoadComponents(uid, component);
             _triggerSystem.Trigger(uid);
         }
     }

--- a/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
@@ -30,6 +30,8 @@ public sealed class TwoStageTriggerSystem : EntitySystem
             return;
 
         component.Triggered = true;
+        if (!component.ComponentsIsLoaded)
+            LoadComponents(uid, component);
         component.NextTriggerTime = _timing.CurTime + component.TriggerDelay;
     }
 
@@ -55,14 +57,10 @@ public sealed class TwoStageTriggerSystem : EntitySystem
         base.Update(frameTime);
 
         var enumerator = EntityQueryEnumerator<TwoStageTriggerComponent>();
-
         while (enumerator.MoveNext(out var uid, out var component))
         {
             if (component.NextTriggerTime == null)
                 continue;
-
-            if (component.Triggered && !component.ComponentsIsLoaded)
-                LoadComponents(uid, component);
 
             if (_timing.CurTime < component.NextTriggerTime)
                 continue;

--- a/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
@@ -1,8 +1,6 @@
 using Robust.Shared.Timing;
 using Robust.Shared.Serialization.Manager;
 using Content.Server.Explosion.Components.OnTrigger;
-using Content.Shared.Popups;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Content.Server.Explosion.EntitySystems;
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -148,7 +148,7 @@
   - type: AnchorOnTrigger
     removeOnTrigger: true
   - type: TwoStageTrigger
-    triggerDelay: 10
+    triggerDelay: 10.45
     components:
       - type: AmbientSound
         enabled: true
@@ -189,20 +189,15 @@
   - type: OnUseTimerTrigger
     delay: 3
     beepInterval: 0.69
-  - type: SoundOnTrigger
-    removeOnTrigger: true
-    sound:
-      path: /Audio/Effects/Grenades/Supermatter/whitehole_start.ogg
-      volume: 5
-  - type: AmbientSound
-    enabled: false
-    volume: -5
-    range: 14
-    sound:
-      path: /Audio/Effects/Grenades/Supermatter/whitehole_loop.ogg
   - type: TwoStageTrigger
-    triggerDelay: 10
+    triggerDelay: 11.14
     components:
+      - type: AmbientSound
+        enabled: true
+        volume: -5
+        range: 14
+        sound:
+          path: /Audio/Effects/Grenades/Supermatter/whitehole_loop.ogg
       - type: GravityWell
         maxRange: 10
         baseRadialAcceleration: -180
@@ -224,7 +219,6 @@
           params:
             volume: 5
       - type: DeleteOnTrigger
-
 
 - type: entity
   name: the nuclear option

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -189,6 +189,11 @@
   - type: OnUseTimerTrigger
     delay: 3
     beepInterval: 0.69
+  - type: SoundOnTrigger
+    removeOnTrigger: true
+    sound:
+      path: /Audio/Effects/Grenades/Supermatter/whitehole_start.ogg
+      volume: 5
   - type: TwoStageTrigger
     triggerDelay: 11.14
     components:
@@ -217,7 +222,7 @@
         sound:
           path: /Audio/Effects/Grenades/Supermatter/supermatter_end.ogg
           params:
-            volume: 5
+            volume: 15
       - type: DeleteOnTrigger
 
 - type: entity


### PR DESCRIPTION
## Technical details
So, bug was caused by cleaning mistake.
LoadComponents was called with second trigger, also known as BOOM or the END of second stage.
## Media
![image](https://github.com/space-wizards/space-station-14/assets/46600554/00dfa9d0-b1d8-4ec5-9bcd-05d35eb60e12)
![image](https://github.com/space-wizards/space-station-14/assets/46600554/7885cf31-6695-4093-8778-e465cccef2e2)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- fix: Fixed gravitational wells of supermatter and whitehole grenade
