### PR TITLE
Remove hacking protections from atmos and sec airlocks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -21,10 +21,6 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/atmospherics.rsi
-  - type: WiresPanel
-    securityLevel: Level2
-  - type: Construction
-    node: airlockMedSecurity
 
 - type: entity
   parent: Airlock
@@ -85,10 +81,6 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/security.rsi
-  - type: WiresPanel
-    securityLevel: Level2
-  - type: Construction
-    node: airlockMedSecurity
 
 - type: entity
   parent: Airlock


### PR DESCRIPTION
## About the PR
Removes hacking protections from atmos and sec airlocks that were introduced by https://github.com/space-wizards/space-station-14/pull/18894.

## Why / Balance
After a [discussion with the author](https://discord.com/channels/310555209753690112/310555209753690112/1150845828383129621), we agreed to drop hacking protections from atmos and security. Some relevant points from the discussion:

- Hacking protections make hacking way to difficult, requiring effectively a full engineering belt, goggles, and insulated gloves, and takes a significantly longer amount of time.
- It is more fun to extend an existing mechanic, for example, by adding the number of wires, instead of adding an additional orthogonal mechanic.
- Others have expressed that only emagging is worthwhile. It has to be a plausible, roughly equally balanced difficulty/outcome in order for something to be considered a "good" tradeoff, and right now hacking is leaning more strongly towards the "too difficult" side of balance.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
