### PR TITLE
Catch replay start and end errors on round restarts

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Replays.cs
+++ b/Content.Server/GameTicking/GameTicker.Replays.cs
@@ -23,38 +23,45 @@ public sealed partial class GameTicker
     /// </summary>
     private void ReplayStartRound()
     {
-        if (!_cfg.GetCVar(CCVars.ReplayAutoRecord))
-            return;
-
-        if (_replays.IsRecording)
+        try
         {
-            _sawmillReplays.Warning("Already an active replay recording before the start of the round, not starting automatic recording.");
-            return;
+            if (!_cfg.GetCVar(CCVars.ReplayAutoRecord))
+                return;
+
+            if (_replays.IsRecording)
+            {
+                _sawmillReplays.Warning("Already an active replay recording before the start of the round, not starting automatic recording.");
+                return;
+            }
+
+            _sawmillReplays.Debug($"Starting replay recording for round {RoundId}");
+
+            var finalPath = GetAutoReplayPath();
+            var recordPath = finalPath;
+            var tempDir = _cfg.GetCVar(CCVars.ReplayAutoRecordTempDir);
+            ResPath? moveToPath = null;
+
+            if (!string.IsNullOrEmpty(tempDir))
+            {
+                var baseReplayPath = new ResPath(_cfg.GetCVar(CVars.ReplayDirectory)).ToRootedPath();
+                moveToPath = baseReplayPath / finalPath;
+
+                var fileName = finalPath.Filename;
+                recordPath = new ResPath(tempDir) / fileName;
+
+                _sawmillReplays.Debug($"Replay will record in temporary position: {recordPath}");
+            }
+
+            var recordState = new ReplayRecordState(moveToPath);
+
+            if (!_replays.TryStartRecording(_resourceManager.UserData, recordPath.ToString(), state: recordState))
+            {
+                _sawmillReplays.Error("Can't start automatic replay recording!");
+            }
         }
-
-        _sawmillReplays.Debug($"Starting replay recording for round {RoundId}");
-
-        var finalPath = GetAutoReplayPath();
-        var recordPath = finalPath;
-        var tempDir = _cfg.GetCVar(CCVars.ReplayAutoRecordTempDir);
-        ResPath? moveToPath = null;
-
-        if (!string.IsNullOrEmpty(tempDir))
+        catch (Exception e)
         {
-            var baseReplayPath = new ResPath(_cfg.GetCVar(CVars.ReplayDirectory)).ToRootedPath();
-            moveToPath = baseReplayPath / finalPath;
-
-            var fileName = finalPath.Filename;
-            recordPath = new ResPath(tempDir) / fileName;
-
-            _sawmillReplays.Debug($"Replay will record in temporary position: {recordPath}");
-        }
-
-        var recordState = new ReplayRecordState(moveToPath);
-
-        if (!_replays.TryStartRecording(_resourceManager.UserData, recordPath.ToString(), state: recordState))
-        {
-            _sawmillReplays.Error("Can't start automatic replay recording!");
+            Log.Error($"Error while starting an automatic replay recording:\n{e}");
         }
     }
 
@@ -63,9 +70,16 @@ public sealed partial class GameTicker
     /// </summary>
     private void ReplayEndRound()
     {
-        if (_replays.ActiveRecordingState is ReplayRecordState)
+        try
         {
-            _replays.StopRecording();
+            if (_replays.ActiveRecordingState is ReplayRecordState)
+            {
+                _replays.StopRecording();
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Error while stopping replay recording:\n{e}");
         }
     }
 


### PR DESCRIPTION
## About the PR
Same as Discord round start notifications, even if they somehow error the round continues.
Should stop replay errors from stopping round flow.
ReplaysOnRecordingFinished errors are already handled by the two methods invoking them, though it could still error if StopRecording fails in ClientGameStateManager, or if StopRecording fails in OnRunLevelChanged, 
The two wrapped methods also reset the replay manager themselves if an error occurs, but GameTicker wasn't catching the rethrown exception.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
