### PR TITLE
Remove outdated access reader method.

### DIFF
--- a/Content.Client/Research/UI/ResearchConsoleMenu.xaml.cs
+++ b/Content.Client/Research/UI/ResearchConsoleMenu.xaml.cs
@@ -70,7 +70,7 @@ public sealed partial class ResearchConsoleMenu : FancyWindow
 
         var hasAccess = _player.LocalPlayer?.ControlledEntity is not { } local ||
                         !_entity.TryGetComponent<AccessReaderComponent>(Entity, out var access) ||
-                        _accessReader.IsAllowed(local, access);
+                        _accessReader.IsAllowed(local, Entity, access);
         foreach (var techId in _technologyDatabase.CurrentTechnologyCards)
         {
             var tech = _prototype.Index<TechnologyPrototype>(techId);

--- a/Content.Server/Access/Systems/AccessOverriderSystem.cs
+++ b/Content.Server/Access/Systems/AccessOverriderSystem.cs
@@ -260,6 +260,6 @@ public sealed class AccessOverriderSystem : SharedAccessOverriderSystem
             return true;
 
         var privilegedId = component.PrivilegedIdSlot.Item;
-        return privilegedId != null && _accessReader.IsAllowed(privilegedId.Value, reader);
+        return privilegedId != null && _accessReader.IsAllowed(privilegedId.Value, uid, reader);
     }
 }

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -188,7 +188,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
             return true;
 
         var privilegedId = component.PrivilegedIdSlot.Item;
-        return privilegedId != null && _accessReader.IsAllowed(privilegedId.Value, reader);
+        return privilegedId != null && _accessReader.IsAllowed(privilegedId.Value, uid, reader);
     }
 
     private void UpdateStationRecord(EntityUid uid, EntityUid targetId, string newFullName, string newJobTitle, JobPrototype? newJobProto)

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -322,13 +322,13 @@ public sealed class AirAlarmSystem : EntitySystem
             UpdateUI(uid, component);
         }
     }
-    
+
     private void OnCopyDeviceData(EntityUid uid, AirAlarmComponent component, AirAlarmCopyDeviceDataMessage args)
     {
         if (!AccessCheck(uid, args.Session.AttachedEntity, component))
         {
            UpdateUI(uid, component);
-            return;       
+            return;
         }
 
         switch (args.Data)
@@ -339,7 +339,7 @@ public sealed class AirAlarmSystem : EntitySystem
                     SetData(uid, addr, args.Data);
                 }
                 break;
-                
+
             case GasVentScrubberData scrubberData:
                 foreach (string addr in component.ScrubberData.Keys)
                 {
@@ -361,7 +361,7 @@ public sealed class AirAlarmSystem : EntitySystem
         if (user == null)
             return false;
 
-        if (!_access.IsAllowed(user.Value, reader))
+        if (!_access.IsAllowed(user.Value, uid, reader))
         {
             _popup.PopupEntity(Loc.GetString("air-alarm-ui-access-denied"), user.Value, user.Value);
             return false;

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -174,7 +174,7 @@ namespace Content.Server.Communications
 
             if (TryComp<AccessReaderComponent>(console, out var accessReaderComponent) && !HasComp<EmaggedComponent>(console))
             {
-                return _accessReaderSystem.IsAllowed(user, accessReaderComponent);
+                return _accessReaderSystem.IsAllowed(user, console, accessReaderComponent);
             }
             return true;
         }

--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -192,7 +192,7 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!TryComp(target, out AccessReaderComponent? reader) || user == null)
             return true;
 
-        if (_accessSystem.IsAllowed(user.Value, reader))
+        if (_accessSystem.IsAllowed(user.Value, target, reader))
             return true;
 
         _audioSystem.PlayPvs(component.SoundNoAccess, user.Value, AudioParams.Default.WithVolume(-2f).WithPitchScale(1.2f));

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -232,7 +232,7 @@ public sealed class NewsSystem : EntitySystem
     {
         if (EntityManager.TryGetComponent<AccessReaderComponent>(device, out var accessReader) &&
             user.HasValue &&
-            _accessReader.IsAllowed(user.Value, accessReader))
+            _accessReader.IsAllowed(user.Value, device, accessReader))
         {
             return true;
         }

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -57,7 +57,7 @@ namespace Content.Server.Power.EntitySystems
             if (args.Session.AttachedEntity == null)
                 return;
 
-            if (access == null || _accessReader.IsAllowed(args.Session.AttachedEntity.Value, access))
+            if (access == null || _accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid, access))
             {
                 component.HasAccess = true;
             }
@@ -82,7 +82,7 @@ namespace Content.Server.Power.EntitySystems
             if (args.Session.AttachedEntity == null)
                 return;
 
