### PR TITLE
Syndicate Bomb Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ bld/
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
+# PERSONAL
+.run/
+.github/
+
 # NUNIT
 *.VisualState.xml
 TestResult.xml

--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,6 @@ bld/
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
-# PERSONAL
-.run/
-.github/
-
 # NUNIT
 *.VisualState.xml
 TestResult.xml

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -51,6 +51,7 @@
       openOnActivation: true
       guides:
         - Defusal
+    - type: CollideOnAnchor
 
 - type: entity
   parent: BaseHardBomb

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -33,6 +33,7 @@
       delay: 5
     - type: Physics
       bodyType: Static
+      canCollide: false
     - type: Transform
       noRot: true
     - type: Fixtures


### PR DESCRIPTION
## About the PR
Your able to walk over the syndicate bomb.
Fixes #20368

I don't know if it was intentional that it was a solid object you couldn't passthrough.
## Why / Balance
A fix to you getting thrown into a wall when spawning the syndicate bomb

**Changelog**
:cl:
- tweak: Syndicate bomb no longer has anomalous properties.
