### PR TITLE
Adds Cap Cap to Captains Hardsuit+Clothing Locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -55,6 +55,7 @@
       - id: WeaponAntiqueLaser
       - id: JetpackCaptainFilled
       - id: MedalCase
+      - id: ClothingHeadHatCapcap
 
 - type: entity
   id: LockerCaptainFilled


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
The captains locker (with hardsuit) didn't spawn with the captains cap. This PR fixes that.

## Why / Balance
While it _could_ have been intentional to leave this hat out of the captains locker... I don't imagine it was seeing as its in the main one. Mostly doing this for the sake of consistency.... plus its annoying not always being able to wear the captains cap.

## Media

https://github.com/space-wizards/space-station-14/assets/91865152/a71ca40a-359c-4bfb-afec-4866c363f057


https://github.com/space-wizards/space-station-14/assets/91865152/64bdb37d-334f-4ba1-901f-a80fa2ae7296


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: PursuitinAshes
- fix: Nanotrasen now properly supplies its captains with appropriate headgear in all of their lockers.