### PR TITLE
Remove usages of obsolete SharedPointLightComponent setters

### DIFF
--- a/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
@@ -10,6 +10,8 @@ namespace Content.Client.Atmos.EntitySystems;
 /// </summary>
 public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent>
 {
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -86,7 +88,8 @@ public sealed class FireVisualizerSystem : VisualizerSystem<FireVisualsComponent
         light.Color = component.LightColor;
 
         // light needs a minimum radius to be visible at all, hence the + 1.5f
-        light.Radius = Math.Clamp(1.5f + component.LightRadiusPerStack * fireStacks, 0f, component.MaxLightRadius);
+        _pointLight.SetRadius(component.LightEntity.Value,
+            Math.Clamp(1.5f + component.LightRadiusPerStack * fireStacks, 0f, component.MaxLightRadius), light);
         light.Energy = Math.Clamp(1 + component.LightEnergyPerStack * fireStacks, 0f, component.MaxLightEnergy);
 
         // TODO flickering animation? Or just add a noise mask to the light? But that requires an engine PR.

--- a/Content.Client/Explosion/ExplosionOverlaySystem.cs
+++ b/Content.Client/Explosion/ExplosionOverlaySystem.cs
@@ -16,6 +16,7 @@ public sealed class ExplosionOverlaySystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly IResourceCache _resCache = default!;
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
     /// <summary>
     ///     For how many seconds should an explosion stay on-screen once it has finished expanding?
@@ -65,7 +66,9 @@ public sealed class ExplosionOverlaySystem : EntitySystem
         // spawn in a client-side light source at the epicenter
         var lightEntity = Spawn("ExplosionLight", component.Epicenter);
         var light = EnsureComp<PointLightComponent>(lightEntity);
-        light.Energy = light.Radius = component.Intensity.Count;
+        var intensity = component.Intensity.Count;
+        light.Energy = intensity;
+        _pointLight.SetRadius(lightEntity, intensity, light);
         light.Color = type.LightColor;
 
         textures.LightEntity = lightEntity;

--- a/Content.Client/Light/Components/LightBehaviourComponent.cs
+++ b/Content.Client/Light/Components/LightBehaviourComponent.cs
@@ -51,20 +51,16 @@ namespace Content.Client.Light.Components
             _entMan = entMan;
             _parent = parent;
 
-            if (Enabled && _entMan.TryGetComponent(_parent, out PointLightComponent? light))
-            {
-                light.Enabled = true;
-            }
+            if (Enabled && _entMan.TryGetComponent<PointLightComponent>(_parent, out var light))
+                _entMan.EntitySysManager.GetEntitySystem<SharedPointLightSystem>().SetEnabled(_parent, true, light);
 
             OnInitialize();
         }
 
         public void UpdatePlaybackValues(Animation owner)
         {
-            if (_entMan.TryGetComponent(_parent, out PointLightComponent? light))
-            {
-                light.Enabled = true;
-            }
+            if (_entMan.TryGetComponent<PointLightComponent>(_parent, out var light))
+                _entMan.EntitySysManager.GetEntitySystem<SharedPointLightSystem>().SetEnabled(_parent, true, light);
 
             if (MinDuration > 0)
             {

--- a/Content.Client/Revenant/RevenantOverloadedLightsSystem.cs
+++ b/Content.Client/Revenant/RevenantOverloadedLightsSystem.cs
@@ -6,6 +6,8 @@ namespace Content.Client.Revenant;
 
 public sealed class RevenantOverloadedLightsSystem : SharedRevenantOverloadedLightsSystem
 {
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -33,7 +35,7 @@ public sealed class RevenantOverloadedLightsSystem : SharedRevenantOverloadedLig
         component.OriginalEnergy = light.Energy;
         component.OriginalEnabled = light.Enabled;
 
-        light.Enabled = component.OriginalEnabled;
+        _pointLight.SetEnabled(uid, component.OriginalEnabled, light);
         Dirty(light);
     }
 
@@ -49,7 +51,7 @@ public sealed class RevenantOverloadedLightsSystem : SharedRevenantOverloadedLig
         }
 
         light.Energy = component.OriginalEnergy.Value;
-        light.Enabled = component.OriginalEnabled;
+        _pointLight.SetEnabled(uid, component.OriginalEnabled, light);
         Dirty(light);
     }
 

--- a/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
+++ b/Content.Client/Toggleable/ToggleableLightVisualsSystem.cs
@@ -13,6 +13,7 @@ namespace Content.Client.Toggleable;
 public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLightVisualsComponent>
 {
     [Dependency] private readonly SharedItemSystem _itemSys = default!;
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
     public override void Initialize()
     {
@@ -40,7 +41,7 @@ public sealed class ToggleableLightVisualsSystem : VisualizerSystem<ToggleableLi
         if (TryComp(uid, out PointLightComponent? light))
         {
             DebugTools.Assert(!light.NetSyncEnabled, "light visualizers require point lights without net-sync");
-            light.Enabled = enabled;
+            _pointLight.SetEnabled(uid, enabled, light);
             if (enabled && modulate)
                 light.Color = color;
         }

--- a/Content.Server/Botany/Systems/BotanySystem.Seed.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Seed.cs
@@ -28,6 +28,7 @@ public sealed partial class BotanySystem : EntitySystem
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
     public override void Initialize()
     {
@@ -174,7 +175,7 @@ public sealed partial class BotanySystem : EntitySystem
             if (proto.Bioluminescent)
             {
                 var light = EnsureComp<PointLightComponent>(entity);
-                light.Radius = proto.BioluminescentRadius;
+                _pointLight.SetRadius(entity, proto.BioluminescentRadius, light);
                 light.Color = proto.BioluminescentColor;
                 light.CastShadows = false; // this is expensive, and botanists make lots of plants
                 Dirty(light);

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -40,6 +40,7 @@ namespace Content.Server.Botany.Systems
         [Dependency] private readonly SolutionContainerSystem _solutionSystem = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
         public const float HydroponicsSpeedMultiplier = 1f;
         public const float HydroponicsConsumptionMultiplier = 2f;
@@ -856,7 +857,7 @@ namespace Content.Server.Botany.Systems
             if (component.Seed != null && component.Seed.Bioluminescent)
             {
                 var light = EnsureComp<PointLightComponent>(uid);
-                light.Radius = component.Seed.BioluminescentRadius;
+                _pointLight.SetRadius(uid, component.Seed.BioluminescentRadius, light);
                 light.Color = component.Seed.BioluminescentColor;
                 light.CastShadows = false; // this is expensive, and botanists make lots of plants
                 Dirty(light);

--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Gravity
         [Dependency] private readonly GravitySystem _gravitySystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
         public override void Initialize()
         {
@@ -233,10 +234,10 @@ namespace Content.Server.Gravity
             var appearance = EntityManager.GetComponentOrNull<AppearanceComponent>(uid);
             _appearance.SetData(uid, GravityGeneratorVisuals.Charge, grav.Charge, appearance);
 
-            if (EntityManager.TryGetComponent(uid, out PointLightComponent? pointLight))
+            if (TryComp<PointLightComponent>(uid, out var light))
             {
-                pointLight.Enabled = grav.Charge > 0;
-                pointLight.Radius = MathHelper.Lerp(grav.LightRadiusMin, grav.LightRadiusMax, grav.Charge);
+                _pointLight.SetEnabled(uid, grav.Charge > 0, light);
+                _pointLight.SetRadius(uid, MathHelper.Lerp(grav.LightRadiusMin, grav.LightRadiusMax, grav.Charge), light);
             }
 
             if (!grav.Intact)

--- a/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
@@ -20,6 +20,7 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly AmbientSoundSystem _ambient = default!;
         [Dependency] private readonly StationSystem _station = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
         public override void Initialize()
         {
@@ -199,10 +200,8 @@ namespace Content.Server.Light.EntitySystems
 
         private void TurnOff(EmergencyLightComponent component)
         {
-            if (TryComp(component.Owner, out PointLightComponent? light))
-            {
-                light.Enabled = false;
-            }
+            if (TryComp<PointLightComponent>(component.Owner, out var light))
+                _pointLight.SetEnabled(component.Owner, false, light);
 
             if (TryComp(component.Owner, out AppearanceComponent? appearance))
                 _appearance.SetData(appearance.Owner, EmergencyLightVisuals.On, false, appearance);
@@ -212,10 +211,8 @@ namespace Content.Server.Light.EntitySystems
 
         private void TurnOn(EmergencyLightComponent component)
         {
-            if (TryComp(component.Owner, out PointLightComponent? light))
-            {
-                light.Enabled = true;
-            }
+            if (TryComp<PointLightComponent>(component.Owner, out var light))
+                _pointLight.SetEnabled(component.Owner, true, light);
 
             if (TryComp(component.Owner, out AppearanceComponent? appearance))
             {

--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -29,6 +29,7 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly IPrototypeManager _proto = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
         // TODO: Ideally you'd be able to subscribe to power stuff to get events at certain percentages.. or something?
         // But for now this will be better anyway.
@@ -220,7 +221,7 @@ namespace Content.Server.Light.EntitySystems
                 return false;
             }
 
-            pointLightComponent.Enabled = false;
+            _pointLight.SetEnabled(uid, false, pointLightComponent);
             SetActivated(uid, false, component, makeNoise);
             component.Level = null;
             _activeLights.Remove(component);
@@ -252,7 +253,7 @@ namespace Content.Server.Light.EntitySystems
                 return false;
             }
 
-            pointLightComponent.Enabled = true;
+            _pointLight.SetEnabled(uid, true, pointLightComponent);
             SetActivated(uid, true, component, true);
             _activeLights.Add(component);
 

--- a/Content.Server/Light/EntitySystems/LitOnPoweredSystem.cs
+++ b/Content.Server/Light/EntitySystems/LitOnPoweredSystem.cs
@@ -7,6 +7,8 @@ namespace Content.Server.Light.EntitySystems
 {
     public sealed class LitOnPoweredSystem : EntitySystem
     {
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -16,18 +18,14 @@ namespace Content.Server.Light.EntitySystems
 
         private void OnPowerChanged(EntityUid uid, LitOnPoweredComponent component, ref PowerChangedEvent args)
         {
-            if (EntityManager.TryGetComponent<PointLightComponent>(uid, out var light))
-            {
-                light.Enabled = args.Powered;
-            }
+            if (TryComp<PointLightComponent>(uid, out var light))
+                _pointLight.SetEnabled(uid, args.Powered, light);
         }
 
         private void OnPowerSupply(EntityUid uid, LitOnPoweredComponent component, ref PowerNetBatterySupplyEvent args)
         {
-            if (EntityManager.TryGetComponent<PointLightComponent>(uid, out var light))
-            {
-                light.Enabled = args.Supply;
-            }
+            if (TryComp<PointLightComponent>(uid, out var light))
+                _pointLight.SetEnabled(uid, args.Supply, light);
         }
     }
 }

--- a/Content.Server/Light/EntitySystems/MatchstickSystem.cs
+++ b/Content.Server/Light/EntitySystems/MatchstickSystem.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly TransformSystem _transformSystem = default!;
         [Dependency] private readonly SharedItemSystem _item = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
         private HashSet<MatchstickComponent> _litMatches = new();
 
@@ -92,10 +93,8 @@ namespace Content.Server.Light.EntitySystems
         {
             component.CurrentState = value;
 
-            if (TryComp<PointLightComponent>(component.Owner, out var pointLightComponent))
-            {
-                pointLightComponent.Enabled = component.CurrentState == SmokableState.Lit;
-            }
+            if (TryComp<PointLightComponent>(component.Owner, out var light))
+                _pointLight.SetEnabled(component.Owner, component.CurrentState == SmokableState.Lit, light);
 
             if (EntityManager.TryGetComponent(component.Owner, out ItemComponent? item))
             {

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -44,6 +44,7 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly PowerReceiverSystem _power = default!;
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
         private static readonly TimeSpan ThunkDelay = TimeSpan.FromSeconds(2);
         public const string LightBulbContainer = "light_bulb";
@@ -397,12 +398,12 @@ namespace Content.Server.Light.EntitySystems
 
             if (EntityManager.TryGetComponent(uid, out PointLightComponent? pointLight))
             {
-                pointLight.Enabled = value;
+                _pointLight.SetEnabled(uid, value, pointLight);
 
                 if (color != null)
                     pointLight.Color = color.Value;
                 if (radius != null)
-                    pointLight.Radius = (float) radius;
+                    _pointLight.SetRadius(uid,  (float) radius, pointLight);
                 if (energy != null)
                     pointLight.Energy = (float) energy;
                 if (softness != null)

--- a/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
+++ b/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
@@ -21,6 +21,7 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
         public override void Initialize()
         {
@@ -90,7 +91,7 @@ namespace Content.Server.Light.EntitySystems
                 return;
 
             flashlight.LightOn = !flashlight.LightOn;
-            light.Enabled = flashlight.LightOn;
+            _pointLight.SetEnabled(uid, flashlight.LightOn, light);
 
             _appearance.SetData(uid, UnpoweredFlashlightVisuals.LightOn, flashlight.LightOn);
 

--- a/Content.Server/Security/Systems/DeployableBarrierSystem.cs
+++ b/Content.Server/Security/Systems/DeployableBarrierSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Server.Security.Systems
     {
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly PullingSystem _pulling = default!;
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
         public override void Initialize()
         {
@@ -42,8 +43,8 @@ namespace Content.Server.Security.Systems
             if (TryComp<SharedPullableComponent>(uid, out var pullable))
                 _pulling.TryStopPull(pullable);
 
-            if (TryComp(uid, out PointLightComponent? light))
-                light.Enabled = isDeployed;
+            if (TryComp<PointLightComponent>(uid, out var light))
+                _pointLight.SetEnabled(uid, isDeployed, light);
         }
     }
 }

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -33,6 +33,7 @@ public sealed class ThrusterSystem : EntitySystem
     [Dependency] private readonly FixtureSystem _fixtureSystem = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
     // Essentially whenever thruster enables we update the shuttle's available impulses which are used for movement.
     // This is done for each direction available.
@@ -284,10 +285,8 @@ public sealed class ThrusterSystem : EntitySystem
             _appearance.SetData(uid, ThrusterVisualState.State, true, appearance);
         }
 
-        if (EntityManager.TryGetComponent(uid, out PointLightComponent? pointLightComponent))
-        {
-            pointLightComponent.Enabled = true;
-        }
+        if (TryComp<PointLightComponent>(uid, out var light))
+            _pointLight.SetEnabled(uid, true, light);
 
         _ambient.SetAmbience(uid, true);
         RefreshCenter(uid, shuttleComponent);
@@ -372,10 +371,8 @@ public sealed class ThrusterSystem : EntitySystem
             _appearance.SetData(uid, ThrusterVisualState.State, false, appearance);
         }
 
-        if (EntityManager.TryGetComponent(uid, out PointLightComponent? pointLightComponent))
-        {
-            pointLightComponent.Enabled = false;
-        }
+        if (TryComp<PointLightComponent>(uid, out var light))
+            _pointLight.SetEnabled(uid, false, light);
 
         _ambient.SetAmbience(uid, false);
 

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -22,6 +22,7 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly PhysicsSystem _physics = default!;
     [Dependency] private readonly AppearanceSystem _visualizer = default!;
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
     public override void Initialize()
     {
@@ -325,10 +326,8 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
     /// </summary>
     public void UpdateConnectionLights(ContainmentFieldGeneratorComponent component)
     {
-        if (EntityManager.TryGetComponent<PointLightComponent>(component.Owner, out var pointLightComponent))
-        {
-            pointLightComponent.Enabled = component.Connections.Count > 0;
-        }
+        if (TryComp<PointLightComponent>(component.Owner, out var light))
+            _pointLight.SetEnabled(component.Owner, component.Connections.Count > 0, light);
     }
 
     /// <summary>

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -26,6 +26,7 @@ namespace Content.Server.Tools
 
         [Dependency] private readonly AppearanceSystem _appearanceSystem = default!;
         [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+        [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
         private readonly HashSet<EntityUid> _activeWelders = new();
 
@@ -125,7 +126,7 @@ namespace Content.Server.Tools
             _appearanceSystem.SetData(uid, ToggleableLightVisuals.Enabled, true);
 
             if (light != null)
-                light.Enabled = true;
+                _pointLight.SetEnabled(uid, true, light);
 
             _audioSystem.PlayPvs(welder.WelderOnSounds, uid, AudioParams.Default.WithVariation(0.125f).WithVolume(-5f));
 
@@ -172,7 +173,7 @@ namespace Content.Server.Tools
             _appearanceSystem.SetData(uid, ToggleableLightVisuals.Enabled, false);
 
             if (light != null)
-                light.Enabled = false;
+                _pointLight.SetEnabled(uid, false, light);
 
             _audioSystem.PlayPvs(welder.WelderOffSounds, uid, AudioParams.Default.WithVariation(0.125f).WithVolume(-5f));
 

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -24,6 +24,7 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
 
     public override void Initialize()
     {
@@ -52,10 +53,9 @@ public abstract partial class SharedCryoPodSystem: EntitySystem
         if (!Resolve(uid, ref cryoPod))
             return;
         var cryoPodEnabled = HasComp<ActiveCryoPodComponent>(uid);
+
         if (TryComp<SharedPointLightComponent>(uid, out var light))
-        {
-            light.Enabled = cryoPodEnabled && cryoPod.BodyContainer.ContainedEntity != null;
-        }
+            _pointLight.SetEnabled(uid, cryoPodEnabled && cryoPod.BodyContainer.ContainedEntity != null, light);
 
         if (!Resolve(uid, ref appearance))
             return;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

Note that I sometimes use `Component.Owner` in cases where it's already being used, as refactoring that here would make the PR a mess.