### PR TITLE
Add SpawnEquipDeleteBenchmark

### DIFF
--- a/Content.Benchmarks/DeviceNetworkingBenchmark.cs
+++ b/Content.Benchmarks/DeviceNetworkingBenchmark.cs
@@ -59,6 +59,7 @@ public class DeviceNetworkingBenchmark
     public async Task SetupAsync()
     {
         ProgramShared.PathOffset = "../../../../";
+        PoolManager.Startup(typeof(DeviceNetworkingBenchmark).Assembly);
         _pair = await PoolManager.GetServerClient();
         var server = _pair.Server;
 
@@ -91,6 +92,7 @@ public class DeviceNetworkingBenchmark
     public async Task Cleanup()
     {
         await _pair.DisposeAsync();
+        PoolManager.Shutdown();
     }
 
     [Benchmark(Baseline = true, Description = "Entity Events")]

--- a/Content.Benchmarks/MapLoadBenchmark.cs
+++ b/Content.Benchmarks/MapLoadBenchmark.cs
@@ -26,6 +26,7 @@ public class MapLoadBenchmark
     public void Setup()
     {
         ProgramShared.PathOffset = "../../../../";
+        PoolManager.Startup(null);
 
         _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
         var server = _pair.Server;
@@ -42,6 +43,7 @@ public class MapLoadBenchmark
     public async Task Cleanup()
     {
         await _pair.DisposeAsync();
+        PoolManager.Shutdown();
     }
 
     public static IEnumerable<string> MapsSource { get; set; }

--- a/Content.Benchmarks/Program.cs
+++ b/Content.Benchmarks/Program.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using Content.IntegrationTests;
 using Content.Server.Maps;
+#if DEBUG
+using BenchmarkDotNet.Configs;
+#else
 using Robust.Benchmarks.Configs;
+#endif
 using Robust.Shared.Prototypes;
 
 namespace Content.Benchmarks
@@ -25,6 +28,7 @@ namespace Content.Benchmarks
             var gameMaps = pair.Server.ResolveDependency<IPrototypeManager>().EnumeratePrototypes<GameMapPrototype>().ToList();
             MapLoadBenchmark.MapsSource = gameMaps.Select(x => x.ID);
             await pair.CleanReturnAsync();
+            PoolManager.Shutdown();
 
 #if DEBUG
             Console.ForegroundColor = ConsoleColor.Red;
@@ -35,8 +39,6 @@ namespace Content.Benchmarks
             var config = Environment.GetEnvironmentVariable("ROBUST_BENCHMARKS_ENABLE_SQL") != null ? DefaultSQLConfig.Instance : null;
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
 #endif
-
-            PoolManager.Shutdown();
         }
     }
 }

--- a/Content.Benchmarks/SpawnEquipDeleteBenchmark.cs
+++ b/Content.Benchmarks/SpawnEquipDeleteBenchmark.cs
@@ -1,0 +1,66 @@
+﻿using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Content.IntegrationTests;
+using Content.IntegrationTests.Pair;
+using Content.Server.Station.Systems;
+using Content.Shared.Roles;
+using Robust.Shared;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.Benchmarks;
+
+/// <summary>
+/// This benchmarks spawns several humans, gives them captain equipment and then deletes them.
+/// This measures performance for spawning, deletion, containers, and inventory code.
+/// </summary>
+[Virtual, MemoryDiagnoser]
+public class SpawnEquipDeleteBenchmark
+{
+    private TestPair _pair = default!;
+    private StationSpawningSystem _spawnSys = default!;
+    private const string Mob = "MobHuman";
+    private StartingGearPrototype _gear = default!;
+    private EntityUid _entity;
+    private EntityCoordinates _coords;
+
+    [Params(1, 4, 16, 64)]
+    public int N;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        ProgramShared.PathOffset = "../../../../";
+        PoolManager.Startup(null);
+        _pair = await PoolManager.GetServerClient();
+        var server = _pair.Server;
+
+        var mapData = await _pair.CreateTestMap();
+        _coords = mapData.GridCoords;
+        _spawnSys = server.System<StationSpawningSystem>();
+        _gear = server.ProtoMan.Index<StartingGearPrototype>("CaptainGear");
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _pair.DisposeAsync();
+        PoolManager.Shutdown();
+    }
+
+    [Benchmark]
+    public async Task SpawnDeletePlayer()
+    {
+        await _pair.Server.WaitPost(() =>
+        {
+            var server = _pair.Server;
+            for (var i = 0; i < N; i++)
+            {
+                _entity = server.EntMan.SpawnAttachedTo(Mob, _coords);
+                _spawnSys.EquipStartingGear(_entity, _gear, null);
+                server.EntMan.DeleteEntity(_entity);
+            }
+        });
+    }
+}

--- a/Content.IntegrationTests/Pair/TestPair.Prototypes.cs
+++ b/Content.IntegrationTests/Pair/TestPair.Prototypes.cs
@@ -26,7 +26,11 @@ public sealed partial class TestPair
             instance.ProtoMan.LoadString(file, changed: changed);
         }
 
-        await instance.WaitPost(() => instance.ProtoMan.ReloadPrototypes(changed));
+        await instance.WaitPost(() =>
+        {
+            instance.ProtoMan.ResolveResults();
+            instance.ProtoMan.ReloadPrototypes(changed);
+        });
 
         foreach (var (kind, ids) in changed)
         {


### PR DESCRIPTION
Adds a new benchmark and fixes existing benchmarks & release-mode tests.
The new benchmark is effectively a variant of the engine's `SpawnDeleteEntityBenchmark` that is probably more applicable to how content spawns entities.