### PR TITLE
apc tweaks/refactor

### DIFF
--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -18,6 +18,12 @@ public sealed partial class ApcComponent : BaseApcNetComponent
 
     [DataField("lastExternalState")]
     public ApcExternalPowerState LastExternalState;
+
+    /// <summary>
+    /// Time the ui was last updated automatically.
+    /// Done after every <see cref="VisualsChangeDelay"/> to show the latest load.
+    /// If charge state changes it will be instantly updated.
+    /// </summary>
     [DataField("lastUiUpdate", customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan LastUiUpdate;
 

--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -13,12 +13,12 @@ public sealed partial class ApcComponent : BaseApcNetComponent
 
     [DataField("lastChargeState")]
     public ApcChargeState LastChargeState;
-    [DataField("lastChargeStateTime", customTypeSerializer: typeof(TimeOffsetSerializer)]
+    [DataField("lastChargeStateTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan LastChargeStateTime;
 
     [DataField("lastExternalState")]
     public ApcExternalPowerState LastExternalState;
-    [DataField("lastUiUpdate", customTypeSerializer: typeof(TimeOffsetSerializer)]
+    [DataField("lastUiUpdate", customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan LastUiUpdate;
 
     [DataField("enabled")]

--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.Power.NodeGroups;
 using Content.Shared.APC;
 using Robust.Shared.Audio;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Power.Components;
 
@@ -10,16 +11,20 @@ public sealed partial class ApcComponent : BaseApcNetComponent
     [DataField("onReceiveMessageSound")]
     public SoundSpecifier OnReceiveMessageSound = new SoundPathSpecifier("/Audio/Machines/machine_switch.ogg");
 
-    [ViewVariables]
+    [DataField("lastChargeState")]
     public ApcChargeState LastChargeState;
+    [DataField("lastChargeStateTime", customTypeSerializer: typeof(TimeOffsetSerializer)]
     public TimeSpan LastChargeStateTime;
 
-    [ViewVariables]
+    [DataField("lastExternalState")]
     public ApcExternalPowerState LastExternalState;
+    [DataField("lastUiUpdate", customTypeSerializer: typeof(TimeOffsetSerializer)]
     public TimeSpan LastUiUpdate;
 
-    [ViewVariables]
+    [DataField("enabled")]
     public bool MainBreakerEnabled = true;
+    // TODO: remove this since it probably breaks when 2 people use it
+    [DataField("hasAccess")]
     public bool HasAccess = false;
 
     public const float HighPowerThreshold = 0.9f;

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -8,22 +8,20 @@ using Content.Shared.APC;
 using Content.Shared.Emag.Components;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Popups;
-using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Power.EntitySystems
 {
-    [UsedImplicitly]
-    internal sealed class ApcSystem : EntitySystem
+    public sealed class ApcSystem : EntitySystem
     {
         [Dependency] private readonly AccessReaderSystem _accessReader = default!;
-        [Dependency] private readonly UserInterfaceSystem _ui = default!;
-        [Dependency] private readonly PopupSystem _popup = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
+        [Dependency] private readonly PopupSystem _popup = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
+        [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
         public override void Initialize()
         {
@@ -50,23 +48,18 @@ namespace Content.Server.Power.EntitySystems
         {
             UpdateApcState(uid, component);
         }
+
         //Update the HasAccess var for UI to read
         private void OnBoundUiOpen(EntityUid uid, ApcComponent component, BoundUIOpenedEvent args)
         {
-            TryComp<AccessReaderComponent>(uid, out var access);
             if (args.Session.AttachedEntity == null)
                 return;
 
-            if (access == null || _accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid, access))
-            {
-                component.HasAccess = true;
-            }
-            else
-            {
-                component.HasAccess = false;
-            }
+            // TODO: this should be per-player not stored on the apc
+            component.HasAccess = _accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid);
             UpdateApcState(uid, component);
         }
+
         private void OnToggleMainBreaker(EntityUid uid, ApcComponent component, ApcToggleMainBreakerMessage args)
         {
             var attemptEv = new ApcToggleMainBreakerAttemptEvent();
@@ -78,11 +71,10 @@ namespace Content.Server.Power.EntitySystems
                 return;
             }
 
-            TryComp<AccessReaderComponent>(uid, out var access);
             if (args.Session.AttachedEntity == null)
                 return;
 
-            if (access == null || _accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid, access))
+            if (_accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid))
             {
                 ApcToggleBreaker(uid, component);
             }

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -12,184 +12,183 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Timing;
 
-namespace Content.Server.Power.EntitySystems
+namespace Content.Server.Power.EntitySystems;
+
+public sealed class ApcSystem : EntitySystem
 {
-    public sealed class ApcSystem : EntitySystem
+    [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly UserInterfaceSystem _ui = default!;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly AccessReaderSystem _accessReader = default!;
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
-        [Dependency] private readonly PopupSystem _popup = default!;
-        [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-        [Dependency] private readonly SharedAudioSystem _audio = default!;
-        [Dependency] private readonly UserInterfaceSystem _ui = default!;
+        base.Initialize();
 
-        public override void Initialize()
+        UpdatesAfter.Add(typeof(PowerNetSystem));
+
+        SubscribeLocalEvent<ApcComponent, BoundUIOpenedEvent>(OnBoundUiOpen);
+        SubscribeLocalEvent<ApcComponent, MapInitEvent>(OnApcInit);
+        SubscribeLocalEvent<ApcComponent, ChargeChangedEvent>(OnBatteryChargeChanged);
+        SubscribeLocalEvent<ApcComponent, ApcToggleMainBreakerMessage>(OnToggleMainBreaker);
+        SubscribeLocalEvent<ApcComponent, GotEmaggedEvent>(OnEmagged);
+
+        SubscribeLocalEvent<ApcComponent, EmpPulseEvent>(OnEmpPulse);
+    }
+
+    // Change the APC's state only when the battery state changes, or when it's first created.
+    private void OnBatteryChargeChanged(EntityUid uid, ApcComponent component, ref ChargeChangedEvent args)
+    {
+        UpdateApcState(uid, component);
+    }
+
+    private void OnApcInit(EntityUid uid, ApcComponent component, MapInitEvent args)
+    {
+        UpdateApcState(uid, component);
+    }
+
+    //Update the HasAccess var for UI to read
+    private void OnBoundUiOpen(EntityUid uid, ApcComponent component, BoundUIOpenedEvent args)
+    {
+        if (args.Session.AttachedEntity == null)
+            return;
+
+        // TODO: this should be per-player not stored on the apc
+        component.HasAccess = _accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid);
+        UpdateApcState(uid, component);
+    }
+
+    private void OnToggleMainBreaker(EntityUid uid, ApcComponent component, ApcToggleMainBreakerMessage args)
+    {
+        var attemptEv = new ApcToggleMainBreakerAttemptEvent();
+        RaiseLocalEvent(uid, ref attemptEv);
+        if (attemptEv.Cancelled)
         {
-            base.Initialize();
-
-            UpdatesAfter.Add(typeof(PowerNetSystem));
-
-            SubscribeLocalEvent<ApcComponent, BoundUIOpenedEvent>(OnBoundUiOpen);
-            SubscribeLocalEvent<ApcComponent, MapInitEvent>(OnApcInit);
-            SubscribeLocalEvent<ApcComponent, ChargeChangedEvent>(OnBatteryChargeChanged);
-            SubscribeLocalEvent<ApcComponent, ApcToggleMainBreakerMessage>(OnToggleMainBreaker);
-            SubscribeLocalEvent<ApcComponent, GotEmaggedEvent>(OnEmagged);
-
-            SubscribeLocalEvent<ApcComponent, EmpPulseEvent>(OnEmpPulse);
+            _popup.PopupCursor(Loc.GetString("apc-component-on-toggle-cancel"),
+                args.Session, PopupType.Medium);
+            return;
         }
 
-        // Change the APC's state only when the battery state changes, or when it's first created.
-        private void OnBatteryChargeChanged(EntityUid uid, ApcComponent component, ref ChargeChangedEvent args)
+        if (args.Session.AttachedEntity == null)
+            return;
+
+        if (_accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid))
         {
-            UpdateApcState(uid, component);
+            ApcToggleBreaker(uid, component);
         }
-
-        private void OnApcInit(EntityUid uid, ApcComponent component, MapInitEvent args)
+        else
         {
-            UpdateApcState(uid, component);
-        }
-
-        //Update the HasAccess var for UI to read
-        private void OnBoundUiOpen(EntityUid uid, ApcComponent component, BoundUIOpenedEvent args)
-        {
-            if (args.Session.AttachedEntity == null)
-                return;
-
-            // TODO: this should be per-player not stored on the apc
-            component.HasAccess = _accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid);
-            UpdateApcState(uid, component);
-        }
-
-        private void OnToggleMainBreaker(EntityUid uid, ApcComponent component, ApcToggleMainBreakerMessage args)
-        {
-            var attemptEv = new ApcToggleMainBreakerAttemptEvent();
-            RaiseLocalEvent(uid, ref attemptEv);
-            if (attemptEv.Cancelled)
-            {
-                _popup.PopupCursor(Loc.GetString("apc-component-on-toggle-cancel"),
-                    args.Session, PopupType.Medium);
-                return;
-            }
-
-            if (args.Session.AttachedEntity == null)
-                return;
-
-            if (_accessReader.IsAllowed(args.Session.AttachedEntity.Value, uid))
-            {
-                ApcToggleBreaker(uid, component);
-            }
-            else
-            {
-                _popup.PopupCursor(Loc.GetString("apc-component-insufficient-access"),
-                    args.Session, PopupType.Medium);
-            }
-        }
-
-        public void ApcToggleBreaker(EntityUid uid, ApcComponent? apc = null, PowerNetworkBatteryComponent? battery = null)
-        {
-            if (!Resolve(uid, ref apc, ref battery))
-                return;
-
-            apc.MainBreakerEnabled = !apc.MainBreakerEnabled;
-            battery.CanDischarge = apc.MainBreakerEnabled;
-
-            UpdateUIState(uid, apc);
-            _audio.PlayPvs(apc.OnReceiveMessageSound, uid, AudioParams.Default.WithVolume(-2f));
-        }
-
-        private void OnEmagged(EntityUid uid, ApcComponent comp, ref GotEmaggedEvent args)
-        {
-            // no fancy conditions
-            args.Handled = true;
-        }
-
-        public void UpdateApcState(EntityUid uid,
-            ApcComponent? apc=null,
-            PowerNetworkBatteryComponent? battery = null)
-        {
-            if (!Resolve(uid, ref apc, ref battery))
-                return;
-
-            var newState = CalcChargeState(uid, battery.NetworkBattery);
-            if (newState != apc.LastChargeState && apc.LastChargeStateTime + ApcComponent.VisualsChangeDelay < _gameTiming.CurTime)
-            {
-                apc.LastChargeState = newState;
-                apc.LastChargeStateTime = _gameTiming.CurTime;
-
-                if (TryComp(uid, out AppearanceComponent? appearance))
-                {
-                    _appearance.SetData(uid, ApcVisuals.ChargeState, newState, appearance);
-                }
-            }
-
-            var extPowerState = CalcExtPowerState(uid, battery.NetworkBattery);
-            if (extPowerState != apc.LastExternalState
-                || apc.LastUiUpdate + ApcComponent.VisualsChangeDelay < _gameTiming.CurTime)
-            {
-                apc.LastExternalState = extPowerState;
-                apc.LastUiUpdate = _gameTiming.CurTime;
-                UpdateUIState(uid, apc, battery);
-            }
-        }
-
-        public void UpdateUIState(EntityUid uid,
-            ApcComponent? apc = null,
-            PowerNetworkBatteryComponent? netBat = null,
-            ServerUserInterfaceComponent? ui = null)
-        {
-            if (!Resolve(uid, ref apc, ref netBat, ref ui))
-                return;
-
-            var battery = netBat.NetworkBattery;
-
-            var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled, apc.HasAccess,
-                (int) MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
-                battery.CurrentStorage / battery.Capacity);
-
-            _ui.TrySetUiState(uid, ApcUiKey.Key, state, ui: ui);
-        }
-
-        private ApcChargeState CalcChargeState(EntityUid uid, PowerState.Battery battery)
-        {
-            if (HasComp<EmaggedComponent>(uid))
-                return ApcChargeState.Emag;
-
-            if (battery.CurrentStorage / battery.Capacity > ApcComponent.HighPowerThreshold)
-            {
-                return ApcChargeState.Full;
-            }
-
-            var delta = battery.CurrentSupply - battery.CurrentReceiving;
-            return delta < 0 ? ApcChargeState.Charging : ApcChargeState.Lack;
-        }
-
-        private ApcExternalPowerState CalcExtPowerState(EntityUid uid, PowerState.Battery battery)
-        {
-            if (battery.CurrentReceiving == 0 && !MathHelper.CloseTo(battery.CurrentStorage / battery.Capacity, 1))
-            {
-                return ApcExternalPowerState.None;
-            }
-
-            var delta = battery.CurrentSupply - battery.CurrentReceiving;
-            if (!MathHelper.CloseToPercent(delta, 0, 0.1f) && delta < 0)
-            {
-                return ApcExternalPowerState.Low;
-            }
-
-            return ApcExternalPowerState.Good;
-        }
-
-        private void OnEmpPulse(EntityUid uid, ApcComponent component, ref EmpPulseEvent args)
-        {
-            if (component.MainBreakerEnabled)
-            {
-                args.Affected = true;
-                args.Disabled = true;
-                ApcToggleBreaker(uid, component);
-            }
+            _popup.PopupCursor(Loc.GetString("apc-component-insufficient-access"),
+                args.Session, PopupType.Medium);
         }
     }
 
-    [ByRefEvent]
-    public record struct ApcToggleMainBreakerAttemptEvent(bool Cancelled);
+    public void ApcToggleBreaker(EntityUid uid, ApcComponent? apc = null, PowerNetworkBatteryComponent? battery = null)
+    {
+        if (!Resolve(uid, ref apc, ref battery))
+            return;
+
+        apc.MainBreakerEnabled = !apc.MainBreakerEnabled;
+        battery.CanDischarge = apc.MainBreakerEnabled;
+
+        UpdateUIState(uid, apc);
+        _audio.PlayPvs(apc.OnReceiveMessageSound, uid, AudioParams.Default.WithVolume(-2f));
+    }
+
+    private void OnEmagged(EntityUid uid, ApcComponent comp, ref GotEmaggedEvent args)
+    {
+        // no fancy conditions
+        args.Handled = true;
+    }
+
+    public void UpdateApcState(EntityUid uid,
+        ApcComponent? apc=null,
+        PowerNetworkBatteryComponent? battery = null)
+    {
+        if (!Resolve(uid, ref apc, ref battery))
+            return;
+
+        var newState = CalcChargeState(uid, battery.NetworkBattery);
+        if (newState != apc.LastChargeState && apc.LastChargeStateTime + ApcComponent.VisualsChangeDelay < _gameTiming.CurTime)
+        {
+            apc.LastChargeState = newState;
+            apc.LastChargeStateTime = _gameTiming.CurTime;
+
+            if (TryComp(uid, out AppearanceComponent? appearance))
+            {
+                _appearance.SetData(uid, ApcVisuals.ChargeState, newState, appearance);
+            }
+        }
+
+        var extPowerState = CalcExtPowerState(uid, battery.NetworkBattery);
+        if (extPowerState != apc.LastExternalState
+            || apc.LastUiUpdate + ApcComponent.VisualsChangeDelay < _gameTiming.CurTime)
+        {
+            apc.LastExternalState = extPowerState;
+            apc.LastUiUpdate = _gameTiming.CurTime;
+            UpdateUIState(uid, apc, battery);
+        }
+    }
+
+    public void UpdateUIState(EntityUid uid,
+        ApcComponent? apc = null,
+        PowerNetworkBatteryComponent? netBat = null,
+        ServerUserInterfaceComponent? ui = null)
+    {
+        if (!Resolve(uid, ref apc, ref netBat, ref ui))
+            return;
+
+        var battery = netBat.NetworkBattery;
+
+        var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled, apc.HasAccess,
+            (int) MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
+            battery.CurrentStorage / battery.Capacity);
+
+        _ui.TrySetUiState(uid, ApcUiKey.Key, state, ui: ui);
+    }
+
+    private ApcChargeState CalcChargeState(EntityUid uid, PowerState.Battery battery)
+    {
+        if (HasComp<EmaggedComponent>(uid))
+            return ApcChargeState.Emag;
+
+        if (battery.CurrentStorage / battery.Capacity > ApcComponent.HighPowerThreshold)
+        {
+            return ApcChargeState.Full;
+        }
+
+        var delta = battery.CurrentSupply - battery.CurrentReceiving;
+        return delta < 0 ? ApcChargeState.Charging : ApcChargeState.Lack;
+    }
+
+    private ApcExternalPowerState CalcExtPowerState(EntityUid uid, PowerState.Battery battery)
+    {
+        if (battery.CurrentReceiving == 0 && !MathHelper.CloseTo(battery.CurrentStorage / battery.Capacity, 1))
+        {
+            return ApcExternalPowerState.None;
+        }
+
+        var delta = battery.CurrentSupply - battery.CurrentReceiving;
+        if (!MathHelper.CloseToPercent(delta, 0, 0.1f) && delta < 0)
+        {
+            return ApcExternalPowerState.Low;
+        }
+
+        return ApcExternalPowerState.Good;
+    }
+
+    private void OnEmpPulse(EntityUid uid, ApcComponent component, ref EmpPulseEvent args)
+    {
+        if (component.MainBreakerEnabled)
+        {
+            args.Affected = true;
+            args.Disabled = true;
+            ApcToggleBreaker(uid, component);
+        }
+    }
 }
+
+[ByRefEvent]
+public record struct ApcToggleMainBreakerAttemptEvent(bool Cancelled);


### PR DESCRIPTION
## About the PR
- add datafield to everything for saving
- make the access logic cleaner
- add comment about HasAccess since it is evil
- general refactor

## Why / Balance
code

## Technical details
IsAllowed already checks if it has no access reader so no need to do that explicitly in apc

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun