### PR TITLE
fix ninja no guns

### DIFF
--- a/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
@@ -12,6 +12,11 @@ public record struct ShotAttemptedEvent
     /// </summary>
     public EntityUid User;
 
+    /// <summary>
+    /// The gun being shot.
+    /// </summary>
+    public EntityUid Used;
+
     public bool Cancelled { get; private set; }
 
     /// </summary>

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -226,9 +226,14 @@ public abstract partial class SharedGunSystem : EntitySystem
         // check if anything wants to prevent shooting
         var prevention = new ShotAttemptedEvent
         {
-            User = user
+            User = user,
+            Used = gunUid
         };
         RaiseLocalEvent(gunUid, ref prevention);
+        if (prevention.Cancelled)
+            return;
+
+        RaiseLocalEvent(user, ref prevention);
         if (prevention.Cancelled)
             return;
 


### PR DESCRIPTION
## About the PR
event was raised on the gun but never the user bruh
this just raises it on the user, adding gun as a field for flexibility in the future if anything needs it

## Why / Balance
i saw some pussy using a shotgun then panic

## Technical details
ninja system checks for event on user but gun system raised it on the gun...

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun