### PR TITLE
Fix race condition causing some people being unable to connect.

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -82,6 +82,8 @@ namespace Content.Client.Lobby
             _gameTicker.LobbyLateJoinStatusUpdated += LobbyLateJoinStatusUpdated;
 
             _preferencesManager.OnServerDataLoaded += PreferencesDataLoaded;
+
+            _lobby.CharacterPreview.UpdateUI();
         }
 
         protected override void Shutdown()

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -80,6 +80,8 @@ namespace Content.Client.Lobby
             _gameTicker.InfoBlobUpdated += UpdateLobbyUi;
             _gameTicker.LobbyStatusUpdated += LobbyStatusUpdated;
             _gameTicker.LobbyLateJoinStatusUpdated += LobbyLateJoinStatusUpdated;
+
+            _preferencesManager.OnServerDataLoaded += PreferencesDataLoaded;
         }
 
         protected override void Shutdown()
@@ -100,6 +102,13 @@ namespace Content.Client.Lobby
 
             _characterSetup?.Dispose();
             _characterSetup = null;
+
+            _preferencesManager.OnServerDataLoaded -= PreferencesDataLoaded;
+        }
+
+        private void PreferencesDataLoaded()
+        {
+            _lobby?.CharacterPreview.UpdateUI();
         }
 
         private void OnSetupPressed(BaseButton.ButtonEventArgs args)

--- a/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
+++ b/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
@@ -76,8 +76,6 @@ namespace Content.Client.Lobby.UI
             AddChild(vBox);
 
             UpdateUI();
-
-            _preferencesManager.OnServerDataLoaded += UpdateUI;
         }
 
         public Button CharacterSetupButton { get; }
@@ -85,7 +83,6 @@ namespace Content.Client.Lobby.UI
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            _preferencesManager.OnServerDataLoaded -= UpdateUI;
 
             if (!disposing) return;
             if (_previewDummy != null) _entityManager.DeleteEntity(_previewDummy.Value);


### PR DESCRIPTION
This would happen if MsgPreferencesAndSettings arrived on the client before MsgPlayerList.

The LobbyCharacterPreviewPanel is for some reason always loaded by the UI system, meaning it was always hooked to the IClientPreferencesManager.OnServerDataLoaded event. If the preferences loaded before MsgPlayerList (which sets the client run level to "Connected"), it would try to spawn the preview human client entities before the entity system was initialized.

Fixed by moving the event subscription to LobbyState, so it's only listening when we're in the lobby (after the client is properly connected).