### PR TITLE
Make NPC names proper nouns & fix some genders

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -97,6 +97,7 @@
       task: SimpleHostileCompound
   - type: Grammar
     attributes:
+      proper: true
       gender: female
   - type: Tag
     tags:
@@ -114,6 +115,7 @@
       - PetsNT
   - type: Grammar
     attributes:
+      proper: true
       gender: male
   - type: Tag
     tags:
@@ -153,6 +155,7 @@
   components:
   - type: Grammar
     attributes:
+      proper: true
       gender: male
   - type: Tag
     tags:
@@ -212,6 +215,7 @@
       path: /Audio/Animals/cat_meow.ogg
   - type: Grammar
     attributes:
+      proper: true
       gender: epicene
   - type: Tag
     tags:
@@ -431,6 +435,7 @@
       path: /Audio/Animals/pig_oink.ogg
   - type: Grammar
     attributes:
+      proper: true
       gender: male
   - type: Tag
     tags:
@@ -686,6 +691,9 @@
     makeSentient: true
     name: ghost-role-information-smile-name
     description: ghost-role-information-smile-description
+  - type: Grammar
+    attributes:
+      proper: true
 
 - type: entity
   name: Pun Pun
@@ -715,3 +723,7 @@
     - VimPilot
   - type: Loadout
     prototypes: [ MobMonkeyGear ]
+  - type: Grammar
+    attributes:
+      proper: true
+      gender: male

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -694,6 +694,7 @@
   - type: Grammar
     attributes:
       proper: true
+      gender: female
 
 - type: entity
   name: Pun Pun

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -163,7 +163,7 @@
     - VimPilot
 
 - type: entity
-  name: bingus
+  name: Bingus
   parent: SimpleMobBase
   id: MobBingus
   description: Bingus my beloved...
@@ -223,7 +223,7 @@
     - VimPilot
 
 - type: entity
-  name: mcgriff
+  name: McGriff
   parent: SimpleMobBase
   id: MobMcGriff
   description: This dog can tell something smells around here, and that something is CRIME!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -112,6 +112,9 @@
   - type: GuideHelp
     guides:
     - MinorAntagonists
+  - type: Grammar
+    attributes:
+      gender: male
 
 - type: entity
   id: MobRatKingBuff


### PR DESCRIPTION
## About the PR
For some pets, when petting them, the message said things like "You pet the bingus [...]" instead of "You pet Bingus [...]".
This PR sets pet names to be proper nouns, makes the Rat King and Pun Pun male and Smiles female.

## Why / Balance
Pun Pun is male on [the SS13 wiki here](https://tgstation13.org/wiki/Critters), the rat king is a king and Smile's gender was professionally determined:
![image](https://github.com/space-wizards/space-station-14/assets/60073468/3871650b-421d-4ced-b5db-2865f333caee)

## Technical details
Not much.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl:
- fix: You can now pet Runtime instead of petting >the< Runtime. Also, Smile is now a girl.
