### PR TITLE
show non-sheet material units in lathe

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -71,11 +71,7 @@ public sealed partial class LatheMenu : DefaultWindow
             if (!_prototypeManager.TryIndex(materialId, out MaterialPrototype? material))
                 continue;
 
-            var unit = Loc.GetString(material.Unit);
-            var amountText = Loc.GetString("lathe-menu-material-amount", ("amount", volume / 100), ("unit", unit));
-            var name = Loc.GetString(material.Name);
-            var mat = Loc.GetString("lathe-menu-material-display", ("material", name), ("amount", amountText));
-            var volumePerSheet = 0;
+            var volumePerSheet = 100;
             var maxEjectableSheets = 0;
 
             if (material.StackEntity != null)
@@ -88,6 +84,11 @@ public sealed partial class LatheMenu : DefaultWindow
                     maxEjectableSheets = (int) MathF.Floor((float) volume / volumePerSheet);
                 }
             }
+
+            var unit = Loc.GetString(material.Unit);
+            var amountText = Loc.GetString("lathe-menu-material-amount", ("amount", volume / volumePerSheet), ("unit", unit));
+            var name = Loc.GetString(material.Name);
+            var mat = Loc.GetString("lathe-menu-material-display", ("material", name), ("amount", amountText));
 
             var row = new LatheMaterialEjector(materialId, OnEjectPressed, volumePerSheet, maxEjectableSheets)
             {

--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -71,9 +71,10 @@ public sealed partial class LatheMenu : DefaultWindow
             if (!_prototypeManager.TryIndex(materialId, out MaterialPrototype? material))
                 continue;
 
+            var unit = Loc.GetString(material.Unit);
+            var amountText = Loc.GetString("lathe-menu-material-amount", ("amount", volume / 100), ("unit", unit));
             var name = Loc.GetString(material.Name);
-            var mat = Loc.GetString("lathe-menu-material-display",
-                ("material", name), ("amount", volume / 100));
+            var mat = Loc.GetString("lathe-menu-material-display", ("material", name), ("amount", amountText));
             var volumePerSheet = 0;
             var maxEjectableSheets = 0;
 
@@ -152,9 +153,10 @@ public sealed partial class LatheMenu : DefaultWindow
 
                 var adjustedAmount = SharedLatheSystem.AdjustMaterial(amount, prototype.ApplyMaterialDiscount, component.MaterialUseMultiplier);
 
-                sb.Append(Loc.GetString("lathe-menu-tooltip-display",
-                    ("amount", MathF.Round(adjustedAmount / 100f, 2)),
-                    ("material", Loc.GetString(proto.Name))));
+                var unit = Loc.GetString(proto.Unit);
+                var amountText = Loc.GetString("lathe-menu-material-amount", ("amount", MathF.Round(adjustedAmount / 100f)), ("unit", unit));
+                var name = Loc.GetString(proto.Name);
+                sb.Append(Loc.GetString("lathe-menu-tooltip-display", ("material", name), ("amount", amountText)));
             }
 
             var icon = prototype.Icon == null

--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -26,6 +26,11 @@ public sealed partial class LatheMenu : DefaultWindow
     public event Action<string, int>? OnEjectPressed;
     public List<string> Recipes = new();
 
