### PR TITLE
Tweak: Round start protections for airlocks and doors against hacking

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -21,10 +21,6 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/atmospherics.rsi
-  - type: WiresPanel
-    securityLevel: Level2
-  - type: Construction
-    node: airlockMedSecurity
 
 - type: entity
   parent: Airlock
@@ -74,9 +70,9 @@
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/command.rsi
   - type: WiresPanel
-    securityLevel: Level5
+    securityLevel: Level2
   - type: Construction
-    node: airlockMaxSecurity
+    node: airlockMedSecurity
 
 - type: entity
   parent: Airlock
@@ -85,10 +81,6 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/security.rsi
-  - type: WiresPanel
-    securityLevel: Level2
-  - type: Construction
-    node: airlockMedSecurity
 
 - type: entity
   parent: Airlock
@@ -176,10 +168,6 @@
     sprite: Structures/Doors/Airlocks/Glass/atmospherics.rsi
   - type: PaintableAirlock
     group: Glass
-  - type: WiresPanel
-    securityLevel: Level2
-  - type: Construction
-    node: glassAirlockMedSecurity
 
 - type: entity
   parent: AirlockGlass
@@ -231,9 +219,9 @@
   - type: PaintableAirlock
     group: Glass
   - type: WiresPanel
-    securityLevel: Level5
+    securityLevel: Level2
   - type: Construction
-    node: glassAirlockMaxSecurity
+    node: glassAirlockMedSecurity
 
 - type: entity
   parent: AirlockGlass
@@ -244,10 +232,6 @@
     sprite: Structures/Doors/Airlocks/Glass/security.rsi
   - type: PaintableAirlock
     group: Glass
-  - type: WiresPanel
-    securityLevel: Level2
-  - type: Construction
-    node: glassAirlockMedSecurity
 
 - type: entity
   parent: AirlockGlass

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -67,6 +67,7 @@
     enabled: false
     usesApcPower: true
   - type: WiresPanel
+    securityLevel: Level5
   - type: Wires
     BoardName: wires-board-name-highsec
     LayoutId: HighSec
@@ -92,3 +93,6 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: Construction
+    graph: HighSecDoor
+    node: maxSecurity

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/highsec.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/highsec.yml
@@ -1,0 +1,166 @@
+- type: constructionGraph
+  id: HighSecDoor
+  start: start
+  graph:
+  - node: start
+    actions:
+    - !type:ChangeWiresPanelSecurityLevel
+      level: Level0
+    edges:
+    - to: medSecurityBreached
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 2
+    
+    - to: highSecurityBreached
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - material: Plasteel
+        amount: 2
+        doAfter: 2
+
+## Medium security level door: a layer of steel plating protects the internal wiring
+  - node: medSecurityBreached
+    actions:
+      - !type:ChangeWiresPanelSecurityLevel
+        level: Level1    
+    edges:
+    - to: start 
+      completed:
+      - !type:GivePrototype
+        prototype: SheetSteel1
+        amount: 2
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - tool: Prying
+        doAfter: 4
+    
+    - to: medSecurity 
+      conditions:  
+      - !type:WirePanel {}
+      steps:
+      - tool: Welding
+        doAfter: 3
+      
+  - node: medSecurity
+    actions:
+      - !type:ChangeWiresPanelSecurityLevel
+        level: Level2
+    edges:
+    - to: medSecurityBreached 
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - tool: Welding
+        doAfter: 10
+
+## High security level door: a layer of plasteel plating protects the internal wiring
+  - node: highSecurityBreached
+    actions:
+      - !type:ChangeWiresPanelSecurityLevel
+        level: Level3   
+    edges:
+    - to: start 
+      completed:
+      - !type:GivePrototype
+        prototype: SheetPlasteel1
+        amount: 2
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - tool: Prying
+        doAfter: 4
+    
+    - to: highSecurity 
+      conditions:  
+      - !type:WirePanel {}
+      steps:
+      - tool: Welding
+        doAfter: 5
+      
+  - node: highSecurity
+    actions:
+      - !type:ChangeWiresPanelSecurityLevel
+        level: Level4
+    edges:
+    - to: highSecurityBreached
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - tool: Welding
+        doAfter: 15
+    
+    - to: maxSecurity
+      conditions:
+      - !type:WirePanel {}
+      steps:     
+      - material: MetalRod
+        amount: 2
+        doAfter: 1
+
+## Max security level door: an electric grill is added        
+  - node: maxSecurity
+    actions:
+      - !type:ChangeWiresPanelSecurityLevel
+        level: Level5
+    edges:
+    - to: highSecurity 
+      completed:
+      - !type:AttemptElectrocute
+      - !type:GivePrototype
+        prototype: PartRodMetal1
+        amount: 2
+      conditions:  
+      - !type:WirePanel {}
+      steps:
+      - tool: Cutting
+        doAfter: 0.5 
+
+    - to: superMaxSecurityBreached
+      conditions:
+      - !type:WirePanel {}
+      steps:     
+      - material: Plasteel
+        amount: 2
+        doAfter: 2
+
+## Super max security level door: an additional layer of plasteel is added     
+  - node: superMaxSecurityBreached
+    actions:
+      - !type:ChangeWiresPanelSecurityLevel
+        level: Level6
+    edges:
+    - to: maxSecurity 
+      completed:
+      - !type:GivePrototype
+        prototype: SheetPlasteel1
+        amount: 2
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - tool: Prying
+        doAfter: 4
+    
+    - to: superMaxSecurity 
+      conditions:  
+      - !type:WirePanel {}
+      steps:
+      - tool: Welding
+        doAfter: 5
+      
+  - node: superMaxSecurity
+    actions:
+      - !type:ChangeWiresPanelSecurityLevel
+        level: Level7
+    edges:
+    - to: superMaxSecurityBreached 
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - tool: Welding
+        doAfter: 15


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR tweaks the level of hacking protection doors and airlocks possess at round start. Specifically:
- All starting protections have been removed from security and atmospheric departmental airlocks
- The protections on command-level doors have been reduced to a single welded steel plate
- High security doors (i.e., the doors to the vault, gravity generator, AI room) are now protected by a single welded plasteel plate and an electric security grille

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This change is being made in response to a balance discussion on the Discord

[Initial discussion](https://discord.com/channels/310555209753690112/310555209753690112/1150121999436366046)
[Follow up discussion and finalization](https://discord.com/channels/310555209753690112/310555209753690112/1150845828383129621)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
N/A

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Adjusted hacking protections on security, atmospherics, command, and high security airlocks.