### PR TITLE
Add new body examine state for unrecoverable

### DIFF
--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -212,7 +212,9 @@ public sealed class MindSystem : EntitySystem
         var dead = _mobStateSystem.IsDead(uid);
         var hasSession = mindContainer.Mind?.Session;
 
-        if (dead && hasSession == null)
+        if (dead && !mindContainer.HasMind)
+            args.PushMarkup($"[color=mediumpurple]{Loc.GetString("comp-mind-examined-dead-and-irrecoverable", ("ent", uid))}[/color]");
+        else if (dead && hasSession == null)
             args.PushMarkup($"[color=yellow]{Loc.GetString("comp-mind-examined-dead-and-ssd", ("ent", uid))}[/color]");
         else if (dead)
             args.PushMarkup($"[color=red]{Loc.GetString("comp-mind-examined-dead", ("ent", uid))}[/color]");

--- a/Resources/Locale/en-US/mind/components/mind-component.ftl
+++ b/Resources/Locale/en-US/mind/components/mind-component.ftl
@@ -7,4 +7,5 @@ comp-mind-ghosting-prevented = You are not able to ghost right now.
 comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. The stresses of life in deep-space must have been too much for { OBJECT($ent) }. Any recovery is unlikely.
 comp-mind-examined-dead = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } dead.
 comp-mind-examined-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-HAVE($ent) } a blank, absent-minded stare and appears completely unresponsive to anything. { CAPITALIZE(SUBJECT($ent)) } may snap out of it soon.
-comp-mind-examined-dead-and-ssd = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. Any recovery is unlikely.
+comp-mind-examined-dead-and-ssd = { CAPITALIZE(POSS-ADJ($ent)) } soul lies dormant and may return soon.
+comp-mind-examined-dead-and-irrecoverable = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. Any recovery is unlikely.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Splits the old yellow "soul has departed and moved on. Any recovery is unlikely." to two different states.
 
For a player who is dead and SSD (meaning they can reconnect and be revived) it now says "soul lies dormant and may return soon." in yellow. For a player who is dead and cannot return (suicided or taken a ghost role) it now says "soul has departed and moved on. Any recovery is unlikely." in purple.

The purple colour was chosen because it matches the catatonic state which it parallels.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This was made because players have no way of knowing if a dead player is just disconnected or permanently gone. This causes confusion for chefs, medical, and others. Potentially resolves #8495, please confirm if this is true.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a check similar to the catatonic check, but for when they're also dead.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/44417085/aad1c6b4-70df-4ad5-b2ed-349b28377cff)
![image](https://github.com/space-wizards/space-station-14/assets/44417085/d9b1563a-84d5-40f1-97ed-d1f32bd5d7cc)
![SSDchart](https://github.com/space-wizards/space-station-14/assets/44417085/417bf48b-43a3-40d3-a4b2-4e700eb45676)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
<!--
## Breaking changes

List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: crazybrain
- tweak: The dead body examine text is more accurate for dead, disconnected players.

~~I'm not too keen on the changelog wording, because it feels hard to explain what I've done.~~
*(new changelog suggested by notafet)*