### PR TITLE
Fix missing localization for bibles, crit, internals, mime, sleeping and voice mask

### DIFF
--- a/Resources/Locale/en-US/abilities/mime.ftl
+++ b/Resources/Locale/en-US/abilities/mime.ftl
@@ -1,5 +1,4 @@
 mime-cant-speak = Your vow of silence prevents you from speaking.
-mime-invisible-wall = Create Invisible Wall
 mime-invisible-wall-popup = {CAPITALIZE(THE($mime))} brushes up against an invisible wall!
 mime-invisible-wall-failed = You can't create an invisible wall there.
 mime-not-ready-repent = You aren't ready to repent for your broken vow yet.

--- a/Resources/Locale/en-US/actions/actions/crit.ftl
+++ b/Resources/Locale/en-US/actions/actions/crit.ftl
@@ -1,0 +1,1 @@
+﻿action-name-crit-last-words = Say Last Words

--- a/Resources/Locale/en-US/actions/actions/internals.ftl
+++ b/Resources/Locale/en-US/actions/actions/internals.ftl
@@ -1,2 +1,5 @@
+action-name-internals-toggle = Toggle Internals
+action-description-internals-toggle = Breathe from the equipped gas tank. Also requires equipped breath mask.
+
 internals-no-breath-tool = You are not wearing a breathing tool
 internals-no-tank = You are not wearing a gas tank

--- a/Resources/Locale/en-US/actions/actions/sleep.ftl
+++ b/Resources/Locale/en-US/actions/actions/sleep.ftl
@@ -1,3 +1,5 @@
+action-name-wake = Wake up
+
 sleep-onomatopoeia = Zzz...
 sleep-examined = [color=lightblue]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} asleep.[/color]
 

--- a/Resources/Locale/en-US/chapel/bible.ftl
+++ b/Resources/Locale/en-US/chapel/bible.ftl
@@ -7,6 +7,8 @@ bible-heal-fail-self = You hit {THE($target)} with {THE($bible)}, and it lands w
 bible-heal-fail-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}, and it lands with a sad thack, dazing {OBJECT($target)}!
 bible-sizzle = The book sizzles in your hands!
 
+bible-summon-verb = Summon familiar
+bible-summon-verb-desc = Summon a familiar that will aid you and gain humanlike intelligence once inhabited by a soul.
 bible-summon-requested = Your familiar will arrive once a willing soul comes forth.
 bible-summon-respawn-ready = {CAPITALIZE(THE($book))} surges with ethereal power. {CAPITALIZE(POSS-ADJ($book))} resident is home again.
 

--- a/Resources/Locale/en-US/voice-mask.ftl
+++ b/Resources/Locale/en-US/voice-mask.ftl
@@ -1,5 +1,7 @@
 voice-mask-name-change-window = Voice Mask Name Change
 voice-mask-name-change-info = Type in the name you want to mimic.
+voice-mask-name-change-set = Set name
+voice-mask-name-change-set-description = Change the name others hear to something else.
 
 voice-mask-popup-success = Name set successfully.
 voice-mask-popup-failure = Name could not be set.


### PR DESCRIPTION
## About the PR
Turns out that despite them being named action-, they are not only used for actions. Checked on most but missed some. From https://github.com/space-wizards/space-station-14/pull/20023
Removed the mime one since that one isn't used manually anymore.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/10968691/ba276ce4-c7b9-4b2e-a5de-c6c003250630)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed some missing localization.
