### PR TITLE
Add TestPair.WaitCommand()

### DIFF
--- a/Content.IntegrationTests/Pair/TestPair.Helpers.cs
+++ b/Content.IntegrationTests/Pair/TestPair.Helpers.cs
@@ -76,4 +76,22 @@ public sealed partial class TestPair
 
         return otherUid.Value;
     }
+
+    /// <summary>
+    /// Execute a command on the server and wait some number of ticks.
+    /// </summary>
+    public async Task WaitCommand(string cmd, int numTicks = 10)
+    {
+        await Server.ExecuteCommand(cmd);
+        await RunTicksSync(numTicks);
+    }
+
+    /// <summary>
+    /// Execute a command on the client and wait some number of ticks.
+    /// </summary>
+    public async Task WaitClientCommand(string cmd, int numTicks = 10)
+    {
+        await Client.ExecuteCommand(cmd);
+        await RunTicksSync(numTicks);
+    }
 }


### PR DESCRIPTION
Adds a simple helper method to make executing commands in integration tests slightly less tedious.

Requires space-wizards/RobustToolbox/pull/4466