### PR TITLE
move advanced laser gun into t3 lasers tech

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -34,12 +34,13 @@ research-technology-cloning = Cloning
 research-technology-salvage-weapons = Salvage Weapons
 research-technology-draconic-munitions = Draconic Munitions
 research-technology-explosive-technology = Explosive Technology
-research-technology-advanced-laser-manipulation = Advanced Laser Manipulation
+research-technology-weaponized-laser-manipulation = Weaponized Laser Manipulation
 research-technology-nonlethal-ammunition = Nonlethal Ammunition
 research-technology-concentrated-laser-weaponry = Concentrated Laser Weaponry
 research-technology-wave-particle-harnessing = Wave Particle Harnessing
 research-technology-advanced-riot-control = Advanced Riot Control
 research-technology-handheld-electrical-propulsion = Handheld Electrical Propulsion
+research-technology-portable-microfusion-weaponry = Portable Microfusion Weaponry
 
 research-technology-basic-robotics = Basic Robotics
 research-technology-basic-anomalous-research = Basic Anomalous Research

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -56,14 +56,13 @@
   id: AdvancedLaserManipulation
   name: research-technology-advanced-laser-manipulation
   icon:
-    sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
+    sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
     state: icon
   discipline: Arsenal
   tier: 1
-  cost: 10000
+  cost: 7500
   recipeUnlocks:
   - WeaponLaserCarbine
-  - WeaponAdvancedLaser
 
 - type: technology
   id: NonlethalAmmunition
@@ -91,12 +90,13 @@
   id: ConcentratedLaserWeaponry
   name: research-technology-concentrated-laser-weaponry
   icon:
-    sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
+    sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
     state: icon
   discipline: Arsenal
   tier: 2
   cost: 10000
   recipeUnlocks:
+  - WeaponAdvancedLaser
   - WeaponLaserCannon
 
 - type: technology

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -53,8 +53,8 @@
   - ExplosivePayload
 
 - type: technology
-  id: AdvancedLaserManipulation
-  name: research-technology-advanced-laser-manipulation
+  id: WeaponizedLaserManipulation
+  name: research-technology-weaponized-laser-manipulation
   icon:
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
     state: icon
@@ -90,13 +90,12 @@
   id: ConcentratedLaserWeaponry
   name: research-technology-concentrated-laser-weaponry
   icon:
-    sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
+    sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
     state: icon
   discipline: Arsenal
   tier: 2
   cost: 10000
   recipeUnlocks:
-  - WeaponAdvancedLaser
   - WeaponLaserCannon
 
 - type: technology
@@ -136,3 +135,15 @@
   cost: 15000
   recipeUnlocks:
   - WeaponTaser
+
+- type: technology
+  id: PortableMicrofusionWeaponry
+  name: research-technology-portable-microfusion-weaponry
+  icon:
+    sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
+    state: icon
+  discipline: Arsenal
+  tier: 3
+  cost: 15000
+  recipeUnlocks:
+  - WeaponAdvancedLaser


### PR DESCRIPTION
## About the PR
moved it from Advanced Laser Manipulation (renamed to Weaponized Laser Manipulation since sounds good) into its own t3 tech

## Why / Balance
doesnt make sense for what is essentially the antique laser gun to be available as the first thing you research
its t3 so same level as taser, its basically antique laser gun

## Technical details
no

## Media
![11:43:11](https://github.com/space-wizards/space-station-14/assets/39013340/f434871b-99b8-4610-b72c-45f70b61f078)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Advanced Laser Guns are now in the Tier 3 Portable Microfusion Weaponry research.