### PR TITLE
Nerf canister bombs

### DIFF
--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Server.Atmos.Components
     [RegisterComponent]
     public sealed partial class GasTankComponent : Component, IGasMixtureHolder
     {
-        public const float MaxExplosionRange = 80f;
+        public const float MaxExplosionRange = 26f;
         private const float DefaultLowPressure = 0f;
         private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Previous attempts to limit the ability of canister bombs haven't been too effective. It's pretty often that entire rounds are snuffed out by a valve being opened. 

## Why / Balance
This will allow canister bombs to be slightly more destructive than the syndicate bomb, and if you don't wanna kill yourself, it requires a bit of set up. However, there isn't really any counterplay to canister bombs other than someone noticing you setting up for it. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Lowered the maximum explosion range of canister bombs. 
