### PR TITLE
welder fix

### DIFF
--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -152,6 +152,8 @@ namespace Content.Server.Tools
             // Optional components.
             Resolve(uid, ref item, ref appearance, false);
 
+            _light.ResolveLight(uid, ref light);
+
             welder.Lit = false;
 
             // Logging

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -85,7 +85,7 @@ namespace Content.Server.Tools
                 return false;
 
             // Optional components.
-            Resolve(uid, ref item,ref appearance, false);
+            Resolve(uid, ref item, ref appearance, false);
 
             _light.ResolveLight(uid, ref light);
 
@@ -150,7 +150,7 @@ namespace Content.Server.Tools
                 return false;
 
             // Optional components.
-            Resolve(uid, ref item, ref light, ref appearance, false);
+            Resolve(uid, ref item, ref appearance, false);
 
             welder.Lit = false;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This fixes the bug that prevented you from turning off a lighter/welder after turning it on
Resolves #20039
Resolves #20040 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It wasn't working
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removed `ref light` from the `Resolve` in the `TryTurnWelderOff` function (Sloth removed it in `TryTurnWelderOn` but probably forgot to remove it here too)
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Welders can be toggled off again.
