### PR TITLE
Fix BuyerJobCondition not being checked when the user has no job

### DIFF
--- a/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
+++ b/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
@@ -37,38 +37,36 @@ public sealed partial class BuyerDepartmentCondition : ListingCondition
             return true;
 
         var jobs = ent.System<SharedJobSystem>();
-        if (jobs.MindTryGetJob(mindId, out var job, out _))
+        jobs.MindTryGetJob(mindId, out var job, out _);
+
+
+        if (Blacklist != null && job?.PrototypeId != null)
         {
-            if (Blacklist != null)
+            foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
+            {
+                if (department.Roles.Contains(job.PrototypeId) && Blacklist.Contains(department.ID))
+                    return false;
+            }
+        }
+
+        if (Whitelist != null)
+        {
+            var found = false;
+
+            if (job?.PrototypeId != null)
             {
                 foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
                 {
-                    if (job.PrototypeId == null ||
-                        !department.Roles.Contains(job.PrototypeId) ||
-                        !Blacklist.Contains(department.ID))
-                        continue;
-
-                    return false;
+                    if (department.Roles.Contains(job.PrototypeId) && Whitelist.Contains(department.ID))
+                    {
+                        found = true;
+                        break;
+                    }
                 }
             }
 
-            if (Whitelist != null)
-            {
-                var found = false;
-                foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
-                {
-                    if (job.PrototypeId == null ||
-                        !department.Roles.Contains(job.PrototypeId) ||
-                        !Whitelist.Contains(department.ID))
-                        continue;
-
-                    found = true;
-                    break;
-                }
-
-                if (!found)
-                    return false;
-            }
+            if (!found)
+                return false;
         }
 
         return true;

--- a/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
+++ b/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
@@ -39,7 +39,6 @@ public sealed partial class BuyerDepartmentCondition : ListingCondition
         var jobs = ent.System<SharedJobSystem>();
         jobs.MindTryGetJob(mindId, out var job, out _);
 
-
         if (Blacklist != null && job?.PrototypeId != null)
         {
             foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())

--- a/Content.Server/Store/Conditions/BuyerJobCondition.cs
+++ b/Content.Server/Store/Conditions/BuyerJobCondition.cs
@@ -34,19 +34,18 @@ public sealed partial class BuyerJobCondition : ListingCondition
             return true;
 
         var jobs = ent.System<SharedJobSystem>();
-        if (jobs.MindTryGetJob(mindId, out var job, out _))
-        {
-            if (Blacklist != null)
-            {
-                if (job.PrototypeId != null && Blacklist.Contains(job.PrototypeId))
-                    return false;
-            }
+        jobs.MindTryGetJob(mindId, out var job, out _);
 
-            if (Whitelist != null)
-            {
-                if (job.PrototypeId == null || !Whitelist.Contains(job.PrototypeId))
-                    return false;
-            }
+        if (Blacklist != null)
+        {
+            if (job?.PrototypeId != null && Blacklist.Contains(job.PrototypeId))
+                return false;
+        }
+
+        if (Whitelist != null)
+        {
+            if (job?.PrototypeId == null || !Whitelist.Contains(job.PrototypeId))
+                return false;
         }
 
         return true;


### PR DESCRIPTION
## About the PR
I love mind/job/role code man.
Also cleans up BuyerDepartmentCondition though that one worked properly.
The other conditions don't check jobs.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed nukeops being able to buy job restricted items.
