### PR TITLE
Further interaction outline tweaks (tonemap rework)

### DIFF
--- a/Resources/Prototypes/Shaders/outline.yml
+++ b/Resources/Prototypes/Shaders/outline.yml
@@ -4,7 +4,9 @@
   path: "/Textures/Shaders/outline.swsl"
   params:
     outline_color: "#FF000055"
-    light_boost: 1
+    light_boost: 2
+    light_gamma: 1.5
+    light_whitepoint: 48
 
 - type: shader
   id: SelectionOutlineInrange
@@ -13,3 +15,5 @@
   params:
     outline_color: "#00FF0055"
     light_boost: 2
+    light_gamma: 0.9
+    light_whitepoint: 1

--- a/Resources/Textures/Shaders/outline.swsl
+++ b/Resources/Textures/Shaders/outline.swsl
@@ -31,6 +31,12 @@ uniform highp float outline_width; // = 2.0;
 uniform highp vec4 outline_color; // =vec4(1.0,0.0,0.0,0.33);
 uniform bool outline_fullbright; // =false;
 uniform highp float light_boost; // = 4.0;
+uniform highp float light_gamma; // = 1.0;
+uniform highp float light_whitepoint; // = 1.0;
+
+highp float grayscale(highp vec3 col) {
+	return mix(0.0, 1.0, (col.r * 0.299) + (col.g * 0.587) + (col.b * 0.114)); //These luminance values are taken from Rec. ITU-R BT.601-7. This isn't suitable for player-facing grayscaling due to SDTV having a funky colorspace, but it's perfect for outlines.
+}
 
 void fragment() {
 	highp vec4 col = zTexture(UV);
@@ -72,7 +78,7 @@ void fragment() {
     maxa = max(a, maxa);
     mina = min(a, mina);
 
-	lowp float sampledLight = outline_fullbright ? 1.0 : sqrt(mix(0.0, 1.0, (lightSample.r * 0.34) + (lightSample.g * 0.5) + (lightSample.b * 0.16)) * light_boost);
-	COLOR = mix(col, outline_color * vec4(vec3(sampledLight), 1.0), maxa - col.a);
+	lowp float sampledLight = outline_fullbright ? 1.0 : clamp( (pow( grayscale(lightSample.rgb) * light_whitepoint, light_gamma) / light_whitepoint ) * light_boost, 0.0, 1.0);
+	COLOR = mix(col, outline_color * vec4(vec3(1.0), sampledLight), maxa - col.a);
 	lightSample = vec3(1.0);
 }


### PR DESCRIPTION
## About the PR
This PR is essentially a follow-up to #18599. This PR makes a single major change to interaction outlines: it replaces the hardcoded tonemap in the fragment function with a far more flexible one that allows shader prototypes to directly fiddle with the gamma curve, granting further artistic control over the effect. This PR leverages the functionality to give out-of-range interaction outlines a sharp falloff in shadows, whilst allowing in-range interaction outlines to stand out as they currently do in dim lighting conditions.

## Why / Balance

![image](https://github.com/space-wizards/space-station-14/assets/6356337/9832e63f-50fe-4e94-ade8-da8e6906b5ef)
The above is happening as a side effect of #18599; the tonemap we've applied to light samples was there to ensure that the fadeout of interaction outlines aligned with the actual perceptual brightness of lighting, but with that PR having adjusted the shader to only apply the lightmap's scaling to the outline's RGB, the tonemap was no longer necessary to achieve that. This results in consequences that even we didn't foresee, with the above image showing interaction outlines being visible in trace amounts of light bleed; an edge-case condition that simply is not visible at all in the slightest to the human eye (look at it! it's a solid `#000000`!).

We were originally going to just axe the tonemap and call it a day, but then we realized there was actually plenty of room for improvement for interaction outlines. This PR is the result of our tinkering. The media section directly shows the impact this PR will have.

## Technical details
The main meat and potatoes of this PR is replacing the sqrt() in the outline shader with a pow(), which in turn allows far greater control over the actual curve that gets applied to the lightmap. The `light_gamma` var controls the exponent applied to the fragment's light sample, and `light_whitepoint` controls the internal scaling, essentially determining what value is effectively `1` in the eyes of the exponent. [Here's a graph you can interact with if you'd like to play around with the new tonemapping function](https://www.desmos.com/calculator/ynlsdezh28). Additionally, the result is now actually properly clamped, which fixes the issue that was previously present where overbright lighting caused outlines to go wild.

For the sake of readability, this PR also shunts the grayscale conversion into a separate function. This has no overhead as far as we're aware (we've compared our vsync-off FPS with several outlines active simultaneously, both with and without the changes in this PR, and there doesn't seem to be a difference). The grayscale conversion has also been given a little bit of love, in that the luminance values are no longer ones we golfed while heavily sleep deprived, but rather, are now from an actual standardized source (specifically: ITU-R's Rec. BT-601-7, which contains standardized definitions for the standard SDTV colorspace. This isn't necessarily suitable for directly player-facing grayscale, but the compressed luminance values that come from SDTV having a wonky colorspace allows interaction outlines to be visible in `#0000FF` lighting)

This PR also changes how the sampled light gets applied to the final outline. Before, the sampled light was applied by multiplying with the outline's RGB. Now, the sampled light is applied by multiplying the outline's alpha. This fixes the edge-case of objects in space and objects in the dark on top of glass floors appearing to grow in size when being moused over (as the outline now simply no longer exists if there's no light at all), and also comes with the added benefit of interaction outlines retaining their vibrance whilst fading out. While this definitely isn't physically correct, it definitely looks a *lot* nicer in our opinions.

## Media

***Player in-range outline* - before**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/51414f38-80f5-4294-818c-536c992bed13)

***Player in-range outline* - after**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/7f837b3a-7e99-4375-8d8a-90296e259d7e)


***Out-of-range chair* - before**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/ee7269dc-4946-4396-920a-f3ad4bcaa5f0)

