### PR TITLE
`InAir` tweaks & chasm fixes

### DIFF
--- a/Content.Server/Tiles/LavaSystem.cs
+++ b/Content.Server/Tiles/LavaSystem.cs
@@ -1,7 +1,6 @@
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.StepTrigger.Systems;
-using Robust.Shared.Physics.Components;
 
 namespace Content.Server.Tiles;
 
@@ -18,8 +17,7 @@ public sealed class LavaSystem : EntitySystem
 
     private void OnLavaStepTriggerAttempt(EntityUid uid, LavaComponent component, ref StepTriggerAttemptEvent args)
     {
-        if (!HasComp<FlammableComponent>(args.Tripper)
-            || TryComp<PhysicsComponent>(args.Tripper, out var physics) && physics.BodyStatus == BodyStatus.InAir)
+        if (!HasComp<FlammableComponent>(args.Tripper))
             return;
 
         args.Continue = true;

--- a/Content.Server/Tiles/LavaSystem.cs
+++ b/Content.Server/Tiles/LavaSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.StepTrigger.Systems;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Server.Tiles;
 
@@ -15,10 +16,10 @@ public sealed class LavaSystem : EntitySystem
         SubscribeLocalEvent<LavaComponent, StepTriggerAttemptEvent>(OnLavaStepTriggerAttempt);
     }
 
-
     private void OnLavaStepTriggerAttempt(EntityUid uid, LavaComponent component, ref StepTriggerAttemptEvent args)
     {
-        if (!HasComp<FlammableComponent>(args.Tripper))
+        if (!HasComp<FlammableComponent>(args.Tripper)
+            || TryComp<PhysicsComponent>(args.Tripper, out var physics) && physics.BodyStatus == BodyStatus.InAir)
             return;
 
         args.Continue = true;

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -53,17 +53,6 @@ public sealed class ChasmSystem : EntitySystem
             return;
 
         StartFalling(uid, component, args.Tripper);
-
-        // checking for strap is necessary so that buckled entities actually have the visuals and can't just
-        // unbuckle to prevent death
-        if (!TryComp<StrapComponent>(uid, out var strap))
-            return;
-
-        foreach (var ent in strap.BuckledEntities)
-        {
-            // don't play sound for any buckled ents since we'll have already played it once
-            StartFalling(uid, component, ent, playSound: false);
-        }
     }
 
     public void StartFalling(EntityUid chasm, ChasmComponent component, EntityUid tripper, bool playSound = true)

--- a/Content.Shared/Movement/Components/CanMoveInAirComponent.cs
+++ b/Content.Shared/Movement/Components/CanMoveInAirComponent.cs
@@ -1,11 +1,12 @@
-﻿using Robust.Shared.Physics.Components;
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.Movement.Components;
 
 /// <summary>
 ///     On mobs that are allowed to move while their body status is <see cref="BodyStatus.InAir"/>
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class CanMoveInAirComponent : Component
 {
 }

--- a/Content.Shared/Movement/Components/CanMoveInAirComponent.cs
+++ b/Content.Shared/Movement/Components/CanMoveInAirComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.Physics.Components;
+
+namespace Content.Shared.Movement.Components;
+
+/// <summary>
+///     On mobs that are allowed to move while their body status is <see cref="BodyStatus.InAir"/>
+/// </summary>
+[RegisterComponent]
+public sealed partial class CanMoveInAirComponent : Component
+{
+}

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -6,6 +6,8 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Movement.Systems;
@@ -17,6 +19,7 @@ public abstract class SharedJetpackSystem : EntitySystem
     [Dependency] protected readonly SharedContainerSystem Container = default!;
     [Dependency] private   readonly SharedMoverController _mover = default!;
     [Dependency] private   readonly SharedPopupSystem _popup = default!;
+    [Dependency] private   readonly SharedPhysicsSystem _physics = default!;
 
     public override void Initialize()
     {
@@ -98,6 +101,10 @@ public abstract class SharedJetpackSystem : EntitySystem
     {
         var userComp = EnsureComp<JetpackUserComponent>(user);
         _mover.SetRelay(user, jetpackUid);
+
+        if (TryComp<PhysicsComponent>(user, out var physics))
+            _physics.SetBodyStatus(physics, BodyStatus.InAir);
+
         userComp.Jetpack = jetpackUid;
     }
 
@@ -105,6 +112,9 @@ public abstract class SharedJetpackSystem : EntitySystem
     {
         if (!RemComp<JetpackUserComponent>(uid))
             return;
+
+        if (TryComp<PhysicsComponent>(uid, out var physics))
+            _physics.SetBodyStatus(physics, BodyStatus.OnGround);
 
         RemComp<RelayInputMoverComponent>(uid);
     }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -150,21 +150,13 @@ namespace Content.Shared.Movement.Systems
             LerpRotation(uid, mover, frameTime);
 
             if (!canMove
-                || physicsComponent.BodyStatus != BodyStatus.OnGround
+                || physicsComponent.BodyStatus != BodyStatus.OnGround && !HasComp<CanMoveInAirComponent>(uid)
                 || PullableQuery.TryGetComponent(uid, out var pullable) && pullable.BeingPulled)
             {
                 UsedMobMovement[uid] = false;
                 return;
             }
 
-            // Get current tile def for things like speed/weightless mods
-            ContentTileDefinition? tileDef = null;
-
-            if (_mapManager.TryFindGridAt(xform.MapPosition, out var grid, out var gridComp)
-                && _mapSystem.TryGetTileRef(grid, gridComp, xform.Coordinates, out var tile))
-            {
-                tileDef = (ContentTileDefinition) _tileDefinitionManager[tile.Tile.TypeId];
-            }
 
             UsedMobMovement[uid] = true;
             // Specifically don't use mover.Owner because that may be different to the actual physics body being moved.
@@ -188,6 +180,18 @@ namespace Content.Shared.Movement.Systems
                     if (!touching && TryComp<MobMoverComponent>(uid, out var mobMover))
                         touching |= IsAroundCollider(PhysicsSystem, xform, mobMover, physicsUid, physicsComponent);
                 }
+            }
+
+            // Get current tile def for things like speed/friction mods
+            ContentTileDefinition? tileDef = null;
+
+            // Don't bother getting the tiledef here if we're weightless or in-air
+            // since no tile-based modifiers should be applying in that situation
+            if (_mapManager.TryFindGridAt(xform.MapPosition, out var grid, out var gridComp)
+                && _mapSystem.TryGetTileRef(grid, gridComp, xform.Coordinates, out var tile)
+                && !(weightless || physicsComponent.BodyStatus == BodyStatus.InAir))
+            {
+                tileDef = (ContentTileDefinition) _tileDefinitionManager[tile.Tile.TypeId];
             }
 
             // Regular movement.

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -53,6 +53,7 @@ namespace Content.Shared.Movement.Systems
         protected EntityQuery<RelayInputMoverComponent> RelayQuery;
         protected EntityQuery<SharedPullableComponent> PullableQuery;
         protected EntityQuery<TransformComponent> XformQuery;
+        protected EntityQuery<CanMoveInAirComponent> CanMoveInAirQuery;
 
         private const float StepSoundMoveDistanceRunning = 2;
         private const float StepSoundMoveDistanceWalking = 1.5f;
@@ -83,6 +84,7 @@ namespace Content.Shared.Movement.Systems
             RelayQuery = GetEntityQuery<RelayInputMoverComponent>();
             PullableQuery = GetEntityQuery<SharedPullableComponent>();
             XformQuery = GetEntityQuery<TransformComponent>();
+            CanMoveInAirQuery = GetEntityQuery<CanMoveInAirComponent>();
 
             InitializeFootsteps();
             InitializeInput();
@@ -150,7 +152,7 @@ namespace Content.Shared.Movement.Systems
             LerpRotation(uid, mover, frameTime);
 
             if (!canMove
-                || physicsComponent.BodyStatus != BodyStatus.OnGround && !HasComp<CanMoveInAirComponent>(uid)
+                || physicsComponent.BodyStatus != BodyStatus.OnGround && !CanMoveInAirQuery.HasComponent(uid)
                 || PullableQuery.TryGetComponent(uid, out var pullable) && pullable.BeingPulled)
             {
                 UsedMobMovement[uid] = false;

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -168,9 +168,6 @@ namespace Content.Shared.Movement.Systems
 
             UsedMobMovement[uid] = true;
             // Specifically don't use mover.Owner because that may be different to the actual physics body being moved.
-
-            // We differentiate between grav/other sources of weightless for tiles which want to use weightless accel (like ice)
-            // but don't care about requiring touching etc
             var weightless = _gravity.IsWeightless(physicsUid, physicsComponent, xform);
             var (walkDir, sprintDir) = GetVelocityInput(mover);
             var touching = false;

--- a/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
@@ -354,7 +354,6 @@ public abstract class SharedSingularitySystem : EntitySystem
     /// <param name="args">The event arguments.</param>
     private void UpdateBody(EntityUid uid, PhysicsComponent comp, SingularityLevelChangedEvent args)
     {
-        _physics.SetBodyStatus(comp, (args.NewValue > 1) ? BodyStatus.InAir : BodyStatus.OnGround);
         if (args.NewValue <= 1 && args.OldValue > 1) // Apparently keeps singularities from getting stuck in the corners of containment fields.
             _physics.SetLinearVelocity(uid, Vector2.Zero, body: comp); // No idea how stopping the singularities movement keeps it from getting stuck though.
     }

--- a/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
@@ -42,10 +42,17 @@ public sealed partial class StepTriggerComponent : Component
     public float RequiredTriggerSpeed = 3.5f;
 
     /// <summary>
-    /// If any entities occupy the blacklist on the same tile then steptrigger won't work.
+    ///     If any entities occupy the blacklist on the same tile then steptrigger won't work.
     /// </summary>
     [DataField("blacklist")]
     public EntityWhitelist? Blacklist;
+
+    /// <summary>
+    ///     If this is true, steptrigger will still occur on entities that are in air / weightless. They do not
+    ///     by default.
+    /// </summary>
+    [DataField("ignoreWeightless")]
+    public bool IgnoreWeightless = false;
 }
 
 [RegisterComponent]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: bat
