### PR TITLE
Fix combat mode context menu

### DIFF
--- a/Content.Client/CombatMode/CombatModeSystem.cs
+++ b/Content.Client/CombatMode/CombatModeSystem.cs
@@ -1,4 +1,5 @@
 using Content.Client.Hands.Systems;
+using Content.Shared.Actions;
 using Content.Shared.CombatMode;
 using Content.Shared.Targeting;
 using Content.Shared.CCVar;
@@ -17,30 +18,29 @@ public sealed class CombatModeSystem : SharedCombatModeSystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IInputManager _inputManager = default!;
     [Dependency] private readonly IEyeManager _eye = default!;
-    public event Action? LocalPlayerCombatModeUpdated;
+
+    /// <summary>
+    /// Raised whenever combat mode changes.
+    /// </summary>
+    public event Action<bool>? LocalPlayerCombatModeUpdated;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<CombatModeComponent, ComponentHandleState>(OnHandleState);
+        SubscribeLocalEvent<CombatModeComponent, AfterAutoHandleStateEvent>(OnHandleState);
 
         _cfg.OnValueChanged(CCVars.CombatModeIndicatorsPointShow, OnShowCombatIndicatorsChanged, true);
     }
 
-    private void OnHandleState(EntityUid uid, CombatModeComponent component, ref ComponentHandleState args)
+    private void OnHandleState(EntityUid uid, CombatModeComponent component, ref AfterAutoHandleStateEvent args)
     {
-        if (args.Current is not CombatModeComponentState state)
-            return;
-
-        component.IsInCombatMode = state.IsInCombatMode;
-        component.ActiveZone = state.TargetingZone;
         UpdateHud(uid);
     }
 
     public override void Shutdown()
     {
-        _cfg.OnValueChanged(CCVars.CombatModeIndicatorsPointShow, OnShowCombatIndicatorsChanged);
+        _cfg.UnsubValueChanged(CCVars.CombatModeIndicatorsPointShow, OnShowCombatIndicatorsChanged);
         _overlayManager.RemoveOverlay<CombatModeIndicatorsOverlay>();
 
         base.Shutdown();
@@ -61,9 +61,9 @@ public sealed class CombatModeSystem : SharedCombatModeSystem
         return IsInCombatMode(entity.Value);
     }
 
-    public override void SetInCombatMode(EntityUid entity, bool inCombatMode, CombatModeComponent? component = null)
+    public override void SetInCombatMode(EntityUid entity, bool value, CombatModeComponent? component = null)
     {
-        base.SetInCombatMode(entity, inCombatMode, component);
+        base.SetInCombatMode(entity, value, component);
         UpdateHud(entity);
     }
 
@@ -75,12 +75,13 @@ public sealed class CombatModeSystem : SharedCombatModeSystem
 
     private void UpdateHud(EntityUid entity)
     {
-        if (entity != _playerManager.LocalPlayer?.ControlledEntity)
+        if (entity != _playerManager.LocalPlayer?.ControlledEntity || !Timing.IsFirstTimePredicted)
         {
             return;
         }
 
-        LocalPlayerCombatModeUpdated?.Invoke();
+        var inCombatMode = IsInCombatMode();
+        LocalPlayerCombatModeUpdated?.Invoke(inCombatMode);
     }
 
     private void OnShowCombatIndicatorsChanged(bool isShow)

--- a/Content.Client/ContextMenu/UI/ContextMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/ContextMenuUIController.cs
@@ -210,9 +210,10 @@ namespace Content.Client.ContextMenu.UI
             menu.InvalidateMeasure();
         }
 
-        private void OnCombatModeUpdated()
+        private void OnCombatModeUpdated(bool inCombatMode)
         {
-            Close();
+            if (inCombatMode)
+                Close();
         }
 
         public void OnSystemLoaded(CombatModeSystem system)

--- a/Content.Server/CombatMode/CombatModeSystem.cs
+++ b/Content.Server/CombatMode/CombatModeSystem.cs
@@ -1,20 +1,7 @@
 using Content.Shared.CombatMode;
-using JetBrains.Annotations;
-using Robust.Shared.GameStates;
 
 namespace Content.Server.CombatMode;
 
 public sealed class CombatModeSystem : SharedCombatModeSystem
 {
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<CombatModeComponent, ComponentGetState>(OnGetState);
-    }
-
-    private void OnGetState(EntityUid uid, CombatModeComponent component, ref ComponentGetState args)
-    {
-        args.State = new CombatModeComponentState(component.IsInCombatMode, component.ActiveZone);
-    }
 }

--- a/Content.Shared/CombatMode/CombatModeComponent.cs
+++ b/Content.Shared/CombatMode/CombatModeComponent.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Actions;
 using Content.Shared.Actions.ActionTypes;
 using Content.Shared.Targeting;
 using Robust.Shared.Audio;
