### PR TITLE
Make portable generators noRot

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -38,6 +38,7 @@
     - type: Appearance
     - type: Sprite
       sprite: Structures/Power/Generation/portable_generator.rsi
+      noRot: true
 
     # Construction, interaction
     - type: WiresPanel


### PR DESCRIPTION
Matches fuel tanks and the likes and looks better IMO.

:cl:
- tweak: Portable generators no longer rotate with the camera.