### PR TITLE
Make PA use MV power.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/power_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/power_box.yml
@@ -8,13 +8,13 @@
     sprite: Structures/Power/Generation/PA/power_box.rsi
   - type: ParticleAcceleratorPowerBox
   - type: PowerConsumer
-    voltage: High
+    voltage: Medium
   - type: NodeContainer
     examinable: true
     nodes:
       input:
         !type:CableDeviceNode
-        nodeGroupID: HVPower
+        nodeGroupID: MVPower
   - type: Construction
     graph: ParticleAcceleratorPowerBox
 


### PR DESCRIPTION
Will need map changes.

## Why / Balance
Rest of the equipment like the field also uses MV. This makes it so the PA can be ran off the same network, which makes it easier to bootstrap power.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


:cl:
- tweak: The particle accelerator now uses an MV power wire instead of HV. You might need to manually connect it up before the maps get fixed.
