### PR TITLE
Fix mispredict when closing a crematorium you are standing over

### DIFF
--- a/Content.Shared/Morgue/Components/EntityStorageLayingDownOverrideComponent.cs
+++ b/Content.Shared/Morgue/Components/EntityStorageLayingDownOverrideComponent.cs
@@ -1,7 +1,6 @@
-namespace Content.Server.Morgue.Components;
+namespace Content.Shared.Morgue.Components;
 
 [RegisterComponent]
 public sealed partial class EntityStorageLayingDownOverrideComponent : Component
 {
-
 }

--- a/Content.Shared/Morgue/EntityStorageLayingDownOverrideSystem.cs
+++ b/Content.Shared/Morgue/EntityStorageLayingDownOverrideSystem.cs
@@ -1,9 +1,9 @@
-using Content.Server.Morgue.Components;
 using Content.Shared.Body.Components;
+using Content.Shared.Morgue.Components;
 using Content.Shared.Standing;
 using Content.Shared.Storage.Components;
 
-namespace Content.Server.Morgue;
+namespace Content.Shared.Morgue;
 
 public sealed class EntityStorageLayingDownOverrideSystem : EntitySystem
 {


### PR DESCRIPTION
## About the PR
## Media
https://github.com/space-wizards/space-station-14/assets/10968691/26d71a2e-48ce-44f0-bf3a-a0fdb0f5ff94

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed getting moved briefly when closing a crematorium that you are standing over.