### PR TITLE
Nukies will be able to buy carp

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -824,8 +824,8 @@
     Telecrystal: 2
   categories:
   - UplinkTools
- conditions:
- - !type:ListingLimitedStockCondition
+  conditions:
+  - !type:ListingLimitedStockCondition
     stock: 10
 
 # Job Specific

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -826,7 +826,7 @@
   - UplinkTools
  conditions:
  - !type:ListingLimitedStockCondition
-   stock: 10
+    stock: 10
 
 # Job Specific
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -824,6 +824,9 @@
     Telecrystal: 2
   categories:
   - UplinkTools
+ conditions:
+ - !type:ListingLimitedStockCondition
+   stock: 10
 
 # Job Specific
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -824,11 +824,6 @@
     Telecrystal: 2
   categories:
   - UplinkTools
-  conditions:
-  - !type:StoreWhitelistCondition
-    blacklist:
-      tags:
-      - NukeOpsUplink
 
 # Job Specific
 


### PR DESCRIPTION
## About the PR
Nuclear Operatives will be able to buy carps.

## Why / Balance
Nuclear Operatives should be able to buy carps for fishops.

:cl:
- add: Nuclear Operatives will be able to buy carps. They are limited to 10 per operative.
