### PR TITLE
microwaved pais get scrambled name + randomly bricked

### DIFF
--- a/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
@@ -124,6 +124,7 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
                 {
                     if (component.Deleted || !HasComp<GhostTakeoverAvailableComponent>(uid))
                         return;
+
                     RemCompDeferred<GhostTakeoverAvailableComponent>(uid);
                     RemCompDeferred<GhostRoleComponent>(uid);
                     _popup.PopupEntity(Loc.GetString(component.StopSearchVerbPopup), uid, args.User);
@@ -132,5 +133,26 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
             };
             args.Verbs.Add(verb);
         }
+    }
+
+    /// <summary>
+    /// If there is a player present, kicks it out.
+    /// If not, prevents future ghosts taking it.
+    /// No popups are made, but appearance is updated.
+    /// </summary>
+    public void Wipe(EntityUid uid)
+    {
+        if (TryComp<MindContainerComponent>(uid, out var mindContainer) &&
+            mindContainer.HasMind &&
+            _mind.TryGetMind(uid, out var mindId, out var mind))
+        {
+            _mind.TransferTo(mindId, null, mind: mind);
+        }
+
+        if (!HasComp<GhostTakeoverAvailableComponent>(uid))
+            return;
+
+        RemCompDeferred<GhostTakeoverAvailableComponent>(uid);
+        RemCompDeferred<GhostRoleComponent>(uid);
     }
 }

--- a/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
@@ -154,5 +154,6 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
 
         RemCompDeferred<GhostTakeoverAvailableComponent>(uid);
         RemCompDeferred<GhostRoleComponent>(uid);
+        UpdateAppearance(uid, ToggleableGhostRoleStatus.Off);
     }
 }

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -106,7 +106,7 @@ public sealed class PAISystem : SharedPAISystem
 
         // if its named add 's pAI back to the scrambled name
         // since scrambling stops at '
-        var val = name.ToString() : 
+        var val = name.ToString();
         val = comp.LastUser == null
             ? val
             : Loc.GetString("pai-system-pai-name", ("owner", val));

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -111,7 +111,6 @@ public sealed class PAISystem : SharedPAISystem
             ? val
             : Loc.GetString("pai-system-pai-name", ("owner", val));
         _metaData.SetEntityName(uid, val);
-        name.ToString());
     }
 
     public void PAITurningOff(EntityUid uid)

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -21,9 +21,9 @@ public sealed class PAISystem : SharedPAISystem
     [Dependency] private readonly ToggleableGhostRoleSystem _toggleableGhostRole = default!;
 
     /// <summary>
-    /// Possible symbols that can replace characters in the pai's owner name when microwaved.
+    /// Possible symbols that can be part of a scrambled pai's name.
     /// </summary>
