### PR TITLE
Make bound-UI range checks consistent with interaction.

### DIFF
--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -36,6 +36,8 @@ namespace Content.Server.Interaction
             base.Initialize();
 
             SubscribeNetworkEvent<DragDropRequestEvent>(HandleDragDropRequestEvent);
+
+            SubscribeLocalEvent<BoundUserInterfaceCheckRangeEvent>(HandleUserInterfaceRangeCheck);
         }
 
         public override bool CanAccessViaStorage(EntityUid user, EntityUid target)
@@ -93,5 +95,20 @@ namespace Content.Server.Interaction
         }
 
         #endregion
+
+        private void HandleUserInterfaceRangeCheck(ref BoundUserInterfaceCheckRangeEvent ev)
+        {
+            if (ev.Player.AttachedEntity is not { } user)
+                return;
+
+            if (InRangeUnobstructed(user, ev.Target, ev.UserInterface.InteractionRange))
+            {
+                ev.Result = BoundUserInterfaceRangeResult.Pass;
+            }
+            else
+            {
+                ev.Result = BoundUserInterfaceRangeResult.Fail;
+            }
+        }
     }
 }


### PR DESCRIPTION
That means no more "interaction outline green, but can't open interface".

Requires https://github.com/space-wizards/RobustToolbox/pull/4301

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Objects with interfaces now correctly respect interaction range, so green outline really means you can open them.
