### PR TITLE
Metabolism fixes

### DIFF
--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -14,6 +14,7 @@ public sealed class DrunkOverlay : Overlay
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IEntitySystemManager _sysMan = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
     public override bool RequestScreenTexture => true;
@@ -34,6 +35,7 @@ public sealed class DrunkOverlay : Overlay
 
     protected override void FrameUpdate(FrameEventArgs args)
     {
+
         var playerEntity = _playerManager.LocalPlayer?.ControlledEntity;
 
         if (playerEntity == null)
@@ -47,8 +49,12 @@ public sealed class DrunkOverlay : Overlay
         if (!statusSys.TryGetTime(playerEntity.Value, SharedDrunkSystem.DrunkKey, out var time, status))
             return;
 
-        var timeLeft = (float) (time.Value.Item2 - time.Value.Item1).TotalSeconds;
-        CurrentBoozePower += (timeLeft - CurrentBoozePower) * args.DeltaSeconds / 16f;
+        var curTime = _timing.CurTime;
+        var timeLeft = (float) (time.Value.Item2 - curTime).TotalSeconds;
+
+
+        CurrentBoozePower += 8f * (0.5f*timeLeft - CurrentBoozePower) * args.DeltaSeconds / (timeLeft+1);
+        Logger.Debug($"Current power: {CurrentBoozePower}  Time Left: {timeLeft}");
     }
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)
@@ -83,6 +89,14 @@ public sealed class DrunkOverlay : Overlay
     /// <param name="boozePower"></param>
     private float BoozePowerToVisual(float boozePower)
     {
-        return Math.Clamp((boozePower - VisualThreshold) / PowerDivisor, 0.0f, 1.0f);
+        // Clamp booze power when it's low, to prevent really jittery effects
+        if (boozePower < 50f)
+        {
+            return 0;
+        }
+        else
+        {
+            return Math.Clamp((boozePower - VisualThreshold) / PowerDivisor, 0.0f, 1.0f);
+        }
     }
 }

--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -54,7 +54,6 @@ public sealed class DrunkOverlay : Overlay
 
 
         CurrentBoozePower += 8f * (0.5f*timeLeft - CurrentBoozePower) * args.DeltaSeconds / (timeLeft+1);
