### PR TITLE
Fix wallmount devices being indeconstructible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -248,6 +248,12 @@
     node: generator
   - type: StaticPrice
     price: 14
+  - type: ContainerFill
+    containers:
+      board: [ WallmountGeneratorElectronics ]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
 
 - type: entity
   parent: BaseGeneratorWallmount
@@ -263,6 +269,12 @@
     node: APU
   - type: StaticPrice
     price: 38
+  - type: ContainerFill
+    containers:
+      board: [ WallmountGeneratorAPUElectronics ]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
 
 # RTG - no fuel requirement
 

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -130,6 +130,12 @@
   - type: Clickable
   - type: AccessReader
     access: [["Engineering"]]
+  - type: ContainerFill
+    containers:
+      board: [ WallmountSubstationElectronics ]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
   - type: InteractionOutline
   - type: Physics
     bodyType: Static

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -63,6 +63,12 @@
     LayoutId: AirAlarm
   - type: AccessReader
     access: [["Atmospherics"]]
+  - type: ContainerFill
+    containers:
+      board: [ AirAlarmElectronics ]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
   - type: Appearance
   - type: WiresVisuals
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -44,6 +44,12 @@
   - type: FireAlarm
   - type: AccessReader
     access: [ [ "Atmospherics" ] ]
+  - type: ContainerFill
+    containers:
+      board: [ FireAlarmElectronics ]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
   - type: Appearance
   - type: WiresVisuals
   - type: AlertLevelDisplay

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
@@ -23,6 +23,12 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Appearance
+  - type: ContainerFill
+    containers:
+      board: [ IntercomElectronics ]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
   - type: Sprite
     noRot: false
     sprite: Structures/Wallmounts/intercom.rsi

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/station_map.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/station_map.yml
@@ -51,6 +51,12 @@
     - type: Icon
       sprite: Structures/Machines/station_map.rsi
       state: station_map0
+    - type: ContainerFill
+      containers:
+        board: [ StationMapCircuitboard ]
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
     - type: ApcPowerReceiver
       powerLoad: 200
       priority: Low

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/station_maps.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/station_maps.yml
@@ -67,8 +67,6 @@
     edges:
     - to: wired
       conditions:
-      - !type:AllWiresCut {}
-      - !type:WirePanel {}
       - !type:ContainerNotEmpty
         container: board
       completed:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title pretty much. Applies fix to necessary devices, which was most of the wallmounts.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Some construction graphs (like `Resources\Prototypes\Recipes\Construction\Graphs\utilities\air_alarms.yml`) specify a container `board` to hold electronics but it wasn't defined for most wallmounts. Here I define it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed wallmount devices being unable to be deconstructed.

