### PR TITLE
add binary translator key to uplink

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -118,6 +118,9 @@ uplink-headset-desc = A headset that allows you to communicate with other syndic
 uplink-encryption-key-name = Syndicate Encryption Keys
 uplink-encryption-key-desc = Two encryption keys for access to the secret frequency of our special agents. Give the spare to a friend, but make sure it doesn't fall into enemy hands.
 
+uplink-binary-translator-key-name = Binary Translator Key
+uplink-binary-translator-key-desc = Lets you tap into the silicons' binary channel. Don't talk on it though, at least not without a voice mask.
+
 uplink-hypopen-name = Hypopen
 uplink-hypopen-desc = A chemical hypospray disguised as a pen, capable of instantly injecting up to 10u of reagents. Starts empty.
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -459,6 +459,17 @@
   - UplinkUtility
 
 - type: listing
+  id: UplinkBinaryTranslatorKey
+  name: uplink-binary-translator-key-name
+  description: uplink-binary-translator-key-desc
+  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: rd_label }
+  productEntity: EncryptionKeyBinary
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkUtility
+
+- type: listing
   id: UplinkHypopen
   name: uplink-hypopen-name
   description: uplink-hypopen-desc

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -218,7 +218,7 @@
   parent: EncryptionKey
   id: EncryptionKeyBinary
   name: binary translator key
-  description: An encryption key that translates to binary signals used by silicons.
+  description: An encryption key that translates binary signals used by silicons.
   components:
   - type: EncryptionKey
     channels:

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -213,3 +213,18 @@
     layers:
     - state: crypt_red
     - state: synd_label
+
+- type: entity
+  parent: EncryptionKey
+  id: EncryptionKeyBinary
+  name: binary translator key
+  description: An encryption key that translates to binary signals used by silicons.
+  components:
+  - type: EncryptionKey
+    channels:
+    - Binary
+    defaultChannel: Binary
+  - type: Sprite
+    layers:
+    - state: crypt_silver
+    - state: rd_label


### PR DESCRIPTION
## About the PR
for 4 tc lets you hear and talk on the binary channel
obviously talking instantly outs youself as a traitor so only do it if you have a voicemask or are big troll

## Why / Balance
exists in tg so why not
bit cheaper since there is no ai not as useful

## Technical details
no

## Media
![19:52:36](https://github.com/space-wizards/space-station-14/assets/39013340/90130189-7c66-4f72-b5cc-97c85242e3a6)

![19:50:28](https://github.com/space-wizards/space-station-14/assets/39013340/18615a18-a4b1-4828-9871-74491d7730a5)

![19:50:41](https://github.com/space-wizards/space-station-14/assets/39013340/2cb8f268-94ee-451f-9c33-5d037de27376)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: The Syndicate has cracked the binary radio channel's encryption and is offering keys for 4 TC.
