### PR TITLE
The training bomb now mirrors the syndicate bomb's wires

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -23,8 +23,8 @@
       maxIntensity: 4
     - type: ExplodeOnTrigger
     - type: OnUseTimerTrigger
-      delay: 100
-      delayOptions: [100, 130, 160, 190, 220, 250, 280, 310]
+      delay: 120
+      delayOptions: [120, 150, 180, 210, 240, 270, 300]
       initialBeepDelay: 0
       beepSound: /Audio/Machines/timer.ogg
     - type: Anchorable

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -14,7 +14,7 @@
           type: WiresBoundUserInterface
     - type: Wires
       LayoutId: Defusable
-      alwaysRandomize: true
+      alwaysRandomize: false
     - type: Defusable
     - type: Explosive
       explosionType: Default
@@ -22,11 +22,9 @@
       intensitySlope: 5
       maxIntensity: 4
     - type: ExplodeOnTrigger
-    # If you nerf the syndicate bomb in any major way, this should probably drop down to at least 100s (not 90s to compensate for slower movement speed & less lag in SS14)
-    # Unless, of course, you want the 90 seconds regardless. I can't stop you.
     - type: OnUseTimerTrigger
-      delay: 120
-      delayOptions: [120, 150, 180, 210, 240, 270, 300]
+      delay: 100
+      delayOptions: [100, 130, 160, 190, 220, 250, 280, 310]
       initialBeepDelay: 0
       beepSound: /Audio/Machines/timer.ogg
     - type: Anchorable
@@ -58,9 +56,6 @@
   name: training bomb
   description: A bomb for dummies, manual not included.
   components:
-    - type: Wires
-      LayoutId: Defusable
-      alwaysRandomize: true
     - type: Sprite
       sprite: Structures/Machines/bomb.rsi
       layers:


### PR DESCRIPTION
## About the PR
Makes the training bomb mirror the syndicate bomb's wires, like in SS13.

## Why / Balance
The syndicate bomb is clearly overpowered and this sticks out as a large potential culprit - this feature was (presumably) pivotal to preventing the bomb in SS13 but is just flat-out missing here. This may or may not cause the bomb to become useless considering the playerbase differences but it is at least worth a try - we should implement the thing like it is in SS13 before immediately jumping to rebalancing a version of it that was feature-incomplete to begin with.

Besides that, it makes sense for a couple of other reasons - having a 55% chance dice roll for a gigantic explosive like this is probably not good considering it can destroy departments singlehandedly, and this will also be far from a free win as security - not only do they have to remember to do the training bomb in the first place, but they have to actually find & defuse the bomb within 120 seconds, have wirecutters and a screwdriver on them during that time, and also remember the wire after defusing the bomb.
Syndicates will also likely have to be smarter with their bombing targets, probably usually planting them in harder to notice places to get away with defusing it instead of just putting it in the hallway and hoping nobody defuses it.

**Changelog**
:cl:
- tweak: The training bomb's wires now match those on the syndicate bomb.