### PR TITLE
disposal emag fix and refactoring

### DIFF
--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -542,7 +542,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         if (entry == default || component is not DisposalUnitComponent sDisposals)
         {
             component.Engaged = false;
-            Dirty(component);
+            Dirty(uid, component);
             return false;
         }
 
@@ -550,7 +550,10 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
 
         _disposalTubeSystem.TryInsert(entry, sDisposals, beforeFlushArgs.Tags);
 
-        component.NextPressurized = GameTiming.CurTime + TimeSpan.FromSeconds(1f / PressurePerSecond);
+        component.NextPressurized = GameTiming.CurTime;
+        if (!component.DisablePressure)
+            component.NextPressurized += TimeSpan.FromSeconds(1f / PressurePerSecond);
+
         component.Engaged = false;
         // stop queuing NOW
         component.NextFlush = null;
@@ -558,7 +561,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         UpdateVisualState(uid, component, true);
         UpdateInterface(uid, component, component.Powered);
 
-        Dirty(component);
+        Dirty(uid, component);
 
         return true;
     }
@@ -674,7 +677,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
             component.RecentlyEjected.Add(toRemove);
 
         UpdateVisualState(uid, component);
-        Dirty(component);
+        Dirty(uid, component);
     }
 
     public bool CanFlush(EntityUid unit, SharedDisposalUnitComponent component)
@@ -689,7 +692,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         component.Engaged = true;
         UpdateVisualState(uid, component);
         UpdateInterface(uid, component, component.Powered);
-        Dirty(component);
+        Dirty(uid, component);
 
         if (!CanFlush(uid, component))
             return;
@@ -713,7 +716,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
 
         UpdateVisualState(uid, component);
         UpdateInterface(uid, component, component.Powered);
-        Dirty(component);
+        Dirty(uid, component);
     }
 
     /// <summary>

--- a/Content.Shared/Disposal/Components/SharedDisposalUnitComponent.cs
+++ b/Content.Shared/Disposal/Components/SharedDisposalUnitComponent.cs
@@ -55,7 +55,7 @@ public abstract partial class SharedDisposalUnitComponent : Component
     /// Removes the pressure requirement for flushing.
     /// </summary>
     [DataField("disablePressure"), ViewVariables(VVAccess.ReadWrite)]
-    public bool DisablePressure = false;
+    public bool DisablePressure;
 
     /// <summary>
     ///     Last time that an entity tried to exit this disposal unit.

--- a/Content.Shared/Disposal/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/SharedDisposalUnitSystem.cs
@@ -80,8 +80,7 @@ public abstract class SharedDisposalUnitSystem : EntitySystem
         var otherBody = args.OtherEntity;
 
         // Items dropped shouldn't collide but items thrown should
-        if (EntityManager.HasComponent<ItemComponent>(otherBody) &&
-            !EntityManager.HasComponent<ThrownItemComponent>(otherBody))
+        if (HasComp<ItemComponent>(otherBody) && !HasComp<ThrownItemComponent>(otherBody))
         {
             args.Cancelled = true;
             return;
@@ -110,25 +109,20 @@ public abstract class SharedDisposalUnitSystem : EntitySystem
 
     public virtual bool CanInsert(EntityUid uid, SharedDisposalUnitComponent component, EntityUid entity)
     {
-        if (!EntityManager.GetComponent<TransformComponent>(uid).Anchored)
+        if (!Transform(uid).Anchored)
             return false;
 
         // TODO: Probably just need a disposable tag.
-        if (!EntityManager.TryGetComponent(entity, out ItemComponent? storable) &&
-            !EntityManager.HasComponent<BodyComponent>(entity))
-        {
+        var storable = HasComp<ItemComponent>(entity);
+        if (!storable && !HasComp<BodyComponent>(entity))
             return false;
-        }
 
         //Check if the entity is a mob and if mobs can be inserted
         if (TryComp<MobStateComponent>(entity, out var damageState) && !component.MobsCanEnter)
             return false;
 
-        if (EntityManager.TryGetComponent(entity, out PhysicsComponent? physics) &&
-            (physics.CanCollide || storable != null))
-        {
+        if (TryComp<PhysicsComponent>(entity, out var physics) && (physics.CanCollide || storable))
             return true;
-        }
 
         return damageState != null && (!component.MobsCanEnter || _mobState.IsDead(entity, damageState));
     }


### PR DESCRIPTION
## About the PR
- a little bit of refactoring
- someone broke disposals emagging so its fixed now

also pro tider strat i thought of
1. buy an emag
2. buy some rigged gloves for the boys
3. emag recycler and wall it up
4. go around stunning people and flushing them
5. :trollface:

## Why / Balance
m

## Technical details
sets the time when its pressurized to be now so there is no delay
due to disposals implementation being different than before its now silent too when emagged, which i will call a feature for being stealthy. not sure if there are any other side effects but it seems to work fine

## Media
it work
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Emagging disposal units both works again and makes them silent.
