### PR TITLE
Fix thrusters, add new max velocity calculation

### DIFF
--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -250,7 +250,7 @@ namespace Content.Server.Physics.Controllers
             var horizIndex = vel.X > 0 ? 1 : 3; // east else west
             var vertIndex = vel.Y > 0 ? 2 : 0; // north else south
             var horizComp = MathF.Pow(Vector2.Dot(vel, new (shuttle.BaseLinearThrust[horizIndex] / shuttle.LinearThrust[horizIndex], 0f)), 2);
-            var vertComp = MathF.Pow(Vector2.Dot(vel, new (0, shuttle.BaseLinearThrust[vertIndex] / shuttle.LinearThrust[vertIndex])), 2);
+            var vertComp = MathF.Pow(Vector2.Dot(vel, new (0f, shuttle.BaseLinearThrust[vertIndex] / shuttle.LinearThrust[vertIndex])), 2);
 
             return shuttle.BaseMaxLinearVelocity * vel * MathF.ReciprocalSqrtEstimate(horizComp + vertComp);
         }

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -16,7 +16,11 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         public const float BrakeCoefficient = 1.5f;
 
-        public const float MaxLinearVelocity = 20f;
+        /// <summary>
+        /// Maximum velocity assuming unupgraded, tier 1 thrusters
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float BaseMaxLinearVelocity = 20f;
 
         public const float MaxAngularVelocity = 4f;
 
@@ -25,6 +29,12 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         [ViewVariables]
         public readonly float[] LinearThrust = new float[4];
+
+        /// <summary>
+        /// The cached thrust available for each cardinal direction, if all thrusters are T1
+        /// </summary>
+        [ViewVariables]
+        public readonly float[] BaseLinearThrust = new float[4];
 
         /// <summary>
         /// The thrusters contributing to each direction for impulse.

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -175,7 +175,7 @@ public sealed class ThrusterSystem : EntitySystem
         shuttleComponent.LinearThrust[oldDirection] -= component.Thrust;
         shuttleComponent.BaseLinearThrust[oldDirection] -= component.BaseThrust;
         DebugTools.Assert(shuttleComponent.LinearThrusters[oldDirection].Contains(uid));
-        shuttleComponent.LinearThrusters[oldDirection].Remove(uid); // actually, don't remove it
+        shuttleComponent.LinearThrusters[oldDirection].Remove(uid);
 
         shuttleComponent.LinearThrust[direction] += component.Thrust;
         shuttleComponent.BaseLinearThrust[direction] += component.BaseThrust;

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -173,10 +173,12 @@ public sealed class ThrusterSystem : EntitySystem
         var direction = (int) args.NewRotation.GetCardinalDir() / 2;
 
         shuttleComponent.LinearThrust[oldDirection] -= component.Thrust;
+        shuttleComponent.BaseLinearThrust[oldDirection] -= component.BaseThrust;
         DebugTools.Assert(shuttleComponent.LinearThrusters[oldDirection].Contains(uid));
-        shuttleComponent.LinearThrusters[oldDirection].Remove(uid);
+        shuttleComponent.LinearThrusters[oldDirection].Remove(uid); // actually, don't remove it
 
         shuttleComponent.LinearThrust[direction] += component.Thrust;
+        shuttleComponent.BaseLinearThrust[direction] += component.BaseThrust;
         DebugTools.Assert(!shuttleComponent.LinearThrusters[direction].Contains(uid));
         shuttleComponent.LinearThrusters[direction].Add(uid);
     }
@@ -257,6 +259,7 @@ public sealed class ThrusterSystem : EntitySystem
                 var direction = (int) xform.LocalRotation.GetCardinalDir() / 2;
 
                 shuttleComponent.LinearThrust[direction] += component.Thrust;
+                shuttleComponent.BaseLinearThrust[direction] += component.BaseThrust;
                 DebugTools.Assert(!shuttleComponent.LinearThrusters[direction].Contains(uid));
                 shuttleComponent.LinearThrusters[direction].Add(uid);
 
@@ -355,6 +358,7 @@ public sealed class ThrusterSystem : EntitySystem
                 var direction = (int) angle.Value.GetCardinalDir() / 2;
 
                 shuttleComponent.LinearThrust[direction] -= component.Thrust;
+                shuttleComponent.BaseLinearThrust[direction] -= component.BaseThrust;
                 DebugTools.Assert(shuttleComponent.LinearThrusters[direction].Contains(uid));
                 shuttleComponent.LinearThrusters[direction].Remove(uid);
                 break;
@@ -552,9 +556,15 @@ public sealed class ThrusterSystem : EntitySystem
 
     private void OnRefreshParts(EntityUid uid, ThrusterComponent component, RefreshPartsEvent args)
     {
+        if (component.IsOn) // safely disable thruster to prevent negative thrust
+            DisableThruster(uid, component);
+
         var thrustRating = args.PartRatings[component.MachinePartThrust];
 
         component.Thrust = component.BaseThrust * MathF.Pow(component.PartRatingThrustMultiplier, thrustRating - 1);
+
+        if (component.Enabled && CanEnable(uid, component))
+            EnableThruster(uid, component);
     }
 
     private void OnUpgradeExamine(EntityUid uid, ThrusterComponent component, UpgradeExamineEvent args)


### PR DESCRIPTION
## About the PR
Shuttles no longer spazz out whenever negative thrust is introduced, and can now have their maximum speed enhanced by addition of more thrusters.

## Why / Balance
Issue #18585, which was triggered by seemingly disabling a thruster - was caused by thrusters that were RPED-ed while being enabled - is fixed in this PR. This was due to the `OnRefreshParts` method only updating the thruster component and not the shuttle.
As a side bonus, upgraded thrusters will now contribute to the shuttle's maximum speed by contributing to a direction-specific thrust factor - as there is no incentive to upgrade thrusters when you could just buy more. The new tier speeds are: 20, 30, 45, 67.5 meters per second. This balance is not final, as even at 60 TPS these speeds can cause problems \*coughs\* non-deltatime extended bounding box phasing \*coughs\*, but is presented anyway.

## Technical details
After an RPED change, the thruster is disabled, updated and reenabled.
The ShuttleComponent now also has a BaseLinearThrust array representing the sum of all `BaseThrust`s of every thruster in a direction, which is used to calculate a thrust factor. The thrust factor is simply `LinearThrust / BaseLinearThrust`, and is calculated per-direction.
Since you can't really use circles for this potentially unidirectional rescale, ovals/ellipses are used, with each LinearThrust semi-axis acting on the two quadrants beside it to resize max velocity.

Unfortunately, this code has a downside, which only happens at TPS ≥ 60, and is probably related to some other physics code I haven't seen (i really *really* hope it's fixable), which is that shuttles get their speed outright capped at 35, but raised to 70 whenever TPS is at a value between 30 (24?) - 59. This also happens at lower tickrates, sudden jumps at 20, 15, 12, 9, each increasing speed by an increment of 35. I have no idea what spaghetti causes this.

## Media
https://github.com/space-wizards/space-station-14/assets/21104932/9329d82b-c61b-4453-91f0-566f600bff68

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
ShuttleComponent.MaxLinearVelocity no longer exists, use ShuttleComponent.BaseMaxLinearVelocity.

**Changelog**

:cl: router
- fix: Shuttles no longer go hog wild whenever they're above their former maximum velocity of 20.
- add: Upgraded thrusters now contribute to a direction-specific thrust factor, calculated by dividing total thrust over thrust if every thruster was T1. The maximum speed with T4 parts is 67.5.
