### PR TITLE
Adjust chair buckle offset

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -24,7 +24,7 @@
     noRot: true
   - type: Strap
     position: Stand
-    buckleOffset: "0,0.15"
+    buckleOffset: "0,-0.05"
   - type: Pullable
   - type: Damageable
     damageContainer: Inorganic


### PR DESCRIPTION
## About the PR
Adjusts the chair buckle offset so that sitting in a chair looks a bit more comfortable.

## Why / Balance
This is what it looks like before:

![image](https://github.com/space-wizards/space-station-14/assets/3229565/8db76f63-bb66-454d-aa32-b31105d46575)

This is clearly not comfortable. Let's take a look at after:

![image](https://github.com/space-wizards/space-station-14/assets/3229565/08dd393a-080c-48d1-82ed-6124694a1c49)

## Technical details

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
