### PR TITLE
Tech disks sell for 10x less

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
@@ -58,7 +58,7 @@
         datadisk_base: Sixteen
   - type: TechnologyDisk
   - type: StaticPrice
-    price: 1000
+    price: 100
 
 - type: entity
   parent: TechnologyDisk


### PR DESCRIPTION
Closes #19734

Selling for 1000 was absurd, this makes research points still an (okay-ish) source of points so that's cool

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: Lank
- tweak: Technology Disks now sell for considerably less. 

