### PR TITLE
remove directional switches sprite offsets

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -186,8 +186,6 @@
   components:
   - type: WallMount
     arc: 180
-  - type: Sprite
-    offset: 0,-0.25
   - type: Construction
     graph: SignalSwitchDirectionalGraph
     node: SignalSwitchDirectionalNode
@@ -200,8 +198,6 @@
   components:
   - type: WallMount
     arc: 180
-  - type: Sprite
-    offset: 0,-0.25
   - type: Construction
     graph: SignalButtonDirectionalGraph
     node: SignalButtonDirectionalNode
@@ -214,8 +210,6 @@
   components:
   - type: WallMount
     arc: 180
-  - type: Sprite
-    offset: 0,-0.25
   - type: Construction
     graph: LightSwitchDirectionalGraph
     node: LightSwitchDirectionalNode


### PR DESCRIPTION
## About the PR
doesnt change any functionality just makes sprite not evil

## Why / Balance
it was evil

## Technical details
no

## Media
which one is directional who could tell...
![00:45:20](https://github.com/space-wizards/space-station-14/assets/39013340/442dda90-cc87-48f1-bacb-0f645e8dc864)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun