### PR TITLE
Fix component generic usages where IComponent would not be valid

### DIFF
--- a/Content.Client/ContextMenu/UI/EntityMenuPresenterGrouping.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuPresenterGrouping.cs
@@ -35,8 +35,8 @@ namespace Content.Client.ContextMenu.UI
                 (a, b, entMan) => entMan.GetComponent<MetaDataComponent>(a).EntityPrototype!.ID == entMan.GetComponent<MetaDataComponent>(b).EntityPrototype!.ID,
                 (a, b, entMan) =>
                 {
-                    entMan.TryGetComponent<SpriteComponent?>(a, out var spriteA);
-                    entMan.TryGetComponent<SpriteComponent?>(b, out var spriteB);
+                    entMan.TryGetComponent(a, out SpriteComponent? spriteA);
+                    entMan.TryGetComponent(b, out SpriteComponent? spriteB);
 
                     if (spriteA == null || spriteB == null)
                         return spriteA == spriteB;

--- a/Content.Client/Instruments/UI/InstrumentBoundUserInterface.cs
+++ b/Content.Client/Instruments/UI/InstrumentBoundUserInterface.cs
@@ -49,7 +49,7 @@ namespace Content.Client.Instruments.UI
 
         protected override void Open()
         {
-            if (!EntMan.TryGetComponent<InstrumentComponent?>(Owner, out var instrument))
+            if (!EntMan.TryGetComponent(Owner, out InstrumentComponent? instrument))
                 return;
 
             Instrument = instrument;

--- a/Content.Client/Radiation/Overlays/RadiationPulseOverlay.cs
+++ b/Content.Client/Radiation/Overlays/RadiationPulseOverlay.cs
@@ -107,7 +107,7 @@ namespace Content.Client.Radiation.Overlays
             {
                 if (_entityManager.EntityExists(pulseEntity) &&
                     PulseQualifies(pulseEntity, currentEyeLoc) &&
-                    _entityManager.TryGetComponent<RadiationPulseComponent?>(pulseEntity, out var pulse))
+                    _entityManager.TryGetComponent(pulseEntity, out RadiationPulseComponent? pulse))
                 {
                     var shaderInstance = _pulses[pulseEntity];
                     shaderInstance.instance.CurrentMapCoords = _entityManager.GetComponent<TransformComponent>(pulseEntity).MapPosition;

--- a/Content.Server/Administration/Commands/SetOutfitCommand.cs
+++ b/Content.Server/Administration/Commands/SetOutfitCommand.cs
@@ -76,7 +76,7 @@ namespace Content.Server.Administration.Commands
 
         public static bool SetOutfit(EntityUid target, string gear, IEntityManager entityManager, Action<EntityUid, EntityUid>? onEquipped = null)
         {
-            if (!entityManager.TryGetComponent<InventoryComponent?>(target, out var inventoryComponent))
+            if (!entityManager.TryGetComponent(target, out InventoryComponent? inventoryComponent))
                 return false;
 
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
@@ -85,7 +85,7 @@ namespace Content.Server.Administration.Commands
 
             HumanoidCharacterProfile? profile = null;
             // Check if we are setting the outfit of a player to respect the preferences
-            if (entityManager.TryGetComponent<ActorComponent?>(target, out var actorComponent))
+            if (entityManager.TryGetComponent(target, out ActorComponent? actorComponent))
             {
                 var userId = actorComponent.PlayerSession.UserId;
                 var preferencesManager = IoCManager.Resolve<IServerPreferencesManager>();
@@ -106,7 +106,7 @@ namespace Content.Server.Administration.Commands
                     }
                     var equipmentEntity = entityManager.SpawnEntity(gearStr, entityManager.GetComponent<TransformComponent>(target).Coordinates);
                     if (slot.Name == "id" &&
-                        entityManager.TryGetComponent<PdaComponent?>(equipmentEntity, out var pdaComponent) &&
+                        entityManager.TryGetComponent(equipmentEntity, out PdaComponent? pdaComponent) &&
                         entityManager.TryGetComponent<IdCardComponent>(pdaComponent.ContainedId, out var id))
                     {
                         id.FullName = entityManager.GetComponent<MetaDataComponent>(target).EntityName;

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -19,7 +19,7 @@ public sealed partial class AdminVerbSystem
     // All antag verbs have names so invokeverb works.
     private void AddAntagVerbs(GetVerbsEvent<Verb> args)
     {
-        if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+        if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
             return;
 
         var player = actor.PlayerSession;

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -80,7 +80,7 @@ public sealed partial class AdminVerbSystem
     // All smite verbs have names so invokeverb works.
     private void AddSmiteVerbs(GetVerbsEvent<Verb> args)
     {
-        if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+        if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
             return;
 
         var player = actor.PlayerSession;

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -57,7 +57,7 @@ public sealed partial class AdminVerbSystem
 
     private void AddTricksVerbs(GetVerbsEvent<Verb> args)
     {
-        if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+        if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
             return;
 
         var player = actor.PlayerSession;

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -79,7 +79,7 @@ namespace Content.Server.Administration.Systems
 
         private void AddAdminVerbs(GetVerbsEvent<Verb> args)
         {
-            if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+            if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
                 return;
 
             var player = actor.PlayerSession;
@@ -215,7 +215,7 @@ namespace Content.Server.Administration.Systems
 
         private void AddDebugVerbs(GetVerbsEvent<Verb> args)
         {
-            if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+            if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
                 return;
 
             var player = actor.PlayerSession;
@@ -349,7 +349,7 @@ namespace Content.Server.Administration.Systems
 
             // Get Disposal tube direction verb
             if (_groupController.CanCommand(player, "tubeconnections") &&
-                EntityManager.TryGetComponent<DisposalTubeComponent?>(args.Target, out var tube))
+                EntityManager.TryGetComponent(args.Target, out DisposalTubeComponent? tube))
             {
                 Verb verb = new()
                 {
@@ -376,7 +376,7 @@ namespace Content.Server.Administration.Systems
             }
 
             if (_groupController.CanAdminMenu(player) &&
-                EntityManager.TryGetComponent<ConfigurationComponent?>(args.Target, out var config))
+                EntityManager.TryGetComponent(args.Target, out ConfigurationComponent? config))
             {
                 Verb verb = new()
                 {

--- a/Content.Server/Alert/Click/BreakVow.cs
+++ b/Content.Server/Alert/Click/BreakVow.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Alert.Click
         {
             var entManager = IoCManager.Resolve<IEntityManager>();
 
-           if (entManager.TryGetComponent<MimePowersComponent?>(player, out var mimePowers))
+           if (entManager.TryGetComponent(player, out MimePowersComponent? mimePowers))
            {
                 entManager.System<MimePowersSystem>().BreakVow(player, mimePowers);
            }

--- a/Content.Server/Alert/Click/RetakeVow.cs
+++ b/Content.Server/Alert/Click/RetakeVow.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Alert.Click
         {
             var entManager = IoCManager.Resolve<IEntityManager>();
 
-           if (entManager.TryGetComponent<MimePowersComponent?>(player, out var mimePowers))
+           if (entManager.TryGetComponent(player, out MimePowersComponent? mimePowers))
            {
                 entManager.System<MimePowersSystem>().RetakeVow(player, mimePowers);
            }

--- a/Content.Server/Alert/Click/StopBeingPulled.cs
+++ b/Content.Server/Alert/Click/StopBeingPulled.cs
@@ -20,7 +20,7 @@ namespace Content.Server.Alert.Click
             if (!entityManager.System<ActionBlockerSystem>().CanInteract(player, null))
                 return;
 
-            if (entityManager.TryGetComponent<SharedPullableComponent?>(player, out var playerPullable))
+            if (entityManager.TryGetComponent(player, out SharedPullableComponent? playerPullable))
             {
                 entityManager.System<SharedPullingSystem>().TryStopPull(playerPullable);
             }

--- a/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
+++ b/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
@@ -242,7 +242,7 @@ public sealed class AmeControllerSystem : EntitySystem
             return;
         }
 
-        if (!HasComp<AmeFuelContainerComponent?>(args.Used))
+        if (!HasComp<AmeFuelContainerComponent>(args.Used))
         {
             _popupSystem.PopupEntity(Loc.GetString("ame-controller-component-interact-using-fail"), uid, args.User);
             return;

--- a/Content.Server/Animals/Systems/UdderSystem.cs
+++ b/Content.Server/Animals/Systems/UdderSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Server.Animals.Systems
                     udder.AccumulatedFrameTime -= udder.UpdateRate;
 
                     // Actually there is food digestion so no problem with instant reagent generation "OnFeed"
-                    if (EntityManager.TryGetComponent<HungerComponent?>(udder.Owner, out var hunger))
+                    if (EntityManager.TryGetComponent(udder.Owner, out HungerComponent? hunger))
                     {
                         // Is there enough nutrition to produce reagent?
                         if (_hunger.GetHungerThreshold(hunger) < HungerThreshold.Peckish)

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
@@ -42,7 +42,7 @@ public sealed partial class ChemistrySystem
         if (!args.CanAccess || !args.CanInteract || args.Hands == null)
             return;
 
-        if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+        if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
             return;
 
         // Add specific transfer verbs according to the container's size
@@ -312,7 +312,7 @@ public sealed partial class ChemistrySystem
 
         // Move units from attackSolution to targetSolution
         Solution removedSolution;
-        if (TryComp<StackComponent>(targetEntity, out var stack)) 
+        if (TryComp<StackComponent>(targetEntity, out var stack))
             removedSolution = _solutions.SplitStackSolution(injector, solution, realTransferAmount, stack.Count);
         else
           removedSolution = _solutions.SplitSolution(injector, solution, realTransferAmount);

--- a/Content.Server/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -48,7 +48,7 @@ namespace Content.Server.Chemistry.EntitySystems
             if (!args.CanAccess || !args.CanInteract || !component.CanChangeTransferAmount || args.Hands == null)
                 return;
 
-            if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+            if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
                 return;
 
             // Custom transfer verb

--- a/Content.Server/Construction/Conditions/MachineFrameComplete.cs
+++ b/Content.Server/Construction/Conditions/MachineFrameComplete.cs
@@ -34,7 +34,7 @@ namespace Content.Server.Construction.Conditions
 
             var entityManager = IoCManager.Resolve<IEntityManager>();
 
-            if (!entityManager.TryGetComponent<MachineFrameComponent?>(entity, out var machineFrame))
+            if (!entityManager.TryGetComponent(entity, out MachineFrameComponent? machineFrame))
                 return false;
 
             if (!machineFrame.HasBoard)

--- a/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Damage.Systems
                 return;
 
             if (component.WeldingDamage is {} weldingDamage
-                && EntityManager.TryGetComponent<WelderComponent?>(args.Used, out var welder)
+                && EntityManager.TryGetComponent(args.Used, out WelderComponent? welder)
                 && welder.Lit
                 && !welder.TankSafe)
             {
@@ -39,7 +39,7 @@ namespace Content.Server.Damage.Systems
                 args.Handled = true;
             }
             else if (component.DefaultDamage is {} damage
-                && EntityManager.TryGetComponent<ToolComponent?>(args.Used, out var tool)
+                && EntityManager.TryGetComponent(args.Used, out ToolComponent? tool)
                 && tool.Qualities.ContainsAny(component.Tools))
             {
                 var dmg = _damageableSystem.TryChangeDamage(args.Target, damage, origin: args.User);

--- a/Content.Server/Engineering/EntitySystems/SpawnAfterInteractSystem.cs
+++ b/Content.Server/Engineering/EntitySystems/SpawnAfterInteractSystem.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Engineering.EntitySystems
             if (component.Deleted || !IsTileClear())
                 return;
 
-            if (EntityManager.TryGetComponent<StackComponent?>(component.Owner, out var stackComp)
+            if (EntityManager.TryGetComponent(component.Owner, out StackComponent? stackComp)
                 && component.RemoveOnInteract && !_stackSystem.Use(uid, 1, stackComp))
             {
                 return;

--- a/Content.Server/Light/EntitySystems/MatchboxSystem.cs
+++ b/Content.Server/Light/EntitySystems/MatchboxSystem.cs
@@ -18,7 +18,7 @@ namespace Content.Server.Light.EntitySystems
         private void OnInteractUsing(EntityUid uid, MatchboxComponent component, InteractUsingEvent args)
         {
             if (!args.Handled
-                && EntityManager.TryGetComponent<MatchstickComponent?>(args.Used, out var matchstick)
+                && EntityManager.TryGetComponent(args.Used, out MatchstickComponent? matchstick)
                 && matchstick.CurrentState == SmokableState.Unlit)
             {
                 _stickSystem.Ignite(args.Used, matchstick, args.User);

--- a/Content.Server/Morgue/MorgueSystem.cs
+++ b/Content.Server/Morgue/MorgueSystem.cs
@@ -62,7 +62,7 @@ public sealed class MorgueSystem : EntitySystem
             if (!hasMob && HasComp<BodyComponent>(ent))
                 hasMob = true;
 
-            if (HasComp<ActorComponent?>(ent))
+            if (HasComp<ActorComponent>(ent))
             {
                 _appearance.SetData(uid, MorgueVisuals.Contents, MorgueContents.HasSoul, app);
                 return;

--- a/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
@@ -39,7 +39,7 @@ namespace Content.Server.Nutrition.EntitySystems
         {
             _audio.Play(_audio.GetSound(creamPie.Sound), Filter.Pvs(uid), uid, false, new AudioParams().WithVariation(0.125f));
 
-            if (EntityManager.TryGetComponent<FoodComponent?>(uid, out var foodComp))
+            if (EntityManager.TryGetComponent(uid, out FoodComponent? foodComp))
             {
                 if (_solutions.TryGetSolution(uid, foodComp.SolutionName, out var solution))
                 {

--- a/Content.Server/Power/Components/BaseNetConnectorComponent.cs
+++ b/Content.Server/Power/Components/BaseNetConnectorComponent.cs
@@ -55,7 +55,7 @@ namespace Content.Server.Power.Components
 
         private bool TryFindNet([NotNullWhen(true)] out TNetType? foundNet)
         {
-            if (_entMan.TryGetComponent<NodeContainerComponent?>(Owner, out var container))
+            if (_entMan.TryGetComponent(Owner, out NodeContainerComponent? container))
             {
                 var compatibleNet = container.Nodes.Values
                     .Where(node => (NodeId == null || NodeId == node.Name) && node.NodeGroupID == (NodeGroupID) Voltage)

--- a/Content.Server/Prayer/PrayerSystem.cs
+++ b/Content.Server/Prayer/PrayerSystem.cs
@@ -36,7 +36,7 @@ public sealed class PrayerSystem : EntitySystem
     private void AddPrayVerb(EntityUid uid, PrayableComponent comp, GetVerbsEvent<ActivationVerb> args)
     {
         // if it doesn't have an actor and we can't reach it then don't add the verb
-        if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+        if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
             return;
 
         // this is to prevent ghosts from using it

--- a/Content.Server/Sandbox/Commands/ColorNetworkCommand.cs
+++ b/Content.Server/Sandbox/Commands/ColorNetworkCommand.cs
@@ -79,7 +79,7 @@ namespace Content.Server.Sandbox.Commands
 
             foreach (var x in group.Nodes)
             {
-                if (!IoCManager.Resolve<IEntityManager>().TryGetComponent<AtmosPipeColorComponent?>(x.Owner, out var atmosPipeColorComponent)) continue;
+                if (!IoCManager.Resolve<IEntityManager>().TryGetComponent(x.Owner, out AtmosPipeColorComponent? atmosPipeColorComponent)) continue;
 
                 EntitySystem.Get<AtmosPipeColorSystem>().SetColor(x.Owner, atmosPipeColorComponent, color);
             }

--- a/Content.Server/Tabletop/TabletopSystem.Session.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Session.cs
@@ -78,7 +78,7 @@ namespace Content.Server.Tabletop
             if (session.Players.ContainsKey(player))
                 return;
 
-            if(EntityManager.TryGetComponent<TabletopGamerComponent?>(attachedEntity, out var gamer))
+            if(EntityManager.TryGetComponent(attachedEntity, out TabletopGamerComponent? gamer))
                 CloseSessionFor(player, gamer.Tabletop, false);
 
             // Set the entity as an absolute GAMER.

--- a/Content.Server/Tabletop/TabletopSystem.cs
+++ b/Content.Server/Tabletop/TabletopSystem.cs
@@ -124,7 +124,7 @@ namespace Content.Server.Tabletop
             if (!args.CanAccess || !args.CanInteract)
                 return;
 
-            if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+            if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
                 return;
 
             var playVerb = new ActivationVerb()

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -61,7 +61,7 @@ namespace Content.Shared.Pulling
                 return false;
             }
 
-            if (EntityManager.TryGetComponent<BuckleComponent?>(puller, out var buckle))
+            if (EntityManager.TryGetComponent(puller, out BuckleComponent? buckle))
             {
                 // Prevent people pulling the chair they're on, etc.
                 if (buckle is { PullStrap: false, Buckled: true } && (buckle.LastEntityBuckledTo == pulled))
@@ -113,11 +113,11 @@ namespace Content.Shared.Pulling
 
         public bool TryStartPull(EntityUid puller, EntityUid pullable)
         {
-            if (!EntityManager.TryGetComponent<SharedPullerComponent?>(puller, out var pullerComp))
+            if (!EntityManager.TryGetComponent(puller, out SharedPullerComponent? pullerComp))
             {
                 return false;
             }
-            if (!EntityManager.TryGetComponent<SharedPullableComponent?>(pullable, out var pullableComp))
+            if (!EntityManager.TryGetComponent(pullable, out SharedPullableComponent? pullableComp))
             {
                 return false;
             }
@@ -154,7 +154,7 @@ namespace Content.Shared.Pulling
             var oldPullable = puller.Pulling;
             if (oldPullable != null)
             {
-                if (EntityManager.TryGetComponent<SharedPullableComponent?>(oldPullable.Value, out var oldPullableComp))
+                if (EntityManager.TryGetComponent(oldPullable.Value, out SharedPullableComponent? oldPullableComp))
                 {
                     if (!TryStopPull(oldPullableComp))
                     {


### PR DESCRIPTION
## About the PR
For Arch or if we change the generic constraints in the engine to IComponent before then.
Also makes component structs possible as well.

## Technical details
Some of the generic component manipulation methods in the engine are either not constrained at all (some overloads of HasComponent) or are constrained to Component instead of IComponent (queries). This change makes it possible to change all of those cases to `where T : IComponent`.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
