### PR TITLE
Reduce the health of some mobs

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -39,7 +39,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        100: Dead
+        50: Dead
     - type: Stamina
       critThreshold: 100
     - type: MovementAlwaysTouching

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -34,7 +34,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      150: Dead
+      100: Dead
   - type: Stamina
     critThreshold: 150
   - type: MovementAlwaysTouching
@@ -218,7 +218,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      130: Dead
+      90: Dead
   - type: Stamina
     critThreshold: 150
   - type: DamageStateVisuals

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -66,7 +66,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      160: Dead
+      120: Dead
   - type: Grammar
     attributes:
       gender: male


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
These mobs have gotten significantly more tanky after their crit states were removed. This brings it back to how it was, Cerbs get to enjoy slightly more hp than before though. 

## Why / Balance
These mobs used to have a crit state that didn't have different sprites. That crit state was removed but their dead hps weren't adjusted. These mobs are now rather tanky and very powerful. Fighting a holocarp was sometimes more scary than fighting a space dragon during a salvage mission for example.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->