### PR TITLE
Meleespeech Action, Holoparasite Meleespeech

### DIFF
--- a/Content.Client/Weapons/Melee/UI/MeleeSpeechWindow.xaml
+++ b/Content.Client/Weapons/Melee/UI/MeleeSpeechWindow.xaml
@@ -1,8 +1,8 @@
 <DefaultWindow xmlns="https://spacestation14.io"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            Title="{Loc north-star-menu-title}">
+            Title="{Loc melee-speech-menu-title}">
     <BoxContainer Orientation="Vertical" SeparationOverride="4" MinWidth="150" >
-        <Label Name="CurrentBattlecry" Text="{Loc 'north-star-current-battlecry'}" />
+        <Label Name="CurrentBattlecry" Text="{Loc 'melee-speech-current-battlecry'}" />
         <LineEdit Name="BattlecryLineEdit" />
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Server/Speech/EntitySystems/MeleeSpeechSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MeleeSpeechSystem.cs
@@ -1,76 +1,83 @@
 using Content.Server.Administration.Logs;
+using Content.Shared.Actions;
 using Content.Shared.Speech.Components;
 using Content.Shared.Speech.EntitySystems;
 using Content.Shared.Database;
-
+using Robust.Server.GameObjects;
 
 namespace Content.Server.Speech.EntitySystems;
 
 public sealed class MeleeSpeechSystem : SharedMeleeSpeechSystem
 {
-
-	[Dependency] private readonly IAdminLogManager _adminLogger = default!;
-
-
-	public override void Initialize()
-	{
-		base.Initialize();
-		SubscribeLocalEvent<MeleeSpeechComponent, MeleeSpeechBattlecryChangedMessage>(OnBattlecryChanged);
-	}
-
-
-	private void OnBattlecryChanged(EntityUid uid, MeleeSpeechComponent comp, MeleeSpeechBattlecryChangedMessage args)
-	{
-
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly SharedActionsSystem _actionSystem = default!;
+    [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<MeleeSpeechComponent, MeleeSpeechBattlecryChangedMessage>(OnBattlecryChanged);
+        SubscribeLocalEvent<MeleeSpeechComponent, MeleeSpeechConfigureActionEvent>(OnConfigureAction);
+        SubscribeLocalEvent<MeleeSpeechComponent, GetItemActionsEvent>(OnGetActions);
+        SubscribeLocalEvent<MeleeSpeechComponent, ComponentInit>(OnComponentInit);
+    }
+    private void OnComponentInit(EntityUid uid, MeleeSpeechComponent component, ComponentInit args)
+    {
+        if (component.ConfigureAction != null)
+            _actionSystem.AddAction(uid, component.ConfigureAction, uid);
+    }
+    private void OnGetActions(EntityUid uid, MeleeSpeechComponent component, GetItemActionsEvent args)
+    {
+        if (component.ConfigureAction != null)
+            args.Actions.Add(component.ConfigureAction);
+    }
+    private void OnBattlecryChanged(EntityUid uid, MeleeSpeechComponent comp, MeleeSpeechBattlecryChangedMessage args)
+    {
         if (!TryComp<MeleeSpeechComponent>(uid, out var meleeSpeechUser))
-			return;
-
-        string battlecry = args.Battlecry;
-
+            return;
+        var battlecry = args.Battlecry;
         if (battlecry.Length > comp.MaxBattlecryLength)
             battlecry = battlecry[..comp.MaxBattlecryLength];
-
         TryChangeBattlecry(uid, battlecry, meleeSpeechUser);
-	}
-
-
-
-
-	/// <summary>
-	/// Attempts to change the battlecry of an entity.
-	/// Returns true/false.
-	/// </summary>
-	/// <remarks>
-	/// If provided with a player's EntityUid to the player parameter, adds the change to the admin logs.
-	/// </remarks>
-	public bool TryChangeBattlecry(EntityUid uid, string? battlecry, MeleeSpeechComponent? meleeSpeechComp = null)
-	{
-
+    }
+    /// <summary>
+    /// Attempts to open the Battlecry UI.
+    /// </summary>
+    private void OnConfigureAction(EntityUid uid, MeleeSpeechComponent comp, MeleeSpeechConfigureActionEvent args)
+    {
+        TryOpenUi(args.Performer, uid, comp);
+    }
+    public void TryOpenUi(EntityUid user, EntityUid source, MeleeSpeechComponent? component = null)
+    {
+        if (!Resolve(source, ref component))
+            return;
+        if (!TryComp<ActorComponent>(user, out var actor))
+            return;
+        _uiSystem.TryToggleUi(source, MeleeSpeechUiKey.Key, actor.PlayerSession);
+    }
+    /// <summary>
+    /// Attempts to change the battlecry of an entity.
+    /// Returns true/false.
+    /// </summary>
+    /// <remarks>
+    /// Logs changes to an entity's battlecry
+    /// </remarks>
+    public bool TryChangeBattlecry(EntityUid uid, string? battlecry, MeleeSpeechComponent? meleeSpeechComp = null)
+    {
         if (!Resolve(uid, ref meleeSpeechComp))
-			return false;
-
-		if (!string.IsNullOrWhiteSpace(battlecry))
-		{
-			battlecry = battlecry.Trim();
-
-
-		}
-		else
-		{
-			battlecry = null;
-		}
-
-		if (meleeSpeechComp.Battlecry == battlecry)
-
-			return true;
-
-
-
-		meleeSpeechComp.Battlecry = battlecry;
-		Dirty(meleeSpeechComp);
-
-		_adminLogger.Add(LogType.ItemConfigure, LogImpact.Medium, $" {ToPrettyString(uid):entity}'s battlecry has been changed to {battlecry}");
-		return true;
-	}
+            return false;
+        if (!string.IsNullOrWhiteSpace(battlecry))
+        {
+            battlecry = battlecry.Trim();
+        }
+        else
+        {
+            battlecry = null;
+        }
+        if (meleeSpeechComp.Battlecry == battlecry)
+            return true;
+        meleeSpeechComp.Battlecry = battlecry;
+        Dirty(meleeSpeechComp);
+        _adminLogger.Add(LogType.ItemConfigure, LogImpact.Medium, $" {ToPrettyString(uid):entity}'s battlecry has been changed to {battlecry}");
+        return true;
+    }
 }
