### PR TITLE
Fix body system & gibbing. (people shouldn't have two hearts, that is one too many)

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -1,12 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Body.Components;
 using Content.Server.GameTicking;
 using Content.Server.Humanoid;
 using Content.Server.Kitchen.Components;
-using Content.Server.Mind;
 using Content.Shared.Body.Components;
-using Content.Shared.Body.Organ;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Systems;
 using Content.Shared.Humanoid;
@@ -16,11 +13,8 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Random.Helpers;
 using Robust.Shared.Audio;
-using Robust.Shared.Containers;
-using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Body.Systems;
 
@@ -136,22 +130,16 @@ public sealed class BodySystem : SharedBodySystem
 
         _audio.Play(body.GibSound, filter, coordinates, true, audio);
 
-        var containers = GetBodyContainers(bodyId, body: body).ToList();
-
-        foreach (var container in containers)
+        foreach (var entity in gibs)
         {
-            foreach (var entity in container.ContainedEntities)
+            if (deleteItems)
             {
-                if (deleteItems)
-                {
-                    QueueDel(entity);
-                }
-                else
-                {
-                    container.Remove(entity, EntityManager, force: true);
-                    SharedTransform.SetCoordinates(entity,coordinates);
-                    entity.RandomOffset(0.25f);
-                }
+                QueueDel(entity);
+            }
+            else
+            {
+                SharedTransform.SetCoordinates(entity, coordinates);
+                entity.RandomOffset(0.25f);
             }
         }
         RaiseLocalEvent(bodyId, new BeingGibbedEvent(gibs));

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Numerics;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Organ;
@@ -134,7 +134,6 @@ public partial class SharedBodySystem
         Dirty(rootPartEntity, rootPart);
 
         // Setup the rest of the body entities.
-        SetupOrgans(rootPartEntity, rootPart, protoRoot.Organs);
         MapInitParts(rootPartEntity, prototype);
     }
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Damage;
+using Content.Shared.Damage;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Standing;
 using Robust.Shared.Containers;
@@ -50,7 +50,7 @@ public abstract partial class SharedBodySystem : EntitySystem
         // This is blursed
         var slotIndex = containerSlotId.IndexOf(PartSlotContainerIdPrefix, StringComparison.Ordinal);
 
-        if (slotIndex < -1)
+        if (slotIndex < 0)
             return null;
 
         var slotId = containerSlotId.Remove(slotIndex, PartSlotContainerIdPrefix.Length);


### PR DESCRIPTION
## About the PR
This makes it so that bodies no longer have two sets of torsos and that gibbed bodies get spread around on the floor again.

## Why / Balance
Pretty sure the body system refactor broke both of these.

## Technical details
The loop that adds body parts now explicitly checks if a part is the root and if so it does not add it again.
The gibs weren't getting positioned randomly anymore because the super function of the GibBody() function in BodySystem.cs already removes all parts from the body, meaning that GibBody got 0 containers when it looked for them.
It now just spreads the list of gibs it gets from its super function.

## Media
It just makes things behave like they used to when gibbing a body, I tested it in-game.
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
:cl:
- fix: People and animals no longer have two hearts, livers, sets of lungs or kidneys. You probably didn't need the extra pair anyways.
