### PR TITLE
Raise GasMinMoles

### DIFF
--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -2,6 +2,7 @@ using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
+using Content.Shared.Atmos;
 using Content.Shared.Body.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared;

--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -128,7 +128,7 @@ namespace Content.IntegrationTests.Tests.Body
                     metaSys.Update(1.0f);
                     metaSys.Update(1.0f);
                     respSys.Update(2.0f);
-                    Assert.That(GetMapMoles(), Is.EqualTo(startingMoles).Within(0.0001));
+                    Assert.That(GetMapMoles(), Is.EqualTo(startingMoles).Within(Atmospherics.GasMinMoles * 2));
                 });
             }
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -87,7 +87,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     Minimum number of moles a gas can have.
         /// </summary>
-        public const float GasMinMoles = 0.00000005f;
+        public const float GasMinMoles = 0.001f;
 
         public const float OpenHeatTransferCoefficient = 0.4f;
 


### PR DESCRIPTION
## About the PR
Raises `GasMinMoles`, the minimum quantity of gas in moles considered to be non-zero, from `0.00000005f` to `0.001f`.

## Why / Balance
The old number is 50 parts-per-billion (ppb), which while is detectable in some contexts IRL, basically doesn't matter in Space Station 14 and results in situations like this where a tiny trace amount of gas stays in the gas analyzer forever:

![gas-analyzer-bug](https://github.com/space-wizards/space-station-14/assets/3229565/081303b3-5a08-4b07-a75b-09144bd0bc6b)

This change brings the zero-threshold to `0.001f`, which is already 10× less than `0.01f`, the YAML-hardcoded minimum threshold for most reactions to take place.

## Technical details
`GasMinMoles` is used by the atmosphere system in 3 places:

- LINDA to decide when to stop moving gases
- By the gas analyzer to decide when a gas mixture is effectively zero
- By `GasMixture` to determine when to zero out that value in gases removed

This change would (marginally) speed up LINDA by ignoring gases that don't matter and also spam the gas analyzer less with gases that basically don't matter.

I double checked that removing small amounts of gas doesn't affect typical tritium setups after this change:

![image](https://github.com/space-wizards/space-station-14/assets/3229565/45585f8b-0159-48de-97bf-a309aaefa722)

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase