### PR TITLE
Fix doafters always being red for the client

### DIFF
--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -207,7 +207,6 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         var doAfter = new DoAfter(id.Value.Index, args, GameTiming.CurTime);
 
         // Networking yay
-        doAfter.NetUserPosition = GetNetCoordinates(doAfter.UserPosition);
         doAfter.NetInitialItem = GetNetEntity(doAfter.InitialItem);
 
         // Networking yay
@@ -225,6 +224,8 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             var targetPosition = Transform(args.Target.Value).Coordinates;
             doAfter.UserPosition.TryDistance(EntityManager, targetPosition, out doAfter.TargetDistance);
         }
+
+        doAfter.NetUserPosition = GetNetCoordinates(doAfter.UserPosition);
 
         // For this we need to stay on the same hand slot and need the same item in that hand slot
         // (or if there is no item there we need to keep it free).


### PR DESCRIPTION
## About the PR
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
**Changelog**
- fix: Fixed action delay bar always being red on the client.