### PR TITLE
Fix loading a map with a ThirstComponent crashing the game

### DIFF
--- a/Content.Shared/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Shared/Nutrition/Components/ThirstComponent.cs
@@ -35,7 +35,7 @@ public sealed partial class ThirstComponent : Component
     /// </summary>
     [DataField("nextUpdateTime", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
-    public TimeSpan NextUpdateTime = TimeSpan.MaxValue;
+    public TimeSpan NextUpdateTime;
 
     /// <summary>
     /// The time between each update.


### PR DESCRIPTION
## About the PR
This was done to fix tests at the time but doesn't seem to be necessary anymore.
On unpause, ThirstSystem would add onto this value causing an overflow.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase