### PR TITLE
Fix for uplink syndicate bomb timeout

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -248,7 +248,7 @@
     Telecrystal: 11
   categories:
     - UplinkExplosives
-  restockTime: 10
+  restockTime: 30
 
 # Ammo
 


### PR DESCRIPTION
## About the PR
A small fix for this PR: #20214 left my testing time limit in the config for the syndicate bomb. 😩 

## Why / Balance
Correct issue on previous PR

## Technical details
Updated config on YML to 30min instead of 10min for syndicate bomb

## Media
![image](https://github.com/space-wizards/space-station-14/assets/47093363/6890a711-746f-4218-8e34-2040af070549)


- [X] I have added screenshots/videos to this PR showcasing its changes in game, **or** this PR does not require an in game showcase

## Breaking changes
None

**Changelog**
Fixes correct time for syndicate bomb lockout. don't think it needs in game changelog.
