### PR TITLE
ninja hotfixes

### DIFF
--- a/Content.Server/Ninja/Events/BatteryChangedEvent.cs
+++ b/Content.Server/Ninja/Events/BatteryChangedEvent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Ninja.Events;
+
+/// <summary>
+/// Raised on the ninja when the suit has its powercell changed.
+/// </summary>
+[ByRefEvent]
+public record struct NinjaBatteryChangedEvent(EntityUid Battery, EntityUid BatteryHolder);

--- a/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
+++ b/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
+using Content.Server.Power.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Ninja.Components;
@@ -24,6 +25,7 @@ public sealed class BatteryDrainerSystem : SharedBatteryDrainerSystem
         base.Initialize();
 
         SubscribeLocalEvent<BatteryDrainerComponent, BeforeInteractHandEvent>(OnBeforeInteractHand);
+        SubscribeLocalEvent<BatteryDrainerComponent, BatteryChangedEvent>(OnBatteryChanged);
     }
 
     /// <summary>
@@ -54,6 +56,11 @@ public sealed class BatteryDrainerSystem : SharedBatteryDrainerSystem
         };
 
         _doAfter.TryStartDoAfter(doAfterArgs);
+    }
+
+    private void OnBatteryChanged(EntityUid uid, BatteryDrainerComponent comp, ref BatteryChangedEvent args)
+    {
+        SetBattery(uid, args.Battery, comp);
     }
 
     /// <inheritdoc/>

--- a/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
+++ b/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
@@ -1,6 +1,6 @@
+using Content.Server.Ninja.Events;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
-using Content.Server.Power.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Ninja.Components;
@@ -25,7 +25,7 @@ public sealed class BatteryDrainerSystem : SharedBatteryDrainerSystem
         base.Initialize();
 
         SubscribeLocalEvent<BatteryDrainerComponent, BeforeInteractHandEvent>(OnBeforeInteractHand);
-        SubscribeLocalEvent<BatteryDrainerComponent, BatteryChangedEvent>(OnBatteryChanged);
+        SubscribeLocalEvent<BatteryDrainerComponent, NinjaBatteryChangedEvent>(OnBatteryChanged);
     }
 
     /// <summary>
@@ -58,7 +58,7 @@ public sealed class BatteryDrainerSystem : SharedBatteryDrainerSystem
         _doAfter.TryStartDoAfter(doAfterArgs);
     }
 
-    private void OnBatteryChanged(EntityUid uid, BatteryDrainerComponent comp, ref BatteryChangedEvent args)
+    private void OnBatteryChanged(EntityUid uid, BatteryDrainerComponent comp, ref NinjaBatteryChangedEvent args)
     {
         SetBattery(uid, args.Battery, comp);
     }

--- a/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
@@ -1,9 +1,8 @@
 using Content.Server.Communications;
 using Content.Server.DoAfter;
 using Content.Server.Mind;
-using Content.Server.Ninja.Systems;
+using Content.Server.Ninja.Events;
 using Content.Server.Power.Components;
-using Content.Server.Power.Events;
 using Content.Server.Roles;
 using Content.Shared.Communications;
 using Content.Shared.DoAfter;

--- a/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
@@ -23,11 +23,10 @@ namespace Content.Server.Ninja.Systems;
 public sealed class NinjaGlovesSystem : SharedNinjaGlovesSystem
 {
     [Dependency] private readonly EmagProviderSystem _emagProvider = default!;
-    [Dependency] private readonly SharedBatteryDrainerSystem _drainer = default!;
-    [Dependency] private readonly SharedStunProviderSystem _stunProvider = default!;
-    [Dependency] private readonly SpaceNinjaSystem _ninja = default!;
     [Dependency] private readonly CommsHackerSystem _commsHacker = default!;
     [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly SharedStunProviderSystem _stunProvider = default!;
+    [Dependency] private readonly SpaceNinjaSystem _ninja = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.DoAfter;
 using Content.Server.Mind;
 using Content.Server.Ninja.Systems;
 using Content.Server.Power.Components;
+using Content.Server.Power.Events;
 using Content.Server.Roles;
 using Content.Shared.Communications;
 using Content.Shared.DoAfter;
@@ -73,6 +74,10 @@ public sealed class NinjaGlovesSystem : SharedNinjaGlovesSystem
 
     private void EnableGloves(EntityUid uid, NinjaGlovesComponent comp, EntityUid user, SpaceNinjaComponent ninja)
     {
+        // can't use abilities if suit is not equipped, this is checked elsewhere but just making sure to satisfy nullability
+        if (ninja.Suit == null)
+            return;
+
         comp.User = user;
         Dirty(uid, comp);
         _ninja.AssignGloves(user, uid, ninja);
@@ -82,8 +87,8 @@ public sealed class NinjaGlovesSystem : SharedNinjaGlovesSystem
         _stunProvider.SetNoPowerPopup(user, "ninja-no-power", stun);
         if (_ninja.GetNinjaBattery(user, out var battery, out var _))
         {
-            _drainer.SetBattery(user, battery, drainer);
-            _stunProvider.SetBattery(user, battery, stun);
+            var ev = new BatteryChangedEvent(battery.Value, ninja.Suit.Value);
+            RaiseLocalEvent(user, ref ev);
         }
 
         var emag = EnsureComp<EmagProviderComponent>(user);

--- a/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
@@ -85,7 +85,7 @@ public sealed class NinjaGlovesSystem : SharedNinjaGlovesSystem
         _stunProvider.SetNoPowerPopup(user, "ninja-no-power", stun);
         if (_ninja.GetNinjaBattery(user, out var battery, out var _))
         {
-            var ev = new BatteryChangedEvent(battery.Value, ninja.Suit.Value);
+            var ev = new NinjaBatteryChangedEvent(battery.Value, ninja.Suit.Value);
             RaiseLocalEvent(user, ref ev);
         }
 

--- a/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
@@ -1,7 +1,7 @@
 using Content.Server.Emp;
+using Content.Server.Ninja.Events;
 using Content.Server.Popups;
 using Content.Server.Power.Components;
-using Content.Server.Power.Events;
 using Content.Server.PowerCell;
 using Content.Shared.Actions;
 using Content.Shared.Clothing.EntitySystems;

--- a/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
@@ -47,6 +47,11 @@ public sealed class NinjaSuitSystem : SharedNinjaSuitSystem
     // TODO: or put MaxCharge in shared along with powercellslot
     private void OnSuitInsertAttempt(EntityUid uid, NinjaSuitComponent comp, ContainerIsInsertingAttemptEvent args)
     {
+        // this is for handling battery upgrading, not stopping actions from being added
+        // if another container like ActionsContainer is specified, don't handle it
+        if (TryComp<PowerCellSlotComponent>(uid, out var slot) && args.Container.ID != slot.CellSlotId)
+            return;
+
         // no power cell for some reason??? allow it
         if (!_powerCell.TryGetBatteryFromSlot(uid, out var battery))
             return;
@@ -56,8 +61,6 @@ public sealed class NinjaSuitSystem : SharedNinjaSuitSystem
         {
             args.Cancel();
         }
-
-        // TODO: raise event on ninja telling it to update battery
     }
 
     private void OnEmpAttempt(EntityUid uid, NinjaSuitComponent comp, EmpAttemptEvent args)

--- a/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Emp;
 using Content.Server.Popups;
 using Content.Server.Power.Components;
+using Content.Server.Power.Events;
 using Content.Server.PowerCell;
 using Content.Shared.Actions;
 using Content.Shared.Clothing.EntitySystems;
@@ -8,6 +9,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Ninja.Components;
 using Content.Shared.Ninja.Systems;
 using Content.Shared.Popups;
+using Content.Shared.PowerCell.Components;
 using Robust.Shared.Containers;
 
 namespace Content.Server.Ninja.Systems;
@@ -61,6 +63,14 @@ public sealed class NinjaSuitSystem : SharedNinjaSuitSystem
         {
             args.Cancel();
         }
+
+        // tell ninja abilities that use battery to update it so they don't use charge from the old one
+        var user = Transform(uid).ParentUid;
+        if (!HasComp<SpaceNinjaComponent>(user))
+            return;
+
+        var ev = new BatteryChangedEvent(args.EntityUid, uid);
+        RaiseLocalEvent(user, ref ev);
     }
 
     private void OnEmpAttempt(EntityUid uid, NinjaSuitComponent comp, EmpAttemptEvent args)

--- a/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
@@ -69,7 +69,7 @@ public sealed class NinjaSuitSystem : SharedNinjaSuitSystem
         if (!HasComp<SpaceNinjaComponent>(user))
             return;
 
-        var ev = new BatteryChangedEvent(args.EntityUid, uid);
+        var ev = new NinjaBatteryChangedEvent(args.EntityUid, uid);
         RaiseLocalEvent(user, ref ev);
     }
 

--- a/Content.Server/Ninja/Systems/StunProviderSystem.cs
+++ b/Content.Server/Ninja/Systems/StunProviderSystem.cs
@@ -1,5 +1,5 @@
+using Content.Server.Ninja.Events;
 using Content.Server.Power.EntitySystems;
-using Content.Server.Power.Events;
 using Content.Shared.Electrocution;
 using Content.Shared.Interaction;
 using Content.Shared.Ninja.Components;
@@ -28,7 +28,7 @@ public sealed class StunProviderSystem : SharedStunProviderSystem
         base.Initialize();
 
         SubscribeLocalEvent<StunProviderComponent, BeforeInteractHandEvent>(OnBeforeInteractHand);
-        SubscribeLocalEvent<StunProviderComponent, BatteryChangedEvent>(OnBatteryChanged);
+        SubscribeLocalEvent<StunProviderComponent, NinjaBatteryChangedEvent>(OnBatteryChanged);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public sealed class StunProviderSystem : SharedStunProviderSystem
         args.Handled = true;
     }
 
-    private void OnBatteryChanged(EntityUid uid, StunProviderComponent comp, ref BatteryChangedEvent args)
+    private void OnBatteryChanged(EntityUid uid, StunProviderComponent comp, ref NinjaBatteryChangedEvent args)
     {
         SetBattery(uid, args.Battery, comp);
     }

--- a/Content.Server/Ninja/Systems/StunProviderSystem.cs
+++ b/Content.Server/Ninja/Systems/StunProviderSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Ninja.Components;
 using Content.Shared.Ninja.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Whitelist;
+using Robust.Shared.Audio;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Ninja.Systems;
@@ -17,6 +18,7 @@ public sealed class StunProviderSystem : SharedStunProviderSystem
 {
     [Dependency] private readonly BatterySystem _battery = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedElectrocutionSystem _electrocution = default!;
     [Dependency] private readonly SharedNinjaGlovesSystem _gloves = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -50,6 +52,8 @@ public sealed class StunProviderSystem : SharedStunProviderSystem
             _popup.PopupEntity(Loc.GetString(comp.NoPowerPopup), uid, uid);
             return;
         }
+
+        _audio.PlayPvs(comp.Sound, target);
 
         // not holding hands with target so insuls don't matter
         _electrocution.TryDoElectrocution(target, uid, comp.StunDamage, comp.StunTime, false, ignoreInsulation: true);

--- a/Content.Server/Ninja/Systems/StunProviderSystem.cs
+++ b/Content.Server/Ninja/Systems/StunProviderSystem.cs
@@ -1,10 +1,11 @@
+using Content.Server.Power.EntitySystems;
+using Content.Server.Power.Events;
 using Content.Shared.Electrocution;
 using Content.Shared.Interaction;
 using Content.Shared.Ninja.Components;
 using Content.Shared.Ninja.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Whitelist;
-using Content.Server.Power.EntitySystems;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Ninja.Systems;
@@ -25,6 +26,7 @@ public sealed class StunProviderSystem : SharedStunProviderSystem
         base.Initialize();
 
         SubscribeLocalEvent<StunProviderComponent, BeforeInteractHandEvent>(OnBeforeInteractHand);
+        SubscribeLocalEvent<StunProviderComponent, BatteryChangedEvent>(OnBatteryChanged);
     }
 
     /// <summary>
