### PR TITLE
better logging for shared objective system

### DIFF
--- a/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
+++ b/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
@@ -63,12 +63,9 @@ public abstract class SharedObjectivesSystem : EntitySystem
             return null;
         }
 
-        Log.Debug($"Created objective {proto} ({uid})");
-
         if (!CanBeAssigned(uid, mindId, mind, comp))
         {
-            Del(uid);
-            Log.Warning($"Objective {uid} did not match the requirements for {_mind.MindOwnerLoggingString(mind)}, deleted it");
+            Log.Warning($"Objective {proto} did not match the requirements for {_mind.MindOwnerLoggingString(mind)}, deleted it");
             return null;
         }
 
@@ -77,7 +74,7 @@ public abstract class SharedObjectivesSystem : EntitySystem
         if (ev.Cancelled)
         {
             Del(uid);
-            Log.Warning($"Could not assign objective {uid}, deleted it");
+            Log.Warning($"Could not assign objective {proto}, deleted it");
             return null;
         }
 
@@ -85,6 +82,7 @@ public abstract class SharedObjectivesSystem : EntitySystem
         var afterEv = new ObjectiveAfterAssignEvent(mindId, mind, comp, MetaData(uid));
         RaiseLocalEvent(uid, ref afterEv);
 
+        Log.Debug($"Created objective {ToPrettyString(uid):objective}");
         return uid;
     }
 


### PR DESCRIPTION
## About the PR
was bad before
- logging uid of entity about to be deleted so doesnt matter
- not logging prototype on same line

made warnings better
moved debug line to the end (only print it if adding succeeded) and gave it title of the objective too

should they even be warnings still it doesnt necessarily mean somethings wrong

## Why / Balance
good

## Technical details
no

## Media
![13:53:05](https://github.com/space-wizards/space-station-14/assets/39013340/37945afd-4ab8-466b-8823-1a85ffa9411c)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun