### PR TITLE
Follow mouse rotation in combat mode

### DIFF
--- a/Content.Client/MouseRotator/MouseRotatorSystem.cs
+++ b/Content.Client/MouseRotator/MouseRotatorSystem.cs
@@ -41,6 +41,22 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
 
         var curRot = _transform.GetWorldRotation(xform);
 
+        // 4-dir handling is separate --
+        // only raise event if the cardinal direction has changed
+        if (rotator.Simple4DirMode)
+        {
+            var angleDir = angle.GetCardinalDir();
+            if (angleDir == curRot.GetCardinalDir())
+                return;
+
+            RaisePredictiveEvent(new  RequestMouseRotatorRotationSimpleEvent()
+            {
+                Direction = angleDir,
+            });
+
+            return;
+        }
+
         // Don't raise event if mouse ~hasn't moved (or if too close to goal rotation already)
         var diff = Angle.ShortestDistance(angle, curRot);
         if (Math.Abs(diff.Theta) < rotator.AngleTolerance.Theta)

--- a/Content.Shared/CombatMode/CombatModeComponent.cs
+++ b/Content.Shared/CombatMode/CombatModeComponent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.MouseRotator;
+using Content.Shared.Movement.Components;
 using Content.Shared.Targeting;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -40,6 +42,13 @@ namespace Content.Shared.CombatMode
 
         [ViewVariables(VVAccess.ReadWrite), DataField("isInCombatMode"), AutoNetworkedField]
         public bool IsInCombatMode;
+
+        /// <summary>
+        ///     Will add <see cref="MouseRotatorComponent"/> and <see cref="NoRotateOnMoveComponent"/>
+        ///     to entities with this flag enabled that enter combat mode, and vice versa for removal.
+        /// </summary>
+        [DataField, AutoNetworkedField]
+        public bool ToggleMouseRotator = true;
 
         [ViewVariables(VVAccess.ReadWrite), DataField("activeZone"), AutoNetworkedField]
         public TargetingZone ActiveZone;

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -1,4 +1,6 @@
 using Content.Shared.Actions;
+using Content.Shared.MouseRotator;
+using Content.Shared.Movement.Components;
 using Content.Shared.Popups;
 using Content.Shared.Targeting;
 using Robust.Shared.Network;
@@ -30,6 +32,8 @@ public abstract class SharedCombatModeSystem : EntitySystem
     private void OnShutdown(EntityUid uid, CombatModeComponent component, ComponentShutdown args)
     {
         _actionsSystem.RemoveAction(uid, component.CombatToggleActionEntity);
+
+        SetMouseRotatorComponents(uid, false);
     }
 
     private void OnActionPerform(EntityUid uid, CombatModeComponent component, ToggleCombatActionEvent args)
@@ -76,6 +80,12 @@ public abstract class SharedCombatModeSystem : EntitySystem
 
         if (component.CombatToggleActionEntity != null)
             _actionsSystem.SetToggled(component.CombatToggleActionEntity, component.IsInCombatMode);
+
+        // Change mouse rotator comps if flag is set
+        if (!component.ToggleMouseRotator)
+            return;
+
+        SetMouseRotatorComponents(entity, value);
     }
 
     public virtual void SetActiveZone(EntityUid entity, TargetingZone zone,
@@ -85,6 +95,20 @@ public abstract class SharedCombatModeSystem : EntitySystem
             return;
 
         component.ActiveZone = zone;
+    }
+
+    private void SetMouseRotatorComponents(EntityUid uid, bool value)
+    {
+        if (value)
+        {
+            EnsureComp<MouseRotatorComponent>(uid);
+            EnsureComp<NoRotateOnMoveComponent>(uid);
+        }
+        else
+        {
+            RemComp<MouseRotatorComponent>(uid);
+            RemComp<NoRotateOnMoveComponent>(uid);
+        }
     }
 }
 

--- a/Content.Shared/MouseRotator/MouseRotatorComponent.cs
+++ b/Content.Shared/MouseRotator/MouseRotatorComponent.cs
@@ -14,22 +14,31 @@ public sealed partial class MouseRotatorComponent : Component
     /// <summary>
     ///     How much the desired angle needs to change before a predictive event is sent
     /// </summary>
-    [DataField]
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField]
     public Angle AngleTolerance = Angle.FromDegrees(20.0);
 
     /// <summary>
     ///     The angle that will be lerped to
     /// </summary>
-    [AutoNetworkedField, DataField]
+    [DataField, AutoNetworkedField]
     public Angle? GoalRotation;
 
     /// <summary>
     ///     Max degrees the entity can rotate per second
     /// </summary>
-    [DataField]
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField]
     public double RotationSpeed = float.MaxValue;
+
+    /// <summary>
+    ///     This one is important. If this is true, <see cref="AngleTolerance"/> does not apply, and the system will
+    ///     use <see cref="RequestMouseRotatorRotationSimpleEvent"/> instead. In this mode, the client will only send
+    ///     events when an entity should snap to a different cardinal direction, rather than for every angle change.
+    ///
+    ///     This is useful for cases like humans, where what really matters is the visual sprite direction, as opposed to something
+    ///     like turrets or ship guns, which have finer range of movement.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Simple4DirMode = true;
 }
 
 /// <summary>
