### PR TITLE
Fix missing toolshed command perms and tests

### DIFF
--- a/Content.IntegrationTests/Tests/Toolshed/LocTest.cs
+++ b/Content.IntegrationTests/Tests/Toolshed/LocTest.cs
@@ -16,8 +16,6 @@ public sealed class LocTest : ToolshedTest
     {
         await Server.WaitAssertion(() =>
         {
-            IoCManager.Resolve<ILocalizationManager>().LoadCulture(new CultureInfo("en-US"));
-
             Assert.That(InvokeCommand("cmd:list where { cmd:descloc loc:tryloc isnull }", out var res));
             Assert.That((IEnumerable<CommandSpec>)res!, Is.Empty, "All commands must have localized descriptions.");
         });

--- a/Resources/toolshedEngineCommandPerms.yml
+++ b/Resources/toolshedEngineCommandPerms.yml
@@ -1,4 +1,4 @@
-- Flags: QUERY
+﻿- Flags: QUERY
   Commands:
     - entities
     - nearby
@@ -146,7 +146,7 @@
     - stepnext
     - stepprev
     - checkedto
-    - saturactedto
+    - saturatedto
     - truncto
     - iscanonical
     - iscomplex

--- a/Resources/toolshedEngineCommandPerms.yml
+++ b/Resources/toolshedEngineCommandPerms.yml
@@ -146,7 +146,7 @@
     - stepnext
     - stepprev
     - checkedto
-    - saturatedto
+    - saturateto
     - truncto
     - iscanonical
     - iscomplex


### PR DESCRIPTION
## About the PR
One command was misspelled, and localization culture was already being set.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
