### PR TITLE
Remove obsolete TestPair.Pair

### DIFF
--- a/Content.Benchmarks/DeviceNetworkingBenchmark.cs
+++ b/Content.Benchmarks/DeviceNetworkingBenchmark.cs
@@ -60,7 +60,7 @@ public class DeviceNetworkingBenchmark
     {
         ProgramShared.PathOffset = "../../../../";
         _pair = await PoolManager.GetServerClient();
-        var server = _pair.Pair.Server;
+        var server = _pair.Server;
 
         await server.WaitPost(() =>
         {
@@ -96,9 +96,9 @@ public class DeviceNetworkingBenchmark
     [Benchmark(Baseline = true, Description = "Entity Events")]
     public async Task EventSentBaseline()
     {
-        var server = _pair.Pair.Server;
+        var server = _pair.Server;
 
-        _pair.Pair.Server.Post(() =>
+        _pair.Server.Post(() =>
         {
             foreach (var entity in _targetEntities)
             {
@@ -113,9 +113,9 @@ public class DeviceNetworkingBenchmark
     [Benchmark(Description = "Device Net Broadcast No Connection Checks")]
     public async Task DeviceNetworkBroadcastNoConnectionChecks()
     {
-        var server = _pair.Pair.Server;
+        var server = _pair.Server;
 
-        _pair.Pair.Server.Post(() =>
+        _pair.Server.Post(() =>
         {
             _deviceNetworkSystem.QueuePacket(_sourceEntity, null, _payload, 100);
         });
@@ -127,9 +127,9 @@ public class DeviceNetworkingBenchmark
     [Benchmark(Description = "Device Net Broadcast Wireless Connection Checks")]
     public async Task DeviceNetworkBroadcastWirelessConnectionChecks()
     {
-        var server = _pair.Pair.Server;
+        var server = _pair.Server;
 
-        _pair.Pair.Server.Post(() =>
+        _pair.Server.Post(() =>
         {
             _deviceNetworkSystem.QueuePacket(_sourceWirelessEntity, null, _payload, 100);
         });

--- a/Content.Benchmarks/MapLoadBenchmark.cs
+++ b/Content.Benchmarks/MapLoadBenchmark.cs
@@ -28,7 +28,7 @@ public class MapLoadBenchmark
         ProgramShared.PathOffset = "../../../../";
 
         _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
-        var server = _pair.Pair.Server;
+        var server = _pair.Server;
 
         Paths = server.ResolveDependency<IPrototypeManager>()
             .EnumeratePrototypes<GameMapPrototype>()
@@ -55,7 +55,7 @@ public class MapLoadBenchmark
     public async Task LoadMap()
     {
         var mapPath = Paths[Map];
-        var server = _pair.Pair.Server;
+        var server = _pair.Server;
         await server.WaitPost(() =>
         {
             var success = _mapLoader.TryLoad(new MapId(10), mapPath, out _);
@@ -67,7 +67,7 @@ public class MapLoadBenchmark
     [IterationCleanup]
     public void IterationCleanup()
     {
-        var server = _pair.Pair.Server;
+        var server = _pair.Server;
         server.WaitPost(() =>
         {
             _mapManager.DeleteMap(new MapId(10));

--- a/Content.Benchmarks/Program.cs
+++ b/Content.Benchmarks/Program.cs
@@ -22,7 +22,7 @@ namespace Content.Benchmarks
         {
             PoolManager.Startup(typeof(Program).Assembly);
             var pair = await PoolManager.GetServerClient();
-            var gameMaps = pair.Pair.Server.ResolveDependency<IPrototypeManager>().EnumeratePrototypes<GameMapPrototype>().ToList();
+            var gameMaps = pair.Server.ResolveDependency<IPrototypeManager>().EnumeratePrototypes<GameMapPrototype>().ToList();
             MapLoadBenchmark.MapsSource = gameMaps.Select(x => x.ID);
             await pair.CleanReturnAsync();
 

--- a/Content.IntegrationTests/Pair/TestPair.cs
+++ b/Content.IntegrationTests/Pair/TestPair.cs
@@ -15,10 +15,6 @@ namespace Content.IntegrationTests.Pair;
 /// </summary>
 public sealed partial class TestPair
 {
-    // TODO remove this.
-    [Obsolete("Field access is redundant")]
-    public TestPair Pair => this;
-
     public readonly int Id;
     private bool _initialized;
     private TextWriter _testOut = default!;
@@ -31,7 +27,7 @@ public sealed partial class TestPair
 
     public PoolTestLogHandler ServerLogHandler { get;  private set; } = default!;
     public PoolTestLogHandler ClientLogHandler { get;  private set; } = default!;
-    
+
     public TestPair(int id)
     {
         Id = id;
@@ -72,7 +68,7 @@ public sealed partial class TestPair
             await Client.WaitRunTicks(1);
         }
     }
-    
+
     public void Kill()
     {
         State = PairState.Dead;
@@ -100,7 +96,7 @@ public sealed partial class TestPair
             throw new InvalidOperationException($"Pair is not ready to use. State: {State}");
         State = PairState.InUse;
     }
-    
+
     public enum PairState : byte
     {
         Ready = 0,

--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -277,7 +277,7 @@ public static partial class PoolManager
         }
 
         pair.ValidateSettings(poolSettings);
-        
+
         var poolRetrieveTime = poolRetrieveTimeWatch.Elapsed;
         await testOut.WriteLineAsync(
             $"{nameof(GetServerClientPair)}: Retrieving pair {pair.Id} from pool took {poolRetrieveTime.TotalMilliseconds} ms");
@@ -298,7 +298,7 @@ public static partial class PoolManager
             {
                 if (Pairs[pair])
                     continue;
-                
+
                 if (!pair.Settings.CanFastRecycle(poolSettings))
                 {
                     fallback = pair;
@@ -320,15 +320,14 @@ public static partial class PoolManager
             {
                 var x = 2;
             }
-            
+
             return fallback;
         }
     }
 
     /// <summary>
-    /// Used by PairTracker after checking the server/client pair, Don't use this.
+    /// Used by TestPair after checking the server/client pair, Don't use this.
     /// </summary>
-    /// <param name="pair"></param>
     public static void NoCheckReturn(TestPair pair)
     {
         lock (PairLock)
@@ -384,12 +383,12 @@ we are just going to end this here to save a lot of time. This is the exception 
     /// <summary>
     /// Creates a map, a grid, and a tile, and gives back references to them.
     /// </summary>
-    /// <param name="pairTracker">A pairTracker</param>
+    /// <param name="pair">A pair</param>
     /// <returns>A TestMapData</returns>
     [Obsolete("use TestPair.CreateMap")]
-    public static async Task<TestMapData> CreateTestMap(TestPair pairTracker)
+    public static async Task<TestMapData> CreateTestMap(TestPair pair)
     {
-        return await pairTracker.CreateTestMap();
+        return await pair.CreateTestMap();
     }
 
     /// <summary>
@@ -406,7 +405,7 @@ we are just going to end this here to save a lot of time. This is the exception 
             await pair.Client.WaitRunTicks(1);
         }
     }
-    
+
     /// <summary>
     /// Runs a server, or a client until a condition is true
     /// </summary>

--- a/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
+++ b/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
@@ -16,7 +16,7 @@ namespace Content.IntegrationTests.Tests.Access
         public async Task TestProtoTags()
         {
             await using var pair = await PoolManager.GetServerClient();
-            var server = pair.Pair.Server;
+            var server = pair.Server;
 
             var protoManager = server.ResolveDependency<IPrototypeManager>();
             var accessName = server.ResolveDependency<IComponentFactory>().GetComponentName(typeof(AccessReaderComponent));
@@ -44,8 +44,8 @@ namespace Content.IntegrationTests.Tests.Access
         [Test]
         public async Task TestTags()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var entityManager = server.ResolveDependency<IEntityManager>();
 
 
@@ -121,7 +121,7 @@ namespace Content.IntegrationTests.Tests.Access
                     Assert.That(system.AreAccessTagsAllowed(Array.Empty<string>(), reader), Is.False);
                 });
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
     }

--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -26,15 +26,15 @@ public sealed class AddTests
     [Test]
     public async Task AddAndGetSingleLog()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(LogTestSettings);
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var server = pair.Server;
         var sEntities = server.ResolveDependency<IEntityManager>();
 
         var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
 
         var guid = Guid.NewGuid();
 
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
         var coordinates = testMap.GridCoords;
         await server.WaitPost(() =>
         {
@@ -65,14 +65,14 @@ public sealed class AddTests
             return false;
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AddAndGetUnformattedLog()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(LogTestSettings);
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var server = pair.Server;
 
         var sDatabase = server.ResolveDependency<IServerDbManager>();
         var sEntities = server.ResolveDependency<IEntityManager>();
@@ -83,7 +83,7 @@ public sealed class AddTests
 
         var guid = Guid.NewGuid();
 
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
         var coordinates = testMap.GridCoords;
         await server.WaitPost(() =>
         {
@@ -130,20 +130,20 @@ public sealed class AddTests
             json.Dispose();
         }
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     [TestCase(500)]
     public async Task BulkAddLogs(int amount)
     {
-        await using var pairTracker = await PoolManager.GetServerClient(LogTestSettings);
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var server = pair.Server;
 
         var sEntities = server.ResolveDependency<IEntityManager>();
         var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
 
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
         var coordinates = testMap.GridCoords;
         await server.WaitPost(() =>
         {
@@ -161,14 +161,14 @@ public sealed class AddTests
             return messages.Count >= amount;
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AddPlayerSessionLog()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(LogTestSettings);
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var server = pair.Server;
 
         var sPlayers = server.ResolveDependency<IPlayerManager>();
 
@@ -197,7 +197,7 @@ public sealed class AddTests
             Assert.That(logs.First().Players, Does.Contain(playerGuid));
             return true;
         });
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
@@ -210,8 +210,8 @@ public sealed class AddTests
             AdminLogsEnabled = true
         };
 
-        await using var pairTracker = await PoolManager.GetServerClient(setting);
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(setting);
+        var server = pair.Server;
 
         var sDatabase = server.ResolveDependency<IServerDbManager>();
         var sSystems = server.ResolveDependency<IEntitySystemManager>();
@@ -264,14 +264,14 @@ public sealed class AddTests
 
             json.Dispose();
         }
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task DuplicatePlayerDoesNotThrowTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(LogTestSettings);
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var server = pair.Server;
 
         var sPlayers = server.ResolveDependency<IPlayerManager>();
         var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
@@ -300,15 +300,15 @@ public sealed class AddTests
             return true;
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
         Assert.Pass();
     }
 
     [Test]
     public async Task DuplicatePlayerIdDoesNotThrowTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(LogTestSettings);
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(LogTestSettings);
+        var server = pair.Server;
 
         var sPlayers = server.ResolveDependency<IPlayerManager>();
 
@@ -338,7 +338,7 @@ public sealed class AddTests
             return true;
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
         Assert.Pass();
     }
 }

--- a/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
@@ -14,8 +14,8 @@ public sealed class FilterTests
     [TestCase(DateOrder.Descending)]
     public async Task Date(DateOrder order)
     {
-        await using var pairTracker = await PoolManager.GetServerClient(AddTests.LogTestSettings);
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(AddTests.LogTestSettings);
+        var server = pair.Server;
 
         var sEntities = server.ResolveDependency<IEntityManager>();
 
@@ -24,7 +24,7 @@ public sealed class FilterTests
         var commonGuid = Guid.NewGuid();
         var firstGuid = Guid.NewGuid();
         var secondGuid = Guid.NewGuid();
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
         var coordinates = testMap.GridCoords;
 
         await server.WaitPost(() =>
@@ -96,6 +96,6 @@ public sealed class FilterTests
 
             return firstFound && secondFound;
         });
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Administration/Logs/QueryTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/QueryTests.cs
@@ -15,8 +15,8 @@ public sealed class QueryTests
     [Test]
     public async Task QuerySingleLog()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(AddTests.LogTestSettings);
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(AddTests.LogTestSettings);
+        var server = pair.Server;
 
         var sSystems = server.ResolveDependency<IEntitySystemManager>();
         var sPlayers = server.ResolveDependency<IPlayerManager>();
@@ -55,6 +55,6 @@ public sealed class QueryTests
             return false;
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Atmos/AlarmThresholdTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AlarmThresholdTest.cs
@@ -24,8 +24,8 @@ namespace Content.IntegrationTests.Tests.Atmos
         [Test]
         public async Task TestAlarmThreshold()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
             AtmosAlarmThreshold threshold = default!;
@@ -134,7 +134,7 @@ namespace Content.IntegrationTests.Tests.Atmos
                     Assert.That(alarmType, Is.EqualTo(AtmosAlarmType.Normal));
                 }
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Atmos/ConstantsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/ConstantsTest.cs
@@ -12,8 +12,8 @@ namespace Content.IntegrationTests.Tests.Atmos
         [Test]
         public async Task TotalGasesTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var entityManager = server.ResolveDependency<IEntityManager>();
 
             await server.WaitPost(() =>
@@ -26,7 +26,7 @@ namespace Content.IntegrationTests.Tests.Atmos
                     Assert.That(Enum.GetValues(typeof(Gas)), Has.Length.EqualTo(Atmospherics.TotalNumberOfGases));
                 });
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Atmos/GasMixtureTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GasMixtureTest.cs
@@ -12,8 +12,8 @@ namespace Content.IntegrationTests.Tests.Atmos
         [Test]
         public async Task TestMerge()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var atmosphereSystem = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<AtmosphereSystem>();
 
@@ -57,7 +57,7 @@ namespace Content.IntegrationTests.Tests.Atmos
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
@@ -69,8 +69,8 @@ namespace Content.IntegrationTests.Tests.Atmos
         [TestCase(Atmospherics.BreathPercentage)]
         public async Task RemoveRatio(float ratio)
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             await server.WaitAssertion(() =>
             {
@@ -104,7 +104,7 @@ namespace Content.IntegrationTests.Tests.Atmos
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Body/LegTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LegTest.cs
@@ -29,8 +29,8 @@ namespace Content.IntegrationTests.Tests.Body
         [Test]
         public async Task RemoveLegsFallTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             EntityUid human = default!;
             AppearanceComponent appearance = null;
@@ -72,7 +72,7 @@ namespace Content.IntegrationTests.Tests.Body
                 Assert.That(state, Is.EqualTo(RotationState.Horizontal));
 #pragma warning restore NUnit2045
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -53,8 +53,8 @@ namespace Content.IntegrationTests.Tests.Body
         public async Task AirConsistencyTest()
         {
             // --- Setup
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             await server.WaitIdleAsync();
 
@@ -132,14 +132,14 @@ namespace Content.IntegrationTests.Tests.Body
                 });
             }
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task NoSuffocationTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -198,7 +198,7 @@ namespace Content.IntegrationTests.Tests.Body
                 });
             }
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Body/SaveLoadReparentTest.cs
+++ b/Content.IntegrationTests/Tests/Body/SaveLoadReparentTest.cs
@@ -24,8 +24,8 @@ public sealed class SaveLoadReparentTest
     [Test]
     public async Task Test()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entities = server.ResolveDependency<IEntityManager>();
         var maps = server.ResolveDependency<IMapManager>();
@@ -159,6 +159,6 @@ public sealed class SaveLoadReparentTest
             }
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -49,10 +49,10 @@ namespace Content.IntegrationTests.Tests.Buckle
         [Test]
         public async Task BuckleUnbuckleCooldownRangeTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
             var coordinates = testMap.GridCoords;
             var entityManager = server.ResolveDependency<IEntityManager>();
             var actionBlocker = entityManager.System<ActionBlockerSystem>();
@@ -236,16 +236,16 @@ namespace Content.IntegrationTests.Tests.Buckle
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task BuckledDyingDropItemsTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
             var coordinates = testMap.GridCoords;
 
             EntityUid human = default;
@@ -329,16 +329,16 @@ namespace Content.IntegrationTests.Tests.Buckle
                 buckleSystem.TryUnbuckle(human, human, true, buckleComp: buckle);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task ForceUnbuckleBuckleTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
             var coordinates = testMap.GridCoords;
             var entityManager = server.ResolveDependency<IEntityManager>();
             var buckleSystem = entityManager.System<SharedBuckleSystem>();
@@ -405,7 +405,7 @@ namespace Content.IntegrationTests.Tests.Buckle
                     Assert.That(buckle.Buckled);
                 });
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -17,10 +17,10 @@ public sealed class CargoTest
     [Test]
     public async Task NoCargoOrderArbitrage()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
 
         var entManager = server.ResolveDependency<IEntityManager>();
         var mapManager = server.ResolveDependency<IMapManager>();
@@ -46,15 +46,15 @@ public sealed class CargoTest
             mapManager.DeleteMap(mapId);
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
     [Test]
     public async Task NoCargoBountyArbitageTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
 
         var entManager = server.ResolveDependency<IEntityManager>();
         var mapManager = server.ResolveDependency<IMapManager>();
@@ -86,16 +86,16 @@ public sealed class CargoTest
             mapManager.DeleteMap(mapId);
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task NoStaticPriceAndStackPrice()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
 
         var entManager = server.ResolveDependency<IEntityManager>();
         var mapManager = server.ResolveDependency<IMapManager>();
@@ -109,7 +109,7 @@ public sealed class CargoTest
 
             var protoIds = protoManager.EnumeratePrototypes<EntityPrototype>()
                 .Where(p => !p.Abstract)
-                .Where(p => !pairTracker.Pair.IsTestPrototype(p))
+                .Where(p => !pair.IsTestPrototype(p))
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // Grids are not for sale.
                 .Select(p => p.ID)
                 .ToList();
@@ -142,7 +142,7 @@ public sealed class CargoTest
             mapManager.DeleteMap(mapId);
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
 
@@ -168,8 +168,8 @@ public sealed class CargoTest
     [Test]
     public async Task StackPrice()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
         var priceSystem = entManager.System<PricingSystem>();
@@ -178,6 +178,6 @@ public sealed class CargoTest
         var price = priceSystem.GetPrice(ent);
         Assert.That(price, Is.EqualTo(100.0));
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Chemistry/SolutionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/SolutionSystemTests.cs
@@ -46,13 +46,13 @@ public sealed class SolutionSystemTests
     [Test]
     public async Task TryAddTwoNonReactiveReagent()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
         var protoMan = server.ResolveDependency<IPrototypeManager>();
         var containerSystem = entityManager.EntitySysManager.GetEntitySystem<SolutionContainerSystem>();
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
         var coordinates = testMap.GridCoords;
 
         EntityUid beaker;
@@ -82,7 +82,7 @@ public sealed class SolutionSystemTests
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     // This test mimics current behavior
@@ -90,10 +90,10 @@ public sealed class SolutionSystemTests
     [Test]
     public async Task TryAddTooMuchNonReactiveReagent()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
 
         var entityManager = server.ResolveDependency<IEntityManager>();
         var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -127,20 +127,20 @@ public sealed class SolutionSystemTests
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     // Unlike TryAddSolution this adds and two solution without then splits leaving only threshold in original
     [Test]
     public async Task TryMixAndOverflowTooMuchReagent()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
 
         var entityManager = server.ResolveDependency<IEntityManager>();
         var protoMan = server.ResolveDependency<IPrototypeManager>();
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
         var containerSystem = entityManager.EntitySysManager.GetEntitySystem<SolutionContainerSystem>();
         var coordinates = testMap.GridCoords;
 
@@ -182,20 +182,20 @@ public sealed class SolutionSystemTests
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     // TryMixAndOverflow will fail if Threshold larger than MaxVolume
     [Test]
     public async Task TryMixAndOverflowTooBigOverflow()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
         var protoMan = server.ResolveDependency<IPrototypeManager>();
         var containerSystem = entityManager.EntitySysManager.GetEntitySystem<SolutionContainerSystem>();
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
         var coordinates = testMap.GridCoords;
 
         EntityUid beaker;
@@ -220,14 +220,14 @@ public sealed class SolutionSystemTests
                 Is.False);
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestTemperatureCalculations()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
         var protoMan = server.ResolveDependency<IPrototypeManager>();
         const float temp = 100.0f;
 
@@ -259,6 +259,6 @@ public sealed class SolutionSystemTests
             Assert.That(solutionOne.GetHeatCapacity(protoMan) * solutionOne.Temperature, Is.EqualTo(thermalEnergyOne + thermalEnergyTwo));
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
@@ -27,12 +27,12 @@ namespace Content.IntegrationTests.Tests.Chemistry
         [Test]
         public async Task TryAllTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var entityManager = server.ResolveDependency<IEntityManager>();
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
             var coordinates = testMap.GridCoords;
             var solutionSystem = server.ResolveDependency<IEntitySystemManager>()
                 .GetEntitySystem<SolutionContainerSystem>();
@@ -89,7 +89,7 @@ namespace Content.IntegrationTests.Tests.Chemistry
                 });
 
             }
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 

--- a/Content.IntegrationTests/Tests/Cleanup/EuiManagerTest.cs
+++ b/Content.IntegrationTests/Tests/Cleanup/EuiManagerTest.cs
@@ -13,12 +13,12 @@ public sealed class EuiManagerTest
         // Even though we are using the server EUI here, we actually want to see if the client EUIManager crashes
         for (var i = 0; i < 2; i++)
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 Connected = true,
                 Dirty = true
             });
-            var server = pairTracker.Pair.Server;
+            var server = pair.Server;
 
             var sPlayerManager = server.ResolveDependency<IPlayerManager>();
             var eui = server.ResolveDependency<EuiManager>();
@@ -29,7 +29,7 @@ public sealed class EuiManagerTest
                 var ui = new AdminAnnounceEui();
                 eui.OpenEui(ui, clientSession);
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/ClickableTest.cs
+++ b/Content.IntegrationTests/Tests/ClickableTest.cs
@@ -44,9 +44,9 @@ namespace Content.IntegrationTests.Tests
         [TestCase("ClickTestRotatingCornerInvisibleNoRot", 0.25f, 0.25f, DirSouthEastJustShy, 1, ExpectedResult = true)]
         public async Task<bool> Test(string prototype, float clickPosX, float clickPosY, double angle, float scale)
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var server = pair.Server;
+            var client = pair.Client;
             EntityUid entity = default;
             var clientEntManager = client.ResolveDependency<IEntityManager>();
             var serverEntManager = server.ResolveDependency<IEntityManager>();
@@ -55,7 +55,7 @@ namespace Content.IntegrationTests.Tests
             var xformQuery = clientEntManager.GetEntityQuery<TransformComponent>();
             var eye = client.ResolveDependency<IEyeManager>().CurrentEye;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
             await server.WaitPost(() =>
             {
                 var ent = serverEntManager.SpawnEntity(prototype, testMap.GridCoords);
@@ -64,7 +64,7 @@ namespace Content.IntegrationTests.Tests
             });
 
             // Let client sync up.
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
             var hit = false;
 
@@ -87,7 +87,7 @@ namespace Content.IntegrationTests.Tests
                 serverEntManager.DeleteEntity(entity);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
 
             return hit;
         }

