### PR TITLE
Items will display size when examined.

### DIFF
--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Stacks;
 using Content.Shared.Verbs;
+using Content.Shared.Examine;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -26,6 +27,8 @@ public abstract class SharedItemSystem : EntitySystem
 
         SubscribeLocalEvent<ItemComponent, ComponentGetState>(OnGetState);
         SubscribeLocalEvent<ItemComponent, ComponentHandleState>(OnHandleState);
+
+        SubscribeLocalEvent<ItemComponent, ExaminedEvent>(OnExamine);
     }
 
     #region Public API
@@ -127,6 +130,12 @@ public abstract class SharedItemSystem : EntitySystem
             verb.Text = Loc.GetString("pick-up-verb-get-data-text");
 
         args.Verbs.Add(verb);
+    }
+
+    private void OnExamine(EntityUid uid, ItemComponent component, ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("item-component-on-examine-size",
+            ("size", component.Size)));
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/items/components/item-component.ftl
+++ b/Resources/Locale/en-US/items/components/item-component.ftl
@@ -5,3 +5,5 @@ pick-up-verb-get-data-text = Pick Up
 # "pick up" doesn't make sense if the item is already in their inventory
 
 pick-up-verb-get-data-text-inventory = Put in hand
+
+item-component-on-examine-size = Size: {$size}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds a line on every item that displays its size when examined. 
<!-- What did you change in this PR? -->

## Why / Balance
It's not normally possible to know an item size without it being inside a container. Removing items one by one from your backpack to fit in an item you don't know the size of only to realise it's actually too big to fit in the first place makes people cranky.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
Every ItemComponent now adds tacks on its size when the OnExamine event happens.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
![image](https://github.com/space-wizards/space-station-14/assets/3650235/cf94273a-01c4-453f-9772-b0433b14bdf9)
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- add: Examining an item now shows its size.
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
