### PR TITLE
Body temperature change

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -49,7 +49,7 @@
   - type: Temperature # Moths hate the heat and thrive in the cold.
     heatDamageThreshold: 335
     coldDamageThreshold: 230
-    currentTemperature: 310.15
+    currentTemperature: 293
     specificHeat: 46
     coldDamage:
       types:
@@ -57,6 +57,8 @@
     heatDamage:
       types:
         Heat : 0.2 #per second, scales with temperature & other constants
+  - type: ThermalRegulator
+    normalBodyTemperature: 293 # 20 °C
   - type: Sprite # sprite again because we want different layer ordering
     noRot: true
     drawdepth: Mobs

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -47,7 +47,7 @@
   - type: Temperature
     heatDamageThreshold: 400
     coldDamageThreshold: 285
-    currentTemperature: 310.15
+    currentTemperature: 319
     specificHeat: 46
     coldDamage:
       types:
@@ -55,6 +55,8 @@
     heatDamage:
       types:
         Heat : 0.1 #per second, scales with temperature & other constants
+  - type: ThermalRegulator
+    normalBodyTemperature: 319 # 46 °C
   - type: MovementSpeedModifier
     baseWalkSpeed : 2.7
     baseSprintSpeed : 4.5


### PR DESCRIPTION
## About the PR
Reptilian and Moth body temperatures are changed to better work with the adjusted alerts (#19913) and match their stated hot and cold preference.

## Why / Balance
It would be more thematic if reptilian body temperature was elevated and their warm preference was more apparent. They will be uncomfortably but not dangerously cold at room temperature (even after 19913 squashes the warning ranges), but become comfortable again if they put on a winter coat so they can self-regulate, or if they find some other form of heating themselves/their room

The moth change follows a similar logic though would not make any noticeable difference currently. If thermal imaging ever becomes a thing, it could make them more difficult to detect which might be interesting

## Technical details
For moths the center point of their safe range almost perfectly lines up with the 20 °C room temperature. With our simplified system for what it takes to be comfortable, this means they more or less have an easier time staying at their ideal temperature than the actual humans.  I find this rather amusing, and almost makes one wonder if moths adapt to human habitats _so well_ that the only reason NT hired them is because it's impossible to get rid of moths once they have appeared on your station. How appropriate.

Reptilians are trickier, because their "sweetspot" is around 70 °C. This is so much hotter than the air which surrounds them that it causes issues. Their metabolism is unable to cope, and their temperature crashes worse than with the default 36 °C value (since they quickly fall too far from their ideal temperature to be able to shiver). Instead of boosting their metabolic values, I think a body temperature of 46 °C would work. It is just barely above their Cold 1 warning, and not a temperature they can actually sustain in room temperature. But they stabilise at around 40 °C, still before hitting the Cold 2 warning. And if they put on a coat they are now able to self-regulate to their comfortable temperature. As a result reptilians will complain about the cold and wear coats even more than before. This feels fine.

## Media
![Screenshot from 2023-09-08 19-41-44](https://github.com/space-wizards/space-station-14/assets/35878406/27fe01f6-8d6a-4730-9d24-ad7df743f219)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl: Errant
- tweak: The natural body temperature of moths and reptilians is now 20 °C and 46 °C, respectively.