--- a/Content.IntegrationTests/Tests/Commands/PardonCommand.cs
+++ b/Content.IntegrationTests/Tests/Commands/PardonCommand.cs
@@ -15,9 +15,9 @@ namespace Content.IntegrationTests.Tests.Commands
         [Test]
         public async Task PardonTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var server = pair.Server;
+            var client = pair.Client;
 
             var sPlayerManager = server.ResolveDependency<IPlayerManager>();
             var sConsole = server.ResolveDependency<IServerConsoleHost>();
@@ -62,7 +62,7 @@ namespace Content.IntegrationTests.Tests.Commands
                 Assert.That(await sDatabase.GetServerBansAsync(null, clientId, null), Has.Count.EqualTo(1));
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
             Assert.That(sPlayerManager.Sessions.Count(), Is.EqualTo(0));
             Assert.That(!netMan.IsConnected);
 
@@ -146,10 +146,10 @@ namespace Content.IntegrationTests.Tests.Commands
             Assert.That(sPlayerManager.Sessions.Count(), Is.EqualTo(0));
             client.SetConnectTarget(server);
             await client.WaitPost(() => netMan.ClientConnect(null!, 0, null!));
-            await pairTracker.RunTicksSync(5);
+            await pair.RunTicksSync(5);
             Assert.That(sPlayerManager.Sessions.Count(), Is.EqualTo(1));
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Commands/RejuvenateTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/RejuvenateTest.cs
@@ -33,8 +33,8 @@ namespace Content.IntegrationTests.Tests.Commands
         [Test]
         public async Task RejuvenateDeadTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var entManager = server.ResolveDependency<IEntityManager>();
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
             var mobStateSystem = entManager.EntitySysManager.GetEntitySystem<MobStateSystem>();
@@ -89,7 +89,7 @@ namespace Content.IntegrationTests.Tests.Commands
                     Assert.That(damageable.TotalDamage, Is.EqualTo(FixedPoint2.Zero));
                 });
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Commands/RestartRoundTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/RestartRoundTest.cs
@@ -16,18 +16,18 @@ namespace Content.IntegrationTests.Tests.Commands
         [TestCase(false)]
         public async Task RestartRoundAfterStart(bool lobbyEnabled)
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 DummyTicker = false,
                 Dirty = true
             });
-            var server = pairTracker.Pair.Server;
+            var server = pair.Server;
 
             var configManager = server.ResolveDependency<IConfigurationManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var gameTicker = entityManager.EntitySysManager.GetEntitySystem<GameTicker>();
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
             GameTick tickBeforeRestart = default;
 
@@ -49,7 +49,7 @@ namespace Content.IntegrationTests.Tests.Commands
                 }
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 15);
+            await PoolManager.RunTicksSync(pair, 15);
 
             await server.WaitAssertion(() =>
             {
@@ -58,8 +58,8 @@ namespace Content.IntegrationTests.Tests.Commands
                 Assert.That(tickBeforeRestart, Is.LessThan(tickAfterRestart));
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
-            await pairTracker.CleanReturnAsync();
+            await PoolManager.RunTicksSync(pair, 5);
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Construction/ConstructionActionValid.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionActionValid.cs
@@ -47,8 +47,8 @@ namespace Content.IntegrationTests.Tests.Construction
         [Test]
         public async Task ConstructionGraphSpawnPrototypeValid()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
 
@@ -79,7 +79,7 @@ namespace Content.IntegrationTests.Tests.Construction
                     }
                 }
             }
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
 
             Assert.That(valid, Is.True, $"One or more SpawnPrototype actions specified invalid entity prototypes!\n{message}");
         }
