### PR TITLE
give cooked meats construction component

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -792,7 +792,7 @@
     count: 3
     slice: FoodMeatDuckCutletCooked
   - type: Construction
-    graph: CookedDuck
+    graph: DuckSteak
     node: cooked duck
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -622,6 +622,9 @@
   - type: SliceableFood
     count: 3
     slice: FoodMeatCutletCooked
+  - type: Construction
+    graph: MeatSteak
+    node: meat steak
 
 - type: entity
   name: bacon
@@ -676,6 +679,9 @@
   - type: SliceableFood
     count: 3
     slice: FoodMeatBearCutletCooked
+  - type: Construction
+    graph: BearSteak
+    node: filet migrawr
 
 - type: entity
   name: penguin filet
@@ -701,6 +707,9 @@
   - type: SliceableFood
     count: 3
     slice: FoodMeatPenguinCutletCooked
+  - type: Construction
+    graph: PenguinSteak
+    node: cooked penguin
 
 - type: entity
   name: cooked chicken
@@ -726,6 +735,9 @@
   - type: SliceableFood
     count: 3
     slice: FoodMeatChickenCutletCooked
+  - type: Construction
+    graph: ChickenSteak
+    node: cooked chicken
 
 - type: entity
   name: fried chicken
@@ -779,6 +791,9 @@
   - type: SliceableFood
     count: 3
     slice: FoodMeatDuckCutletCooked
+  - type: Construction
+    graph: CookedDuck
+    node: cooked duck
 
 - type: entity
   name: cooked crab
@@ -804,6 +819,9 @@
           Quantity: 5
         - ReagentId: Protein
           Quantity: 5
+  - type: Construction
+    graph: CrabSteak
+    node: cooked crab
 
 - type: entity
   name: goliath steak
@@ -826,6 +844,9 @@
           Quantity: 5
         - ReagentId: Protein
           Quantity: 5
+  - type: Construction
+    graph: GoliathSteak
+    name: goliath steak
 
 - type: entity
   name: lizard steak
@@ -851,6 +872,9 @@
   - type: SliceableFood
     count: 3
     slice: FoodMeatLizardCutletCooked
+  - type: Construction
+    graph: LizardSteak
+    name: lizard steak
 
 - type: entity
   name: boiled spider leg

--- a/Resources/Prototypes/Recipes/Construction/Graphs/food/steak.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/food/steak.yml
@@ -86,7 +86,7 @@
       - minTemperature: 345 #apparently trichinellosis is a concern
 
   - node: filet migrawr
-    entity: FoodMealBearsteak
+    entity: FoodMeatBearCooked
 
 # crab steak
 - type: constructionGraph


### PR DESCRIPTION
## About the PR
fixes #20248

no idea how cooking steaks worked just fine before this but yeah

also bear steak (nothing else) had the target entity be FoodMealBearsteak which is very weird everything else used the cooked X meat prototype

## Why / Balance
bug

## Technical details
no

## Media
meat fresh out of the fire
![13:13:46](https://github.com/space-wizards/space-station-14/assets/39013340/00266fc0-06c5-4a8c-aa3c-342778eecff9)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun