### PR TITLE
Fix Bingus' head being fuzzy

### DIFF
--- a/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
@@ -5,6 +5,7 @@
 petting-success-generic = You pet {THE($target)} on {POSS-ADJ($target)} head.
 petting-success-soft-floofy = You pet {THE($target)} on {POSS-ADJ($target)} soft floofy head.
 
+petting-success-bingus = You pet {THE($target)} on {POSS-ADJ($target)} wrinkly little head.
 petting-success-bird = You pet {THE($target)} on {POSS-ADJ($target)} cute feathery head.
 petting-success-cat = You pet {THE($target)} on {POSS-ADJ($target)} fuzzy little head.
 petting-success-corrupted-corgi = In an act of hubris, you pet {THE($target)} on {POSS-ADJ($target)} cursed little head.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -206,7 +206,7 @@
       amount: 2
   - type: InteractionPopup
     successChance: 0.9
-    interactSuccessString: petting-success-cat
+    interactSuccessString: petting-success-bingus
     interactFailureString: petting-failure-generic
     interactSuccessSound:
       path: /Audio/Animals/cat_meow.ogg


### PR DESCRIPTION
## About the PR
Bingus now has a wrinkly little head instead of a fuzzy one when he gets pet.

## Why / Balance
His head being fuzzy is blatant Bingus slander, his head does not have fuzz.

## Technical details
Just a new locale string.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**

:cl:
- fix: Bingus is no longer fuzzy.