### PR TITLE
Non-RnD-produced medium power cell availability nerf

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -56,7 +56,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMedium
+        startingItem: PowerCellSmall
   - type: Item
     heldPrefix: off
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -258,7 +258,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMedium
+        startingItem: PowerCellSmall
 
 - type: entity
   id: PlayerBorgBattery
@@ -273,4 +273,4 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMedium
+        startingItem: PowerCellSmall

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -17,7 +17,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMedium
+        startingItem: PowerCellSmall
   - type: Sprite
     sprite: Objects/Devices/Holoprojectors/custodial.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
@@ -62,7 +62,7 @@
     #  slots:
     #    cell_slot:
     #      name: power-cell-slot-component-slot-name-default
-    #      startingItem: PowerCellMedium
+    #      startingItem: PowerCellSmall
   
 - type: entity
   name: Hot Food Cart

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -46,7 +46,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMedium
+        startingItem: PowerCellSmall
   - type: Sprite
     sprite: Objects/Tools/flashlight.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   name: lantern
   parent: BaseItem
   id: Lantern
@@ -49,7 +49,7 @@
       slots:
         cell_slot:
           name: power-cell-slot-component-slot-name-default
-          startingItem: PowerCellMedium
+          startingItem: PowerCellSmall
     - type: ContainerContainer
       containers:
         cell_slot: !type:ContainerSlot {}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Battery-powered items that spawns with power cell are now spawned with small power cell instead of medium.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Medium powercells are science unlock items and shouldn't just be lying around in maints.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Battery-powered items are now spawned with small power cell instead of medium. Please contact your local RND department for larger power cells.