### PR TITLE
Make slow spacing variables CCVars

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
@@ -16,6 +16,9 @@ namespace Content.Server.Atmos.EntitySystems
         public bool MonstermosDepressurization { get; private set; }
         public bool MonstermosRipTiles { get; private set; }
         public bool GridImpulse { get; private set; }
+        public float SpacingEscapeRatio { get; private set; }
+        public float SpacingMinGas { get; private set; }
+        public float SpacingMaxWind { get; private set; }
         public bool Superconduction { get; private set; }
         public bool ExcitedGroups { get; private set; }
         public bool ExcitedGroupsSpaceIsAllConsuming { get; private set; }
@@ -40,6 +43,9 @@ namespace Content.Server.Atmos.EntitySystems
             _cfg.OnValueChanged(CCVars.MonstermosDepressurization, value => MonstermosDepressurization = value, true);
             _cfg.OnValueChanged(CCVars.MonstermosRipTiles, value => MonstermosRipTiles = value, true);
             _cfg.OnValueChanged(CCVars.AtmosGridImpulse, value => GridImpulse = value, true);
+            _cfg.OnValueChanged(CCVars.AtmosSpacingEscapeRatio, value => SpacingEscapeRatio = value, true);
+            _cfg.OnValueChanged(CCVars.AtmosSpacingMinGas, value => SpacingMinGas = value, true);
+            _cfg.OnValueChanged(CCVars.AtmosSpacingMaxWind, value => SpacingMaxWind = value, true);
             _cfg.OnValueChanged(CCVars.Superconduction, value => Superconduction = value, true);
             _cfg.OnValueChanged(CCVars.AtmosMaxProcessTime, value => AtmosMaxProcessTime = value, true);
             _cfg.OnValueChanged(CCVars.AtmosTickRate, value => AtmosTickRate = value, true);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -467,19 +467,20 @@ namespace Content.Server.Atmos.EntitySystems
                     otherTile.Air.Temperature = Atmospherics.TCMB;
                     continue;
                 }
-
-                // Pressure as a multiple of normal air pressure (takes temperature into account)
-                float pressureMultiple = (otherTile.Air.Pressure / 110.0f);
-                var sum = otherTile.Air.TotalMoles * SpacingEscapeRatio * pressureMultiple;
-                if (sum < SpacingMinGas)
+                var sum = otherTile.Air.TotalMoles;
+                if (SpacingEscapeRatio < 1f)
                 {
-                    // Boost the last bit of air draining from the tile.
-                    sum = Math.Min(SpacingMinGas, otherTile.Air.TotalMoles);
-                }
-                if (sum + otherTile.MonstermosInfo.CurrentTransferAmount > SpacingMaxWind * pressureMultiple)
-                {
-                    // Limit the flow of air out of tiles which have air flowing into them from elsewhere.
-                    sum = Math.Max(SpacingMinGas, SpacingMaxWind * pressureMultiple - otherTile.MonstermosInfo.CurrentTransferAmount);
+                    sum *= SpacingEscapeRatio;
+                    if (sum < SpacingMinGas)
+                    {
+                        // Boost the last bit of air draining from the tile.
+                        sum = Math.Min(SpacingMinGas, otherTile.Air.TotalMoles);
+                    }
+                    if (sum + otherTile.MonstermosInfo.CurrentTransferAmount > SpacingMaxWind)
+                    {
+                        // Limit the flow of air out of tiles which have air flowing into them from elsewhere.
+                        sum = Math.Max(SpacingMinGas, SpacingMaxWind - otherTile.MonstermosInfo.CurrentTransferAmount);
+                    }
                 }
                 totalMolesRemoved += sum;
                 otherTile.MonstermosInfo.CurrentTransferAmount += sum;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -470,16 +470,16 @@ namespace Content.Server.Atmos.EntitySystems
 
                 // Pressure as a multiple of normal air pressure (takes temperature into account)
                 float pressureMultiple = (otherTile.Air.Pressure / 110.0f);
-                var sum = otherTile.Air.TotalMoles * Atmospherics.SpacingEscapeRatio * pressureMultiple;
-                if (sum < Atmospherics.SpacingMinGas)
+                var sum = otherTile.Air.TotalMoles * SpacingEscapeRatio * pressureMultiple;
+                if (sum < SpacingMinGas)
                 {
                     // Boost the last bit of air draining from the tile.
-                    sum = Math.Min(Atmospherics.SpacingMinGas, otherTile.Air.TotalMoles);
+                    sum = Math.Min(SpacingMinGas, otherTile.Air.TotalMoles);
                 }
