### PR TITLE
mouse cant open doors

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -980,7 +980,6 @@
     - Trash
     - VimPilot
     - Mouse
-    - DoorBumpOpener
   - type: Respirator
     damage:
       types:


### PR DESCRIPTION
## About the PR
fixes #19973
mice no longer open doors or trigger the access lights

## Why / Balance
bug

## Technical details
no

## Media
![16:43:49](https://github.com/space-wizards/space-station-14/assets/39013340/3288f417-2672-4e0e-973a-e9e28b7a0ce8)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun