### PR TITLE
ninja can spawn earlier, 1h reoccurence

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -78,7 +78,7 @@
     duration: 1
     earliestStart: 30
     reoccurrenceDelay: 60
-    minimumPlayers: 15
+    minimumPlayers: 40
   - type: NinjaSpawnRule
 
 - type: entity

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -76,7 +76,8 @@
   - type: StationEvent
     weight: 10
     duration: 1
-    earliestStart: 45
+    earliestStart: 30
+    reoccurrenceDelay: 60
     minimumPlayers: 15
   - type: NinjaSpawnRule
 


### PR DESCRIPTION
## About the PR
so far ive only seen ninja in 3 rounds:
- a 2h round with 1 flukinja and 1 ninja that spawned as evac docked to centcom
- another round i dont remember
- just now ninja spawned 20s before evac
this lets them spawn 30m in which should make it more common for lizard
also upped player requirement to 40 so no steamrolling

## Why / Balance
ghosts want something to do + very rare
also i learned that reoccurence is a thing so why not

## Technical details
no

## Media
video of me waiting 43 mins 11 seconds for ninja spawn too big to upload sorry
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Ninjas can spawn from 30 mins in, instead of 45.
