### PR TITLE
FTL on a spaced tile yeets instead of gibs

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -529,9 +529,6 @@ public sealed partial class ShuttleSystem
             var foo = childXform.LocalPosition - shuttleBody.LocalCenter;
             _throwing.TryThrow(tossed, foo.Normalized() * 10.0f, 50.0f);
         }
-
-
-
     }
 
     /// <summary>

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Stunnable;
 using Content.Shared.GameTicking;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Shuttles.Systems;
+using Content.Shared.Throwing;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
@@ -36,6 +37,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
     [Dependency] private readonly ShuttleConsoleSystem _console = default!;
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly StunSystem _stuns = default!;
+    [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly ThrusterSystem _thruster = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;


### PR DESCRIPTION
## About the PR
Being on a space tile when FTL starts or ends currently gibs you. This changes it so you're instead thrownaway from the shuttle center, if you're not buckled.

## Why / Balance
Being on any shuttle with lattice on the interior deletes you from the game with no warning. A character on a shuttle that's been bombed getting gibbed, a salvager on the wrong tile, a number of situations that should be recoverable instead result in instant death. 
As the reason of this was originally done to avoid people riding shuttles on the outside, this still solves that issue without impacting the gameplay of other shuttle usage.

## Technical details
On FTL, if unbuckled and dropped down, check if the body is on a spaced tile, and if so, throw the body in a direction away from the shuttle.

## Media

https://github.com/space-wizards/space-station-14/assets/3650235/8efefcd2-cddb-4370-b8fd-d4c7737b5603


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.

- 
-->
:cl:
- tweak: FTL transit on damaged shuttles is not lethal anymore, but passengers should still hold on tight and remain inside the vehicle.