***Out-of-range chair* - after**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/97145ce6-ec6b-4c02-a543-c4fff15ae005)

***In-range chair* - before**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/49bd7ede-f8a0-467f-ad2b-86257d3a6563)

***In-range chair* - after**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/4b01ec0c-33f4-4177-ad51-e1f11cdfc6b8)

***Out-of-range item in the dark(tm)* - before**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/2c1194ed-208d-403c-a658-6ee99c745ef8)

***Out-of-range item in the dark(tm)* - after**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/1b1a779f-f511-4c0e-9ef5-cbdd2d5eb3d0)

***Out-of-range chair on glass flooring* - before**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/21176a8d-bb8f-4d5e-80f7-f8eaf47a5eb8)

***Out-of-range chair on glass flooring* - after**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/ce5b3c98-fd82-4ea7-bfc6-aff002bf081f)

***Out-of-range object in actual decent lighting conditions* - before**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/ff642dd6-469e-4e9f-b8f1-7f312f4cbf95)

***Out-of-range object in good lighting conditions* - after**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/cca69500-1bde-4157-b1b8-f0f2083a4a49)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Any shader prototypes that use `outline.swsl` will need to be re-adjusted to compensate for the new tonemapping. To revert a lighting-aware outline to the behavior from #18599, simply set `light_gamma` to `0.5`. To revert the behavior to what was originally present when lighting-aware outlines were first introduced, leave `light_gamma` at `1.0`.

**Changelog**

:cl: Bhijn and Myr
- tweak: Interaction outlines have been slightly reworked, and feature finer artistic control. Edge cases no longer result in interaction outlines being faintly visible in pitch black areas, out-of-range outlines are far less visible in dim conditions, outlines now properly fade when over a fullbright backdrop like parallax, and outlines now do a much better job at fading with penumbras.
