### PR TITLE
gib hitchhikers on ftl

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -77,8 +77,18 @@ public sealed partial class ShuttleSystem
     /// </summary>
     public const float FTLDestinationMass = 500f;
 
+    private EntityQuery<BodyComponent> _bodyQuery;
+    private EntityQuery<BuckleComponent> _buckleQuery;
+    private EntityQuery<StatusEffectsComponent> _statusQuery;
+    private EntityQuery<TransformComponent> _xformQuery;
+
     private void InitializeFTL()
     {
+        _bodyQuery = GetEntityQuery<BodyComponent>();
+        _buckleQuery = GetEntityQuery<BuckleComponent>();
+        _statusQuery = GetEntityQuery<StatusEffectsComponent>();
+        _xformQuery = GetEntityQuery<TransformComponent>();
+
         SubscribeLocalEvent<StationGridAddedEvent>(OnStationGridAdd);
     }
 
@@ -463,9 +473,6 @@ public sealed partial class ShuttleSystem
     /// </summary>
     private void DoTheDinosaur(TransformComponent xform)
     {
-        var buckleQuery = GetEntityQuery<BuckleComponent>();
-        var statusQuery = GetEntityQuery<StatusEffectsComponent>();
-
         // gib anything sitting outside aka on a lattice
         // this is done before knocking since why knock down if they are gonna be gibbed too
         var toGib = new ValueList<(EntityUid, BodyComponent)>();
@@ -478,22 +485,22 @@ public sealed partial class ShuttleSystem
 
         // Get enumeration exceptions from people dropping things if we just paralyze as we go
         var toKnock = new ValueList<EntityUid>();
-        KnockOverKids(xform, buckleQuery, statusQuery, ref toKnock);
+        KnockOverKids(xform, ref toKnock);
 
         foreach (var child in toKnock)
         {
-            if (!statusQuery.TryGetComponent(child, out var status)) continue;
+            if (!_statusQuery.TryGetComponent(child, out var status)) continue;
             _stuns.TryParalyze(child, _hyperspaceKnockdownTime, true, status);
         }
     }
 
-    private void KnockOverKids(TransformComponent xform, EntityQuery<BuckleComponent> buckleQuery, EntityQuery<StatusEffectsComponent> statusQuery, ref ValueList<EntityUid> toKnock)
+    private void KnockOverKids(TransformComponent xform, ref ValueList<EntityUid> toKnock)
     {
         // Not recursive because probably not necessary? If we need it to be that's why this method is separate.
         var childEnumerator = xform.ChildEnumerator;
         while (childEnumerator.MoveNext(out var child))
         {
-            if (!buckleQuery.TryGetComponent(child.Value, out var buckle) || buckle.Buckled)
+            if (!_buckleQuery.TryGetComponent(child.Value, out var buckle) || buckle.Buckled)
                 continue;
 
             toKnock.Add(child.Value);
@@ -502,18 +509,15 @@ public sealed partial class ShuttleSystem
 
     private void GibKids(TransformComponent xform, ref ValueList<(EntityUid, BodyComponent)> toGib)
     {
-        var bodyQuery = GetEntityQuery<BodyComponent>();
-        var xformQuery = GetEntityQuery<TransformComponent>();
-
         // this is not recursive so people hiding in crates are spared, sadly
         var childEnumerator = xform.ChildEnumerator;
         while (childEnumerator.MoveNext(out var child))
         {
-            if (!xformQuery.TryGetComponent(child.Value, out var childXform))
+            if (!_xformQuery.TryGetComponent(child.Value, out var childXform))
                 continue;
 
             // not something that can be gibbed
-            if (!bodyQuery.TryGetComponent(child.Value, out var body))
+            if (!_bodyQuery.TryGetComponent(child.Value, out var body))
                 continue;
 
             // only gib if its on lattice/space


### PR DESCRIPTION
## About the PR
if you are on lattice or space when ftl starts or ends you will get gibbed

fixes #18441

## Why / Balance
see issue

## Technical details
checks tile under every mob to see if it should get gibbed

caveat of it is it does not check recursively so you can survive in a crate/locker/disposal unit/a dragons stomach/ripley

## Media

A) skeletony gibbed when ftl starts, skelebro is ok since he is on plating
B) skelebro is pushed onto lattice when ftl ends, he is gibbed

https://github.com/space-wizards/space-station-14/assets/39013340/de6679e1-430d-4723-856b-61fed529a6b4

ok sound is sus it seems to be played only for the person being gibbed, but using bang stick on someone else plays sound still... very sus


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: A fracture in bluespace is now causing spacemen that hitchhike on shuttles to be gibbed before and after FTL travel. Keep legs inside the vehicle at all times.