### PR TITLE
HoloBarrier Fix and Buff

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -66,8 +66,11 @@
         - trigger:
             !type:DamageTrigger
             damage: 30
+          behaviors:
+          - !type:DoActsBehavior
+             acts: [ "Destruction" ]
     - type: TimedDespawn
-      lifetime: 60
+      lifetime: 180
     - type: PointLight
       enabled: true
       radius: 3


### PR DESCRIPTION
## About the PR
Makes the HoloBarrier actually destructible and buffs it's uptime from a single minute to three minutes, akin to the HoloFan.

## Why / Balance
HoloBarriers were basically fucking useless with only a minute. You place one down, go to handle the situation and less than halfway through it'd already go down. Now that you can break them in about 6 swings of a combat knife it shouldn't be that big of an issue either.

## Media
- [X] This PR does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Holobarriers being unable to be destroyed.