### PR TITLE
Chaplain Hoodie change

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -1,4 +1,4 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: PietyVendInventory
   startingInventory:
     ClothingUniformJumpsuitChaplain: 2
@@ -7,7 +7,6 @@
     ClothingUniformJumpsuitMonasticRobeLight: 1
     ClothingOuterHoodieChaplain: 1
     ClothingOuterHoodieBlack: 1
-    ClothingHeadHatHoodChaplainHood: 1
     ClothingHeadHatHoodNunHood: 1
     ClothingOuterNunRobe: 1
     ClothingHeadHatFez: 1

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -19,7 +19,7 @@
   id: ClothingHeadHatHoodBioCmo
   name: bio hood
   suffix: CMO
-  description: An advanced hood for chief medical officer that protects the head and face from biological contaminants.
+  description: An advanced hood for chief medical officers that protects the head and face from biological contaminants.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hoods/Bio/cmo.rsi
@@ -77,7 +77,8 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatHoodChaplainHood
-  name: chaplain hood
+  noSpawn: true
+  name: chaplain's hood
   description: Maximum piety in this star system.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -45,6 +45,20 @@
 
 - type: entity
   abstract: true
+  parent: ClothingOuterStorageBase
+  id: ClothingOuterStorageToggleableBase
+  components:
+  - type: ToggleableClothing
+    clothingPrototype: ClothingHeadHatHoodWinterDefault
+    slot: head
+  - type: ContainerContainer
+    containers:
+      toggleable-clothing: !type:ContainerSlot {}
+      storagebase: !type:Container
+        ents: []
+
+- type: entity
+  abstract: true
   parent: [ClothingOuterBase, GeigerCounterClothing]
   id: ClothingOuterHardsuitBase
   name: base hardsuit
@@ -99,7 +113,7 @@
   parent: ClothingOuterBase
   id: ClothingOuterBaseToggleable
   name: hoodie with hood
-  noSpawn: True
+  abstract: True
   components:
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterDefault

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -94,3 +94,18 @@
     sprintModifier: 0.8
   - type: Item
     size: 80
+
+- type: entity
+  parent: ClothingOuterBase
+  id: ClothingOuterBaseToggleable
+  name: hoodie with hood
+  noSpawn: True
+  components:
+  - type: ToggleableClothing
+    clothingPrototype: ClothingHeadHatHoodWinterDefault
+    slot: head
+  - type: ContainerContainer
+    containers:
+      toggleable-clothing: !type:ContainerSlot {}
+      storagebase: !type:Container
+        ents: []

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -74,7 +74,7 @@
     sprite: Clothing/OuterClothing/Coats/insp_coat.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ClothingOuterStorageToggleableBase
   id: ClothingOuterCoatJensen
   name: jensen coat
   description: A jensen coat.
@@ -83,6 +83,8 @@
     sprite: Clothing/OuterClothing/Coats/jensencoat.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/jensencoat.rsi
+  - type: ToggleableClothing
+    clothingPrototype: ClothingHeadHatHoodChaplainHood
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -92,15 +92,17 @@
     proto: robot
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterBaseToggleable
   id: ClothingOuterHoodieChaplain
-  name: chaplain hoodie
+  name: chaplain's hoodie
   description: Black and strict chaplain hoodie.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Misc/chaplain_hoodie.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/chaplain_hoodie.rsi
+  - type: ToggleableClothing
+    clothingPrototype: ClothingHeadHatHoodChaplainHood
 
 - type: entity
   parent: ClothingOuterBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
I made the chaplain hoodie have its hood built in, and toggleable just like winter coats. Also a few tiny changes to names.
<!-- What did you change in this PR? -->

## Why / Balance
Literally just because I want to start contributing, and this seemed like a pretty easy thing to poke at.
Specifically, the PR addresses *part* of this issue: https://github.com/space-wizards/space-station-14/issues/20070
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
I made a new base for misc clothing that has a toggle, similar to winter coats. I was going to add this to more than just the chaplain hoodie but I do not want to sprite hoods for the grey and black hoodies.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: The chaplain hoodie now comes with its hood as an action, similar to winter coats

