### PR TITLE
Prevent pull-moving

### DIFF
--- a/Content.Server/Physics/Controllers/PullController.cs
+++ b/Content.Server/Physics/Controllers/PullController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Gravity;
 using Content.Shared.Pulling;
 using Content.Shared.Pulling.Components;
@@ -37,6 +38,7 @@ namespace Content.Server.Physics.Controllers
         // How much you must move for the puller movement check to actually hit.
         private const float MinimumMovementDistance = 0.005f;
 
+        [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
         [Dependency] private readonly SharedPullingSystem _pullableSystem = default!;
         [Dependency] private readonly SharedGravitySystem _gravity = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
@@ -191,9 +193,10 @@ namespace Content.Server.Physics.Controllers
                 var impulse = accel * physics.Mass * frameTime;
                 PhysicsSystem.ApplyLinearImpulse(pullableEnt, impulse, body: physics);
 
-                // if the puller is weightless, then we apply the inverse impulse.
+                // if the puller is weightless or can't move, then we apply the inverse impulse (Newton's third law).
                 // doing it under gravity produces an unsatisfying wiggling when pulling.
-                if (_gravity.IsWeightless(puller) && pullerXform.GridUid == null)
+                // If player can't move, assume they are on a chair and we need to prevent pull-moving.
+                if ((_gravity.IsWeightless(puller) && pullerXform.GridUid == null) || !_actionBlockerSystem.CanMove(puller))
                 {
                     PhysicsSystem.WakeBody(puller);
                     PhysicsSystem.ApplyLinearImpulse(puller, -impulse);


### PR DESCRIPTION
## About the PR
Some clever players have been seen "pull-moving", as shown below:

https://github.com/space-wizards/space-station-14/assets/3229565/721a2ce5-0509-4205-a89c-9326992fddd2

This PR stops this.

## Why / Balance
This is a clever little bit of cheese, but a clear violation of [Newton's third law](https://en.wikipedia.org/wiki/Newton's_third_law).

## Technical details
Apply an equal and opposite impulse if the player cannot move (for example, if they are buckled to a chair).

## Media
After this PR:

https://github.com/space-wizards/space-station-14/assets/3229565/414aa242-a235-407a-b8ca-88ef82eb0692

Note that after getting off the chair, you can still pull like normal because you can move (and counteract the equal and opposite force by moving).

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
