### PR TITLE
Armor weight tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -3,7 +3,7 @@
 
 #Basic armor vest
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterBaseMedium
   id: ClothingOuterArmorBasic
   name: armor vest
   description: A standard Type I armored vest that provides decent protection against most types of damage.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -123,3 +123,14 @@
       toggleable-clothing: !type:ContainerSlot {}
       storagebase: !type:Container
         ents: []
+
+- type: entity
+  abstract: true
+  parent: ClothingOuterBase
+  id: ClothingOuterBaseMedium
+  components:
+  - type: Item
+    size: 30
+  - type: Clothing
+    slots:
+    - outerClothing


### PR DESCRIPTION
Armor now takes up 30 places in a backpack.

## About the PR
Armor vests now take 30 places.

## Why / Balance
Why a piece of steel must be 5? 20 armor vests in backpacks looks stupid.

## Media
[Screenshot 2023-09-25 113545](https://github.com/space-wizards/space-station-14/assets/106442259/ec94bf67-0b3b-4c38-93b8-715d7292a0a2)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
