### PR TITLE
Revert "Sets salamander round restart time to 5 minutes"

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/salamander.toml
+++ b/Resources/ConfigPresets/WizardsDen/salamander.toml
@@ -4,7 +4,6 @@
 desc = "Official English Space Station 14 servers. Roleplay required, you must be whitelisted through Discord to play if there are more than 15 online players."
 hostname = "[EN] Wizard's Den Salamander [US West RP]"
 artifact_round_end_timer = 0.0
-round_restart_time = 300
 
 [server]
 rules_file = "RP_Rules.txt"


### PR DESCRIPTION
Reverts space-wizards/space-station-14#19374
The round is never restarting. I think the cvar might be bugged, but this is for now to make sure salamander is still playable. 