### PR TITLE
fire extinguisher go brrrrrr

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -67,7 +67,7 @@ namespace Content.Server.Chemistry.EntitySystems
                 _physics.SetLinearDamping(physics, 0f);
                 _physics.SetAngularDamping(physics, 0f);
 
-                _throwing.TryThrow(vapor.Owner, dir, speed, user: user, pushbackRatio: ThrowingSystem.PushbackDefault * 10f);
+                _throwing.TryThrow(vapor.Owner, dir, speed, user: user);
 
                 var distance = (target.Position - vaporXform.WorldPosition).Length();
                 var time = (distance / physics.LinearVelocity.Length());

--- a/Content.Server/Fluids/Components/SprayComponent.cs
+++ b/Content.Server/Fluids/Components/SprayComponent.cs
@@ -1,9 +1,7 @@
 using Content.Server.Fluids.EntitySystems;
 using Content.Shared.FixedPoint;
-using Content.Shared.Throwing;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Fluids.Components;
 
@@ -13,7 +11,7 @@ public sealed partial class SprayComponent : Component
 {
     public const string SolutionName = "spray";
 
-    [ViewVariables(VVAccess.ReadWrite), DataField,]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public FixedPoint2 TransferAmount = 10;
 
     [ViewVariables(VVAccess.ReadWrite), DataField]

--- a/Content.Server/Fluids/Components/SprayComponent.cs
+++ b/Content.Server/Fluids/Components/SprayComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.Fluids.EntitySystems;
 using Content.Shared.FixedPoint;
+using Content.Shared.Throwing;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -12,25 +13,31 @@ public sealed partial class SprayComponent : Component
 {
     public const string SolutionName = "spray";
 
-    [DataField("transferAmount")]
+    [ViewVariables(VVAccess.ReadWrite), DataField,]
     public FixedPoint2 TransferAmount = 10;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("sprayDistance")]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public float SprayDistance = 3.5f;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("sprayVelocity")]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public float SprayVelocity = 3.5f;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("sprayedPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string SprayedPrototype = "Vapor";
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public EntProtoId SprayedPrototype = "Vapor";
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("vaporAmount")]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public int VaporAmount = 1;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("vaporSpread")]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public float VaporSpread = 90f;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("spraySound", required: true)]
+    /// <summary>
+    /// How much the player is pushed back for each spray.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public float PushbackAmount = 2f;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField(required: true)]
     [Access(typeof(SpraySystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
     public SoundSpecifier SpraySound { get; private set; } = default!;
 }

--- a/Content.Server/Fluids/EntitySystems/SpraySystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpraySystem.cs
@@ -4,12 +4,14 @@ using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Cooldown;
 using Content.Server.Extinguisher;
 using Content.Server.Fluids.Components;
+using Content.Server.Gravity;
 using Content.Server.Popups;
 using Content.Shared.Cooldown;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Vapor;
 using Robust.Server.GameObjects;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -19,6 +21,8 @@ public sealed class SpraySystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly GravitySystem _gravity = default!;
+    [Dependency] private readonly PhysicsSystem _physics = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionContainer = default!;
@@ -104,7 +108,8 @@ public sealed class SpraySystem : EntitySystem
             if (distance > component.SprayDistance)
                 target = userMapPos.Offset(diffNorm * component.SprayDistance);
 
-            var newSolution = _solutionContainer.SplitSolution(uid, solution, component.TransferAmount);
+            var adjustedSolutionAmount = component.TransferAmount / component.VaporAmount;
+            var newSolution = _solutionContainer.SplitSolution(uid, solution, adjustedSolutionAmount);
 
             if (newSolution.Volume <= FixedPoint2.Zero)
                 break;
@@ -132,6 +137,12 @@ public sealed class SpraySystem : EntitySystem
             cooldownTime = MathF.Max(time, cooldownTime);
 
             _vapor.Start(vaporComponent, vaporXform, impulseDirection * diffLength, component.SprayVelocity, target, time, args.User);
+
+            if (TryComp<PhysicsComponent>(args.User, out var body))
+            {
+                if (_gravity.IsWeightless(args.User, body))
+                    _physics.ApplyLinearImpulse(args.User, -impulseDirection.Normalized() * component.PushbackAmount, body: body);
+            }
         }
 
         _audio.PlayPvs(component.SpraySound, uid, component.SpraySound.Params.WithVariation(0.125f));

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -27,6 +27,7 @@
   - type: ItemCooldown
   - type: Spray
     transferAmount: 10
+    pushbackAmount: 60
     spraySound:
       path: /Audio/Effects/extinguish.ogg
     sprayedPrototype: ExtinguisherSpray


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- buffs fire extinguishers to 10 bursts instead of 4
- makes fire extinguishers launch the player farther.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
fire extinguishers are fairly underpowered as mobility tools. This makes them a lot better as a tool for moving around.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/98561806/3393de52-d951-4a16-8a79-ddb6cab987b9


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Fire extinguishers now use less fluid per burst and launch the user farther in low-gravity.
