### PR TITLE
Restore missing tags on BaseMobSpecies

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -214,6 +214,11 @@
   - type: MobPrice
     price: 1500 # Kidnapping a living person and selling them for cred is a good move.
     deathPenalty: 0.01 # However they really ought to be living and intact, otherwise they're worth 100x less.
+  - type: Tag
+    tags:
+    - CanPilot
+    - FootstepSound
+    - DoorBumpOpener
 
 - type: entity
   save: false


### PR DESCRIPTION
## About the PR
Players are unable to bump-open doors or pilot shuttles, and have silent footsteps (surprisingly handy, but not NT-approved). This PR fixes that.

Fixes #20207  
Fixes #20205

## Technical details
In https://github.com/space-wizards/space-station-14/pull/19859, when BaseMobOrganic was split into BaseMobSpecies and BaseMobSpeciesOrganic, the Tag component was accidentally omitted. This PR restores its original values.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
No CL needed, it's just a bugfix.