-    private static readonly char[] SYMBOLS = new[] { '#', '~', '-', '@', '&', '^', '%', '$', '*'};
+    private static readonly char[] SYMBOLS = new[] { '#', '~', '-', '@', '&', '^', '%', '$', '*', ' '};
 
     public override void Initialize()
     {
@@ -85,35 +85,16 @@ public sealed class PAISystem : SharedPAISystem
 
     private void ScrambleName(EntityUid uid, PAIComponent comp)
     {
-        // randomly replace random characters from the old name
-        var oldName = Name(uid);
-        var name = new StringBuilder(oldName.Length);
-        var named = false;
-        foreach (var character in oldName)
+        // create a new random name
+        var len = _rand.Next(6, 18);
+        var name = new StringBuilder(len);
+        for (int i = 0; i < len; i++)
         {
-            // only scramble the owner name, don't scramble "'s pAI"
-            if (character == '\'')
-            {
-                named = true;
-                break;
-            }
-
-            if (_random.Prob(comp.CharScrambleChance))
-            {
-                name.Append(_random.Pick(SYMBOLS));
-            }
-            else
-            {
-                name.Append(character);
-            }
+            name.Append(_random.Pick(SYMBOLS));
         }
 
-        // if its named add 's pAI back to the scrambled name
-        // since scrambling stops at '
-        var val = name.ToString();
-        val = named
-            ? val
-            : Loc.GetString("pai-system-pai-name-raw", ("name", val));
+        // add 's pAI to the scrambled name
+        var val = Loc.GetString("pai-system-pai-name-raw", ("name", name.ToString()));
         _metaData.SetEntityName(uid, val);
     }
 

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -71,8 +71,9 @@ public sealed class PAISystem : SharedPAISystem
         if (_random.Prob(comp.BrickChance))
         {
             _popup.PopupEntity(Loc.GetString(comp.BrickPopup), uid, PopupType.LargeCaution);
-            RemComp<PAIComponent>(uid);
             _toggleableGhostRole.Wipe(uid);
+            RemComp<PAIComponent>(uid);
+            RemComp<ToggleableGhostRoleComponent>(uid);
         }
         else
         {

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -86,7 +86,7 @@ public sealed class PAISystem : SharedPAISystem
     private void ScrambleName(EntityUid uid, PAIComponent comp)
     {
         // create a new random name
-        var len = _rand.Next(6, 18);
+        var len = _random.Next(6, 18);
         var name = new StringBuilder(len);
         for (int i = 0; i < len; i++)
         {

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Ghost.Roles;
+using Content.Server.Ghost.Roles.Components;
 using Content.Server.Instruments;
 using Content.Server.Kitchen.Components;
 using Content.Shared.Interaction.Events;
@@ -103,7 +104,14 @@ public sealed class PAISystem : SharedPAISystem
             }
         }
 
-        _metaData.SetEntityName(uid, name.ToString());
+        // if its named add 's pAI back to the scrambled name
+        // since scrambling stops at '
+        var val = name.ToString() : 
+        val = comp.LastUser == null
+            ? val
+            : Loc.GetString("pai-system-pai-name", ("owner", val));
+        _metaData.SetEntityName(uid, val);
+        name.ToString());
     }
 
     public void PAITurningOff(EntityUid uid)

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -9,119 +9,118 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Random;
 using System.Text;
 
