### PR TITLE
Display minimum temperature required for reaction to occur in guidebook

### DIFF
--- a/Content.Client/Guidebook/Controls/GuideReagentEmbed.xaml
+++ b/Content.Client/Guidebook/Controls/GuideReagentEmbed.xaml
@@ -26,7 +26,8 @@
                             </BoxContainer>
                             <BoxContainer Orientation="Vertical"  VerticalAlignment="Center">
                                 <TextureRect TexturePath="/Textures/Interface/Misc/beakerlarge.png"/>
-                                <Label Text="{Loc 'guidebook-reagent-recipes-mix'}"
+                                <Label Name="MixLabel"
+                                       Text="{Loc 'guidebook-reagent-recipes-mix'}"
                                        HorizontalAlignment="Center"/>
                             </BoxContainer>
                             <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalAlignment="Center">

--- a/Content.Client/Guidebook/Controls/GuideReagentEmbed.xaml
+++ b/Content.Client/Guidebook/Controls/GuideReagentEmbed.xaml
@@ -25,7 +25,8 @@
                                                VerticalAlignment="Center"/>
                             </BoxContainer>
                             <BoxContainer Orientation="Vertical"  VerticalAlignment="Center">
-                                <TextureRect TexturePath="/Textures/Interface/Misc/beakerlarge.png"/>
+                                <TextureRect TexturePath="/Textures/Interface/Misc/beakerlarge.png"
+                                             HorizontalAlignment="Center"/>
                                 <Label Name="MixLabel"
                                        Text="{Loc 'guidebook-reagent-recipes-mix'}"
                                        HorizontalAlignment="Center"/>

--- a/Content.Client/Guidebook/Controls/GuideReagentEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideReagentEmbed.xaml.cs
@@ -116,6 +116,12 @@ public sealed partial class GuideReagentEmbed : BoxContainer, IDocumentTag, ISea
             reactantMsg.Pop();
             ReactantsLabel.SetMessage(reactantMsg);
 
+            if (reactionPrototype.MinimumTemperature > 0.0f)
+            {
+                MixLabel.Text = Loc.GetString("guidebook-reagent-recipes-mix-and-heat",
+                    ("temperature", reactionPrototype.MinimumTemperature));
+            }
+
             var productMsg = new FormattedMessage();
             var productCount = reactionPrototype.Products.Count;
             var u = 0;

--- a/Resources/Locale/en-US/guidebook/chemistry/core.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/core.ftl
@@ -11,6 +11,7 @@ guidebook-reagent-name = [bold][color={$color}]{CAPITALIZE($name)}[/color][/bold
 guidebook-reagent-recipes-header = Recipe
 guidebook-reagent-recipes-reagent-display = [bold]{$reagent}[/bold] \[{$ratio}\]
 guidebook-reagent-recipes-mix = Mix
+guidebook-reagent-recipes-mix-and-heat = Mix and heat to temperature {$temperature}K
 guidebook-reagent-effects-header = Effects
 guidebook-reagent-effects-metabolism-group-rate = [bold]{$group}[/bold] [color=gray]({$rate} units per second)[/color]
 guidebook-reagent-physical-description = Seems to be {$description}.

--- a/Resources/Locale/en-US/guidebook/chemistry/core.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/core.ftl
@@ -11,7 +11,7 @@ guidebook-reagent-name = [bold][color={$color}]{CAPITALIZE($name)}[/color][/bold
 guidebook-reagent-recipes-header = Recipe
 guidebook-reagent-recipes-reagent-display = [bold]{$reagent}[/bold] \[{$ratio}\]
 guidebook-reagent-recipes-mix = Mix
-guidebook-reagent-recipes-mix-and-heat = Mix and heat to temperature {$temperature}K
+guidebook-reagent-recipes-mix-and-heat = Mix at above {$temperature}K
 guidebook-reagent-effects-header = Effects
 guidebook-reagent-effects-metabolism-group-rate = [bold]{$group}[/bold] [color=gray]({$rate} units per second)[/color]
 guidebook-reagent-physical-description = Seems to be {$description}.


### PR DESCRIPTION
## About the PR
I added information about minimum temperature required for reaction to guidebook.

## Why / Balance
Currently, the only way to check minimum temperature needed by reaction was to look at YAML prototypes.
Because of that, many players were wondering why given reaction doesn't occur, even through all ingredients have been added. Because they didn't know they need to heat it up.

## Technical details
If `reactionPrototype.MinimumTemperature` is greater than 0, then instead of displaying `guidebook-reagent-recipes-mix` localized string, it will display `guidebook-reagent-recipes-mix-and-heat`.

## Media
![2023-9-23_10 23 58](https://github.com/space-wizards/space-station-14/assets/40093912/5160af3a-a773-4399-b8b1-9b6efd39645e)
![2023-9-23_15 40 47](https://github.com/space-wizards/space-station-14/assets/40093912/638c9393-ff75-4ac2-af19-e246f34ce622)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl:
- add: After several complaints from chemists, Nanotrasen decided to update their Chemistry Guidebook to include information about environment required by reaction to occur.
