### PR TITLE
Revert "Use full file path for temp replays (#19002)"

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Replays.cs
+++ b/Content.Server/GameTicking/GameTicker.Replays.cs
@@ -43,7 +43,9 @@ public sealed partial class GameTicker
         {
             var baseReplayPath = new ResPath(_cfg.GetCVar(CVars.ReplayDirectory)).ToRootedPath();
             moveToPath = baseReplayPath / finalPath;
-            recordPath = new ResPath(tempDir) / finalPath;
+
+            var fileName = finalPath.Filename;
+            recordPath = new ResPath(tempDir) / fileName;
 
             _sawmillReplays.Debug($"Replay will record in temporary position: {recordPath}");
         }


### PR DESCRIPTION
This reverts commit 610a10fb85e03b88f6288f9328aaf9f00eacbae5.

This PR didn't actually fix the issue it wanted to, and just made a mess of the directory paths. We're lucky it didn't break anything.