### PR TITLE
fix zombies and xenos being able to pry bolted doors

### DIFF
--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -159,7 +159,7 @@ public sealed class DoorSystem : SharedDoorSystem
         {
             Text = Loc.GetString("door-pry"),
             Impact = LogImpact.Low,
-            Act = () => TryPryDoor(uid, args.User, args.User, component, out _, force: true),
+            Act = () => TryPryDoor(uid, args.User, args.User, component, out _),
         });
     }
 

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -167,6 +167,9 @@ namespace Content.Server.Zombies
                 tool.Qualities = new ("Prying");
                 tool.UseSound = new SoundPathSpecifier("/Audio/Items/crowbar.ogg");
                 Dirty(tool);
+
+                // allow prying open powered doors
+                EnsureComp<ToolForcePoweredComponent>(target);
             }
 
             Dirty(melee);

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -27,6 +27,7 @@
       - Prying
     useSound:
       path: /Audio/Items/crowbar.ogg
+  - type: ToolForcePowered
   - type: Reactive
     groups:
       Flammable: [Touch]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes zombies and xenos unable to pry open doors that are bolted.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Assumed to be a bug.
Resolves #20275

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The TryPryDoor() in alt interact was set to force = true, which meant it never checked if the door was bolted. Removes the force parameter, zombies and xenos now rely upon ToolForcePoweredComponent in order to be able to open powered doors.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->


https://github.com/space-wizards/space-station-14/assets/62370007/819461d9-8146-464c-b4c7-b5e298faab1e


https://github.com/space-wizards/space-station-14/assets/62370007/0dad30c5-cb96-46f0-b8fd-37c290a2b41c



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Zombies and xenos can no longer pry open bolted doors.

