### PR TITLE
After killing all nuclear operatives, shuttle will be called instead of instant round end

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -298,7 +298,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         Color? colorOverride = null
         )
     {
-        var wrappedMessage = Loc.etString("chat-manager-sender-announcement-wrap-message", ("sender", sender), ("message", FormattedMessage.EscapeText(message)));
+        var wrappedMessage = Loc.GetString("chat-manager-sender-announcement-wrap-message", ("sender", sender), ("message", FormattedMessage.EscapeText(message)));
         _chatManager.ChatMessageToAll(ChatChannel.Radio, message, wrappedMessage, default, false, true, colorOverride);
         if (playSound)
         {

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -298,7 +298,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         Color? colorOverride = null
         )
     {
-        var wrappedMessage = Loc.GetString("chat-manager-sender-announcement-wrap-message", ("sender", sender), ("message", FormattedMessage.EscapeText(message)));
+        var wrappedMessage = Loc.etString("chat-manager-sender-announcement-wrap-message", ("sender", sender), ("message", FormattedMessage.EscapeText(message)));
         _chatManager.ChatMessageToAll(ChatChannel.Radio, message, wrappedMessage, default, false, true, colorOverride);
         if (playSound)
         {

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -32,9 +32,10 @@ public sealed partial class NukeopsRuleComponent : Component
 
     /// <summary>
     /// Whether or not all of the nuclear operatives dying will end the round. Used by LoneOpsSpawn event.
+    /// 
     /// </summary>
-    [DataField("endsRound")]
-    public bool EndsRound = true;
+    [DataField("roundEndBehavior")]
+    public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.ShuttleCall;
 
     /// <summary>
     /// Whether or not to spawn the nuclear operative outpost. Used by LoneOpsSpawn event.
@@ -204,4 +205,22 @@ public enum WinCondition : byte
     AllNukiesDead,
     SomeNukiesAlive,
     AllNukiesAlive
+}
+
+public enum RoundEndBehavior : byte
+{
+    /// <summary>
+    /// Instantly end round
+    /// </summary>
+    InstantEnd,
+
+    /// <summary>
+    /// Call shuttle with custom announcement
+    /// </summary>
+    ShuttleCall,
+
+    /// <summary>
+    /// Do nothing
+    /// </summary>
+    Nothing
 }

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -31,11 +31,22 @@ public sealed partial class NukeopsRuleComponent : Component
     public int MaxOperatives = 5;
 
     /// <summary>
-    /// Whether or not all of the nuclear operatives dying will end the round. Used by LoneOpsSpawn event.
-    /// 
+    /// What will happen if all of the nuclear operatives will die. Used by LoneOpsSpawn event.
     /// </summary>
     [DataField("roundEndBehavior")]
     public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.ShuttleCall;
+
+    /// <summary>
+    /// Text for shuttle call if RoundEndBehavior is ShuttleCall.
+    /// </summary>
+    [DataField("roundEndTextShuttleCall")]
+    public string RoundEndTextShuttleCall = "nuke-ops-no-more-threat-announcement-shuttle-call";
+
+    /// <summary>
+    /// Text for announcement if RoundEndBehavior is ShuttleCall. Used if shuttle is already called
+    /// </summary>
+    [DataField("roundEndTextAnnouncement")]
+    public string RoundEndTextAnnouncement = "nuke-ops-no-more-threat-announcement";
 
     /// <summary>
     /// Whether or not to spawn the nuclear operative outpost. Used by LoneOpsSpawn event.

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.NPC.Components;
+using Content.Server.RoundEnd;
 using Content.Server.StationEvents.Events;
 using Content.Shared.Dataset;
 using Content.Shared.Roles;
@@ -35,7 +36,7 @@ public sealed partial class NukeopsRuleComponent : Component
     /// </summary>
     [DataField("roundEndBehavior")]
     public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.ShuttleCall;
-    
+
     /// <summary>
     /// Text for shuttle call if RoundEndBehavior is ShuttleCall.
     /// </summary>
@@ -228,22 +229,4 @@ public enum WinCondition : byte
     AllNukiesDead,
     SomeNukiesAlive,
     AllNukiesAlive
-}
-
-public enum RoundEndBehavior : byte
-{
-    /// <summary>
-    /// Instantly end round
-    /// </summary>
-    InstantEnd,
-
-    /// <summary>
-    /// Call shuttle with custom announcement
-    /// </summary>
-    ShuttleCall,
-
-    /// <summary>
-    /// Do nothing
-    /// </summary>
-    Nothing
 }

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -55,6 +55,12 @@ public sealed partial class NukeopsRuleComponent : Component
     public string RoundEndTextAnnouncement = "nuke-ops-no-more-threat-announcement";
 
     /// <summary>
+    /// Time to emergency shuttle to arrive if RoundEndBehavior is ShuttleCall.
+    /// </summary>
+    [DataField("evacShuttleTime")]
+    public TimeSpan EvacShuttleTime = TimeSpan.FromMinutes(10);
+
+    /// <summary>
     /// Whether or not to spawn the nuclear operative outpost. Used by LoneOpsSpawn event.
     /// </summary>
     [DataField("spawnOutpost")]

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -35,6 +35,12 @@ public sealed partial class NukeopsRuleComponent : Component
     /// </summary>
     [DataField("roundEndBehavior")]
     public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.ShuttleCall;
+    
+    /// <summary>
+    /// Text for shuttle call if RoundEndBehavior is ShuttleCall.
+    /// </summary>
+    [DataField("roundEndTextSender")]
+    public string RoundEndTextSender = "comms-console-announcement-title-centcom";
 
     /// <summary>
     /// Text for shuttle call if RoundEndBehavior is ShuttleCall.

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -491,11 +491,13 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 if (_roundEndSystem.IsRoundEndRequested())
                 {
                     _chatSystem.DispatchGlobalAnnouncement(Loc.GetString(component.RoundEndTextAnnouncement),
+                        Loc.GetString(component.RoundEndTextSender)
                         colorOverride: Color.Gold);
                 }
                 else
                 {
-                    _roundEndSystem.RequestRoundEnd(TimeSpan.FromMinutes(5), null, false, component.RoundEndTextShuttleCall, "Central Command");
+                    _roundEndSystem.RequestRoundEnd(TimeSpan.FromMinutes(5), null, false, component.RoundEndTextShuttleCall,
+                        Loc.GetString(component.RoundEndTextSender));
                 }
                 
                 break;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -491,7 +491,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 if (_roundEndSystem.IsRoundEndRequested())
                 {
                     _chatSystem.DispatchGlobalAnnouncement(Loc.GetString(component.RoundEndTextAnnouncement),
-                        Loc.GetString(component.RoundEndTextSender)
+                        Loc.GetString(component.RoundEndTextSender),
                         colorOverride: Color.Gold);
                 }
                 else

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -495,7 +495,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 }
                 else
                 {
-                    _roundEndSystem.RequestRoundEnd(TimeSpan.FromMinutes(5), null, false, component.RoundEndTextShuttleCall);
+                    _roundEndSystem.RequestRoundEnd(TimeSpan.FromMinutes(5), null, false, component.RoundEndTextShuttleCall, "Central Command");
                 }
                 
                 break;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -490,12 +490,12 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 // Check that shuttle is called or not. We should dispatch only announcement if it's already called
                 if (_roundEndSystem.IsRoundEndRequested())
                 {
-                    _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("nuke-ops-no-more-threat-announcement"),
+                    _chatSystem.DispatchGlobalAnnouncement(Loc.GetString(component.RoundEndTextAnnouncement),
                         colorOverride: Color.Gold);
                 }
                 else
                 {
-                    _roundEndSystem.RequestRoundEnd(TimeSpan.FromMinutes(5), null, false, "nuke-ops-no-more-threat-announcement-shuttle-call");
+                    _roundEndSystem.RequestRoundEnd(TimeSpan.FromMinutes(5), null, false, component.RoundEndTextShuttleCall);
                 }
                 
                 break;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -476,33 +476,6 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
             _roundEndSystem.EndRound();
     }
 
