### PR TITLE
butcherable gloves + glove cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -1,5 +1,15 @@
+# gloves that cover the fingertips and have synthetic fibers
 - type: entity
+  abstract: true
   parent: ClothingHandsBase
+  id: ClothingHandsGlovesSyntheticBase
+  components:
+  - type: Fiber
+    fiberMaterial: fibers-synthetic
+  - type: FingerprintMask
+
+- type: entity
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorPurple
   name: purple gloves
   description: Regular purple gloves that do not keep you from frying.
@@ -9,12 +19,10 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/purple.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-purple
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorRed
   name: red gloves
   description: Regular red gloves that do not keep you from frying.
@@ -24,12 +32,10 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/red.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-red
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorBlack
   name: black gloves
   description: Regular black gloves that do not keep you from frying.
@@ -40,13 +46,15 @@
     sprite: Clothing/Hands/Gloves/Color/black.rsi
   - type: GloveHeatResistance
     heatResistance: 1400
+  - type: Butcherable
+    butcheringType: Knife
+    spawned:
+    - id: ClothingHandsGlovesFingerless
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-black
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorBlue
   name: blue gloves
   description: Regular blue gloves that do not keep you from frying.
@@ -56,12 +64,10 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/blue.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-blue
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorBrown
   name: brown gloves
   description: Regular brown gloves that do not keep you from frying.
@@ -71,12 +77,10 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/brown.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-brown
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorGray
   name: grey gloves
   description: Regular grey gloves that do not keep you from frying.
@@ -86,12 +90,10 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/gray.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-grey
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorGreen
   name: green gloves
   description: Regular green gloves that do not keep you from frying.
@@ -101,12 +103,10 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/green.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-green
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorLightBrown
   name: light brown gloves
   description: Regular light brown gloves that do not keep you from frying.
@@ -116,12 +116,10 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/lightbrown.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-brown
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorOrange
   name: orange gloves
   description: Regular orange gloves that do not keep you from frying.
@@ -131,12 +129,10 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/orange.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-orange
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorWhite
   name: white gloves
   description: Those gloves look fancy.
@@ -146,12 +142,10 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/white.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
     fiberColor: fibers-white
-  - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorYellow
   name: insulated gloves
   description: These gloves will protect the wearer from electric shocks.
@@ -162,11 +156,14 @@
     sprite: Clothing/Hands/Gloves/Color/yellow.rsi
   - type: GloveHeatResistance
     heatResistance: 1400
+  - type: Butcherable
+    butcheringType: Knife
+    spawned:
+    - id: ClothingHandsGlovesFingerlessInsulated
   - type: Insulated
   - type: Fiber
     fiberMaterial: fibers-insulative
     fiberColor: fibers-yellow
-  - type: FingerprintMask
 
 - type: entity
   parent: ClothingHandsGlovesColorYellow
@@ -174,27 +171,22 @@
   name: budget insulated gloves
   description: These gloves are cheap knockoffs of the coveted ones - no way this can end badly.
   components:
-    - type: Clothing
-    - type: GloveHeatResistance
-      heatResistance: 0
-    - type: Insulated
-    - type: Fiber
-      fiberMaterial: fibers-insulative
-      fiberColor: fibers-yellow
-    - type: FingerprintMask
-    - type: RandomInsulation
-      # Why repeated numbers? So some numbers are more common, of course!
-      list:
-        - 0
-        - 0
-        - 0
-        - 0.5
-        - 0.5
-        - 0.5
-        - 0.75
-        - 1.25
-        - 1.25
-        - 1.5
-        - 1.5
-        - 1.5
-        - 1.5
+  - type: GloveHeatResistance
+    # can't take out lights using budgets
+    heatResistance: 0
+  - type: RandomInsulation
+    # Why repeated numbers? So some numbers are more common, of course!
+    list:
+      - 0
+      - 0
+      - 0
+      - 0.5
+      - 0.5
+      - 0.5
+      - 0.75
+      - 1.25
+      - 1.25
+      - 1.5
+      - 1.5
+      - 1.5
+      - 1.5

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -217,25 +217,18 @@
   - type: Electrified
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesColorBlack
   id: ClothingHandsGlovesCombat
   name: combat gloves
   description: These tactical gloves are fireproof and shock resistant.
   components:
-  - type: Sprite
-    sprite: Clothing/Hands/Gloves/Color/black.rsi
-  - type: Clothing
-    sprite: Clothing/Hands/Gloves/Color/black.rsi
-  - type: GloveHeatResistance
-    heatResistance: 1400
   - type: Insulated
   - type: Fiber
     fiberMaterial: fibers-insulative