-            if (access == null || _accessReader.IsAllowed(args.Session.AttachedEntity.Value, access))
+            if (access == null || _accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid, access))
             {
                 ApcToggleBreaker(uid, component);
             }

--- a/Content.Server/Research/Systems/ResearchSystem.Console.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Console.cs
@@ -25,7 +25,7 @@ public sealed partial class ResearchSystem
         if (!this.IsPowered(uid, EntityManager))
             return;
 
-        if (TryComp<AccessReaderComponent>(uid, out var access) && !_accessReader.IsAllowed(ent, access))
+        if (TryComp<AccessReaderComponent>(uid, out var access) && !_accessReader.IsAllowed(ent, uid, access))
         {
             _popup.PopupEntity(Loc.GetString("research-console-no-access-popup"), ent);
             return;

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -226,7 +226,7 @@ namespace Content.Server.VendingMachines
             if (!TryComp<AccessReaderComponent?>(uid, out var accessReader))
                 return true;
 
-            if (_accessReader.IsAllowed(sender, accessReader) || HasComp<EmaggedComponent>(uid))
+            if (_accessReader.IsAllowed(sender, uid, accessReader) || HasComp<EmaggedComponent>(uid))
                 return true;
 
             Popup.PopupEntity(Loc.GetString("vending-machine-component-try-eject-access-denied"), uid);

--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -26,25 +26,30 @@ public sealed partial class AccessReaderComponent : Component
     public HashSet<string> DenyTags = new();
 
     /// <summary>
-    ///     List of access lists to check allowed against. For an access check to pass
-    ///     there has to be an access list that is a subset of the access in the checking list.
+    /// List of access groups that grant access to this reader. Only a single matching group is required to gain access.
+    /// A group matches if it is a subset of the set being checked against.
     /// </summary>
     [DataField("access")]
     public List<HashSet<string>> AccessLists = new();
 
     /// <summary>
-    /// A list of valid stationrecordkeys
+    /// A list of <see cref="StationRecordKey"/>s that grant access. Only a single matching key is required tp gaim
+    /// access.
     /// </summary>
     [DataField("accessKeys")]
     public HashSet<StationRecordKey> AccessKeys = new();
 
-
     /// <summary>
-    ///     The name of the container in which additional
-    ///     AccessReaderComponents may be found.
+    /// If specified, then this access reader will instead pull access requirements from entities contained in the
+    /// given container.
     /// </summary>
+    /// <remarks>
+    /// This effectively causes <see cref="DenyTags"/>, <see cref="AccessLists"/>, and <see cref="AccessKeys"/> to be
+    /// ignored, though <see cref="Enabled"/> is still respected. Access is denied if there are no valid entities or
+    /// they all deny access.
+    /// </remarks>
     [DataField("containerAccessProvider")]
-    public string? ContainerAccessProvider = null;
+    public string? ContainerAccessProvider;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -53,7 +53,7 @@ public sealed class AccessReaderSystem : EntitySystem
     {
         if (args.User == null) // AutoLink (and presumably future external linkers) have no user.
             return;
-        if (!HasComp<EmaggedComponent>(uid) && !IsAllowed(args.User.Value, component))
+        if (!HasComp<EmaggedComponent>(uid) && !IsAllowed(args.User.Value, uid, component))
             args.Cancel();
     }
 
@@ -65,77 +65,62 @@ public sealed class AccessReaderSystem : EntitySystem
     }
 
     /// <summary>
-    /// Finds all AccessReaderComponents in the container of the
-    /// required entity.
-    /// </summary>
-    /// <param name="target">The entity to search for a container</param>
-    /// <param name="accessReader"></param>
-    /// <param name="result"></param>
-    private bool FindAccessReadersInContainer(EntityUid target, AccessReaderComponent accessReader, out List<AccessReaderComponent> result)
-    {
-        result = new();
-        if (accessReader.ContainerAccessProvider == null)
-            return false;
-
-        if (!_containerSystem.TryGetContainer(target, accessReader.ContainerAccessProvider, out var container))
-            return false;
-
-        foreach (var entity in container.ContainedEntities)
-        {
-            if (TryComp<AccessReaderComponent>(entity, out var entityAccessReader))
-                result.Add(entityAccessReader);
-        }
-
-        return result.Any();
-    }
-
-    /// <summary>
     /// Searches the source for access tags
     /// then compares it with the all targets accesses to see if it is allowed.
     /// </summary>
-    /// <param name="source">The entity that wants access.</param>
+    /// <param name="user">The entity that wants access.</param>
     /// <param name="target">The entity to search for an access reader</param>
     /// <param name="reader">Optional reader from the target entity</param>
