### PR TITLE
Shift Sec HUD To The Right Side

### DIFF
--- a/Resources/Prototypes/StatusEffects/job.yml
+++ b/Resources/Prototypes/StatusEffects/job.yml
@@ -2,7 +2,7 @@
   id: JobIcon
   abstract: true
   priority: 1
-  locationPreference: Left
+  locationPreference: Right
 
 - type: statusIcon
   parent: JobIcon


### PR DESCRIPTION
## About the PR
Makes the Sec HUD job icons prefer the right side.

## Why
The chat indicator would constantly get overlapped by the job icons and make it hard to tell whenever someone was typing, which was quite annoying.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/110078045/81f48b0c-60b0-4fe8-b6dc-d3e67a108b55)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl:
- fix: Fixed Sec HUD icons overlapping with speech indicators.