### PR TITLE
Move view variables verb to the top of the list with no category and localize it

### DIFF
--- a/Content.Client/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Client/Administration/Systems/AdminVerbSystem.cs
@@ -24,10 +24,9 @@ namespace Content.Client.Administration.Systems
             // View variables verbs
             if (_clientConGroupController.CanViewVar())
             {
-                Verb verb = new()
+                var verb = new VvVerb()
                 {
-                    Category = VerbCategory.Debug,
-                    Text = "View Variables",
+                    Text = Loc.GetString("view-variables"),
                     Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/vv.svg.192dpi.png")),
                     Act = () => _clientConsoleHost.ExecuteCommand($"vv {GetNetEntity(args.Target)}"),
                     ClientExclusive = true // opening VV window is client-side. Don't ask server to run this verb.

--- a/Content.Shared/Verbs/Verb.cs
+++ b/Content.Shared/Verbs/Verb.cs
@@ -1,7 +1,7 @@
-using Robust.Shared.Serialization;
-using Robust.Shared.Utility;
 using Content.Shared.Database;
 using Content.Shared.Interaction.Events;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Verbs
 {
@@ -215,6 +215,7 @@ namespace Content.Shared.Verbs
         public static List<Type> VerbTypes = new()
         {
             typeof(Verb),
+            typeof(VvVerb),
             typeof(InteractionVerb),
             typeof(UtilityVerb),
             typeof(InnateVerb),
@@ -223,6 +224,16 @@ namespace Content.Shared.Verbs
             typeof(ExamineVerb),
             typeof(EquipmentVerb)
         };
+    }
+
+    /// <summary>
+    ///     View variables verbs.
+    /// </summary>
+    /// <remarks>Currently only used for the verb that opens the view variables panel.</remarks>
+    [Serializable, NetSerializable]
+    public sealed class VvVerb : Verb
+    {
+        public override int TypePriority => int.MaxValue;
     }
 
     /// <summary>


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/4454

## About the PR
Before you needed to right click, flail around trying to find the debug category while waiting for the server to come back from getting cigs, go into the debug category, and then click view variables.
Now you just click it and it doesn't move even after the server responds to the verbs request.

## Media
https://github.com/space-wizards/space-station-14/assets/10968691/faef5f9c-a1b2-4f8d-9ef8-1aa0de678f29

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
