### PR TITLE
Switch security techfab to produce magazines

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -518,17 +518,14 @@
       - ForensicPad
       - ClothingEyesGlassesSecurity
       - RiotShield
-      - CartridgePistol
-      - CartridgeMagnum
       - ShellShotgun
       - ShellShotgunFlare
       - ShellTranquilizer
-      - CartridgeLightRifle
-      - CartridgeRifle
-      - MagazineBoxPistol
-      - MagazineBoxMagnum
-      - MagazineBoxRifle
-      - MagazineBoxLightRifle
+      - MagazinePistol
+      - MagazinePistolSubMachineGun
+      - MagazinePistolSubMachineGunTopMounted
+      - MagazineRifle
+      - MagazineLightRifle
       - TargetHuman
       - TargetSyndicate
       - TargetClown

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -526,6 +526,10 @@
       - MagazinePistolSubMachineGunTopMounted
       - MagazineRifle
       - MagazineLightRifle
+      - MagazineBoxPistol
+      - MagazineBoxMagnum
+      - MagazineBoxRifle
+      - MagazineBoxLightRifle
       - TargetHuman
       - TargetSyndicate
       - TargetClown

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -232,6 +232,27 @@
     Steel: 500
 
 - type: latheRecipe
+  id: MagazinePistol
+  result: MagazinePistol
+  completetime: 5
+  materials:
+    Steel: 100
+
+- type: latheRecipe
+  id: MagazinePistolSubMachineGun
+  result: MagazinePistolSubMachineGun
+  completetime: 5
+  materials:
+    Steel: 300
+
+- type: latheRecipe
+  id: MagazinePistolSubMachineGunTopMounted
+  result: MagazinePistolSubMachineGunTopMounted
+  completetime: 5
+  materials:
+    Steel: 300
+
+- type: latheRecipe
   id: MagazineBoxPistol
   result: MagazineBoxPistol
   completetime: 5
@@ -260,6 +281,20 @@
   materials:
     Steel: 350
     Plastic: 300
+
+- type: latheRecipe
+  id: MagazineRifle
+  result: MagazineRifle
+  completetime: 5
+  materials:
+    Steel: 375
+
+- type: latheRecipe
+  id: MagazineLightRifle
+  result: MagazineLightRifle
+  completetime: 5
+  materials:
+    Steel: 375
 
 - type: latheRecipe
   id: MagazineBoxRifle


### PR DESCRIPTION
## About the PR
This removes individual cartridge lathe recipes from the security techfab in favor of new recipes for all of the magazines in common use by NanoTrasen security.

## Why / Balance
- [People don't like individual cartridges](https://discord.com/channels/310555209753690112/675078881425752124/1147710750912151593)
- The emagged autolathe is untouched. Syndicate agents can continue to painstakingly fill their magazines manually.
- The special (rubber/incindiary) rounds are not touched

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
![image](https://github.com/space-wizards/space-station-14/assets/3229565/cb287ae0-94fe-4283-bc20-bbb0e67af3c5)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: notafet
- tweak: Security techfabs now produce magazines instead of individual cartridges.