### PR TITLE
Remove some UI color hardcodes for background

### DIFF
--- a/Content.Client/Administration/UI/AdminRemarks/AdminMessagePopupWindow.xaml
+++ b/Content.Client/Administration/UI/AdminRemarks/AdminMessagePopupWindow.xaml
@@ -1,13 +1,9 @@
 <ui:FancyWindow xmlns="https://spacestation14.io"
                 xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
-                xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                 VerticalExpand="True" HorizontalExpand="True"
                 Title="{Loc admin-notes-message-window-title}"
                 MinSize="600 170">
-    <PanelContainer VerticalExpand="True" HorizontalExpand="True">
-        <PanelContainer.PanelOverride>
-            <graphics:StyleBoxFlat BackgroundColor="#25252A" />
-        </PanelContainer.PanelOverride>
+    <PanelContainer VerticalExpand="True" HorizontalExpand="True" StyleClasses="BackgroundDark">
         <ScrollContainer HScrollEnabled="False" VerticalExpand="True" HorizontalExpand="True" Margin="4">
             <BoxContainer Orientation="Vertical" SeparationOverride="10" VerticalAlignment="Bottom">
                 <Label Name="AdminLabel" Text="Loading..." />

--- a/Content.Client/Administration/UI/AdminRemarks/AdminRemarksWindow.xaml
+++ b/Content.Client/Administration/UI/AdminRemarks/AdminRemarksWindow.xaml
@@ -1,13 +1,9 @@
 <ui:FancyWindow xmlns="https://spacestation14.io"
                 xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
-                xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                 VerticalExpand="True" HorizontalExpand="True"
                 Title="{Loc admin-remarks-title}"
                 SetSize="600 400">
-    <PanelContainer>
-        <PanelContainer.PanelOverride>
-            <graphics:StyleBoxFlat BackgroundColor="#25252A" />
-        </PanelContainer.PanelOverride>
+    <PanelContainer StyleClasses="BackgroundDark">
         <BoxContainer Orientation="Vertical" Margin="4">
             <ScrollContainer VerticalExpand="True" HorizontalExpand="True" HScrollEnabled="False">
                 <BoxContainer Orientation="Vertical" Name="NotesContainer" Access="Public" VerticalExpand="True" />

--- a/Content.Client/Administration/UI/BanList/BanListControl.xaml
+++ b/Content.Client/Administration/UI/BanList/BanListControl.xaml
@@ -1,11 +1,7 @@
 ﻿<controls:BanListControl
     xmlns="https://spacestation14.io"
-    xmlns:controls="clr-namespace:Content.Client.Administration.UI.BanList"
-    xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
-    <PanelContainer>
-        <PanelContainer.PanelOverride>
-            <graphics:StyleBoxFlat BackgroundColor="#25252A"/>
-        </PanelContainer.PanelOverride>
+    xmlns:controls="clr-namespace:Content.Client.Administration.UI.BanList">
+    <PanelContainer StyleClasses="BackgroundDark">
         <ScrollContainer>
             <BoxContainer Name="Bans" Access="Public" Orientation="Vertical">
                 <controls:BanListHeader Name="BansHeader"/>

--- a/Content.Client/Administration/UI/BanList/BanListIdsPopup.xaml
+++ b/Content.Client/Administration/UI/BanList/BanListIdsPopup.xaml
@@ -1,9 +1,5 @@
-﻿<Popup xmlns="https://spacestation14.io"
-       xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
-    <PanelContainer>
-        <PanelContainer.PanelOverride>
-            <graphics:StyleBoxFlat BackgroundColor="#25252A"/>
-        </PanelContainer.PanelOverride>
+﻿<Popup xmlns="https://spacestation14.io">
+    <PanelContainer StyleClasses="BackgroundDark">
         <BoxContainer Orientation="Vertical">
             <Label Name="ID" HorizontalExpand="True"/>
             <Label Name="IP" HorizontalExpand="True"/>

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -1,11 +1,7 @@
 ﻿<Control
     xmlns="https://spacestation14.io"
-    xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
-    xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
-    <PanelContainer>
-         <PanelContainer.PanelOverride>
-            <gfx:StyleBoxFlat BackgroundColor="#25252A"/>
-         </PanelContainer.PanelOverride>
+    xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls">
+    <PanelContainer StyleClasses="BackgroundDark">
         <SplitContainer Orientation="Horizontal" VerticalExpand="True">
             <cc:PlayerListControl Access="Public" Name="ChannelSelector" HorizontalExpand="True" SizeFlagsStretchRatio="1" />
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="2">

--- a/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml
+++ b/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml
@@ -1,10 +1,6 @@
 ﻿<Control xmlns="https://spacestation14.io"
-         xmlns:aui="clr-namespace:Content.Client.Administration.UI.CustomControls"
-         xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
-    <PanelContainer>
-        <PanelContainer.PanelOverride>
-            <gfx:StyleBoxFlat BackgroundColor="#25252A"/>
-        </PanelContainer.PanelOverride>
+         xmlns:aui="clr-namespace:Content.Client.Administration.UI.CustomControls">
+    <PanelContainer StyleClasses="BackgroundDark">
         <BoxContainer Orientation="Horizontal">
             <BoxContainer Orientation="Vertical">
                 <BoxContainer Orientation="Horizontal" MinWidth="400">

--- a/Content.Client/Administration/UI/Notes/AdminNotesControl.xaml
+++ b/Content.Client/Administration/UI/Notes/AdminNotesControl.xaml
@@ -1,9 +1,5 @@
-<Control xmlns="https://spacestation14.io"
-         xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
-    <PanelContainer>
-        <PanelContainer.PanelOverride>
-            <gfx:StyleBoxFlat BackgroundColor="#25252A"/>
-        </PanelContainer.PanelOverride>
+<Control xmlns="https://spacestation14.io">
+    <PanelContainer StyleClasses="BackgroundDark">
         <BoxContainer Orientation="Vertical">
             <ScrollContainer VerticalExpand="True" HorizontalExpand="True" HScrollEnabled="False">
                 <BoxContainer Orientation="Vertical" Name="Notes" Access="Public" VerticalExpand="True"/>

--- a/Content.Client/Administration/UI/Notes/AdminNotesLinePopup.xaml
+++ b/Content.Client/Administration/UI/Notes/AdminNotesLinePopup.xaml
@@ -1,8 +1,8 @@
 <Popup xmlns="https://spacestation14.io"
        xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
-    <PanelContainer>
+    <PanelContainer StyleClasses="BackgroundDark">
         <PanelContainer.PanelOverride>
-            <gfx:StyleBoxFlat BackgroundColor="#25252A" BorderThickness="1" BorderColor="#18181B"/>
+            <gfx:StyleBoxFlat BorderThickness="1" BorderColor="#18181B"/>
         </PanelContainer.PanelOverride>
         <BoxContainer Orientation="Vertical">
             <Label Name="PlayerNameLabel"/>

--- a/Content.Client/Cargo/UI/CargoProductRow.xaml
+++ b/Content.Client/Cargo/UI/CargoProductRow.xaml
@@ -1,5 +1,4 @@
 ﻿<PanelContainer xmlns="https://spacestation14.io"
-                xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                 HorizontalExpand="True">
     <Button Name="MainButton"
             ToolTip=""
@@ -15,10 +14,7 @@
         <Label Name="ProductName"
                Access="Public"
                HorizontalExpand="True" />
-        <PanelContainer>
-            <PanelContainer.PanelOverride>
-                <gfx:StyleBoxFlat BackgroundColor="#25252A" />
-            </PanelContainer.PanelOverride>
+        <PanelContainer StyleClasses="BackgroundDark">
             <Label Name="PointCost"
                    Access="Public"
                    MinSize="52 32"

--- a/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml
+++ b/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml
@@ -1,11 +1,7 @@
 <Control xmlns="https://spacestation14.io"
          xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
-         xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
          Margin="0 0 0 10">
-    <PanelContainer VerticalExpand="True">
-        <PanelContainer.PanelOverride>
-            <gfx:StyleBoxFlat BackgroundColor="#25252a"/>
-        </PanelContainer.PanelOverride>
+    <PanelContainer VerticalExpand="True" StyleClasses="BackgroundDark">
         <BoxContainer Orientation="Vertical"
                       HorizontalExpand="True"
                       VerticalExpand="True"

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml
@@ -1,17 +1,12 @@
 ﻿<widgets:ChatBox
     xmlns="https://spacestation14.io"
-    xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.Chat.Widgets"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Systems.Chat.Controls"
     MouseFilter="Stop"
     HorizontalExpand="True"
     VerticalExpand="True"
     MinSize="465 225">
-    <PanelContainer HorizontalExpand="True" VerticalExpand="True">
-        <PanelContainer.PanelOverride>
-            <graphics:StyleBoxFlat BackgroundColor="#25252AAA" />
-        </PanelContainer.PanelOverride>
-
+    <PanelContainer HorizontalExpand="True" VerticalExpand="True" StyleClasses="BackgroundDark">
         <BoxContainer Orientation="Vertical" SeparationOverride="4" HorizontalExpand="True" VerticalExpand="True">
             <OutputPanel Name="Contents" HorizontalExpand="True" VerticalExpand="True" Margin="8 8 8 4" />
             <controls:ChatInputBox HorizontalExpand="True" Name="ChatInput" Access="Public" Margin="2"/>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Ever since I found out you did not need to hardcode the UI color background in https://github.com/space-wizards/space-station-14/pull/20268#discussion_r1328106545 my life had changed. I could not live with the mention of some background stuff being hardcoded. Today we take a stance against this cringe.

For reals this just removes the background hardcode in the UI and uses the styleclass instead. Theres some other hardcoded colors but I'm not touching em unless you know of the style class for them or however it works.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

I was bored and I guess it's cleaner.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Everything looks exactly the same no player or you would notice anything.

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

None I'm aware of... enforcing the use of ``StyleClasses="BackgroundDark"``??