### PR TITLE
add training bombs to cargo

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-armory.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-armory.ftl
@@ -7,5 +7,8 @@ ent-ArmoryShotgun = { ent-CrateArmoryShotgun }
 ent-TrackingImplants = { ent-CrateTrackingImplants }
     .desc = { ent-CrateTrackingImplants.desc }
 
+ent-TrainingBombs = { ent-CrateTrainingBombs }
+    .desc = { ent-CrateTrainingBombs.desc }
+
 ent-ArmoryLaser = { ent-CrateArmoryLaser }
     .desc = { ent-CrateArmoryLaser.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
@@ -7,6 +7,9 @@ ent-CrateArmoryShotgun = Shotgun crate
 ent-CrateTrackingImplants = Tracking implants
     .desc = Contains a handful of tracking implanters. Good for prisoners you'd like to release but still keep track of.
 
+ent-CrateTrainingBombs = Training bombs
+    .desc = Contains three low-yield training bombs for security to learn defusal and safe ordnance disposal, EOD suit not included. Requires Armory access to open.
+
 ent-CrateArmoryLaser = lasers crate
     .desc = Contains three standard-issue laser rifles. Requires Armory access to open.
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -29,6 +29,16 @@
   group: market
 
 - type: cargoProduct
+  id: TrainingBombs
+  icon:
+    sprite: Structures/Machines/bomb.rsi
+    state: training-bomb
+  product: CrateTrainingBombs
+  cost: 3000
+  category: Armory
+  group: market
+
+- type: cargoProduct
   id: ArmoryLaser
   icon:
     sprite: Objects/Weapons/Guns/Battery/laser_retro.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -30,6 +30,15 @@
         amount: 5
 
 - type: entity
+  parent: CrateWeaponSecure
+  id: CrateTrainingBombs
+  components:
+  - type: StorageFill
+    contents:
+    - id: TrainingBomb
+      amount: 3
+
+- type: entity
   id: CrateArmoryLaser
   parent: CrateWeaponSecure
   components:


### PR DESCRIPTION
## About the PR
Adds a crate of 3 training bombs to cargo for $3k

## Why / Balance
A way to get training bombs before they are mapped or if they got destroyed already.

## Technical details
no

## Media
![17:06:17](https://github.com/space-wizards/space-station-14/assets/39013340/5a2fe7d8-0f4c-479f-9dcd-12edb339c02d)

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Training bombs are now available for purchase at cargo.
