### PR TITLE
Crayon buff 5 -> 15

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -43,7 +43,6 @@
     heldPrefix: white
   - type: Crayon
     color: white
-    capacity: 5
   - type: Tag
     tags:
     - Write
@@ -66,7 +65,6 @@
     heldPrefix: mime
   - type: Crayon
     color: white
-    capacity: 5
   - type: Tag
     tags:
     - Write
@@ -112,7 +110,6 @@
     heldPrefix: black
   - type: Crayon
     color: black
-    capacity: 5
   - type: Tag
     tags:
     - Write
@@ -135,7 +132,6 @@
     heldPrefix: red
   - type: Crayon
     color: red
-    capacity: 5
   - type: Tag
     tags:
     - Write
@@ -158,7 +154,6 @@
     heldPrefix: orange
   - type: Crayon
     color: orange
-    capacity: 5
   - type: Tag
     tags:
     - Write
@@ -181,7 +176,6 @@
     heldPrefix: yellow
   - type: Crayon
     color: yellow
-    capacity: 5
   - type: Tag
     tags:
     - Write
@@ -204,7 +198,6 @@
     heldPrefix: green
   - type: Crayon
     color: green
-    capacity: 5
   - type: Tag
     tags:
     - Write
@@ -227,7 +220,6 @@
     heldPrefix: blue
   - type: Crayon
     color: lightblue
-    capacity: 5
   - type: Tag
     tags:
     - Write
@@ -250,7 +242,6 @@
     heldPrefix: purple
   - type: Crayon
     color: purple
-    capacity: 5
   - type: Tag
     tags:
     - Write

--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -16,7 +16,7 @@
     - key: enum.CrayonUiKey.Key
       type: CrayonBoundUserInterface
   - type: Crayon
-    capacity: 5
+    capacity: 15
   - type: Food
   - type: SolutionContainerManager
     solutions:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Crayons now has 15 amount of uses instead of 5

## Why / Balance
5 uses is too few. It's not enough for most things made with decals. For example text writing: Most sentences probably have more than 5 letters in it. If you want to write something, you need to use another crayon that probably has different color and wouldn't look good with the other text. We also have people that draw arts with decals and they probably need a lot of crayons to do them.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none
