### PR TITLE
buff gauze

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -253,8 +253,8 @@
       - Biological
     damage:
       types:
-        Slash: -2.5
-        Piercing: -2.5
+        Slash: -5
+        Piercing: -10
     bloodlossModifier: -10
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"


### PR DESCRIPTION
## About the PR
changes gauze from healing 2.5 slash and piercing to be 5 slash and 10 piercing

## Why / Balance
as it stands gauze is a complete joke and only used either:
- by noobs that expect it to actually be good and have never used it before
- as a last resort when you have literally nothing else

this makes it on par with bruise packs for slash, and twice as good for piercing which makes sense as its gauze not a bandaid. it will be much more effective to wrap yourself up in gauze after a firefight than to use bruisepacks.

inb4 but it stop bleeding, welding touching a light or using cautery are faster at stopping bleeding, and bruise packs on their own will stop bleeding. if you are badly shot stopping bleeding a few seconds earlier doesn't matter much when you already lost half your blood. nobody uses gauze to stop bleeding, welding is far more effective

## Technical details
no

## Media
no
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes


**Changelog**
:cl:
- tweak: Gauze is now more effective at treating slash and piercing damage.
