### PR TITLE
Fix: Crossbreeding resulting in all reagents being removed.

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -320,7 +320,10 @@ public sealed class MutationSystem : EntitySystem
             {
                 if (Random(0.5f))
                 {
-                    val.Remove(this_chem.Key);
+                    if (val.Count > 1)
+                    {
+                        val.Remove(this_chem.Key);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Crossbreeding plants has chance in some circumstances to have all their reagents be removed. This PR makes sure at least one reagent remains.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Produce with no chemicals in them seems silly.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Just simple check if chemical count is more than 1 when removing them in crossbreeding.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None

**Changelog**