### PR TITLE
Makes training bombs unable to space

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -88,6 +88,7 @@
       totalIntensity: 5.0
       intensitySlope: 5
       maxIntensity: 4
+      canCreateVacuum: false
     - type: Defusable
       disposable: false
 


### PR DESCRIPTION
Honestly why could they do this wtf

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase



**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: Lank
- tweak: Training bombs are now unable to space tiles.

