### PR TITLE
fix admins Flags arrays

### DIFF
--- a/Content.Shared/Administration/AdminCommandPermissions.cs
+++ b/Content.Shared/Administration/AdminCommandPermissions.cs
@@ -38,7 +38,7 @@ public sealed class AdminCommandPermissions
                     {
                         var newArr = new AdminFlags[exFlags.Length + 1];
                         exFlags.CopyTo(newArr, 0);
-                        exFlags[^1] = flags;
+                        newArr[^1] = flags;
                         AdminCommands[cmd] = newArr;
                     }
                 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
just fix admins flags where all admins have acces to edit vv

Incorrect reading of rewrite rights from yml rights of the RobustToolbox
through a function

because weird is - make new array > ask flag to old array > and  ask new array.

toolshed uses the same function.
because toolshed rights it also loads from 2x yml files.
in toolshed ```LoadPermissionsFromStream```  if you add rights to 2 teams, then access will be only for the first one and 2nd it turns out `None` - for all admins
 and that make bug.
 
## Why / Balance
it's not good when a person has 1 flag on Adminhelp, but he also gets the DEBUG flag somehow, where they can edit lines is entities VV.

## Media
 Unfix:
![image](https://github.com/space-wizards/space-station-14/assets/124053750/668068f6-b4c6-4e4e-b64f-ac4026bcd7d9)

fix:
![image](https://github.com/space-wizards/space-station-14/assets/124053750/4c253da9-f59e-42d8-9f5d-690192f7686e)

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
no cl no fun
