### PR TITLE
Blindy changes a bunch of event spawnrates in hopes that it does something.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -26,7 +26,7 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 0
+    weight: 1
     reoccurrenceDelay: 5
     earliestStart: 1
     duration: 1
@@ -61,7 +61,7 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 1
+    weight: 5
     duration: 1
     earliestStart: 45
     minimumPlayers: 20
@@ -74,7 +74,7 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 5
+    weight: 7.5
     duration: 1
     earliestStart: 45
     minimumPlayers: 20
@@ -127,8 +127,8 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 5
-    minimumPlayers: 20
+    weight: 10
+    minimumPlayers: 10 #Enough to hopefully have at least one engineering guy
     startAnnouncement: station-event-meteor-swarm-start-announcement
     endAnnouncement: station-event-meteor-swarm-end-announcement
     startAudio:
@@ -300,7 +300,7 @@
   - type: StationEvent
     earliestStart: 20
     minimumPlayers: 15
-    weight: 2
+    weight: 1
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -314,7 +314,7 @@
   components:
   - type: StationEvent
     earliestStart: 50
-    weight: 2.5
+    weight: 5
     duration: 1
   - type: ZombieRule
     minStartDelay: 0 #let them know immediately
@@ -361,7 +361,7 @@
     startAnnouncement: station-event-immovable-rod-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    weight: 1
+    weight: 5
     duration: 1
     earliestStart: 45
     minimumPlayers: 20

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -127,7 +127,7 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 10
+    weight: 7.5
     minimumPlayers: 10 #Enough to hopefully have at least one engineering guy
     startAnnouncement: station-event-meteor-swarm-start-announcement
     endAnnouncement: station-event-meteor-swarm-end-announcement
@@ -176,7 +176,7 @@
       path: /Audio/Announcements/power_off.ogg
       params:
        volume: -4
-    startDelay: 12
+    startDelay: 24
     duration: 60
     maxDuration: 120
   - type: PowerGridCheckRule


### PR DESCRIPTION
## About the PR
This PR blindly changes a bunch of the event weights in hopes that it does something.
Do I know what these numbers do? No
Do I have any way to test it without wasting my time? No

## Why / Balance
The game has very little emergent gameplay right now, at least compared to SS13. Stuff like space dragon and zombie outbreak appears practically never. Also there's no way to test these properly without merging so like. You know.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Changed a bunch of events to be more common.