-namespace Content.Server.PAI
+namespace Content.Server.PAI;
+
+public sealed class PAISystem : SharedPAISystem
 {
-    public sealed class PAISystem : SharedPAISystem
+    [Dependency] private readonly InstrumentSystem _instrumentSystem = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ToggleableGhostRoleSystem _toggleableGhostRole = default!;
+
+    /// <summary>
+    /// Possible symbols that can replace characters in the pai's owner name when microwaved.
+    /// </summary>
+    private static readonly char[] SYMBOLS = new[] { '#', '~', '-', '@', '&', '^', '%', '$', '*'};
+
+    public override void Initialize()
     {
-        [Dependency] private readonly InstrumentSystem _instrumentSystem = default!;
-        [Dependency] private readonly IRobustRandom _random = default!;
-        [Dependency] private readonly MetaDataSystem _metaData = default!;
-        [Dependency] private readonly SharedPopupSystem _popup = default!;
-        [Dependency] private readonly ToggleableGhostRoleSystem _toggleableGhostRole = default!;
+        base.Initialize();
 
-        /// <summary>
-        /// Possible symbols that can replace characters in the pai's owner name when microwaved.
-        /// </summary>
-        private static readonly char[] SYMBOLS = new[] { '#', '~', '-', '@', '&', '^', '%', '$', '*'};
+        SubscribeLocalEvent<PAIComponent, UseInHandEvent>(OnUseInHand);
+        SubscribeLocalEvent<PAIComponent, MindAddedMessage>(OnMindAdded);
+        SubscribeLocalEvent<PAIComponent, MindRemovedMessage>(OnMindRemoved);
+        SubscribeLocalEvent<PAIComponent, BeingMicrowavedEvent>(OnMicrowaved);
+    }
 
-        public override void Initialize()
+    private void OnUseInHand(EntityUid uid, PAIComponent component, UseInHandEvent args)
+    {
+        if (!TryComp<MindContainerComponent>(uid, out var mind) || !mind.HasMind)
+            component.LastUser = args.User;
+    }
+
+    private void OnMindAdded(EntityUid uid, PAIComponent component, MindAddedMessage args)
+    {
+        if (component.LastUser == null)
+            return;
+
+        // Ownership tag
+        var val = Loc.GetString("pai-system-pai-name", ("owner", component.LastUser));
+
+        // TODO Identity? People shouldn't dox-themselves by carrying around a PAI.
+        // But having the pda's name permanently be "old lady's PAI" is weird.
+        // Changing the PAI's identity in a way that ties it to the owner's identity also seems weird.
+        // Cause then you could remotely figure out information about the owner's equipped items.
+
+        _metaData.SetEntityName(uid, val);
+    }
+
+    private void OnMindRemoved(EntityUid uid, PAIComponent component, MindRemovedMessage args)
+    {
+        // Mind was removed, shutdown the PAI.
+        PAITurningOff(uid);
+    }
+
+    private void OnMicrowaved(EntityUid uid, PAIComponent comp, BeingMicrowavedEvent args)
+    {
+        // name will always be scrambled whether it gets bricked or not, this is the reward
+        ScrambleName(uid, comp);
+
+        // randomly brick it
+        if (_random.Prob(comp.BrickChance))
         {
-            base.Initialize();
-
-            SubscribeLocalEvent<PAIComponent, UseInHandEvent>(OnUseInHand);
-            SubscribeLocalEvent<PAIComponent, MindAddedMessage>(OnMindAdded);
-            SubscribeLocalEvent<PAIComponent, MindRemovedMessage>(OnMindRemoved);
-            SubscribeLocalEvent<PAIComponent, BeingMicrowavedEvent>(OnMicrowaved);
+            _popup.PopupEntity(Loc.GetString(comp.BrickPopup), uid, PopupType.LargeCaution);
+            RemComp<PAIComponent>(uid);
+            _toggleableGhostRole.Wipe(uid);
         }
-
-        private void OnUseInHand(EntityUid uid, PAIComponent component, UseInHandEvent args)
+        else
         {
-            if (!TryComp<MindContainerComponent>(uid, out var mind) || !mind.HasMind)
-                component.LastUser = args.User;
+            // you are lucky...
+            _popup.PopupEntity(Loc.GetString(comp.ScramblePopup), uid, PopupType.Large);
         }
+    }
 
-        private void OnMindAdded(EntityUid uid, PAIComponent component, MindAddedMessage args)
+    private void ScrambleName(EntityUid uid, PAIComponent comp)
+    {
+        // randomly replace random characters from the old name
+        var oldName = Name(uid);
+        var name = new StringBuilder(oldName.Length);
+        foreach (var character in oldName)
         {
-            if (component.LastUser == null)
-                return;
+            // only scramble the owner name, don't scramble "'s pAI"
+            if (character == '\'')
+                break;
 
-            // Ownership tag
-            var val = Loc.GetString("pai-system-pai-name", ("owner", component.LastUser));
-
-            // TODO Identity? People shouldn't dox-themselves by carrying around a PAI.
-            // But having the pda's name permanently be "old lady's PAI" is weird.
-            // Changing the PAI's identity in a way that ties it to the owner's identity also seems weird.
-            // Cause then you could remotely figure out information about the owner's equipped items.
-
-            _metaData.SetEntityName(uid, val);
-        }
-
-        private void OnMindRemoved(EntityUid uid, PAIComponent component, MindRemovedMessage args)
-        {
-            // Mind was removed, shutdown the PAI.
-            PAITurningOff(uid);
-        }
-
-        private void OnMicrowaved(EntityUid uid, PAIComponent comp, BeingMicrowavedEvent args)
-        {
-            // name will always be scrambled whether it gets bricked or not, this is the reward
-            ScrambleName(uid, comp);
-
-            // randomly brick it
-            if (_random.Prob(comp.BrickChance))
+            if (_random.Prob(comp.CharScrambleChance))
             {
-                _popup.PopupEntity(Loc.GetString(comp.BrickPopup), uid, PopupType.LargeCaution);
-                RemComp<PAIComponent>(uid);
-                _toggleableGhostRole.Wipe(uid);
+                name.Append(_random.Pick(SYMBOLS));
             }
             else
             {
-                // you are lucky...
-                _popup.PopupEntity(Loc.GetString(comp.ScramblePopup), uid, PopupType.Large);
+                name.Append(character);
             }
         }
 
-        private void ScrambleName(EntityUid uid, PAIComponent comp)
+        _metaData.SetEntityName(uid, name.ToString());
+    }
+
+    public void PAITurningOff(EntityUid uid)
+    {
+        //  Close the instrument interface if it was open
+        //  before closing
+        if (HasComp<ActiveInstrumentComponent>(uid) && TryComp<ActorComponent>(uid, out var actor))
         {
-            // randomly replace random characters from the old name
-            var oldName = Name(uid);
-            var name = new StringBuilder(oldName.Length);
-            foreach (var character in oldName)
-            {
-                // only scramble the owner name, don't scramble "'s pAI"
-                if (character == '\'')
-                    break;
-
-                if (_random.Prob(comp.CharScrambleChance))
-                {
-                    name.Append(_random.Pick(SYMBOLS));
-                }
-                else
-                {
-                    name.Append(character);
-                }
-            }
-
-            _metaData.SetEntityName(uid, name.ToString());
+            _instrumentSystem.ToggleInstrumentUi(uid, actor.PlayerSession);
         }
 
-        public void PAITurningOff(EntityUid uid)
+        //  Stop instrument
+        if (TryComp<InstrumentComponent>(uid, out var instrument)) _instrumentSystem.Clean(uid, instrument);
+        if (TryComp<MetaDataComponent>(uid, out var metadata))
         {
-            //  Close the instrument interface if it was open
-            //  before closing
-            if (HasComp<ActiveInstrumentComponent>(uid) && TryComp<ActorComponent>(uid, out var actor))
-            {
-                _instrumentSystem.ToggleInstrumentUi(uid, actor.PlayerSession);
-            }
-
-            //  Stop instrument
-            if (TryComp<InstrumentComponent>(uid, out var instrument)) _instrumentSystem.Clean(uid, instrument);
-            if (TryComp<MetaDataComponent>(uid, out var metadata))
-            {
-                var proto = metadata.EntityPrototype;
-                if (proto != null)
-                    _metaData.SetEntityName(uid, proto.Name);
-            }
+            var proto = metadata.EntityPrototype;
+            if (proto != null)
+                _metaData.SetEntityName(uid, proto.Name);
         }
     }
 }

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -109,7 +109,7 @@ public sealed class PAISystem : SharedPAISystem
         var val = name.ToString();
         val = comp.LastUser == null
             ? val
-            : Loc.GetString("pai-system-pai-name", ("owner", val));
+            : Loc.GetString("pai-system-pai-name-raw", ("name", val));
         _metaData.SetEntityName(uid, val);
     }
 

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -88,11 +88,15 @@ public sealed class PAISystem : SharedPAISystem
         // randomly replace random characters from the old name
         var oldName = Name(uid);
         var name = new StringBuilder(oldName.Length);
+        var named = false;
         foreach (var character in oldName)
         {
             // only scramble the owner name, don't scramble "'s pAI"
             if (character == '\'')
+            {
+                named = true;
                 break;
+            }
 
             if (_random.Prob(comp.CharScrambleChance))
             {
@@ -107,7 +111,7 @@ public sealed class PAISystem : SharedPAISystem
         // if its named add 's pAI back to the scrambled name
         // since scrambling stops at '
         var val = name.ToString();
-        val = comp.LastUser == null
+        val = named
             ? val
             : Loc.GetString("pai-system-pai-name-raw", ("name", val));
         _metaData.SetEntityName(uid, val);

--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -35,7 +35,7 @@ public sealed partial class PAIComponent : Component
     /// When microwaved there is this chance to brick the pai, kicking out its player and preventing it from being used again.
     /// </summary>
     [DataField("brickChance")]
-    public float BrickChance = 0.25f;
+    public float BrickChance = 0.5f;
 
     /// <summary>
     /// Locale id for the popup shown when the pai gets bricked.
@@ -48,10 +48,4 @@ public sealed partial class PAIComponent : Component
     /// </summary>
     [DataField("scramblePopup")]
     public string ScramblePopup = "pai-system-scramble-popup";
-
-    /// <summary>
-    /// Chance for an individual character to be scrambled.
-    /// </summary>
-    [DataField("charScrambleChance")]
-    public float CharScrambleChance = 0.2f;
 }

--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -41,13 +41,13 @@ public sealed partial class PAIComponent : Component
     /// Locale id for the popup shown when the pai gets bricked.
     /// </summary>
     [DataField("brickPopup")]
-    public string BrickPopup = "pai-component-brick-popup";
+    public string BrickPopup = "pai-system-brick-popup";
 
     /// <summary>
     /// Locale id for the popup shown when the pai is microwaved but does not get bricked.
     /// </summary>
     [DataField("scramblePopup")]
-    public string ScramblePopup = "pai-component-scramble-popup";
+    public string ScramblePopup = "pai-system-scramble-popup";
 
     /// <summary>
     /// Chance for an individual character to be scrambled.

--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -53,5 +53,5 @@ public sealed partial class PAIComponent : Component
     /// Chance for an individual character to be scrambled.
     /// </summary>
     [DataField("charScrambleChance")]
-    public float CharScrambleChance = 0.5f;
+    public float CharScrambleChance = 0.2f;
 }

--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -2,58 +2,56 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Shared.PAI
+namespace Content.Shared.PAI;
+
+/// <summary>
+/// pAIs, or Personal AIs, are essentially portable ghost role generators.
+/// In their current implementation in SS14, they create a ghost role anyone can access,
+/// and that a player can also "wipe" (reset/kick out player).
+/// Theoretically speaking pAIs are supposed to use a dedicated "offer and select" system,
+///  with the player holding the pAI being able to choose one of the ghosts in the round.
+/// This seems too complicated for an initial implementation, though,
+///  and there's not always enough players and ghost roles to justify it.
+/// All logic in PAISystem.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PAIComponent : Component
 {
     /// <summary>
-    /// pAIs, or Personal AIs, are essentially portable ghost role generators.
-    /// In their current implementation in SS14, they create a ghost role anyone can access,
-    /// and that a player can also "wipe" (reset/kick out player).
-    /// Theoretically speaking pAIs are supposed to use a dedicated "offer and select" system,
-    ///  with the player holding the pAI being able to choose one of the ghosts in the round.
-    /// This seems too complicated for an initial implementation, though,
-    ///  and there's not always enough players and ghost roles to justify it.
-    /// All logic in PAISystem.
+    /// The last person who activated this PAI.
+    /// Used for assigning the name.
     /// </summary>
-    [RegisterComponent, NetworkedComponent]
-    public sealed partial class PAIComponent : Component
-    {
-        /// <summary>
-        /// The last person who activated this PAI.
-        /// Used for assigning the name.
-        /// </summary>
-        [DataField("lastUser"), ViewVariables(VVAccess.ReadWrite)]
-        public EntityUid? LastUser;
+    [DataField("lastUser"), ViewVariables(VVAccess.ReadWrite)]
+    public EntityUid? LastUser;
 
-        [DataField("midiActionId", serverOnly: true,
-            customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-        public string? MidiActionId = "ActionPAIPlayMidi";
+    [DataField("midiActionId", serverOnly: true,
+        customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string? MidiActionId = "ActionPAIPlayMidi";
 
-        [DataField("midiAction", serverOnly: true)] // server only, as it uses a server-BUI event !type
-        public EntityUid? MidiAction;
+    [DataField("midiAction", serverOnly: true)] // server only, as it uses a server-BUI event !type
+    public EntityUid? MidiAction;
 
-        /// <summary>
-        /// When microwaved there is this chance to brick the pai, kicking out its player and preventing it from being used again.
-        /// </summary>
-        [DataField("brickChance")]
-        public float BrickChance = 0.25f;
+    /// <summary>
+    /// When microwaved there is this chance to brick the pai, kicking out its player and preventing it from being used again.
+    /// </summary>
+    [DataField("brickChance")]
+    public float BrickChance = 0.25f;
 
-        /// <summary>
-        /// Locale id for the popup shown when the pai gets bricked.
-        /// </summary>
-        [DataField("brickPopup")]
-        public string BrickPopup = "pai-component-brick-popup";
+    /// <summary>
+    /// Locale id for the popup shown when the pai gets bricked.
+    /// </summary>
+    [DataField("brickPopup")]
+    public string BrickPopup = "pai-component-brick-popup";
 
-        /// <summary>
-        /// Locale id for the popup shown when the pai is microwaved but does not get bricked.
-        /// </summary>
-        [DataField("scramblePopup")]
-        public string ScramblePopup = "pai-component-scramble-popup";
+    /// <summary>
+    /// Locale id for the popup shown when the pai is microwaved but does not get bricked.
+    /// </summary>
+    [DataField("scramblePopup")]
+    public string ScramblePopup = "pai-component-scramble-popup";
 
-        /// <summary>
-        /// Chance for an individual character to be scrambled.
-        /// </summary>
-        [DataField("charScrambleChance")]
-        public float CharScrambleChance = 0.5f;
-    }
+    /// <summary>
+    /// Chance for an individual character to be scrambled.
+    /// </summary>
+    [DataField("charScrambleChance")]
+    public float CharScrambleChance = 0.5f;
 }
-

--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -30,6 +30,30 @@ namespace Content.Shared.PAI
 
         [DataField("midiAction", serverOnly: true)] // server only, as it uses a server-BUI event !type
         public EntityUid? MidiAction;
+
+        /// <summary>
+        /// When microwaved there is this chance to brick the pai, kicking out its player and preventing it from being used again.
+        /// </summary>
+        [DataField("brickChance")]
+        public float BrickChance = 0.25f;
+
+        /// <summary>
+        /// Locale id for the popup shown when the pai gets bricked.
+        /// </summary>
+        [DataField("brickPopup")]
+        public string BrickPopup = "pai-component-brick-popup";
+
+        /// <summary>
+        /// Locale id for the popup shown when the pai is microwaved but does not get bricked.
+        /// </summary>
+        [DataField("scramblePopup")]
+        public string ScramblePopup = "pai-component-scramble-popup";
+
+        /// <summary>
+        /// Chance for an individual character to be scrambled.
+        /// </summary>
+        [DataField("charScrambleChance")]
+        public float CharScrambleChance = 0.5f;
     }
 }
 

--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -21,7 +21,7 @@ namespace Content.Shared.PAI
         /// The last person who activated this PAI.
         /// Used for assigning the name.
         /// </summary>
-        [DataField("lastUSer"), ViewVariables(VVAccess.ReadWrite)]
+        [DataField("lastUser"), ViewVariables(VVAccess.ReadWrite)]
         public EntityUid? LastUser;
 
         [DataField("midiActionId", serverOnly: true,

--- a/Resources/Locale/en-US/pai/pai-system.ftl
+++ b/Resources/Locale/en-US/pai/pai-system.ftl
@@ -18,3 +18,5 @@ pai-system-stopped-searching = The device stopped searching for a pAI.
 
 pai-system-pai-name = { CAPITALIZE(THE($owner)) }'s pAI
 
+pai-system-brick-popup = The pAI's circuits loudly pop and fizzle out!
+pai-system-scramble-popup = The pAI's circuits are overloaded with electricity!

--- a/Resources/Locale/en-US/pai/pai-system.ftl
+++ b/Resources/Locale/en-US/pai/pai-system.ftl
@@ -17,6 +17,7 @@ pai-system-stop-searching-verb-text = Stop searching
 pai-system-stopped-searching = The device stopped searching for a pAI.
 
 pai-system-pai-name = { CAPITALIZE(THE($owner)) }'s pAI
+pai-system-pai-name-raw = {$name}'s pAI
 
 pai-system-brick-popup = The pAI's circuits loudly pop and fizzle out!
 pai-system-scramble-popup = The pAI's circuits are overloaded with electricity!


### PR DESCRIPTION
## About the PR
microwaving a pai will replace some of its names letters with random symbols
theres a chance to brick it which will boot a player if it has one and prevent future ghosts taking it
also minor refactoring

## Why / Balance
funny and has some utility if you want to kinda anonymize a pai

## Technical details
`ScrambleName` added to pai system which is called when microwaving
added `Wipe` helper to toggleable ghost role system which random bricking uses

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/c185e3f2-38ac-472d-afd1-424311c8a69e


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
renamed lastUSer to lastUser but its unlikely that anything used it

**Changelog**
no cl no fun