### PR TITLE
hide syndicate channel from examine

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
@@ -107,7 +107,7 @@ public sealed class StealthClothingSystem : EntitySystem
 /// <summary>
 /// Raised on the stealth clothing when attempting to add an action.
 /// </summary>
-public class AddStealthActionEvent : CancellableEntityEventArgs
+public sealed class AddStealthActionEvent : CancellableEntityEventArgs
 {
     /// <summary>
     /// User that equipped the stealth clothing.
@@ -123,7 +123,7 @@ public class AddStealthActionEvent : CancellableEntityEventArgs
 /// <summary>
 /// Raised on the stealth clothing when the user is attemping to enable it.
 /// </summary>
-public class AttemptStealthEvent : CancellableEntityEventArgs
+public sealed class AttemptStealthEvent : CancellableEntityEventArgs
 {
     /// <summary>
     /// User that is attempting to enable the stealth clothing.

--- a/Content.Shared/Radio/Components/EncryptionKeyHolderComponent.cs
+++ b/Content.Shared/Radio/Components/EncryptionKeyHolderComponent.cs
@@ -53,4 +53,10 @@ public sealed partial class EncryptionKeyHolderComponent : Component
     /// </summary>
     [ViewVariables]
     public string? DefaultChannel;
+
+    /// <summary>
+    /// Whether to show hidden radio channels when examined.
+    /// </summary>
+    [DataField("showHidden"), ViewVariables(VVAccess.ReadWrite)]
+    public bool ShowHidden;
 }

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -212,6 +212,8 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         foreach (var id in channels)
         {
             proto = _protoManager.Index<RadioChannelPrototype>(id);
+            if (proto.Hidden)
+                continue;
 
             var key = id == SharedChatSystem.CommonChannel
                 ? SharedChatSystem.RadioCommonPrefix.ToString()

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -184,7 +184,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         if (component.Channels.Count > 0)
         {
             args.PushMarkup(Loc.GetString("examine-encryption-channels-prefix"));
-            AddChannelsExamine(component.Channels, component.DefaultChannel, args, _protoManager, "examine-encryption-channel");
+            AddChannelsExamine(component.Channels, component.DefaultChannel, args, _protoManager, "examine-encryption-channel", component.ShowHidden);
         }
     }
 
@@ -196,7 +196,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         if(component.Channels.Count > 0)
         {
             args.PushMarkup(Loc.GetString("examine-encryption-channels-prefix"));
-            AddChannelsExamine(component.Channels, component.DefaultChannel, args, _protoManager, "examine-encryption-channel");
+            AddChannelsExamine(component.Channels, component.DefaultChannel, args, _protoManager, "examine-encryption-channel", true);
         }
     }
 
@@ -205,21 +205,22 @@ public sealed partial class EncryptionKeySystem : EntitySystem
     /// </summary>
     /// <param name="channels">HashSet of channels in headset, encryptionkey or etc.</param>
     /// <param name="protoManager">IPrototypeManager for getting prototypes of channels with their variables.</param>
-    /// <param name="channelFTLPattern">String that provide id of pattern in .ftl files to format channel with variables of it.</param>
-    public void AddChannelsExamine(HashSet<string> channels, string? defaultChannel, ExaminedEvent examineEvent, IPrototypeManager protoManager, string channelFTLPattern)
+    /// <param name="channelLocale">Locale id to format channel with variables of it.</param>
+    /// <param name="showHidden">If true hidden channels will be shown.</param>
+    public void AddChannelsExamine(HashSet<string> channels, string? defaultChannel, ExaminedEvent examineEvent, IPrototypeManager protoManager, string channelLocale, bool showHidden)
     {
         RadioChannelPrototype? proto;
         foreach (var id in channels)
         {
             proto = _protoManager.Index<RadioChannelPrototype>(id);
-            if (proto.Hidden)
+            if (proto.Hidden && !showHidden)
                 continue;
 
             var key = id == SharedChatSystem.CommonChannel
                 ? SharedChatSystem.RadioCommonPrefix.ToString()
                 : $"{SharedChatSystem.RadioChannelPrefix}{proto.KeyCode}";
 
-            examineEvent.PushMarkup(Loc.GetString(channelFTLPattern,
+            examineEvent.PushMarkup(Loc.GetString(channelLocale,
                 ("color", proto.Color),
                 ("key", key),
                 ("id", proto.LocalizedName),

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -30,9 +30,9 @@ public sealed class RadioChannelPrototype : IPrototype
     public string ID { get; } = default!;
 
     /// <summary>
-    /// If channel is long range it doesn't require telecommunication server 
+    /// If channel is long range it doesn't require telecommunication server
     /// and messages can be sent across different stations
     /// </summary>
-    [DataField("longRange"), ViewVariables]
-    public bool LongRange = false;
+    [DataField("longRange")]
+    public bool LongRange;
 }

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -35,4 +35,10 @@ public sealed class RadioChannelPrototype : IPrototype
     /// </summary>
     [DataField("longRange")]
     public bool LongRange;
+
+    /// <summary>
+    /// Hidden radio channels cannot be seen in by examining a headset, only by taking them out.
+    /// </summary>
+    [DataField("hidden")]
+    public bool Hidden;
 }

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -138,6 +138,8 @@
   - type: Headset
   - type: EncryptionKeyHolder
     keySlots: 5
+    # its already valid so no use hiding the sus channel
+    showHidden: true
   - type: ContainerFill
     containers:
       key_slots:

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -203,7 +203,7 @@
   parent: EncryptionKey
   id: EncryptionKeySyndie
   name: blood-red encryption key
-  description: An encryption key used by... wait... Who is owner of this chip?
+  description: An encryption key used by... wait... Who is the owner of this chip?
   components:
   - type: EncryptionKey
     channels:

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -69,6 +69,7 @@
   frequency: 1213
   color: "#8f4a4b"
   longRange: true
+  hidden: true
 
 - type: radioChannel
   id: Handheld


### PR DESCRIPTION
## About the PR
syndicate radio channel is hidden from examine of most headsets
still visible when examining blood-red headset and encryption key

also fix grammar of blood-red key

## Why / Balance
makes it harder for trollers doing random cavity searches to put someone in perma for having valid radio channel, now they really need to bust their ass and get a screwdriver

## Technical details
adds `hidden` field to the radio channel prototype, which is true for syndicate channel
adds `showHidden` field to encryption key holder so when it makes sense it can be shown (blood-red headset is already valid so no use hiding it)

i think due to how radio works a malf client could just show it anyway since im pretty sure the examine is done clientside

## Media
cant see sus channel in examine:
![11:40:48](https://github.com/space-wizards/space-station-14/assets/39013340/d586b713-b46e-40b3-bfdb-c5140530bfdf)

blood-red headset is valid so dont bother hiding:
![11:52:17](https://github.com/space-wizards/space-station-14/assets/39013340/8eba4ad5-9132-459f-8889-4ea5019099f9)

new players need to see :t so dont hide it:
![11:52:26](https://github.com/space-wizards/space-station-14/assets/39013340/4639e01a-a018-4dfe-b6f8-2e7b951c18b3)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: The syndicate radio channel is hidden when examining headsets.