### PR TITLE
Revert "Fix some non-norot sprites (#19130)"

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -8,7 +8,6 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/secret_door.rsi
-    noRot: true
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -17,7 +17,6 @@
     mode: NoSprite
   - type: SmoothEdge
   - type: Sprite
-    noRot: true
     sprite: Structures/Walls/rock.rsi
     layers:
       - state: rock_asteroid


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This reverts commit 912aba5e8c7b6b4844ceec07e39740af1c4d5917 (#19130).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Adding `norot: true` caused the asteroid and secret door to rotate with the camera, which looked bad. It also meant that secret walls weren't able to match the walls surrounding it. See videos for visual demo.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
#19130

https://github.com/space-wizards/space-station-14/assets/44417085/af6875e4-ce0d-4453-9255-93edd1d01609

After revert:

https://github.com/space-wizards/space-station-14/assets/44417085/c7ff4dd3-0f3e-4e61-a69c-3eec6e765a4b
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: crazybrain
- fix: Secret doors can be manually rotated again (at least until a dynamic solution is found).
