### PR TITLE
Health analyzers now show the user the chemicals inside the person being scanned

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -71,6 +71,10 @@ namespace Content.Client.HealthAnalyzer.UI
                     }
                     text.AppendLine();
                 }
+
+                //show chemicals in the bloodstream
+                text.Append("Chemicals:\n")
+
                 Diagnostics.Text = text.ToString();
                 SetSize = new Vector2(250, 600);
             }

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -72,11 +72,36 @@ namespace Content.Client.HealthAnalyzer.UI
                     text.AppendLine();
                 }
 
-                //show chemicals in the bloodstream
-                text.Append("Chemicals:\n")
+                //a bit of spacing
+                text.AppendLine();
+
+                //check if chemical information is actually sent
+                if (msg.Chemicals != null)
+                {
+                    //get rid of blood (we don't care if it's in someone)
+                    msg.Chemicals.Remove("Blood"); //human, dward, moff and lizard
+                    msg.Chemicals.Remove("SpiderBlood"); //for the arachnid
+                    msg.Chemicals.Remove("Slime"); //for the slime
+                    msg.Chemicals.Remove("Water"); //for the diona
+
+                    //if they have chemicals then do something
+                    if (msg.Chemicals.Count > 0)
+                    {
+                        //show them the chems
+                        text.Append($"{Loc.GetString("health-analyzer-window-contains-chemicals")}\n");
+                        foreach (KeyValuePair<string, FixedPoint2> pair in msg.Chemicals)
+                        {
+                            text.Append($"{Loc.GetString("health-analyzer-window-chemical", ("name", pair.Key), ("quantity", pair.Value))}\n");
+                        }
+                    } else
+                    {
+                        //No Chems?
+                        text.Append($"{Loc.GetString("health-analyzer-window-contains-no-chemicals")}");
+                    }
+                }
 
                 Diagnostics.Text = text.ToString();
-                SetSize = new Vector2(250, 600);
+                SetSize = new Vector2(250, 800);
             }
             else
             {

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Mobs.Components;
 using Robust.Server.GameObjects;
 using Content.Server.Temperature.Components;
 using Content.Server.Body.Components;
+using Content.Server.Chemistry.Components;
 
 namespace Content.Server.Medical
 {
@@ -73,10 +74,21 @@ namespace Content.Server.Medical
             TryComp<TemperatureComponent>(target, out var temp);
             TryComp<BloodstreamComponent>(target, out var bloodstream);
 
+            var Dictionary<string, FixedPoint2> chemicals = new();
+
+            //get the chemicals in the target
+            if (TryComp<SolutionContainerManagerComponent>(target, out var solutionContainerManagerComponent) && solutionContainerManagerComponent != null) {
+                foreach (KeyValuePair<string, Solution> pair in solutionContainerManagerComponent.Solutions) {
+                    foreach (ReagentQuantity reagent in Solution.Contents) {
+                        reagent.
+                    }
+                }
+            }
+
             OpenUserInterface(user, healthAnalyzer);
 
             _uiSystem.SendUiMessage(healthAnalyzer.UserInterface, new HealthAnalyzerScannedUserMessage(target, temp != null ? temp.CurrentTemperature : float.NaN,
-                bloodstream != null ? bloodstream.BloodSolution.FillFraction : float.NaN));
+                bloodstream != null ? bloodstream.BloodSolution.FillFraction : float.NaN, null));
         }
     }
 }

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Serialization;
+using Content.Shared.FixedPoint;
 
 namespace Content.Shared.MedicalScanner;
 
@@ -12,11 +13,14 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
     public float Temperature;
     public float BloodLevel;
 
-    public HealthAnalyzerScannedUserMessage(EntityUid? targetEntity, float temperature, float bloodLevel)
+    public Dictionary<string, FixedPoint2>? Chemicals;
+
+    public HealthAnalyzerScannedUserMessage(EntityUid? targetEntity, float temperature, float bloodLevel, Dictionary<string, FixedPoint2>? chemicals= null)
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
         BloodLevel = bloodLevel;
+        Chemicals = chemicals;
     }
 }
 

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -15,7 +15,7 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
 
     public Dictionary<string, FixedPoint2>? Chemicals;
 
-    public HealthAnalyzerScannedUserMessage(EntityUid? targetEntity, float temperature, float bloodLevel, Dictionary<string, FixedPoint2>? chemicals= null)
+    public HealthAnalyzerScannedUserMessage(EntityUid? targetEntity, float temperature, float bloodLevel, Dictionary<string, FixedPoint2>? chemicals = null)
     {
         TargetEntity = targetEntity;
         Temperature = temperature;

--- a/Resources/Locale/en-US/medical/components/health-analyzer-component.ftl
+++ b/Resources/Locale/en-US/medical/components/health-analyzer-component.ftl
@@ -28,3 +28,7 @@ health-analyzer-window-damage-type-Radiation = Radiation
 
 health-analyzer-window-damage-group-Genetic = Genetic
 health-analyzer-window-damage-type-Cellular = Cellular
+
+health-analyzer-window-contains-chemicals = Chemicals:
+health-analyzer-window-contains-no-chemicals = No chemicals
+health-analyzer-window-chemical = -{$name}: {$quantity}u


### PR DESCRIPTION
## About the PR
* Health Analyzers readouts now have a section denoting the chemicals inside the scanned person.

## Why / Balance
Playing medical roles would greatly benefit from the ability to see what chemicals are in someone. This could be for reasons like treating poisons, avoiding overdoses or knowing when one course of drugs has finished to administer the next. It is also general QOL.

## Technical details
* Modified HealthAnalyzerScannedUserMessage (a struct that is sent from HealthAnalyzerSystem to HealthAnalyzerWindow) to have an extra nullable field called chemicals which stores a list of the chemicals in the scanned person.
* HealthAnalyzerSystem counts the chemicals in the scanned person and adds it to the HealthAnalyzerScannedUserMessage,
* HealthAnalyzerWindow reads the chemicals from the message, and handles if it is null (it its null it does nothing). If it's not null then it removes blood chemicals from the chemicals list (Blood, SpiderBlood, Slime, Water). If there is atleast one chemicals then it shows them all in a list.
* The HealthAnalyzerWindow is a bit larger to compensate for the extra space needed to display the chemicals.

## Media
Here is a video demonstrating scanning chemicals:
https://github.com/space-wizards/space-station-14/assets/66873282/412701e0-9c96-4006-8967-3abdb4a13d68

## Breaking changes
* HealthAnalyzerScannedUserMessage has an extra field called Chemicals which defaults to null and is handled if it's left to default to null (so maybe it's not actually breaking).

**Changelog**
:cl:
- tweak: Health analyzers (medical PDAs included) can now show you the chemicals inside someone.
