### PR TITLE
water reaction but it's an explosion

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -108,6 +108,28 @@
       maxTotalIntensity: 30
 
 - type: reaction
+  id: HydrogenExplosion
+  impact: High
+  priority: 20
+  minTemp: 300 # Room temperature is 293
+  reactants:
+    Hydrogen:
+      amount: 2
+    Oxygen:
+      amount: 1
+  effects:
+    - !type:CreateGas
+      gas: 5 # The ID of Water Vapor
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 8
+      intensityPerUnit: 1
+      intensitySlope: .5
+      maxTotalIntensity: 30
+  products:
+    Water: 0.1
+
+- type: reaction
   id: Smoke
   priority: 10
   impact: High

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -111,7 +111,7 @@
   id: HydrogenExplosion
   impact: High
   priority: 20
-  minTemp: 300 # Room temperature is 293
+  minTemp: 370 # IRL the min temp for this reaction is ~700K but we're keeping it player-friendly here
   reactants:
     Hydrogen:
       amount: 2

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -126,8 +126,6 @@
       intensityPerUnit: 1
       intensitySlope: .5
       maxTotalIntensity: 30
-  products:
-    Water: 0.1
 
 - type: reaction
   id: Smoke

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -122,10 +122,10 @@
       gas: 5 # The ID of Water Vapor
     - !type:ExplosionReactionEffect
       explosionType: Default
-      maxIntensity: 8
-      intensityPerUnit: 1
+      maxIntensity: 4
+      intensityPerUnit: 0.25
       intensitySlope: .5
-      maxTotalIntensity: 30
+      maxTotalIntensity: 20
 
 - type: reaction
   id: Smoke


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

(this description updated for the most recent commit)

## About the PR
<!-- What did you change in this PR? -->

For eons young chemists have realized, when looking at a recipe requiring water, that they have no water. These chemists think "Oh, h2o, I'll just mix hydrogen and oxygen!". They then mix the two elements and face disappointment when absolutely nothing happens. This changes now. Because that infinite water in the form of reactions has been vetoed (see #15451 and #18267), this PR has hydrogen and oxygen make water _vapor_ instead, plus a bunch of energy.

You see, it turns out mixing hydrogen, oxygen, and a bit of heat perfectly completes the Fire Triangle. This fire is so vigorous that many people call it an "explosion". Indeed, this PR makes it so mixing oxygen, hydrogen, and a massive dump of heat creates an explosion similar yet weaker to the potassium explosion, plus one mol of water vapor gas for every unit of reagent that reacted.

Now, chemists shall stop saying "Huh, nothing happened," and start saying "Oh, the humanity!" as they receive a crippling 22.5 damage.

At some point in this game's development someone's probably going to enable water vapor condensation, and when that happens the balance here might change. But that's a problem for the future.

Currently the reaction requires heat so as to not get in the way of existing hydrogen/oxygen reactions. On the other hand, if heat wasn't required it would make hydrogen/oxygen reactions more !!fun!!, and it would make more water-wanting chemists explode which is always nice. Currently the heat requirement is kept so as to reduce the impact of this PR, but if changing that sounds like a good idea tell me.

Many people are opposed to no heat requirement and in fact want the opposite. IRL the combustion temperature is like 700K but nobody wants to sit still for 5 minutes waiting for their water to heat up, so 370 is what will be used.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

- It's weird to try and make the single most well-known compound and have absolutely nothing happen
- More explosions
- It's funny to watch chemists explode (i don't actually believe this, I'm just saying it to appease Emisse. merge pls)
- It's water vapor and not actual water so game design is preserved

Precise numbers:

- Reaction is 2 parts hydrogen and 1 part oxygen (since 1 unit seems to be volume-based this is actually inaccurate but whatever) plus heating to 360 K (reagents are dispensed at 293 K)
- Creates an explosion similar to potassium explosion but worse
- Also creates 1 mol of water vapor per unit in the reaction
- There are explosion numbers in there, and they are way smaller than potassium explosion

Many people say "but wait, that's an explosion and it's in chemistry, what will happen when bad players get their hands on this??" but fear not, this reaction is far weaker than even that of potassium. 90u of reactants deals like 22.5 damage to people at the epicenter. This explosion is so weak that literally the only people using this purposefully will be rulebreakers using it at bar patrons, since no antagonist with half a powergamer neuron in their brain will ever use such a weak explosion. Plus it takes like 45 seconds to heat to the ignition point.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

I do not actually understand explosion code so I've just set the explosion values to random offsets of the potassium explosion reaction.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

(this footage is from the most recent commit, if you want footage from before that then ask me, and if you want footage from after that then just try and use your imagination)

https://github.com/space-wizards/space-station-14/assets/113810873/54428dab-7b13-41cb-a6b7-45a5342f564d



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- add: Mixing hydrogen, oxygen, and heat will now create gaseous water plus a large surplus of energy!