### PR TITLE
hopefully fix no objectives

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -176,7 +176,7 @@
   components:
   - type: Objective
     # hos has a gun ce does not, higher difficulty than most
-    difficulty: 3.5
+    difficulty: 3
   - type: NotJobRequirement
     job: HeadOfSecurity
   - type: StealCondition
@@ -256,7 +256,7 @@
     # high difficulty since the hardest item both to steal, and to not get caught down the road,
     # since anyone with a pinpointer can track you down and kill you
     # it's close to being a stealth loneop
-    difficulty: 4.5
+    difficulty: 4
   - type: NotCommandRequirement
   - type: StealCondition
     prototype: NukeDisk

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -250,7 +250,7 @@
 - type: entity
   noSpawn: true
   parent: BaseCaptainObjective
-  id: StealNukeDiskObjective
+  id: NukeDiskStealObjective
   components:
   - type: Objective
     # high difficulty since the hardest item both to steal, and to not get caught down the road,

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -131,7 +131,7 @@
 - type: entity
   noSpawn: true
   parent: BaseTraitorStealObjective
-  id: HyposprayStealObjective
+  id: CMOHyposprayStealObjective
   components:
   - type: NotJobRequirement
     job: ChiefMedicalOfficer


### PR DESCRIPTION
## About the PR
pretty sure its why people were getting few/no objectives since the max difficulty is 5 but idk

also along with other changes that somehow didnt get commited fixed hypo objective id

would need logs of it happening to confirm

## Why / Balance
disk being 4.5 means physically impossible to get any other objective which is too much

## Technical details
no

## Media
hypo objective doesnt throw anymore
![11:11:10](https://github.com/space-wizards/space-station-14/assets/39013340/f331c4e4-7080-4ed5-ae75-bfcbb5dbb49a)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed objectives not being given in some cases.
