### PR TITLE
Add cryogenic gas tanks

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-atmospherics.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-atmospherics.ftl
@@ -9,3 +9,12 @@ ent-AtmosphericsNitrogen = { ent-NitrogenCanister }
 
 ent-AtmosphericsCarbonDioxide = { ent-CarbonDioxideCanister }
     .desc = { ent-CarbonDioxideCanister.desc }
+
+ent-AtmosphericsLiquidOxygen = { ent-LiquidOxygenCanister }
+    .desc = { ent-LiquidOxygenCanister.desc }
+
+ent-AtmosphericsLiquidNitrogen = { ent-LiquidNitrogenCanister }
+    .desc = { ent-LiquidNitrogenCanister.desc }
+
+ent-AtmosphericsLiquidCarbonDioxide = { ent-LiquidCarbonDioxideCanister }
+    .desc = { ent-LiquidCarbonDioxideCanister.desc }

--- a/Resources/Locale/en-US/prototypes/entities/structures/storage/canisters/gas-canisters.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/storage/canisters/gas-canisters.ftl
@@ -10,11 +10,20 @@ ent-AirCanister = Air canister
 ent-OxygenCanister = Oxygen canister
     .desc = A canister that can contain any type of gas. This one is supposed to contain oxygen. It can be attached to connector ports using a wrench.
 
+ent-LiquidOxygenCanister = Liquid oxygen canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain liquid oxygen. It can be attached to connector ports using a wrench.
+
 ent-NitrogenCanister = Nitrogen canister
     .desc = A canister that can contain any type of gas. This one is supposed to contain nitrogen. It can be attached to connector ports using a wrench.
 
+ent-LiquidNitrogenCanister = Liquid nitrogen canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain liquid nitrogen. It can be attached to connector ports using a wrench.
+
 ent-CarbonDioxideCanister = Carbon dioxide canister
     .desc = A canister that can contain any type of gas. This one is supposed to contain carbon dioxide. It can be attached to connector ports using a wrench.
+
+ent-LiquidCarbonDioxideCanister = Liquid carbon dioxide canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain liquid carbon dioxide. It can be attached to connector ports using a wrench.
 
 ent-PlasmaCanister = Plasma canister
     .desc = A canister that can contain any type of gas. This one is supposed to contain plasma. It can be attached to connector ports using a wrench.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -24,7 +24,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: LiquidOxygenCanister
-  cost: 11000
+  cost: 2500
   category: Atmospherics
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: LiquidNitrogenCanister
-  cost: 11000
+  cost: 2500
   category: Atmospherics
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: LiquidCarbonDioxideCanister
-  cost: 22000 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
+  cost: 4000
   category: Atmospherics
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -19,6 +19,16 @@
   group: market
 
 - type: cargoProduct
+  id: AtmosphericsLiquidOxygen
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: blue
+  product: LiquidOxygenCanister
+  cost: 11000
+  category: Atmospherics
+  group: market
+
+- type: cargoProduct
   id: AtmosphericsNitrogen
   icon:
     sprite: Structures/Storage/canister.rsi
@@ -29,12 +39,32 @@
   group: market
 
 - type: cargoProduct
+  id: AtmosphericsLiquidNitrogen
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: red
+  product: LiquidNitrogenCanister
+  cost: 11000
+  category: Atmospherics
+  group: market
+
+- type: cargoProduct
   id: AtmosphericsCarbonDioxide
   icon:
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
   cost: 2200 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
+  category: Atmospherics
+  group: market
+
+- type: cargoProduct
+  id: AtmosphericsLiquidCarbonDioxide
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: black
+  product: LiquidCarbonDioxideCanister
+  cost: 22000 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
   category: Atmospherics
   group: market
 

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -220,6 +220,17 @@
       - !type:DumpCanisterBehavior
 
 - type: entity
+  id: LiquidOxygenCanister
+  parent: OxygenCanister
+  components:
+  - type: GasCanister
+    gasMixture:
+      volume: 1000
+      moles:
+        - 18710.71051 # oxygen
+      temperature: 72
+
+- type: entity
   parent: GasCanister
   id: NitrogenCanister
   components:
@@ -256,6 +267,18 @@
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
         - !type:DumpCanisterBehavior
+
+- type: entity
+  id: LiquidNitrogenCanister
+  parent: NitrogenCanister
+  components:
+  - type: GasCanister
+    gasMixture:
+      volume: 1000
+      moles:
+        - 0 # oxygen
+        - 18710.71051 # nitrogen
+      temperature: 72
 
 - type: entity
   parent: GasCanister
@@ -297,6 +320,19 @@
         - !type:DumpCanisterBehavior
     - type: Lock
       locked: true
+
+- type: entity
+  id: LiquidCarbonDioxideCanister
+  parent: CarbonDioxideCanister
+  components:
+  - type: GasCanister
+    gasMixture:
+      volume: 1000
+      moles:
+        - 0 # oxygen
+        - 0 # nitrogen
+        - 18710.71051 # CO2
+      temperature: 72
 
 - type: entity
   parent: GasCanister

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -229,6 +229,8 @@
       moles:
         - 18710.71051 # oxygen
       temperature: 72
+  - type: AccessReader
+    access: [["Atmospherics"]]
 
 - type: entity
   parent: GasCanister
@@ -279,6 +281,8 @@
         - 0 # oxygen
         - 18710.71051 # nitrogen
       temperature: 72
+  - type: AccessReader
+    access: [["Atmospherics"]]
 
 - type: entity
   parent: GasCanister
@@ -333,6 +337,8 @@
         - 0 # nitrogen
         - 18710.71051 # CO2
       temperature: 72
+  - type: AccessReader
+    access: [["Atmospherics"]]
 
 - type: entity
   parent: GasCanister


### PR DESCRIPTION
## About the PR
This adds cryogenic versions of the oxygen, nitrogen, and carbon dioxide gas canisters. Cryogenic gas tanks store gases at cryogenic temperatures and need to be heated before being pumped to distro, but on the plus side hold 10x more gas.

## Why / Balance
In preparation for [gas miners to be phased out](https://discord.com/channels/310555209753690112/770682801607278632/1143586109486530620), the station is going to need a way to reorder larger quantities of gas. This is the same capacity increase as #11242, but instead of increasing volume, this decreases the temperature to give a tradeoff for using these types of canisters.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: notafet
- add: Cryogenic gas cylinders are now available for purchase from cargo.