### PR TITLE
make atmos pipes cost 1 steel

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -49,7 +49,7 @@
     sound:
       path: /Audio/Ambience/Objects/gas_hiss.ogg
   - type: StaticPrice
-    price: 22
+    price: 11
 
 #Note: The PipeDirection of the PipeNode should be the south-facing version, because the entity starts at an angle of 0 (south)
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_pipes.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_pipes.yml
@@ -7,31 +7,31 @@
     - to: half
       steps:
       - material: Steel
-        amount: 2
+        amount: 1
         doAfter: 1
 
     - to: straight
       steps:
       - material: Steel
-        amount: 2
+        amount: 1
         doAfter: 1
 
     - to: bend
       steps:
       - material: Steel
-        amount: 2
+        amount: 1
         doAfter: 1
 
     - to: tjunction
       steps:
       - material: Steel
-        amount: 2
+        amount: 1
         doAfter: 1
 
     - to: fourway
       steps:
       - material: Steel
-        amount: 2
+        amount: 1
         doAfter: 1
 
   - node: half
@@ -44,7 +44,7 @@
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
-        amount: 2
+        amount: 1
       - !type:DeleteEntity
       steps:
       - tool: Welding
@@ -60,7 +60,7 @@
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
-        amount: 2
+        amount: 1
       - !type:DeleteEntity
       steps:
       - tool: Welding
@@ -76,7 +76,7 @@
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
-        amount: 2
+        amount: 1
       - !type:DeleteEntity
       steps:
       - tool: Welding
@@ -92,7 +92,7 @@
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
-        amount: 2
+        amount: 1
       - !type:DeleteEntity
       steps:
       - tool: Welding
@@ -108,7 +108,7 @@
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
-        amount: 2
+        amount: 1
       - !type:DeleteEntity
       steps:
       - tool: Welding


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
title
tested, each pipe costs and gives 1 steel correctly

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
pipes, for being just pipes, are way too expensive as they are right now
economy considerations: 1000 money -> 90 steel -> 90 pipes -> 990 sell value

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->