### PR TITLE
Added ore boxes to cargo.

### DIFF
--- a/.run/Content Server+Client.run.xml
+++ b/.run/Content Server+Client.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Content Server+Client" type="CompoundRunConfigurationType">
+    <toRun name="Content.Client" type="DotNetProject" />
+    <toRun name="Content.Server" type="DotNetProject" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Content Server+Client.run.xml
+++ b/.run/Content Server+Client.run.xml
@@ -1,7 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Content Server+Client" type="CompoundRunConfigurationType">
-    <toRun name="Content.Client" type="DotNetProject" />
-    <toRun name="Content.Server" type="DotNetProject" />
-    <method v="2" />
-  </configuration>
-</component>

--- a/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
@@ -9,6 +9,16 @@
   group: market
 
 - type: cargoProduct
+  id: CargoOreBox
+  icon:
+    sprite:  /Textures/Structures/Storage/orebox.rsi
+    state: orebox
+  product: OreBox
+  cost: 500
+  category: Cargo
+  group: market
+
+- type: cargoProduct
   id: CargoLuxuryHardsuit
   icon:
     sprite: Clothing/Head/Hardsuits/luxury.rsi

--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -4,6 +4,8 @@
   description: A large storage container for holding unprocessed ores.
   parent: BaseStructureDynamic
   components:
+  - type: StaticPrice
+    price: 500
   - type: Anchorable
   - type: InteractionOutline
   - type: Damageable


### PR DESCRIPTION
## About the PR
Fixes #20251.

Adds orderable empty ore boxes to cargo.

**Changelog**
:cl:
- add: Empty ore boxes are now orderable from cargo.