@@ -87,8 +87,8 @@ namespace Content.IntegrationTests.Tests.Construction
         [Test]
         public async Task ConstructionGraphEdgeValid()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
 
@@ -110,7 +110,7 @@ namespace Content.IntegrationTests.Tests.Construction
             }
 
             Assert.That(valid, Is.True, $"One or more edges specified invalid node targets!\n{message}");
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
@@ -21,13 +21,13 @@ namespace Content.IntegrationTests.Tests.Construction
         [Test]
         public async Task TestStartNodeValid()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var entMan = server.ResolveDependency<IEntityManager>();
             var protoMan = server.ResolveDependency<IPrototypeManager>();
 
-            var map = await PoolManager.CreateTestMap(pairTracker);
+            var map = await PoolManager.CreateTestMap(pair);
 
             await server.WaitAssertion(() =>
             {
@@ -47,14 +47,14 @@ namespace Content.IntegrationTests.Tests.Construction
                 }
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestStartIsValid()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
 
@@ -65,14 +65,14 @@ namespace Content.IntegrationTests.Tests.Construction
 
                 Assert.That(graph.Nodes.ContainsKey(start), $"Found no startNode \"{start}\" on graph \"{graph.ID}\" for construction prototype \"{proto.ID}\"!");
             }
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestTargetIsValid()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
 
@@ -83,14 +83,14 @@ namespace Content.IntegrationTests.Tests.Construction
 
                 Assert.That(graph.Nodes.ContainsKey(target), $"Found no targetNode \"{target}\" on graph \"{graph.ID}\" for construction prototype \"{proto.ID}\"!");
             }
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task DeconstructionIsValid()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var entMan = server.ResolveDependency<IEntityManager>();
             var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -101,7 +101,7 @@ namespace Content.IntegrationTests.Tests.Construction
             {
                 foreach (var proto in protoMan.EnumeratePrototypes<EntityPrototype>())
                 {
-                    if (proto.Abstract || pairTracker.Pair.IsTestPrototype(proto) || !proto.Components.TryGetValue(name, out var reg))
+                    if (proto.Abstract || pair.IsTestPrototype(proto) || !proto.Components.TryGetValue(name, out var reg))
                         continue;
 
                     var comp = (ConstructionComponent) reg.Component;
@@ -114,14 +114,14 @@ namespace Content.IntegrationTests.Tests.Construction
                 }
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestStartReachesValidTarget()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
             var entMan = server.ResolveDependency<IEntityManager>();
@@ -142,7 +142,7 @@ namespace Content.IntegrationTests.Tests.Construction
                 Assert.That(entity.Components.ContainsKey("Construction"), $"The next node ({next.Name}) in the path from the start node ({start}) to the target node ({target}) specified an entity prototype ({next.Entity}) without a ConstructionComponent.");
 #pragma warning restore NUnit2045
             }
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/ContainerOcclusionTest.cs
+++ b/Content.IntegrationTests/Tests/ContainerOcclusionTest.cs
@@ -34,9 +34,9 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task TestA()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-            var s = pairTracker.Pair.Server;
-            var c = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var s = pair.Server;
+            var c = pair.Client;
 
             var cEntities = c.ResolveDependency<IEntityManager>();
             var ent = s.ResolveDependency<IEntityManager>();
@@ -55,7 +55,7 @@ namespace Content.IntegrationTests.Tests
                 entStorage.Insert(dummy, container);
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
             await c.WaitAssertion(() =>
             {
@@ -68,15 +68,15 @@ namespace Content.IntegrationTests.Tests
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestB()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-            var s = pairTracker.Pair.Server;
-            var c = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var s = pair.Server;
+            var c = pair.Client;
 
             var cEntities = c.ResolveDependency<IEntityManager>();
             var ent = s.ResolveDependency<IEntityManager>();
@@ -95,7 +95,7 @@ namespace Content.IntegrationTests.Tests
                 entStorage.Insert(dummy, container);
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
             await c.WaitAssertion(() =>
             {
@@ -108,15 +108,15 @@ namespace Content.IntegrationTests.Tests
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestAb()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-            var s = pairTracker.Pair.Server;
-            var c = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var s = pair.Server;
+            var c = pair.Client;
 
             var cEntities = c.ResolveDependency<IEntityManager>();
             var ent = s.ResolveDependency<IEntityManager>();
@@ -137,7 +137,7 @@ namespace Content.IntegrationTests.Tests
                 entStorage.Insert(dummy, containerB);
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
             await c.WaitAssertion(() =>
             {
@@ -150,7 +150,7 @@ namespace Content.IntegrationTests.Tests
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
@@ -73,8 +73,8 @@ namespace Content.IntegrationTests.Tests.Damageable
         [Test]
         public async Task TestDamageableComponents()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var sMapManager = server.ResolveDependency<IMapManager>();
@@ -237,7 +237,7 @@ namespace Content.IntegrationTests.Tests.Damageable
                 sDamageableSystem.TryChangeDamage(uid, new DamageSpecifier(group3, -100));
                 Assert.That(sDamageableComponent.TotalDamage, Is.EqualTo(FixedPoint2.Zero));
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/DeleteInventoryTest.cs
+++ b/Content.IntegrationTests/Tests/DeleteInventoryTest.cs
@@ -14,9 +14,9 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
+            var testMap = await PoolManager.CreateTestMap(pair);
             var entMgr = server.ResolveDependency<IEntityManager>();
             var sysManager = server.ResolveDependency<IEntitySystemManager>();
             var coordinates = testMap.GridCoords;
@@ -44,7 +44,7 @@ namespace Content.IntegrationTests.Tests
                 // Assert that child item was also deleted.
                 Assert.That(item.Deleted, Is.True);
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageGroupTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageGroupTest.cs
@@ -18,10 +18,10 @@ namespace Content.IntegrationTests.Tests.Destructible
         [Test]
         public async Task AndTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var sPrototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -193,7 +193,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                 // No new thresholds reached as triggers once is set to true and it already triggered before
                 Assert.That(sTestThresholdListenerSystem.ThresholdsReached, Is.Empty);
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
@@ -15,10 +15,10 @@ namespace Content.IntegrationTests.Tests.Destructible
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var sEntitySystemManager = server.ResolveDependency<IEntitySystemManager>();
@@ -186,7 +186,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                 // No new thresholds reached as triggers once is set to true and it already triggered before
                 Assert.That(sTestThresholdListenerSystem.ThresholdsReached, Is.Empty);
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
@@ -14,10 +14,10 @@ namespace Content.IntegrationTests.Tests.Destructible
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var sPrototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -88,7 +88,7 @@ namespace Content.IntegrationTests.Tests.Destructible
 
                 Assert.That(found, Is.True);
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleThresholdActivationTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleThresholdActivationTest.cs
@@ -20,15 +20,15 @@ namespace Content.IntegrationTests.Tests.Destructible
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var sPrototypeManager = server.ResolveDependency<IPrototypeManager>();
             var sEntitySystemManager = server.ResolveDependency<IEntitySystemManager>();
             var audio = sEntitySystemManager.GetEntitySystem<SharedAudioSystem>();
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             EntityUid sDestructibleEntity = default;
             DamageableComponent sDamageableComponent = null;
@@ -288,7 +288,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                     Assert.That(sTestThresholdListenerSystem.ThresholdsReached, Is.Empty);
                 });
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/DeviceNetwork/DeviceNetworkTest.cs
+++ b/Content.IntegrationTests/Tests/DeviceNetwork/DeviceNetworkTest.cs
@@ -51,8 +51,8 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
         [Test]
         public async Task NetworkDeviceSendAndReceive()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -105,15 +105,15 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
             {
                 CollectionAssert.AreEquivalent(deviceNetTestSystem.LastPayload, payload);
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task WirelessNetworkDeviceSendAndReceive()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
+            var testMap = await PoolManager.CreateTestMap(pair);
             var coordinates = testMap.GridCoords;
 
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -190,15 +190,15 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
                 CollectionAssert.AreNotEqual(deviceNetTestSystem.LastPayload, payload);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task WiredNetworkDeviceSendAndReceive()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
+            var testMap = await PoolManager.CreateTestMap(pair);
             var coordinates = testMap.GridCoords;
 
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -273,7 +273,7 @@ namespace Content.IntegrationTests.Tests.DeviceNetwork
                 CollectionAssert.AreEqual(deviceNetTestSystem.LastPayload, payload);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -147,10 +147,10 @@ namespace Content.IntegrationTests.Tests.Disposal
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             EntityUid human = default!;
             EntityUid wrench = default!;
@@ -240,7 +240,7 @@ namespace Content.IntegrationTests.Tests.Disposal
                 // Re-pressurizing
                 Flush(disposalUnit, unitComponent, false, disposalSystem);
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
+++ b/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
@@ -32,8 +32,8 @@ namespace Content.IntegrationTests.Tests.DoAfter
         [Test]
         public async Task TestSerializable()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             await server.WaitIdleAsync();
             var refMan = server.ResolveDependency<IReflectionManager>();
 
@@ -53,14 +53,14 @@ namespace Content.IntegrationTests.Tests.DoAfter
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestFinished()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             await server.WaitIdleAsync();
 
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -83,14 +83,14 @@ namespace Content.IntegrationTests.Tests.DoAfter
             await server.WaitRunTicks(1);
             Assert.That(ev.Cancelled, Is.False);
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestCancelled()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var entityManager = server.ResolveDependency<IEntityManager>();
             var timing = server.ResolveDependency<IGameTiming>();
             var doAfterSystem = entityManager.EntitySysManager.GetEntitySystem<SharedDoAfterSystem>();
@@ -118,7 +118,7 @@ namespace Content.IntegrationTests.Tests.DoAfter
             await server.WaitRunTicks(3);
             Assert.That(ev.Cancelled);
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
@@ -53,8 +53,8 @@ namespace Content.IntegrationTests.Tests.Doors
         [Test]
         public async Task OpenCloseDestroyTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var entityManager = server.ResolveDependency<IEntityManager>();
             var doors = entityManager.EntitySysManager.GetEntitySystem<DoorSystem>();
@@ -106,14 +106,14 @@ namespace Content.IntegrationTests.Tests.Doors
 
             server.RunTicks(5);
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task AirlockBlockTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             await server.WaitIdleAsync();
 
@@ -178,7 +178,7 @@ namespace Content.IntegrationTests.Tests.Doors
             {
                 Assert.That(Math.Abs(xformSystem.GetWorldPosition(AirlockPhysicsDummy).X - 1), Is.GreaterThan(0.01f));
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/DummyIconTest.cs
+++ b/Content.IntegrationTests/Tests/DummyIconTest.cs
@@ -12,8 +12,8 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var client = pair.Client;
             var prototypeManager = client.ResolveDependency<IPrototypeManager>();
             var resourceCache = client.ResolveDependency<IResourceCache>();
 
@@ -21,7 +21,7 @@ namespace Content.IntegrationTests.Tests
             {
                 foreach (var proto in prototypeManager.EnumeratePrototypes<EntityPrototype>())
                 {
-                    if (proto.NoSpawn || proto.Abstract || pairTracker.Pair.IsTestPrototype(proto) || !proto.Components.ContainsKey("Sprite"))
+                    if (proto.NoSpawn || proto.Abstract || pair.IsTestPrototype(proto) || !proto.Components.ContainsKey("Sprite"))
                         continue;
 
                     Assert.DoesNotThrow(() =>
@@ -31,7 +31,7 @@ namespace Content.IntegrationTests.Tests
                         proto.ID);
                 }
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -22,8 +22,8 @@ namespace Content.IntegrationTests.Tests
             // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
             // is minimal relative to the rest of the test.
             var settings = new PoolSettings { Dirty = true };
-            await using var pairTracker = await PoolManager.GetServerClient(settings);
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient(settings);
+            var server = pair.Server;
 
             var entityMan = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -34,7 +34,7 @@ namespace Content.IntegrationTests.Tests
                 var protoIds = prototypeMan
                     .EnumeratePrototypes<EntityPrototype>()
                     .Where(p => !p.Abstract)
-                    .Where(p => !pairTracker.Pair.IsTestPrototype(p))
+                    .Where(p => !pair.IsTestPrototype(p))
                     .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                     .Select(p => p.ID)
                     .ToList();
@@ -69,7 +69,7 @@ namespace Content.IntegrationTests.Tests
                 Assert.That(entityMan.EntityCount, Is.Zero);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
@@ -78,9 +78,9 @@ namespace Content.IntegrationTests.Tests
             // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
             // is minimal relative to the rest of the test.
             var settings = new PoolSettings { Dirty = true };
-            await using var pairTracker = await PoolManager.GetServerClient(settings);
-            var server = pairTracker.Pair.Server;
-            var map = await PoolManager.CreateTestMap(pairTracker);
+            await using var pair = await PoolManager.GetServerClient(settings);
+            var server = pair.Server;
+            var map = await PoolManager.CreateTestMap(pair);
 
             var entityMan = server.ResolveDependency<IEntityManager>();
             var prototypeMan = server.ResolveDependency<IPrototypeManager>();
@@ -91,7 +91,7 @@ namespace Content.IntegrationTests.Tests
                 var protoIds = prototypeMan
                     .EnumeratePrototypes<EntityPrototype>()
                     .Where(p => !p.Abstract)
-                    .Where(p => !pairTracker.Pair.IsTestPrototype(p))
+                    .Where(p => !pair.IsTestPrototype(p))
                     .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                     .Select(p => p.ID)
                     .ToList();
@@ -121,7 +121,7 @@ namespace Content.IntegrationTests.Tests
                 Assert.That(entityMan.EntityCount, Is.Zero);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -134,9 +134,9 @@ namespace Content.IntegrationTests.Tests
             // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round
             // is minimal relative to the rest of the test.
             var settings = new PoolSettings { Connected = true, Dirty = true };
-            await using var pairTracker = await PoolManager.GetServerClient(settings);
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(settings);
+            var server = pair.Server;
+            var client = pair.Client;
 
             var cfg = server.ResolveDependency<IConfigurationManager>();
             var prototypeMan = server.ResolveDependency<IPrototypeManager>();
@@ -148,7 +148,7 @@ namespace Content.IntegrationTests.Tests
             var protoIds = prototypeMan
                 .EnumeratePrototypes<EntityPrototype>()
                 .Where(p => !p.Abstract)
-                .Where(p => !pairTracker.Pair.IsTestPrototype(p))
+                .Where(p => !pair.IsTestPrototype(p))
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                 .Select(p => p.ID)
                 .ToList();
@@ -167,7 +167,7 @@ namespace Content.IntegrationTests.Tests
                 }
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 15);
+            await PoolManager.RunTicksSync(pair, 15);
 
             // Make sure the client actually received the entities
             // 500 is completely arbitrary. Note that the client & sever entity counts aren't expected to match.
@@ -193,7 +193,7 @@ namespace Content.IntegrationTests.Tests
                 Assert.That(sEntMan.EntityCount, Is.Zero);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
@@ -216,8 +216,8 @@ namespace Content.IntegrationTests.Tests
                 "BiomeSelection", // Whaddya know, requires config.
             };
 
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -290,7 +290,7 @@ namespace Content.IntegrationTests.Tests
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
@@ -313,8 +313,8 @@ namespace Content.IntegrationTests.Tests
                 "BiomeSelection", // Whaddya know, requires config.
             };
 
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -420,7 +420,7 @@ namespace Content.IntegrationTests.Tests
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Fluids/FluidSpillTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/FluidSpillTest.cs
@@ -30,8 +30,8 @@ public sealed class FluidSpill
     [Test]
     public async Task SpillCorner()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
         var mapManager = server.ResolveDependency<IMapManager>();
         var entityManager = server.ResolveDependency<IEntityManager>();
         var puddleSystem = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<PuddleSystem>();
@@ -106,6 +106,6 @@ public sealed class FluidSpill
             }
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
@@ -16,10 +16,10 @@ namespace Content.IntegrationTests.Tests.Fluids
         [Test]
         public async Task TilePuddleTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
             var spillSystem = entitySystemManager.GetEntitySystem<PuddleSystem>();
@@ -34,18 +34,18 @@ namespace Content.IntegrationTests.Tests.Fluids
 
                 Assert.That(spillSystem.TrySpillAt(coordinates, solution, out _), Is.True);
             });
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task SpaceNoPuddleTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
             var spillSystem = entitySystemManager.GetEntitySystem<PuddleSystem>();
