### PR TITLE
decouple briefing from traitor

### DIFF
--- a/Content.Client/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Client/CharacterInfo/CharacterInfoSystem.cs
@@ -58,7 +58,7 @@ public sealed class CharacterInfoSystem : EntitySystem
         EntityUid Entity,
         string Job,
         Dictionary<string, List<ConditionInfo>> Objectives,
-        string Briefing,
+        string? Briefing,
         string EntityName
     );
 

--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -140,11 +140,14 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
                 objectiveControl.AddChild(conditionControl);
             }
 
+            _window.Objectives.AddChild(objectiveControl);
+        }
+
+        if (briefing != null)
+        {
             var briefingControl = new ObjectiveBriefingControl();
             briefingControl.Label.Text = briefing;
-
-            objectiveControl.AddChild(briefingControl);
-            _window.Objectives.AddChild(objectiveControl);
+            _window.Objectives.AddChild(briefingControl);
         }
 
         var controls = _characterInfo.GetCharacterInfoControls(entity);
@@ -153,7 +156,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             _window.Objectives.AddChild(control);
         }
 
-        _window.RolePlaceholder.Visible = !controls.Any() && !objectives.Any();
+        _window.RolePlaceholder.Visible = breifing == null && !controls.Any() && !objectives.Any();
     }
 
     private void CharacterDetached()

--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -156,7 +156,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             _window.Objectives.AddChild(control);
         }
 
-        _window.RolePlaceholder.Visible = breifing == null && !controls.Any() && !objectives.Any();
+        _window.RolePlaceholder.Visible = briefing == null && !controls.Any() && !objectives.Any();
     }
 
     private void CharacterDetached()

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -29,7 +29,7 @@ public sealed class CharacterInfoSystem : EntitySystem
 
         var conditions = new Dictionary<string, List<ConditionInfo>>();
         var jobTitle = "No Profession";
-        var briefing = null;
+        string? briefing = null;
         if (_minds.TryGetMind(entity, out var mindId, out var mind))
         {
             // Get objectives

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -29,7 +29,7 @@ public sealed class CharacterInfoSystem : EntitySystem
 
         var conditions = new Dictionary<string, List<ConditionInfo>>();
         var jobTitle = "No Profession";
-        var briefing = "!!ERROR: No Briefing!!"; //should never show on the UI unless there's an issue
+        var briefing = null;
         if (_minds.TryGetMind(entity, out var mindId, out var mind))
         {
             // Get objectives
@@ -48,7 +48,7 @@ public sealed class CharacterInfoSystem : EntitySystem
                 jobTitle = jobName;
 
             // Get briefing
-            briefing = _roles.MindGetBriefing(mindId) ?? string.Empty;
+            briefing = _roles.MindGetBriefing(mindId);
         }
 
         RaiseNetworkEvent(new CharacterInfoEvent(entity, jobTitle, conditions, briefing), args.SenderSession);

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -253,11 +253,18 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         var traitorRole = new TraitorRoleComponent
         {
             PrototypeId = traitorRule.TraitorPrototypeId,
-            Briefing = briefing
         };
 
         // Assign traitor roles
-        _roleSystem.MindAddRole(mindId, traitorRole);
+        _roleSystem.MindAddRole(mindId, new TraitorRoleComponent
+        {
+            PrototypeId = traitorRule.TraitorPrototypeId
+        });
+        // Assign briefing
+        _roleSystem.MindAddRole(mindId, new RoleBriefingComponent
+        {
+            Briefing = briefing
+        });
         SendTraitorBriefing(mindId, traitorRule.Codewords, code);
         traitorRule.TraitorMinds.Add(mindId);
 

--- a/Content.Server/Roles/RoleBriefingComponent.cs
+++ b/Content.Server/Roles/RoleBriefingComponent.cs
@@ -1,0 +1,10 @@
+﻿namespace Content.Server.Roles;
+
+/// <summary>
+/// Adds a briefing to the character info menu, does nothing else.
+/// </summary>
+[RegisterComponent]
+public sealed partial class RoleBriefingComponent : Component
+{
+    public string Briefing;
+}

--- a/Content.Server/Roles/RoleBriefingComponent.cs
+++ b/Content.Server/Roles/RoleBriefingComponent.cs
@@ -6,5 +6,6 @@
 [RegisterComponent]
 public sealed partial class RoleBriefingComponent : Component
 {
+    [DataField("briefing"), ViewVariables(VVAccess.ReadWrite)]
     public string Briefing;
 }

--- a/Content.Server/Roles/RoleBriefingSystem.cs
+++ b/Content.Server/Roles/RoleBriefingSystem.cs
@@ -1,0 +1,25 @@
+namespace Content.Server.Roles;
+
+public sealed class RoleBriefingSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoleBriefingComponent, GetBriefingEvent>(OnGetBriefing);
+    }
+
+    private void OnGetBriefing(EntityUid uid, RoleBriefingComponent comp, ref GetBriefingEvent args)
+    {
+        if (args.Briefing == null)
+        {
+            // no previous briefing so just set it
+            args.Briefing = comp.Briefing;
+        }
+        else
+        {
+            // there is a previous briefing so append to it
+            args.Briefing += "\n" + comp.Briefing;
+        }
+    }
+}

--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -160,7 +160,7 @@ public sealed class RoleSystem : EntitySystem
             return null;
 
         var ev = new GetBriefingEvent();
-        RaiseLocalEvent(mindId, ref ev);
+        RaiseLocalEvent(mindId.Value, ref ev);
         return ev.Briefing;
     }
 

--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -156,8 +156,12 @@ public sealed class RoleSystem : EntitySystem
 
     public string? MindGetBriefing(EntityUid? mindId)
     {
-        // TODO this should be an event
-        return CompOrNull<TraitorRoleComponent>(mindId)?.Briefing;
+        if (mindId == null)
+            return null;
+
+        var ev = new GetBriefingEvent();
+        RaiseLocalEvent(mindId, ref ev);
+        return ev.Briefing;
     }
 
     public bool IsAntagonistRole<T>()
@@ -165,3 +169,10 @@ public sealed class RoleSystem : EntitySystem
         return _antagTypes.Contains(typeof(T));
     }
 }
+
+/// <summary>
+/// Event raised on the mind to get its briefing.
+/// Handlers can either replace or append to the briefing, whichever is more appropriate.
+/// </summary>
+[ByRefEvent]
+public record struct GetBriefingEvent(string? Briefing = null);

--- a/Content.Server/Roles/TraitorRoleComponent.cs
+++ b/Content.Server/Roles/TraitorRoleComponent.cs
@@ -3,5 +3,4 @@
 [RegisterComponent]
 public sealed partial class TraitorRoleComponent : AntagonistRoleComponent
 {
-    public string? Briefing;
 }

--- a/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
+++ b/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
@@ -20,9 +20,9 @@ public sealed class CharacterInfoEvent : EntityEventArgs
     public readonly EntityUid EntityUid;
     public readonly string JobTitle;
     public readonly Dictionary<string, List<ConditionInfo>> Objectives;
-    public readonly string Briefing;
+    public readonly string? Briefing;
 
-    public CharacterInfoEvent(EntityUid entityUid, string jobTitle, Dictionary<string, List<ConditionInfo>> objectives, string briefing)
+    public CharacterInfoEvent(EntityUid entityUid, string jobTitle, Dictionary<string, List<ConditionInfo>> objectives, string? briefing)
     {
         EntityUid = entityUid;
         JobTitle = jobTitle;


### PR DESCRIPTION
## About the PR
- briefing can now be added separately from traitor
- fixed not showing briefing when there are no objectives (found in monkey ops) and showing briefing twice if there are multiple objective groups (found in ninja when ninja is tator'd)

to add it manually vv the mind then add `RoleBriefingComponent` and edit its briefing field to be whatever. no newlines since vv editor is pro
 
## Why / Balance
make code less bad and allows for admeme things like giving ert soldiers a briefing to go kill the bad guys without making them traitors, could be used to copy paste ghost role rules into briefing in the future idk

## Technical details
- added GetBriefingEvent instead of hardcoding a component with the briefing
- traitor adds RoleBriefingComponent to the mind to store the briefing

ideally it would be a custom control and removed from characterdata entirely but not sure about how to do it

## Media
tator still works
![21:24:32](https://github.com/space-wizards/space-station-14/assets/39013340/d3dd4647-6f8d-4f97-8dc3-37e940a1c5c7)

cool custom briefing for non traitor
![21:23:05](https://github.com/space-wizards/space-station-14/assets/39013340/330e6c78-49b4-4bcb-86f4-44298ee19752)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
removed `Briefing` field from TraitorRoleComponent, its now in `RoleBriefingComponent`
briefing character data fields are now optional so you might have to handle nulls

**Changelog**
no cl no fun