### PR TITLE
Fixed Telescopic Shield Lighting

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -424,7 +424,6 @@
         - state: teleriot-icon
         - state: teleriot-on
           visible: false
-          shader: shaded
           map: [ "shield" ]
     - type: Item
       size: 10
@@ -437,10 +436,8 @@
       inhandVisuals:
         left:
           - state: inhand-left-shield
-            shader: shaded
         right:
           - state: inhand-right-shield
-            shader: shaded
     - type: Appearance
     - type: Destructible
       thresholds:

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -424,7 +424,7 @@
         - state: teleriot-icon
         - state: teleriot-on
           visible: false
-          shader: unshaded
+          shader: shaded
           map: [ "shield" ]
     - type: Item
       size: 10
@@ -437,10 +437,10 @@
       inhandVisuals:
         left:
           - state: inhand-left-shield
-            shader: unshaded
+            shader: shaded
         right:
           - state: inhand-right-shield
-            shader: unshaded
+            shader: shaded
     - type: Appearance
     - type: Destructible
       thresholds:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixes #20199
Deployed Telescopic shield no longer glows in the dark when held or when dropped.

## Why / Balance
Bug

## Media
https://github.com/space-wizards/space-station-14/assets/43478115/fcbc2d28-5a56-4ad4-8326-ee1831662301
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
🆑

-  Fix: Telescopic Shield no longer glows in the dark when deployed.

