### PR TITLE
prevent mice going under secret doors

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -23,7 +23,7 @@
         mask:
         - FullTileMask
         layer:
-        - AirlockLayer
+        - WallLayer
   - type: Door
     bumpOpen: false
     clickOpen: true


### PR DESCRIPTION
## About the PR
made it have wall mask like high security airlock

## Why / Balance
mice should not be able to "validcheck" walls

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun