### PR TITLE
Phalanximine works on plants + slippery fruits fix

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantPhalanximine.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantPhalanximine.cs
@@ -1,0 +1,36 @@
+using Content.Server.Botany.Components;
+using Content.Server.Botany.Systems;
+using Content.Shared.Chemistry.Reagent;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Toolshed.TypeParsers;
+
+namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
+{
+    [UsedImplicitly]
+    [DataDefinition]
+    public sealed partial class PlantPhalanximine : ReagentEffect
+    {
+        public override void Effect(ReagentEffectArgs args)
+        {
+            if (!args.EntityManager.TryGetComponent(args.SolutionEntity, out PlantHolderComponent? plantHolderComp)
+                                    || plantHolderComp.Seed == null || plantHolderComp.Dead ||
+                                    plantHolderComp.Seed.Immutable)
+                return;
+
+
+            var plantHolder = args.EntityManager.System<PlantHolderSystem>();
+            var random = IoCManager.Resolve<IRobustRandom>();
+            if (args.Source == null) return;
+            var source = args.Source;
+            //Need at least 5u, had to do it like this because plant metabolism is weird
+            if (source.TryGetReagent("Phalanximine", out var quantity) && quantity >= 4.00)
+            {
+                plantHolderComp.Seed.Viable = true;
+            }
+        }
+
+        protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) => Loc.GetString("reagent-effect-guidebook-missing", ("chance", Probability));
+    }
+}

--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantPhalanximine.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantPhalanximine.cs
@@ -1,10 +1,7 @@
 using Content.Server.Botany.Components;
-using Content.Server.Botany.Systems;
 using Content.Shared.Chemistry.Reagent;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
-using Robust.Shared.Toolshed.TypeParsers;
 
 namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
 {
@@ -19,10 +16,8 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
                                     plantHolderComp.Seed.Immutable)
                 return;
 
-
-            var plantHolder = args.EntityManager.System<PlantHolderSystem>();
-            var random = IoCManager.Resolve<IRobustRandom>();
             if (args.Source == null) return;
+
             var source = args.Source;
             //Need at least 5u, had to do it like this because plant metabolism is weird
             if (source.TryGetReagent("Phalanximine", out var quantity) && quantity >= 4.00)

--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantPhalanximine.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantPhalanximine.cs
@@ -16,14 +16,7 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
                                     plantHolderComp.Seed.Immutable)
                 return;
 
-            if (args.Source == null) return;
-
-            var source = args.Source;
-            //Need at least 5u, had to do it like this because plant metabolism is weird
-            if (source.TryGetReagent("Phalanximine", out var quantity) && quantity >= 4.00)
-            {
-                plantHolderComp.Seed.Viable = true;
-            }
+            plantHolderComp.Seed.Viable = true;
         }
 
         protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) => Loc.GetString("reagent-effect-guidebook-missing", ("chance", Probability));

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -547,6 +547,10 @@
   physicalDesc: reagent-physical-desc-acrid
   flavor: medicine
   color: "#c8ff75"
+  plantMetabolism:
+    - !type:PlantAdjustToxins
+      amount: 4
+    - !type:PlantPhalanximine {}
   metabolisms:
     Medicine:
       effects:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -549,7 +549,7 @@
   color: "#c8ff75"
   plantMetabolism:
     - !type:PlantAdjustToxins
-      amount: 4
+      amount: 6
     - !type:PlantPhalanximine {}
   metabolisms:
     Medicine:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -550,7 +550,10 @@
   plantMetabolism:
     - !type:PlantAdjustToxins
       amount: 6
-    - !type:PlantPhalanximine {}
+    - !type:PlantPhalanximine
+      conditions:
+      - !type:ReagentThreshold
+        min: 4
   metabolisms:
     Medicine:
       effects:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR makes the following changes:
- Phalanximine can be used to repair damaged plant genes (It raises the tray's toxin level amount by a fair amount, though)
- Produce harvested from a plant with the slippery trait now slips people the way it's supposed to
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Currently plant mutations feel unintuitive and too punishing, since more often than not using unstable mutagen will cause the plant's genes to become 'unviable' which makes the plant die before it reaches maturity. This has a relatively high chance to happen, isn't avoidable, and can ruin a seed with otherwise good traits and values, effectively wasting the time the player spent tweaking it.
Phalanximine is a fairly complex and niche chemical, so it's unlikely it'll be available very often or in large quantities, which balances out its new utility.

As for the slippery trait, this is simply a fix because it didn't work at all.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Added a new PlantPhalanximine reaction which makes the plant viable if there's at least 4 (practically 5) units of phalanximine in its tray.
- The slippery plant trait now disables the CollisionWake component on the resulting produce and adds a new physics fixture with the slip layer to it, in order to prevent its collision box from being disabled and to let mobs slip on it like they would on a banana peel.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Genetically damaged plants can now be repaired with small amounts of phalanximine.