### PR TITLE
Suppress pathfinding debug assert

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -558,10 +558,13 @@ public sealed partial class PathfindingSystem
                             }
                         }
 
+                        /*This is causing too many issues and I'd rather just ignore it until pathfinder refactor
+                          to just get tiles at runtime.
                         if ((flags & PathfindingBreadcrumbFlag.Space) != 0x0)
                         {
-                            DebugTools.Assert(tileEntities.Count == 0);
+                            // DebugTools.Assert(tileEntities.Count == 0);
                         }
+                        */
 
                         var crumb = new PathfindingBreadcrumb()
                         {


### PR DESCRIPTION
- It'll get removed on pathfinder refactor.
- Fixing it well for the current pathfinder is a PITA.
- Causes issues with planetmaps.