### PR TITLE
Show role playtimes in lobby

### DIFF
--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -103,6 +103,17 @@ public sealed class JobRequirementsManager
         return CheckRoleTime(job.Requirements, out reason);
     }
 
+    /// <summary>
+    /// Returns the playtime for a particular role.
+    /// </summary>
+    public TimeSpan GetRoleTime(string role)
+    {
+        if (_roles.TryGetValue(role, out var time))
+            return time;
+
+        return TimeSpan.Zero;
+    }
+
     public bool CheckRoleTime(HashSet<JobRequirement>? requirements, [NotNullWhen(false)] out FormattedMessage? reason)
     {
         reason = null;

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml
@@ -119,7 +119,7 @@
                 <BoxContainer Orientation="Vertical">
                     <!-- Jobs -->
                     <OptionButton Name="CPreferenceUnavailableButton" />
-                    <ScrollContainer VerticalExpand="True">
+                    <ScrollContainer Name="CJobScrollList" VerticalExpand="True">
                         <BoxContainer Name="CJobList" Orientation="Vertical" />
                     </ScrollContainer>
                 </BoxContainer>

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -1155,7 +1155,8 @@ namespace Content.Client.Preferences.UI
                 {
                     FirstButtonStyle = StyleBase.ButtonOpenRight,
                     ButtonStyle = StyleBase.ButtonOpenBoth,
-                    LastButtonStyle = StyleBase.ButtonOpenLeft
+                    LastButtonStyle = StyleBase.ButtonOpenLeft,
+                    SetSize = new Vector2(360, 30),
                 };
                 //Override default radio option button width
                 Options.GenerateItem = GenerateButton;
@@ -1175,6 +1176,7 @@ namespace Content.Client.Preferences.UI
                     Visible = false,
                     HorizontalExpand = true,
                     MouseFilter = MouseFilterMode.Stop,
+                    SetSize = new Vector2(360, 30),
                     Children =
                     {
                         _requirementsLabel
@@ -1211,18 +1213,17 @@ namespace Content.Client.Preferences.UI
                 if (icon != null)
                     container.AddChild(icon);
                 container.AddChild(titleLabel);
-                container.AddChild(Options);
-                container.AddChild(_lockStripe);
                 container.AddChild(new Control()
                 {
                     HorizontalExpand = true,
                 });
                 container.AddChild(new Label()
                 {
-                    Text = playTime.ToString("hh':'mm"),
+                    Text = playTime.ToString("dd':'hh':'mm"),
                     HorizontalAlignment = HAlignment.Right
                 });
-
+                container.AddChild(Options);
+                container.AddChild(_lockStripe);
                 AddChild(container);
             }
 


### PR DESCRIPTION
Doesn't look the greatest but this screen already needs some cleanup.
Needs https://github.com/space-wizards/RobustToolbox/pull/4449 to not shift on first scroll.

![image](https://github.com/space-wizards/space-station-14/assets/31366439/6d7e47a9-9f7b-43c5-aa4c-e5f52af8aa98)

:cl:
- add: Added role playtimes on the lobby screen so you can stop asking admins.
