### PR TITLE
nukie shuttle gets syndicate airlocks

### DIFF
--- a/Resources/Maps/infiltrator.yml
+++ b/Resources/Maps/infiltrator.yml
@@ -574,7 +574,7 @@ entities:
     - type: GasTileOverlay
     - type: SpreaderGrid
     - type: GridPathfinding
-- proto: AirlockExternal
+- proto: AirlockSyndicateLocked
   entities:
   - uid: 69
     components:
@@ -616,7 +616,7 @@ entities:
     - pos: -4.5,-10.5
       parent: 73
       type: Transform
-- proto: AirlockSecurity
+- proto: AirlockSyndicateLocked
   entities:
   - uid: 201
     components:
@@ -637,7 +637,7 @@ entities:
     - pos: -0.5,-14.5
       parent: 73
       type: Transform
-- proto: AirlockSecurityGlass
+- proto: AirlockSyndicateGlassLocked
   entities:
   - uid: 371
     components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
the nukie shuttle now gets its own airlocks which only agent ID's and the syndicate ID the commander and agent get
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
so its harder for crew to nuke nukie planet and it just makes sense logically

they are syndicate level instead of nukie level so if you buy the agent ID you aren't locked out, useful for reinforcements
## Media
![image](https://github.com/space-wizards/space-station-14/assets/130668733/175887c7-6605-4403-9748-e7e5627b401c)
![image](https://github.com/space-wizards/space-station-14/assets/130668733/32cbbfca-5050-4ed0-9098-caf8450d481f)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl: JoeHammad
- add: The nukie ship now has syndicate access airlocks