### PR TITLE
Increases Blast Door dmg resistance.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -24,6 +24,9 @@
   - type: Appearance
   - type: RadiationBlocker
     resistance: 8
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: StrongMetallic
 
 - type: entity
   id: BlastDoorOpen


### PR DESCRIPTION
## About the PR
Bumps the dmg modifier on blast doors from Metallic to StrongMetallic.

## Why / Balance
Because for doors that are intended to contain explosions they are kinda squishy. Also because carps can break them down which is an issue on my downstream map.

## Technical details
n/a

## Media
n/a

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a...unless you want players to be aware of this change? I'll add it. 
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