-    private void DoRoundEndBehavior(NukeopsRuleComponent component)
-    {
-        switch (component.RoundEndBehavior)
-        {
-            case RoundEndBehavior.InstantEnd:
-                _roundEndSystem.EndRound();
-                break;
-            case RoundEndBehavior.ShuttleCall:
-                // Prevent it being called multiple times
-                component.RoundEndBehavior = RoundEndBehavior.Nothing;
-
-                // Check is shuttle called or not. We should only dispatch announcement if it's already called
-                if (_roundEndSystem.IsRoundEndRequested())
-                {
-                    _chatSystem.DispatchGlobalAnnouncement(Loc.GetString(component.RoundEndTextAnnouncement),
-                        Loc.GetString(component.RoundEndTextSender),
-                        colorOverride: Color.Gold);
-                }
-                else
-                {
-                    _roundEndSystem.RequestRoundEnd(component.EvacShuttleTime, null, false, component.RoundEndTextShuttleCall,
-                        Loc.GetString(component.RoundEndTextSender));
-                }
-                break;
-        }
-    }
-
     private void CheckRoundShouldEnd()
     {
         var query = EntityQueryEnumerator<NukeopsRuleComponent, GameRuleComponent>();
@@ -565,7 +538,11 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 : WinCondition.AllNukiesDead);
 
             SetWinType(uid, WinType.CrewMajor, nukeops, false);
-            DoRoundEndBehavior(nukeops);
+            _roundEndSystem.DoRoundEndBehavior(
+                nukeops.RoundEndBehavior, nukeops.EvacShuttleTime, nukeops.RoundEndTextSender, nukeops.RoundEndTextShuttleCall, nukeops.RoundEndTextAnnouncement);
+
+            // prevent it called multiple times
+            nukeops.RoundEndBehavior = RoundEndBehavior.Nothing;
         }
     }
 

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -487,7 +487,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 // Prevent it being called multiple times
                 component.RoundEndBehavior = RoundEndBehavior.Nothing;
 
-                // Check that shuttle is called or not. We should dispatch only announcement if it's already called
+                // Check is shuttle called or not. We should only dispatch announcement if it's already called
                 if (_roundEndSystem.IsRoundEndRequested())
                 {
                     _chatSystem.DispatchGlobalAnnouncement(Loc.GetString(component.RoundEndTextAnnouncement),
@@ -496,10 +496,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 }
                 else
                 {
-                    _roundEndSystem.RequestRoundEnd(TimeSpan.FromMinutes(5), null, false, component.RoundEndTextShuttleCall,
+                    _roundEndSystem.RequestRoundEnd(component.EvacShuttleTime, null, false, component.RoundEndTextShuttleCall,
                         Loc.GetString(component.RoundEndTextSender));
                 }
-                
                 break;
         }
     }

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -90,7 +90,12 @@ namespace Content.Server.RoundEnd
             return _cooldownTokenSource == null;
         }
 
-        public void RequestRoundEnd(EntityUid? requester = null, bool checkCooldown = true, bool autoCall = false)
+        public bool IsRoundEndRequested()
+        {
+            return _countdownTokenSource != null;
+        }
+
+        public void RequestRoundEnd(EntityUid? requester = null, bool checkCooldown = true, string text = "round-end-system-shuttle-called-announcement")
         {
             var duration = DefaultCountdownDuration;
 
@@ -105,10 +110,10 @@ namespace Content.Server.RoundEnd
                 }
             }
 
-            RequestRoundEnd(duration, requester, checkCooldown, autoCall);
+            RequestRoundEnd(duration, requester, checkCooldown, text);
         }
 
-        public void RequestRoundEnd(TimeSpan countdownTime, EntityUid? requester = null, bool checkCooldown = true, bool autoCall = false)
+        public void RequestRoundEnd(TimeSpan countdownTime, EntityUid? requester = null, bool checkCooldown = true, string text = "round-end-system-shuttle-called-announcement")
         {
             if (_gameTicker.RunLevel != GameRunLevel.InRound) return;
 
@@ -141,26 +146,13 @@ namespace Content.Server.RoundEnd
                units = "eta-units-minutes";
             }
 
-            if (autoCall)
-            {
-                _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-auto-called-announcement",
-                    ("time", time),
-                    ("units", Loc.GetString(units))),
-                    Loc.GetString("Station"),
-                    false,
-                    null,
-                    Color.Gold);
-            }
-            else
-            {
-                _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-called-announcement",
-                    ("time", time),
-                    ("units", Loc.GetString(units))),
-                    Loc.GetString("Station"),
-                    false,
-                    null,
-                    Color.Gold);
-            }
+            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString(text,
+                ("time", time),
+                ("units", Loc.GetString(units))),
+                Loc.GetString("Station"),
+                false,
+                null,
+                Color.Gold);
 
             SoundSystem.Play("/Audio/Announcements/shuttlecalled.ogg", Filter.Broadcast());
 
@@ -260,7 +252,7 @@ namespace Content.Server.RoundEnd
             {
                 if (!_shuttle.EmergencyShuttleArrived && ExpectedCountdownEnd is null)
                 {
-                    RequestRoundEnd(null, false, true);
+                    RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
                     AutoCalledBefore = true;
                 }
 

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -95,7 +95,7 @@ namespace Content.Server.RoundEnd
             return _countdownTokenSource != null;
         }
 
-        public void RequestRoundEnd(EntityUid? requester = null, bool checkCooldown = true, string text = "round-end-system-shuttle-called-announcement")
+        public void RequestRoundEnd(EntityUid? requester = null, bool checkCooldown = true, string text = "round-end-system-shuttle-called-announcement", string name = "Station")
         {
             var duration = DefaultCountdownDuration;
 
@@ -110,10 +110,10 @@ namespace Content.Server.RoundEnd
                 }
             }
 
-            RequestRoundEnd(duration, requester, checkCooldown, text);
+            RequestRoundEnd(duration, requester, checkCooldown, text, name);
         }
 
-        public void RequestRoundEnd(TimeSpan countdownTime, EntityUid? requester = null, bool checkCooldown = true, string text = "round-end-system-shuttle-called-announcement")
+        public void RequestRoundEnd(TimeSpan countdownTime, EntityUid? requester = null, bool checkCooldown = true, string text = "round-end-system-shuttle-called-announcement", string name = "Station")
         {
             if (_gameTicker.RunLevel != GameRunLevel.InRound) return;
 
@@ -149,7 +149,7 @@ namespace Content.Server.RoundEnd
             _chatSystem.DispatchGlobalAnnouncement(Loc.GetString(text,
                 ("time", time),
                 ("units", Loc.GetString(units))),
-                Loc.GetString("Station"),
+                Loc.GetString(name),
                 false,
                 null,
                 Color.Gold);

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -224,6 +224,30 @@ namespace Content.Server.RoundEnd
             Timer.Spawn(countdownTime.Value, AfterEndRoundRestart, _countdownTokenSource.Token);
         }
 
+        public void DoRoundEndBehavior(RoundEndBehavior behavior, TimeSpan time, string sender, string textCall, string textAnnounce)
+        {
+            switch (behavior)
+            {
+                case RoundEndBehavior.InstantEnd:
+                    EndRound();
+                    break;
+                case RoundEndBehavior.ShuttleCall:
+                    // Check is shuttle called or not. We should only dispatch announcement if it's already called
+                    if (IsRoundEndRequested())
+                    {
+                        _chatSystem.DispatchGlobalAnnouncement(Loc.GetString(textAnnounce),
+                            Loc.GetString(sender),
+                            colorOverride: Color.Gold);
+                    }
+                    else
+                    {
+                        RequestRoundEnd(time, null, false, textCall,
+                            Loc.GetString(sender));
+                    }
+                    break;
+            }
+        }
+
         private void AfterEndRoundRestart()
         {
             if (_gameTicker.RunLevel != GameRunLevel.PostRound) return;
@@ -266,4 +290,22 @@ namespace Content.Server.RoundEnd
     {
         public static RoundEndSystemChangedEvent Default { get; } = new();
     }
+
+    public enum RoundEndBehavior : byte
+{
+        /// <summary>
+        /// Instantly end round
+        /// </summary>
+        InstantEnd,
+
+        /// <summary>
+        /// Call shuttle with custom announcement
+        /// </summary>
+        ShuttleCall,
+
+        /// <summary>
+        /// Do nothing
+        /// </summary>
+        Nothing
+}
 }

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -149,7 +149,7 @@ namespace Content.Server.RoundEnd
             _chatSystem.DispatchGlobalAnnouncement(Loc.GetString(text,
                 ("time", time),
                 ("units", Loc.GetString(units))),
-                Loc.GetString(name),
+                name,
                 false,
                 null,
                 Color.Gold);

--- a/Content.Server/StationEvents/Events/LoneOpsSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/LoneOpsSpawnRule.cs
@@ -37,7 +37,7 @@ public sealed class LoneOpsSpawnRule : StationEventSystem<LoneOpsSpawnRuleCompon
         component.AdditionalRule = nukeopsEntity;
         var nukeopsComp = EntityManager.GetComponent<NukeopsRuleComponent>(nukeopsEntity);
         nukeopsComp.SpawnOutpost = false;
-        nukeopsComp.EndsRound = false;
+        nukeopsComp.RoundEndBehavior = RoundEndBehavior.Nothing;
         _gameTicker.StartGameRule(nukeopsEntity);
     }
 

--- a/Content.Server/StationEvents/Events/LoneOpsSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/LoneOpsSpawnRule.cs
@@ -5,6 +5,7 @@ using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.StationEvents.Components;
+using Content.Server.RoundEnd;
 
 namespace Content.Server.StationEvents.Events;
 

--- a/Resources/Locale/en-US/nukeops/nuke-ops.ftl
+++ b/Resources/Locale/en-US/nukeops/nuke-ops.ftl
@@ -1,0 +1,2 @@
+nuke-ops-no-more-threat-announcement-shuttle-call = Based on our scans from our long-range sensors, the nuclear threat is now eliminated. We will call emergency shuttle that will arrive shortly. ETA: {$time} {$units}. You can recall the shuttle to extend the shift.
+nuke-ops-no-more-threat-announcement = Based on our scans from our long-range sensors, the nuclear threat is now eliminated. Shuttle is already called.


### PR DESCRIPTION
## About the PR
After killing all nuclear operatives, shuttle will be called instead of instant round end.

## Why / Balance
I thought it would be good that players can play round more if they managed to win too fast. 

## Technical details
`NukeopsRuleComponent`:
- `EndsRound` property was replaced with `RoundEndBehavior` which is enum type with 3 values: `Nothing`, `ShuttleCall`, `InstantEnd`.
- `RoundEndTextSender`, `RoundEndTextShuttleCall` and `RoundEndTextAnnouncement` that provides text for shuttle call and announcement (`RoundEndTextAnnouncement` used if shuttle already called)
- `EvacShuttleTime` that provides time to emergency shuttle to arrive

`NukeopsRuleSystem`:
- `SetWinType()` now has `endRound` field (true by default). Before, `SetWinType()` could end round. Now it will not if `endRound` was false.
- New method `DoRoundEndBehavior()` does behavior defined in `NukeopsRuleComponent.RoundEndBehavior`
- `CheckRoundShouldEnd()` now does the behavior instead of ending round by `SetWinType()` (it's still there but doesn't end round because of `endRound` field is false).

`RoundEndSystem`:
- `RequestRoundEnd()` now has field `text` and `sender`. They're passed into announcement on shuttle call. Field `autoCall` is deleted as it did just the same but with hard-coded text.
- Auto-calls now just provide their announcement text into `RequestRoundEnd()`
- New method `IsRoundEndRequested()` that returns true if shuttle is called

## Media
https://github.com/space-wizards/space-station-14/assets/56765288/e08603fd-4c21-4eeb-a712-ed8011c58bb9

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- tweak: Now after killing all nuclear operatives, the emergency shuttle will be called instead of instant round end. Shuttle arrives in 10 minutes and you can recall it.
