### PR TITLE
Changed produce spills into dynamic from hardcoded.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -53,14 +53,13 @@
       - !type:PlaySoundBehavior
         sound:
           collection: desecration
+      - !type:SpillBehavior
+        solution: food
       - !type:SpawnEntitiesBehavior
         spawn:
           Eggshells:
             min: 1
             max: 1
-          PuddleEgg:
-            min: 1
-            max: 2
           # Wow double-yolk you're so lucky!
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -73,11 +73,8 @@
       - !type:PlaySoundBehavior
         sound:
           collection: desecration
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          PuddleFlour:
-            min: 1
-            max: 1
+      - !type:SpillBehavior
+        solution: food
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: TrashOnEmpty
@@ -117,11 +114,8 @@
       - !type:PlaySoundBehavior
         sound:
           collection: desecration
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          PuddleFlour:
-            min: 1
-            max: 1
+      - !type:SpillBehavior
+        solution: food
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -460,8 +460,10 @@
         maxVol: 14
         reagents:
         - ReagentId: Nutriment
-          Quantity: 10
+          Quantity: 7
         - ReagentId: Vitamin
+          Quantity: 3
+        - ReagentId: Water
           Quantity: 4
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/tomato.rsi
@@ -498,11 +500,8 @@
       - !type:PlaySoundBehavior
         sound:
           collection: desecration
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          PuddleTomato:
-            min: 1
-            max: 1
+      - !type:SpillBehavior
+        solution: food
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -1114,11 +1113,8 @@
       - !type:PlaySoundBehavior
         sound:
           collection: desecration
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          PuddleWatermelon:
-            min: 1
-            max: 1
+      - !type:SpillBehavior
+        solution: food
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: SliceableFood

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -307,11 +307,11 @@
     Nutriment:
       Min: 1
       Max: 7
-      PotencyDivisor: 10
+      PotencyDivisor: 14
     Vitamin:
       Min: 1
       Max: 3
-      PotencyDivisor: 25
+      PotencyDivisor: 33
     Water:
       Min: 1
       Max: 4

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -306,9 +306,13 @@
   chemicals:
     Nutriment:
       Min: 1
-      Max: 10
+      Max: 7
       PotencyDivisor: 10
     Vitamin:
+      Min: 1
+      Max: 3
+      PotencyDivisor: 25
+    Water:
       Min: 1
       Max: 4
       PotencyDivisor: 25


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Tomatoes, Watermelons, Eggs and Flourbags all had 'hardcoded' spills. Tomatoes especially spilled into water that was not even in the contents of the fruit. This pull request replaces spawning the spills with the spill mechanic found in almost every other spillable solution container. I also tweaked tomato chemicals to bring it closer to intended spill. (added some water, and reduced other chemicals to keep the volume same)


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I feel like removing inconsistancy or mechanics in a game centered around simulations and systems is important.


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Replaced `SpawnEntitiesBehavior` from the procude yaml where it was used for destruction of the produce to spawn a predefined puddle with `SpillBehavior` connected to `food` chemical solution container.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
[tomato.webm](https://github.com/space-wizards/space-station-14/assets/87363733/42167ac3-24d6-4983-9f22-4e018e414633)

## Breaking changes

<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None!
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: DrTeaSpoon
- fix: Fixed Tomatoes, Eggs, Watermelons and Flourbags not leaving puddles based on what they actually contain.
