### PR TITLE
Add EyesGlasses into ClothesMate

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -58,6 +58,7 @@
     ClothingHeadFishCap: 2
     ClothingHeadRastaHat: 2
     ClothingBeltStorageWaistbag: 3
+    ClothingEyesGlasses: 6
   contrabandInventory:
     ClothingUniformJumpsuitTacticool: 1
     ClothingUniformJumpskirtTacticool: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added eye glass into ClothesMate

## Why / Balance
For _**style**_

But seriously, because glasses are very rare, and I dont want fight for them.

## Media
- [х] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/space-wizards/space-station-14/assets/68501903/c196211a-f894-4e43-b8c9-733012cca69b)

## Breaking changes

**Changelog**

:cl:
- add: Eyeglass are now available from the ClothesMate.
