### PR TITLE
Mime Wall Nerf

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -1024,7 +1024,7 @@
   name: Invisible Wall
   components:
   - type: TimedDespawn
-    lifetime: 30
+    lifetime: 15
   - type: Tag
     tags:
       - Wall


### PR DESCRIPTION
## About the PR
Adjusts the mime's invisible wall uptime to 15 seconds, half the original time. So;
15 second uptime.
30 second cooldown, (or more effectively a 15 second cooldown because the cooldown starts as soon as the wall goes up.)

## Why / Balance
Mimes before could keep a wall constantly up because it had 30 second uptime, 30 second cooldown.
A mime wall feels like it should be a quick "block this door for a brief moment" type deal, because there's no counter play other than just go around. Which isn't always an option when it comes to one port docked shuttles, one table desks, dead end maint, etc.

## Media
- [X] This PR does not require an ingame showcase.