### PR TITLE
Assign a default value to ClickDamageModifier

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -75,7 +75,7 @@ public sealed partial class MeleeWeaponComponent : Component
     /// Multiplies damage by this amount for single-target attacks.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("clickDamageModifier")]
-    public FixedPoint2 ClickDamageModifier;
+    public FixedPoint2 ClickDamageModifier = FixedPoint2.New(1);
 
     // TODO: Temporarily 1.5 until interactionoutline is adjusted to use melee, then probably drop to 1.2
     /// <summary>


### PR DESCRIPTION
As I wrote in [a comment](https://github.com/space-wizards/space-station-14/pull/19860#issuecomment-1708086646) on #19860, without a value, `ClickDamageModifier` becomes 0, negating all click damage. You can't even kill a mouse with your bare hands!

Judging by the text in #19860, the value is intended to default to 1, i.e. no buff.