@@ -56,5 +58,10 @@ public sealed class StunProviderSystem : SharedStunProviderSystem
         Dirty(uid, comp);
 
         args.Handled = true;
+    }
+
+    private void OnBatteryChanged(EntityUid uid, StunProviderComponent comp, ref BatteryChangedEvent args)
+    {
+        SetBattery(uid, args.Battery, comp);
     }
 }

--- a/Content.Server/Ninja/Systems/StunProviderSystem.cs
+++ b/Content.Server/Ninja/Systems/StunProviderSystem.cs
@@ -59,7 +59,6 @@ public sealed class StunProviderSystem : SharedStunProviderSystem
         _electrocution.TryDoElectrocution(target, uid, comp.StunDamage, comp.StunTime, false, ignoreInsulation: true);
         // short cooldown to prevent instant stunlocking
         comp.NextStun = _timing.CurTime + comp.Cooldown;
-        Dirty(uid, comp);
 
         args.Handled = true;
     }

--- a/Content.Server/Power/Events/BatteryChangedEvent.cs
+++ b/Content.Server/Power/Events/BatteryChangedEvent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Power.Events;
+
+/// <summary>
+/// Raised on an entity when a related entity that stores a powercell has its powercell changed.
+/// </summary>
+[ByRefEvent]
+public record struct BatteryChangedEvent(EntityUid Battery, EntityUid BatteryHolder);

--- a/Content.Server/Power/Events/BatteryChangedEvent.cs
+++ b/Content.Server/Power/Events/BatteryChangedEvent.cs
@@ -1,7 +1,0 @@
-namespace Content.Server.Power.Events;
-
-/// <summary>
-/// Raised on an entity when a related entity that stores a powercell has its powercell changed.
-/// </summary>
-[ByRefEvent]
-public record struct BatteryChangedEvent(EntityUid Battery, EntityUid BatteryHolder);

--- a/Content.Shared/Ninja/Components/StunProviderComponent.cs
+++ b/Content.Shared/Ninja/Components/StunProviderComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Ninja.Systems;
 using Content.Shared.Whitelist;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -18,6 +19,12 @@ public sealed partial class StunProviderComponent : Component
     /// </summary>
     [DataField("batteryUid"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public EntityUid? BatteryUid;
+
+    /// <summary>
+    /// Sound played when stunning someone.
+    /// </summary>
+    [DataField("sound"), ViewVariables(VVAccess.ReadWrite)]
+    public SoundSpecifier Sound = new SoundCollectionSpecifier("sparks");
 
     /// <summary>
     /// Joules required in the battery to stun someone. Defaults to 10 uses on a small battery.

--- a/Content.Shared/Ninja/Components/StunProviderComponent.cs
+++ b/Content.Shared/Ninja/Components/StunProviderComponent.cs
@@ -35,13 +35,13 @@ public sealed partial class StunProviderComponent : Component
     /// Time that someone is stunned for, stacks if done multiple times.
     /// </summary>
     [DataField("stunTime"), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan StunTime = TimeSpan.FromSeconds(3);
+    public TimeSpan StunTime = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// How long stunning is disabled after stunning something.
     /// </summary>
     [DataField("cooldown"), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan Cooldown = TimeSpan.FromSeconds(1);
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Locale string to popup when there is no power


### PR DESCRIPTION
## About the PR
1. fixes actions being removed by powercell upgrade check, fixes #19970
2. upgrading suit battery updates battery used by abilities
3. stun duration and cooldown increased, play sound when stunning

## Why / Balance
1. bug
2. resolve a todo
3. so you dont need to spam stun to get something useful out of it, 3 seconds was way too short for you to turn on combat mode switch to katana then get 1-2 hits in

## Technical details
1. just check the slot against powercell's slot id
2. add BatteryChangedEvent for ninja abilities to use instead of calling SetBattery on them all
   using this in suit system too to update the battery when its upgraded

## Media
![14:38:44](https://github.com/space-wizards/space-station-14/assets/39013340/6a3b8ba8-640f-423f-8bb7-4b080a1c83bb)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed ninja suit not having any actions.
