### PR TITLE
Fixed random traitor alive objective lacking the name of the other tr…

### DIFF
--- a/Content.Server/Objectives/Conditions/RandomTraitorAliveCondition.cs
+++ b/Content.Server/Objectives/Conditions/RandomTraitorAliveCondition.cs
@@ -56,8 +56,7 @@ namespace Content.Server.Objectives.Conditions
             {
                 var entityManager = IoCManager.Resolve<EntityManager>();
                 var mindSystem = entityManager.System<MindSystem>();
-                return _targetMind == null ||
-                       !mindSystem.TryGetMind(_targetMind.Value, out _, out var mind) ||
+                return !entityManager.TryGetComponent(_targetMind, out MindComponent? mind) ||
                        !mindSystem.IsCharacterDeadIc(mind)
                     ? 1f
                     : 0f;

--- a/Content.Server/Objectives/Conditions/RandomTraitorAliveCondition.cs
+++ b/Content.Server/Objectives/Conditions/RandomTraitorAliveCondition.cs
@@ -11,7 +11,7 @@ namespace Content.Server.Objectives.Conditions
     [DataDefinition]
     public sealed partial class RandomTraitorAliveCondition : IObjectiveCondition
     {
-        private EntityUid? _target;
+        private EntityUid? _targetMind;
 
         public IObjectiveCondition GetAssigned(EntityUid mindId, MindComponent mind)
         {
@@ -21,7 +21,7 @@ namespace Content.Server.Objectives.Conditions
 
             if (traitors.Count == 0)
                 return new EscapeShuttleCondition(); //You were made a traitor by admins, and are the first/only.
-            return new RandomTraitorAliveCondition { _target = IoCManager.Resolve<IRobustRandom>().Pick(traitors).Id };
+            return new RandomTraitorAliveCondition { _targetMind = IoCManager.Resolve<IRobustRandom>().Pick(traitors).Id };
         }
 
         public string Title
@@ -31,14 +31,13 @@ namespace Content.Server.Objectives.Conditions
                 var targetName = string.Empty;
                 var ents = IoCManager.Resolve<IEntityManager>();
                 var jobs = ents.System<JobSystem>();
-                var jobName = jobs.MindTryGetJobName(_target);
+                var jobName = jobs.MindTryGetJobName(_targetMind);
 
-                if (_target == null)
+                if (_targetMind == null)
                     return Loc.GetString("objective-condition-other-traitor-alive-title", ("targetName", targetName), ("job", jobName));
 
-                var minds = ents.System<MindSystem>();
-                if (minds.TryGetMind(_target.Value, out _, out var mind) &&
-                    mind.OwnedEntity is { Valid: true } owned)
+                if (ents.TryGetComponent(_targetMind, out MindComponent? mind) &&
+                    mind.OwnedEntity is {Valid: true} owned)
                 {
                     targetName = ents.GetComponent<MetaDataComponent>(owned).EntityName;
                 }
@@ -57,8 +56,8 @@ namespace Content.Server.Objectives.Conditions
             {
                 var entityManager = IoCManager.Resolve<EntityManager>();
                 var mindSystem = entityManager.System<MindSystem>();
-                return _target == null ||
-                       !mindSystem.TryGetMind(_target.Value, out _, out var mind) ||
+                return _targetMind == null ||
+                       !mindSystem.TryGetMind(_targetMind.Value, out _, out var mind) ||
                        !mindSystem.IsCharacterDeadIc(mind)
                     ? 1f
                     : 0f;
@@ -69,7 +68,7 @@ namespace Content.Server.Objectives.Conditions
 
         public bool Equals(IObjectiveCondition? other)
         {
-            return other is RandomTraitorAliveCondition kpc && Equals(_target, kpc._target);
+            return other is RandomTraitorAliveCondition kpc && Equals(_targetMind, kpc._targetMind);
         }
 
         public override bool Equals(object? obj)
@@ -81,7 +80,7 @@ namespace Content.Server.Objectives.Conditions
 
         public override int GetHashCode()
         {
-            return _target?.GetHashCode() ?? 0;
+            return _targetMind?.GetHashCode() ?? 0;
         }
     }
 }

--- a/Content.Server/Objectives/Conditions/RandomTraitorProgressCondition.cs
+++ b/Content.Server/Objectives/Conditions/RandomTraitorProgressCondition.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Objectives.Conditions
     public sealed partial class RandomTraitorProgressCondition : IObjectiveCondition
     {
         // TODO ecs all of this
-        private EntityUid? _target;
+        private EntityUid? _targetMind;
 
         public IObjectiveCondition GetAssigned(EntityUid mindId, MindComponent mind)
         {
@@ -42,7 +42,7 @@ namespace Content.Server.Objectives.Conditions
             }
 
             if (traitors.Count == 0) return new EscapeShuttleCondition{}; //You were made a traitor by admins, and are the first/only.
-            return new RandomTraitorProgressCondition { _target = IoCManager.Resolve<IRobustRandom>().Pick(traitors).Id };
+            return new RandomTraitorProgressCondition { _targetMind = IoCManager.Resolve<IRobustRandom>().Pick(traitors).Id };
         }
 
         public string Title
@@ -52,12 +52,12 @@ namespace Content.Server.Objectives.Conditions
                 var targetName = string.Empty;
                 var entities = IoCManager.Resolve<IEntityManager>();
                 var jobs = entities.System<JobSystem>();
-                var jobName = jobs.MindTryGetJobName(_target);
+                var jobName = jobs.MindTryGetJobName(_targetMind);
 
-                if (_target == null)
+                if (_targetMind == null)
                     return Loc.GetString("objective-condition-other-traitor-progress-title", ("targetName", targetName), ("job", jobName));
 
-                if (entities.TryGetComponent(_target, out MindComponent? mind) &&
+                if (entities.TryGetComponent(_targetMind, out MindComponent? mind) &&
                     mind.OwnedEntity is {Valid: true} owned)
                 {
                     targetName = entities.GetComponent<MetaDataComponent>(owned).EntityName;
@@ -78,14 +78,14 @@ namespace Content.Server.Objectives.Conditions
                 float total = 0f; // how much progress they have
                 float max = 0f; // how much progress is needed for 100%
 
-                if (_target == null)
+                if (_targetMind == null)
                 {
                     Logger.Error("Null target on RandomTraitorProgressCondition.");
                     return 1f;
                 }
 
                 var entities = IoCManager.Resolve<IEntityManager>();
-                if (entities.TryGetComponent(_target, out MindComponent? mind))
+                if (entities.TryGetComponent(_targetMind, out MindComponent? mind))
                 {
                     foreach (var objective in mind.AllObjectives)
                     {
@@ -116,7 +116,7 @@ namespace Content.Server.Objectives.Conditions
 
         public bool Equals(IObjectiveCondition? other)
         {
-            return other is RandomTraitorProgressCondition kpc && Equals(_target, kpc._target);
+            return other is RandomTraitorProgressCondition kpc && Equals(_targetMind, kpc._targetMind);
         }
 
         public override bool Equals(object? obj)
@@ -128,7 +128,7 @@ namespace Content.Server.Objectives.Conditions
 
         public override int GetHashCode()
         {
-            return _target?.GetHashCode() ?? 0;
+            return _targetMind?.GetHashCode() ?? 0;
         }
     }
 }


### PR DESCRIPTION
## About the PR
## Media
![image](https://github.com/space-wizards/space-station-14/assets/10968691/cca99854-c739-4344-b36a-5b03867b84e4)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed not showing the name of the fellow traitor that you have to keep alive.