### PR TITLE
Added the ability to eat organs, mmm tastes like people

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -4,10 +4,21 @@
   abstract: true
   components:
   - type: Organ
+  - type: Food
   - type: Sprite
     sprite: Mobs/Species/Human/organs.rsi
   - type: StaticPrice
     price: 50
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
+  - type: FlavorProfile
+    flavors:
+      - people
 
 
 - type: entity
@@ -35,6 +46,11 @@
       Lung:
         maxVol: 100.0
         canReact: false
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
 
 - type: entity
   id: OrganAnimalStomach
@@ -49,6 +65,11 @@
     solutions:
       stomach:
         maxVol: 40
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
   - type: Stomach
   - type: Metabolizer
     maxReagents: 3

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -16,6 +16,11 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
 
 - type: entity
   id: OrganArachnidStomach
@@ -32,6 +37,11 @@
     solutions:
       stomach:
         maxVol: 50
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
   - type: Metabolizer
     updateFrequency: 1.5
 
@@ -64,6 +74,11 @@
       Lung:
         maxVol: 100.0
         canReact: false
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
 
 - type: entity
   id: OrganArachnidHeart

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -16,6 +16,11 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
 
 - type: entity
   id: OrganDionaBrain
@@ -35,6 +40,11 @@
       Lung:
         maxVol: 100
         canReact: False
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
   - type: Brain
   - type: Lung #lungs in they head. why they there tho?
   - type: Metabolizer
@@ -69,6 +79,11 @@
     solutions:
       stomach:
         maxVol: 50
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
   - type: Stomach
   - type: Metabolizer
     maxReagents: 6

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -21,6 +21,9 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
+  - type: FlavorProfile
+    flavors:
+      - people
 
 - type: entity
   id: OrganDionaBrain

--- a/Resources/Prototypes/Body/Organs/dwarf.yml
+++ b/Resources/Prototypes/Body/Organs/dwarf.yml
@@ -26,6 +26,11 @@
     solutions:
       stomach:
         maxVol: 75
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
   - type: Stomach
   - type: Metabolizer
     # mm very yummy

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -15,6 +15,14 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
+  - type: FlavorProfile
+    flavors:
+      - people
 
 - type: entity
   id: OrganHumanBrain
@@ -98,6 +106,11 @@
       Lung:
         maxVol: 100.0
         canReact: false
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
 
 - type: entity
   id: OrganHumanHeart
@@ -130,6 +143,11 @@
     solutions:
       stomach:
         maxVol: 50
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
   - type: Stomach
   # The stomach metabolizes stuff like foods and drinks.
   # TODO: Have it work off of the ent's solution container, and move this

--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -11,6 +11,11 @@
     solutions:
       stomach:
         maxVol: 50
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
   - type: Metabolizer
     maxReagents: 6
     metabolizerTypes: [ Moth ]

--- a/Resources/Prototypes/Body/Organs/rat.yml
+++ b/Resources/Prototypes/Body/Organs/rat.yml
@@ -15,5 +15,10 @@
     solutions:
       stomach:
         maxVol: 50
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
   - type: Sprite
     state: stomach

--- a/Resources/Prototypes/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/Body/Organs/reptilian.yml
@@ -8,3 +8,8 @@
     solutions:
       stomach:
         maxVol: 50
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -21,6 +21,11 @@
       solutions:
         stomach:
           maxVol: 50.0
+        food:
+          maxVol: 5
+          reagents:
+          - ReagentId: Nutriment
+            Quantity: 5
 
 
 - type: entity
@@ -51,3 +56,8 @@
       Lung:
         maxVol: 100.0
         canReact: false
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5

--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -4,7 +4,7 @@
     sprite: Mobs/Animals/bee.rsi
     state: 0
   product: CrateNPCBee
-  cost: 4000
+  cost: 4125
   category: Livestock
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Mobs/Animals/butterfly.rsi
     state: butterfly
   product: CrateNPCButterflies
-  cost: 2500
+  cost: 2625
   category: Livestock
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Mobs/Animals/chicken.rsi
     state: icon-1
   product: CrateNPCChicken
-  cost: 2500
+  cost: 2525
   category: Livestock
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Mobs/Animals/crab.rsi
     state: crab
   product: CrateNPCCrab
-  cost: 1800
+  cost: 1925
   category: Livestock
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Mobs/Animals/duck.rsi
     state: icon-0
   product: CrateNPCDuck
-  cost: 3500
+  cost: 3725
   category: Livestock
   group: market
 
@@ -124,7 +124,7 @@
     sprite: Mobs/Animals/mouse.rsi
     state: icon-0
   product: CrateNPCMouse
-  cost: 2500
+  cost: 2625
   category: Livestock
   group: market
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
I added the ability to eat basically all organs in the game. 

## Why / Balance
[Issue 20163](https://github.com/space-wizards/space-station-14/issues/20163)
Some organs already have a food attribute (e.x. `BaseHumanOrgan`), which gives them the option in game to be eaten, but nothing happens when it is pressed.

As for balance, one concern is that this makes it very easy to hide bodies that have been gibbed.

## Technical details
Updated all `.yml` files under `Resources/Prototypes/Body/Organs/<thing>.yml` so that the things respective organs are now edible. Every organ is comprised of 5u nutriment. It would be cool if stomachs were comprised of what ever the individual had been eating, but this can be iterated on.

## Media
https://streamable.com/4y4dqc

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No breaking changes.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: You can now eat most organs. Bon appetit!
