### PR TITLE
Add Atmos paintscheme to spraypainter

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/airlock_groups.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/airlock_groups.yml
@@ -2,6 +2,7 @@
   id: Standard
   iconPriority: 100
   stylePaths:
+    atmospherics: Structures/Doors/Airlocks/Standard/atmospherics.rsi
     basic:       Structures/Doors/Airlocks/Standard/basic.rsi
     cargo:       Structures/Doors/Airlocks/Standard/cargo.rsi
     command:     Structures/Doors/Airlocks/Standard/command.rsi
@@ -17,6 +18,7 @@
   id: Glass
   iconPriority: 90
   stylePaths:
+    atmospherics: Structures/Doors/Airlocks/Glass/atmospherics.rsi
     basic:       Structures/Doors/Airlocks/Glass/basic.rsi
     command:     Structures/Doors/Airlocks/Glass/command.rsi
     science:     Structures/Doors/Airlocks/Glass/science.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added the atmospherics airlock to the airlock_group list.

## Why / Balance
This makes the Atmos paint scheme available in the spray painter. All other door paint schemes are already available, so atmos was probably forgotten. This also resolves #17361 

## Technical details
The list defining the airlock group and the glass airlock group were each extended by one entry referencing atmos

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![spraypaint_atmos](https://github.com/space-wizards/space-station-14/assets/61566539/730b54e4-581e-48a2-a551-de597c5b52c3)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