-                if (sum + otherTile.MonstermosInfo.CurrentTransferAmount > Atmospherics.SpacingMaxWind * pressureMultiple)
+                if (sum + otherTile.MonstermosInfo.CurrentTransferAmount > SpacingMaxWind * pressureMultiple)
                 {
                     // Limit the flow of air out of tiles which have air flowing into them from elsewhere.
-                    sum = Math.Max(Atmospherics.SpacingMinGas, Atmospherics.SpacingMaxWind * pressureMultiple - otherTile.MonstermosInfo.CurrentTransferAmount);
+                    sum = Math.Max(SpacingMinGas, SpacingMaxWind * pressureMultiple - otherTile.MonstermosInfo.CurrentTransferAmount);
                 }
                 totalMolesRemoved += sum;
                 otherTile.MonstermosInfo.CurrentTransferAmount += sum;
@@ -493,7 +493,7 @@ namespace Content.Server.Atmos.EntitySystems
                     otherTile2.PressureDirection = otherTile.MonstermosInfo.CurrentTransferDirection;
                 }
 
-                if (otherTile.Air != null && otherTile.Air.Pressure - sum > Atmospherics.SpacingMinGas * 0.1f)
+                if (otherTile.Air != null && otherTile.Air.Pressure - sum > SpacingMinGas * 0.1f)
                 {
                     // Transfer the air into the other tile (space wind :)
                     ReleaseGasTo(otherTile.Air!, otherTile2.Air!, sum);
@@ -652,7 +652,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (!MonstermosRipTiles)
                 return;
 
-            var chance = MathHelper.Clamp(0.01f + (sum / Atmospherics.SpacingMaxWind) * 0.3f, 0.003f, 0.3f);
+            var chance = MathHelper.Clamp(0.01f + (sum / SpacingMaxWind) * 0.3f, 0.003f, 0.3f);
 
             if (sum > 20 && _robustRandom.Prob(chance))
                 PryTile(mapGrid, tile.GridIndices);

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -309,25 +309,6 @@ namespace Content.Shared.Atmos
         /// </summary>
         public const float MaxTransferRate = 200;
 
-        /// <summary>
-        ///     What fraction of air from a spaced tile escapes every tick.
-        ///     1.0 for instant spacing, 0.2 means 20% of remaining air lost each time
-        /// </summary>
-        public const float SpacingEscapeRatio = 0.05f;
-
-        /// <summary>
-        ///     Minimum amount of air allowed on a spaced tile before it is reset to 0 immediately in kPa
-        ///     Since the decay due to SpacingEscapeRatio follows a curve, it would never reach 0.0 exactly
-        ///     unless we truncate it somewhere.
-        /// </summary>
-        public const float SpacingMinGas = 2.0f;
-
-        /// <summary>
-        ///     How much wind can go through a single tile before that tile doesn't depressurize itself
-        ///     (I.e spacing is limited in large rooms heading into smaller spaces)
-        /// </summary>
-        public const float SpacingMaxWind = 500.0f;
-
         #endregion
     }
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -960,6 +960,28 @@ namespace Content.Shared.CCVar
             CVarDef.Create("atmos.grid_impulse", false, CVar.SERVERONLY);
 
         /// <summary>
+        ///     What fraction of air from a spaced tile escapes every tick.
+        ///     1.0 for instant spacing, 0.2 means 20% of remaining air lost each time
+        /// </summary>
+        public static readonly CVarDef<float> AtmosSpacingEscapeRatio =
+            CVarDef.Create("atmos.mmos_spacing_speed", 0.05f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Minimum amount of air allowed on a spaced tile before it is reset to 0 immediately in kPa
+        ///     Since the decay due to SpacingEscapeRatio follows a curve, it would never reach 0.0 exactly
+        ///     unless we truncate it somewhere.
+        /// </summary>
+        public static readonly CVarDef<float> AtmosSpacingMinGas =
+            CVarDef.Create("atmos.mmos_min_gas", 2.0f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     How much wind can go through a single tile before that tile doesn't depressurize itself
+        ///     (I.e spacing is limited in large rooms heading into smaller spaces)
+        /// </summary>
+        public static readonly CVarDef<float> AtmosSpacingMaxWind =
+            CVarDef.Create("atmos.mmos_max_wind", 500f, CVar.SERVERONLY);
+
+        /// <summary>
         ///     Whether atmos superconduction is enabled.
         /// </summary>
         /// <remarks> Disabled by default, superconduction is awful. </remarks>


### PR DESCRIPTION
## About the PR
Moves the constants that control monstermos slow spacing into CCVars.

## Why / Balance
#19837 proposes reverting slow spacing. I think slow spacing is salvageable, and allows spacing that's faster than LINDA-only but not as fast as instant-spacing. We should give server operators the flexibility to chose.

## Technical details

- Move the constants from Atmospherics to real CCVars
- Adjust the calculation for the mole fraction to remove, so that the entire feature can be disabled by setting the CCVar to 1

## Media

https://github.com/space-wizards/space-station-14/assets/3229565/e27c058c-a3c0-4252-99cd-2a6332d50cd5

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
N/A