-    public bool IsAllowed(EntityUid source, EntityUid target, AccessReaderComponent? reader = null)
+    public bool IsAllowed(EntityUid user, EntityUid target, AccessReaderComponent? reader = null)
     {
         if (!Resolve(target, ref reader, false))
             return true;
 
-        if (FindAccessReadersInContainer(target, reader, out var accessReaderList))
-        {
-            foreach (var access in accessReaderList)
-            {
-                if (IsAllowed(source, access))
-                    return true;
-            }
-
-            return false;
-        }
-
-        return IsAllowed(source, reader);
-    }
-    /// <summary>
-    /// Searches the given entity for access tags
-    /// then compares it with the readers access list to see if it is allowed.
-    /// </summary>
-    /// <param name="entity">The entity that wants access.</param>
-    /// <param name="reader">A reader from a different entity</param>
-    public bool IsAllowed(EntityUid entity, AccessReaderComponent reader)
-    {
-        // Access reader is totally disabled, so access is always allowed.
         if (!reader.Enabled)
             return true;
 
-        var allEnts = FindPotentialAccessItems(entity);
+        var accessSources = FindPotentialAccessItems(user);
+        var access = FindAccessTags(user, accessSources);
+        FindStationRecordKeys(user, out var stationKeys, accessSources);
 
-        if (AreAccessTagsAllowed(FindAccessTags(entity, allEnts), reader))
+        return IsAllowed(access, stationKeys, target, reader);
+    }
+
+    /// <summary>
+    /// Check whether the given access permissions satisfy an access reader's requirements.
+    /// </summary>
+    public bool IsAllowed(
+        ICollection<string> access,
+        ICollection<StationRecordKey> stationKeys,
+        EntityUid target,
+        AccessReaderComponent reader)
+    {
+        if (!reader.Enabled)
             return true;
 
-        if (FindStationRecordKeys(entity, out var recordKeys, allEnts)
-            && AreStationRecordKeysAllowed(recordKeys, reader))
-            return true;
+        if (reader.ContainerAccessProvider == null)
+            return IsAllowedInternal(access, stationKeys, reader);
+
+        if (!_containerSystem.TryGetContainer(target, reader.ContainerAccessProvider, out var container))
+            return false;
+
+        foreach (var entity in container.ContainedEntities)
+        {
+            if (!TryComp(entity, out AccessReaderComponent? containedReader))
+                continue;
+
+            if (IsAllowed(access, stationKeys, entity, containedReader))
+                return true;
+        }
 
         return false;
+    }
+
+    private bool IsAllowedInternal(ICollection<string> access, ICollection<StationRecordKey> stationKeys, AccessReaderComponent reader)
+    {
+        return !reader.Enabled
+               || AreAccessTagsAllowed(access, reader)
+               || AreStationRecordKeysAllowed(stationKeys, reader);
     }
 
     /// <summary>
@@ -155,7 +140,16 @@ public sealed class AccessReaderSystem : EntitySystem
             return false;
         }
 
-        return reader.AccessLists.Count == 0 || reader.AccessLists.Any(a => a.IsSubsetOf(accessTags));
+        if (reader.AccessLists.Count == 0)
+            return true;
+
+        foreach (var set in reader.AccessLists)
+        {
+            if (set.IsSubsetOf(accessTags))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -163,7 +157,13 @@ public sealed class AccessReaderSystem : EntitySystem
     /// </summary>
     public bool AreStationRecordKeysAllowed(ICollection<StationRecordKey> keys, AccessReaderComponent reader)
     {
-        return keys.Any() && reader.AccessKeys.Any(keys.Contains);
+        foreach (var key in reader.AccessKeys)
+        {
+            if (keys.Contains(key))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -509,9 +509,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
         return AccessType switch
         {
             // Some game modes modify access rules.
-            AccessTypes.AllowAllIdExternal => !isExternal || _accessReaderSystem.IsAllowed(user.Value, access),
+            AccessTypes.AllowAllIdExternal => !isExternal || _accessReaderSystem.IsAllowed(user.Value, uid, access),
             AccessTypes.AllowAllNoExternal => !isExternal,
-            _ => _accessReaderSystem.IsAllowed(user.Value, access)
+            _ => _accessReaderSystem.IsAllowed(user.Value, uid, access)
         };
     }
 

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -183,7 +183,7 @@ public sealed class LockSystem : EntitySystem
         if (!Resolve(uid, ref reader, false))
             return true;
 
-        if (_accessReader.IsAllowed(user, reader))
+        if (_accessReader.IsAllowed(user, uid, reader))
             return true;
 
         if (!quiet)


### PR DESCRIPTION
Removes the outdated `IsAllowed()` method to ensure that access checks actually use the `ContainerAccessProvider` data field.
AFAIK this shouldn't conflict with #17778 ( or at the very least they should be trivial conflicts).