### PR TITLE
More Boot Fitting Items (Mostly firearms)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -23,7 +23,8 @@
     whitelist:
       tags:
         - Knife
-  
+        - Sidearm
+
 - type: entity
   parent: ClothingShoesBaseButcherable
   id: ClothingShoesBootsSalvage
@@ -60,6 +61,7 @@
     whitelist:
       tags:
         - Knife
+        - Sidearm
 
 - type: entity
   parent: ClothingShoesStorageBase
@@ -75,6 +77,7 @@
     whitelist:
       tags:
         - Knife
+        - Sidearm
 
 - type: entity
   parent: ClothingShoesBaseButcherable

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -591,6 +591,9 @@
   - type: Item
     sprite: Objects/Fun/toys.rsi
     heldPrefix: capgun
+  - type: Tag
+    tags:
+    - Sidearm
   - type: Gun
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -38,6 +38,9 @@
   components:
   - type: Item
     size: 10
+  - type: Tag
+    tags:
+    - Sidearm
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/taser.rsi
     quickEquip: false
@@ -272,6 +275,7 @@
     - type: Tag
       tags:
         - Taser
+        - Sidearm
     - type: Sprite
       sprite: Objects/Weapons/Guns/Battery/disabler.rsi
       layers:
@@ -333,6 +337,7 @@
   - type: Tag
     tags:
     - Taser
+    - Sidearm
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/taser.rsi
     layers:
@@ -392,6 +397,7 @@
   - type: Tag
     tags:
     - HighRiskItem
+    - Sidearm
   - type: StaticPrice
     price: 750
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -13,6 +13,9 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: Item
     size: 10
+  - type: Tag
+    tags:
+    - Sidearm
   - type: Clothing
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -9,6 +9,9 @@
     state: icon
   - type: Item
     size: 10
+  - type: Tag
+    tags:
+    - Sidearm
   - type: Clothing
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -78,6 +78,9 @@
         Slash: 6.5
   - type: Item
     size: 10
+  - type: Tag
+    tags:
+    - Knife
 
 # Like a crusher... but better
 - type: entity

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -874,6 +874,9 @@
   id: Shovel
 
 - type: Tag
+  id: Sidearm
+
+- type: Tag
   id: SkeletonMotorcycleKeys
 
 - type: Tag


### PR DESCRIPTION
## About the PR
Adds a new tag "Sidearm" that allows most small firearms (like pistols, revolvers, disablers, capguns, laser pistols, etc) to fit in combat boots, jackboots and merc boots.

Also seen is adding the knife tag to the crusher dagger to allow it to fit in boots as well because it didn't make sense not to.

## Why / Balance
Backup boot pistols is a pretty common thing in police forces and I think it could be a neat detail.
Could add some fun little interactions like syndicates hiding firearms or officers breaking out of a hostage situation because their boots were neglected to be taken.

## Media
- [X] This PR does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Small firearms now fit in boots.