### PR TITLE
Make arcades hackable again

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
@@ -124,6 +124,8 @@
       entity: !type:BoardNodeEntity { container: board }
       edges:
         - to: monitorUnsecured
+          conditions:
+            - !type:AllWiresCut {}
           steps:
             - tool: Screwing
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR allows people to open the maintenance panel on arcade machines and hack their wires.
I added the AllWiresCut condition to the initial computer disassembly node, so that you need to cut all the wires on the arcade first before disassembling it (in order to prevent the disassembly from overriding the maintenance panel action).
This shouldn't affect regular computers, and should allow for other computer-type machines to easily have hackable wires if we want it in the future.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Arcade machine maintenance panels/hacking have been in the game for a long time but inaccessible due to the computer construction graph overriding it.
Arcade machines don't dispense infinite prizes anymore so this doesn't create the possibility of an infinite money exploit as it once did.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Arcade machine maintenance panels can be opened again.
