### PR TITLE
Security PDAs deal light blunt damage on melee

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -164,6 +164,10 @@
     accentVColor: "#A32D26"
   - type: Icon
     state: pda-interncadet
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 6
 
 - type: entity
   parent: BasePDA
@@ -600,6 +604,11 @@
     accentHColor: "#447987"
   - type: Icon
     state: pda-hos
+  - type: MeleeWeapon
+    damage:
+      types:
+        # strip him naked and he can still eat the syndies for breakfast
+        Blunt: 8
 
 - type: entity
   parent: BasePDA
@@ -615,6 +624,10 @@
     accentVColor: "#949137"
   - type: Icon
     state: pda-warden
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 6
 
 - type: entity
   parent: BasePDA
@@ -629,6 +642,10 @@
     borderColor: "#A32D26"
   - type: Icon
     state: pda-security
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 6
 
 - type: entity
   parent: BasePDA
@@ -949,3 +966,7 @@
     accentVColor: "#DFDFDF"
   - type: Icon
     state: pda-seniorofficer
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 6


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- Security Officer, Senior Officer, Cadet, and Warden PDAs now deal 6 Blunt damage (1 higher than fists)
- The Head of Security PDA deals 8 Blunt damage (same as a crowbar, less than combat knife)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The medical and clown PDAs each have a secondary use (medical can scan, clown can slip people) and so it would make sense that the other types should have secondary uses as well. I think security would be a good start.

With this change security members would have a last resort weapon that syndicate agents might not expect. However the damage isn't high enough to be actually viable as a weapon like the combat knife.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
None.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![sec-pda-dmg](https://github.com/space-wizards/space-station-14/assets/96957003/8f51ff84-c541-4ec5-bb2f-6a3b27f02bd8)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Members of the security department can now use their PDAs as melee weapons.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
