### PR TITLE
Security Jetpacks In Suit Storage

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -21,6 +21,7 @@
       - id: RubberStampWarden
       - id: DoorRemoteArmory
       - id: ClothingOuterHardsuitWarden
+      - id: JetpackSecurityFilled
       - id: HoloprojectorSecurity
       - id: ClothingEyesHudSecurity
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -144,7 +144,6 @@
   - type: StorageFill
     contents:
         - id: NitrogenTankFilled
-        - id: OxygenTankFilled
         - id: JetpackSecurityFilled
         - id: ClothingOuterHardsuitSecurity
         - id: ClothingMaskBreath
@@ -213,7 +212,6 @@
   - type: StorageFill
     contents:
         - id: NitrogenTankFilled
-        - id: OxygenTankFilled
         - id: JetpackSecurityFilled
         - id: ClothingOuterHardsuitWarden
         - id: ClothingMaskBreath

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -39,7 +39,7 @@
         - id: OxygenTankFilled
         - id: ClothingOuterSuitEmergency
         - id: ClothingMaskBreath
-     
+
 #Prisoner EVA
 - type: entity
   id: SuitStorageEVAPrisoner
@@ -80,7 +80,7 @@
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitPirateEVA
         - id: ClothingMaskGas
-        
+
 #NTSRA Voidsuit
 - type: entity
   id: SuitStorageNTSRA
@@ -93,7 +93,7 @@
         - id: ClothingOuterHardsuitAncientEVA
         - id: ClothingHeadHelmetAncient
         - id: ClothingMaskBreath
-        
+
 #HARDSUITS
 #Basic hardsuit
 - type: entity
@@ -145,6 +145,7 @@
     contents:
         - id: NitrogenTankFilled
         - id: OxygenTankFilled
+        - id: JetpackSecurityFilled
         - id: ClothingOuterHardsuitSecurity
         - id: ClothingMaskBreath
 
@@ -213,6 +214,7 @@
     contents:
         - id: NitrogenTankFilled
         - id: OxygenTankFilled
+        - id: JetpackSecurityFilled
         - id: ClothingOuterHardsuitWarden
         - id: ClothingMaskBreath
 
@@ -282,4 +284,3 @@
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitWizard
         - id: ClothingMaskBreath
-        


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Security and warden suit storages come with a jetpack

## Why / Balance
Stations don't supply security with jetpacks. This simple fix makes sure sec is actually space ready incase someone is doing laps around the station with a gun. Also, HOS has one of their own, so why not their lackeys too? You can call this a mapper issue, but I'm not bugging every mapper to add jetpacks to sec.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:Alekshhh
- add: Added jetpacks to security suit storages