### PR TITLE
PDAs deal damage on throw.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -112,6 +112,10 @@
     state: pda
   - type: PdaBorderColor
     borderColor: "#717059"
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -127,6 +131,10 @@
     accentVColor: "#949137"
   - type: Icon
     state: pda-interntech
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -164,6 +172,10 @@
     accentVColor: "#A32D26"
   - type: Icon
     state: pda-interncadet
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: BasePDA
@@ -179,6 +191,10 @@
     accentVColor: "#8900c9"
   - type: Icon
     state: pda-internsci
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -194,6 +210,10 @@
     accentVColor: "#00cc35"
   - type: Icon
     state: pda-internservice
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -208,6 +228,10 @@
     borderColor: "#d7d7d0"
   - type: Icon
     state: pda-cook
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -223,6 +247,10 @@
     accentVColor: "#00cc35"
   - type: Icon
     state: pda-hydro
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -289,6 +317,10 @@
     accentHColor: "#333333"
   - type: Icon
     state: pda-mime
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   name: chaplain PDA
@@ -303,6 +335,10 @@
     borderColor: "#333333"
   - type: Icon
     state: pda-chaplain
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   name: quartermaster PDA
@@ -318,6 +354,10 @@
     accentVColor: "#a23e3e"
   - type: Icon
     state: pda-qm
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -332,6 +372,10 @@
     borderColor: "#e39751"
   - type: Icon
     state: pda-cargo
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -347,6 +391,10 @@
     accentVColor: "#8900c9"
   - type: Icon
     state: pda-miner
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -361,6 +409,10 @@
     borderColor: "#333333"
   - type: Icon
     state: pda-bartender
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -375,6 +427,10 @@
     borderColor: "#858585"
   - type: Icon
     state: pda-library
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -389,6 +445,10 @@
     borderColor: "#6f6192"
   - type: Icon
     state: pda-lawyer
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -403,6 +463,10 @@
     borderColor: "#5D2D56"
   - type: Icon
     state: pda-janitor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -423,6 +487,10 @@
     borderColor: "#7C5D00"
   - type: Icon
     state: pda-captain
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -444,6 +512,10 @@
     accentHColor: "#447987"
   - type: Icon
     state: pda-hop
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -459,6 +531,10 @@
     accentHColor: "#447987"
   - type: Icon
     state: pda-ce
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -474,6 +550,10 @@
     accentVColor: "#A32D26"
   - type: Icon
     state: pda-engineer
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -554,6 +634,10 @@
     scanDelay: 1
     scanningEndSound:
       path: "/Audio/Items/Medical/healthscanner.ogg"
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -570,6 +654,10 @@
     accentVColor: "#8900c9"
   - type: Icon
     state: pda-rd
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -585,6 +673,10 @@
     accentVColor: "#8900c9"
   - type: Icon
     state: pda-science
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -600,6 +692,10 @@
     accentHColor: "#447987"
   - type: Icon
     state: pda-hos
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: BasePDA
@@ -615,6 +711,10 @@
     accentVColor: "#949137"
   - type: Icon
     state: pda-warden
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: BasePDA
@@ -629,6 +729,10 @@
     borderColor: "#A32D26"
   - type: Icon
     state: pda-security
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: BasePDA
@@ -648,6 +752,10 @@
     borderColor: "#00842e"
   - type: Icon
     state: pda-centcom
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: CentcomPDA
@@ -656,6 +764,10 @@
   components:
   - type: Pda
     id: CentcomIDCardSyndie
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: CentcomPDA
@@ -664,6 +776,10 @@
   components:
   - type: Pda
     id: CentcomIDCardDeathsquad
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: BasePDA
@@ -683,6 +799,10 @@
     handheld: true
     bank: 1
     program: 2
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -698,6 +818,10 @@
     accentVColor: "#447987"
   - type: Icon
     state: pda-atmos
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -712,6 +836,10 @@
     borderColor: "#288e4d"
   - type: Icon
     state: pda-clear
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -738,6 +866,10 @@
       whitelist:
         components:
           - Cartridge
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: BasePDA
@@ -754,6 +886,10 @@
     accentVColor: "#447987"
   - type: Icon
     state: pda-ert
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: ERTLeaderPDA
@@ -768,6 +904,10 @@
     borderColor: "#A32D26"
     accentHColor: "#447987"
     accentVColor: "#447987"
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: BasePDA
@@ -797,6 +937,10 @@
     borderColor: "#3f3f74"
   - type: Icon
     state: pda-reporter
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -811,6 +955,10 @@
     borderColor: "#ffe685"
   - type: Icon
     state: pda-zookeeper
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -826,6 +974,10 @@
     accentVColor: "#390504"
   - type: Icon
     state: pda-boxer
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -840,6 +992,10 @@
     borderColor: "#774705"
   - type: Icon
     state: pda-detective
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   parent: BasePDA
@@ -898,6 +1054,10 @@
     accentVColor: "#CD6900"
   - type: Icon
     state: pda-seniorengineer
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -914,6 +1074,10 @@
     accentVColor: "#8900c9"
   - type: Icon
     state: pda-seniorresearcher
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   parent: BasePDA
@@ -949,3 +1113,7 @@
     accentVColor: "#DFDFDF"
   - type: Icon
     state: pda-seniorofficer
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Most PDAs now deal 5 blunt damage when thrown, similar to how a tile works. Exceptions to this include Security where it deals 10 blunt, along with medical where it doesn't deal damage at all. This is a "joke" feature i thought of a while ago, which does not add much to the game but it would be funny if you threw your PDA at someone and they suddenly took damage. The damage is low enough that it does not have a noticeable impact on gameplay.
## Media
- [X] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

![](https://cdn.discordapp.com/attachments/1149633748720168960/1149969644430577664/image.png)
![](https://cdn.discordapp.com/attachments/1149633748720168960/1149969643923050526/image.png)
![](https://cdn.discordapp.com/attachments/1149633748720168960/1149969644178911313/image.png)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: Ubaser
- tweak: Most PDAs now deal damage on throw.

