### PR TITLE
mech filtering handles nitrogen overflow

### DIFF
--- a/Content.Server/Mech/Components/MechAirFilterComponent.cs
+++ b/Content.Server/Mech/Components/MechAirFilterComponent.cs
@@ -15,6 +15,23 @@ public sealed partial class MechAirFilterComponent : Component
     public HashSet<Gas> Gases = new();
 
     /// <summary>
+    /// Gases that will be filtered when above <see cref="OverflowPressure"/>.
+    /// Replaces <see cref="Gases"/> when overflowing.
+    /// </summary>
+    /// <remarks>
+    /// This is intended for nitrogen to be removed at full pressure so as more
+    /// air is replaced oxygen doesn't tend towards 0 as more nitrogen is added
+    /// but not breathed by the animal.
+    /// </remarks>
+    [DataField("overflowGases", required: true)]
+    public HashSet<Gas> OverflowGases = new();
+
+    /// <summary>
+    /// Pressure to filter <see cref="OverflowGases"/> at.
+    /// </summary>
+    public float OverflowPressure = 100f;
+
+    /// <summary>
     /// Target volume to transfer every second.
     /// </summary>
     [DataField("transferRate")]

--- a/Content.Server/Mech/Components/MechAirFilterComponent.cs
+++ b/Content.Server/Mech/Components/MechAirFilterComponent.cs
@@ -35,5 +35,5 @@ public sealed partial class MechAirFilterComponent : Component
     /// Target volume to transfer every second.
     /// </summary>
     [DataField("transferRate")]
-    public float TransferRate = MechAirComponent.GasMixVolume * 0.1f;
+    public float TransferRate = MechAirComponent.GasMixVolume * 0.2f;
 }

--- a/Content.Server/Mech/Systems/MechSystem.Filtering.cs
+++ b/Content.Server/Mech/Systems/MechSystem.Filtering.cs
@@ -55,7 +55,6 @@ public sealed partial class MechSystem
         if (MathHelper.CloseToPercent(removed.TotalMoles, 0f))
             return;
 
-
         var coordinates = Transform(uid).MapPosition;
         GasMixture? destination = null;
         if (_map.TryFindGridAt(coordinates, out _, out var grid))
@@ -64,9 +63,12 @@ public sealed partial class MechSystem
             destination = _atmosphere.GetTileMixture(tile.GridUid, null, tile.GridIndices, true);
         }
 
+        // only scrub OverflowGases when above OverflowPressure
+        var overflow = mechAir.Air.Pressure > filter.OverflowPressure;
+
         if (destination != null)
         {
-            _atmosphere.ScrubInto(removed, destination, filter.Gases);
+            _atmosphere.ScrubInto(removed, destination, overflow ? filter.OverflowGases : filter.Gases);
         }
         else
         {

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -17,6 +17,17 @@
     - 7
     - 8
     #- 9 TODO: fusion
+    overflowGases:
+    # remove nitrogen in overflow
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    #- 9 TODO: fusion
   - type: MechAirIntake
   # for intake and filter to work
   - type: AtmosDevice


### PR DESCRIPTION
## About the PR
when above 100kPa it will filter out nitrogen as well as bad stuff, to counteract the oxygen ratio skewing from breathing only oxygen
also doubled filtering speed so it can keep up with breathing

it could be sidestepped if air was changed to be a thing where you take in oxygen and nitrogen and output co2 and nitrogen separately, then recycle nitrogen to maintain pressure, but too much work

fixes #19863

## Why / Balance
bug permanently making vim death trap

## Technical details
when above `Overflow` pressure, switches from filtering `Gases` to `OverflowGases`, which for base mech includes nitrogen.

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun