### PR TITLE
refactor nukeops rule a bit

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -154,11 +154,10 @@ public sealed partial class NukeopsRuleComponent : Component
 
     /// <summary>
     ///     Players who played as an operative at some point in the round.
-    ///     Stores the session as well as the entity name
+    ///     Stores the mind as well as the entity name
     /// </summary>
-    /// todo: don't store sessions, dingus
     [DataField("operativePlayers")]
-    public Dictionary<string, ICommonSession> OperativePlayers = new();
+    public Dictionary<string, EntityUid> OperativePlayers = new();
 
     [DataField("faction", customTypeSerializer: typeof(PrototypeIdSerializer<NpcFactionPrototype>), required: true)]
     public string Faction = default!;

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
@@ -24,7 +24,8 @@ nukeops-cond-somenukiesalive = Some nuclear operatives died.
 nukeops-cond-allnukiesalive = No nuclear operatives died.
 
 nukeops-list-start = The operatives were:
-nukeops-list-name = - [color=White]{$name}[/color] ([color=gray]{$user}[/color])
+nukeops-list-name = - [color=White]{$name}[/color]
+nukeops-list-name-user = - [color=White]{$name}[/color] ([color=gray]{$user}[/color])
 nukeops-not-enough-ready-players = Not enough players readied up for the game! There were {$readyPlayersCount} players readied up out of {$minimumPlayers} needed. Can't start Nukeops.
 nukeops-no-one-ready = No players readied up! Can't start Nukeops.
 


### PR DESCRIPTION
## About the PR
- general refactoring
- changed from storing session to mind id
- (hopefully) made it display correctly if a nukie disconnected in round end text
- removed comment saying to fix dupe since it should be impossible
- fixes #16698: made it check the rule's players instead of querying nukeoperativecomponent which cant ever include gibbed players

## Why / Balance


## Technical details
storing EntityUid of the player's mind instead of a reference to the session since that bad

## Media
endround while alive:
![09:01:28](https://github.com/space-wizards/space-station-14/assets/39013340/ae5a2298-663a-48bf-aaa5-ebd7609a4058)

suiciding:
![08:59:07](https://github.com/space-wizards/space-station-14/assets/39013340/a68b64b1-b50d-4d3b-9d77-43ce50c4c55b)

gibbed ops count as dead:
![09:04:40](https://github.com/space-wizards/space-station-14/assets/39013340/60372ea9-a1da-46f0-8d74-8fa104dec67f)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
`OperativePlayers` field of `NukeopsRuleComponent` changed from storing ICommonSession to mind EntityUid


**Changelog**
no cl no fun