### PR TITLE
gateway changes

### DIFF
--- a/Content.Client/Gateway/UI/GatewayWindow.xaml.cs
+++ b/Content.Client/Gateway/UI/GatewayWindow.xaml.cs
@@ -163,7 +163,7 @@ public sealed partial class GatewayWindow : FancyWindow,
             var dest = _destinations[i];
             var nextReady = dest.Item3;
             var busy = dest.Item4;
-            _readyLabels[i].Text = ReadyText(now, nextReady);
+            _readyLabels[i].Text = ReadyText(now, nextReady, busy);
             _openButtons[i].Disabled = _current != null || busy || now < nextReady;
         }
     }

--- a/Content.Client/Gateway/UI/GatewayWindow.xaml.cs
+++ b/Content.Client/Gateway/UI/GatewayWindow.xaml.cs
@@ -83,7 +83,7 @@ public sealed partial class GatewayWindow : FancyWindow,
 
             var readyLabel = new Label
             {
-                Text = ReadyText(now, nextReady),
+                Text = ReadyText(now, nextReady, busy),
                 Margin = new Thickness(10f, 0f, 0f, 0f)
             };
             _readyLabels.Add(readyLabel);
@@ -168,8 +168,11 @@ public sealed partial class GatewayWindow : FancyWindow,
         }
     }
 
-    private string ReadyText(TimeSpan now, TimeSpan nextReady)
+    private string ReadyText(TimeSpan now, TimeSpan nextReady, bool busy)
     {
+        if (busy)
+            return Loc.GetString("gateway-window-already-active");
+
         if (now < nextReady)
         {
             var time = nextReady - now;

--- a/Content.Server/Gateway/Components/GatewayComponent.cs
+++ b/Content.Server/Gateway/Components/GatewayComponent.cs
@@ -26,6 +26,12 @@ public sealed partial class GatewayComponent : Component
     public SoundSpecifier CloseSound = new SoundPathSpecifier("/Audio/Effects/Lightning/lightningbolt.ogg");
 
     /// <summary>
+    /// Sound to play when trying to open or close the portal and missing access.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier AccessDeniedSound = new SoundPathSpecifier("/Audio/Machines/custom_deny.ogg");
+
+    /// <summary>
     /// Every other gateway destination on the server.
     /// </summary>
     /// <remarks>

--- a/Content.Server/Gateway/Components/GatewayComponent.cs
+++ b/Content.Server/Gateway/Components/GatewayComponent.cs
@@ -11,10 +11,19 @@ namespace Content.Server.Gateway.Components;
 public sealed partial class GatewayComponent : Component
 {
     /// <summary>
-    /// Sound to play when opening or closing the portal.
+    /// Sound to play when opening the portal.
     /// </summary>
+    /// <remarks>
+    /// Originally named PortalSound as it was used for opening and closing.
+    /// </remarks>
     [DataField("portalSound")]
-    public SoundSpecifier PortalSound = new SoundPathSpecifier("/Audio/Effects/Lightning/lightningbolt.ogg");
+    public SoundSpecifier OpenSound = new SoundPathSpecifier("/Audio/Effects/Lightning/lightningbolt.ogg");
+
+    /// <summary>
+    /// Sound to play when closing the portal.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier CloseSound = new SoundPathSpecifier("/Audio/Effects/Lightning/lightningbolt.ogg");
 
     /// <summary>
     /// Every other gateway destination on the server.
@@ -22,19 +31,19 @@ public sealed partial class GatewayComponent : Component
     /// <remarks>
     /// Added on startup and when a new destination portal is created.
     /// </remarks>
-    [ViewVariables]
+    [DataField]
     public HashSet<EntityUid> Destinations = new();
 
     /// <summary>
     /// The time at which the portal will be closed.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("nextClose", customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [ViewVariables(VVAccess.ReadWrite), DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan NextClose;
 
     /// <summary>
     /// The time at which the portal was last opened.
     /// Only used for UI.
     /// </summary>
-    [ViewVariables]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan LastOpen;
 }

--- a/Content.Server/Gateway/Components/GatewayDestinationComponent.cs
+++ b/Content.Server/Gateway/Components/GatewayDestinationComponent.cs
@@ -13,30 +13,36 @@ public sealed partial class GatewayDestinationComponent : Component
     /// Whether this destination is shown in the gateway ui.
     /// If you are making a gateway for an admeme set this once you are ready for players to select it.
     /// </summary>
-    [DataField("enabled"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool Enabled;
 
     /// <summary>
     /// Name as it shows up on the ui of station gateways.
     /// </summary>
-    [DataField("name"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string Name = string.Empty;
 
     /// <summary>
     /// Time at which this destination is ready to be linked to.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("nextReady", customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [ViewVariables(VVAccess.ReadWrite), DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
     public TimeSpan NextReady;
 
     /// <summary>
     /// How long the portal will be open for after linking.
     /// </summary>
-    [DataField("openTime"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan OpenTime = TimeSpan.FromSeconds(600);
 
     /// <summary>
     /// How long the destination is not ready for after the portal closes.
     /// </summary>
-    [DataField("cooldown"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan Cooldown = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// If true, the portal can be closed by alt clicking it.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool Closeable;
 }

--- a/Content.Server/Gateway/Systems/GatewaySystem.cs
+++ b/Content.Server/Gateway/Systems/GatewaySystem.cs
@@ -1,14 +1,14 @@
 using Content.Server.Gateway.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Gateway;
+using Content.Shared.Popups;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Systems;
+using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Timing;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Content.Server.Gateway.Systems;
 
@@ -19,6 +19,7 @@ public sealed class GatewaySystem : EntitySystem
     [Dependency] private readonly LinkedEntitySystem _linkedEntity = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
     public override void Initialize()
@@ -31,6 +32,7 @@ public sealed class GatewaySystem : EntitySystem
 
         SubscribeLocalEvent<GatewayDestinationComponent, ComponentStartup>(OnDestinationStartup);
         SubscribeLocalEvent<GatewayDestinationComponent, ComponentShutdown>(OnDestinationShutdown);
+        SubscribeLocalEvent<GatewayDestinationComponent, GetVerbsEvent<AlternativeVerb>>(OnDestinationGetVerbs);
     }
 
     public override void Update(float frameTime)
@@ -78,7 +80,7 @@ public sealed class GatewaySystem : EntitySystem
             destinations.Add((GetNetEntity(destUid), dest.Name, dest.NextReady, HasComp<PortalComponent>(destUid)));
         }
 
-        GetDestination(uid, out var current);
+        _linkedEntity.GetLink(uid, out var current);
         var state = new GatewayBoundUserInterfaceState(destinations, GetNetEntity(current), comp.NextClose, comp.LastOpen);
         _ui.TrySetUiState(uid, GatewayUiKey.Key, state);
     }
@@ -95,7 +97,7 @@ public sealed class GatewaySystem : EntitySystem
 
         // if the gateway has an access reader check it before allowing opening
         var user = args.Session.AttachedEntity.Value;
-        if (!_accessReader.IsAllowed(user, uid))
+        if (CheckAccess(user, uid))
             return;
 
         // can't link if portal is already open on either side, the destination is invalid or on cooldown
@@ -123,18 +125,21 @@ public sealed class GatewaySystem : EntitySystem
         // close automatically after time is up
         comp.NextClose = comp.LastOpen + destComp.OpenTime;
 
-        _audio.PlayPvs(comp.PortalSound, uid);
-        _audio.PlayPvs(comp.PortalSound, dest);
+        _audio.PlayPvs(comp.OpenSound, uid);
+        _audio.PlayPvs(comp.OpenSound, dest);
 
         UpdateUserInterface(uid, comp);
         UpdateAppearance(uid);
         UpdateAppearance(dest);
     }
 
-    private void ClosePortal(EntityUid uid, GatewayComponent comp)
+    private void ClosePortal(EntityUid uid, GatewayComponent? comp = null)
     {
+        if (!Resolve(uid, ref comp))
+            return;
+
         RemComp<PortalComponent>(uid);
-        if (!GetDestination(uid, out var dest))
+        if (!_linkedEntity.GetLink(uid, out var dest))
             return;
 
         if (TryComp<GatewayDestinationComponent>(dest, out var destComp))
@@ -143,30 +148,14 @@ public sealed class GatewaySystem : EntitySystem
             destComp.NextReady = _timing.CurTime + destComp.Cooldown;
         }
 
-        _audio.PlayPvs(comp.PortalSound, uid);
-        _audio.PlayPvs(comp.PortalSound, dest.Value);
+        _audio.PlayPvs(comp.CloseSound, uid);
+        _audio.PlayPvs(comp.CloseSound, dest.Value);
 
         _linkedEntity.TryUnlink(uid, dest.Value);
         RemComp<PortalComponent>(dest.Value);
         UpdateUserInterface(uid, comp);
         UpdateAppearance(uid);
         UpdateAppearance(dest.Value);
-    }
-
-    private bool GetDestination(EntityUid uid, [NotNullWhen(true)] out EntityUid? dest)
-    {
-        dest = null;
-        if (TryComp<LinkedEntityComponent>(uid, out var linked))
-        {
-            var first = linked.LinkedEntities.FirstOrDefault();
-            if (first != EntityUid.Invalid)
-            {
-                dest = first;
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private void OnDestinationStartup(EntityUid uid, GatewayDestinationComponent comp, ComponentStartup args)
@@ -189,5 +178,48 @@ public sealed class GatewaySystem : EntitySystem
             gateway.Destinations.Remove(uid);
             UpdateUserInterface(gatewayUid, gateway);
         }
+    }
+
+    private void OnDestinationGetVerbs(EntityUid uid, GatewayDestinationComponent comp, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!comp.Closeable || !args.CanInteract || !args.CanAccess)
+            return;
+
+        // a portal is open so add verb to close it
+        args.Verbs.Add(new AlternativeVerb()
+        {
+            Act = () => TryClose(uid, args.User),
+            Text = Loc.GetString("gateway-close-portal")
+        });
+    }
+
+    private void TryClose(EntityUid uid, EntityUid user)
+    {
+        // portal already closed so cant close it
+        if (!_linkedEntity.GetLink(uid, out var source))
+            return;
+
+        // not allowed to close it
+        if (CheckAccess(user, source.Value))
+            return;
+
+        ClosePortal(source.Value);
+    }
+
+    /// <summary>
+    /// Checks the user's access. Makes popup and plays sound if missing access.
+    /// Returns whether access was missing.
+    /// </summary>
+    private bool CheckAccess(EntityUid user, EntityUid uid, GatewayComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return false;
+
+        if (_accessReader.IsAllowed(user, uid))
+            return false;
+
+        _popup.PopupEntity(Loc.GetString("gateway-access-denied"), user);
+        _audio.PlayPvs(comp.AccessDeniedSound, uid);
+        return true;
     }
 }

--- a/Content.Shared/Teleportation/Systems/LinkedEntitySystem.cs
+++ b/Content.Shared/Teleportation/Systems/LinkedEntitySystem.cs
@@ -1,6 +1,7 @@
-﻿using System.Linq;
 using Content.Shared.Teleportation.Components;
 using Robust.Shared.GameStates;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Content.Shared.Teleportation.Systems;
 
@@ -111,6 +112,26 @@ public sealed class LinkedEntitySystem : EntitySystem
             QueueDel(second);
 
         return success;
+    }
+
+    /// <summary>
+    /// Get the first entity this entity is linked to.
+    /// If multiple are linked only the first one is picked.
+    /// </summary>
+    public bool GetLink(EntityUid uid, [NotNullWhen(true)] out EntityUid? dest, LinkedEntityComponent? comp = null)
+    {
+        dest = null;
+        if (!Resolve(uid, ref comp))
+            return false;
+
+        var first = comp.LinkedEntities.FirstOrDefault();
+        if (first != default)
+        {
+            dest = first;
+            return true;
+        }
+
+        return false;
     }
 
     #endregion

--- a/Content.Shared/Teleportation/Systems/LinkedEntitySystem.cs
+++ b/Content.Shared/Teleportation/Systems/LinkedEntitySystem.cs
@@ -121,7 +121,7 @@ public sealed class LinkedEntitySystem : EntitySystem
     public bool GetLink(EntityUid uid, [NotNullWhen(true)] out EntityUid? dest, LinkedEntityComponent? comp = null)
     {
         dest = null;
-        if (!Resolve(uid, ref comp))
+        if (!Resolve(uid, ref comp, false))
             return false;
 
         var first = comp.LinkedEntities.FirstOrDefault();

--- a/Resources/Locale/en-US/gateway/gateway.ftl
+++ b/Resources/Locale/en-US/gateway/gateway.ftl
@@ -1,6 +1,7 @@
 gateway-window-title = Gateway
 gateway-window-ready = Ready!
 gateway-window-ready-in = Ready in: {$time}s
+gateway-window-already-active = Already active
 gateway-window-open-portal = Open Portal
 gateway-window-no-destinations = No destinations found.
 gateway-window-portal-closing = Portal closing

--- a/Resources/Locale/en-US/gateway/gateway.ftl
+++ b/Resources/Locale/en-US/gateway/gateway.ftl
@@ -4,3 +4,6 @@ gateway-window-ready-in = Ready in: {$time}s
 gateway-window-open-portal = Open Portal
 gateway-window-no-destinations = No destinations found.
 gateway-window-portal-closing = Portal closing
+
+gateway-access-denied = Access denied!
+gateway-close-portal = Close Portal


### PR DESCRIPTION
## About the PR
stuff useful for downstream:
- for destinations with `closeable: true` alt clicking an open destination gateway, with the correct access, will close it
- added popup and sound for access denied
- support different portal closing sound

also cleaned the code up a bit

## Why / Balance
good
closing destinations might let you counter "ddosing" a portal idk

## Technical details
m

## Media
this gateway opened the destination
![00:38:15](https://github.com/space-wizards/space-station-14/assets/39013340/e5276272-46a5-44d3-82e2-674f888853fb)

this one didnt
![00:39:31](https://github.com/space-wizards/space-station-14/assets/39013340/97f59892-b97f-429a-8785-f529dae3e91b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun