### PR TITLE
Revert click damage mod

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -74,15 +74,8 @@ public sealed partial class MeleeWeaponComponent : Component
     /// <summary>
     /// Multiplies damage by this amount for single-target attacks.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("heavyDamageModifier")]
-    public FixedPoint2 HeavyDamageModifier = FixedPoint2.New(1.25);
-
-    //TODO: Was set to 0 value as of 2023-08-06, might want to delete later if we never go back to this idea
-    /// <summary>
-    /// How much stamina it costs for a heavy attack.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("heavyStaminaCost")]
-    public float HeavyStaminaCost = 0f;
+    [ViewVariables(VVAccess.ReadWrite), DataField("clickDamageModifier")]
+    public FixedPoint2 ClickDamageModifier;
 
     // TODO: Temporarily 1.5 until interactionoutline is adjusted to use melee, then probably drop to 1.2
     /// <summary>

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -104,7 +104,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (gun.NextFire > component.NextAttack)
         {
             component.NextAttack = gun.NextFire;
-            Dirty(component);
+            Dirty(uid, component);
         }
     }
 
@@ -133,7 +133,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return;
 
         component.NextAttack = minimum;
-        Dirty(component);
+        Dirty(uid, component);
     }
 
     private void OnGetBonusMeleeDamage(EntityUid uid, BonusMeleeDamageComponent component, ref GetMeleeDamageEvent args)
@@ -173,7 +173,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return;
 
         weapon.Attacking = false;
-        Dirty(weapon);
+        Dirty(weaponUid, weapon);
     }
 
     private void OnLightAttack(LightAttackEvent msg, EntitySessionEventArgs args)
@@ -272,7 +272,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return FixedPoint2.Zero;
 
-        var ev = new GetHeavyDamageModifierEvent(uid, component.HeavyDamageModifier, 1, user);
+        var ev = new GetHeavyDamageModifierEvent(uid, component.ClickDamageModifier, 1, user);
         RaiseLocalEvent(uid, ref ev);
 
         return ev.DamageModifier * ev.Multipliers;
@@ -398,7 +398,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             swings++;
         }
 
-        Dirty(weapon);
+        Dirty(weaponUid, weapon);
 
         // Do this AFTER attack so it doesn't spam every tick
         var ev = new AttemptMeleeEvent();
@@ -565,12 +565,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         if (targetMap.MapId != userXform.MapID)
             return false;
-
-        if (!_stamina.TryTakeStamina(user, component.HeavyStaminaCost))
-        {
-            PopupSystem.PopupClient(Loc.GetString("melee-stamina"), user, user);
-            return false;
-        }
 
         var userPos = TransformSystem.GetWorldPosition(userXform);
         var direction = targetMap.Position - userPos;

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -271,8 +271,7 @@
     attackRate: 1
     damage:
       types:
-        # Actually does 5 damage due to +25% damage bonus on all single target melee attacks
-        Blunt: 4
+        Blunt: 5
   - type: Pullable
   - type: DoAfter
   - type: CreamPied

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -43,8 +43,7 @@
     animation: WeaponArcPunch
     damage:
       types:
-        # Actually does 5 damage due to +25% damage bonus on all single target melee attacks
-        Piercing: 4
+        Piercing: 5
   - type: Temperature
     heatDamageThreshold: 400
     coldDamageThreshold: 285


### PR DESCRIPTION
Maybe swings should be default and we make the animation not shit and the prediction slightly better.

Will add wide charge and move it to left-click in a separate PR.

Don't know if any weapon values were updated but I was specifically telling people not to touch it.

:cl:
- tweak: Revert 25% click attack buff.