@@ -12,7 +11,7 @@ namespace Content.Shared.CombatMode
     ///     This is used to differentiate between regular item interactions or
     ///     using *everything* as a weapon.
     /// </summary>
-    [RegisterComponent, NetworkedComponent]
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
     [Access(typeof(SharedCombatModeSystem))]
     public sealed partial class CombatModeComponent : Component
     {
@@ -33,40 +32,16 @@ namespace Content.Shared.CombatMode
 
         #endregion
 
-        private bool _isInCombatMode;
-        private TargetingZone _activeZone;
-
         [DataField("combatToggleActionId", customTypeSerializer: typeof(PrototypeIdSerializer<InstantActionPrototype>))]
         public string CombatToggleActionId = "CombatModeToggle";
 
         [DataField("combatToggleAction")]
         public InstantAction? CombatToggleAction;
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        public bool IsInCombatMode
-        {
-            get => _isInCombatMode;
-            set
-            {
-                if (_isInCombatMode == value) return;
-                _isInCombatMode = value;
-                if (CombatToggleAction != null)
-                    EntitySystem.Get<SharedActionsSystem>().SetToggled(CombatToggleAction, _isInCombatMode);
+        [ViewVariables(VVAccess.ReadWrite), DataField("isInCombatMode"), AutoNetworkedField]
+        public bool IsInCombatMode;
 
-                Dirty();
-            }
-        }
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        public TargetingZone ActiveZone
-        {
-            get => _activeZone;
-            set
-            {
-                if (_activeZone == value) return;
-                _activeZone = value;
-                Dirty();
-            }
-        }
+        [ViewVariables(VVAccess.ReadWrite), DataField("activeZone"), AutoNetworkedField]
+        public TargetingZone ActiveZone;
     }
 }

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -11,11 +11,11 @@ namespace Content.Shared.CombatMode;
 
 public abstract class SharedCombatModeSystem : EntitySystem
 {
-    [Dependency] private readonly IPrototypeManager _protoMan = default!;
-    [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly INetManager _netMan = default!;
+    [Dependency] protected readonly IGameTiming Timing = default!;
+    [Dependency] private   readonly INetManager _netMan = default!;
+    [Dependency] private   readonly IPrototypeManager _protoMan = default!;
+    [Dependency] private   readonly SharedActionsSystem _actionsSystem = default!;
+    [Dependency] private   readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -55,7 +55,7 @@ public abstract class SharedCombatModeSystem : EntitySystem
         // TODO better handling of predicted pop-ups.
         // This probably breaks if the client has prediction disabled.
 
-        if (!_netMan.IsClient || !_timing.IsFirstTimePredicted)
+        if (!_netMan.IsClient || !Timing.IsFirstTimePredicted)
             return;
 
         var msg = component.IsInCombatMode ? "action-popup-combat-enabled" : "action-popup-combat-disabled";
@@ -75,13 +75,19 @@ public abstract class SharedCombatModeSystem : EntitySystem
         return entity != null && Resolve(entity.Value, ref component, false) && component.IsInCombatMode;
     }
 
-    public virtual void SetInCombatMode(EntityUid entity, bool inCombatMode,
-        CombatModeComponent? component = null)
+    public virtual void SetInCombatMode(EntityUid entity, bool value, CombatModeComponent? component = null)
     {
         if (!Resolve(entity, ref component))
             return;
 
-        component.IsInCombatMode = inCombatMode;
+        if (component.IsInCombatMode == value)
+            return;
+
+        component.IsInCombatMode = value;
+        Dirty(entity, component);
+
+        if (component.CombatToggleAction != null)
+            _actionsSystem.SetToggled(component.CombatToggleAction, component.IsInCombatMode);
     }
 
     public virtual void SetActiveZone(EntityUid entity, TargetingZone zone,
@@ -91,19 +97,6 @@ public abstract class SharedCombatModeSystem : EntitySystem
             return;
 
         component.ActiveZone = zone;
-    }
-
-    [Serializable, NetSerializable]
-    protected sealed class CombatModeComponentState : ComponentState
-    {
-        public bool IsInCombatMode { get; }
-        public TargetingZone TargetingZone { get; }
-
-        public CombatModeComponentState(bool isInCombatMode, TargetingZone targetingZone)
-        {
-            IsInCombatMode = isInCombatMode;
-            TargetingZone = targetingZone;
-        }
     }
 }
 


### PR DESCRIPTION
Doesn't implement pjb's request I just wanted to make sure this is fixed first before proceeding.

tl;dr the state handling was closing the context menu as it never checked if combat mode was being turned on.

Resolves https://github.com/space-wizards/space-station-14/issues/19650

:cl:
- fix: Fix context menu not opening if you toggled combat mode immediately prior.