+    /// <summary>
+    /// Default volume for a sheet if the material's entity prototype has no material composition.
+    /// </summary>
+    private const int DEFAULT_SHEET_VOLUME = 100;
+
     public LatheMenu(LatheBoundUserInterface owner)
     {
         RobustXamlLoader.Load(this);
@@ -72,11 +77,11 @@ public sealed partial class LatheMenu : DefaultWindow
                 continue;
 
             var sheetVolume = SheetVolume(material);
-            // rounded here not in locale since doesn't make sense to show 0.5 sheets if you cant eject it
-            var maxEjectableSheets = (int) MathF.Floor((float) volume / sheetVolume);
+            var sheets = (float) volume / sheetVolume;
+            var maxEjectableSheets = (int) MathF.Floor(sheets);
 
             var unit = Loc.GetString(material.Unit);
-            var amountText = Loc.GetString("lathe-menu-material-amount", ("amount", maxEjectableSheets), ("unit", unit));
+            var amountText = Loc.GetString("lathe-menu-material-amount", ("amount", sheets), ("unit", unit));
             var name = Loc.GetString(material.Name);
             var mat = Loc.GetString("lathe-menu-material-display", ("material", name), ("amount", amountText));
 
@@ -201,12 +206,12 @@ public sealed partial class LatheMenu : DefaultWindow
     private int SheetVolume(MaterialPrototype material)
     {
         if (material.StackEntity == null)
-            return 100;
+            return DEFAULT_SHEET_VOLUME;
 
         var proto = _prototypeManager.Index<EntityPrototype>(material.StackEntity);
 
         if (!proto.TryGetComponent<PhysicalCompositionComponent>(out var composition))
-            return 100;
+            return DEFAULT_SHEET_VOLUME;
 
         return composition.MaterialComposition.FirstOrDefault(kvp => kvp.Key == material.ID).Value;
     }

--- a/Content.Shared/Materials/MaterialPrototype.cs
+++ b/Content.Shared/Materials/MaterialPrototype.cs
@@ -33,7 +33,15 @@ namespace Content.Shared.Materials
         public string? StackEntity;
 
         [DataField("name")]
-        public string Name = "";
+        public string Name = string.Empty;
+
+        /// <summary>
+        /// Locale id for the unit of this material.
+        /// Lathe recipe tooltips and material storage display use this to let you change a material to sound nicer.
+        /// For example, 5 bars of gold is better than 5 sheets of gold.
+        /// </summary>
+        [DataField("unit")]
+        public string Unit = "materials-unit-sheet";
 
         [DataField("color")]
         public Color Color { get; private set; } = Color.Gray;

--- a/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
+++ b/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
@@ -8,7 +8,7 @@ lathe-menu-amount = Amount:
 lathe-menu-material-display = {$material} ({$amount})
 lathe-menu-tooltip-display = {$amount} of {$material}
 lathe-menu-material-amount = { $amount ->
-    [1] {NATURALFIXED($amount, 2)} $unit
+    [1] {NATURALFIXED($amount, 2)} {$unit}
     *[other] {NATURALFIXED($amount, 2)} {MAKEPLURAL($unit)}
 }
 lathe-menu-no-materials-message = No materials loaded.

--- a/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
+++ b/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
@@ -5,14 +5,12 @@ lathe-menu-sync = Sync
 lathe-menu-search-designs = Search designs
 lathe-menu-search-filter = Filter
 lathe-menu-amount = Amount:
-lathe-menu-material-display = {$material} ({ $amount ->
-        [1] {NATURALFIXED($amount, 2)} sheet
-        *[other] {NATURALFIXED($amount, 2)} sheets
-    })
-lathe-menu-tooltip-display = { $amount ->
-        [1] {NATURALFIXED($amount, 2)} sheet
-        *[other] {NATURALFIXED($amount, 2)} sheets
-    } of {$material}
+lathe-menu-material-display = {$material} ({$amount})
+lathe-menu-tooltip-display = {$amount} of {$material}
+lathe-menu-material-amount = { $amount ->
+    [1] {NATURALFIXED($amount, 2)} $unit
+    *[other] {NATURALFIXED($amount, 2)} {MAKEPLURAL($unit)}
+}
 lathe-menu-no-materials-message = No materials loaded.
 lathe-menu-fabricating-message = Fabricating...
 lathe-menu-materials-title = Materials

--- a/Resources/Locale/en-US/materials/materials.ftl
+++ b/Resources/Locale/en-US/materials/materials.ftl
@@ -12,6 +12,7 @@ materials-plasteel = plasteel
 
 # Other
 materials-biomass = biomass
+materials-cardboard = cardboard
 materials-cloth = cloth
 materials-durathread = durathread
 materials-plasma = plasma
@@ -20,6 +21,7 @@ materials-wood = wood
 materials-uranium = uranium
 materials-bananium = bananium
 materials-meat = meat
+materials-web = silk
 
 # Material Reclaimer
 material-reclaimer-upgrade-process-rate = process rate

--- a/Resources/Locale/en-US/materials/units.ftl
+++ b/Resources/Locale/en-US/materials/units.ftl
@@ -1,0 +1,20 @@
+# sheets of steel
+materials-unit-sheet = sheet
+# bars of gold
+materials-unit-bar = bar
+# planks of wood
+materials-unit-plank = plank
+# rolls of cloth
+materials-unit-roll = roll
+# pieces of biomass
+materials-unit-piece = piece
+# bunches of bananium
+materials-unit-bunch = bunch
+# slabs of meat
+materials-unit-slab = slab
+# webs of silk
+materials-unit-web = web
+
+# bills of spesos... not very good but they are not (yet?) used for crafting anything
+# also the lathe/atm would need bigger denominations to output...
+materials-unit-bill = bill

--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -43,6 +43,7 @@
 - type: material
   id: Credit
   name: speso
+  unit: materials-unit-bill
   stackEntity: SpaceCash
   icon: { sprite: /Textures/Objects/Economy/cash.rsi, state: cash }
   price: 1

--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -39,6 +39,10 @@
         mask:
         - ItemMask
   - type: Appearance
+  # speso crafting real
+  - type: Tag
+    tags:
+    - RawMaterial
 
 - type: material
   id: Credit

--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -39,10 +39,6 @@
         mask:
         - ItemMask
   - type: Appearance
-  # speso crafting real
-  - type: Tag
-    tags:
-    - RawMaterial
 
 - type: material
   id: Credit

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -2,6 +2,7 @@
   id: Biomass
   stackEntity: MaterialBiomass1
   name: materials-biomass
+  unit: materials-unit-piece
   icon: { sprite: /Textures/Objects/Misc/monkeycube.rsi, state: cube }
   color: "#8A9A5B"
   price: 0.1
@@ -18,6 +19,7 @@
   id: Cloth
   stackEntity: MaterialCloth1
   name: materials-cloth
+  unit: materials-unit-roll
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cloth }
   color: "#e7e7de"
   price: 0.05
