### PR TITLE
fix weldable

### DIFF
--- a/Content.Server/Construction/Conditions/StorageWelded.cs
+++ b/Content.Server/Construction/Conditions/StorageWelded.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Construction.Conditions
 
         public bool Condition(EntityUid uid, IEntityManager entityManager)
         {
-            return entityManager.System<WeldableSystem>().IsWelded(uid);
+            return entityManager.System<WeldableSystem>().IsWelded(uid) == Welded;
         }
 
         public bool DoExamine(ExaminedEvent args)


### PR DESCRIPTION
## About the PR
fixes #19874

## Why / Balance
bug

## Technical details
the condition was inverted because `== Welded` got removed in refactor
this just adds it back

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/8c49adb2-128a-444b-91af-0b1cdf0f242c


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
on

**Changelog**
:cl:
- fix: Fixes crates requiring to be welded to deconstruct them.