-  parent: SimpleMobBase
+  parent: [ SimpleMobBase, FlyingMobBase ]
   id: MobBat
   description: Some cultures find them terrifying, others crunchy on the teeth.
   components:
@@ -13,7 +13,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: bat
       sprite: Mobs/Animals/bat.rsi
-  - type: Physics
   - type: Speech
     speechSounds: Squeak
     speechVerb: SmallMob
@@ -59,7 +58,6 @@
     damage:
       types:
         Piercing: 5
-  - type: NoSlip
   - type: Puller
     needsHands: true
   - type: Tag
@@ -68,7 +66,7 @@
 
 - type: entity
   name: bee
-  parent: SimpleMobBase
+  parent: [ SimpleMobBase, FlyingMobBase ]
   id: MobBee
   description: Nice to have, but you can't build a civilization on a foundation of honey alone.
   components:
@@ -82,7 +80,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: 0
       sprite: Mobs/Animals/bee.rsi
-  - type: Physics
   - type: Fixtures
     fixtures:
       fix1:
@@ -112,7 +109,6 @@
     - Bee
   - type: Bloodstream
     bloodMaxVolume: 0.1
-  - type: NoSlip
   - type: MobPrice
     price: 50
   - type: Puller
@@ -354,7 +350,7 @@
 
 - type: entity
   name: butterfly
-  parent: SimpleMobBase
+  parent: [ SimpleMobBase, FlyingMobBase ]
   id: MobButterfly
   description: Despite popular misconceptions, it's not actually made of butter.
   components:
@@ -367,7 +363,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: butterfly
       sprite: Mobs/Animals/butterfly.rsi
-  - type: Physics
   - type: Fixtures
     fixtures:
       fix1:
@@ -396,7 +391,6 @@
         Base: dead
   - type: Bloodstream
     bloodMaxVolume: 0.1
-  - type: NoSlip
   - type: MobPrice
     price: 50
   - type: Puller
@@ -1234,7 +1228,7 @@
 # Would be cool to have some functionality for the parrot to be able to sit on stuff
 - type: entity
   name: parrot
-  parent: SimpleMobBase
+  parent: [ SimpleMobBase, FlyingMobBase ]
   id: MobParrot
   description: Infiltrates your domain, spies on you, and somehow still a cool pet.
   components:
@@ -1247,7 +1241,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: parrot
       sprite: Mobs/Animals/parrot.rsi
-  - type: Physics
   - type: Fixtures
     fixtures:
       fix1:
@@ -1277,7 +1270,6 @@
       path: /Audio/Animals/parrot_raught.ogg
   - type: Bloodstream
     bloodMaxVolume: 50
-  - type: NoSlip
 
 - type: entity
   name: penguin

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: behonker
-  parent: SimpleSpaceMobBase
+  parent: [ SimpleSpaceMobBase, FlyingMobBase ]
   id: BaseMobBehonker
   abstract: true
   description: A floating demon aspect of the honkmother.
@@ -70,8 +70,6 @@
       groups:
         - id: Medicine
         - id: Poison
-    - type: MovementAlwaysTouching
-    - type: NoSlip
     - type: Butcherable
       spawned:
         - id: MaterialBananium1

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: space carp
   id: BaseMobCarp
-  parent: SimpleSpaceMobBase
+  parent: [ SimpleSpaceMobBase, FlyingMobBase ]
   description: It's a space carp.
   abstract: true
   components:
@@ -42,7 +42,6 @@
         50: Dead
     - type: Stamina
       critThreshold: 100
-    - type: MovementAlwaysTouching
     - type: DamageStateVisuals
       states:
         Alive:
@@ -68,7 +67,6 @@
           Slash: 10
     - type: TypingIndicator
       proto: alien
-    - type: NoSlip
     - type: Tag
       tags:
         - Carp

