### PR TITLE
fish 2tc again

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -821,7 +821,7 @@
   description: uplink-carp-dehydrated-desc
   productEntity: DehydratedSpaceCarp
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkTools
   conditions:


### PR DESCRIPTION
## About the PR
fish is back to 2tc. still blacklisted from nukies so still no fishops... yet

## Why / Balance
after it got nerfed its too expensive that its barely used anymore, hopefully this will make it viable once more outside of buying 6 fish and going all in with nothing else
fishtrap doesnt work anymore because fish ai breaks windows so that isnt a concern anymore

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Dehydrated space carp's price has been lowered back to 2 telecrystals.