-

--- a/Content.Server/Speech/EntitySystems/MeleeSpeechSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MeleeSpeechSystem.cs
@@ -76,7 +76,7 @@ public sealed class MeleeSpeechSystem : SharedMeleeSpeechSystem
         if (meleeSpeechComp.Battlecry == battlecry)
             return true;
         meleeSpeechComp.Battlecry = battlecry;
-        Dirty(meleeSpeechComp);
+        Dirty(uid, meleeSpeechComp);
         _adminLogger.Add(LogType.ItemConfigure, LogImpact.Medium, $" {ToPrettyString(uid):entity}'s battlecry has been changed to {battlecry}");
         return true;
     }

--- a/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
+++ b/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.Actions.ActionTypes;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 namespace Content.Shared.Speech.Components;
+
 [RegisterComponent, NetworkedComponent]
 [AutoGenerateComponentState]
 
@@ -15,6 +16,7 @@ public sealed partial class MeleeSpeechComponent : Component
     [DataField("Battlecry")]
     [AutoNetworkedField]
     public string? Battlecry;
+
     /// <summary>
     /// The maximum amount of characters allowed in a battlecry
     /// </summary>
@@ -22,6 +24,7 @@ public sealed partial class MeleeSpeechComponent : Component
     [DataField("MaxBattlecryLength")]
     [AutoNetworkedField]
     public int MaxBattlecryLength = 12;
+
     /// <summary>
     /// The action to open the battlecry UI
     /// </summary>

--- a/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
+++ b/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
@@ -70,4 +70,4 @@ public sealed class MeleeSpeechBattlecryChangedMessage : BoundUserInterfaceMessa
     }
 }
 
-public sealed class MeleeSpeechConfigureActionEvent : InstantActionEvent { }
+public sealed partial class MeleeSpeechConfigureActionEvent : InstantActionEvent { }

