### PR TITLE
Orderable Security Barriers

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -67,3 +67,13 @@
   cost: 800
   category: Security
   group: market
+
+- type: cargoProduct
+  id: SecurityBarrier
+  icon:
+    sprite: Objects\Specific\Security\barrier.rsi
+    state: idle
+  product: DeployableBarrier
+  cost: 1000
+  category: Security
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -71,7 +71,7 @@
 - type: cargoProduct
   id: SecurityBarrier
   icon:
-    sprite: Objects\Specific\Security\barrier.rsi
+    sprite: Objects/Specific/Security/barrier.rsi
     state: idle
   product: DeployableBarrier
   cost: 1000


### PR DESCRIPTION
## About the PR
Allows for security barriers to be purchased by cargo for 1000 spesos each.

## Why / Balance
While niche there was no other way to obtain more of these unless mapped. Hopefully the ability to order more will also see some more actual use of them in places other than security itself, but we'll have to see.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/110078045/1026a004-efa9-4432-bc8f-6774323e4cd1)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl:
- tweak: Security Barriers can now be ordered by cargo.