### PR TITLE
prevent pulse throw from throwing observers

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/ThrowArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/ThrowArtifactSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.Maps;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Ghost;
 using Content.Shared.Maps;
 using Content.Shared.Throwing;
 using Robust.Shared.Map;
@@ -43,6 +44,9 @@ public sealed class ThrowArtifactSystem : EntitySystem
         var lookup = _lookup.GetEntitiesInRange(uid, component.Range, LookupFlags.Dynamic | LookupFlags.Sundries);
         foreach (var ent in lookup)
         {
+            if (HasComp<GhostComponent>(ent))
+                continue;
+
             var tempXform = Transform(ent);
 
             var foo = tempXform.MapPosition.Position - xform.MapPosition.Position;

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/ThrowArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/ThrowArtifactSystem.cs
@@ -4,8 +4,10 @@ using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
 using Content.Shared.Ghost;
 using Content.Shared.Maps;
+using Content.Shared.Physics;
 using Content.Shared.Throwing;
 using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Random;
 
 namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
@@ -42,9 +44,11 @@ public sealed class ThrowArtifactSystem : EntitySystem
         }
 
         var lookup = _lookup.GetEntitiesInRange(uid, component.Range, LookupFlags.Dynamic | LookupFlags.Sundries);
+        var physQuery = GetEntityQuery<PhysicsComponent>();
         foreach (var ent in lookup)
         {
-            if (HasComp<GhostComponent>(ent))
+            if (physQuery.TryGetComponent(ent, out var phys)
+                && (phys.CollisionMask & (int) CollisionGroup.GhostImpassable) != 0)
                 continue;
 
             var tempXform = Transform(ent);

--- a/Content.Shared/Anomaly/Effects/SharedGravityAnomalySystem.cs
+++ b/Content.Shared/Anomaly/Effects/SharedGravityAnomalySystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Content.Shared.Anomaly.Components;
 using Content.Shared.Anomaly.Effects.Components;
+using Content.Shared.Ghost;
 using Content.Shared.Throwing;
 using Robust.Shared.Map;
 
@@ -31,6 +32,8 @@ public abstract class SharedGravityAnomalySystem : EntitySystem
 
         foreach (var ent in lookup)
         {
+            if (HasComp<GhostComponent>(ent))
+                continue;
             var foo = _xform.GetWorldPosition(ent, xformQuery) - worldPos;
             _throwing.TryThrow(ent, foo * 10, strength, uid, 0);
         }
@@ -54,6 +57,8 @@ public abstract class SharedGravityAnomalySystem : EntitySystem
 
         foreach (var ent in lookup)
         {
+            if (HasComp<GhostComponent>(ent))
+                continue;
             var foo = _xform.GetWorldPosition(ent, xformQuery) - worldPos;
             _throwing.TryThrow(ent, foo * 5, strength, uid, 0);
         }

--- a/Content.Shared/Anomaly/Effects/SharedGravityAnomalySystem.cs
+++ b/Content.Shared/Anomaly/Effects/SharedGravityAnomalySystem.cs
@@ -4,6 +4,8 @@ using Content.Shared.Anomaly.Effects.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Throwing;
 using Robust.Shared.Map;
+using Content.Shared.Physics;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.Anomaly.Effects;
 
@@ -29,11 +31,14 @@ public abstract class SharedGravityAnomalySystem : EntitySystem
         var lookup = _lookup.GetEntitiesInRange(uid, range, LookupFlags.Dynamic | LookupFlags.Sundries);
         var xformQuery = GetEntityQuery<TransformComponent>();
         var worldPos = _xform.GetWorldPosition(xform, xformQuery);
+        var physQuery = GetEntityQuery<PhysicsComponent>();
 
         foreach (var ent in lookup)
         {
-            if (HasComp<GhostComponent>(ent))
+            if (physQuery.TryGetComponent(ent, out var phys)
+                && (phys.CollisionMask & (int) CollisionGroup.GhostImpassable) != 0)
                 continue;
+
             var foo = _xform.GetWorldPosition(ent, xformQuery) - worldPos;
             _throwing.TryThrow(ent, foo * 10, strength, uid, 0);
         }
@@ -54,11 +59,14 @@ public abstract class SharedGravityAnomalySystem : EntitySystem
         var strength = component.MaxThrowStrength * 2;
         var lookup = _lookup.GetEntitiesInRange(uid, range, LookupFlags.Dynamic | LookupFlags.Sundries);
         var xformQuery = GetEntityQuery<TransformComponent>();
+        var physQuery = GetEntityQuery<PhysicsComponent>();
 
         foreach (var ent in lookup)
         {
-            if (HasComp<GhostComponent>(ent))
+            if (physQuery.TryGetComponent(ent, out var phys)
+                && (phys.CollisionMask & (int) CollisionGroup.GhostImpassable) != 0)
                 continue;
+
             var foo = _xform.GetWorldPosition(ent, xformQuery) - worldPos;
             _throwing.TryThrow(ent, foo * 5, strength, uid, 0);
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Prevents grav anomaly and artifacts from pushing ghost observers. Fix #15775, #14028

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Iterator checks entities' `collisionMask` and skips GhostImpassable.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/69696513/8a0b6035-ae4f-41c1-8817-536e968cc9fc


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- fix: Anomalies and artifacts cannot push observers anymore.

