### PR TITLE
Shutdown AME when the fuel is empty

### DIFF
--- a/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
+++ b/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
@@ -155,7 +155,7 @@ public sealed class AmeControllerSystem : EntitySystem
             return;
 
         controller.Injecting = value;
-        _appearanceSystem.SetData(uid, AmeControllerVisuals.DisplayState, value ? AmeControllerState.On : AmeControllerState.Off);
+        UpdateDisplay(uid, controller.Stability, controller);
         if (!value && TryComp<PowerSupplierComponent>(uid, out var powerOut))
             powerOut.MaxSupply = 0;
 
@@ -215,15 +215,20 @@ public sealed class AmeControllerSystem : EntitySystem
         if (!Resolve(uid, ref controller, ref appearance))
             return;
 
+        var ameControllerState = stability switch
+        {
+            < 10 => AmeControllerState.Fuck,
+            < 50 => AmeControllerState.Critical,
+            _ => AmeControllerState.On,
+        };
+
+        if (!controller.Injecting)
+            ameControllerState = AmeControllerState.Off;
+
         _appearanceSystem.SetData(
             uid,
             AmeControllerVisuals.DisplayState,
-            stability switch
-            {
-                < 10 => AmeControllerState.Fuck,
-                < 50 => AmeControllerState.Critical,
-                _ => AmeControllerState.On,
-            },
+            ameControllerState,
             appearance
         );
     }

--- a/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
+++ b/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
@@ -80,7 +80,9 @@ public sealed class AmeControllerSystem : EntitySystem
                 if (TryComp<PowerSupplierComponent>(uid, out var powerOutlet))
                     powerOutlet.MaxSupply = powerOutput;
                 fuelJar.FuelAmount -= availableInject;
-                _audioSystem.PlayPvs(controller.InjectSound, uid, AudioParams.Default.WithVolume(overloading ? 10f : 0f));
+                // only play audio if we actually had an injection
+                if (availableInject > 0)
+                    _audioSystem.PlayPvs(controller.InjectSound, uid, AudioParams.Default.WithVolume(overloading ? 10f : 0f));
                 UpdateUi(uid, controller);
             }
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The AME now automatically shuts down whe the inserted juel jar is empty. This works exactly like turning the AME off manually - the cores get dark, the Controller display turns off, and it stops making noises.

The AME no longer makes noises when the Injection level is set to 0.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Solves #20113 

That the AME did not change optically or visually when running out of fuel was a confusing state that is now solved. That it does not make sounds at 0 injections regardless of fuel level further makes the AME show more clearly how it is currently operationg in an immersive manner.

Balance-wise: The absence of sound and the visual indicators make it more easy for Engineering to see when the AME has run out of fuel.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The auto-shutdown and no noise at 0 injection are solved by simply checking if the required conditions (fuelJar empty, no fuel injected) are fulfilled.

To make that work cleanly the "UpdateDisplay" function was improved to handle all 4 possible display states, adding the "Off" state that was previously handled directly during setting the Injection state.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![AME_autoshutdown](https://github.com/space-wizards/space-station-14/assets/61566539/540e9fcb-616c-4528-992d-7768dfe29ccd)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: The AME now shuts down when the inserted fuel jar is empty
- tweak: The AME no longer makes sounds if no fuel was injected

