### PR TITLE
Rebalance Ore Conversions

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -833,10 +833,10 @@
         - SheetPlasma30
         - SheetPGlass30
         - SheetRPGlass30
-        - SheetUranium1
-        - IngotGold1
-        - IngotSilver1
-        - MaterialBananium1
+        - SheetUranium30
+        - IngotGold30
+        - IngotSilver30
+        - MaterialBananium10
 
 - type: entity
   parent: BaseLathe

--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -70,6 +70,34 @@
     Plasma: 3000
 
 - type: latheRecipe
+  id: SheetUranium30
+  result: SheetUranium
+  completetime: 2
+  materials:
+    Uranium: 3000
+  
+- type: latheRecipe
+  id: IngotGold30
+  result: IngotGold
+  completetime: 2
+  materials:
+    Gold: 3000
+  
+- type: latheRecipe
+  id: IngotSilver30
+  result: IngotSilver
+  completetime: 2
+  materials:
+    Silver: 3000
+
+- type: latheRecipe
+  id: MaterialBananium10
+  result: MaterialBananium
+  completetime: 2
+  materials:
+    Bananium: 3000
+    
+- type: latheRecipe
   id: SheetUranium1
   result: SheetUranium1
   completetime: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Silver, gold, uranium, and bananium all followed different conversion amounts. You'd effectively have to mine 5x more of these materials to match things like steel or glass. The ores were actually more valuable than the processed sheets or ingots. I spent a few days playing only salvage, and noticed we'd get 40+ stacks of everything, but barely manage a single stack of silver or any of the other 4. 

## Why / Balance
Now that silver, gold, and uranium are all commonly used on the station, they require way too much work in order to obtain a reasonable amount. The random boxes would drop a stack of gold, which is the same as getting 30 gold ore. This PR makes it so mining is consistent where 6 pieces of ore will equal a stack of refined material.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Rebalanced the conversion rates of gold, silver, uranium, and bananium ores. 


