### PR TITLE
navmap beacon on armed nuke

### DIFF
--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.AlertLevel;
 using Content.Server.Audio;
 using Content.Server.Chat.Systems;
 using Content.Server.Explosion.EntitySystems;
+using Content.Server.Pinpointer;
 using Content.Server.Popups;
 using Content.Server.Station.Systems;
 using Content.Shared.Audio;
@@ -29,6 +30,7 @@ public sealed class NukeSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ITileDefinitionManager _tileDefManager = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+    [Dependency] private readonly NavMapSystem _navMap = default!;
     [Dependency] private readonly PointLightSystem _pointLight = default!;
     [Dependency] private readonly PopupSystem _popups = default!;
     [Dependency] private readonly ServerGlobalSoundSystem _sound = default!;
@@ -458,6 +460,8 @@ public sealed class NukeSystem : EntitySystem
 
         // turn on the spinny light
         _pointLight.SetEnabled(uid, true);
+        // enable the navmap beacon for people to find it
+        _navMap.SetBeaconEnabled(uid, true);
 
         _itemSlots.SetLock(uid, component.DiskSlot, true);
         if (!nukeXform.Anchored)
@@ -500,6 +504,8 @@ public sealed class NukeSystem : EntitySystem
 
         // turn off the spinny light
         _pointLight.SetEnabled(uid, false);
+        // disable the navmap beacon now that its disarmed
+        _navMap.SetBeaconEnabled(uid, false);
 
         // start bomb cooldown
         _itemSlots.SetLock(uid, component.DiskSlot, false);

--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -130,7 +130,7 @@ public sealed class NavMapSystem : SharedNavMapSystem
 
         while (beaconQuery.MoveNext(out var beaconUid, out var beacon, out var xform))
         {
-            if (xform.GridUid != uid || !CanBeacon(beaconUid, xform))
+            if (!beacon.Enabled || xform.GridUid != uid || !CanBeacon(beaconUid, xform))
                 continue;
 
             // TODO: Make warp points use metadata name instead.

--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -246,7 +246,6 @@ public sealed class NavMapSystem : SharedNavMapSystem
             return;
 
         comp.Enabled = enabled;
-        Dirty(uid, comp);
 
         RefreshNavGrid(uid);
     }

--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -236,4 +236,29 @@ public sealed class NavMapSystem : SharedNavMapSystem
 
         Dirty(component);
     }
+
+    /// <summary>
+    /// Sets the beacon's Enabled field and refreshes the grid.
+    /// </summary>
+    public void SetBeaconEnabled(EntityUid uid, bool enabled, NavMapBeaconComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp) || comp.Enabled = enabled)
+            return;
+
+        comp.Enabled = enabled;
+        Dirty(uid, comp);
+
+        RefreshNavGrid(uid);
+    }
+
+    /// <summary>
+    /// Toggles the beacon's Enabled field and refreshes the grid.
+    /// </summary>
+    public void ToggleBeacon(EntityUid uid, NavMapBeaconComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return;
+
+        SetBeaconEnabled(uid, !comp.Enabled, comp);
+    }
 }

--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -242,7 +242,7 @@ public sealed class NavMapSystem : SharedNavMapSystem
     /// </summary>
     public void SetBeaconEnabled(EntityUid uid, bool enabled, NavMapBeaconComponent? comp = null)
     {
-        if (!Resolve(uid, ref comp) || comp.Enabled = enabled)
+        if (!Resolve(uid, ref comp) || comp.Enabled == enabled)
             return;
 
         comp.Enabled = enabled;

--- a/Content.Shared/Pinpointer/NavMapBeaconComponent.cs
+++ b/Content.Shared/Pinpointer/NavMapBeaconComponent.cs
@@ -16,4 +16,10 @@ public sealed partial class NavMapBeaconComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
     public Color Color = Color.Orange;
+
+    /// <summary>
+    /// Only enabled beacons can be seen on a station map.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    public bool Enabled = true;
 }

--- a/Content.Shared/Pinpointer/NavMapBeaconComponent.cs
+++ b/Content.Shared/Pinpointer/NavMapBeaconComponent.cs
@@ -11,9 +11,9 @@ public sealed partial class NavMapBeaconComponent : Component
     /// <summary>
     /// Defaults to entity name if nothing found.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("text"), AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
     public string? Text;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("color"), AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
     public Color Color = Color.Orange;
 }

--- a/Content.Shared/Pinpointer/NavMapBeaconComponent.cs
+++ b/Content.Shared/Pinpointer/NavMapBeaconComponent.cs
@@ -5,21 +5,21 @@ namespace Content.Shared.Pinpointer;
 /// <summary>
 /// Will show a marker on a NavMap.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, Access(typeof(SharedNavMapSystem))]
 public sealed partial class NavMapBeaconComponent : Component
 {
     /// <summary>
     /// Defaults to entity name if nothing found.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public string? Text;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public Color Color = Color.Orange;
 
     /// <summary>
     /// Only enabled beacons can be seen on a station map.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public bool Enabled = true;
 }

--- a/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
@@ -31,6 +31,10 @@
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight
     speed: 120
+  - type: NavMapBeacon
+    color: "#ff0000"
+    text: nuclear fission explosive
+    enabled: false
   - type: NukeLabel
   - type: Nuke
     explosionType: Default


### PR DESCRIPTION
## About the PR
nuke gets a beacon enabled when armed so people can find it without pinpointer
also adds api for other stuff (dragon)

## Why / Balance
good

## Technical details
- added Enabled bool to beacon
- server will not send client disabled beacons
- added SetBeaconEnabled / ToggleBeacon to navmap system api
- unnetworked the beacon and its fields since client code never touched it and it has no reason to and it shouldnt be possible for client to know about it anyway (can undo if theres plans for prediction or something)

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/354a86b9-5bf3-476e-9995-b019a992fc2a

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
`NavMapBeaconComponent` is no longer networked

**Changelog**
:cl:
- tweak: Armed nuclear explosives can be seen on station maps.