-    fiberColor: fibers-black
-  - type: FingerprintMask
 
+# can't parent combat gloves since they are butcherable
 - type: entity
-  parent: ClothingHandsGlovesCombat
+  parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsTacticalMaidGloves
   name: tactical maid gloves
   description: Tactical maid gloves, every self-respecting maid should be able to discreetly eliminate her goals.
@@ -244,9 +237,14 @@
     sprite: Clothing/Hands/Gloves/tacticalmaidgloves.rsi
   - type: Clothing
     sprite: Clothing/Hands/Gloves/tacticalmaidgloves.rsi
+  - type: GloveHeatResistance
+    heatResistance: 1400
+  - type: Insulated
+  - type: Fiber
+    fiberColor: fibers-black
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: ClothingHandsGlovesCombat
   id: ClothingHandsMercGlovesCombat
   name: mercenary combat gloves
   description: High-quality combat gloves to protect hands from mechanical damage during combat.
@@ -255,13 +253,13 @@
     sprite: Clothing/Hands/Gloves/Color/olive.rsi
   - type: Clothing
     sprite: Clothing/Hands/Gloves/Color/olive.rsi
-  - type: GloveHeatResistance
-    heatResistance: 1400
-  - type: Insulated
+  - type: Butcherable
+    butcheringType: Knife
+    spawned:
+    - id: ClothingHandsGlovesMercFingerless
   - type: Fiber
     fiberMaterial: fibers-insulative
     fiberColor: fibers-olive
-  - type: FingerprintMask
 
 - type: entity
   parent: ClothingHandsBase
@@ -306,25 +304,17 @@
     fiberColor: fibers-olive
 
 - type: entity
-  parent: ClothingHandsBase
+  # Intentionally named after regular gloves, they're meant to be sneaky.
+  # This means they can also be butchered if you need to look unsus before a very thorough search...
+  parent: ClothingHandsGlovesColorBlack
   id: ThievingGloves
   suffix: Thieving
-  name: black gloves #Intentionally named after regular gloves, they're meant to be sneaky.
-  description: Regular black gloves that do not keep you from frying.
   components:
-    - type: Tag
-      tags: [] # ignore "WhitelistChameleon" tag
-    - type: Sprite
-      sprite: Clothing/Hands/Gloves/Color/black.rsi
-    - type: Clothing
-      sprite: Clothing/Hands/Gloves/Color/black.rsi
-    - type: Thieving
-      stripTimeReduction: 1.5
-      stealthy: true
-    - type: Fiber
-      fiberMaterial: fibers-synthetic
-      fiberColor: fibers-black
-    - type: FingerprintMask
+  - type: Tag
+    tags: [] # ignore "WhitelistChameleon" tag
+  - type: Thieving
+    stripTimeReduction: 1.5
+    stealthy: true
 
 - type: entity
   parent: ClothingHandsGlovesColorWhite
@@ -334,7 +324,6 @@
   description:  A cursed pair of cluwne hands.
   components:
   - type: Unremoveable
-
 
 - type: entity
   parent: ClothingHandsBase

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -300,7 +300,7 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/mercfingerless.rsi
   - type: Fiber
-    fiberMaterial: fibers-synthetic
+    fiberMaterial: fibers-insulative
     fiberColor: fibers-olive
 
 - type: entity


### PR DESCRIPTION
## About the PR
fingerless gloves can be accquired by butchering their fingerful variants:
- black gloves, combat gloves, thieving gloves -> fingerless gloves
- budgets, insuls -> fingerless insuls
- merc gloves -> fingerless merc gloves

chameleon gloves not changed since they might not be set to black gloves + already valid so no point

also cleaned up the files a bit

## Why / Balance
they already exist so why not
also lets you "launder" combat and thieving gloves to not be valid once you are done with them
sec can also use this say if a tider is being a shitter shocking doors, get out your knife and cut them up right infront of him :trollface:

## Technical details
made all the coloured gloves inherit a base synthetic glove prototype to reduce duplication

## Media
forensics still works fine
![16:33:21](https://github.com/space-wizards/space-station-14/assets/39013340/a72c0f6f-23df-4641-9b8f-322dffd67e62)


https://github.com/space-wizards/space-station-14/assets/39013340/3f76cbf9-bc1d-4760-8c18-10a30e25be70



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
- tweak: Black, yellow and mercenary gloves can be butchered to cut their fingertips off.
