### PR TITLE
Fixed trying to resolve unregistered NPCComponent type, fix NPCs

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -5,16 +5,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Administration.Managers;
 using Content.Server.Destructible;
-using Content.Server.NPC.Components;
+using Content.Server.NPC.HTN;
 using Content.Shared.Administration;
-using Content.Shared.Climbing;
-using Content.Shared.Interaction;
 using Content.Shared.NPC;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
-using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Players;
 using Robust.Shared.Random;
@@ -421,7 +418,7 @@ namespace Content.Server.NPC.Pathfinding
 
         public PathFlags GetFlags(EntityUid uid)
         {
-            if (!TryComp<NPCComponent>(uid, out var npc))
+            if (!TryComp<HTNComponent>(uid, out var npc))
             {
                 return PathFlags.None;
             }

--- a/Content.Server/NPC/Systems/NPCSystem.Blackboard.cs
+++ b/Content.Server/NPC/Systems/NPCSystem.Blackboard.cs
@@ -1,10 +1,10 @@
-using Content.Server.NPC.Components;
+using Content.Server.NPC.HTN;
 
 namespace Content.Server.NPC.Systems;
 
 public sealed partial class NPCSystem
 {
-    public void SetBlackboard(EntityUid uid, string key, object value, NPCComponent? component = null)
+    public void SetBlackboard(EntityUid uid, string key, object value, HTNComponent? component = null)
     {
         if (!Resolve(uid, ref component, false))
         {

--- a/Content.Server/NPC/Systems/NPCSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSystem.cs
@@ -3,7 +3,6 @@ using Content.Server.NPC.HTN;
 using Content.Shared.CCVar;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
-using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
 
@@ -36,12 +35,12 @@ namespace Content.Server.NPC.Systems
             _configurationManager.OnValueChanged(CCVars.NPCMaxUpdates, SetMaxUpdates, true);
         }
 
-        public void OnPlayerNPCAttach(EntityUid uid, NPCComponent component, PlayerAttachedEvent args)
+        public void OnPlayerNPCAttach(EntityUid uid, HTNComponent component, PlayerAttachedEvent args)
         {
             SleepNPC(uid, component);
         }
 
-        public void OnPlayerNPCDetach(EntityUid uid, NPCComponent component, PlayerDetachedEvent args)
+        public void OnPlayerNPCDetach(EntityUid uid, HTNComponent component, PlayerDetachedEvent args)
         {
             if (_mobState.IsIncapacitated(uid) || TerminatingOrDeleted(uid))
                 return;
@@ -59,13 +58,13 @@ namespace Content.Server.NPC.Systems
             _configurationManager.UnsubValueChanged(CCVars.NPCMaxUpdates, SetMaxUpdates);
         }
 
-        public void OnNPCMapInit(EntityUid uid, NPCComponent component, MapInitEvent args)
+        public void OnNPCMapInit(EntityUid uid, HTNComponent component, MapInitEvent args)
         {
             component.Blackboard.SetValue(NPCBlackboard.Owner, uid);
             WakeNPC(uid, component);
         }
 
-        public void OnNPCShutdown(EntityUid uid, NPCComponent component, ComponentShutdown args)
+        public void OnNPCShutdown(EntityUid uid, HTNComponent component, ComponentShutdown args)
         {
             SleepNPC(uid, component);
         }
@@ -73,7 +72,7 @@ namespace Content.Server.NPC.Systems
         /// <summary>
         /// Is the NPC awake and updating?
         /// </summary>
-        public bool IsAwake(EntityUid uid, NPCComponent component, ActiveNPCComponent? active = null)
+        public bool IsAwake(EntityUid uid, HTNComponent component, ActiveNPCComponent? active = null)
         {
             return Resolve(uid, ref active, false);
         }
@@ -81,7 +80,7 @@ namespace Content.Server.NPC.Systems
         /// <summary>
         /// Allows the NPC to actively be updated.
         /// </summary>
-        public void WakeNPC(EntityUid uid, NPCComponent? component = null)
+        public void WakeNPC(EntityUid uid, HTNComponent? component = null)
         {
             if (!Resolve(uid, ref component, false))
             {
@@ -92,7 +91,7 @@ namespace Content.Server.NPC.Systems
             EnsureComp<ActiveNPCComponent>(uid);
         }
 
-        public void SleepNPC(EntityUid uid, NPCComponent? component = null)
+        public void SleepNPC(EntityUid uid, HTNComponent? component = null)
         {
             if (!Resolve(uid, ref component, false))
             {
@@ -128,7 +127,7 @@ namespace Content.Server.NPC.Systems
             _htn.UpdateNPC(ref _count, _maxUpdates, frameTime);
         }
 
-        public void OnMobStateChange(EntityUid uid, NPCComponent component, MobStateChangedEvent args)
+        public void OnMobStateChange(EntityUid uid, HTNComponent component, MobStateChangedEvent args)
         {
             if (HasComp<ActorComponent>(uid))
                 return;


### PR DESCRIPTION
## About the PR
We removed component references for NPCComponent but didn't update any usages that were trying to resolve it as a component type.
This fixes NPCs and the map renderer.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- fix: Fixed NPCs not working.