### PR TITLE
Make PA constructible again

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -324,9 +324,6 @@ namespace Content.Server.Construction
                 }
             }
 
-            // TODO: Is this call necessary?
-            UpdatePathfinding(newUid, newConstruction);
-
             // If the new entity has the *same* construction graph, stay on the same node.
             // If not, we effectively restart the construction graph, so the new entity can be completed.
             if (construction.Graph == newConstruction.Graph)

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -324,11 +324,20 @@ namespace Content.Server.Construction
                 }
             }
 
-            // We set the graph and node accordingly.
-            ChangeGraph(newUid, userUid, construction.Graph, construction.Node, false, newConstruction);
+            // TODO: Is this call necessary?
+            UpdatePathfinding(newUid, newConstruction);
 
-            if (construction.TargetNode is {} targetNode)
-                SetPathfindingTarget(newUid, targetNode, newConstruction);
+            // If the new entity has the *same* construction graph, stay on the same node.
+            // If not, we effectively restart the construction graph, so the new entity can be completed.
+            if (construction.Graph == newConstruction.Graph)
+            {
+                ChangeNode(newUid, userUid, construction.Node, false, newConstruction);
+
+                // Retain the target node if an entity change happens in response to deconstruction;
+                // in that case, we must continue to move towards the start node.
+                if (construction.TargetNode is {} targetNode)
+                    SetPathfindingTarget(newUid, targetNode, newConstruction);
+            }
 
             // Transfer all pending interaction events too.
             while (construction.InteractionQueue.TryDequeue(out var ev))


### PR DESCRIPTION
## About the PR

Make it possible to construct the Particle Accelerator again.

Fixes #18511  
Fixes #19342

## Why / Balance

After inserting the appropriate board into a machine or computer frame, it was impossible to finish construction of any PA part.

## Technical details

I believe the previous call to `ChangeGraph` to have been erroneous, or at the very least incompatible with how the PA is built. I elaborated on this in https://github.com/space-wizards/space-station-14/issues/18511#issuecomment-1687893199, but to recap:

1. If the graph is the same (`construction.Graph == newConstruction.Graph`), then the call to `ChangeGraph()` effectively does nothing – it just spends some time in `UpdatePathfinding()` – and only the `Node` and `TargetNode` updates actually matter[^1].
2. If the graph is *different*, then the call to `ChangeGraph()` completely overwrites the new entity's construction graph, making it completely unreachable. In this case, we shouldn't do anything: the new entity is already in the right state.

As far as I can tell, *only* the PA parts actually cause a construction graph change, and everything else keeps the same graph.

When deconstructing a fully finished PA part, it is not possible, and has never been possible, to deconstruct back to machine/computer frame, because there's no way back to the `Machine` or `Computer` graph.

[^1]: For deconstruction. When the entity changes, the default target appears to be the "completed" state (e.g. `machine`, `computer`, `completed`), sometimes null. During deconstruction it must however be set to the initial state, seemingly universally named `start`.

## Media

A video of me constructing a PA from machine and computer frames:

https://github.com/space-wizards/space-station-14/assets/30327355/e20a8e66-1a8b-49d5-b18f-5058ad09d6b3

(the brief freeze near the beginning is where I disable a breakpoint I'd forgotten about)

And to show that the change does *not* break construction or deconstruction of other things:

https://streamable.com/pn1ktq (too big for GitHub)
(also available on my domain – https://scaly.green/misc/ss14_pr_construction.mp4)

I wanted to be as thorough as possible, since the construction system is a fundamental component of the game, hence the length of these videos.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Particle Accelerators can now be constructed again
