### PR TITLE
Bomb balance adjustments

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -136,7 +136,13 @@
     contents:
       - id: ClothingHeadHelmetBombSuit
       - id: ClothingOuterSuitBomb
-      - id: ClothingMaskGas
+      # NT is cheap, what can you do...
+      - id: Wirecutter
+        prob: 0.9
+      - id: Screwdriver
+        prob: 0.9
+      - id: Multitool
+        prob: 0.5
 
 - type: entity
   parent: GunSafe

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -107,8 +107,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.90
-        Slash: 0.90
+        Blunt: 0.95
+        Slash: 0.95
         Piercing: 0.95
 
 #Cult Helmet

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -11,12 +11,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
+        Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.75
   - type: ExplosionResistance
-    damageCoefficient: 0.2
+    damageCoefficient: 0.15
   - type: GroupExamine
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -26,7 +26,7 @@
     # Unless, of course, you want the 90 seconds regardless. I can't stop you.
     - type: OnUseTimerTrigger
       delay: 300
-      delayOptions: [300, 600, 900]
+      delayOptions: [180, 240, 300, 600, 900]
       initialBeepDelay: 0
       beepSound: /Audio/Machines/timer.ogg
     - type: Anchorable

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -25,8 +25,8 @@
     # If you nerf the syndicate bomb in any major way, this should probably drop down to at least 100s (not 90s to compensate for slower movement speed & less lag in SS14)
     # Unless, of course, you want the 90 seconds regardless. I can't stop you.
     - type: OnUseTimerTrigger
-      delay: 120
-      delayOptions: [120, 150, 180, 210, 240, 270, 300]
+      delay: 300
+      delayOptions: [300, 600, 900]
       initialBeepDelay: 0
       beepSound: /Audio/Machines/timer.ogg
     - type: Anchorable

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -25,7 +25,7 @@
     # If you nerf the syndicate bomb in any major way, this should probably drop down to at least 100s (not 90s to compensate for slower movement speed & less lag in SS14)
     # Unless, of course, you want the 90 seconds regardless. I can't stop you.
     - type: OnUseTimerTrigger
-      delay: 300
+      delay: 180
       delayOptions: [180, 240, 300, 600, 900]
       initialBeepDelay: 0
       beepSound: /Audio/Machines/timer.ogg


### PR DESCRIPTION
## About the PR
Various bomb balance changes, see below:

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
- **Give EOD closet a chance to start with wirecutters, screwdrivers, and multitools.** These are required to attempt bomb diffusal. It takes too long for you to be looking for the bomb and for tools. This is an EOD closet, it should give you the tools you actually need. Obviously, NT is cheap so these are not guaranteed.
- **Decrease bomb/suit resistances.** These need to be weaker than security's default armor, otherwise there will be folks who raid the EOD closet at round start, leaving no bomb suit when there's an actual bomb emergency.
- **Increase bomb suit explosion protection.** Only by 5%. You will still get crit'd if you're defusing a syndicate bomb and it explodes.
- **Increase minimum bomb timer to 5 minutes.** This was [discussed on Discord](https://discord.com/channels/310555209753690112/675078881425752124/1152430302485041292). You need time to 1) hear the beeping, 2) find the bomb, 3) get security to show up with a bomb suit, 4) evacuate the area, and 5) try to defuse it. Obviously, syndicate members want the bomb to go off sooner. However, this is already a wire that you can pulse to do that. We're all for trade-offs, aren't we?

## Media
![image](https://github.com/space-wizards/space-station-14/assets/3229565/5d10e9f6-4ead-4738-ae60-fb30a2469c2a)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase