### PR TITLE
Craftable steel secure crate

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
@@ -8,9 +8,9 @@
           steps:
             - material: Steel
               amount: 5
-              doAfter: 5
             - material: Cable
               amount: 2
+              doAfter: 5
 
 
     - node: cratesecure

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
@@ -9,6 +9,8 @@
             - material: Steel
               amount: 5
               doAfter: 5
+            - material: Cable
+              amount: 2
 
 
     - node: cratesecure
@@ -19,13 +21,14 @@
             - tool: Screwing
               doAfter: 5
           conditions:
-            - !type:StorageWelded
-              welded: false
             - !type:Locked
               locked: false
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 5
+            - !type:SpawnPrototype
+              prototype: CableApcStack1
+              amount: 2
             - !type:EmptyAllContainers
             - !type:DeleteEntity

--- a/Resources/Prototypes/Recipes/Crafting/crates.yml
+++ b/Resources/Prototypes/Recipes/Crafting/crates.yml
@@ -21,6 +21,17 @@
   objectType: Structure
 
 - type: construction
+  name: secure crate
+  id: CrateSecure
+  graph: CrateSecure
+  startNode: start
+  targetNode: cratesecure
+  category: construction-category-storage
+  description: A secure metal crate for storing things. Requires no special access, can be configured with an Access Configurator.
+  icon: { sprite: Structures/Storage/Crates/secure.rsi, state: icon }
+  objectType: Structure
+
+- type: construction
   name: plastic crate
   id: CratePlastic
   graph: CratePlastic


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added the secure crate as a craftable structure, with the additional requirement of 2 LV cable.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Currently secure crates are to my knowledge only accessible by cargo order, and only with paints and respective access. With the relatively recent addition of Access Configurators, the unpainted secure crates can now be locked to certain access after creation, instead of being a weird extra step for an otherwise completely unsecure box.

This also sets up for the idea of a crate painter, as discussed in the #ideamen channel in discord.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Interestingly the graph already existed for it, effectively being a duplicate of `CrateGenericSteel`. I just made minor tweaks; the material cost needing (and decrafting to) 2 cables, and since the secure steel crate cannot be welded shut with my testing, I also removed the `!type:StorageWelded` check. 
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![dotnet_WfC4fmrgZ9](https://github.com/space-wizards/space-station-14/assets/33369477/0beaefba-7c24-4ecd-9b81-cf55ae8c1486)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
nope
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Secure crates are now craftable with 5 steel and 2 LV cable
