### PR TITLE
Rename ThreatPrototype and mark fields as required

### DIFF
--- a/Content.Server/Communications/CommsHackerSystem.cs
+++ b/Content.Server/Communications/CommsHackerSystem.cs
@@ -64,7 +64,7 @@ public sealed class CommsHackerSystem : SharedCommsHackerSystem
 
         var threats = _proto.Index<WeightedRandomPrototype>(comp.Threats);
         var threat = threats.Pick(_random);
-        CallInThreat(_proto.Index<ThreatPrototype>(threat));
+        CallInThreat(_proto.Index<NinjaHackingThreatPrototype>(threat));
 
         // prevent calling in multiple threats
         RemComp<CommsHackerComponent>(uid);
@@ -76,10 +76,10 @@ public sealed class CommsHackerSystem : SharedCommsHackerSystem
     /// <summary>
     /// Makes announcement and adds game rule of the threat.
     /// </summary>
-    public void CallInThreat(ThreatPrototype threat)
+    public void CallInThreat(NinjaHackingThreatPrototype ninjaHackingThreat)
     {
-        _gameTicker.StartGameRule(threat.Rule, out _);
-        _chat.DispatchGlobalAnnouncement(Loc.GetString(threat.Announcement), playSound: true, colorOverride: Color.Red);
+        _gameTicker.StartGameRule(ninjaHackingThreat.Rule, out _);
+        _chat.DispatchGlobalAnnouncement(Loc.GetString(ninjaHackingThreat.Announcement), playSound: true, colorOverride: Color.Red);
     }
 }
 

--- a/Content.Shared/Communications/CommsHackerComponent.cs
+++ b/Content.Shared/Communications/CommsHackerComponent.cs
@@ -29,8 +29,8 @@ public sealed partial class CommsHackerComponent : Component
 /// Generally some kind of mid-round minor antag, though you could make it call in scrubber backflow if you wanted to.
 /// You wouldn't do that, right?
 /// </summary>
-[Prototype("threat")]
-public sealed class ThreatPrototype : IPrototype
+[Prototype("ninjaHackingThreat")]
+public sealed class NinjaHackingThreatPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;
@@ -38,12 +38,12 @@ public sealed class ThreatPrototype : IPrototype
     /// <summary>
     /// Locale id for the announcement to be made from CentCom.
     /// </summary>
-    [DataField]
-    public string Announcement = default!;
+    [DataField(required: true)]
+    public LocId Announcement;
 
     /// <summary>
     /// The game rule for the threat to be added, it should be able to work when added mid-round otherwise this will do nothing.
     /// </summary>
-    [DataField]
-    public EntProtoId Rule = default!;
+    [DataField(required: true)]
+    public EntProtoId Rule;
 }

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -5,12 +5,12 @@
     Dragon: 1
     Revenant: 1
 
-- type: threat
+- type: ninjaHackingThreat
   id: Dragon
   announcement: terror-dragon
   rule: Dragon
 
-- type: threat
+- type: ninjaHackingThreat
   id: Revenant
   announcement: terror-revenant
   rule: RevenantSpawn


### PR DESCRIPTION
Marks non-optional data-fields as required, which is the main reason this PR exists, though it also renames the prototype. The reason for renaming it is just because IMO "threat" is far too generic for a prototype tied to ninja comms console hacking and would probably eventually conflict with other prototypes (e.g. dynamic game mode).

This PR is required for an engine PR, but can be merged on its own. However in order to check that tests pass with the engine PR merged:
Requires: space-wizards/RobustToolbox/pull/4462