### PR TITLE
fix species skin colors

### DIFF
--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -163,9 +163,9 @@ namespace Content.Shared.Humanoid
                     break;
                 case HumanoidSkinColor.Hues:
                 case HumanoidSkinColor.TintedHues:
-                    var rbyte = random.Next(0, 255);
-                    var gbyte = random.Next(0, 255);
-                    var bbyte = random.Next(0, 255);
+                    var rbyte = random.NextByte();
+                    var gbyte = random.NextByte();
+                    var bbyte = random.NextByte();
                     newSkinColor = new Color(rbyte, gbyte, bbyte);
                     break;
             }

--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -118,7 +118,7 @@ public static class SkinColor
     public static Color TintedHues(Color color)
     {
         var newColor = Color.ToHsv(color);
-        newColor.Y = .1f;
+        newColor.Y *= 0.1f;
 
         return Color.FromHsv(newColor);
     }

--- a/Resources/Prototypes/Datasets/Names/skeleton_first.yml
+++ b/Resources/Prototypes/Datasets/Names/skeleton_first.yml
@@ -12,13 +12,19 @@
   - Radius
   - Ulna
   - Carpals
-  - Phanages
+  - Phalanges
   - Pelvis
   - Femur
   - Tibia
   - Fibula
   - Marrow
-  - Tarsalls
+  - Tarsals
   - Patella
   - Tailbone
   - Boner
+  - Rib
+  - Hyoid
+  - Coccyx
+  - Tarsus
+  - Lacrimal
+  - Bone

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -4,6 +4,7 @@
   roundStart: true
   prototype: MobDiona
   sprites: MobDionaSprites
+  defaultSkinTone: "#cdb369"
   markingLimits: MobDionaMarkingLimits
   dollPrototype: MobDionaDummy
   skinColoration: Hues

--- a/Resources/Prototypes/Species/skeleton.yml
+++ b/Resources/Prototypes/Species/skeleton.yml
@@ -4,6 +4,7 @@
   roundStart: false
   prototype: MobSkeletonPerson
   sprites: MobSkeletonSprites
+  defaultSkinTone: "#fff9e2"
   markingLimits: MobHumanMarkingLimits
   maleFirstNames: skeletonNamesFirst
   femaleFirstNames: skeletonNamesFirst


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
diona always spawned as gray and skeletons skin color validation was broke af

threw in extra skelebone names because why the hell not

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/eac91428-7964-44fe-8360-4d72a6f47b8a)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Freshly spawned diona are no longer gray.
- fix: Skeletons are no longer extremely saturated in color.
