### PR TITLE
GetFlags System.NullReferenceException fix (Caught exception in "entsys")

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Administration.Managers;
 using Content.Server.Destructible;
-using Content.Server.NPC.Components;
+using Content.Server.NPC.HTN;
 using Content.Shared.Administration;
 using Content.Shared.Climbing;
 using Content.Shared.Interaction;
@@ -421,7 +421,7 @@ namespace Content.Server.NPC.Pathfinding
 
         public PathFlags GetFlags(EntityUid uid)
         {
-            if (!TryComp<NPCComponent>(uid, out var npc))
+            if (!TryComp<HTNComponent>(uid, out var npc))
             {
                 return PathFlags.None;
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixes this error that happens after this PR: https://github.com/space-wizards/space-station-14/pull/19480
```
[ERRO] runtime: Caught exception in "entsys" Exception: System.NullReferenceException: Object reference not set to an instance of an object.
    at Content.Server.NPC.Pathfinding.PathfindingSystem.GetFlags(EntityUid uid) in space-station-14/Content.Server/NPC/Pathfinding/PathfindingSystem.cs:line 424
```
which happens whenever AI is added onto a map
I am not sure this is the right way to do it, but it works

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
After all ComponentReferences to unregistered NPCComponent ceased to exist, `TryComp<NPCComponent>` no longer works and makes shit crash & burn, so I replaced it with `TryComp<HTNComponent>`

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
idk, probably none

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
no cl
