### PR TITLE
Improved botany's chemical and gas crossbreeding.

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -86,7 +86,7 @@ public sealed class MutationSystem : EntitySystem
     {
         SeedData result = b.Clone();
 
-        result.Chemicals = Random(0.5f) ? a.Chemicals : result.Chemicals;
+        CrossChemicals(ref result.Chemicals, a.Chemicals);
 
         CrossFloat(ref result.NutrientConsumption, a.NutrientConsumption);
         CrossFloat(ref result.WaterConsumption, a.WaterConsumption);
@@ -115,8 +115,9 @@ public sealed class MutationSystem : EntitySystem
         CrossBool(ref result.Bioluminescent, a.Bioluminescent);
         CrossBool(ref result.TurnIntoKudzu, a.TurnIntoKudzu);
         CrossBool(ref result.CanScream, a.CanScream);
-        result.ExudeGasses = Random(0.5f) ? a.ExudeGasses : result.ExudeGasses;
-        result.ConsumeGasses = Random(0.5f) ? a.ConsumeGasses : result.ConsumeGasses;
+        CrossGasses(ref result.ExudeGasses, a.ExudeGasses);
+        CrossGasses(ref result.ConsumeGasses, a.ConsumeGasses);
+
         result.BioluminescentColor = Random(0.5f) ? a.BioluminescentColor : result.BioluminescentColor;
 
         // Hybrids have a high chance of being seedless. Balances very
@@ -292,6 +293,70 @@ public sealed class MutationSystem : EntitySystem
         return color;
     }
 
+    private void CrossChemicals(ref Dictionary<string, SeedChemQuantity> val, Dictionary<string, SeedChemQuantity> other)
+    {
+        // Go through chemicals from the pollen in swab
+        foreach (var other_chem in other)
+        {
+            // if both have same chemical, randomly pick potency ratio from the two.
+            if (val.ContainsKey(other_chem.Key))
+            {
+                val[other_chem.Key] = Random(0.5f) ? other_chem.Value : val[other_chem.Key];
+            }
+            // if target plant doesn't have this chemical, has 50% chance to add it. 
+            else
+            {
+                if (Random(0.5f))
+                {
+                    val.Add(other_chem.Key, other_chem.Value);
+                }
+            }
+        }
+
+        // if the target plant has chemical that the pollen in swab does not, 50% chance to remove it.
+        foreach (var this_chem in val)
+        {
+            if (!other.ContainsKey(this_chem.Key))
+            {
+                if (Random(0.5f))
+                {
+                    val.Remove(this_chem.Key);
+                }
+            }
+        }
+    }
+
+    private void CrossGasses(ref Dictionary<Gas, float> val, Dictionary<Gas, float> other)
+    {
+        // Go through gasses from the pollen in swab
+        foreach (var other_gas in other)
+        {
+            // if both have same gas, randomly pick ammount from the two.
+            if (val.ContainsKey(other_gas.Key))
+            {
+                val[other_gas.Key] = Random(0.5f) ? other_gas.Value : val[other_gas.Key];
+            }
+            // if target plant doesn't have this gas, has 50% chance to add it.
+            else
+            {
+                if (Random(0.5f))
+                {
+                    val.Add(other_gas.Key, other_gas.Value);
+                }
+            }
+        }
+        // if the target plant has gas that the pollen in swab does not, 50% chance to remove it.
+        foreach (var this_gas in val)
+        {
+            if (!other.ContainsKey(this_gas.Key))
+            {
+                if (Random(0.5f))
+                {
+                    val.Remove(this_gas.Key);
+                }
+            }
+        }
+    }
     private void CrossFloat(ref float val, float other)
     {
         val = Random(0.5f) ? val : other;


### PR DESCRIPTION
Chemicals and Gasses are not all wholesale swapped but given 50/50 for every chemical or gas.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added to new methods in `MutationSystem` that mix chemical or gas dictionaries from two `SeedData` together. `CrossChemicals` and `CrossGasses`. Replaced the wholesale swap of the dictionaries when crossbreeding happens with call to these functions.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Crossbreeding had very bad game feel when chemicals for the plant to function in it's purpose was very particular. Such cross breeding something into wheat had very likely effect of completely removing flour from it's chemicals. This also enables crossbreeding have more depth as it was very binary what chemicals won over. Botanists can now aim for that super drug plant that has all those chemicals from exotic crate in one single plant.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
When crossbreeding plants, the chemicals and gasses (exuded and consumed) are no longer swapped wholesale but instead each chamical/gas individually has 50% chance of being add/removed if it does not appear in both plants. If both appear, the potency/ammount is swapped with 50% chance.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: DrTeaSpoon
- tweak: Crossing plants may now combine their produced chemicals.
