### PR TITLE
use weighted random for ninja threats

### DIFF
--- a/Content.Server/Communications/CommsHackerSystem.cs
+++ b/Content.Server/Communications/CommsHackerSystem.cs
@@ -4,6 +4,9 @@ using Content.Server.Ninja.Systems;
 using Content.Shared.Communications;
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
+using Content.Shared.Random;
+using Content.Shared.Random.Helpers;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 
@@ -13,6 +16,7 @@ public sealed class CommsHackerSystem : SharedCommsHackerSystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     // TODO: remove when generic check event is used
     [Dependency] private readonly NinjaGlovesSystem _gloves = default!;
@@ -55,11 +59,12 @@ public sealed class CommsHackerSystem : SharedCommsHackerSystem
     /// </summary>
     private void OnDoAfter(EntityUid uid, CommsHackerComponent comp, TerrorDoAfterEvent args)
     {
-        if (args.Cancelled || args.Handled || comp.Threats.Count == 0 || args.Target == null)
+        if (args.Cancelled || args.Handled || args.Target == null)
             return;
 
-        var threat = _random.Pick(comp.Threats);
-        CallInThreat(threat);
+        var threats = _proto.Index<WeightedRandomPrototype>(comp.Threats);
+        var threat = threats.Pick(_random);
+        CallInThreat(_proto.Index<ThreatPrototype>(threat));
 
         // prevent calling in multiple threats
         RemComp<CommsHackerComponent>(uid);
@@ -71,7 +76,7 @@ public sealed class CommsHackerSystem : SharedCommsHackerSystem
     /// <summary>
     /// Makes announcement and adds game rule of the threat.
     /// </summary>
-    public void CallInThreat(Threat threat)
+    public void CallInThreat(ThreatPrototype threat)
     {
         _gameTicker.StartGameRule(threat.Rule, out _);
         _chat.DispatchGlobalAnnouncement(Loc.GetString(threat.Announcement), playSound: true, colorOverride: Color.Red);

--- a/Content.Server/GameTicking/Rules/Components/NinjaRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NinjaRuleComponent.cs
@@ -1,6 +1,8 @@
 using Content.Server.Ninja.Systems;
 using Content.Shared.Communications;
+using Content.Shared.Random;
 using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.GameTicking.Rules.Components;
 
@@ -15,7 +17,7 @@ public sealed partial class NinjaRuleComponent : Component
     /// List of threats that can be called in. Copied onto <see cref="CommsHackerComponent"/> when gloves are enabled.
     /// </summary>
     [DataField(required: true)]
-    public List<Threat> Threats = new();
+    public ProtoId<WeightedRandomPrototype> Threats = string.Empty;
 
     /// <summary>
     /// Sound played when making the player a ninja via antag control or ghost role

--- a/Content.Shared/Communications/CommsHackerComponent.cs
+++ b/Content.Shared/Communications/CommsHackerComponent.cs
@@ -1,7 +1,6 @@
+using Content.Shared.Random;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Communications;
 
@@ -15,14 +14,14 @@ public sealed partial class CommsHackerComponent : Component
     /// <summary>
     /// Time taken to hack the console
     /// </summary>
-    [DataField("delay")]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan Delay = TimeSpan.FromSeconds(20);
 
     /// <summary>
-    /// Possible threats to choose from.
+    /// Weighted random for the possible threats to choose from.
     /// </summary>
-    [DataField("threats", required: true)]
-    public List<Threat> Threats = new();
+    [DataField(required: true)]
+    public ProtoId<WeightedRandomPrototype> Threats = string.Empty;
 }
 
 /// <summary>
@@ -30,18 +29,21 @@ public sealed partial class CommsHackerComponent : Component
 /// Generally some kind of mid-round minor antag, though you could make it call in scrubber backflow if you wanted to.
 /// You wouldn't do that, right?
 /// </summary>
-[DataDefinition]
-public sealed partial class Threat
+[Prototype("threat")]
+public sealed class ThreatPrototype : IPrototype
 {
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
     /// <summary>
     /// Locale id for the announcement to be made from CentCom.
     /// </summary>
-    [DataField("announcement")]
+    [DataField]
     public string Announcement = default!;
 
     /// <summary>
     /// The game rule for the threat to be added, it should be able to work when added mid-round otherwise this will do nothing.
     /// </summary>
-    [DataField("rule", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string Rule = default!;
+    [DataField]
+    public EntProtoId Rule = default!;
 }

--- a/Content.Shared/Communications/SharedCommsHackerSystem.cs
+++ b/Content.Shared/Communications/SharedCommsHackerSystem.cs
@@ -10,9 +10,9 @@ namespace Content.Shared.Communications;
 public abstract class SharedCommsHackerSystem : EntitySystem
 {
     /// <summary>
-    /// Set the list of threats to choose from when hacking a comms console.
+    /// Set the threats prototype to choose from when hacking a comms console.
     /// </summary>
-    public void SetThreats(EntityUid uid, List<Threat> threats, CommsHackerComponent? comp = null)
+    public void SetThreats(EntityUid uid, string threats, CommsHackerComponent? comp = null)
     {
         if (!Resolve(uid, ref comp))
             return;

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -14,8 +14,4 @@
     - TerrorObjective
     - NinjaSurviveObjective
   - type: NinjaRule
-    threats:
-    - announcement: terror-dragon
-      rule: Dragon
-    - announcement: terror-revenant
-      rule: RevenantSpawn
+    threats: NinjaThreats

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -1,0 +1,16 @@
+# threats called in by ninja hacking comms console
+- type: weightedRandom
+  id: NinjaThreats
+  weights:
+    Dragon: 1
+    Revenant: 1
+
+- type: threat
+  id: Dragon
+  announcement: terror-dragon
+  rule: Dragon
+
+- type: threat
+  id: Revenant
+  announcement: terror-revenant
+  rule: RevenantSpawn


### PR DESCRIPTION
## About the PR
so rarer threats can be supported

## Why / Balance
le ss13 balance make stronger thing rarer

## Technical details
replaced List<Threat> with ProtoId<WeightedRandomPrototype>
threat is ThreatPrototype defined in yml separately from the ninja rule

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
gonna guess nothing depends on it downstream :trollface:

**Changelog**
no cl no fun