@@ -26,6 +28,8 @@
   id: Durathread
   stackEntity: MaterialDurathread1
   name: materials-durathread
+  # not exactly a sheet but its sprite suggests it cant be rolled like cloth
+  unit: materials-unit-sheet
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: durathread }
   color: "#8291a1"
   price: 0.15 # 1-1 mix of plastic and cloth.
@@ -50,6 +54,7 @@
   id: Wood
   stackEntity: MaterialWoodPlank1
   name: materials-wood
+  unit: materials-unit-plank
   icon: { sprite: Objects/Materials/materials.rsi, state: wood }
   color: "#966F33"
   price: 0.05
@@ -66,6 +71,7 @@
   id: Bananium
   stackEntity: MaterialBananium1
   name: materials-bananium
+  unit: materials-unit-bunch
   icon: { sprite: Objects/Materials/materials.rsi, state: bananium }
   color: "#32a852"
   price: 0.2
@@ -73,6 +79,7 @@
 - type: material
   id: Meaterial # you can't take this pun from me
   name: materials-meat
+  unit: materials-unit-slab
   icon: { sprite: Objects/Materials/Sheets/meaterial.rsi, state: meat }
   color: "#c53648"
   price: 0.05
@@ -80,6 +87,7 @@
 - type: material
   id: WebSilk
   name: materials-web
+  unit: materials-unit-web
   icon: { sprite: Objects/Materials/silk.rsi, state: icon }
   color: "#eeeeee" #eeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
   price: 0 # Maybe better for it to be priceless, knowing how greedy cargo is.

--- a/Resources/Prototypes/Reagents/Materials/metals.yml
+++ b/Resources/Prototypes/Reagents/Materials/metals.yml
@@ -9,6 +9,7 @@
   id: Gold
   stackEntity: IngotGold1
   name: materials-gold
+  unit: materials-unit-bar
   icon: { sprite: Objects/Materials/ingots.rsi, state: gold }
   color: "#FFD700"
   price: 0.2
@@ -17,6 +18,7 @@
   id: Silver
   stackEntity: IngotSilver1
   name: materials-silver
+  unit: materials-unit-bar
   icon: { sprite: Objects/Materials/ingots.rsi, state: silver }
   color: "#C0C0C0"
   price: 0.15


### PR DESCRIPTION
## About the PR
things that arent sheets have unique units in the lathe ui now, resolves #19892

also cleaned up lathe menu locale a little bit, it duplicated the amount match thing for tooltip and material amount

also undid rounding the amount in recipe tooltip since a lot of recipes use half sheets of stuff especially gold

## Why / Balance
sheets of gold, sheets of biomass, sheets of bananium, sheets of meat (works but its still improved) are evil
bars of gold, pieces of biomass (cubes are eh since 1 biomass is a cube so is 100), bunches of bananium, slabs of meat
etc

## Technical details
added `Unit` to material prototype, a locale id for the unit which defaults to sheet
updated all the ui and locale to use this

## Media
all of them (ignore funny 6.67 bananium i forgor its sus and used 1000cm3 in the recipe)
![19:00:29](https://github.com/space-wizards/space-station-14/assets/39013340/577a9f1d-e994-4247-9fef-c2015b3e7ea4)

(soap recipe obviously not committed)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun