### PR TITLE
Practice Ammunition Tech

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -36,6 +36,7 @@ research-technology-draconic-munitions = Draconic Munitions
 research-technology-explosive-technology = Explosive Technology
 research-technology-weaponized-laser-manipulation = Weaponized Laser Manipulation
 research-technology-nonlethal-ammunition = Nonlethal Ammunition
+research-technology-practice-ammunition = Practice Ammunition
 research-technology-concentrated-laser-weaponry = Concentrated Laser Weaponry
 research-technology-wave-particle-harnessing = Wave Particle Harnessing
 research-technology-advanced-riot-control = Advanced Riot Control

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -536,45 +536,45 @@
       - TargetSyndicate
       - TargetClown
     dynamicRecipes:
-      - CartridgePistolRubber
-      - CartridgeMagnumRubber
-      - ShellShotgunBeanbag
-      - CartridgeRifleRubber
-      - CartridgeLightRifleRubber
-      - MagazineBoxPistolRubber
-      - MagazineBoxMagnumRubber
-      - MagazineBoxRifleRubber
-      - MagazineBoxLightRifleRubber
-      - ShellShotgunIncendiary
-      - CartridgePistolIncendiary
-      - CartridgeMagnumIncendiary
       - CartridgeLightRifleIncendiary
+      - CartridgeMagnumIncendiary
+      - CartridgePistolIncendiary
       - CartridgeRifleIncendiary
-      - MagazineBoxPistolIncendiary
-      - MagazineBoxMagnumIncendiary
+      - CartridgeLightRifleRubber
+      - CartridgeMagnumRubber
+      - CartridgePistolRubber
+      - CartridgeRifleRubber
+      - ExplosivePayload
+      - FlashPayload
+      - HoloprojectorSecurity
       - MagazineBoxLightRifleIncendiary
+      - MagazineBoxMagnumIncendiary
+      - MagazineBoxPistolIncendiary
       - MagazineBoxRifleIncendiary
-      - ShellShotgunPractice
-      - MagazineBoxPistolPractice
-      - MagazineBoxMagnumPractice
       - MagazineBoxLightRiflePractice
+      - MagazineBoxMagnumPractice
+      - MagazineBoxPistolPractice
       - MagazineBoxRiflePractice
-      - WeaponLaserCarbinePractice
-      - WeaponDisablerPractice
+      - MagazineBoxLightRifleRubber
+      - MagazineBoxMagnumRubber
+      - MagazineBoxPistolRubber
+      - MagazineBoxRifleRubber
+      - ShellShotgunBeanbag
+      - ShellShotgunIncendiary
+      - ShellShotgunPractice
       - Signaller
       - SignalTrigger
-      - VoiceTrigger
+      - TelescopicShield
       - TimerTrigger
       - Truncheon
-      - TelescopicShield
-      - HoloprojectorSecurity
-      - FlashPayload
-      - ExplosivePayload
-      - WeaponLaserCarbine
+      - VoiceTrigger
       - WeaponAdvancedLaser
+      - WeaponDisablerPractice
       - WeaponLaserCannon
-      - WeaponXrayCannon
+      - WeaponLaserCarbine
+      - WeaponLaserCarbinePractice
       - WeaponTaser
+      - WeaponXrayCannon
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -554,6 +554,13 @@
       - MagazineBoxMagnumIncendiary
       - MagazineBoxLightRifleIncendiary
       - MagazineBoxRifleIncendiary
+      - ShellShotgunPractice
+      - MagazineBoxPistolPractice
+      - MagazineBoxMagnumPractice
+      - MagazineBoxLightRiflePractice
+      - MagazineBoxRiflePractice
+      - WeaponLaserCarbinePractice
+      - WeaponDisablerPractice
       - Signaller
       - SignalTrigger
       - VoiceTrigger

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -412,3 +412,56 @@
   completetime: 5
   materials:
     Plastic: 950
+
+- type: latheRecipe
+  id: ShellShotgunPractice
+  result: ShellShotgunPractice
+  completetime: 2
+  materials:
+    Plastic: 20
+
+- type: latheRecipe
+  id: MagazineBoxPistolPractice
+  result: MagazineBoxPistolPractice
+  completetime: 5
+  materials:
+    Plastic: 600
+
+- type: latheRecipe
+  id: MagazineBoxMagnumPractice
+  result: MagazineBoxMagnumPractice
+  completetime: 5
+  materials:
+    Plastic: 1200
+
+- type: latheRecipe
+  id: MagazineBoxLightRiflePractice
+  result: MagazineBoxLightRiflePractice
+  completetime: 5
+  materials:
+    Plastic: 1000
+
+- type: latheRecipe
+  id: MagazineBoxRiflePractice
+  result: MagazineBoxRiflePractice
+  completetime: 5
+  materials:
+    Plastic: 900
+
+- type: latheRecipe
+  id: WeaponLaserCarbinePractice
+  result: WeaponLaserCarbinePractice
+  completetime: 6
+  materials:
+    Steel: 1800
+    Glass: 400
+    Plastic: 250
+
+- type: latheRecipe
+  id: WeaponDisablerPractice
+  result: WeaponDisablerPractice
+  completetime: 4
+  materials:
+    Steel: 500
+    Glass: 100
+    Plastic: 200

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -84,6 +84,25 @@
   - MagazineBoxLightRifleRubber
   - MagazineBoxRifleRubber
 
+- type: technology
+  id: PracticeAmmunition
+  name: research-technology-practice-ammunition
+  icon:
+    sprite: Objects/Weapons/Guns/Ammunition/Casings/shotgun_shell.rsi
+    state: practice
+  discipline: Arsenal
+  tier: 1
+  cost: 2000
+  recipeUnlocks:
+  - ShellShotgunPractice
+  - CartridgeRifleRubber
+  - MagazineBoxPistolPractice
+  - MagazineBoxMagnumPractice
+  - MagazineBoxLightRiflePractice
+  - MagazineBoxRiflePractice
+  - WeaponLaserCarbinePractice
+  - WeaponDisablerPractice
+
 # Tier 2
 
 - type: technology

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -95,7 +95,6 @@
   cost: 2000
   recipeUnlocks:
   - ShellShotgunPractice
-  - CartridgeRifleRubber
   - MagazineBoxPistolPractice
   - MagazineBoxMagnumPractice
   - MagazineBoxLightRiflePractice


### PR DESCRIPTION
## About the PR
Adds a practice ammunition technology and recipes for science to unlock.
Tier 1 for 2000 points.
Includes all the basic types of rounds in practice form but also practice disablers and laser rifles.

Reorders the dynamicRecipes list to be alphabetical as requested.
## Why / Balance
A very niche tech, but it's good for people who want to create ranges or actually use practice gear for teachings. There wasn't a way to get any of these before unless mapped so that handles that as well.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/110078045/5b69a7dc-8f82-48e4-a296-d11976c22828)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl:
- add: Science can now research practice ammunition for security.