### PR TITLE
Make bucket transfer 100u by default

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -26,7 +26,7 @@
       bucket:
         maxVol: 250
   - type: SolutionTransfer
-    transferAmount: 50
+    transferAmount: 100
     maxTransferAmount: 100
     minTransferAmount: 10
     canChangeTransferAmount: true


### PR DESCRIPTION
## About the PR
Makes it so that buckets transfer 100u instead of 50u by default.

## Why / Balance
As a janitor, I have to change this every. single. round. and it is getting annoying.

## Technical details
The number is now different.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No.