@@ -40,4 +49,14 @@ public sealed partial class MouseRotatorComponent : Component
 public sealed class RequestMouseRotatorRotationEvent : EntityEventArgs
 {
     public Angle Rotation;
+}
+
+/// <summary>
+///     Simpler version of <see cref="RequestMouseRotatorRotationEvent"/> for implementations
+///     that only require snapping to 4-dir and not full angle rotation.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class RequestMouseRotatorRotationSimpleEvent : EntityEventArgs
+{
+    public Direction Direction;
 }

--- a/Content.Shared/MouseRotator/MouseRotatorComponent.cs
+++ b/Content.Shared/MouseRotator/MouseRotatorComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class MouseRotatorComponent : Component
     /// </summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
-    public Angle AngleTolerance = Angle.FromDegrees(5.0);
+    public Angle AngleTolerance = Angle.FromDegrees(20.0);
 
     /// <summary>
     ///     The angle that will be lerped to

--- a/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
+++ b/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
@@ -69,7 +69,6 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
             return;
         }
 
-        Log.Info("requested " + ev.Direction);
         rotator.GoalRotation = ev.Direction.ToAngle();
         Dirty(ent, rotator);
     }

--- a/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
+++ b/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
@@ -16,6 +16,7 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
         base.Initialize();
 
         SubscribeAllEvent<RequestMouseRotatorRotationEvent>(OnRequestRotation);
+        SubscribeAllEvent<RequestMouseRotatorRotationSimpleEvent>(OnRequestSimpleRotation);
     }
 
     public override void Update(float frameTime)
@@ -48,13 +49,28 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
 
     private void OnRequestRotation(RequestMouseRotatorRotationEvent msg, EntitySessionEventArgs args)
     {
-        if (args.SenderSession.AttachedEntity is not { } ent || !TryComp<MouseRotatorComponent>(ent, out var rotator))
+        if (args.SenderSession.AttachedEntity is not { } ent
+            || !TryComp<MouseRotatorComponent>(ent, out var rotator) || rotator.Simple4DirMode)
         {
-            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting local rotation without a mouse rotator component attached!");
+            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting local rotation directly without a valid mouse rotator component attached!");
             return;
         }
 
         rotator.GoalRotation = msg.Rotation;
+        Dirty(ent, rotator);
+    }
+
+    private void OnRequestSimpleRotation(RequestMouseRotatorRotationSimpleEvent ev, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } ent
+            || !TryComp<MouseRotatorComponent>(ent, out var rotator) || !rotator.Simple4DirMode)
+        {
+            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting 4-dir rotation directly without a valid mouse rotator component attached!");
+            return;
+        }
+
+        Log.Info("requested " + ev.Direction);
+        rotator.GoalRotation = ev.Direction.ToAngle();
         Dirty(ent, rotator);
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -113,6 +113,7 @@
     - type: MouseRotator
       angleTolerance: 5
       rotationSpeed: 180
+      simple4DirMode: false
     - type: NoRotateOnInteract
     - type: NoRotateOnMove
     - type: Input

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -66,6 +66,7 @@
       interactSuccessSound:
         path: /Audio/Effects/double_beep.ogg
     - type: CombatMode
+      toggleMouseRotator: false
     - type: Damageable
       damageContainer: Inorganic
     - type: Destructible
@@ -110,6 +111,7 @@
         SoundTargetInLOS: !type:SoundPathSpecifier
           path: /Audio/Effects/double_beep.ogg
     - type: MouseRotator
+      angleTolerance: 5
       rotationSpeed: 180
     - type: NoRotateOnInteract
     - type: NoRotateOnMove


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

combat mode now will rotate your character to follow your cursor. does not apply in any other situation other than being directly in combat mode

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

- makes fights more readable as now people are facing towards who they're trying to attack
- no jank visuals like being able to shoot behind you and then immediately turning around because you're walking
- just more representative of what would actually be happening as it allows for strafing, running backwards, etc
- there are basically zero situations where you would need to be in combat mode and your OOC mouse position doesn't map directly to where your character is implied to be looking IC (there -are- situations like this in non-combat mode, like organizing inventory, looking at right click menu, UIs in general)
- good for RP. people can just enter combat mode to get this form of movement whenever they want for any situation

potential things we will have to think about @metalgearsloth :
- combat mode action may need a small delay so people cant easily spam archetype changes
- ~~angle tolerance may need to be upped even more. i changed it from 5 to 20 so events only get sent to the server at increments of 20 deg change by default but it may need to go up closer to 45 deg~~ not relevant with simple 4dir mode
- ~~maybe send a float instead of an angle to reduce bandwidth (and just convert back to an angle when handling) since precision isnt necessary? iirc this is what source games do but even more quantized (facing angle x/y is only 8 bits or something https://youtu.be/mlhw6RqvOgs?si=AnXA7a5E6nRh7F2J&t=100)~~ not relevant with simple 4dir mode (sort of, we maybe should still do this)
- use input handlers or whatever instead of raising a predictive event? idk it just feels like this should be handled by input code ~~or also make it a netmessage directly instead of a networked event which i assume is slower due to being a wrapper over netmessage~~

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

just a bool on combat mode comp. made it a separate comp at first but i want it to be opt-out behavior not opt-in

added simple 4 dir mode to mouse rotator
- sends a `Direction` (sbyte) instead of a full `Angle` (double)
- only sends event on cardinal direction change instead of the full breadth of angles
- old mode still exists, toggleable on mouse rotator comp
- combat mode mouse rotator uses it

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/19853115/7f429e87-5359-47cf-89a6-c4c77f6e354b

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Your character will now rotate in the direction of your mouse cursor while in combat mode