--- a/Resources/Prototypes/Entities/Mobs/NPCs/flying_animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/flying_animals.yml
@@ -1,0 +1,10 @@
+﻿# Used for entities that are considered flying,
+# i.e. shouldnt slip, have free movement in weightlesness, and should go over chasms/lava
+- type: entity
+  id: FlyingMobBase
+  abstract: true
+  components:
+  - type: Physics
+    bodyStatus: InAir
+  - type: NoSlip
+  - type: MovementAlwaysTouching

--- a/Resources/Prototypes/Entities/Mobs/NPCs/flying_animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/flying_animals.yml
@@ -8,3 +8,4 @@
     bodyStatus: InAir
   - type: NoSlip
   - type: MovementAlwaysTouching
+  - type: CanMoveInAir

--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   name: watcher
   id: MobWatcherBase
-  parent: SimpleSpaceMobBase
+  parent: [ SimpleSpaceMobBase, FlyingMobBase ]
   abstract: true
   description: It's like its staring right through you.
   components:
@@ -46,8 +46,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 5
     baseSprintSpeed: 7
-  - type: MovementAlwaysTouching
-  - type: NoSlip
   - type: ProjectileBatteryAmmoProvider
     proto: WatcherBolt
     fireCost: 50

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: SimpleSpaceMobBase
+  parent: [ SimpleSpaceMobBase, FlyingMobBase ]
   id: BaseMobDragon
   suffix: ""
   name: space dragon
@@ -90,8 +90,6 @@
     groups:
     - id: Medicine
     - id: Poison
-  - type: MovementAlwaysTouching
-  - type: NoSlip
   - type: Butcherable
     spawned:
     - id: FoodMeatDragon

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -10,9 +10,6 @@
   - type: MindContainer
   - type: Clickable
   - type: InteractionOutline
-  - type: Physics
-    bodyType: KinematicController
-    fixedRotation: true
   - type: Fixtures
     fixtures:
       fix1:
@@ -23,8 +20,6 @@
         mask:
         - GhostImpassable
   - type: InputMover
-  - type: Physics
-    bodyStatus: InAir
   - type: Appearance
   - type: Eye
     drawFov: false
@@ -62,6 +57,11 @@
     baseSprintSpeed: 12
     baseWalkSpeed: 8
   - type: MovementIgnoreGravity
+  - type: Physics
+    bodyType: KinematicController
+    fixedRotation: true
+    bodyStatus: InAir
+  - type: CanMoveInAir
   - type: Tag
     tags:
       - BypassInteractionRangeChecks

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -59,7 +59,6 @@
   - type: MovementIgnoreGravity
   - type: Physics
     bodyType: KinematicController
-    fixedRotation: true
     bodyStatus: InAir
   - type: CanMoveInAir
   - type: Tag

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -23,6 +23,8 @@
         mask:
         - GhostImpassable
   - type: InputMover
+  - type: Physics
+    bodyStatus: InAir
   - type: Appearance
   - type: Eye
     drawFov: false

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -31,6 +31,7 @@
       weightlessAcceleration: 1
       weightlessFriction: 0.3
       weightlessModifier: 1.2
+    - type: CanMoveInAir
     - type: Sprite
       sprite: Objects/Tanks/Jetpacks/blue.rsi
       state: icon

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -11,6 +11,8 @@
       path: /Audio/Effects/singularity.ogg
   - type: Physics
     bodyType: Dynamic
+    bodyStatus: InAir
+  - type: CanMoveInAir
   - type: EventHorizon # To make the singularity consume things.
     radius: 0.5
     canBreachContainment: false


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

fixes #19386
fixes #19706 
fixes #19804

- bodystatus inair has now been added to all flying mobs
- `CanMoveInAir` comp added to allow them to move if in air
- steptrigger now won't trigger by default if the stepping entity is weightless or inair
- chasm now also falls buckled people bc i noticed it didnt do that and it looked weird
- jetpacks makes you inair as well
- inair/weightless mobs no longer affected by tile friction/acceleration

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

testing flying mob / observer / jetpack / weightlessness

https://github.com/space-wizards/space-station-14/assets/19853115/d8ed826c-d341-4457-9bd7-45b6eac77d98

still works if you arent inair or weightless yes

https://github.com/space-wizards/space-station-14/assets/19853115/380aaa46-962d-48dc-b8d5-ac8ed6224487

catwalks can be placed on chasms idk why sloth said they couldnt

https://github.com/space-wizards/space-station-14/assets/19853115/840249c8-61f3-4fc6-b165-62262c26fb74

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Jetpacks, being weightless, and flying mobs can now pass over lava & chasms unharmed (as well as other obstacles)
- fix: Observers are no longer affected by ice physics
- tweak: Step trigger (slipping, shards, etc) now by default won't trigger if the stepping entity is weightless or set as in air
