### PR TITLE
Adjust hard bomb shape

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -41,7 +41,7 @@
         fix1:
           shape:
             !type:PhysShapeAabb
-            bounds: "-0.45,-0.45,0.45,0.45"
+            bounds: "-0.3,-0.3,0.3,0.3"
           density: 190
           mask:
             - MachineMask


### PR DESCRIPTION
## About the PR
Adjust the hard bomb fixture to make the collision shape match the sprite.

## Why / Balance
The hard bomb fixture was much larger than the sprite suggests, leading to minor collision weirdness.

**Before**
![image](https://github.com/space-wizards/space-station-14/assets/3229565/61d42489-212f-4455-bffc-9dd4d66ac5e9)

**After**
![image](https://github.com/space-wizards/space-station-14/assets/3229565/a048e5a1-8238-4cc4-9c06-3b4305e24ed2)

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
