### PR TITLE
Hypo can inject solutions back into beakers

### DIFF
--- a/Content.Server/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Server/Chemistry/Components/HyposprayComponent.cs
@@ -19,5 +19,11 @@ namespace Content.Server.Chemistry.Components
 
         [DataField("injectSound")]
         public SoundSpecifier InjectSound = new SoundPathSpecifier("/Audio/Items/hypospray.ogg");
+
+        /// <summary>
+        /// Whether or not the hypo is able to inject only into mobs. On false you can inject into beakers/jugs
+        /// </summary>
+        [DataField("onlyMobs")]
+        public bool OnlyMobs = true;
     }
 }

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
@@ -74,7 +74,7 @@ namespace Content.Server.Chemistry.EntitySystems
             if (!Resolve(uid, ref component))
                 return false;
 
-            if (!EligibleEntity(target, _entMan))
+            if (!EligibleEntity(target, _entMan, component))
                 return false;
 
             if (TryComp(uid, out UseDelayComponent? delayComp) && _useDelay.ActiveDelay(uid, delayComp))
@@ -84,7 +84,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
             if (target == user)
                 msgFormat = "hypospray-component-inject-self-message";
-            else if (EligibleEntity(user, _entMan) && _interaction.TryRollClumsy(user, component.ClumsyFailChance))
+            else if (EligibleEntity(user, _entMan, component) && _interaction.TryRollClumsy(user, component.ClumsyFailChance))
             {
                 msgFormat = "hypospray-component-inject-self-clumsy-message";
                 target = user;
@@ -143,13 +143,15 @@ namespace Content.Server.Chemistry.EntitySystems
             return true;
         }
 
-        static bool EligibleEntity([NotNullWhen(true)] EntityUid? entity, IEntityManager entMan)
+        static bool EligibleEntity([NotNullWhen(true)] EntityUid? entity, IEntityManager entMan, HyposprayComponent component)
         {
             // TODO: Does checking for BodyComponent make sense as a "can be hypospray'd" tag?
             // In SS13 the hypospray ONLY works on mobs, NOT beakers or anything else.
             // But this is 14, we dont do what SS13 does just because SS13 does it.
-
-            return entMan.HasComponent<SolutionContainerManagerComponent>(entity);
+            return component.OnlyMobs
+                ? entMan.HasComponent<SolutionContainerManagerComponent>(entity) &&
+                  entMan.HasComponent<MobStateComponent>(entity)
+                : entMan.HasComponent<SolutionContainerManagerComponent>(entity);
         }
     }
 }

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
@@ -147,9 +147,9 @@ namespace Content.Server.Chemistry.EntitySystems
         {
             // TODO: Does checking for BodyComponent make sense as a "can be hypospray'd" tag?
             // In SS13 the hypospray ONLY works on mobs, NOT beakers or anything else.
+            // But this is 14, we dont do what SS13 does just because SS13 does it.
 
-            return entMan.HasComponent<SolutionContainerManagerComponent>(entity)
-                && entMan.HasComponent<MobStateComponent>(entity);
+            return entMan.HasComponent<SolutionContainerManagerComponent>(entity);
         }
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -47,6 +47,7 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+    onlyMobs: false
   - type: UseDelay
     delay: 0.5
 
@@ -331,6 +332,7 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+    onlyMobs: false
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -18,6 +18,7 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+    onlyMobs: false
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This allows Hypopens/Sprays to inject their solutions in beakers/anything that can carry the liquid

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This was mostly for HypoSpray, right now if you put a bit too many chems in the Hypospray you just have to find something to inject, this can just let you empty your spray back in the jug.

~~This though buffs hypopens so that their solution can also be injected. I was unsure if this would be bad so I decided to wait for reviewers to tell me to potentially make a component to allow the old behavior.~~

nevermind

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Nearly forgot to mention, since of ALL the comments below I added a new component to hypospray called `mobOnly` by default it's `true` which means everything will have the old behavior still. But in this pr I set the hypospray item to `false` which will let you inject into beakers.

If you think medipens should be able to inject themselves into beakers then just change the default value to false or add the component 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: Vasilis
- tweak: Changed fun!
-->

:cl: Vasilis
- tweak: Hyposprays can inject their solutions back into beakers/jugs/whatever can hold the solution.