--- a/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
+++ b/Content.Shared/Speech/Components/MeleeSpeechComponent.cs
@@ -1,21 +1,40 @@
-using Content.Shared.Speech.EntitySystems;
+using Content.Shared.Actions;
+using Content.Shared.Actions.ActionTypes;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
-
 namespace Content.Shared.Speech.Components;
-
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 [AutoGenerateComponentState]
+
 public sealed partial class MeleeSpeechComponent : Component
 {
-
-	[ViewVariables(VVAccess.ReadWrite)]
-	[DataField("Battlecry")]
-	[AutoNetworkedField]
-	public string? Battlecry;
-
+    /// <summary>
+    /// The battlecry to be said when an entity attacks with this component
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("Battlecry")]
+    [AutoNetworkedField]
+    public string? Battlecry;
+    /// <summary>
+    /// The maximum amount of characters allowed in a battlecry
+    /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("MaxBattlecryLength")]
+    [AutoNetworkedField]
     public int MaxBattlecryLength = 12;
+    /// <summary>
+    /// The action to open the battlecry UI
+    /// </summary>
+    [DataField("configureAction")]
+    public InstantAction ConfigureAction = new()
+    {
+        UseDelay = TimeSpan.FromSeconds(1),
+        ItemIconStyle = ItemActionIconStyle.BigItem,
+        DisplayName = "melee-speech-config",
+        Description = "melee-speech-config-desc",
+        Priority = -20,
+        Event = new MeleeSpeechConfigureActionEvent(),
+    };
 }
 
 /// <summary>
@@ -35,7 +54,6 @@ public enum MeleeSpeechUiKey : byte
 public sealed class MeleeSpeechBoundUserInterfaceState : BoundUserInterfaceState
 {
     public string CurrentBattlecry { get; }
-
     public MeleeSpeechBoundUserInterfaceState(string currentBattlecry)
     {
         CurrentBattlecry = currentBattlecry;
@@ -51,3 +69,5 @@ public sealed class MeleeSpeechBattlecryChangedMessage : BoundUserInterfaceMessa
         Battlecry = battlecry;
     }
 }
+
+public sealed class MeleeSpeechConfigureActionEvent : InstantActionEvent { }

--- a/Resources/Locale/en-US/clothing/components/northstar-component.ftl
+++ b/Resources/Locale/en-US/clothing/components/northstar-component.ftl
@@ -1,2 +1,0 @@
-north-star-current-battlecry = Battlecry:
-north-star-menu-title = Set Battlecry

--- a/Resources/Locale/en-US/speech/melee-speech.ftl
+++ b/Resources/Locale/en-US/speech/melee-speech.ftl
@@ -1,0 +1,4 @@
+melee-speech-config = Set Battlecry
+melee-speech-config-desc = Set a custom battlecry for when you attack!
+melee-speech-current-battlecry = Battlecry:
+melee-speech-menu-title = Set Battlecry

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -322,6 +322,7 @@
   components:
   - type: Unremoveable
 
+
 - type: entity
   parent: ClothingHandsBase
   id: ClothingHandsGlovesNorthStar

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -350,6 +350,7 @@
     key: enum.MeleeSpeechUiKey.Key
     closeOnHandDeselect: false
     rightClickOnly: true
+  - type: Actions
   - type: UserInterface
     interfaces:
       - key: enum.MeleeSpeechUiKey.Key

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -89,6 +89,11 @@
       damage:
         types:
           Blunt: 20
+    - type: MeleeSpeech
+    - type: UserInterface
+      interfaces:
+      - key: enum.MeleeSpeechUiKey.Key
+        type: MeleeSpeechBoundUserInterface
     - type: Actions
     - type: Guardian
     - type: InteractionPopup


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
Previous PR, #18501 got stuck in git bash mistake hell. 
## About the PR
<!-- What did you change in this PR? -->
Makes the MeleeSpeech component have an action to configure your battlecry.
Adds MeleeSpeech to Holoparasites.

Be advised that this is my first foray into actions and I was very much figuring out how they work over this PR. It's likely a bit flawed in implementation.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: The Syndicate's Holoparasite have taken to yelling catchphrases as they fight.
