### PR TITLE
Make `AmbientSoundComponent.Enabled` readonly

### DIFF
--- a/Content.Shared/Audio/AmbientSoundComponent.cs
+++ b/Content.Shared/Audio/AmbientSoundComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Audio;
 [Access(typeof(SharedAmbientSoundSystem))]
 public sealed partial class AmbientSoundComponent : Component, IComponentTreeEntry<AmbientSoundComponent>
 {
-    [DataField("enabled")]
+    [DataField("enabled", readOnly: true)]
     [ViewVariables(VVAccess.ReadWrite)] // only for map editing
     public bool Enabled { get; set; } = true;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

i am not of the opinion this should ever be getting saved to maps separate from prototype because it gets fucked up constantly by power changes and **this should just be getting set on mapinit with power events anyway for most things!!!!** so it doesnt even matter

resaving bagel with this saves literally 100kb
