### PR TITLE
Add speedloader to secfab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -531,6 +531,7 @@
       - MagazineBoxMagnum
       - MagazineBoxRifle
       - MagazineBoxLightRifle
+      - SpeedLoaderMagnum
       - TargetHuman
       - TargetSyndicate
       - TargetClown

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -344,6 +344,13 @@
     Plastic: 600
 
 - type: latheRecipe
+  id: SpeedLoaderMagnum
+  result: SpeedLoaderMagnum
+  completetime: 5
+  materials:
+    Steel: 200
+
+- type: latheRecipe
   id: ShellShotgunIncendiary
   result: ShellShotgunIncendiary
   completetime: 2


### PR DESCRIPTION
## About the PR
Adds the speedloader to the secfab.

## Why / Balance
This was requested by many in the discussions for https://github.com/space-wizards/space-station-14/pull/19769.

The recipe steel usage is a bit suspiciously low, but is commensurate for the steel cost of 6 individual magnum cartridges (6 × 20 steel each = 120), plus overhead of the speedloader.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/3229565/75c1e5a6-8ffe-4f9e-9565-db6d04727c8e)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

