### PR TITLE
Add method for real atmos tick rate

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -327,6 +327,23 @@ namespace Content.Server.Atmos.EntitySystems
             return true;
         }
 
+        /**
+         * UpdateProcessing() takes a different number of calls to go through all of atmos
+         * processing depending on what options are enabled. This returns the actual effective time
+         * between atmos updates that devices actually experience.
+         */
+        public float RealAtmosTime()
+        {
+            int num = (int)AtmosphereProcessingState.NumStates;
+            if (!MonstermosEqualization)
+                num--;
+            if (!ExcitedGroups)
+                num--;
+            if (!Superconduction)
+                num--;
+            return num * AtmosTime;
+        }
+
         private bool ProcessAtmosDevices(GridAtmosphereComponent atmosphere)
         {
             if(!atmosphere.ProcessingPaused)
@@ -336,7 +353,7 @@ namespace Content.Server.Atmos.EntitySystems
             var number = 0;
             while (atmosphere.CurrentRunAtmosDevices.TryDequeue(out var device))
             {
-                RaiseLocalEvent(device.Owner, new AtmosDeviceUpdateEvent(AtmosTime * (int)AtmosphereProcessingState.NumStates), false);
+                RaiseLocalEvent(device.Owner, new AtmosDeviceUpdateEvent(RealAtmosTime()), false);
                 device.LastProcess = time;
 
                 if (number++ < LagCheckIterations) continue;


### PR DESCRIPTION
## About the PR
In #18847 I said: "All touched devices will have a small 10% increase in transfer rate because the old game timer subtraction method systematically under-calculates the correct transfer rate by not accounting for the duration of the current tick."

This is not correct. The real reason that I was off-by-one tick was because atmos takes a *variable* number of atmos sub-ticks to complete processing depending on the configuration options, and because superconduction is disabled by default, I was off by one.

## Why / Balance
This brings the atmos update rate for all devices back to their numbers before #18847, which is about 3.6% faster than what it is now and 0% faster than what it was before.

|                                 |            |
|---------------------------------|------------|
| Old (incorrect) atmos tick time | 0.6        |
| New real atmos tick time        | 0.53333336 |
| Difference                      | 3.6%       |