### PR TITLE
Buff thermomachines

### DIFF
--- a/Content.Server/Atmos/Components/HeatExchangerComponent.cs
+++ b/Content.Server/Atmos/Components/HeatExchangerComponent.cs
@@ -31,6 +31,6 @@ public sealed partial class HeatExchangerComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("radiationCoefficient")]
-    public float alpha { get; set; } = 140f;
+    public float alpha { get; set; } = 1400f;
 }
 

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -286,7 +286,7 @@
             True: { state: freezerOn }
             False: { state: freezerOff }
     - type: GasThermoMachine
-      coefficientOfPerformance: -64
+      coefficientOfPerformance: -1024
     - type: ApcPowerReceiver
       powerDisabled: true #starts off
     - type: Machine
@@ -329,7 +329,7 @@
             True: { state: heaterOn }
             False: { state: heaterOff }
     - type: GasThermoMachine
-      coefficientOfPerformance: 32
+      coefficientOfPerformance: 512
     - type: ApcPowerReceiver
       powerDisabled: true #starts off
     - type: Machine

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -286,7 +286,7 @@
             True: { state: freezerOn }
             False: { state: freezerOff }
     - type: GasThermoMachine
-      coefficientOfPerformance: -1024
+      coefficientOfPerformance: -140
     - type: ApcPowerReceiver
       powerDisabled: true #starts off
     - type: Machine
@@ -329,7 +329,7 @@
             True: { state: heaterOn }
             False: { state: heaterOff }
     - type: GasThermoMachine
-      coefficientOfPerformance: 512
+      coefficientOfPerformance: 70
     - type: ApcPowerReceiver
       powerDisabled: true #starts off
     - type: Machine


### PR DESCRIPTION
## About the PR
This PR significantly buffs thermomachines and radiators.

## Why / Balance
#18984 effectively made Atmos's difficulty curve extremely steep for entry by nerfing freezers and heaters into uselessness for the average atmos tech, with the original intent of making the TEG unexploitable - and that PR still failed to balance it, providing a 2.6x gain (see media), which is why thermomachines are rebuffed in this PR.
This [unfortunately breaks the TEG balance again](https://github.com/space-wizards/space-station-14/issues/19300), but also reopens atmospherics design for inexperienced players.

Radiators were also previously nigh unusable in most situations, and have been buffed tenfold.

## Media
Current TEG (as of a6b8105)
![image](https://github.com/space-wizards/space-station-14/assets/21104932/080c0d27-3a7c-4f73-8835-77bbb3bdec7b)
Pre-nerf TEG
![image](https://github.com/space-wizards/space-station-14/assets/21104932/515c7bac-a58c-4db5-99bc-d1d4e716fef7)
TEG after this PR
![image](https://github.com/space-wizards/space-station-14/assets/21104932/921aa5cf-77af-49ab-a53a-26c900315955)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: router
- tweak: Freezers are now 4x as strong, heaters are now 16x stronger, lowering the skill floor of Atmos back from orbital levels.
- tweak: Radiators are now 10x stronger, sporting a whopping 1400 tiles of surface area.
