### PR TITLE
Un-network TimedDespawnComponent

### DIFF
--- a/Content.Shared/Spawners/Components/TimedDespawnComponent.cs
+++ b/Content.Shared/Spawners/Components/TimedDespawnComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Spawners.Components;
 /// <summary>
 /// Put this component on something you would like to despawn after a certain amount of time
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent]
 public sealed partial class TimedDespawnComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Spawners/EntitySystems/SharedTimedDespawnSystem.cs
+++ b/Content.Shared/Spawners/EntitySystems/SharedTimedDespawnSystem.cs
@@ -13,30 +13,14 @@ public abstract class SharedTimedDespawnSystem : EntitySystem
     {
         base.Initialize();
         UpdatesOutsidePrediction = true;
-        SubscribeLocalEvent<TimedDespawnComponent, ComponentGetState>(OnDespawnGetState);
-        SubscribeLocalEvent<TimedDespawnComponent, ComponentHandleState>(OnDespawnHandleState);
-    }
-
-    private void OnDespawnGetState(EntityUid uid, TimedDespawnComponent component, ref ComponentGetState args)
-    {
-        args.State = new TimedDespawnComponentState()
-        {
-            Lifetime = component.Lifetime,
-        };
-    }
-
-    private void OnDespawnHandleState(EntityUid uid, TimedDespawnComponent component, ref ComponentHandleState args)
-    {
-        if (args.Current is not TimedDespawnComponentState state)
-            return;
-
-        component.Lifetime = state.Lifetime;
     }
 
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
 
+        // AAAAAAAAAAAAAAAAAAAAAAAAAAA
+        // Client both needs to predict this, but also can't properly handle prediction resetting.
         if (!_timing.IsFirstTimePredicted)
             return;
 
@@ -59,10 +43,4 @@ public abstract class SharedTimedDespawnSystem : EntitySystem
     }
 
     protected abstract bool CanDelete(EntityUid uid);
-
-    [Serializable, NetSerializable]
-    private sealed class TimedDespawnComponentState : ComponentState
-    {
-        public float Lifetime;
-    }
 }


### PR DESCRIPTION
The client cannot predict the deletion if the entity/component is getting networked, so there is no point in networking it.