### PR TITLE
Tweak - Mechs can now open locked doors if the pilot has access to that door.

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
+using Content.Shared.Mech.Components;
 using Content.Shared.Physics;
 using Content.Shared.Stunnable;
 using Content.Shared.Tag;
@@ -500,6 +501,15 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
         if (!Resolve(uid, ref access, false))
             return true;
+
+        // Mechs dont forward the pilots access, which is why we need to check if the user is a mech.
+        MechComponent? mech = null;
+        if (Resolve(user.Value, ref mech, false))
+        {
+            // Check if theres a pilot in there, this is because people might try to push a mech into a door or something.
+            if (mech.PilotSlot.ContainedEntity.HasValue)
+                user = mech.PilotSlot.ContainedEntity.Value;
+        }
 
         var isExternal = access.AccessLists.Any(list => list.Contains("External"));
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Doors will now check for a pilot when a mech attempts to open a door by bumping it. When a pilot is found, the pilots access is used.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The Ripley is pretty much useless in its current form. Getting in and out only to open a door takes a long time and having someone else do it for you gets boring real fast. Even worse when no one is around. This PR changes it so that doors check for pilots in mechs and it will use their access instead. 

Also see [this discord post](https://canary.discord.com/channels/310555209753690112/1150113194388496474)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/63975668/d920f192-0e98-4a2e-abed-8dd4b379a5fa

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Mechs can now open locked doors if the pilot has access to that door.