### PR TITLE
Fix SpawnItemsOnUseComponent with zero uses

### DIFF
--- a/Content.Server/Storage/Components/SpawnItemsOnUseComponent.cs
+++ b/Content.Server/Storage/Components/SpawnItemsOnUseComponent.cs
@@ -24,6 +24,7 @@ namespace Content.Server.Storage.Components
         /// <summary>
         ///     How many uses before the item should delete itself.
         /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
         [DataField("uses")]
         public int Uses = 1;
     }

--- a/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
@@ -65,6 +65,10 @@ namespace Content.Server.Storage.EntitySystems
             if (args.Handled)
                 return;
 
+            // If starting with zero or less uses, this component is a no-op
+            if (component.Uses <= 0)
+                return;
+
             var coords = Transform(args.User).Coordinates;
             var spawnEntities = GetSpawns(component.Items, _random);
             EntityUid? entityToPlaceInHands = null;
@@ -79,7 +83,9 @@ namespace Content.Server.Storage.EntitySystems
                 SoundSystem.Play(component.Sound.GetSound(), Filter.Pvs(uid), uid);
 
             component.Uses--;
-            if (component.Uses == 0)
+
+            // Delete entity only if component was successfully used
+            if (component.Uses <= 0)
             {
                 args.Handled = true;
                 EntityManager.DeleteEntity(uid);


### PR DESCRIPTION
## About the PR
An entity with SpawnItemsOnUseComponent that has zero uses currently still has one use. This is currently not an issue because there are no such components with less than 1 use. This PR fixes this edge case.

## Why / Balance
- #19393 is trying to bring in peelable bananas. Supporting a SpawnItemsOnUseComponent with zero uses would reduce YAML duplication.
- Handling edge cases to make the code more robust is good.

## Technical details
When an entity with zero or less uses in SpawnItemsOnUseComponent is used, it is ignored.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
N/A