### PR TITLE
change min temp delta to 0.1

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -123,7 +123,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     Minimum temperature difference before the gas temperatures are just set to be equal.
         /// </summary>
-        public const float MinimumTemperatureDeltaToConsider = 0.5f;
+        public const float MinimumTemperatureDeltaToConsider = 0.1f;
 
         /// <summary>
         ///     Minimum temperature for starting superconduction.


### PR DESCRIPTION
## About the PR
lets heaters work on extreme temperature difference or heat capacity gases.

## Why / Balance
fix heater not working sometimes

## Technical details
basically why it didnt work:
- heater tells atmos system to heat it by 83kJ
- atmos system calculates ~1 degree difference, increases mixture temperature
- when the heater and connector port equalize the difference becomes less than 0.5 degrees and it gets ignored
- heating stops

this decreases it to 0.1 which makes heater always work but it might have performance concerns or something idk

## Media
plasma and liquid oxygen get heated real
![08:09:53](https://github.com/space-wizards/space-station-14/assets/39013340/bd8af0ed-3209-4670-9b70-643e3d22076b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no cl no fun