### PR TITLE
Multi-gun firerate nerf

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -105,6 +105,12 @@ public partial class GunComponent : Component
     public float FireRate = 8f;
 
     /// <summary>
+    /// Starts fire cooldown when equipped if true.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("resetOnHandSelected")]
+    public bool ResetOnHandSelected = true;
+
+    /// <summary>
     /// How fast the projectile moves.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("projectileSpeed")]

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Actions;
 using Content.Shared.Examine;
+using Content.Shared.Hands;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Utility;
@@ -102,5 +103,28 @@ public abstract partial class SharedGunSystem
     private void OnCycleMode(EntityUid uid, GunComponent component, CycleModeEvent args)
     {
         SelectFire(uid, component, args.Mode, args.Performer);
+    }
+
+    private void OnGunSelected(EntityUid uid, GunComponent component, HandSelectedEvent args)
+    {
+        var fireDelay = 1f / component.FireRate;
+        if (fireDelay.Equals(0f))
+            return;
+
+        if (!component.ResetOnHandSelected)
+            return;
+
+        if (Paused(uid))
+            return;
+
+        // If someone swaps to this weapon then reset its cd.
+        var curTime = Timing.CurTime;
+        var minimum = curTime + TimeSpan.FromSeconds(fireDelay);
+
+        if (minimum < component.NextFire)
+            return;
+
+        component.NextFire = minimum;
+        Dirty(uid, component);
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Gravity;
+using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using Content.Shared.Popups;
 using Content.Shared.Projectiles;
@@ -88,6 +89,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         SubscribeLocalEvent<GunComponent, GetVerbsEvent<AlternativeVerb>>(OnAltVerb);
         SubscribeLocalEvent<GunComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<GunComponent, CycleModeEvent>(OnCycleMode);
+        SubscribeLocalEvent<GunComponent, HandSelectedEvent>(OnGunSelected);
         SubscribeLocalEvent<GunComponent, EntityUnpausedEvent>(OnGunUnpaused);
 
 #if DEBUG


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
🕷️warpath

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Holding multiple guns straight up doubles your firerate. that is insanium. Especially for future guns with slower firerates like rifles and snipers, it makes sense to have a period where you get the gun into a firing position wherein you're unable to shoot it.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
literally just what melee weapons do.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
i had a gif but it was so awful i removed it.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Swapping between guns now has a small delay before you can fire.
