### PR TITLE
Space Damage Increase Part 2

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -235,7 +235,7 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.35 #per second, scales with pressure and other constants.
+        Blunt: 0.55 #per second, scales with pressure and other constants.
   # Organs
   - type: StatusEffects
     allowed:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -38,7 +38,7 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.45 #per second, scales with pressure and other constants. Slighty more than humans.
+        Blunt: 0.60 #per second, scales with pressure and other constants. Slighty more than humans.
   - type: Reactive
     groups:
       Flammable: [ Touch ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Spacing has been changed in the past months to now be slower. There are often times in a larger room you have twenty or so extra seconds before you even get the pressure warning. With rooms equaling pressure out and such you get even more time. This pr increases the damage by a fair bit while still giving plenty of time to escape to safety.

## Why / Balance
This change makes it so all species have about 40 seconds of survival the moment damage starts until you hit crit, With o2 on this increases by about 10 seconds, slimes only get about an extra second or so of survival due to how slow they breathe. With a space pen injection you get nearly 40 more seconds if you have o2 on giving you plenty of time to fight or flight.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Increased the amount of barotrauma damage you receive. 

