### PR TITLE
Stop verb menu appearing when no verbs exist

### DIFF
--- a/Content.Client/Verbs/UI/VerbMenuUIController.cs
+++ b/Content.Client/Verbs/UI/VerbMenuUIController.cs
@@ -77,6 +77,9 @@ namespace Content.Client.Verbs.UI
             CurrentVerbs = _verbSystem.GetVerbs(target, user, Verb.VerbTypes, force);
             OpenMenu = menu;
 
+            if (CurrentVerbs.Count == 0)
+                return;
+
             // Fill in client-side verbs.
             FillVerbPopup(menu);
 


### PR DESCRIPTION
(kind of) Resolves #20648. The verb menu now doesn't appear at all when there's nothing to show rather than pretending its' waiting for the server- still works fine otherwise in my testing. 
