### PR TITLE
Change "Battery Power" to "Load"

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -47,7 +47,7 @@ namespace Content.Client.Power.APC.UI
 
             if (PowerLabel != null)
             {
-                PowerLabel.Text = castState.Power + "W";
+                PowerLabel.Text = castState.Power + " W";
             }
 
             if (ExternalPowerStateLabel != null)

--- a/Resources/Locale/en-US/ui/power-apc.ftl
+++ b/Resources/Locale/en-US/ui/power-apc.ftl
@@ -1,7 +1,7 @@
 apc-menu-title = APC
 apc-menu-breaker-label = Main Breaker
 apc-menu-breaker-button = Toggle
-apc-menu-power-label = Battery Power
+apc-menu-power-label = Load
 apc-menu-external-label = External Power
 apc-menu-charge-label = {$percent} Charged
 


### PR DESCRIPTION
## About the PR
This changes the load label on APC's from "Battery Power" to "Load", and adds a space between the number and unit. See screenshot below.

## Why / Balance
As discussed in https://github.com/space-wizards/space-station-14/pull/14196 and https://github.com/space-wizards/space-station-14/pull/14258 "Battery Power" is confusing because it could be misunderstood to mean "power left in battery" which doesn't even make sense because a battery contains energy (Joules) and not power. As [discussed on Discord](https://discord.com/channels/310555209753690112/310555209753690112/1147636831047921674) "Load" is better since that is what we're actually measuring.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
![image](https://github.com/space-wizards/space-station-14/assets/3229565/0be41aa1-3308-430b-9389-758902909162)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
