### PR TITLE
Gas tank output pressure limit

### DIFF
--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -48,6 +48,12 @@ namespace Content.Server.Atmos.Components
         public float OutputPressure = DefaultOutputPressure;
 
         /// <summary>
+        ///     The maximum allowed output pressure.
+        /// </summary>
+        [DataField("maxOutputPressure"), ViewVariables(VVAccess.ReadWrite)]
+        public float MaxOutputPressure = 3 * DefaultOutputPressure;
+
+        /// <summary>
         ///     Tank is connected to internals.
         /// </summary>
         [ViewVariables]

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -69,7 +69,12 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnGasTankSetPressure(EntityUid uid, GasTankComponent component, GasTankSetPressureMessage args)
         {
-            component.OutputPressure = args.Pressure;
+            var pressure = Math.Min(args.Pressure, component.MaxOutputPressure);
+
+            component.OutputPressure = pressure;
+
+            // Why isn't this working?
+            UpdateUserInterface(component, true);
         }
 
         public void UpdateUserInterface(GasTankComponent component, bool initialUpdate = false)

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -73,7 +73,6 @@ namespace Content.Server.Atmos.EntitySystems
 
             component.OutputPressure = pressure;
 
-            // Why isn't this working?
             UpdateUserInterface(component, true);
         }
 


### PR DESCRIPTION
## About the PR
All types of gas tanks now have a max output pressure value of 304 kPa, so internals cannot be changed beyond (what would be) a safe range.
Not related to the release pressure of canisters, which is unaffected


![Screenshot from 2023-09-06 20-54-33](https://github.com/space-wizards/space-station-14/assets/35878406/fa75384d-b936-4508-afd1-fd4a7ab324c0)


## Why / Balance
It is currently possible to set gas tanks to any arbitrarily high output pressure, and inhale their entire volume in one breath, only to discover this somehow does not kill you. By limiting the output pressure to a humanoid-safe range (keeping in mind we are painting with broad strokes, don't come at me with scuba diving documentation), this change somewhat masks this missing barotrauma functionality, and in case such code gets added it will prevent inexperienced or malicious crewmembers from setting any standard issue company gas tank to be instantly crippling/lethal. If desired, it will still be possible to include ways to sabotage the safety on specific gas tanks, or have certain prototypes spawn with a higher output limit

Alternatively, this makes it possible to create inferior gas tanks which can't output the required 21 kPa oxygen/nitrogen pressure, so using them causes gasping and a slow gradual buildup of asphyxiation

## Technical details
No prototypes were modified, all current ones inherit a default value ( 3 x atmospheric pressure ) from GasTankComponent