-        Logger.Debug($"Current power: {CurrentBoozePower}  Time Left: {timeLeft}");
     }
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -130,11 +130,16 @@ namespace Content.Server.Body.Systems
             int reagents = 0;
             foreach (var (reagent, quantity) in list)
             {
-                Logger.Debug("------------------------------");
-                Logger.Debug($"Reagent: {reagent} - Quantity: {quantity}");
+                var debug = true;
+                if (reagent.Prototype == "Beer" || reagent.Prototype == "Ethanol" || reagent.Prototype == "Vodka")
+                    debug = true;
+
+                if (debug) Logger.Debug("------------------------------");
+                if (debug) Logger.Debug($"Reagent: {reagent} - Quantity: {quantity}");
                 if (!_prototypeManager.TryIndex<ReagentPrototype>(reagent.Prototype, out var proto))
                     continue;
 
+                if (debug) Logger.Debug("Checkpoint 1");
                 var mostToRemove = FixedPoint2.Zero;
                 if (proto.Metabolisms == null)
                 {
@@ -147,30 +152,37 @@ namespace Content.Server.Body.Systems
                     continue;
                 }
 
+                if (debug) Logger.Debug("Checkpoint 2");
+                if (debug) Logger.Debug($"Number of reagents: {reagents} List length: {list.Length} Max: {meta.MaxReagentsProcessable}");
                 // we're done here entirely if this is true
                 if (reagents >= meta.MaxReagentsProcessable)
                     return;
 
-                reagents += 1;
+
+                if (debug) Logger.Debug("Checkpoint 2.5");
 
                 // loop over all our groups and see which ones apply
                 if (meta.MetabolismGroups == null)
                     continue;
 
+                if (debug) Logger.Debug("Checkpoint 3");
+
                 foreach (var group in meta.MetabolismGroups)
                 {
+                    if (debug) Logger.Debug($"Metabolism group: {group.Id}");
                     if (!proto.Metabolisms.ContainsKey(group.Id))
                         continue;
 
                     var entry = proto.Metabolisms[group.Id];
                     // Is this calculation right?
                     // The rate modifier seems to be buggy
-                    Logger.Debug($"Metab rate: {entry.MetabolismRate}  Modifier: {group.MetabolismRateModifier}");
+                    if (debug) Logger.Debug($"Metab rate: {entry.MetabolismRate}  Modifier: {group.MetabolismRateModifier}");
                     var rate = entry.MetabolismRate * group.MetabolismRateModifier;
 
                     // we don't remove reagent for every group, just whichever had the biggest rate
                     // this comment is misleading, or the code is super broken
-                    // wait is this the thing thats broken? does it just need a continue?
+                    // also this shouldn't be true anyways, as liver and stomach are both referenced
+                    // as processing at the same time somewhere else
                     if (rate > mostToRemove)
                         mostToRemove = rate;
 
@@ -182,7 +194,7 @@ namespace Content.Server.Body.Systems
 
                     // Rate is bugged? Huhh????
                     float scale = (float) mostToRemove / (float) rate;
-                    Logger.Debug($"Scale: {scale}  Remove: {mostToRemove}  Rate: {rate}");
+                    if (debug) Logger.Debug($"Scale: {scale}  Remove: {mostToRemove}  Rate: {rate}");
 
                     // if it's possible for them to be dead, and they are,
                     // then we shouldn't process any effects, but should probably
@@ -196,12 +208,12 @@ namespace Content.Server.Body.Systems
                     var actualEntity = organ?.Body ?? solutionEntityUid.Value;
                     var args = new ReagentEffectArgs(actualEntity, uid, solution, proto, mostToRemove,
                         EntityManager, null, scale);
-                    Logger.Debug($"Reagent: {reagent}");
+                    if (debug) Logger.Debug($"Reagent: {reagent}");
 
                     // do all effects, if conditions apply
                     foreach (var effect in entry.Effects)
                     {
-                        Logger.Debug("Maybe effecting target");
+                        // Logger.Debug("Maybe effecting target");
                         if (!effect.ShouldApply(args, _random))
                             continue;
 
@@ -210,7 +222,7 @@ namespace Content.Server.Body.Systems
                             _adminLogger.Add(LogType.ReagentEffect, effect.LogImpact,
                                 $"Metabolism effect {effect.GetType().Name:effect} of reagent {proto.LocalizedName:reagent} applied on entity {actualEntity:entity} at {Transform(actualEntity).Coordinates:coordinates}");
                         }
-                        Logger.Debug("Effecting target");
+                        if (debug) Logger.Debug($"Metabolism effect {effect.GetType().Name:effect}");
 
                         effect.Effect(args);
                     }
@@ -221,6 +233,9 @@ namespace Content.Server.Body.Systems
                 {
                     Logger.Debug($"Removing {mostToRemove} reagent from {solution.Name}");
                     _solutionContainerSystem.RemoveReagent(solutionEntityUid.Value, solution, reagent, mostToRemove);
+
+                    // We have processed a reagant, so count it towards the cap
+                    reagents += 1;
                 }
             }
         }

