### PR TITLE
Change .editorconfig to keep existing attribute arrangement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -196,7 +196,7 @@ csharp_preserve_single_line_blocks = true
 #dotnet_naming_style.begins_with_i.word_separator =
 #dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-dotnet_diagnostic.IDE0055.severity = warning
+dotnet_diagnostic.ide0055.severity = warning
 
 dotnet_naming_rule.constants_rule.severity = warning
 dotnet_naming_rule.constants_rule.style = upper_camel_case_style
@@ -336,6 +336,7 @@ dotnet_naming_symbols.type_parameters_symbols.applicable_kinds = type_parameter
 
 # ReSharper properties
 resharper_braces_for_ifelse = required_for_multiline
+resharper_keep_existing_attribute_arrangement = true
 
 [*.{csproj,xml,yml,dll.config,msbuildproj,targets}]
 indent_size = 2


### PR DESCRIPTION
## About the PR
Fixes the warning about missing line break for fields with DataField, VV and other attributes.
This was changed in https://github.com/space-wizards/space-station-14/commit/0542726907b1248e0e9a3448dad4021c171667d4 to affect single-line if statements but it also affected this.
This change makes it so you can have the field declaration in the same line as its attributes, or on a separate one, without a warning in either case. I'm not sure if there's a better setting for this.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase