### PR TITLE
Fixed pAIs not wiping correctly

### DIFF
--- a/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
@@ -1,5 +1,4 @@
-﻿using Content.Server.Ghost.Roles.Components;
-using Content.Server.PAI;
+using Content.Server.Ghost.Roles.Components;
 using Content.Shared.Examine;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Mind;
@@ -17,8 +16,6 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
-    //todo this really shouldn't be in here but this system was converted from PAIs
-    [Dependency] private readonly PAISystem _pai = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -86,6 +83,8 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
 
     private void OnMindRemoved(EntityUid uid, ToggleableGhostRoleComponent component, MindRemovedMessage args)
     {
+        // Mind was removed, prepare for re-toggle of the role
+        RemCompDeferred<GhostRoleComponent>(uid);
         UpdateAppearance(uid, ToggleableGhostRoleStatus.Off);
     }
 
@@ -110,11 +109,8 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
                         return;
                     // Wiping device :(
                     // The shutdown of the Mind should cause automatic reset of the pAI during OnMindRemoved
-                    // EDIT: But it doesn't!!!! Wtf? Do stuff manually
                     _mind.TransferTo(mindId, null, mind: mind);
                     _popup.PopupEntity(Loc.GetString(component.WipeVerbPopup), uid, args.User, PopupType.Large);
-                    UpdateAppearance(uid, ToggleableGhostRoleStatus.Off);
-                    _pai.PAITurningOff(uid);
                 }
             };
             args.Verbs.Add(verb);
@@ -132,7 +128,6 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
                     RemCompDeferred<GhostRoleComponent>(uid);
                     _popup.PopupEntity(Loc.GetString(component.StopSearchVerbPopup), uid, args.User);
                     UpdateAppearance(uid, ToggleableGhostRoleStatus.Off);
-                    _pai.PAITurningOff(uid);
                 }
             };
             args.Verbs.Add(verb);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Small fix that make pAIs reusable again after being wiped.

Resolves #17426

## Technical details
It now removes Ghost Role component when mind is removed (wiped or suicided).

Also removes dependency on pAI system in `ToggleableGhostRoleSystem` because it seems like everything works without it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: The firmware bug that wiped critical system parts of pAI alongside the module itself is now fixed.