### PR TITLE
Fix replay recording temporary paths not supporting subdirectories 

### DIFF
--- a/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
+++ b/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
@@ -43,8 +43,8 @@ public sealed class ReplayTests
         // Reset cvars
         server.CfgMan.SetCVar(CVars.ReplayServerRecordingEnabled, false);
         server.CfgMan.SetCVar(CCVars.ReplayAutoRecord, autoRec);
-        server.CfgMan.SetCVar(CCVars.ReplayAutoRecordTempDir, autoRecName);
-        server.CfgMan.SetCVar(CCVars.ReplayAutoRecordName, tempDir);
+        server.CfgMan.SetCVar(CCVars.ReplayAutoRecordTempDir, tempDir);
+        server.CfgMan.SetCVar(CCVars.ReplayAutoRecordName, autoRecName);
 
         // Restart the round again to disable the current recording.
         await server.WaitPost(() => ticker.RestartRound());

--- a/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
+++ b/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
@@ -1,0 +1,57 @@
+using Content.Server.GameTicking;
+using Content.Shared.CCVar;
+using Robust.Shared;
+using Robust.Shared.Replays;
+
+namespace Content.IntegrationTests.Tests.Replays;
+
+[TestFixture]
+public sealed class ReplayTests
+{
+    /// <summary>
+    /// Simple test that just makes sure that replays auto recording on round restarts works without any issues.
+    /// </summary>
+    [Test]
+    public async Task AutoRecordReplayTest()
+    {
+        var settings = new PoolSettings {DummyTicker = false};
+        await using var pair = await PoolManager.GetServerClient(settings);
+        var server = pair.Server;
+
+        Assert.That(server.CfgMan.GetCVar(CVars.ReplayServerRecordingEnabled), Is.False);
+        var recordMan = server.ResolveDependency<IReplayRecordingManager>();
+        Assert.That(recordMan.IsRecording, Is.False);
+
+        var autoRec = server.CfgMan.GetCVar(CCVars.ReplayAutoRecord);
+        var autoRecName = server.CfgMan.GetCVar(CCVars.ReplayAutoRecordName);
+        var tempDir = server.CfgMan.GetCVar(CCVars.ReplayAutoRecordTempDir);
+
+        // Setup auto record cvars.
+        server.CfgMan.SetCVar(CVars.ReplayServerRecordingEnabled, true);
+        server.CfgMan.SetCVar(CCVars.ReplayAutoRecord, true);
+        server.CfgMan.SetCVar(CCVars.ReplayAutoRecordTempDir, "/a/b/");
+        server.CfgMan.SetCVar(CCVars.ReplayAutoRecordName, $"c/d/{autoRecName}");
+
+        var ticker = server.System<GameTicker>();
+
+        await server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(25);
+        Assert.That(recordMan.IsRecording, Is.True);
+
+        await server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(25);
+        Assert.That(recordMan.IsRecording, Is.True);
+
+        // Reset cvars
+        server.CfgMan.SetCVar(CVars.ReplayServerRecordingEnabled, false);
+        server.CfgMan.SetCVar(CCVars.ReplayAutoRecord, autoRec);
+        server.CfgMan.SetCVar(CCVars.ReplayAutoRecordTempDir, autoRecName);
+        server.CfgMan.SetCVar(CCVars.ReplayAutoRecordName, tempDir);
+
+        await server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(25);
+        Assert.That(recordMan.IsRecording, Is.False);
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
+++ b/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
@@ -21,23 +21,21 @@ public sealed class ReplayTests
         Assert.That(server.CfgMan.GetCVar(CVars.ReplayServerRecordingEnabled), Is.False);
         var recordMan = server.ResolveDependency<IReplayRecordingManager>();
         Assert.That(recordMan.IsRecording, Is.False);
-
+        
+        // Setup cvars.
         var autoRec = server.CfgMan.GetCVar(CCVars.ReplayAutoRecord);
         var autoRecName = server.CfgMan.GetCVar(CCVars.ReplayAutoRecordName);
         var tempDir = server.CfgMan.GetCVar(CCVars.ReplayAutoRecordTempDir);
-
-        // Setup auto record cvars.
         server.CfgMan.SetCVar(CVars.ReplayServerRecordingEnabled, true);
         server.CfgMan.SetCVar(CCVars.ReplayAutoRecord, true);
         server.CfgMan.SetCVar(CCVars.ReplayAutoRecordTempDir, "/a/b/");
         server.CfgMan.SetCVar(CCVars.ReplayAutoRecordName, $"c/d/{autoRecName}");
 
+        // Restart the round a few times
         var ticker = server.System<GameTicker>();
-
         await server.WaitPost(() => ticker.RestartRound());
         await pair.RunTicksSync(25);
         Assert.That(recordMan.IsRecording, Is.True);
-
         await server.WaitPost(() => ticker.RestartRound());
         await pair.RunTicksSync(25);
         Assert.That(recordMan.IsRecording, Is.True);
@@ -48,6 +46,7 @@ public sealed class ReplayTests
         server.CfgMan.SetCVar(CCVars.ReplayAutoRecordTempDir, autoRecName);
         server.CfgMan.SetCVar(CCVars.ReplayAutoRecordName, tempDir);
 
+        // Restart the round again to disable the current recording.
         await server.WaitPost(() => ticker.RestartRound());
         await pair.RunTicksSync(25);
         Assert.That(recordMan.IsRecording, Is.False);

--- a/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
+++ b/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
@@ -21,7 +21,7 @@ public sealed class ReplayTests
         Assert.That(server.CfgMan.GetCVar(CVars.ReplayServerRecordingEnabled), Is.False);
         var recordMan = server.ResolveDependency<IReplayRecordingManager>();
         Assert.That(recordMan.IsRecording, Is.False);
-        
+
         // Setup cvars.
         var autoRec = server.CfgMan.GetCVar(CCVars.ReplayAutoRecord);
         var autoRecName = server.CfgMan.GetCVar(CCVars.ReplayAutoRecordName);

--- a/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
+++ b/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
@@ -9,7 +9,7 @@ namespace Content.IntegrationTests.Tests.Replays;
 public sealed class ReplayTests
 {
     /// <summary>
-    /// Simple test that just makes sure that replays auto recording on round restarts works without any issues.
+    /// Simple test that just makes sure that automatic replay recording on round restarts works without any issues.
     /// </summary>
     [Test]
     public async Task AutoRecordReplayTest()

--- a/Content.Server/GameTicking/GameTicker.Replays.cs
+++ b/Content.Server/GameTicking/GameTicker.Replays.cs
@@ -72,13 +72,14 @@ public sealed partial class GameTicker
         if (data.State is not ReplayRecordState state)
             return;
 
-        if (state.MoveToPath != null)
-        {
-            _sawmillReplays.Info($"Moving replay into final position: {state.MoveToPath}");
+        if (state.MoveToPath == null)
+            return;
 
-            _taskManager.BlockWaitOnTask(_replays.WaitWriteTasks());
-            data.Directory.Rename(data.Path, state.MoveToPath.Value);
-        }
+        _sawmillReplays.Info($"Moving replay into final position: {state.MoveToPath}");
+        _taskManager.BlockWaitOnTask(_replays.WaitWriteTasks());
+        DebugTools.Assert(!_replays.IsWriting());
+        data.Directory.CreateDir(state.MoveToPath.Value.Directory);
+        data.Directory.Rename(data.Path, state.MoveToPath.Value);
     }
 
     private ResPath GetAutoReplayPath()

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1748,6 +1748,7 @@ namespace Content.Shared.CCVar
         /// <summary>
         /// Path that, if provided, automatic replays are initially recorded in.
         /// When the recording is done, the file is moved into its final destination.
+        /// Unless this path is rooted, it will be relative to <see cref="CVars.ReplayDirectory"/>.
         /// </summary>
         public static readonly CVarDef<string> ReplayAutoRecordTempDir =
             CVarDef.Create("replay.auto_record_temp_dir", "", CVar.SERVERONLY);


### PR DESCRIPTION
This should fix the bug described in #19002 by adding a `CreateDir()` call when moving replay files from the temporary directory.

This also adds a basic test, and thus:
Requires space-wizards/RobustToolbox/pull/4354