### PR TITLE
add plates to autolathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -106,6 +106,10 @@
       - LightTube
       - LightBulb
       - Bucket
+      - FoodPlate
+      - FoodPlateSmall
+      - FoodPlatePlastic
+      - FoodPlatePlasticSmall
       - SprayBottle
       - PowerCellSmall
       - MicroManipulatorStockPart

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -109,7 +109,7 @@
       - FoodPlate
       - FoodPlateSmall
       - FoodPlatePlastic
-      - FoodPlatePlasticSmall
+      - FoodPlateSmallPlastic
       - SprayBottle
       - PowerCellSmall
       - MicroManipulatorStockPart

--- a/Resources/Prototypes/Recipes/Lathes/cooking.yml
+++ b/Resources/Prototypes/Recipes/Lathes/cooking.yml
@@ -34,3 +34,31 @@
   completetime: 0.8
   materials:
     Glass: 50
+
+- type: latheRecipe
+  id: FoodPlate
+  result: FoodPlate
+  completetime: 0.8
+  materials:
+    Glass: 100
+
+- type: latheRecipe
+  id: FoodPlateSmall
+  result: FoodPlateSmall
+  completetime: 0.4
+  materials:
+    Glass: 50
+
+- type: latheRecipe
+  id: FoodPlatePlastic
+  result: FoodPlatePlastic
+  completetime: 0.8
+  materials:
+    Plastic: 100
+
+- type: latheRecipe
+  id: FoodPlateSmallPlastic
+  result: FoodPlateSmallPlastic
+  completetime: 0.4
+  materials:
+    Plastic: 50


### PR DESCRIPTION
## About the PR
adds a recipe for every plate to autolathe available roundstart
same cost as broken plates given when recycled

## Why / Balance
if shitters break all the plates roundstart you dont need to buy an entire restock crate, can just get glass or plastic and make some
once plates arent useless this will be essential, like shitters breaking glasses

## Technical details
no

## Media
![05:52:28](https://github.com/space-wizards/space-station-14/assets/39013340/4ee5d914-84a7-4839-aa7c-b0bac892e3d1)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: All plates can now be made in the autolathe.
