### PR TITLE
make hardbombs indestructible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -45,20 +45,6 @@
           layer:
             - MachineLayer
     - type: WiresPanel
-    - type: Damageable
-      damageContainer: Inorganic
-      damageModifierSet: Metallic
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 100
-          behaviors:
-            - !type:DoActsBehavior
-              acts: ["Destruction"]
-            - !type:PlaySoundBehavior
-              sound:
-                path: /Audio/Effects/metalbreak.ogg
     - type: GuideHelp
       openOnActivation: true
       guides:

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -56,7 +56,6 @@
           behaviors:
             - !type:DoActsBehavior
               acts: ["Destruction"]
-            - !type:ExplodeBehavior
             - !type:PlaySoundBehavior
               sound:
                 path: /Audio/Effects/metalbreak.ogg


### PR DESCRIPTION
## About the PR
prevents a horrible meta on both sides

## Why / Balance
you could link c4 to a signaller then put c4 on a hardbomb and effectively be able to instantly detonate the hardbomb from anywhere

likewise if it was simply made to not explode when destroyed you could get a bat and "defuse" it in a few clicks

this just makes it indestructible to avoid both of these problems

for reference this is what happens if you do the troll tactic in sec on saltern...
they have no time to even realise whats happening let alone use any of the wires which makes hardbombs unique
![17:45:53](https://github.com/space-wizards/space-station-14/assets/39013340/4308ae5f-7fba-43d6-a84d-8df6c7e2e0b3)


## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun