### PR TITLE
Fix eye target not updating on rider shutdown

### DIFF
--- a/Content.Client/Vehicle/VehicleSystem.cs
+++ b/Content.Client/Vehicle/VehicleSystem.cs
@@ -31,9 +31,9 @@ public sealed class VehicleSystem : SharedVehicleSystem
     private void OnRiderShutdown(EntityUid uid, RiderComponent component, ComponentShutdown args)
     {
         // reset the riders eye centering.
-        if (TryComp(uid, out EyeComponent? eyeComp) && eyeComp.Target == component.Vehicle)
+        if (TryComp(uid, out EyeComponent? eyeComp))
         {
-            _eye.SetTarget(uid, eyeComp.Target, eyeComp);
+            _eye.SetTarget(uid, null, eyeComp);
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/space-wizards/space-station-14/issues/20046

:cl:
- fix: Fix eye not updating correctly when stopping riding (e.g. leaving vehicles).