--- a/Content.Server/Speech/EntitySystems/SlurredSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SlurredSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Drunk;
 using Content.Shared.Speech.EntitySystems;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -11,6 +12,9 @@ public sealed class SlurredSystem : SharedSlurredSystem
 {
     [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+
 
     [ValidatePrototypeId<StatusEffectPrototype>]
     private const string SlurKey = "SlurredSpeech";
@@ -39,8 +43,9 @@ public sealed class SlurredSystem : SharedSlurredSystem
         if (!_statusEffectsSystem.TryGetTime(uid, SharedDrunkSystem.DrunkKey, out var time))
             return 0;
 
-        var timeLeft = (float) (time.Value.Item2 - time.Value.Item1).TotalSeconds;
-        return Math.Clamp(timeLeft / 200, 0f, 1f);
+        var curTime = _timing.CurTime;
+        var timeLeft = (float) (time.Value.Item2 - curTime).TotalSeconds;
+        return Math.Clamp((timeLeft - 80) / 1100, 0f, 1f);
     }
 
     private void OnAccent(EntityUid uid, SlurredAccentComponent component, AccentGetEvent args)

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -120,12 +120,12 @@
   boilingPoint: 78.2
   meltingPoint: -114.1
   metabolisms:
-    Poison:
+    Alcohol:
       effects:
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 5
+          min: 15
         - !type:OrganType
           type: Dwarf
           shouldHave: false
@@ -136,7 +136,7 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 5
+          min: 15
         - !type:OrganType
           type: Dwarf
         damage:
@@ -145,7 +145,7 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 5
+          min: 15
         - !type:OrganType
           type: Dwarf
         damage:
@@ -156,15 +156,13 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Ethanol
-          min: 3
+          min: 12
         # dwarves immune to vomiting from alcohol
         - !type:OrganType
           type: Dwarf
           shouldHave: false
-    Alcohol:
-      effects:
       - !type:Drunk
-        boozePower: 20
+        boozePower: 2
 
 - type: reagent
   id: Gin

--- a/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
@@ -1,4 +1,4 @@
-﻿- type: reagent
+- type: reagent
   id: BaseDrink
   group: Drinks
   abstract: true
@@ -48,7 +48,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.05
+        amount: 0.06
   reactiveEffects:
     Flammable:
       methods: [ Touch ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR fixes a few bugs I found in the metabolism system when I was tweaking alcohol recipes in my last PR. The bugs are that:

- The alcohol shader incorrectly used the total time of the drunk effect to calculate strength, instead of the time remaining, like a comment in the code implied. This caused the shader effect to abruptly cut off when you sobered up.
- Likewise, the slur system made a similar mistake. Both of these have been tweaked and reworked to effect less when you're sobering up.
- Reagent limits were applying wrong. When you had multiple reagents in your system, and a metabolism tried processing an invalid one, it would count it towards the reagent limit no matter what. The randomized order of reagent processing lead to situations incorrectly triggering the reagent limit. This especially mattered for the liver which had a limit of 1, which made the drunk effect very inconsistent, and it would barely extend itself previously before it expired.
- The `scale` in the reagent system was being calculated wrong when metabolisms had a rate modifier. The liver has a modifier of 0.1, and this caused the scale to always be 10% of what it was supposed to be. Gas metabolisms have a very high modifier, and I suspect this bug is what was causing instadeath from plasma and other toxic gases, though I haven't confirmed that.
- The heart was filtering out alcohol much faster than the liver because of the Poison metabolism tag on ethanol. It was filtering alcohol so fast that it was impossible to trigger the negative effects of it unless playing slime or diona, because it could never build up. This tag has been removed so only the liver will process alcohol.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
These changes affect the drunk effect quite a bit. Previous systems were built to work around these bugs, and I retuned everything to have a reasonable effect. I'm not 100% convinced I got it right and feedback is welcome. 

The important positive benefits are that:
- The screen and slur effect tune down as you're sobering up
- It's no longer possible to roll badly and for the drunk effect to cancel itself, I've noticed this in game a few times
- Metabolizing medicine, poison, and alcohol will be more consistent when you have food or other unrelated reagents in your system 

The thing that affects balance the most is that it's now relatively easy to build ethanol up in your system if you drink too much. The drunk affect lasts a little longer as well, though the screen effect and slur should be a little less strong than before.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The surgeons at Centcomm have made it so drinking too much alcohol will now cause liver failure instead of heart failure. Alcoholics rejoice!