@@ -63,7 +63,7 @@ namespace Content.IntegrationTests.Tests.Fluids
                 }
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
             await server.WaitAssertion(() =>
             {
@@ -73,7 +73,7 @@ namespace Content.IntegrationTests.Tests.Fluids
                 Assert.That(spillSystem.TrySpillAt(coordinates, solution, out _), Is.False);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/FollowerSystemTest.cs
+++ b/Content.IntegrationTests/Tests/FollowerSystemTest.cs
@@ -14,8 +14,8 @@ public sealed class FollowerSystemTest
     [Test]
     public async Task FollowerMapDeleteTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
         var mapMan = server.ResolveDependency<IMapManager>();
@@ -42,6 +42,6 @@ public sealed class FollowerSystemTest
 
             entMan.DeleteEntity(mapMan.GetMapEntityId(map));
         });
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
@@ -37,8 +37,8 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             EntityUid human;
             EntityUid otherHuman;
@@ -98,7 +98,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
                 Assert.That(cuffed.CuffedHandCount, Is.EqualTo(4), "Player doesn't have correct amount of hands cuffed");
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         private static void AddHand(EntityUid to, IServerConsoleHost host)

--- a/Content.IntegrationTests/Tests/GameObjects/Components/EntityPrototypeComponentsTest.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/EntityPrototypeComponentsTest.cs
@@ -16,9 +16,9 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components
         [Test]
         public async Task PrototypesHaveKnownComponents()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
+            var client = pair.Client;
 
             var sResourceManager = server.ResolveDependency<IResourceManager>();
             var prototypePath = new ResPath("/Prototypes/");
@@ -93,7 +93,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components
 
             if (unknownComponentsClient.Count + unknownComponentsServer.Count == 0)
             {
-                await pairTracker.CleanReturnAsync();
+                await pair.CleanReturnAsync();
                 Assert.Pass($"Validated {entitiesValidated} entities with {componentsValidated} components in {paths.Length} files.");
                 return;
             }
@@ -118,9 +118,9 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components
         [Test]
         public async Task IgnoredComponentsExistInTheCorrectPlaces()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
+            var client = pair.Client;
             var serverComponents = server.ResolveDependency<IComponentFactory>();
             var ignoredServerNames = Server.Entry.IgnoredComponents.List;
             var clientComponents = client.ResolveDependency<IComponentFactory>();
@@ -138,7 +138,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components
                 }
             }
             Assert.That(failureMessages, Is.Empty);
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/AlertsComponentTests.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/AlertsComponentTests.cs
@@ -16,13 +16,13 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
         [Test]
         public async Task AlertsTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 Connected = true,
                 DummyTicker = false
             });
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            var server = pair.Server;
+            var client = pair.Client;
 
             var clientPlayerMgr = client.ResolveDependency<Robust.Client.Player.IPlayerManager>();
             var clientUIMgr = client.ResolveDependency<IUserInterfaceManager>();
@@ -52,7 +52,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
                 Assert.That(alerts, Has.Count.EqualTo(alertCount + 2));
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
             AlertsUI clientAlertsUI = default;
             await client.WaitAssertion(() =>
@@ -98,7 +98,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
                 alertsSystem.ClearAlert(playerUid, AlertType.Debug1);
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
             await client.WaitAssertion(() =>
             {
@@ -110,7 +110,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
                 Assert.That(alertIDs, Is.SupersetOf(expectedIDs));
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/GameRules/RuleMaxTimeRestartTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/RuleMaxTimeRestartTest.cs
@@ -16,8 +16,8 @@ namespace Content.IntegrationTests.Tests.GameRules
         [Test]
         public async Task RestartTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+            var server = pair.Server;
 
             var entityManager = server.ResolveDependency<IEntityManager>();
             var sGameTicker = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<GameTicker>();
@@ -39,7 +39,7 @@ namespace Content.IntegrationTests.Tests.GameRules
             });
 
             var ticks = sGameTiming.TickRate * (int) Math.Ceiling(maxTime.RoundMaxTime.TotalSeconds * 1.1f);
-            await PoolManager.RunTicksSync(pairTracker.Pair, ticks);
+            await PoolManager.RunTicksSync(pair, ticks);
 
             await server.WaitAssertion(() =>
             {
@@ -47,14 +47,14 @@ namespace Content.IntegrationTests.Tests.GameRules
             });
 
             ticks = sGameTiming.TickRate * (int) Math.Ceiling(maxTime.RoundEndDelay.TotalSeconds * 1.1f);
-            await PoolManager.RunTicksSync(pairTracker.Pair, ticks);
+            await PoolManager.RunTicksSync(pair, ticks);
 
             await server.WaitAssertion(() =>
             {
                 Assert.That(sGameTicker.RunLevel, Is.EqualTo(GameRunLevel.PreRoundLobby));
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/GameRules/SecretStartsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/SecretStartsTest.cs
@@ -13,9 +13,9 @@ public sealed class SecretStartsTest
     [Test]
     public async Task TestSecretStarts()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Dirty = true });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Dirty = true });
 
-        var server = pairTracker.Pair.Server;
+        var server = pair.Server;
         await server.WaitIdleAsync();
         var gameTicker = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<GameTicker>();
 
@@ -38,6 +38,6 @@ public sealed class SecretStartsTest
             gameTicker.ClearGameRules();
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/GameRules/StartEndGameRulesTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/StartEndGameRulesTest.cs
@@ -15,12 +15,12 @@ public sealed class StartEndGameRulesTest
     [Test]
     public async Task TestAllConcurrent()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             Dirty = true,
             DummyTicker = false
         });
-        var server = pairTracker.Pair.Server;
+        var server = pair.Server;
         await server.WaitIdleAsync();
         var gameTicker = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<GameTicker>();
         var cfg = server.ResolveDependency<IConfigurationManager>();
@@ -48,6 +48,6 @@ public sealed class StartEndGameRulesTest
             Assert.That(!gameTicker.GetAddedGameRules().Any());
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
+++ b/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
@@ -33,15 +33,15 @@ namespace Content.IntegrationTests.Tests.Gravity
         [Test]
         public async Task WeightlessStatusTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var entityManager = server.ResolveDependency<IEntityManager>();
             var alertsSystem = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<AlertsSystem>();
 
             EntityUid human = default;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             await server.WaitAssertion(() =>
             {
@@ -51,7 +51,7 @@ namespace Content.IntegrationTests.Tests.Gravity
             });
 
             // Let WeightlessSystem and GravitySystem tick
-            await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+            await PoolManager.RunTicksSync(pair, 10);
             var generatorUid = EntityUid.Invalid;
             await server.WaitAssertion(() =>
             {
@@ -62,7 +62,7 @@ namespace Content.IntegrationTests.Tests.Gravity
             });
 
             // Let WeightlessSystem and GravitySystem tick
-            await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+            await PoolManager.RunTicksSync(pair, 10);
 
             await server.WaitAssertion(() =>
             {
@@ -72,16 +72,16 @@ namespace Content.IntegrationTests.Tests.Gravity
                 entityManager.DeleteEntity(generatorUid);
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+            await PoolManager.RunTicksSync(pair, 10);
 
             await server.WaitAssertion(() =>
             {
                 Assert.That(alertsSystem.IsShowingAlert(human, AlertType.Weightless));
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+            await PoolManager.RunTicksSync(pair, 10);
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/GravityGridTest.cs
+++ b/Content.IntegrationTests/Tests/GravityGridTest.cs
@@ -30,10 +30,10 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             EntityUid generator = default;
             var entityMan = server.ResolveDependency<IEntityManager>();
@@ -96,7 +96,7 @@ namespace Content.IntegrationTests.Tests
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Guidebook/DocumentParsingTest.cs
+++ b/Content.IntegrationTests/Tests/Guidebook/DocumentParsingTest.cs
@@ -45,8 +45,8 @@ whitespace before newlines are ignored.
     [Test]
     public async Task ParseTestDocument()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var client = pairTracker.Pair.Client;
+        await using var pair = await PoolManager.GetServerClient();
+        var client = pair.Client;
         await client.WaitIdleAsync();
         var parser = client.ResolveDependency<DocumentParsingManager>();
 
@@ -134,7 +134,7 @@ whitespace before newlines are ignored.
         subTest2.Params.TryGetValue("k", out val);
         Assert.That(val, Is.EqualTo(@"<>\>=""=<-_?*3.0//"));
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     public sealed class TestControl : Control, IDocumentTag

--- a/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
@@ -15,8 +15,8 @@ public sealed class GuideEntryPrototypeTests
     [Test]
     public async Task ValidatePrototypeContents()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-        var client = pairTracker.Pair.Client;
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var client = pair.Client;
         await client.WaitIdleAsync();
         var protoMan = client.ResolveDependency<IPrototypeManager>();
         var resMan = client.ResolveDependency<IResourceManager>();
@@ -35,6 +35,6 @@ public sealed class GuideEntryPrototypeTests
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Hands/HandTests.cs
+++ b/Content.IntegrationTests/Tests/Hands/HandTests.cs
@@ -13,20 +13,20 @@ public sealed class HandTests
     [Test]
     public async Task TestPickupDrop()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             Connected = true,
             DummyTicker = false
         });
-        var server = pairTracker.Pair.Server;
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IEntityManager>();
         var playerMan = server.ResolveDependency<IPlayerManager>();
         var mapMan = server.ResolveDependency<IMapManager>();
         var sys = entMan.System<SharedHandsSystem>();
 
-        var data = await PoolManager.CreateTestMap(pairTracker);
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        var data = await PoolManager.CreateTestMap(pair);
+        await PoolManager.RunTicksSync(pair, 5);
 
         EntityUid item = default;
         EntityUid player = default;
@@ -41,7 +41,7 @@ public sealed class HandTests
         });
 
         // run ticks here is important, as errors may happen within the container system's frame update methods.
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
         Assert.That(hands.ActiveHandEntity, Is.EqualTo(item));
 
         await server.WaitPost(() =>
@@ -49,10 +49,10 @@ public sealed class HandTests
             sys.TryDrop(player, item, null!);
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
         Assert.That(hands.ActiveHandEntity, Is.Null);
 
         await server.WaitPost(() => mapMan.DeleteMap(data.MapId));
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
+++ b/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
@@ -56,9 +56,9 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
+            var testMap = await PoolManager.CreateTestMap(pair);
             var coordinates = testMap.GridCoords;
 
             EntityUid human = default;
@@ -132,7 +132,7 @@ namespace Content.IntegrationTests.Tests
                 mapMan.DeleteMap(testMap.MapId);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         private static bool IsDescendant(EntityUid descendant, EntityUid parent, IEntityManager entManager)

--- a/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
@@ -39,8 +39,8 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
         [Test]
         public async Task InteractionTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -103,14 +103,14 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task InteractionObstructionTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -174,14 +174,14 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task InteractionInRangeTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -243,15 +243,15 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
 
         [Test]
         public async Task InteractionOutOfRangeTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -313,14 +313,14 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task InsideContainerInteractionBlockTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -404,7 +404,7 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             });
 
             testInteractionSystem.ClearHandlers();
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Reflect(false)]

--- a/Content.IntegrationTests/Tests/Interaction/InRangeUnobstructed.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InRangeUnobstructed.cs
@@ -26,8 +26,8 @@ namespace Content.IntegrationTests.Tests.Interaction
         [Test]
         public async Task EntityEntityTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -107,7 +107,7 @@ namespace Content.IntegrationTests.Tests.Interaction
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
@@ -66,7 +66,7 @@ public abstract partial class InteractionTest
         Task? tickTask = null;
         while (!task.IsCompleted)
         {
-            tickTask = PoolManager.RunTicksSync(PairTracker.Pair, 1);
+            tickTask = PoolManager.RunTicksSync(Pair, 1);
             await Task.WhenAny(task, tickTask);
         }
 
@@ -699,7 +699,7 @@ public abstract partial class InteractionTest
 
     protected async Task RunTicks(int ticks)
     {
-        await PoolManager.RunTicksSync(PairTracker.Pair, ticks);
+        await PoolManager.RunTicksSync(Pair, ticks);
     }
 
     protected int SecondsToTicks(float seconds)

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.cs
@@ -41,11 +41,11 @@ public abstract partial class InteractionTest
 {
     protected virtual string PlayerPrototype => "InteractionTestMob";
 
-    protected TestPair PairTracker = default!;
-    protected TestMapData MapData => PairTracker.TestMap!;
+    protected TestPair Pair = default!;
+    protected TestMapData MapData => Pair.TestMap!;
 
-    protected RobustIntegrationTest.ServerIntegrationInstance Server => PairTracker.Server;
-    protected RobustIntegrationTest.ClientIntegrationInstance Client => PairTracker.Client;
+    protected RobustIntegrationTest.ServerIntegrationInstance Server => Pair.Server;
+    protected RobustIntegrationTest.ClientIntegrationInstance Client => Pair.Client;
 
     protected MapId MapId => MapData.MapId;
 
@@ -141,7 +141,7 @@ public abstract partial class InteractionTest
     [SetUp]
     public virtual async Task Setup()
     {
-        PairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        Pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
 
         // server dependencies
         SEntMan = Server.ResolveDependency<IEntityManager>();
@@ -173,7 +173,7 @@ public abstract partial class InteractionTest
         CLogger = Client.ResolveDependency<ILogManager>().RootSawmill;
 
         // Setup map.
-        await PairTracker.CreateTestMap();
+        await Pair.CreateTestMap();
         PlayerCoords = MapData.GridCoords.Offset(new Vector2(0.5f, 0.5f)).WithEntityId(MapData.MapUid, Transform, SEntMan);
         TargetCoords = MapData.GridCoords.Offset(new Vector2(1.5f, 0.5f)).WithEntityId(MapData.MapUid, Transform, SEntMan);
         await SetTile(Plating, grid: MapData.MapGrid);
@@ -226,7 +226,7 @@ public abstract partial class InteractionTest
         });
 
         // Final player asserts/checks.
-        await PairTracker.ReallyBeIdle(5);
+        await Pair.ReallyBeIdle(5);
         Assert.Multiple(() =>
         {
             Assert.That(cPlayerMan.LocalPlayer.ControlledEntity, Is.EqualTo(Player));
@@ -238,7 +238,7 @@ public abstract partial class InteractionTest
     public async Task TearDownInternal()
     {
         await Server.WaitPost(() => MapMan.DeleteMap(MapId));
-        await PairTracker.CleanReturnAsync();
+        await Pair.CleanReturnAsync();
         await TearDown();
     }
 

--- a/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
+++ b/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
@@ -41,8 +41,8 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SpawnItemInSlotTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
             var systemMan = sEntities.EntitySysManager;
@@ -90,7 +90,7 @@ namespace Content.IntegrationTests.Tests
                 sEntities.DeleteEntity(human);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Lobby/CharacterCreationTest.cs
+++ b/Content.IntegrationTests/Tests/Lobby/CharacterCreationTest.cs
@@ -15,9 +15,9 @@ namespace Content.IntegrationTests.Tests.Lobby
         [Test]
         public async Task CreateDeleteCreateTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+            var server = pair.Server;
+            var client = pair.Client;
 
             var clientNetManager = client.ResolveDependency<IClientNetManager>();
             var clientStateManager = client.ResolveDependency<IStateManager>();
@@ -27,7 +27,7 @@ namespace Content.IntegrationTests.Tests.Lobby
 
 
             // Need to run them in sync to receive the messages.
-            await PoolManager.RunTicksSync(pairTracker.Pair, 1);
+            await PoolManager.RunTicksSync(pair, 1);
 
             await PoolManager.WaitUntil(client, () => clientStateManager.CurrentState is LobbyState, 600);
 
@@ -109,7 +109,7 @@ namespace Content.IntegrationTests.Tests.Lobby
                 Assert.That(serverCharacters, Has.Count.EqualTo(2));
                 Assert.That(serverCharacters[1].MemberwiseEquals(profile));
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Lobby/ServerReloginTest.cs
+++ b/Content.IntegrationTests/Tests/Lobby/ServerReloginTest.cs
@@ -10,13 +10,13 @@ public sealed class ServerReloginTest
     [Test]
     public async Task Relogin()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             Connected = true,
             DummyTicker = false
         });
-        var server = pairTracker.Pair.Server;
-        var client = pairTracker.Pair.Client;
+        var server = pair.Server;
+        var client = pair.Client;
         var originalMaxPlayers = 0;
         string username = null;
 
@@ -39,7 +39,7 @@ public sealed class ServerReloginTest
             clientNetManager.ClientDisconnect("For testing");
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 20);
+        await PoolManager.RunTicksSync(pair, 20);
 
         await server.WaitAssertion(() =>
         {
@@ -51,7 +51,7 @@ public sealed class ServerReloginTest
             clientNetManager.ClientConnect(null!, 0, username);
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 20);
+        await PoolManager.RunTicksSync(pair, 20);
 
         await server.WaitAssertion(() =>
         {
@@ -63,6 +63,6 @@ public sealed class ServerReloginTest
             serverConfig.SetCVar(CCVars.SoftMaxPlayers, originalMaxPlayers);
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/LogErrorTest.cs
+++ b/Content.IntegrationTests/Tests/LogErrorTest.cs
@@ -12,9 +12,9 @@ public sealed class LogErrorTest
     [Test]
     public async Task TestLogErrorCausesTestFailure()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-        var server = pairTracker.Pair.Server;
-        var client = pairTracker.Pair.Client;
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var server = pair.Server;
+        var client = pair.Client;
 
         var cfg = server.ResolveDependency<IConfigurationManager>();
         var logmill = server.ResolveDependency<ILogManager>().RootSawmill;
@@ -29,6 +29,6 @@ public sealed class LogErrorTest
         await server.WaitPost(() => Assert.Throws<AssertionException>(() => logmill.Error("test")));
         await client.WaitPost(() => Assert.Throws<AssertionException>(() => logmill.Error("test")));
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/MachineBoardTest.cs
+++ b/Content.IntegrationTests/Tests/MachineBoardTest.cs
@@ -31,8 +31,8 @@ public sealed class MachineBoardTest
     [Test]
     public async Task TestMachineBoardHasValidMachine()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
@@ -40,7 +40,7 @@ public sealed class MachineBoardTest
         {
             foreach (var p in protoMan.EnumeratePrototypes<EntityPrototype>()
                          .Where(p => !p.Abstract)
-                         .Where(p => !pairTracker.Pair.IsTestPrototype(p))
+                         .Where(p => !pair.IsTestPrototype(p))
                          .Where(p => !_ignoredPrototypes.Contains(p.ID)))
             {
                 if (!p.TryGetComponent<MachineBoardComponent>(out var mbc))
@@ -60,7 +60,7 @@ public sealed class MachineBoardTest
             }
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -70,8 +70,8 @@ public sealed class MachineBoardTest
     [Test]
     public async Task TestComputerBoardHasValidComputer()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var protoMan = server.ResolveDependency<IPrototypeManager>();
 
@@ -79,7 +79,7 @@ public sealed class MachineBoardTest
         {
             foreach (var p in protoMan.EnumeratePrototypes<EntityPrototype>()
                          .Where(p => !p.Abstract)
-                         .Where(p => !pairTracker.Pair.IsTestPrototype(p))
+                         .Where(p => !pair.IsTestPrototype(p))
                          .Where(p => !_ignoredPrototypes.Contains(p.ID)))
             {
                 if (!p.TryGetComponent<ComputerBoardComponent>(out var cbc))
@@ -99,6 +99,6 @@ public sealed class MachineBoardTest
             }
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -30,10 +30,10 @@ public sealed class MaterialArbitrageTest
     [Test]
     public async Task NoMaterialArbitrage()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
-        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var testMap = await PoolManager.CreateTestMap(pair);
         await server.WaitIdleAsync();
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -65,7 +65,7 @@ public sealed class MaterialArbitrageTest
         Dictionary<string, ConstructionComponent> constructionRecipes = new();
         foreach (var proto in protoManager.EnumeratePrototypes<EntityPrototype>())
         {
-            if (proto.NoSpawn || proto.Abstract || pairTracker.Pair.IsTestPrototype(proto))
+            if (proto.NoSpawn || proto.Abstract || pair.IsTestPrototype(proto))
                 continue;
 
             if (!proto.Components.TryGetValue(constructionName, out var destructible))
@@ -125,7 +125,7 @@ public sealed class MaterialArbitrageTest
         // Here we get the set of entities/materials spawned when destroying an entity.
         foreach (var proto in protoManager.EnumeratePrototypes<EntityPrototype>())
         {
-            if (proto.NoSpawn || proto.Abstract || pairTracker.Pair.IsTestPrototype(proto))
+            if (proto.NoSpawn || proto.Abstract || pair.IsTestPrototype(proto))
                 continue;
 
             if (!proto.Components.TryGetValue(destructibleName, out var destructible))
@@ -290,7 +290,7 @@ public sealed class MaterialArbitrageTest
         Dictionary<string, PhysicalCompositionComponent> physicalCompositions = new();
         foreach (var proto in protoManager.EnumeratePrototypes<EntityPrototype>())
         {
-            if (proto.NoSpawn || proto.Abstract || pairTracker.Pair.IsTestPrototype(proto))
+            if (proto.NoSpawn || proto.Abstract || pair.IsTestPrototype(proto))
                 continue;
 
             if (!proto.Components.TryGetValue(compositionName, out var composition))
@@ -338,7 +338,7 @@ public sealed class MaterialArbitrageTest
         });
 
         await server.WaitPost(() => mapManager.DeleteMap(testMap.MapId));
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
 
         async Task<double> GetSpawnedPrice(Dictionary<string, int> ents)
         {

--- a/Content.IntegrationTests/Tests/Materials/MaterialTests.cs
+++ b/Content.IntegrationTests/Tests/Materials/MaterialTests.cs
@@ -20,15 +20,15 @@ namespace Content.IntegrationTests.Tests.Materials
         [Test]
         public async Task MaterialPrototypeSpawnsStackMaterial()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             await server.WaitIdleAsync();
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             await server.WaitAssertion(() =>
             {
@@ -62,7 +62,7 @@ namespace Content.IntegrationTests.Tests.Materials
                 mapManager.DeleteMap(testMap.MapId);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Minds/GhostRoleTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/GhostRoleTests.cs
@@ -31,13 +31,13 @@ public sealed class GhostRoleTests
     [Test]
     public async Task TakeRoleAndReturn()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             DummyTicker = false,
             Connected = true
         });
-        var server = pairTracker.Pair.Server;
-        var client = pairTracker.Pair.Client;
+        var server = pair.Server;
+        var client = pair.Client;
 
         var entMan = server.ResolveDependency<IEntityManager>();
         var sPlayerMan = server.ResolveDependency<Robust.Server.Player.IPlayerManager>();
@@ -55,14 +55,14 @@ public sealed class GhostRoleTests
         });
 
         // Check player got attached.
-        await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+        await PoolManager.RunTicksSync(pair, 10);
         Assert.That(session.AttachedEntity, Is.EqualTo(originalMob));
         Assert.That(originalMind.OwnedEntity, Is.EqualTo(originalMob));
         Assert.Null(originalMind.VisitingEntity);
 
         // Use the ghost command
         conHost.ExecuteCommand("ghost");
-        await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+        await PoolManager.RunTicksSync(pair, 10);
         var ghost = session.AttachedEntity;
         Assert.That(entMan.HasComponent<GhostComponent>(ghost));
         Assert.That(ghost, Is.Not.EqualTo(originalMob));
@@ -82,7 +82,7 @@ public sealed class GhostRoleTests
         });
 
         // Check player got attached to ghost role.
-        await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+        await PoolManager.RunTicksSync(pair, 10);
         var newMind = session.ContentData()!.Mind!;
         Assert.That(newMind, Is.Not.EqualTo(originalMind));
         Assert.That(session.AttachedEntity, Is.EqualTo(ghostRole));
@@ -96,7 +96,7 @@ public sealed class GhostRoleTests
 
         // Ghost again.
         conHost.ExecuteCommand("ghost");
-        await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+        await PoolManager.RunTicksSync(pair, 10);
         var otherGhost = session.AttachedEntity;
         Assert.That(entMan.HasComponent<GhostComponent>(otherGhost));
         Assert.That(otherGhost, Is.Not.EqualTo(originalMob));
@@ -107,7 +107,7 @@ public sealed class GhostRoleTests
 
         // Next, control the original entity again:
         await server.WaitPost(() => mindSystem.SetUserId(originalMind, session.UserId));
-        await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+        await PoolManager.RunTicksSync(pair, 10);
         Assert.That(session.AttachedEntity, Is.EqualTo(originalMob));
         Assert.That(originalMind.OwnedEntity, Is.EqualTo(originalMob));
         Assert.Null(originalMind.VisitingEntity);
@@ -117,6 +117,6 @@ public sealed class GhostRoleTests
         Assert.Null(newMind.VisitingEntity);
         Assert.That(entMan.Deleted(otherGhost));
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Minds/MindTests.Helpers.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.Helpers.cs
@@ -26,13 +26,12 @@ public sealed partial class MindTests
     /// </remarks>
     private static async Task<Pair.TestPair> SetupPair(bool dirty = false)
     {
-        var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+        var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             DummyTicker = false,
             Connected = true,
             Dirty = dirty
         });
-        var pair = pairTracker.Pair;
 
         var entMan = pair.Server.ResolveDependency<IServerEntityManager>();
         var playerMan = pair.Server.ResolveDependency<IPlayerManager>();
@@ -59,7 +58,7 @@ public sealed partial class MindTests
             Assert.That(entMan.EntityExists(mind.OwnedEntity), "The mind's current entity does not exist");
             Assert.That(mind.VisitingEntity == null || entMan.EntityExists(mind.VisitingEntity), "The minds visited entity does not exist.");
         });
-        return pairTracker;
+        return pair;
     }
 
     private static async Task<EntityUid> BecomeGhost(TestPair pair, bool visit = false)

--- a/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
@@ -17,8 +17,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestGhostsCanReconnect()
     {
-        await using var pairTracker = await SetupPair();
-        var pair = pairTracker.Pair;
+        await using var pair = await SetupPair();
         var entMan = pair.Server.ResolveDependency<IEntityManager>();
         var mind = GetMind(pair);
 
@@ -34,7 +33,7 @@ public sealed partial class MindTests
             Assert.That(mind.VisitingEntity, Is.Null);
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     // This test will do the following:
@@ -45,8 +44,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestDeletedCanReconnect()
     {
-        await using var pairTracker = await SetupPair();
-        var pair = pairTracker.Pair;
+        await using var pair = await SetupPair();
         var entMan = pair.Server.ResolveDependency<IEntityManager>();
         var mind = GetMind(pair);
 
@@ -85,7 +83,7 @@ public sealed partial class MindTests
             Assert.That(entMan.HasComponent<GhostComponent>(mind.OwnedEntity));
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     // This test will do the following:
@@ -96,8 +94,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestVisitingGhostReconnect()
     {
-        await using var pairTracker = await SetupPair();
-        var pair = pairTracker.Pair;
+        await using var pair = await SetupPair();
         var entMan = pair.Server.ResolveDependency<IEntityManager>();
         var mind = GetMind(pair);
 
@@ -114,7 +111,7 @@ public sealed partial class MindTests
             Assert.That(entMan.Deleted(ghost));
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     // This test will do the following:
@@ -125,8 +122,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestVisitingReconnect()
     {
-        await using var pairTracker = await SetupPair();
-        var pair = pairTracker.Pair;
+        await using var pair = await SetupPair();
         var entMan = pair.Server.ResolveDependency<IEntityManager>();
         var mindSys = entMan.System<MindSystem>();
         var mind = GetMind(pair);
@@ -152,6 +148,6 @@ public sealed partial class MindTests
             Assert.That(mind.CurrentEntity, Is.EqualTo(visiting));
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Minds/MindTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.cs
@@ -54,8 +54,8 @@ public sealed partial class MindTests
     [Test]
     public async Task TestCreateAndTransferMindToNewEntity()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
 
@@ -74,14 +74,14 @@ public sealed partial class MindTests
             Assert.That(mindSystem.GetMind(entity, mindComp), Is.EqualTo(mind));
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestReplaceMind()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
 
@@ -105,14 +105,14 @@ public sealed partial class MindTests
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestEntityDeadWhenGibbed()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
         var protoMan = server.ResolveDependency<IPrototypeManager>();
@@ -138,7 +138,7 @@ public sealed partial class MindTests
             });
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
 
         await server.WaitAssertion(() =>
         {
@@ -152,21 +152,21 @@ public sealed partial class MindTests
             Assert.That(mindSystem.GetMind(entity, mindContainerComp), Is.EqualTo(mind));
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
 
         await server.WaitAssertion(() =>
         {
             Assert.That(mindSystem.IsCharacterDeadPhysically(mind));
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestMindTransfersToOtherEntity()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
 
@@ -193,24 +193,24 @@ public sealed partial class MindTests
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestOwningPlayerCanBeChanged()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             Connected = true,
             DummyTicker = false
         });
-        var server = pairTracker.Pair.Server;
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
         var mindSystem = entMan.EntitySysManager.GetEntitySystem<MindSystem>();
-        var originalMind = GetMind(pairTracker.Pair);
+        var originalMind = GetMind(pair);
         var userId = originalMind.UserId;
 
         Mind mind = default!;
@@ -229,7 +229,7 @@ public sealed partial class MindTests
             });
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
 
         await server.WaitAssertion(() =>
         {
@@ -248,16 +248,16 @@ public sealed partial class MindTests
             });
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestAddRemoveHasRoles()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
 
@@ -318,15 +318,15 @@ public sealed partial class MindTests
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestPlayerCanGhost()
     {
         // Client is needed to spawn session
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
         var playerMan = server.ResolveDependency<IPlayerManager>();
@@ -351,14 +351,14 @@ public sealed partial class MindTests
             Assert.That(mindSystem.GetMind(entity, mindComp), Is.EqualTo(mind));
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
 
         await server.WaitAssertion(() =>
         {
             entMan.DeleteEntity(entity);
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
 
         EntityUid mob = default!;
         Mind mobMind = default!;
@@ -376,7 +376,7 @@ public sealed partial class MindTests
             mindSystem.TransferTo(mobMind, mob);
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+        await PoolManager.RunTicksSync(pair, 5);
 
         await server.WaitAssertion(() =>
         {
@@ -389,7 +389,7 @@ public sealed partial class MindTests
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     // TODO Implement
@@ -401,13 +401,13 @@ public sealed partial class MindTests
     [Test]
     public async Task TestGhostDoesNotInfiniteLoop()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             DummyTicker = false,
             Connected = true,
             Dirty = true
         });
-        var server = pairTracker.Pair.Server;
+        var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
         var playerMan = server.ResolveDependency<IPlayerManager>();
@@ -441,14 +441,14 @@ public sealed partial class MindTests
             ghostRole = entMan.SpawnEntity("GhostRoleTestEntity", MapCoordinates.Nullspace);
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 20);
+        await PoolManager.RunTicksSync(pair, 20);
 
         await server.WaitAssertion(() =>
         {
             serverConsole.ExecuteCommand(player, "aghost");
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 20);
+        await PoolManager.RunTicksSync(pair, 20);
 
         await server.WaitAssertion(() =>
         {
@@ -456,7 +456,7 @@ public sealed partial class MindTests
             entMan.EntitySysManager.GetEntitySystem<GhostRoleSystem>().Takeover(player, id);
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 20);
+        await PoolManager.RunTicksSync(pair, 20);
 
         await server.WaitAssertion(() =>
         {
@@ -468,7 +468,7 @@ public sealed partial class MindTests
             ghost = player.AttachedEntity!.Value;
         });
 
-        await PoolManager.RunTicksSync(pairTracker.Pair, 20);
+        await PoolManager.RunTicksSync(pair, 20);
 
         await server.WaitAssertion(() =>
         {
@@ -476,6 +476,6 @@ public sealed partial class MindTests
             Assert.That(player.AttachedEntity!.Value, Is.EqualTo(ghost));
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/NPC/NPCTest.cs
+++ b/Content.IntegrationTests/Tests/NPC/NPCTest.cs
@@ -13,7 +13,7 @@ public sealed class NPCTest
     public async Task CompoundRecursion()
     {
         var pool = await PoolManager.GetServerClient();
-        var server = pool.Pair.Server;
+        var server = pool.Server;
 
         await server.WaitIdleAsync();
 

--- a/Content.IntegrationTests/Tests/Networking/NetworkIdsMatchTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/NetworkIdsMatchTest.cs
@@ -8,9 +8,9 @@ namespace Content.IntegrationTests.Tests.Networking
         [Test]
         public async Task TestConnect()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var server = pair.Server;
+            var client = pair.Client;
 
             var clientCompFactory = client.ResolveDependency<IComponentFactory>();
             var serverCompFactory = server.ResolveDependency<IComponentFactory>();
@@ -38,7 +38,7 @@ namespace Content.IntegrationTests.Tests.Networking
                     Assert.That(clientNetComps[netId].Name, Is.EqualTo(serverNetComps[netId].Name));
                 }
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Networking/ReconnectTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/ReconnectTest.cs
@@ -9,9 +9,9 @@ namespace Content.IntegrationTests.Tests.Networking
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var server = pair.Server;
+            var client = pair.Client;
 
             var host = client.ResolveDependency<IClientConsoleHost>();
             var netManager = client.ResolveDependency<IClientNetManager>();
@@ -19,7 +19,7 @@ namespace Content.IntegrationTests.Tests.Networking
             await client.WaitPost(() => host.ExecuteCommand("disconnect"));
 
             // Run some ticks for the disconnect to complete and such.
-            await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+            await PoolManager.RunTicksSync(pair, 5);
 
             await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
 
@@ -29,10 +29,10 @@ namespace Content.IntegrationTests.Tests.Networking
             await client.WaitPost(() => netManager.ClientConnect(null, 0, null));
 
             // Run some ticks for the handshake to complete and such.
-            await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+            await PoolManager.RunTicksSync(pair, 10);
 
             await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
@@ -31,9 +31,9 @@ namespace Content.IntegrationTests.Tests.Networking
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+            var server = pair.Server;
+            var client = pair.Client;
 
             var sMapManager = server.ResolveDependency<IMapManager>();
             var sEntityManager = server.ResolveDependency<IEntityManager>();
@@ -60,8 +60,8 @@ namespace Content.IntegrationTests.Tests.Networking
             });
 
             // Run some ticks and ensure that the buffer has filled up.
-            await pairTracker.SyncTicks();
-            await pairTracker.RunTicksSync(25);
+            await pair.SyncTicks();
+            await pair.RunTicksSync(25);
             Assert.That(cGameTiming.TickTimingAdjustment, Is.EqualTo(0));
             Assert.That(sGameTiming.TickTimingAdjustment, Is.EqualTo(0));
 
@@ -384,7 +384,7 @@ namespace Content.IntegrationTests.Tests.Networking
             }
 
             cfg.SetCVar(CVars.NetLogging, log);
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         public sealed class PredictionTestEntitySystem : EntitySystem

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -69,8 +69,8 @@ namespace Content.IntegrationTests.Tests
         [Test, TestCaseSource(nameof(Grids))]
         public async Task GridsLoadableTest(string mapFile)
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var entManager = server.ResolveDependency<IEntityManager>();
             var mapLoader = entManager.System<MapLoaderSystem>();
@@ -104,14 +104,14 @@ namespace Content.IntegrationTests.Tests
             });
             await server.WaitRunTicks(1);
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task NoSavedPostMapInitTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var resourceManager = server.ResolveDependency<IResourceManager>();
             var mapFolder = new ResPath("/Maps");
@@ -146,14 +146,14 @@ namespace Content.IntegrationTests.Tests
 
                 Assert.That(postMapInit, Is.False, $"Map {map.Filename} was saved postmapinit");
             }
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test, TestCaseSource(nameof(GameMaps))]
         public async Task GameMapsLoadableTest(string mapProto)
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var entManager = server.ResolveDependency<IEntityManager>();
@@ -278,18 +278,18 @@ namespace Content.IntegrationTests.Tests
             });
             await server.WaitRunTicks(1);
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task AllMapsTested()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var protoMan = server.ResolveDependency<IPrototypeManager>();
 
             var gameMaps = protoMan.EnumeratePrototypes<GameMapPrototype>()
-                .Where(x => !pairTracker.Pair.IsTestPrototype(x))
+                .Where(x => !pair.IsTestPrototype(x))
                 .Select(x => x.ID)
                 .ToHashSet();
 
@@ -297,14 +297,14 @@ namespace Content.IntegrationTests.Tests
 
             CollectionAssert.AreEquivalent(GameMaps.ToHashSet(), gameMaps, "Game map prototype missing from test cases.");
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task NonGameMapsLoadableTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var mapLoader = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<MapLoaderSystem>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -364,7 +364,7 @@ namespace Content.IntegrationTests.Tests
             });
 
             await server.WaitRunTicks(1);
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Power/PowerTest.cs
+++ b/Content.IntegrationTests/Tests/Power/PowerTest.cs
@@ -162,8 +162,8 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestSimpleSurplus()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             const float loadPower = 200;
@@ -213,7 +213,7 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
 
@@ -223,8 +223,8 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestSimpleDeficit()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             const float loadPower = 200;
@@ -274,14 +274,14 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestSupplyRamp()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var gameTiming = server.ResolveDependency<IGameTiming>();
@@ -361,14 +361,14 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestBatteryRamp()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var gameTiming = server.ResolveDependency<IGameTiming>();
@@ -460,7 +460,7 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
@@ -468,8 +468,8 @@ namespace Content.IntegrationTests.Tests.Power
         {
             // checks that batteries and supplies properly ramp down if the load is disconnected/disabled.
 
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var batterySys = entityManager.System<BatterySystem>();
@@ -558,14 +558,14 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestSimpleBatteryChargeDeficit()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var gameTiming = server.ResolveDependency<IGameTiming>();
             var entityManager = server.ResolveDependency<IEntityManager>();
@@ -614,14 +614,14 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestFullBattery()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var gameTiming = server.ResolveDependency<IGameTiming>();
@@ -691,14 +691,14 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestFullBatteryEfficiencyPassThrough()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var gameTiming = server.ResolveDependency<IGameTiming>();
@@ -768,14 +768,14 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestFullBatteryEfficiencyDemandPassThrough()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var batterySys = entityManager.System<BatterySystem>();
@@ -860,7 +860,7 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -870,8 +870,8 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestSupplyPrioritized()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var gameTiming = server.ResolveDependency<IGameTiming>();
@@ -959,7 +959,7 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -968,8 +968,8 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestBatteriesProportional()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var batterySys = entityManager.System<BatterySystem>();
@@ -1049,14 +1049,14 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestBatteryEngineCut()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var batterySys = entityManager.System<BatterySystem>();
@@ -1130,7 +1130,7 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -1139,8 +1139,8 @@ namespace Content.IntegrationTests.Tests.Power
         [Test]
         public async Task TestTerminalNodeGroups()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var nodeContainer = entityManager.System<NodeContainerSystem>();
@@ -1198,14 +1198,14 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task ApcChargingTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var batterySys = entityManager.System<BatterySystem>();
@@ -1253,14 +1253,14 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task ApcNetTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
             var batterySys = entityManager.System<BatterySystem>();
@@ -1317,7 +1317,7 @@ namespace Content.IntegrationTests.Tests.Power
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
     }

--- a/Content.IntegrationTests/Tests/Procedural/DungeonTests.cs
+++ b/Content.IntegrationTests/Tests/Procedural/DungeonTests.cs
@@ -12,10 +12,10 @@ public sealed class DungeonTests
     [Test]
     public async Task TestDungeonRoomPackBounds()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var protoManager = pairTracker.Pair.Server.ResolveDependency<IPrototypeManager>();
+        await using var pair = await PoolManager.GetServerClient();
+        var protoManager = pair.Server.ResolveDependency<IPrototypeManager>();
 
-        await pairTracker.Pair.Server.WaitAssertion(() =>
+        await pair.Server.WaitAssertion(() =>
         {
             var sizes = new HashSet<Vector2i>();
 
@@ -56,16 +56,16 @@ public sealed class DungeonTests
             }
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task TestDungeonPresets()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var protoManager = pairTracker.Pair.Server.ResolveDependency<IPrototypeManager>();
+        await using var pair = await PoolManager.GetServerClient();
+        var protoManager = pair.Server.ResolveDependency<IPrototypeManager>();
 
-        await pairTracker.Pair.Server.WaitAssertion(() =>
+        await pair.Server.WaitAssertion(() =>
         {
             var sizes = new HashSet<Vector2i>();
 
@@ -93,6 +93,6 @@ public sealed class DungeonTests
             }
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -32,8 +32,8 @@ public sealed class PrototypeSaveTest
     [Test]
     public async Task UninitializedSaveTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var mapManager = server.ResolveDependency<IMapManager>();
         var entityMan = server.ResolveDependency<IEntityManager>();
@@ -72,7 +72,7 @@ public sealed class PrototypeSaveTest
             if (prototype.Abstract)
                 continue;
 
-            if (pairTracker.Pair.IsTestPrototype(prototype))
+            if (pair.IsTestPrototype(prototype))
                 continue;
 
             // Yea this test just doesn't work with this, it parents a grid to another grid and causes game logic to explode.
@@ -172,7 +172,7 @@ public sealed class PrototypeSaveTest
                 }
             });
         });
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     public sealed class TestEntityUidContext : ISerializationContext,

--- a/Content.IntegrationTests/Tests/PrototypeTests/PrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/PrototypeTests/PrototypeTests.cs
@@ -17,10 +17,10 @@ public sealed class PrototypeTests
     [Test]
     public async Task TestAllServerPrototypesAreSerializable()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
+        await using var pair = await PoolManager.GetServerClient();
         var context = new PrototypeSaveTest.TestEntityUidContext();
-        await SaveThenValidatePrototype(pairTracker.Pair.Server, "server", context);
-        await pairTracker.CleanReturnAsync();
+        await SaveThenValidatePrototype(pair.Server, "server", context);
+        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -30,10 +30,10 @@ public sealed class PrototypeTests
     [Test]
     public async Task TestAllClientPrototypesAreSerializable()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
+        await using var pair = await PoolManager.GetServerClient();
         var context = new PrototypeSaveTest.TestEntityUidContext();
-        await SaveThenValidatePrototype(pairTracker.Pair.Client, "client", context);
-        await pairTracker.CleanReturnAsync();
+        await SaveThenValidatePrototype(pair.Client, "client", context);
+        await pair.CleanReturnAsync();
     }
 
     public async Task SaveThenValidatePrototype(RobustIntegrationTest.IntegrationInstance instance, string instanceId,
@@ -69,10 +69,10 @@ public sealed class PrototypeTests
     [Test]
     public async Task ServerPrototypeSaveLoadSaveTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
+        await using var pair = await PoolManager.GetServerClient();
         var context = new PrototypeSaveTest.TestEntityUidContext();
-        await SaveLoadSavePrototype(pairTracker.Pair.Server, context);
-        await pairTracker.CleanReturnAsync();
+        await SaveLoadSavePrototype(pair.Server, context);
+        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -81,10 +81,10 @@ public sealed class PrototypeTests
     [Test]
     public async Task ClientPrototypeSaveLoadSaveTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
+        await using var pair = await PoolManager.GetServerClient();
         var context = new PrototypeSaveTest.TestEntityUidContext();
-        await SaveLoadSavePrototype(pairTracker.Pair.Client, context);
-        await pairTracker.CleanReturnAsync();
+        await SaveLoadSavePrototype(pair.Client, context);
+        await pair.CleanReturnAsync();
     }
 
     private async Task SaveLoadSavePrototype(

--- a/Content.IntegrationTests/Tests/ResearchTest.cs
+++ b/Content.IntegrationTests/Tests/ResearchTest.cs
@@ -12,8 +12,8 @@ public sealed class ResearchTest
     [Test]
     public async Task DisciplineValidTierPrerequesitesTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
 
@@ -42,14 +42,14 @@ public sealed class ResearchTest
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AllTechPrintableTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
 
@@ -62,7 +62,7 @@ public sealed class ResearchTest
                 if (proto.Abstract)
                     continue;
 
-                if (pairTracker.Pair.IsTestPrototype(proto))
+                if (pair.IsTestPrototype(proto))
                     continue;
 
                 if (!proto.TryGetComponent<LatheComponent>(out var lathe))
@@ -94,6 +94,6 @@ public sealed class ResearchTest
             });
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/ResettingEntitySystemTests.cs
+++ b/Content.IntegrationTests/Tests/ResettingEntitySystemTests.cs
@@ -30,12 +30,12 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task ResettingEntitySystemResetTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 DummyTicker = false,
                 Connected = true
             });
-            var server = pairTracker.Pair.Server;
+            var server = pair.Server;
 
             var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
             var gameTicker = entitySystemManager.GetEntitySystem<GameTicker>();
@@ -54,7 +54,7 @@ namespace Content.IntegrationTests.Tests
 
                 Assert.That(system.HasBeenReset);
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/RestartRoundTest.cs
+++ b/Content.IntegrationTests/Tests/RestartRoundTest.cs
@@ -10,12 +10,12 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 DummyTicker = false,
                 Connected = true
             });
-            var server = pairTracker.Pair.Server;
+            var server = pair.Server;
             var sysManager = server.ResolveDependency<IEntitySystemManager>();
 
             await server.WaitPost(() =>
@@ -23,8 +23,8 @@ namespace Content.IntegrationTests.Tests
                 sysManager.GetEntitySystem<GameTicker>().RestartRound();
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 10);
-            await pairTracker.CleanReturnAsync();
+            await PoolManager.RunTicksSync(pair, 10);
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -13,13 +13,13 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 DummyTicker = false,
                 Connected = true
             });
 
-            var server = pairTracker.Pair.Server;
+            var server = pair.Server;
 
             var entManager = server.ResolveDependency<IEntityManager>();
             var config = server.ResolveDependency<IConfigurationManager>();
@@ -120,7 +120,7 @@ namespace Content.IntegrationTests.Tests
                 var currentCount = Thread.VolatileRead(ref eventCount);
                 while (currentCount == Thread.VolatileRead(ref eventCount) && !timeout.IsCompleted)
                 {
-                    await PoolManager.RunTicksSync(pairTracker.Pair, 5);
+                    await PoolManager.RunTicksSync(pair, 5);
                 }
                 if (timeout.IsCompleted) throw new TimeoutException("Event took too long to trigger");
             }
@@ -137,7 +137,7 @@ namespace Content.IntegrationTests.Tests
                 roundEndSystem.DefaultCountdownDuration = TimeSpan.FromMinutes(4);
                 ticker.RestartRound();
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/SalvageTest.cs
+++ b/Content.IntegrationTests/Tests/SalvageTest.cs
@@ -19,8 +19,8 @@ public sealed class SalvageTest
     [Test]
     public async Task AllSalvageMapsLoadableTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
         var mapLoader = entManager.System<MapLoaderSystem>();
@@ -58,6 +58,6 @@ public sealed class SalvageTest
         });
         await server.WaitRunTicks(1);
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
@@ -18,8 +18,8 @@ namespace Content.IntegrationTests.Tests
         {
             const string mapPath = @"/Maps/Test/TestMap.yml";
 
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var sEntities = server.ResolveDependency<IEntityManager>();
             var mapLoader = sEntities.System<MapLoaderSystem>();
@@ -93,7 +93,7 @@ namespace Content.IntegrationTests.Tests
                 }
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
@@ -21,8 +21,8 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SaveLoadSave()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var entManager = server.ResolveDependency<IEntityManager>();
             var mapLoader = entManager.System<MapLoaderSystem>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -86,7 +86,7 @@ namespace Content.IntegrationTests.Tests
                     TestContext.Error.WriteLine(twoTmp);
                 }
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         private const string TestMap = "Maps/bagel.yml";
@@ -97,8 +97,8 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task LoadSaveTicksSaveBagel()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var mapLoader = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<MapLoaderSystem>();
             var mapManager = server.ResolveDependency<IMapManager>();
 
@@ -163,7 +163,7 @@ namespace Content.IntegrationTests.Tests
             });
 
             await server.WaitPost(() => mapManager.DeleteMap(mapId));
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         /// <summary>
@@ -179,8 +179,8 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task LoadTickLoadBagel()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var mapLoader = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<MapLoaderSystem>();
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -235,7 +235,7 @@ namespace Content.IntegrationTests.Tests
             Assert.That(yamlA, Is.EqualTo(yamlB));
 
             await server.WaitPost(() => mapManager.DeleteMap(mapId));
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
+++ b/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
@@ -17,8 +17,8 @@ public sealed partial class SerializationTest
     [Test]
     public async Task SerializeGenericEnums()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
         var seriMan = server.ResolveDependency<ISerializationManager>();
         var refMan = server.ResolveDependency<IReflectionManager>();
 
@@ -68,7 +68,7 @@ public sealed partial class SerializationTest
         Assert.That(seriMan.ValidateNode<Enum>(typedNode).GetErrors().Any(), Is.True);
         Assert.That(seriMan.ValidateNode<TestEnum>(typedNode).GetErrors().Any(), Is.False);
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     private enum TestEnum : byte { Aa, Bb, Cc, Dd }

--- a/Content.IntegrationTests/Tests/Shuttle/DockTest.cs
+++ b/Content.IntegrationTests/Tests/Shuttle/DockTest.cs
@@ -22,7 +22,7 @@ public sealed class DockTest : ContentUnitTest
     public async Task TestDockingConfig(Vector2 dock1Pos, Vector2 dock2Pos, Angle dock1Angle, Angle dock2Angle, bool result)
     {
         await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Pair.Server;
+        var server = pair.Server;
 
         var map = await PoolManager.CreateTestMap(pair);
 

--- a/Content.IntegrationTests/Tests/ShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/ShuttleTest.cs
@@ -15,8 +15,8 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             await server.WaitIdleAsync();
 
             var mapMan = server.ResolveDependency<IMapManager>();
@@ -51,7 +51,7 @@ namespace Content.IntegrationTests.Tests
             {
                 Assert.That(entManager.GetComponent<TransformComponent>(gridEnt).LocalPosition, Is.Not.EqualTo(Vector2.Zero));
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/StackTest.cs
+++ b/Content.IntegrationTests/Tests/StackTest.cs
@@ -11,8 +11,8 @@ public sealed class StackTest
     [Test]
     public async Task StackCorrectItemSize()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
         var compFact = server.ResolveDependency<IComponentFactory>();
@@ -34,6 +34,6 @@ public sealed class StackTest
             }
         });
 
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/StartTest.cs
+++ b/Content.IntegrationTests/Tests/StartTest.cs
@@ -11,8 +11,8 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task TestClientStart()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient();
+            var client = pair.Client;
             Assert.That(client.IsAlive);
             await client.WaitRunTicks(5);
             Assert.That(client.IsAlive);
@@ -21,14 +21,14 @@ namespace Content.IntegrationTests.Tests
             await client.WaitIdleAsync();
             Assert.That(client.IsAlive);
 
-            var server = pairTracker.Pair.Server;
+            var server = pair.Server;
             Assert.That(server.IsAlive);
             var sRuntimeLog = server.ResolveDependency<IRuntimeLog>();
             Assert.That(sRuntimeLog.ExceptionCount, Is.EqualTo(0), "No exceptions must be logged on server.");
             await server.WaitIdleAsync();
             Assert.That(server.IsAlive);
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Station/StationJobsTest.cs
+++ b/Content.IntegrationTests/Tests/Station/StationJobsTest.cs
@@ -74,8 +74,8 @@ public sealed class StationJobsTest
     [Test]
     public async Task AssignJobsTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
         var fooStationProto = prototypeManager.Index<GameMapPrototype>("FooStation");
@@ -142,14 +142,14 @@ public sealed class StationJobsTest
                 Assert.That(assigned.Values.Select(x => x.Item1).ToList(), Does.Contain("TCaptain"));
             });
         });
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task AdjustJobsTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
         var mapManager = server.ResolveDependency<IMapManager>();
@@ -193,14 +193,14 @@ public sealed class StationJobsTest
                 Assert.That(stationJobs.IsJobUnlimited(station, "TChaplain"), "Could not make TChaplain unlimited.");
             });
         });
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task InvalidRoundstartJobsTest()
     {
-        await using var pairTracker = await PoolManager.GetServerClient();
-        var server = pairTracker.Pair.Server;
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
 
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
 
@@ -232,7 +232,7 @@ public sealed class StationJobsTest
                 }
             });
         });
-        await pairTracker.CleanReturnAsync();
+        await pair.CleanReturnAsync();
     }
 }
 

--- a/Content.IntegrationTests/Tests/StorageTest.cs
+++ b/Content.IntegrationTests/Tests/StorageTest.cs
@@ -20,8 +20,8 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task StorageSizeArbitrageTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var protoManager = server.ResolveDependency<IPrototypeManager>();
 
@@ -36,14 +36,14 @@ namespace Content.IntegrationTests.Tests
                     Assert.That(storage.StorageCapacityMax, Is.LessThanOrEqualTo(item.Size), $"Found storage arbitrage on {proto.ID}");
                 }
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestStorageFillPrototypes()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var protoManager = server.ResolveDependency<IPrototypeManager>();
 
@@ -64,14 +64,14 @@ namespace Content.IntegrationTests.Tests
                     }
                 });
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestSufficientSpaceForFill()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var protoMan = server.ResolveDependency<IPrototypeManager>();
             var compFact = server.ResolveDependency<IComponentFactory>();
@@ -143,7 +143,7 @@ namespace Content.IntegrationTests.Tests
                 return totalSize + groups.Values.Sum();
             }
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Tag/TagTest.cs
+++ b/Content.IntegrationTests/Tests/Tag/TagTest.cs
@@ -44,8 +44,8 @@ namespace Content.IntegrationTests.Tests.Tag
         [Test]
         public async Task TagComponentTest()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var sPrototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -240,7 +240,7 @@ namespace Content.IntegrationTests.Tests.Tag
                     tagSystem.HasAllTags(sTagComponent, UnregisteredTag);
                 });
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Toolshed/ToolshedTest.cs
+++ b/Content.IntegrationTests/Tests/Toolshed/ToolshedTest.cs
@@ -15,7 +15,7 @@ namespace Content.IntegrationTests.Tests.Toolshed;
 [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 public abstract class ToolshedTest : IInvocationContext
 {
-    protected TestPair PairTracker = default!;
+    protected TestPair Pair = default!;
 
     protected virtual bool Connected => false;
     protected virtual bool AssertOnUnexpectedError => true;
@@ -32,7 +32,7 @@ public abstract class ToolshedTest : IInvocationContext
     [TearDown]
     public async Task TearDownInternal()
     {
-        await PairTracker.CleanReturnAsync();
+        await Pair.CleanReturnAsync();
         await TearDown();
     }
 
@@ -45,12 +45,12 @@ public abstract class ToolshedTest : IInvocationContext
     [SetUp]
     public virtual async Task Setup()
     {
-        PairTracker = await PoolManager.GetServerClient(new PoolSettings {Connected = Connected});
-        Server = PairTracker.Server;
+        Pair = await PoolManager.GetServerClient(new PoolSettings {Connected = Connected});
+        Server = Pair.Server;
 
         if (Connected)
         {
-            Client = PairTracker.Client;
+            Client = Pair.Client;
             await Client.WaitIdleAsync();
         }
 

--- a/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
@@ -32,10 +32,10 @@ namespace Content.IntegrationTests.Tests.Utility
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
             var mapCoordinates = testMap.MapCoords;
             var entityCoordinates = testMap.GridCoords;
 
@@ -95,7 +95,7 @@ namespace Content.IntegrationTests.Tests.Utility
                     Assert.That(entity, Is.Not.Null);
                 });
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
@@ -58,10 +58,10 @@ namespace Content.IntegrationTests.Tests.Utility
         [Test]
         public async Task Test()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
             var mapCoordinates = testMap.MapCoords;
 
             var sEntities = server.ResolveDependency<IEntityManager>();
@@ -118,7 +118,7 @@ namespace Content.IntegrationTests.Tests.Utility
                     Assert.That(whitelistSer.IsValid(WhitelistTestInvalidTag), Is.False);
                 });
             });
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
+++ b/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
@@ -105,8 +105,8 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task TestAllRestocksAreAvailableToBuy()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             await server.WaitIdleAsync();
 
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -120,7 +120,7 @@ namespace Content.IntegrationTests.Tests
                 foreach (var proto in prototypeManager.EnumeratePrototypes<EntityPrototype>())
                 {
                     if (proto.Abstract
-                        || pairTracker.Pair.IsTestPrototype(proto)
+                        || pair.IsTestPrototype(proto)
                         || !proto.HasComponent<VendingMachineRestockComponent>())
                     {
                         continue;
@@ -170,14 +170,14 @@ namespace Content.IntegrationTests.Tests
                 });
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestCompleteRestockProcess()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             await server.WaitIdleAsync();
 
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -193,7 +193,7 @@ namespace Content.IntegrationTests.Tests
             VendingMachineRestockComponent restockWrongComponent = default!;
             WiresPanelComponent machineWiresPanel = default!;
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             await server.WaitAssertion(() =>
             {
@@ -256,14 +256,14 @@ namespace Content.IntegrationTests.Tests
                 mapManager.DeleteMap(testMap.MapId);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestRestockBreaksOpen()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             await server.WaitIdleAsync();
 
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
@@ -273,7 +273,7 @@ namespace Content.IntegrationTests.Tests
 
             var damageableSystem = entitySystemManager.GetEntitySystem<DamageableSystem>();
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             EntityUid restock = default;
 
@@ -320,14 +320,14 @@ namespace Content.IntegrationTests.Tests
                 mapManager.DeleteMap(testMap.MapId);
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
 
         [Test]
         public async Task TestRestockInventoryBounds()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             await server.WaitIdleAsync();
 
             var mapManager = server.ResolveDependency<IMapManager>();
@@ -336,7 +336,7 @@ namespace Content.IntegrationTests.Tests
 
             var vendingMachineSystem = entitySystemManager.GetEntitySystem<SharedVendingMachineSystem>();
 
-            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var testMap = await PoolManager.CreateTestMap(pair);
 
             await server.WaitAssertion(() =>
             {
@@ -366,7 +366,7 @@ namespace Content.IntegrationTests.Tests
                     "Machine's available inventory did not stay the same after a third restock.");
             });
 
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
         }
     }
 }

--- a/Content.MapRenderer/Painters/MapPainter.cs
+++ b/Content.MapRenderer/Painters/MapPainter.cs
@@ -26,7 +26,7 @@ namespace Content.MapRenderer.Painters
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 DummyTicker = false,
                 Connected = true,
@@ -34,8 +34,8 @@ namespace Content.MapRenderer.Painters
                 Map = map
             });
 
-            var server = pairTracker.Pair.Server;
-            var client = pairTracker.Pair.Client;
+            var server = pair.Server;
+            var client = pair.Client;
 
             Console.WriteLine($"Loaded client and server in {(int) stopwatch.Elapsed.TotalMilliseconds} ms");
 
@@ -55,7 +55,7 @@ namespace Content.MapRenderer.Painters
             var sEntityManager = server.ResolveDependency<IServerEntityManager>();
             var sPlayerManager = server.ResolveDependency<IPlayerManager>();
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+            await PoolManager.RunTicksSync(pair, 10);
             await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
 
             var sMapManager = server.ResolveDependency<IMapManager>();
@@ -85,7 +85,7 @@ namespace Content.MapRenderer.Painters
                 }
             });
 
-            await PoolManager.RunTicksSync(pairTracker.Pair, 10);
+            await PoolManager.RunTicksSync(pair, 10);
             await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
 
             foreach (var (uid, grid) in grids)
@@ -132,7 +132,7 @@ namespace Content.MapRenderer.Painters
             // We don't care if it fails as we have already saved the images.
             try
             {
-                await pairTracker.CleanReturnAsync();
+                await pair.CleanReturnAsync();
             }
             catch
             {

--- a/Content.MapRenderer/Program.cs
+++ b/Content.MapRenderer/Program.cs
@@ -34,8 +34,8 @@ namespace Content.MapRenderer
             {
                 Console.WriteLine("Didn't specify any maps to paint! Loading the map list...");
 
-                await using var pairTracker = await PoolManager.GetServerClient();
-                var mapIds = pairTracker.Pair.Server
+                await using var pair = await PoolManager.GetServerClient();
+                var mapIds = pair.Server
                     .ResolveDependency<IPrototypeManager>()
                     .EnumeratePrototypes<GameMapPrototype>()
                     .Select(map => map.ID)
@@ -108,8 +108,8 @@ namespace Content.MapRenderer
                 Console.WriteLine("Retrieving map ids by map file names...");
 
                 Console.Write("Fetching map prototypes... ");
-                await using var pairTracker = await PoolManager.GetServerClient();
-                var mapPrototypes = pairTracker.Pair.Server
+                await using var pair = await PoolManager.GetServerClient();
+                var mapPrototypes = pair.Server
                     .ResolveDependency<IPrototypeManager>()
                     .EnumeratePrototypes<GameMapPrototype>()
                     .ToArray();

--- a/Content.YAMLLinter/Program.cs
+++ b/Content.YAMLLinter/Program.cs
@@ -51,20 +51,20 @@ namespace Content.YAMLLinter
         private static async Task<(Dictionary<string, HashSet<ErrorNode>> YamlErrors, List<string> FieldErrors)>
             ValidateClient()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var client = pairTracker.Pair.Client;
+            await using var pair = await PoolManager.GetServerClient();
+            var client = pair.Client;
             var result = await ValidateInstance(client);
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
             return result;
         }
 
         private static async Task<(Dictionary<string, HashSet<ErrorNode>> YamlErrors, List<string> FieldErrors)>
             ValidateServer()
         {
-            await using var pairTracker = await PoolManager.GetServerClient();
-            var server = pairTracker.Pair.Server;
+            await using var pair = await PoolManager.GetServerClient();
+            var server = pair.Server;
             var result = await ValidateInstance(server);
-            await pairTracker.CleanReturnAsync();
+            await pair.CleanReturnAsync();
             return result;
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This removes `TestPair.Pair` which is obsolete. Additionally, all variables named `pairTracker` I renamed to just `pair`, since that makes more sense now.