### PR TITLE
prevent magnet deconstruction when active

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -25,6 +25,7 @@ using Content.Shared.CCVar;
 using Content.Shared.Construction.EntitySystems;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
+using Content.Shared.Tools.Components;
 using Robust.Server.Maps;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Timing;
@@ -68,6 +69,7 @@ namespace Content.Server.Salvage
             SubscribeLocalEvent<SalvageMagnetComponent, RefreshPartsEvent>(OnRefreshParts);
             SubscribeLocalEvent<SalvageMagnetComponent, UpgradeExamineEvent>(OnUpgradeExamine);
             SubscribeLocalEvent<SalvageMagnetComponent, ExaminedEvent>(OnExamined);
+            SubscribeLocalEvent<SalvageMagnetComponent, ToolUseAttemptEvent>(OnToolUseAttempt);
             SubscribeLocalEvent<SalvageMagnetComponent, ComponentShutdown>(OnMagnetRemoval);
             SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoval);
 
@@ -229,6 +231,15 @@ namespace Content.Server.Salvage
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private void OnToolUseAttempt(EntityUid uid, SalvageMagnetComponent comp, ToolUseAttemptEvent args)
+        {
+            // prevent reconstruct exploit to "leak" wrecks or skip cooldowns
+            if (comp.MagnetState != MagnetState.Inactive)
+            {
+                args.Cancel();
             }
         }
 

--- a/Content.Shared/Tools/Components/ToolComponent.cs
+++ b/Content.Shared/Tools/Components/ToolComponent.cs
@@ -22,7 +22,8 @@ namespace Content.Shared.Tools.Components
     }
 
     /// <summary>
-    ///     Attempt event called *before* any do afters to see if the tool usage should succeed or not.
+    /// Attempt event called *before* any do afters to see if the tool usage should succeed or not.
+    /// Raised on both the tool and then target.
     /// </summary>
     public sealed class ToolUseAttemptEvent : CancellableEntityEventArgs
     {

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -180,16 +180,27 @@ public abstract partial class SharedToolSystem : EntitySystem
         if (!Resolve(tool, ref toolComponent))
             return false;
 
+        // check if the tool can do what's required
+        if (!toolComponent.Qualities.ContainsAll(toolQualitiesNeeded))
+            return false;
+
+        // check if the user allows using the tool
         var ev = new ToolUserAttemptUseEvent(target);
         RaiseLocalEvent(user, ref ev);
         if (ev.Cancelled)
             return false;
 
-        if (!toolComponent.Qualities.ContainsAll(toolQualitiesNeeded))
+        // check if the tool allows being used
+        var beforeAttempt = new ToolUseAttemptEvent(user);
+        RaiseLocalEvent(tool, beforeAttempt);
+        if (beforeAttempt.Cancelled)
             return false;
 
-        var beforeAttempt = new ToolUseAttemptEvent(user);
-        RaiseLocalEvent(tool, beforeAttempt, false);
+        // check if the target allows using the tool
+        if (target != null && target != tool)
+        {
+            RaiseLocalEvent(target.Value, beforeAttempt);
+        }
 
         return !beforeAttempt.Cancelled;
     }


### PR DESCRIPTION
## About the PR
just prevents using tools on magnet when its active (pulling, pulled or on cooldown)
fixes #19390 and fixes #17813

## Why / Balance
bug

## Technical details
raises ToolUseAttemptEvent on the target as well as the tool so it can cancel tool usage.
magnet cancels if state is not inactive

## Media
it work trust
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Magnets can no longer be deconstructed while active, preventing a few bugs.
