### PR TITLE
Fix Cognizine Not Working on Monkeys & Entities with Minds

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -35,7 +35,7 @@ public sealed partial class MakeSentient : ReagentEffect
         }
 
         ghostRole = entityManager.AddComponent<GhostRoleComponent>(uid);
-        entityManager.AddComponent<GhostTakeoverAvailableComponent>(uid);
+        entityManager.EnsureComponent<GhostTakeoverAvailableComponent>(uid);
 
         var entityData = entityManager.GetComponent<MetaDataComponent>(uid);
         ghostRole.RoleName = entityData.EntityName;

--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -28,6 +28,8 @@ public sealed partial class MakeSentient : ReagentEffect
             return;
         }
 
+        // Stops from adding a ghost role to things that already have ghost roles
+        // The check for GhostTakeoverAvailableComponent may be redundant but it's hard to tell
         if (entityManager.TryGetComponent(uid, out GhostRoleComponent? ghostRole) ||
             entityManager.TryGetComponent(uid, out GhostTakeoverAvailableComponent? takeOver))
         {

--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -16,19 +16,16 @@ public sealed partial class MakeSentient : ReagentEffect
         var entityManager = args.EntityManager;
         var uid = args.SolutionEntity;
 
-        // This piece of code makes things able to speak "normally". One thing of note is that monkeys have a unique accent and won't be affected by this.
+        // Let affected entities speak normally to make this effect different from, say, the "random sentience" event
+        // This also works on entities that already have a mind
         entityManager.RemoveComponent<ReplacementAccentComponent>(uid);
-
-        // Monke talk. This makes cognizine a cure to AMIV's long term damage funnily enough, do with this information what you will.
         entityManager.RemoveComponent<MonkeyAccentComponent>(uid);
 
-        // This makes it so it doesn't add a ghost role to things that are already sentient
         if (entityManager.HasComponent<MindContainerComponent>(uid))
         {
             return;
         }
 
-        // No idea what anything past this point does
         if (entityManager.TryGetComponent(uid, out GhostRoleComponent? ghostRole) ||
             entityManager.TryGetComponent(uid, out GhostTakeoverAvailableComponent? takeOver))
         {
@@ -43,5 +40,3 @@ public sealed partial class MakeSentient : ReagentEffect
         ghostRole.RoleDescription = Loc.GetString("ghost-role-information-cognizine-description");
     }
 }
-
-// Original code written by areitpog on GitHub in Issue #7666, then I (Interrobang01) copied it and used my nonexistant C# skills to try to make it work again.

--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -18,6 +18,7 @@ public sealed partial class MakeSentient : ReagentEffect
 
         // Let affected entities speak normally to make this effect different from, say, the "random sentience" event
         // This also works on entities that already have a mind
+        // We call this before the mind check to allow things like player-controlled mice to be able to benefit from the effect
         entityManager.RemoveComponent<ReplacementAccentComponent>(uid);
         entityManager.RemoveComponent<MonkeyAccentComponent>(uid);
 

--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -21,6 +21,7 @@ public sealed partial class MakeSentient : ReagentEffect
         entityManager.RemoveComponent<ReplacementAccentComponent>(uid);
         entityManager.RemoveComponent<MonkeyAccentComponent>(uid);
 
+        // Stops from adding a ghost role to things like people who already have a mind
         if (entityManager.HasComponent<MindContainerComponent>(uid))
         {
             return;

--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -16,12 +16,6 @@ public sealed partial class MakeSentient : ReagentEffect
         var entityManager = args.EntityManager;
         var uid = args.SolutionEntity;
 
-        // This makes it so it doesn't affect things that are already sentient
-        if (entityManager.HasComponent<MindContainerComponent>(uid))
-        {
-            return;
-        }
-
         // This piece of code makes things able to speak "normally". One thing of note is that monkeys have a unique accent and won't be affected by this.
         entityManager.RemoveComponent<ReplacementAccentComponent>(uid);
 

--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -28,10 +28,8 @@ public sealed partial class MakeSentient : ReagentEffect
             return;
         }
 
-        // Stops from adding a ghost role to things that already have ghost roles
-        // The check for GhostTakeoverAvailableComponent may be redundant but it's hard to tell
-        if (entityManager.TryGetComponent(uid, out GhostRoleComponent? ghostRole) ||
-            entityManager.TryGetComponent(uid, out GhostTakeoverAvailableComponent? takeOver))
+        // Don't add a ghost role to things that already have ghost roles
+        if (entityManager.TryGetComponent(uid, out GhostRoleComponent? ghostRole))
         {
             return;
         }

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -308,6 +308,7 @@ namespace Content.Server.Ghost.Roles
         {
             if (role.Probability < 1f && !_random.Prob(role.Probability))
             {
+                RemComp<GhostTakeoverAvailableComponent>(uid);
                 RemComp<GhostRoleComponent>(uid);
                 return;
             }

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -308,7 +308,6 @@ namespace Content.Server.Ghost.Roles
         {
             if (role.Probability < 1f && !_random.Prob(role.Probability))
             {
-                RemComp<GhostTakeoverAvailableComponent>(uid);
                 RemComp<GhostRoleComponent>(uid);
                 return;
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

First and foremost I normally spend like an hour writing these PR descriptions but today I am going to only spend 45 minutes, disregard any bad writing that makes me lose face, such as this sentence.

1. Removed bit of code that made cognizine's accent removal not work on entities that already have a mind
2. Cleaned up year-old comments
3. Tweaked the "check to see if the entity already has a ghost role" logic so cognizine can work on monkeys. Also space bears and carps and whatnot.

That first point is the same bug that #18083 happened to fix, except this PR isn't really a refactor and #18083 was.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

1. Some Mind ECS PR a month ago added a bit of code that broke cognizine's accent removal and it got merged with minimal review in the hopes that PRs like this one will fix bugs like this one ( fixes #14692 ... again)
2. Comments were cleaned up because they were bad
3. Cognizine didn't work on monkeys because the probability ghost role system didn't remove the GhostTakeoverAvailableComponent which tripped up the GhostTakeoverAvailableComponent check. That check was only there because the original author of the MakeSentient effect didn't know that EnsureComp was a thing. ( fixes #18084 and also solves the same issue as #19757 so closes #19757 )

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

1. Fixed accent removal not working on entities with minds by removing a check that served no purpose other than to manifest this problem.
2. Cleaned up comments via keyboard and mouse
3. Got rid of the check to abort if GhostTakeoverAvailableComponent is detected, and then changed the AddComp(GhostTakeoverAvailableComponent) to an EnsureComp(GhostTakeoverAvailableComponent). The check for GhostTakeoverAvailableComponent was there because, as stated above, EnsureComp wasn't used for whatever reason.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://github.com/space-wizards/space-station-14/assets/113810873/8be72616-decb-469c-b00c-7d3b35eabd90)
![image](https://github.com/space-wizards/space-station-14/assets/113810873/56f9085f-a375-491c-a206-ac4c6a1f87bc)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Cognizine now works on monkeys.
- fix: Fixed Cognizine not working on player-controlled animals.