### PR TITLE
Resize the non-admin AHelp window to be taller and less wide

### DIFF
--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -478,7 +478,7 @@ public sealed class UserAHelpUIHandler : IAHelpUIHandler
             TitleClass="windowTitleAlert",
             HeaderClass="windowHeaderAlert",
             Title=Loc.GetString("bwoink-user-title"),
-            MinSize = new Vector2(500, 200),
+            MinSize = new Vector2(500, 300),
         };
         _window.OnClose += () => { OnClose?.Invoke(); };
         _window.OnOpen += () => { OnOpen?.Invoke(); };

--- a/Resources/Locale/en-US/administration/bwoink.ftl
+++ b/Resources/Locale/en-US/administration/bwoink.ftl
@@ -2,7 +2,9 @@ bwoink-user-title = Admin Message
 
 bwoink-system-starmute-message-no-other-users = *System: Nobody is available to receive your message. Try pinging Game Admins on Discord.
 
-bwoink-system-messages-being-relayed-to-discord = Your messages are being relayed to the admins via Discord. Issues may be handled without a response.
+bwoink-system-messages-being-relayed-to-discord =
+    Your messages are being relayed to the admins via Discord.
+    Issues may be handled without a response.
 
 bwoink-system-typing-indicator = {$players} {$count ->
 [one] is


### PR DESCRIPTION
## About the PR
## Media
Old one:
![image](https://github.com/space-wizards/space-station-14/assets/10968691/199696d7-9407-433b-946c-4b2b12e93dc8)

New one:
![Content Client_wnamEU9Mfz](https://github.com/space-wizards/space-station-14/assets/10968691/989c34d1-92d1-41c1-9b2a-c9f3cceeea66)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Resized the non-admin Ahelp window to be taller and less wide.