### PR TITLE
Fix players not getting their round start message telling them their supervisors

### DIFF
--- a/Content.Server/Roles/Jobs/JobSystem.cs
+++ b/Content.Server/Roles/Jobs/JobSystem.cs
@@ -21,10 +21,10 @@ public sealed class JobSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<JobComponent, RoleAddedEvent>(MindOnDoGreeting);
+        SubscribeLocalEvent<MindComponent, MindRoleAddedEvent>(MindOnDoGreeting);
     }
 
-    private void MindOnDoGreeting(EntityUid mindId, JobComponent component, RoleAddedEvent args)
+    private void MindOnDoGreeting(EntityUid mindId, MindComponent component, ref MindRoleAddedEvent args)
     {
         if (!_mind.TryGetSession(mindId, out var session))
             return;
@@ -38,9 +38,7 @@ public sealed class JobSystem : EntitySystem
         if (prototype.RequireAdminNotify)
             _chat.DispatchServerMessage(session, Loc.GetString("job-greet-important-disconnect-admin-notify"));
 
-        _chat.DispatchServerMessage(session, Loc.GetString("job-greet-supervisors-warning",
-            ("jobName", Name),
-            ("supervisors", Loc.GetString(prototype.Supervisors))));
+        _chat.DispatchServerMessage(session, Loc.GetString("job-greet-supervisors-warning", ("jobName", prototype.LocalizedName), ("supervisors", Loc.GetString(prototype.Supervisors))));
     }
 
     public void MindAddJob(EntityUid mindId, string jobPrototypeId)

--- a/Content.Server/Roles/MindRoleAddedEvent.cs
+++ b/Content.Server/Roles/MindRoleAddedEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace Content.Server.Roles;
+
+/// <summary>
+///     Raised on mind entities when a role is added to them.
+///     <see cref="RoleAddedEvent"/> for the one raised on player entities.
+/// </summary>
+[ByRefEvent]
+public readonly record struct MindRoleAddedEvent;

--- a/Content.Server/Roles/RoleAddedEvent.cs
+++ b/Content.Server/Roles/RoleAddedEvent.cs
@@ -3,7 +3,8 @@
 namespace Content.Server.Roles;
 
 /// <summary>
-///     Event raised on player entities to indicate that a role was added to their mind.
+///     Raised on player entities when a role is added to them.
+///     <see cref="RoleAddedEvent"/> for the one raised on mind entities.
 /// </summary>
 /// <param name="MindId">The mind id associated with the player.</param>
 /// <param name="Mind">The mind component associated with the mind id.</param>

--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -83,6 +83,9 @@ public sealed class RoleSystem : EntitySystem
         AddComp(mindId, component);
         var antagonist = IsAntagonistRole<T>();
 
+        var mindEv = new MindRoleAddedEvent();
+        RaiseLocalEvent(mindId, ref mindEv);
+
         var message = new RoleAddedEvent(mindId, mind, antagonist);
         if (mind.OwnedEntity != null)
         {


### PR DESCRIPTION
## About the PR
Fixes https://github.com/space-wizards/space-station-14/issues/19633

## Media
![Content Client_1o3qWXS1Ke](https://github.com/space-wizards/space-station-14/assets/10968691/be1a5425-c496-4cb2-b8e5-190b462d0c0d)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Fixed players not getting their round start message telling them their supervisors.