### PR TITLE
Add The Holo-Barrier Projector To The Security TechFab

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -61,3 +61,13 @@
         - HolofanProjector
     - type: StaticPrice
       price: 80
+
+- type: entity
+  parent: HoloprojectorSecurity
+  id: HoloprojectorSecurityEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -559,6 +559,7 @@
       - TimerTrigger
       - Truncheon
       - TelescopicShield
+      - HoloprojectorSecurity
       - FlashPayload
       - ExplosivePayload
       - WeaponLaserCarbine

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -99,6 +99,15 @@
     Glass: 200
 
 - type: latheRecipe
+  id: HoloprojectorSecurity
+  result: HoloprojectorSecurityEmpty
+  completetime: 2
+  materials:
+    Steel: 300
+    Glass: 50
+    Plastic: 50
+
+- type: latheRecipe
   id: RiotShield
   result: RiotShield
   completetime: 4

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -122,6 +122,7 @@
   recipeUnlocks:
   - Truncheon
   - TelescopicShield
+  - HoloprojectorSecurity
 
 # Tier 3
 


### PR DESCRIPTION
## About the PR
Adds a holo-barrier projector crafting recipe in the secfab, unlockable by advanced riot control tech.
To handle this an empty version of the projector was added. (Batteries not included because that's a little stupid.)

## Why / Balance
It was a roundstart item for the HoS and Ward only, which causes it to see very little use. So I thought making it a tier two tech would be fair and it gives a little more reason for security tech to be researched.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/110078045/3e023f86-fd9f-4105-82e6-506902692bf0)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl:
- tweak: Holobarrier projectors can now be researched and produced in the security techfab.