### PR TITLE
Organ fixes

### DIFF
--- a/Content.Server/Body/Systems/BrainSystem.cs
+++ b/Content.Server/Body/Systems/BrainSystem.cs
@@ -19,23 +19,8 @@ namespace Content.Server.Body.Systems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<BrainComponent, AddedToBodyEvent>((uid, _, args) => HandleMind(args.Body, uid));
-            SubscribeLocalEvent<BrainComponent, AddedToPartEvent>((uid, _, args) => HandleMind(args.Part, uid));
             SubscribeLocalEvent<BrainComponent, AddedToPartInBodyEvent>((uid, _, args) => HandleMind(args.Body, uid));
-            SubscribeLocalEvent<BrainComponent, RemovedFromBodyEvent>(OnRemovedFromBody);
-            SubscribeLocalEvent<BrainComponent, RemovedFromPartEvent>((uid, _, args) => HandleMind(uid, args.Old));
             SubscribeLocalEvent<BrainComponent, RemovedFromPartInBodyEvent>((uid, _, args) => HandleMind(args.OldBody, uid));
-        }
-
-        private void OnRemovedFromBody(EntityUid uid, BrainComponent component, RemovedFromBodyEvent args)
-        {
-            // This one needs to be special, okay?
-            if (!EntityManager.TryGetComponent(uid, out OrganComponent? organ))
-            {
-                return;
-            }
-
-            HandleMind(uid, args.Old);
         }
 
         private void HandleMind(EntityUid newEntity, EntityUid oldEntity)

--- a/Content.Shared/Body/Events/MechanismBodyEvents.cs
+++ b/Content.Shared/Body/Events/MechanismBodyEvents.cs
@@ -4,19 +4,6 @@
     // ways.
 
     /// <summary>
-    ///     Raised on a mechanism when it is added to a body.
-    /// </summary>
-    public sealed class AddedToBodyEvent : EntityEventArgs
-    {
-        public EntityUid Body;
-
-        public AddedToBodyEvent(EntityUid body)
-        {
-            Body = body;
-        }
-    }
-
-    /// <summary>
     ///     Raised on a mechanism when it is added to a body part.
     /// </summary>
     public sealed class AddedToPartEvent : EntityEventArgs
@@ -45,28 +32,15 @@
     }
 
     /// <summary>
-    ///     Raised on a mechanism when it is removed from a body.
-    /// </summary>
-    public sealed class RemovedFromBodyEvent : EntityEventArgs
-    {
-        public EntityUid Old;
-
-        public RemovedFromBodyEvent(EntityUid old)
-        {
-            Old = old;
-        }
-    }
-
-    /// <summary>
     ///     Raised on a mechanism when it is removed from a body part.
     /// </summary>
     public sealed class RemovedFromPartEvent : EntityEventArgs
     {
-        public EntityUid Old;
+        public EntityUid OldPart;
 
-        public RemovedFromPartEvent(EntityUid old)
+        public RemovedFromPartEvent(EntityUid oldPart)
         {
-            Old = old;
+            OldPart = oldPart;
         }
     }
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -78,7 +78,7 @@ public partial class SharedBodySystem
 
         if (TryComp(entity, out OrganComponent? organ))
         {
-            RemoveOrgan(entity, uid, uid, organ);
+            RemoveOrgan(entity, uid, organ);
         }
     }
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
@@ -12,7 +12,7 @@ public partial class SharedBodySystem
     private void AddOrgan(EntityUid uid, EntityUid bodyUid, EntityUid parentPartUid, OrganComponent component)
     {
         component.Body = bodyUid;
-        RaiseLocalEvent(uid, new AddedToPartEvent(bodyUid));
+        RaiseLocalEvent(uid, new AddedToPartEvent(parentPartUid));
 
         if (component.Body != null)
             RaiseLocalEvent(uid, new AddedToPartInBodyEvent(component.Body.Value, parentPartUid));
@@ -20,12 +20,14 @@ public partial class SharedBodySystem
         Dirty(uid, component);
     }
 
-    private void RemoveOrgan(EntityUid uid, EntityUid bodyUid, EntityUid parentPartUid, OrganComponent component)
+    private void RemoveOrgan(EntityUid uid, EntityUid parentPartUid, OrganComponent component)
     {
-        RaiseLocalEvent(uid, new RemovedFromPartEvent(bodyUid));
+        RaiseLocalEvent(uid, new RemovedFromPartEvent(parentPartUid));
 
         if (component.Body != null)
+        {
             RaiseLocalEvent(uid, new RemovedFromPartInBodyEvent(component.Body.Value, parentPartUid));
+        }
 
         component.Body = null;
         Dirty(uid, component);

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared.Body.Components;
+using Content.Shared.Body.Events;
 using Content.Shared.Body.Organ;
 using Content.Shared.Body.Part;
 using Content.Shared.Damage;
@@ -85,6 +86,17 @@ public partial class SharedBodySystem
                     {
                         if (TryComp(organ, out OrganComponent? organComp))
                         {
+                            if (bodyUid != null)
+                            {
+                                var ev = new AddedToPartInBodyEvent(bodyUid.Value, children.Id);
+                                RaiseLocalEvent(organ, ev);
+                            }
+                            else if (organComp.Body != null)
+                            {
+                                var ev = new RemovedFromPartInBodyEvent(organComp.Body.Value, children.Id);
+                                RaiseLocalEvent(organ, ev);
+                            }
+
                             organComp.Body = bodyUid;
                             Dirty(organ, organComp);
                         }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -61,7 +61,7 @@ public partial class SharedBodySystem
 
         if (TryComp(entity, out OrganComponent? organ))
         {
-            RemoveOrgan(entity, organ);
+            RemoveOrgan(entity, uid, organ);
         }
     }
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -86,18 +86,20 @@ public partial class SharedBodySystem
                     {
                         if (TryComp(organ, out OrganComponent? organComp))
                         {
+                            var oldBody = organComp.Body;
+                            organComp.Body = bodyUid;
+
                             if (bodyUid != null)
                             {
                                 var ev = new AddedToPartInBodyEvent(bodyUid.Value, children.Id);
                                 RaiseLocalEvent(organ, ev);
                             }
-                            else if (organComp.Body != null)
+                            else if (oldBody != null)
                             {
-                                var ev = new RemovedFromPartInBodyEvent(organComp.Body.Value, children.Id);
+                                var ev = new RemovedFromPartInBodyEvent(oldBody.Value, children.Id);
                                 RaiseLocalEvent(organ, ev);
                             }
 
-                            organComp.Body = bodyUid;
                             Dirty(organ, organComp);
                         }
                     }


### PR DESCRIPTION
- Removed 2 events as they were somewhat unnecessary.
- RecursiveUpdate now also raises the body events as applicable.
- Updated RemoveOrgan to use the correct method (the overloads are completely different).
- Fix the event using body uid not part uid.

This should also fix one of the PVS resolve spams.