### PR TITLE
Replace paramedic with medical windoor on Kettle

### DIFF
--- a/Resources/Maps/kettle.yml
+++ b/Resources/Maps/kettle.yml
@@ -18762,9 +18762,14 @@ entities:
     - pos: 34.5,12.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -507010.16
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 11588
       type: DeviceLinkSink
@@ -18773,9 +18778,14 @@ entities:
     - pos: 34.5,14.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -507010.16
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 11588
       type: DeviceLinkSink
@@ -18800,9 +18810,14 @@ entities:
     - pos: 34.5,13.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -507010.16
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 11588
       type: DeviceLinkSink
@@ -18827,9 +18842,14 @@ entities:
     - pos: 53.5,-25.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18838,9 +18858,14 @@ entities:
     - pos: 53.5,-26.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18849,9 +18874,14 @@ entities:
     - pos: 53.5,-27.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18860,9 +18890,14 @@ entities:
     - pos: 53.5,-28.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18871,9 +18906,14 @@ entities:
     - pos: 53.5,-29.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18882,9 +18922,14 @@ entities:
     - pos: 53.5,-30.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18893,9 +18938,14 @@ entities:
     - pos: 56.5,-25.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18904,9 +18954,14 @@ entities:
     - pos: 56.5,-26.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18915,9 +18970,14 @@ entities:
     - pos: 56.5,-27.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18926,9 +18986,14 @@ entities:
     - pos: 56.5,-28.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18937,9 +19002,14 @@ entities:
     - pos: 56.5,-29.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18948,9 +19018,14 @@ entities:
     - pos: 56.5,-30.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -505275.1
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 8852
       type: DeviceLinkSink
@@ -18959,9 +19034,14 @@ entities:
     - pos: -21.5,50.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -445930.03
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 23015
       type: DeviceLinkSink
@@ -18970,9 +19050,14 @@ entities:
     - pos: -21.5,48.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -445930.03
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 23015
       type: DeviceLinkSink
@@ -18981,9 +19066,14 @@ entities:
     - pos: -21.5,49.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -445930.03
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 23015
       type: DeviceLinkSink
@@ -18992,9 +19082,14 @@ entities:
     - pos: -21.5,47.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -445930.03
-      state: Opening
+    - state: Open
       type: Door
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
     - links:
       - 23015
       type: DeviceLinkSink
@@ -19057,9 +19152,14 @@ entities:
     - pos: 23.5,14.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -507071.4
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 22394
       type: DeviceLinkSink
@@ -19068,9 +19168,14 @@ entities:
     - pos: 23.5,13.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -507071.4
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 22394
       type: DeviceLinkSink
@@ -19079,9 +19184,14 @@ entities:
     - pos: 23.5,12.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -507071.4
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 22394
       type: DeviceLinkSink
@@ -19912,8 +20022,6 @@ entities:
     - pos: 16.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 1128
     components:
     - pos: 16.5,-15.5
@@ -19924,22 +20032,16 @@ entities:
     - pos: 26.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 1412
     components:
     - pos: 16.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 1493
     components:
     - pos: 14.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 1646
     components:
     - pos: 72.5,-8.5
@@ -19950,15 +20052,11 @@ entities:
     - pos: 15.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2039
     components:
     - pos: 14.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2172
     components:
     - pos: 13.5,-18.5
@@ -20044,8 +20142,6 @@ entities:
     - pos: 16.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3181
     components:
     - pos: 27.5,24.5
@@ -20091,127 +20187,91 @@ entities:
     - pos: 31.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3775
     components:
     - pos: 16.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3823
     components:
     - pos: 16.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3824
     components:
     - pos: 16.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3825
     components:
     - pos: 16.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3826
     components:
     - pos: 16.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3827
     components:
     - pos: 16.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3828
     components:
     - pos: 16.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3829
     components:
     - pos: 16.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3830
     components:
     - pos: 16.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3832
     components:
     - pos: 8.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3833
     components:
     - pos: 9.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3834
     components:
     - pos: 10.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3835
     components:
     - pos: 11.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3836
     components:
     - pos: 12.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3838
     components:
     - pos: 13.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3839
     components:
     - pos: 14.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3840
     components:
     - pos: 15.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5517
     components:
     - pos: -43.5,-35.5
@@ -20242,50 +20302,36 @@ entities:
     - pos: -22.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6283
     components:
     - pos: -27.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6319
     components:
     - pos: 16.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6320
     components:
     - pos: 16.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6662
     components:
     - pos: 31.5,66.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6663
     components:
     - pos: 31.5,67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6751
     components:
     - pos: -22.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6752
     components:
     - pos: -23.5,57.5
@@ -20366,85 +20412,61 @@ entities:
     - pos: -27.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6768
     components:
     - pos: -26.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6769
     components:
     - pos: -25.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6770
     components:
     - pos: -24.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6771
     components:
     - pos: -23.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6775
     components:
     - pos: -20.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6776
     components:
     - pos: -19.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6777
     components:
     - pos: -21.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6778
     components:
     - pos: -23.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6779
     components:
     - pos: -28.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6925
     components:
     - pos: 19.5,-88.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6926
     components:
     - pos: 21.5,-88.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6927
     components:
     - pos: 22.5,-90.5
@@ -20460,8 +20482,6 @@ entities:
     - pos: 22.5,-88.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6930
     components:
     - pos: 22.5,-87.5
@@ -20487,8 +20507,6 @@ entities:
     - pos: 18.5,-88.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6935
     components:
     - pos: 18.5,-87.5
@@ -20559,8 +20577,6 @@ entities:
     - pos: 13.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7271
     components:
     - pos: 13.5,72.5
@@ -20596,43 +20612,31 @@ entities:
     - pos: -63.5,-39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7398
     components:
     - pos: 17.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7399
     components:
     - pos: 16.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7400
     components:
     - pos: 15.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7405
     components:
     - pos: 14.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7406
     components:
     - pos: 13.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7573
     components:
     - pos: 86.5,-3.5
@@ -20693,8 +20697,6 @@ entities:
     - pos: 32.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7799
     components:
     - pos: 72.5,0.5
@@ -20785,36 +20787,26 @@ entities:
     - pos: 10.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8347
     components:
     - pos: 10.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8388
     components:
     - pos: 9.5,-51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8713
     components:
     - pos: -46.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8768
     components:
     - pos: -46.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8769
     components:
     - pos: -46.5,-49.5
@@ -20835,8 +20827,6 @@ entities:
     - pos: -10.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10460
     components:
     - pos: -10.5,-8.5
@@ -20912,8 +20902,6 @@ entities:
     - pos: 28.5,-24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11987
     components:
     - pos: 28.5,-25.5
@@ -21174,8 +21162,6 @@ entities:
     - pos: 5.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12103
     components:
     - pos: 5.5,-42.5
@@ -21211,8 +21197,6 @@ entities:
     - pos: 4.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12110
     components:
     - pos: 3.5,-44.5
@@ -21223,8 +21207,6 @@ entities:
     - pos: 3.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12112
     components:
     - pos: 2.5,-45.5
@@ -21260,8 +21242,6 @@ entities:
     - pos: 3.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12119
     components:
     - pos: 2.5,-43.5
@@ -21297,15 +21277,11 @@ entities:
     - pos: 3.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12126
     components:
     - pos: 3.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12127
     components:
     - pos: 3.5,-40.5
@@ -21436,8 +21412,6 @@ entities:
     - pos: 12.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12153
     components:
     - pos: 12.5,-41.5
@@ -21448,15 +21422,11 @@ entities:
     - pos: 11.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12155
     components:
     - pos: 11.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12156
     components:
     - pos: 11.5,-43.5
@@ -21582,8 +21552,6 @@ entities:
     - pos: 16.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12181
     components:
     - pos: 16.5,-41.5
@@ -21639,50 +21607,36 @@ entities:
     - pos: 31.5,56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12507
     components:
     - pos: 31.5,58.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12508
     components:
     - pos: 31.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12737
     components:
     - pos: 31.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12738
     components:
     - pos: 31.5,59.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12739
     components:
     - pos: 31.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12740
     components:
     - pos: 31.5,55.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12881
     components:
     - pos: 21.5,71.5
@@ -21693,8 +21647,6 @@ entities:
     - pos: -34.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14024
     components:
     - pos: 31.5,-35.5
@@ -21775,15 +21727,11 @@ entities:
     - pos: 1.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14060
     components:
     - pos: 2.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14061
     components:
     - pos: 1.5,-13.5
@@ -21924,8 +21872,6 @@ entities:
     - pos: 9.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14089
     components:
     - pos: 9.5,-15.5
@@ -22071,99 +22017,71 @@ entities:
     - pos: 29.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14118
     components:
     - pos: 29.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14119
     components:
     - pos: 28.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14120
     components:
     - pos: 27.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14121
     components:
     - pos: 26.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14122
     components:
     - pos: 25.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14123
     components:
     - pos: 24.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14124
     components:
     - pos: 23.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14125
     components:
     - pos: 22.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14126
     components:
     - pos: 22.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14127
     components:
     - pos: 30.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14128
     components:
     - pos: 31.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14129
     components:
     - pos: 31.5,-10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14130
     components:
     - pos: 31.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14131
     components:
     - pos: 28.5,27.5
@@ -22179,36 +22097,26 @@ entities:
     - pos: 31.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14141
     components:
     - pos: 31.5,-7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14142
     components:
     - pos: 31.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14143
     components:
     - pos: 31.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14144
     components:
     - pos: 31.5,-4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14146
     components:
     - pos: 29.5,-10.5
@@ -22299,15 +22207,11 @@ entities:
     - pos: 25.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14296
     components:
     - pos: 24.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14299
     components:
     - pos: 21.5,72.5
@@ -22328,8 +22232,6 @@ entities:
     - pos: 20.5,-98.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14322
     components:
     - pos: 20.5,-99.5
@@ -22530,8 +22432,6 @@ entities:
     - pos: 20.5,-101.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14362
     components:
     - pos: 20.5,-102.5
@@ -22597,8 +22497,6 @@ entities:
     - pos: 29.5,-92.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14422
     components:
     - pos: 30.5,-92.5
@@ -22824,8 +22722,6 @@ entities:
     - pos: 11.5,-92.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14467
     components:
     - pos: 12.5,-92.5
@@ -22876,8 +22772,6 @@ entities:
     - pos: 15.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14479
     components:
     - pos: 15.5,-47.5
@@ -22978,8 +22872,6 @@ entities:
     - pos: 20.5,-58.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14499
     components:
     - pos: 20.5,-59.5
@@ -23025,15 +22917,11 @@ entities:
     - pos: 19.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14508
     components:
     - pos: 19.5,-64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14509
     components:
     - pos: 21.5,-62.5
@@ -23044,29 +22932,21 @@ entities:
     - pos: 21.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14511
     components:
     - pos: 21.5,-64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14512
     components:
     - pos: 21.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14513
     components:
     - pos: 19.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14514
     components:
     - pos: 14.5,-47.5
@@ -23077,15 +22957,11 @@ entities:
     - pos: 11.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14516
     components:
     - pos: 11.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14517
     components:
     - pos: 10.5,-45.5
@@ -23101,43 +22977,31 @@ entities:
     - pos: 20.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14569
     components:
     - pos: 21.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14570
     components:
     - pos: 23.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14571
     components:
     - pos: 22.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14572
     components:
     - pos: 23.5,31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14573
     components:
     - pos: 23.5,32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14899
     components:
     - pos: -41.5,-40.5
@@ -23198,148 +23062,106 @@ entities:
     - pos: 20.5,29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15014
     components:
     - pos: 20.5,28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15015
     components:
     - pos: 20.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15016
     components:
     - pos: 20.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15017
     components:
     - pos: 20.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15018
     components:
     - pos: 20.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15019
     components:
     - pos: 20.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15020
     components:
     - pos: 20.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15021
     components:
     - pos: 21.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15022
     components:
     - pos: 22.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15023
     components:
     - pos: 23.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15024
     components:
     - pos: 23.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15025
     components:
     - pos: 23.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15026
     components:
     - pos: 24.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15027
     components:
     - pos: 25.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15028
     components:
     - pos: 26.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15029
     components:
     - pos: 27.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15030
     components:
     - pos: 28.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15031
     components:
     - pos: 27.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15032
     components:
     - pos: 28.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15033
     components:
     - pos: 26.5,31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15034
     components:
     - pos: 26.5,32.5
@@ -23350,8 +23172,6 @@ entities:
     - pos: 26.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15036
     components:
     - pos: 26.5,34.5
@@ -23417,36 +23237,26 @@ entities:
     - pos: 20.5,31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15049
     components:
     - pos: 20.5,32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15050
     components:
     - pos: 20.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15051
     components:
     - pos: 20.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15052
     components:
     - pos: 20.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15053
     components:
     - pos: 20.5,36.5
@@ -23457,8 +23267,6 @@ entities:
     - pos: 20.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15055
     components:
     - pos: 20.5,38.5
@@ -23469,29 +23277,21 @@ entities:
     - pos: 20.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15057
     components:
     - pos: 20.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15058
     components:
     - pos: 21.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15060
     components:
     - pos: 23.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15061
     components:
     - pos: 24.5,40.5
@@ -23502,15 +23302,11 @@ entities:
     - pos: 25.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15063
     components:
     - pos: 26.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15064
     components:
     - pos: 27.5,40.5
@@ -23521,15 +23317,11 @@ entities:
     - pos: 27.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15067
     components:
     - pos: 27.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15068
     components:
     - pos: 27.5,46.5
@@ -23555,22 +23347,16 @@ entities:
     - pos: 20.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15074
     components:
     - pos: 20.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15075
     components:
     - pos: 20.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15076
     components:
     - pos: 21.5,43.5
@@ -23581,29 +23367,21 @@ entities:
     - pos: 44.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15133
     components:
     - pos: 44.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15134
     components:
     - pos: 44.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15135
     components:
     - pos: 44.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15136
     components:
     - pos: 45.5,12.5
@@ -23624,22 +23402,16 @@ entities:
     - pos: 48.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15140
     components:
     - pos: 48.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15141
     components:
     - pos: 48.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15142
     components:
     - pos: 47.5,14.5
@@ -23690,8 +23462,6 @@ entities:
     - pos: 46.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15152
     components:
     - pos: 43.5,18.5
@@ -23882,22 +23652,16 @@ entities:
     - pos: 48.5,29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15191
     components:
     - pos: 48.5,28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15192
     components:
     - pos: 48.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15193
     components:
     - pos: 45.5,22.5
@@ -23908,15 +23672,11 @@ entities:
     - pos: 47.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15195
     components:
     - pos: 48.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15196
     components:
     - pos: 48.5,23.5
@@ -23932,8 +23692,6 @@ entities:
     - pos: 37.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15199
     components:
     - pos: 37.5,23.5
@@ -23989,8 +23747,6 @@ entities:
     - pos: 34.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15210
     components:
     - pos: 34.5,29.5
@@ -24006,15 +23762,11 @@ entities:
     - pos: 34.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15213
     components:
     - pos: 34.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15214
     components:
     - pos: 34.5,25.5
@@ -24030,8 +23782,6 @@ entities:
     - pos: 34.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15217
     components:
     - pos: 35.5,23.5
@@ -24217,8 +23967,6 @@ entities:
     - pos: 41.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15254
     components:
     - pos: 42.5,30.5
@@ -24229,8 +23977,6 @@ entities:
     - pos: 41.5,29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15256
     components:
     - pos: 41.5,28.5
@@ -24241,22 +23987,16 @@ entities:
     - pos: 41.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15258
     components:
     - pos: 41.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15259
     components:
     - pos: 41.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15260
     components:
     - pos: 41.5,23.5
@@ -24297,8 +24037,6 @@ entities:
     - pos: -6.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15564
     components:
     - pos: -6.5,2.5
@@ -24709,127 +24447,91 @@ entities:
     - pos: -6.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15646
     components:
     - pos: -7.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15647
     components:
     - pos: -8.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15648
     components:
     - pos: -9.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15649
     components:
     - pos: -10.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15650
     components:
     - pos: -11.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15651
     components:
     - pos: -12.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15652
     components:
     - pos: -13.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15653
     components:
     - pos: -14.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15654
     components:
     - pos: -15.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15655
     components:
     - pos: -16.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15656
     components:
     - pos: -16.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15657
     components:
     - pos: -16.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15658
     components:
     - pos: -16.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15659
     components:
     - pos: -16.5,0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15660
     components:
     - pos: -16.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15661
     components:
     - pos: -15.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15662
     components:
     - pos: -14.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15663
     components:
     - pos: -14.5,-1.5
@@ -24895,57 +24597,41 @@ entities:
     - pos: -10.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15676
     components:
     - pos: -10.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15677
     components:
     - pos: -10.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15678
     components:
     - pos: -10.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15679
     components:
     - pos: -10.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15680
     components:
     - pos: -10.5,10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15681
     components:
     - pos: -10.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15719
     components:
     - pos: -6.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15720
     components:
     - pos: -7.5,14.5
@@ -24956,71 +24642,51 @@ entities:
     - pos: -8.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15722
     components:
     - pos: -9.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15723
     components:
     - pos: -8.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15724
     components:
     - pos: -8.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15725
     components:
     - pos: -8.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15726
     components:
     - pos: -8.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15727
     components:
     - pos: -8.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15728
     components:
     - pos: -7.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15729
     components:
     - pos: -6.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15730
     components:
     - pos: -5.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15731
     components:
     - pos: -5.5,18.5
@@ -25091,869 +24757,621 @@ entities:
     - pos: -5.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15745
     components:
     - pos: -4.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15746
     components:
     - pos: -3.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15747
     components:
     - pos: -2.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15748
     components:
     - pos: -1.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15749
     components:
     - pos: -0.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15750
     components:
     - pos: 0.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15751
     components:
     - pos: 1.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15752
     components:
     - pos: 2.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15753
     components:
     - pos: 3.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15754
     components:
     - pos: 4.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15755
     components:
     - pos: 5.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15756
     components:
     - pos: -4.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15757
     components:
     - pos: -1.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15758
     components:
     - pos: -1.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15759
     components:
     - pos: -1.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15760
     components:
     - pos: -1.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15761
     components:
     - pos: -1.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15762
     components:
     - pos: -1.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15763
     components:
     - pos: -0.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15764
     components:
     - pos: 0.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15765
     components:
     - pos: 1.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15766
     components:
     - pos: 2.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15767
     components:
     - pos: 3.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15768
     components:
     - pos: 4.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15769
     components:
     - pos: 5.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15770
     components:
     - pos: 6.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15771
     components:
     - pos: 4.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15772
     components:
     - pos: 4.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15773
     components:
     - pos: 4.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15774
     components:
     - pos: 4.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15775
     components:
     - pos: 4.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15776
     components:
     - pos: 1.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15777
     components:
     - pos: 7.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15778
     components:
     - pos: 7.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15779
     components:
     - pos: -3.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15780
     components:
     - pos: -2.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15781
     components:
     - pos: -1.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15782
     components:
     - pos: -0.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15783
     components:
     - pos: 0.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15784
     components:
     - pos: 1.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15785
     components:
     - pos: 2.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15786
     components:
     - pos: 3.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15787
     components:
     - pos: 4.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15788
     components:
     - pos: 5.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15789
     components:
     - pos: 6.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15790
     components:
     - pos: -4.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15791
     components:
     - pos: -3.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15792
     components:
     - pos: -2.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15793
     components:
     - pos: -1.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15794
     components:
     - pos: -0.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15795
     components:
     - pos: 0.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15796
     components:
     - pos: 1.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15797
     components:
     - pos: 2.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15798
     components:
     - pos: 3.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15799
     components:
     - pos: 4.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15800
     components:
     - pos: 5.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15801
     components:
     - pos: 6.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15802
     components:
     - pos: -1.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15803
     components:
     - pos: -1.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15804
     components:
     - pos: -0.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15805
     components:
     - pos: 0.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15806
     components:
     - pos: 1.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15807
     components:
     - pos: 2.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15808
     components:
     - pos: 3.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15809
     components:
     - pos: 4.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15810
     components:
     - pos: 5.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15811
     components:
     - pos: 6.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15812
     components:
     - pos: -1.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15813
     components:
     - pos: -1.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15814
     components:
     - pos: -1.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15815
     components:
     - pos: -1.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15816
     components:
     - pos: -1.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15817
     components:
     - pos: -1.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15818
     components:
     - pos: -1.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15819
     components:
     - pos: -0.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15820
     components:
     - pos: 0.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15821
     components:
     - pos: 1.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15822
     components:
     - pos: 2.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15823
     components:
     - pos: 3.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15824
     components:
     - pos: 4.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15825
     components:
     - pos: 5.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15826
     components:
     - pos: 6.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15827
     components:
     - pos: -0.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15828
     components:
     - pos: 0.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15829
     components:
     - pos: 1.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15830
     components:
     - pos: 2.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15831
     components:
     - pos: 3.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15832
     components:
     - pos: 4.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15833
     components:
     - pos: 5.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15834
     components:
     - pos: 6.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15835
     components:
     - pos: 8.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15836
     components:
     - pos: 9.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15837
     components:
     - pos: 10.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15838
     components:
     - pos: 11.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15839
     components:
     - pos: 12.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15840
     components:
     - pos: 13.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15841
     components:
     - pos: 14.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15842
     components:
     - pos: 15.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15843
     components:
     - pos: 16.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15844
     components:
     - pos: 16.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15845
     components:
     - pos: 16.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15846
     components:
     - pos: 16.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15847
     components:
     - pos: 16.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15848
     components:
     - pos: 15.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15849
     components:
     - pos: 14.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15850
     components:
     - pos: 13.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15851
     components:
     - pos: 12.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15852
     components:
     - pos: 11.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15853
     components:
     - pos: 10.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15854
     components:
     - pos: 9.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15855
     components:
     - pos: 8.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15856
     components:
     - pos: 8.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15857
     components:
     - pos: 9.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15858
     components:
     - pos: 10.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15859
     components:
     - pos: 11.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15860
     components:
     - pos: 12.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15861
     components:
     - pos: 13.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15862
     components:
     - pos: 14.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15863
     components:
     - pos: 15.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15864
     components:
     - pos: 16.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15865
     components:
     - pos: 17.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15866
     components:
     - pos: 18.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15867
     components:
     - pos: 19.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15868
     components:
     - pos: 20.5,12.5
@@ -25974,85 +25392,61 @@ entities:
     - pos: 8.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15872
     components:
     - pos: 9.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15873
     components:
     - pos: 10.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15874
     components:
     - pos: 11.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15875
     components:
     - pos: 12.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15876
     components:
     - pos: 13.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15877
     components:
     - pos: 14.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15878
     components:
     - pos: 15.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15879
     components:
     - pos: 16.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15880
     components:
     - pos: 17.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15881
     components:
     - pos: 18.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15882
     components:
     - pos: 19.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15883
     components:
     - pos: 20.5,16.5
@@ -26093,57 +25487,41 @@ entities:
     - pos: -5.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15891
     components:
     - pos: -5.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15892
     components:
     - pos: -5.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15893
     components:
     - pos: -5.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15894
     components:
     - pos: -5.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15895
     components:
     - pos: -5.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15896
     components:
     - pos: -5.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15897
     components:
     - pos: -5.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15898
     components:
     - pos: -6.5,22.5
@@ -26154,22 +25532,16 @@ entities:
     - pos: -7.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15900
     components:
     - pos: -8.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15904
     components:
     - pos: 23.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15905
     components:
     - pos: 24.5,15.5
@@ -26275,8 +25647,6 @@ entities:
     - pos: 28.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15929
     components:
     - pos: 28.5,4.5
@@ -26302,15 +25672,11 @@ entities:
     - pos: 25.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15934
     components:
     - pos: 24.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15935
     components:
     - pos: 24.5,2.5
@@ -26406,64 +25772,46 @@ entities:
     - pos: 23.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15954
     components:
     - pos: 22.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15955
     components:
     - pos: 21.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15956
     components:
     - pos: 20.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15957
     components:
     - pos: 19.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15958
     components:
     - pos: 19.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15959
     components:
     - pos: 19.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15960
     components:
     - pos: 19.5,0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15961
     components:
     - pos: 19.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15962
     components:
     - pos: 19.5,-1.5
@@ -26719,22 +26067,16 @@ entities:
     - pos: 20.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16053
     components:
     - pos: 20.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16055
     components:
     - pos: 0.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16056
     components:
     - pos: 0.5,39.5
@@ -26785,8 +26127,6 @@ entities:
     - pos: -2.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16066
     components:
     - pos: -3.5,35.5
@@ -26887,8 +26227,6 @@ entities:
     - pos: 2.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16087
     components:
     - pos: -3.5,33.5
@@ -26964,64 +26302,46 @@ entities:
     - pos: 6.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16102
     components:
     - pos: 6.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16103
     components:
     - pos: 6.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16104
     components:
     - pos: 6.5,36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16105
     components:
     - pos: 6.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16106
     components:
     - pos: 6.5,38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16107
     components:
     - pos: 6.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16108
     components:
     - pos: 6.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16109
     components:
     - pos: 6.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16110
     components:
     - pos: 5.5,34.5
@@ -27037,15 +26357,11 @@ entities:
     - pos: 3.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16113
     components:
     - pos: 5.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16114
     components:
     - pos: 4.5,39.5
@@ -27071,43 +26387,31 @@ entities:
     - pos: 5.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16119
     components:
     - pos: 5.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16120
     components:
     - pos: 5.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16121
     components:
     - pos: 5.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16122
     components:
     - pos: 5.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16123
     components:
     - pos: 5.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16124
     components:
     - pos: 4.5,46.5
@@ -27118,8 +26422,6 @@ entities:
     - pos: 3.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16126
     components:
     - pos: 6.5,46.5
@@ -27140,78 +26442,56 @@ entities:
     - pos: 7.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16130
     components:
     - pos: 8.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16131
     components:
     - pos: 9.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16132
     components:
     - pos: 10.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16133
     components:
     - pos: 11.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16134
     components:
     - pos: 11.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16135
     components:
     - pos: 11.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16136
     components:
     - pos: 11.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16137
     components:
     - pos: 11.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16138
     components:
     - pos: 10.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16139
     components:
     - pos: 9.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16140
     components:
     - pos: 9.5,40.5
@@ -27322,43 +26602,31 @@ entities:
     - pos: 12.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16162
     components:
     - pos: 13.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16163
     components:
     - pos: 14.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16164
     components:
     - pos: 15.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16165
     components:
     - pos: 16.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16188
     components:
     - pos: -8.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16189
     components:
     - pos: -9.5,48.5
@@ -27889,8 +27157,6 @@ entities:
     - pos: -22.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16316
     components:
     - pos: -22.5,39.5
@@ -27981,22 +27247,16 @@ entities:
     - pos: -22.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16334
     components:
     - pos: -22.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16335
     components:
     - pos: -22.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16336
     components:
     - pos: -22.5,45.5
@@ -28037,22 +27297,16 @@ entities:
     - pos: -28.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16344
     components:
     - pos: -28.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16345
     components:
     - pos: -28.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16346
     components:
     - pos: -28.5,41.5
@@ -28238,155 +27492,111 @@ entities:
     - pos: -29.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16383
     components:
     - pos: -30.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16384
     components:
     - pos: -30.5,38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16385
     components:
     - pos: -30.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16386
     components:
     - pos: -30.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16387
     components:
     - pos: -30.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16388
     components:
     - pos: -30.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16389
     components:
     - pos: -30.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16390
     components:
     - pos: -30.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16391
     components:
     - pos: -30.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16392
     components:
     - pos: -30.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16393
     components:
     - pos: -30.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16394
     components:
     - pos: -30.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16395
     components:
     - pos: -30.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16396
     components:
     - pos: -30.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16397
     components:
     - pos: -31.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16398
     components:
     - pos: -31.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16399
     components:
     - pos: -30.5,36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16400
     components:
     - pos: -30.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16401
     components:
     - pos: -30.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16402
     components:
     - pos: -31.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16403
     components:
     - pos: -31.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16404
     components:
     - pos: -31.5,32.5
@@ -28517,36 +27727,26 @@ entities:
     - pos: -29.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16431
     components:
     - pos: -28.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16432
     components:
     - pos: -27.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16503
     components:
     - pos: -35.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16504
     components:
     - pos: -34.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16505
     components:
     - pos: -33.5,26.5
@@ -28557,8 +27757,6 @@ entities:
     - pos: -32.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16507
     components:
     - pos: -31.5,26.5
@@ -28714,8 +27912,6 @@ entities:
     - pos: -34.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16538
     components:
     - pos: -34.5,28.5
@@ -28726,260 +27922,186 @@ entities:
     - pos: -34.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16540
     components:
     - pos: -34.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16541
     components:
     - pos: -34.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16542
     components:
     - pos: -35.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16543
     components:
     - pos: -36.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16544
     components:
     - pos: -37.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16545
     components:
     - pos: -38.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16546
     components:
     - pos: -39.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16547
     components:
     - pos: -40.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16548
     components:
     - pos: -41.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16549
     components:
     - pos: -42.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16550
     components:
     - pos: -43.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16551
     components:
     - pos: -44.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16552
     components:
     - pos: -45.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16553
     components:
     - pos: -46.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16554
     components:
     - pos: -47.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16555
     components:
     - pos: -47.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16556
     components:
     - pos: -47.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16557
     components:
     - pos: -47.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16558
     components:
     - pos: -47.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16559
     components:
     - pos: -47.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16560
     components:
     - pos: -47.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16561
     components:
     - pos: -47.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16562
     components:
     - pos: -47.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16563
     components:
     - pos: -47.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16564
     components:
     - pos: -48.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16565
     components:
     - pos: -48.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16566
     components:
     - pos: -48.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16567
     components:
     - pos: -48.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16568
     components:
     - pos: -48.5,10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16569
     components:
     - pos: -48.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16570
     components:
     - pos: -48.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16571
     components:
     - pos: -48.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16572
     components:
     - pos: -46.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16573
     components:
     - pos: -46.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16574
     components:
     - pos: -46.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16575
     components:
     - pos: -46.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16576
     components:
     - pos: -46.5,28.5
@@ -29440,8 +28562,6 @@ entities:
     - pos: -11.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16674
     components:
     - pos: -13.5,13.5
@@ -29507,22 +28627,16 @@ entities:
     - pos: -18.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16687
     components:
     - pos: -17.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16688
     components:
     - pos: -16.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16689
     components:
     - pos: -17.5,14.5
@@ -29723,8 +28837,6 @@ entities:
     - pos: -19.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16733
     components:
     - pos: -21.5,5.5
@@ -29920,169 +29032,121 @@ entities:
     - pos: -25.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16772
     components:
     - pos: -26.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16773
     components:
     - pos: -27.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16774
     components:
     - pos: -28.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16775
     components:
     - pos: -29.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16776
     components:
     - pos: -30.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16777
     components:
     - pos: -31.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16778
     components:
     - pos: -31.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16779
     components:
     - pos: -32.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16780
     components:
     - pos: -33.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16781
     components:
     - pos: -34.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16782
     components:
     - pos: -35.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16783
     components:
     - pos: -36.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16784
     components:
     - pos: -37.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16785
     components:
     - pos: -38.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16786
     components:
     - pos: -39.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16787
     components:
     - pos: -40.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16788
     components:
     - pos: -41.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16789
     components:
     - pos: -42.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16790
     components:
     - pos: -43.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16791
     components:
     - pos: -44.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16792
     components:
     - pos: -45.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16793
     components:
     - pos: -45.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16794
     components:
     - pos: -45.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16795
     components:
     - pos: -45.5,5.5
@@ -30283,8 +29347,6 @@ entities:
     - pos: -2.5,56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16836
     components:
     - pos: -1.5,56.5
@@ -30495,8 +29557,6 @@ entities:
     - pos: 21.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16925
     components:
     - pos: 21.5,69.5
@@ -30647,8 +29707,6 @@ entities:
     - pos: 31.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17006
     components:
     - pos: 31.5,69.5
@@ -30659,8 +29717,6 @@ entities:
     - pos: 31.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17008
     components:
     - pos: 20.5,67.5
@@ -30751,8 +29807,6 @@ entities:
     - pos: 17.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17026
     components:
     - pos: 16.5,57.5
@@ -31183,50 +30237,36 @@ entities:
     - pos: 31.5,52.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17115
     components:
     - pos: 31.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17116
     components:
     - pos: 31.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17124
     components:
     - pos: 31.5,62.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17125
     components:
     - pos: 31.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17126
     components:
     - pos: 31.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17127
     components:
     - pos: 31.5,65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17134
     components:
     - pos: 41.5,34.5
@@ -31432,148 +30472,106 @@ entities:
     - pos: 34.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17175
     components:
     - pos: 35.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17176
     components:
     - pos: 36.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17177
     components:
     - pos: 37.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17178
     components:
     - pos: 38.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17179
     components:
     - pos: 39.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17180
     components:
     - pos: 39.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17181
     components:
     - pos: 39.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17182
     components:
     - pos: 39.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17183
     components:
     - pos: 39.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17184
     components:
     - pos: 39.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17185
     components:
     - pos: 39.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17186
     components:
     - pos: 39.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17187
     components:
     - pos: 39.5,38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17188
     components:
     - pos: 39.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17189
     components:
     - pos: 40.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17190
     components:
     - pos: 41.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17191
     components:
     - pos: 42.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17192
     components:
     - pos: 43.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17193
     components:
     - pos: 44.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17194
     components:
     - pos: 45.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17195
     components:
     - pos: 45.5,38.5
@@ -31614,8 +30612,6 @@ entities:
     - pos: 41.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17203
     components:
     - pos: 45.5,34.5
@@ -31776,358 +30772,256 @@ entities:
     - pos: 48.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17235
     components:
     - pos: 49.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17236
     components:
     - pos: 50.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17237
     components:
     - pos: 50.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17238
     components:
     - pos: 50.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17239
     components:
     - pos: 50.5,36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17240
     components:
     - pos: 50.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17241
     components:
     - pos: 51.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17242
     components:
     - pos: 52.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17243
     components:
     - pos: 53.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17244
     components:
     - pos: 54.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17245
     components:
     - pos: 55.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17246
     components:
     - pos: 56.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17247
     components:
     - pos: 46.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17248
     components:
     - pos: 47.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17249
     components:
     - pos: 47.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17250
     components:
     - pos: 47.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17251
     components:
     - pos: 47.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17252
     components:
     - pos: 47.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17253
     components:
     - pos: 47.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17254
     components:
     - pos: 47.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17255
     components:
     - pos: 47.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17256
     components:
     - pos: 47.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17257
     components:
     - pos: 47.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17258
     components:
     - pos: 47.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17259
     components:
     - pos: 47.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17260
     components:
     - pos: 46.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17261
     components:
     - pos: 45.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17262
     components:
     - pos: 44.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17263
     components:
     - pos: 43.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17264
     components:
     - pos: 42.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17265
     components:
     - pos: 41.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17266
     components:
     - pos: 40.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17267
     components:
     - pos: 40.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17268
     components:
     - pos: 40.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17269
     components:
     - pos: 40.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17270
     components:
     - pos: 40.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17271
     components:
     - pos: 45.5,51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17272
     components:
     - pos: 45.5,52.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17273
     components:
     - pos: 45.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17274
     components:
     - pos: 45.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17275
     components:
     - pos: 43.5,51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17276
     components:
     - pos: 43.5,52.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17277
     components:
     - pos: 43.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17278
     components:
     - pos: 43.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17279
     components:
     - pos: 43.5,55.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17280
     components:
     - pos: 40.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17282
     components:
     - pos: 42.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17283
     components:
     - pos: 43.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17284
     components:
     - pos: 43.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17285
     components:
     - pos: 43.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17286
     components:
     - pos: 42.5,11.5
@@ -32138,183 +31032,131 @@ entities:
     - pos: 42.5,10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17288
     components:
     - pos: 42.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17289
     components:
     - pos: 41.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17290
     components:
     - pos: 41.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17291
     components:
     - pos: 40.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17292
     components:
     - pos: 39.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17293
     components:
     - pos: 38.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17294
     components:
     - pos: 37.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17295
     components:
     - pos: 36.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17298
     components:
     - pos: 43.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17299
     components:
     - pos: 44.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17300
     components:
     - pos: 45.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17301
     components:
     - pos: 46.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17302
     components:
     - pos: 47.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17303
     components:
     - pos: 48.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17304
     components:
     - pos: 49.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17305
     components:
     - pos: 50.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17306
     components:
     - pos: 51.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17307
     components:
     - pos: 52.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17308
     components:
     - pos: 53.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17309
     components:
     - pos: 54.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17310
     components:
     - pos: 54.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17311
     components:
     - pos: 54.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17312
     components:
     - pos: 55.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17313
     components:
     - pos: 56.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17372
     components:
     - pos: 79.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17373
     components:
     - pos: 79.5,2.5
@@ -32775,8 +31617,6 @@ entities:
     - pos: 52.5,-50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17568
     components:
     - pos: 53.5,-48.5
@@ -32787,8 +31627,6 @@ entities:
     - pos: 54.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17570
     components:
     - pos: 52.5,-45.5
@@ -32804,8 +31642,6 @@ entities:
     - pos: 54.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17573
     components:
     - pos: 52.5,-41.5
@@ -32851,15 +31687,11 @@ entities:
     - pos: 60.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17582
     components:
     - pos: 60.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17583
     components:
     - pos: 57.5,-42.5
@@ -32870,22 +31702,16 @@ entities:
     - pos: 57.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17585
     components:
     - pos: 56.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17586
     components:
     - pos: 58.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17587
     components:
     - pos: 58.5,-40.5
@@ -32926,8 +31752,6 @@ entities:
     - pos: 53.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17595
     components:
     - pos: 55.5,-35.5
@@ -32938,71 +31762,51 @@ entities:
     - pos: 55.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17597
     components:
     - pos: 55.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17598
     components:
     - pos: 55.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17599
     components:
     - pos: 55.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17600
     components:
     - pos: 55.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17601
     components:
     - pos: 55.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17602
     components:
     - pos: 55.5,-24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17603
     components:
     - pos: 55.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17604
     components:
     - pos: 55.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17605
     components:
     - pos: 55.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17606
     components:
     - pos: 55.5,-20.5
@@ -33028,8 +31832,6 @@ entities:
     - pos: 57.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17715
     components:
     - pos: 54.5,-37.5
@@ -33085,8 +31887,6 @@ entities:
     - pos: 44.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17726
     components:
     - pos: 43.5,-42.5
@@ -33097,8 +31897,6 @@ entities:
     - pos: 42.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17728
     components:
     - pos: 46.5,-41.5
@@ -33109,22 +31907,16 @@ entities:
     - pos: 46.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17730
     components:
     - pos: 47.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17731
     components:
     - pos: 48.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17732
     components:
     - pos: 48.5,-41.5
@@ -33170,15 +31962,11 @@ entities:
     - pos: 42.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17741
     components:
     - pos: 42.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17742
     components:
     - pos: 44.5,-47.5
@@ -33199,8 +31987,6 @@ entities:
     - pos: 44.5,-50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17746
     components:
     - pos: 43.5,-48.5
@@ -33211,8 +31997,6 @@ entities:
     - pos: 42.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17748
     components:
     - pos: 47.5,-46.5
@@ -33243,8 +32027,6 @@ entities:
     - pos: 48.5,-50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17754
     components:
     - pos: 49.5,-46.5
@@ -33400,15 +32182,11 @@ entities:
     - pos: 59.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17816
     components:
     - pos: 59.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17817
     components:
     - pos: 60.5,-14.5
@@ -33449,22 +32227,16 @@ entities:
     - pos: 57.5,-7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17826
     components:
     - pos: 57.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17828
     components:
     - pos: 57.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17829
     components:
     - pos: 57.5,-9.5
@@ -33475,106 +32247,76 @@ entities:
     - pos: 57.5,-10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17831
     components:
     - pos: 57.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17832
     components:
     - pos: 58.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17833
     components:
     - pos: 59.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17834
     components:
     - pos: 60.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17835
     components:
     - pos: 61.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17836
     components:
     - pos: 62.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17837
     components:
     - pos: 63.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17838
     components:
     - pos: 63.5,-7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17839
     components:
     - pos: 63.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17840
     components:
     - pos: 63.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17841
     components:
     - pos: 63.5,-10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17842
     components:
     - pos: 63.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17843
     components:
     - pos: 63.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17844
     components:
     - pos: 62.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17845
     components:
     - pos: 57.5,-5.5
@@ -33625,22 +32367,16 @@ entities:
     - pos: 59.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17855
     components:
     - pos: 60.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17856
     components:
     - pos: 61.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17857
     components:
     - pos: 61.5,0.5
@@ -33906,8 +32642,6 @@ entities:
     - pos: 34.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17918
     components:
     - pos: 35.5,-5.5
@@ -34123,8 +32857,6 @@ entities:
     - pos: 40.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17961
     components:
     - pos: 40.5,0.5
@@ -34175,15 +32907,11 @@ entities:
     - pos: 43.5,-1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17971
     components:
     - pos: 47.5,-1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17972
     components:
     - pos: 40.5,-0.5
@@ -34194,8 +32922,6 @@ entities:
     - pos: 40.5,-1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17974
     components:
     - pos: 40.5,-2.5
@@ -34516,8 +33242,6 @@ entities:
     - pos: 38.5,-10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18041
     components:
     - pos: 38.5,-9.5
@@ -34538,29 +33262,21 @@ entities:
     - pos: 38.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18045
     components:
     - pos: 43.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18046
     components:
     - pos: 43.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18047
     components:
     - pos: 43.5,-7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18048
     components:
     - pos: 42.5,-8.5
@@ -35226,15 +33942,11 @@ entities:
     - pos: -13.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18232
     components:
     - pos: -12.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18233
     components:
     - pos: -11.5,-31.5
@@ -35680,134 +34392,96 @@ entities:
     - pos: 3.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18328
     components:
     - pos: 3.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18329
     components:
     - pos: 3.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18330
     components:
     - pos: 2.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18331
     components:
     - pos: 1.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18332
     components:
     - pos: 0.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18333
     components:
     - pos: -0.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18334
     components:
     - pos: -1.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18335
     components:
     - pos: -2.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18336
     components:
     - pos: -2.5,-50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18337
     components:
     - pos: 3.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18338
     components:
     - pos: 4.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18339
     components:
     - pos: 5.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18340
     components:
     - pos: 6.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18341
     components:
     - pos: 6.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18342
     components:
     - pos: 6.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18343
     components:
     - pos: 7.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18344
     components:
     - pos: 8.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18345
     components:
     - pos: 9.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18346
     components:
     - pos: -7.5,-45.5
@@ -35818,85 +34492,61 @@ entities:
     - pos: -8.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18348
     components:
     - pos: -9.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18349
     components:
     - pos: -10.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18350
     components:
     - pos: -11.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18351
     components:
     - pos: -12.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18352
     components:
     - pos: -13.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18353
     components:
     - pos: -14.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18354
     components:
     - pos: -15.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18355
     components:
     - pos: -16.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18356
     components:
     - pos: -16.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18357
     components:
     - pos: -17.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18358
     components:
     - pos: -18.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18359
     components:
     - pos: -18.5,-45.5
@@ -36207,8 +34857,6 @@ entities:
     - pos: -28.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18459
     components:
     - pos: -24.5,-36.5
@@ -36274,64 +34922,46 @@ entities:
     - pos: -23.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18472
     components:
     - pos: -23.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18473
     components:
     - pos: -23.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18474
     components:
     - pos: -23.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18475
     components:
     - pos: -22.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18476
     components:
     - pos: -21.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18477
     components:
     - pos: -22.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18478
     components:
     - pos: -22.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18479
     components:
     - pos: -23.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18495
     components:
     - pos: -33.5,-25.5
@@ -36492,8 +35122,6 @@ entities:
     - pos: -40.5,-36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18540
     components:
     - pos: -39.5,-36.5
@@ -36724,141 +35352,101 @@ entities:
     - pos: -27.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18601
     components:
     - pos: -26.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18602
     components:
     - pos: -27.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18603
     components:
     - pos: -27.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18604
     components:
     - pos: -27.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18605
     components:
     - pos: -28.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18606
     components:
     - pos: -29.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18607
     components:
     - pos: -30.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18608
     components:
     - pos: -31.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18609
     components:
     - pos: -32.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18610
     components:
     - pos: -33.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18611
     components:
     - pos: -34.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18612
     components:
     - pos: -35.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18613
     components:
     - pos: -36.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18614
     components:
     - pos: -37.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18619
     components:
     - pos: -38.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18620
     components:
     - pos: -39.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18621
     components:
     - pos: -40.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18622
     components:
     - pos: -41.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18623
     components:
     - pos: -41.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18624
     components:
     - pos: -41.5,-48.5
@@ -36869,155 +35457,111 @@ entities:
     - pos: -41.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18626
     components:
     - pos: -41.5,-50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18627
     components:
     - pos: -41.5,-51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18628
     components:
     - pos: -41.5,-52.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18629
     components:
     - pos: -42.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18630
     components:
     - pos: -43.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18631
     components:
     - pos: -44.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18632
     components:
     - pos: -45.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18633
     components:
     - pos: -45.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18634
     components:
     - pos: -45.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18635
     components:
     - pos: -45.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18636
     components:
     - pos: -45.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18637
     components:
     - pos: -45.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18638
     components:
     - pos: -45.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18639
     components:
     - pos: -46.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18640
     components:
     - pos: -47.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18641
     components:
     - pos: -48.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18642
     components:
     - pos: -49.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18643
     components:
     - pos: -50.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18644
     components:
     - pos: -51.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18645
     components:
     - pos: -52.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18663
     components:
     - pos: -43.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18664
     components:
     - pos: -43.5,-24.5
@@ -37213,29 +35757,21 @@ entities:
     - pos: -55.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18717
     components:
     - pos: -54.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18718
     components:
     - pos: -53.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18719
     components:
     - pos: -52.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18720
     components:
     - pos: -51.5,-22.5
@@ -37271,8 +35807,6 @@ entities:
     - pos: -53.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18727
     components:
     - pos: -50.5,-33.5
@@ -37328,50 +35862,36 @@ entities:
     - pos: -53.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18745
     components:
     - pos: -54.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18746
     components:
     - pos: -54.5,-37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18747
     components:
     - pos: -54.5,-36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18748
     components:
     - pos: -54.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18749
     components:
     - pos: -54.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18750
     components:
     - pos: -55.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18751
     components:
     - pos: -55.5,-33.5
@@ -37382,43 +35902,31 @@ entities:
     - pos: -56.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18753
     components:
     - pos: -57.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18754
     components:
     - pos: -58.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18755
     components:
     - pos: -59.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18756
     components:
     - pos: -60.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18757
     components:
     - pos: -60.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18758
     components:
     - pos: -61.5,-35.5
@@ -37444,71 +35952,51 @@ entities:
     - pos: -59.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18763
     components:
     - pos: -59.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18764
     components:
     - pos: -59.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18765
     components:
     - pos: -59.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18766
     components:
     - pos: -59.5,-29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18767
     components:
     - pos: -59.5,-28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18768
     components:
     - pos: -59.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18769
     components:
     - pos: -59.5,-26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18770
     components:
     - pos: -59.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18771
     components:
     - pos: -60.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18772
     components:
     - pos: -61.5,-25.5
@@ -37519,71 +36007,51 @@ entities:
     - pos: -62.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18774
     components:
     - pos: -63.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18775
     components:
     - pos: -64.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18776
     components:
     - pos: -65.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18777
     components:
     - pos: -56.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18778
     components:
     - pos: -57.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18779
     components:
     - pos: -58.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18780
     components:
     - pos: -59.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18781
     components:
     - pos: -59.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18782
     components:
     - pos: -59.5,-24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18783
     components:
     - pos: -49.5,11.5
@@ -37594,43 +36062,31 @@ entities:
     - pos: -50.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18785
     components:
     - pos: -51.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18786
     components:
     - pos: -51.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18787
     components:
     - pos: -52.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18788
     components:
     - pos: -53.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18789
     components:
     - pos: -54.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18796
     components:
     - pos: -48.5,-31.5
@@ -37681,225 +36137,161 @@ entities:
     - pos: 40.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19026
     components:
     - pos: 39.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19027
     components:
     - pos: 38.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19028
     components:
     - pos: 37.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19029
     components:
     - pos: 36.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19030
     components:
     - pos: 36.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19031
     components:
     - pos: 36.5,55.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19032
     components:
     - pos: 36.5,56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19033
     components:
     - pos: 40.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19034
     components:
     - pos: 40.5,55.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19035
     components:
     - pos: 40.5,56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19344
     components:
     - pos: 9.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19345
     components:
     - pos: 10.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19346
     components:
     - pos: 10.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19347
     components:
     - pos: 10.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19348
     components:
     - pos: 10.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19349
     components:
     - pos: 10.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19350
     components:
     - pos: 10.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19351
     components:
     - pos: 10.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19352
     components:
     - pos: 8.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19353
     components:
     - pos: 7.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19354
     components:
     - pos: 7.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19355
     components:
     - pos: 11.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19356
     components:
     - pos: 12.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19357
     components:
     - pos: 13.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19358
     components:
     - pos: 14.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19359
     components:
     - pos: 15.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19360
     components:
     - pos: 16.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19361
     components:
     - pos: 17.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19362
     components:
     - pos: 18.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19363
     components:
     - pos: 19.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19364
     components:
     - pos: 20.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19365
     components:
     - pos: 21.5,7.5
@@ -37995,22 +36387,16 @@ entities:
     - pos: -20.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19384
     components:
     - pos: -20.5,58.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19385
     components:
     - pos: -20.5,59.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19413
     components:
     - pos: 23.5,-35.5
@@ -38021,8 +36407,6 @@ entities:
     - pos: -15.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19456
     components:
     - pos: -16.5,-16.5
@@ -38123,8 +36507,6 @@ entities:
     - pos: -26.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19476
     components:
     - pos: -26.5,-14.5
@@ -38140,8 +36522,6 @@ entities:
     - pos: -26.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19479
     components:
     - pos: -26.5,-11.5
@@ -38397,78 +36777,56 @@ entities:
     - pos: -14.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19531
     components:
     - pos: -14.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19532
     components:
     - pos: -14.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19533
     components:
     - pos: -14.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19534
     components:
     - pos: -14.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19535
     components:
     - pos: -14.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19536
     components:
     - pos: -14.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19537
     components:
     - pos: -13.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19538
     components:
     - pos: -12.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19539
     components:
     - pos: -11.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19540
     components:
     - pos: -10.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19541
     components:
     - pos: -13.5,-17.5
@@ -38489,50 +36847,36 @@ entities:
     - pos: -10.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19545
     components:
     - pos: -10.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19546
     components:
     - pos: -9.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19547
     components:
     - pos: -8.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19548
     components:
     - pos: -8.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19549
     components:
     - pos: -7.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19550
     components:
     - pos: -6.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19551
     components:
     - pos: -5.5,-16.5
@@ -38708,71 +37052,51 @@ entities:
     - pos: -10.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19586
     components:
     - pos: -10.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19587
     components:
     - pos: -10.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19588
     components:
     - pos: -11.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19589
     components:
     - pos: -12.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19590
     components:
     - pos: -13.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19591
     components:
     - pos: -14.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19592
     components:
     - pos: -15.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19593
     components:
     - pos: -16.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19594
     components:
     - pos: -17.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19595
     components:
     - pos: -20.5,-5.5
@@ -38828,15 +37152,11 @@ entities:
     - pos: -24.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19608
     components:
     - pos: -34.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19609
     components:
     - pos: -34.5,-17.5
@@ -38932,8 +37252,6 @@ entities:
     - pos: -34.5,-24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19628
     components:
     - pos: -34.5,-23.5
@@ -38979,8 +37297,6 @@ entities:
     - pos: -32.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19637
     components:
     - pos: -32.5,-10.5
@@ -39036,8 +37352,6 @@ entities:
     - pos: -39.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19648
     components:
     - pos: -40.5,-12.5
@@ -39073,141 +37387,101 @@ entities:
     - pos: -44.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19655
     components:
     - pos: -44.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19656
     components:
     - pos: -44.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19657
     components:
     - pos: -45.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19658
     components:
     - pos: -46.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19659
     components:
     - pos: -47.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19660
     components:
     - pos: -47.5,-10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19661
     components:
     - pos: -47.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19662
     components:
     - pos: -47.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19663
     components:
     - pos: -47.5,-7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19664
     components:
     - pos: -47.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19665
     components:
     - pos: -47.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19666
     components:
     - pos: -47.5,-4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19667
     components:
     - pos: -47.5,-3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19668
     components:
     - pos: -47.5,-2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19669
     components:
     - pos: -48.5,-2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19670
     components:
     - pos: -48.5,-1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19671
     components:
     - pos: -48.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19672
     components:
     - pos: -48.5,0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19673
     components:
     - pos: -48.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19674
     components:
     - pos: -49.5,1.5
@@ -39253,260 +37527,186 @@ entities:
     - pos: -48.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19683
     components:
     - pos: -49.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19684
     components:
     - pos: -50.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19685
     components:
     - pos: -51.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19686
     components:
     - pos: -52.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19687
     components:
     - pos: -53.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19688
     components:
     - pos: -54.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19689
     components:
     - pos: -54.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19690
     components:
     - pos: -54.5,-7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19691
     components:
     - pos: -54.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19692
     components:
     - pos: -54.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19693
     components:
     - pos: -54.5,-10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19694
     components:
     - pos: -54.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19695
     components:
     - pos: -54.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19696
     components:
     - pos: -54.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19697
     components:
     - pos: -54.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19698
     components:
     - pos: -54.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19699
     components:
     - pos: -54.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19700
     components:
     - pos: -54.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19701
     components:
     - pos: -54.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19702
     components:
     - pos: -54.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19703
     components:
     - pos: -53.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19704
     components:
     - pos: -52.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19705
     components:
     - pos: -52.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19706
     components:
     - pos: -51.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19707
     components:
     - pos: -50.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19708
     components:
     - pos: -49.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19709
     components:
     - pos: -48.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19710
     components:
     - pos: -47.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19711
     components:
     - pos: -46.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19712
     components:
     - pos: -45.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19713
     components:
     - pos: -44.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19714
     components:
     - pos: -44.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19715
     components:
     - pos: -44.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19716
     components:
     - pos: -44.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19717
     components:
     - pos: -44.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19718
     components:
     - pos: -44.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19719
     components:
     - pos: -42.5,-11.5
@@ -39547,36 +37747,26 @@ entities:
     - pos: -45.5,-10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19727
     components:
     - pos: -45.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19728
     components:
     - pos: -45.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19729
     components:
     - pos: -45.5,-7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19730
     components:
     - pos: -45.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19731
     components:
     - pos: -33.5,-8.5
@@ -39597,8 +37787,6 @@ entities:
     - pos: -33.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19735
     components:
     - pos: -33.5,-4.5
@@ -39674,15 +37862,11 @@ entities:
     - pos: -34.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19750
     components:
     - pos: -35.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19751
     components:
     - pos: -36.5,-8.5
@@ -39693,8 +37877,6 @@ entities:
     - pos: -37.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19753
     components:
     - pos: -38.5,-8.5
@@ -39705,8 +37887,6 @@ entities:
     - pos: -39.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19755
     components:
     - pos: -40.5,-8.5
@@ -39847,8 +38027,6 @@ entities:
     - pos: -54.5,38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20273
     components:
     - pos: -56.5,47.5
@@ -39864,8 +38042,6 @@ entities:
     - pos: -54.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20669
     components:
     - pos: 21.5,-83.5
@@ -39876,22 +38052,16 @@ entities:
     - pos: -43.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21498
     components:
     - pos: -46.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21499
     components:
     - pos: -45.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21718
     components:
     - pos: 14.5,50.5
@@ -39907,8 +38077,6 @@ entities:
     - pos: 1.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21942
     components:
     - pos: 10.5,38.5
@@ -39929,8 +38097,6 @@ entities:
     - pos: 16.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22007
     components:
     - pos: -64.5,-35.5
@@ -39941,169 +38107,121 @@ entities:
     - pos: -65.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22009
     components:
     - pos: -65.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22010
     components:
     - pos: -65.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22013
     components:
     - pos: -59.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22014
     components:
     - pos: -58.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22015
     components:
     - pos: -57.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22021
     components:
     - pos: -62.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22022
     components:
     - pos: -62.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22023
     components:
     - pos: -62.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22063
     components:
     - pos: 16.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22064
     components:
     - pos: 16.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22065
     components:
     - pos: 16.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22066
     components:
     - pos: 16.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22067
     components:
     - pos: 16.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22068
     components:
     - pos: 16.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22069
     components:
     - pos: 15.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22070
     components:
     - pos: 14.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22071
     components:
     - pos: 13.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22072
     components:
     - pos: 12.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22073
     components:
     - pos: 11.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22074
     components:
     - pos: 10.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22075
     components:
     - pos: 13.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22363
     components:
     - pos: 10.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22364
     components:
     - pos: -14.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22365
     components:
     - pos: -14.5,-32.5
@@ -40124,57 +38242,41 @@ entities:
     - pos: 15.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22704
     components:
     - pos: 16.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22740
     components:
     - pos: -36.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22822
     components:
     - pos: -31.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22823
     components:
     - pos: -32.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22824
     components:
     - pos: -33.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22825
     components:
     - pos: -34.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22826
     components:
     - pos: -35.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22887
     components:
     - pos: 66.5,-20.5
@@ -40295,8 +38397,6 @@ entities:
     - pos: -4.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23033
     components:
     - pos: 24.5,79.5
@@ -40327,15 +38427,11 @@ entities:
     - pos: -6.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23042
     components:
     - pos: -6.5,-64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23043
     components:
     - pos: -4.5,-61.5
@@ -40346,8 +38442,6 @@ entities:
     - pos: -4.5,-64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23487
     components:
     - pos: 0.5,-15.5
@@ -40358,78 +38452,56 @@ entities:
     - pos: -0.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23489
     components:
     - pos: -1.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23490
     components:
     - pos: -1.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23491
     components:
     - pos: -1.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23492
     components:
     - pos: -1.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23728
     components:
     - pos: -1.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23734
     components:
     - pos: -1.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24127
     components:
     - pos: -56.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24128
     components:
     - pos: -55.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24130
     components:
     - pos: -1.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24212
     components:
     - pos: -1.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24482
     components:
     - pos: -54.5,-2.5
@@ -40460,22 +38532,16 @@ entities:
     - pos: -0.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24798
     components:
     - pos: 0.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24804
     components:
     - pos: 0.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25113
     components:
     - pos: 13.5,53.5
@@ -40496,15 +38562,11 @@ entities:
     - pos: 21.5,-82.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25253
     components:
     - pos: -64.5,-39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25311
     components:
     - pos: 34.5,32.5
@@ -40515,8 +38577,6 @@ entities:
     - pos: 21.5,-81.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25313
     components:
     - pos: 19.5,-86.5
@@ -40542,15 +38602,11 @@ entities:
     - pos: 19.5,-82.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25318
     components:
     - pos: 19.5,-81.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25339
     components:
     - pos: -12.5,-7.5
@@ -40586,120 +38642,86 @@ entities:
     - pos: 55.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25388
     components:
     - pos: 56.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25389
     components:
     - pos: 57.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25390
     components:
     - pos: 58.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25391
     components:
     - pos: 59.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25392
     components:
     - pos: 60.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25393
     components:
     - pos: 61.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25394
     components:
     - pos: 62.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25395
     components:
     - pos: 63.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25396
     components:
     - pos: 64.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25397
     components:
     - pos: 65.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25398
     components:
     - pos: 66.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25399
     components:
     - pos: 67.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25400
     components:
     - pos: 68.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25401
     components:
     - pos: 69.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25402
     components:
     - pos: 70.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25403
     components:
     - pos: 71.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25404
     components:
     - pos: 72.5,5.5
@@ -40710,15 +38732,11 @@ entities:
     - pos: 72.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25406
     components:
     - pos: 72.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25407
     components:
     - pos: 73.5,7.5
@@ -40744,8 +38762,6 @@ entities:
     - pos: -37.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25544
     components:
     - pos: -36.5,45.5
@@ -40761,99 +38777,71 @@ entities:
     - pos: -34.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25547
     components:
     - pos: -33.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25548
     components:
     - pos: -33.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25549
     components:
     - pos: -37.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25550
     components:
     - pos: -33.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25551
     components:
     - pos: -33.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25552
     components:
     - pos: -37.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25553
     components:
     - pos: -37.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25554
     components:
     - pos: -37.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25555
     components:
     - pos: -37.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25556
     components:
     - pos: -33.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25557
     components:
     - pos: -34.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25558
     components:
     - pos: -35.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25559
     components:
     - pos: -36.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25718
     components:
     - pos: 30.5,74.5
@@ -40869,8 +38857,6 @@ entities:
     - pos: 30.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25721
     components:
     - pos: 30.5,77.5
@@ -40891,43 +38877,31 @@ entities:
     - pos: 30.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25837
     components:
     - pos: 29.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25838
     components:
     - pos: 28.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25839
     components:
     - pos: 27.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25840
     components:
     - pos: 26.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25841
     components:
     - pos: 31.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25842
     components:
     - pos: 31.5,73.5
@@ -40938,22 +38912,16 @@ entities:
     - pos: 32.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25844
     components:
     - pos: 32.5,74.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25845
     components:
     - pos: 32.5,75.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25963
     components:
     - pos: 50.5,-19.5
@@ -40989,127 +38957,91 @@ entities:
     - pos: -54.5,52.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26015
     components:
     - pos: -54.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26016
     components:
     - pos: -53.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26017
     components:
     - pos: -52.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26018
     components:
     - pos: -51.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26019
     components:
     - pos: -50.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26020
     components:
     - pos: -49.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26021
     components:
     - pos: -48.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26022
     components:
     - pos: -47.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26023
     components:
     - pos: -47.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26024
     components:
     - pos: -46.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26025
     components:
     - pos: -45.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26026
     components:
     - pos: -44.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26027
     components:
     - pos: -43.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26028
     components:
     - pos: -42.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26029
     components:
     - pos: -41.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26030
     components:
     - pos: -40.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26126
     components:
     - pos: -45.5,-39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26127
     components:
     - pos: -46.5,-39.5
@@ -41125,8 +39057,6 @@ entities:
     - pos: -26.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26216
     components:
     - pos: -26.5,18.5
@@ -41222,29 +39152,21 @@ entities:
     - pos: -34.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26235
     components:
     - pos: -34.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26236
     components:
     - pos: -34.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 26237
     components:
     - pos: -34.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
 - proto: CableApcStack
   entities:
   - uid: 4173
@@ -41380,36 +39302,26 @@ entities:
     - pos: 16.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 361
     components:
     - pos: 16.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 1081
     components:
     - pos: 14.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2220
     components:
     - pos: 16.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2225
     components:
     - pos: 16.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2230
     components:
     - pos: 16.5,-15.5
@@ -41420,29 +39332,21 @@ entities:
     - pos: 15.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3777
     components:
     - pos: 15.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3778
     components:
     - pos: 16.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4164
     components:
     - pos: -19.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4487
     components:
     - pos: -22.5,45.5
@@ -41453,15 +39357,11 @@ entities:
     - pos: -28.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4532
     components:
     - pos: -22.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4533
     components:
     - pos: -28.5,45.5
@@ -42692,71 +40592,51 @@ entities:
     - pos: 29.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4784
     components:
     - pos: 28.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4785
     components:
     - pos: 27.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4786
     components:
     - pos: 26.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4787
     components:
     - pos: 25.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4788
     components:
     - pos: 24.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4789
     components:
     - pos: 23.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4790
     components:
     - pos: 22.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4791
     components:
     - pos: 21.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4792
     components:
     - pos: 20.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4793
     components:
     - pos: 19.5,30.5
@@ -42977,295 +40857,211 @@ entities:
     - pos: -5.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4837
     components:
     - pos: -5.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4838
     components:
     - pos: -5.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4839
     components:
     - pos: -5.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4840
     components:
     - pos: -5.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4841
     components:
     - pos: -5.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4842
     components:
     - pos: -5.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4843
     components:
     - pos: -5.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4844
     components:
     - pos: -5.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4845
     components:
     - pos: -6.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4846
     components:
     - pos: -7.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4847
     components:
     - pos: -8.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4848
     components:
     - pos: -8.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4849
     components:
     - pos: -8.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4850
     components:
     - pos: -8.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4851
     components:
     - pos: -8.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4852
     components:
     - pos: -8.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4853
     components:
     - pos: -8.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4854
     components:
     - pos: -8.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4855
     components:
     - pos: -9.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4856
     components:
     - pos: -10.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4857
     components:
     - pos: -10.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4858
     components:
     - pos: -10.5,10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4859
     components:
     - pos: -10.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4860
     components:
     - pos: -10.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4861
     components:
     - pos: -10.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4862
     components:
     - pos: -10.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4863
     components:
     - pos: -10.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4864
     components:
     - pos: -10.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4865
     components:
     - pos: -11.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4866
     components:
     - pos: -12.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4867
     components:
     - pos: -13.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4868
     components:
     - pos: -14.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4869
     components:
     - pos: -15.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4870
     components:
     - pos: -16.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4871
     components:
     - pos: -16.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4872
     components:
     - pos: -16.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4873
     components:
     - pos: -16.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4874
     components:
     - pos: -16.5,0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4875
     components:
     - pos: -16.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4876
     components:
     - pos: -15.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4877
     components:
     - pos: -14.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4878
     components:
     - pos: -14.5,-1.5
@@ -43281,141 +41077,101 @@ entities:
     - pos: -7.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4881
     components:
     - pos: -8.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4882
     components:
     - pos: -9.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4883
     components:
     - pos: -10.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4884
     components:
     - pos: -11.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4885
     components:
     - pos: -12.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4886
     components:
     - pos: -13.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4887
     components:
     - pos: -14.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4888
     components:
     - pos: -14.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4889
     components:
     - pos: -14.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4890
     components:
     - pos: -14.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4891
     components:
     - pos: -14.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4892
     components:
     - pos: -14.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4893
     components:
     - pos: -14.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4894
     components:
     - pos: -13.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4895
     components:
     - pos: -12.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4896
     components:
     - pos: -11.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4897
     components:
     - pos: -10.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4898
     components:
     - pos: -10.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4899
     components:
     - pos: -10.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4904
     components:
     - pos: -6.5,-45.5
@@ -43431,8 +41187,6 @@ entities:
     - pos: -12.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4907
     components:
     - pos: -7.5,-45.5
@@ -43443,421 +41197,301 @@ entities:
     - pos: -8.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4909
     components:
     - pos: -9.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4910
     components:
     - pos: -10.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4911
     components:
     - pos: -11.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4912
     components:
     - pos: -12.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4913
     components:
     - pos: -13.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4914
     components:
     - pos: -14.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4915
     components:
     - pos: -15.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4916
     components:
     - pos: -16.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4922
     components:
     - pos: -22.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4923
     components:
     - pos: -22.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4924
     components:
     - pos: -23.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4925
     components:
     - pos: -24.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4926
     components:
     - pos: -25.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4927
     components:
     - pos: -26.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4928
     components:
     - pos: -27.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4929
     components:
     - pos: -27.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4930
     components:
     - pos: -27.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4931
     components:
     - pos: -28.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4932
     components:
     - pos: -29.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4933
     components:
     - pos: -30.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4934
     components:
     - pos: -31.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4935
     components:
     - pos: -32.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4936
     components:
     - pos: -33.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4937
     components:
     - pos: -34.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4938
     components:
     - pos: -35.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4939
     components:
     - pos: -36.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4940
     components:
     - pos: -37.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4941
     components:
     - pos: -38.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4942
     components:
     - pos: -39.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4943
     components:
     - pos: -40.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4944
     components:
     - pos: -41.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4945
     components:
     - pos: -42.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4946
     components:
     - pos: -43.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4947
     components:
     - pos: -44.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4948
     components:
     - pos: -45.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4949
     components:
     - pos: -46.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4950
     components:
     - pos: -47.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4951
     components:
     - pos: -48.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4952
     components:
     - pos: -49.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4953
     components:
     - pos: -50.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4954
     components:
     - pos: -51.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4955
     components:
     - pos: -52.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4956
     components:
     - pos: -53.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4957
     components:
     - pos: -54.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4958
     components:
     - pos: -54.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4959
     components:
     - pos: -54.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4960
     components:
     - pos: -54.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4961
     components:
     - pos: -54.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4962
     components:
     - pos: -54.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4963
     components:
     - pos: -54.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4964
     components:
     - pos: -54.5,-39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4965
     components:
     - pos: -54.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4966
     components:
     - pos: -54.5,-37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4967
     components:
     - pos: -54.5,-36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4968
     components:
     - pos: -54.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4969
     components:
     - pos: -54.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4970
     components:
     - pos: -55.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4971
     components:
     - pos: -56.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4972
     components:
     - pos: -57.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4973
     components:
     - pos: -4.5,-51.5
@@ -43873,134 +41507,96 @@ entities:
     - pos: -2.5,-51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4976
     components:
     - pos: -2.5,-50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4977
     components:
     - pos: -2.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4978
     components:
     - pos: -1.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4979
     components:
     - pos: -0.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4980
     components:
     - pos: 0.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4981
     components:
     - pos: 1.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4982
     components:
     - pos: 2.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4983
     components:
     - pos: 3.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4984
     components:
     - pos: 4.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4985
     components:
     - pos: 5.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4986
     components:
     - pos: 6.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4995
     components:
     - pos: 6.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4996
     components:
     - pos: 6.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4997
     components:
     - pos: 7.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4998
     components:
     - pos: 8.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4999
     components:
     - pos: 9.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5000
     components:
     - pos: 10.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5001
     components:
     - pos: 11.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5002
     components:
     - pos: 12.5,-47.5
@@ -44161,176 +41757,126 @@ entities:
     - pos: 54.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5034
     components:
     - pos: 54.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5035
     components:
     - pos: 54.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5036
     components:
     - pos: 54.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5037
     components:
     - pos: 53.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5038
     components:
     - pos: 52.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5039
     components:
     - pos: 51.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5040
     components:
     - pos: 50.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5041
     components:
     - pos: 49.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5042
     components:
     - pos: 48.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5043
     components:
     - pos: 47.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5044
     components:
     - pos: 46.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5045
     components:
     - pos: 45.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5046
     components:
     - pos: 44.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5047
     components:
     - pos: 43.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5048
     components:
     - pos: 42.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5049
     components:
     - pos: 41.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5050
     components:
     - pos: 41.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5051
     components:
     - pos: 40.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5052
     components:
     - pos: 39.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5053
     components:
     - pos: 38.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5054
     components:
     - pos: 37.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5055
     components:
     - pos: 36.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5056
     components:
     - pos: 35.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5057
     components:
     - pos: 35.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5058
     components:
     - pos: 34.5,7.5
@@ -44376,127 +41922,91 @@ entities:
     - pos: 31.5,-4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5067
     components:
     - pos: 31.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5068
     components:
     - pos: 31.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5069
     components:
     - pos: 31.5,-7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5070
     components:
     - pos: 31.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5071
     components:
     - pos: 31.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5072
     components:
     - pos: 31.5,-10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5073
     components:
     - pos: 31.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5074
     components:
     - pos: 30.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5075
     components:
     - pos: 29.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5076
     components:
     - pos: 28.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5077
     components:
     - pos: 27.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5078
     components:
     - pos: 26.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5079
     components:
     - pos: 25.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5080
     components:
     - pos: 24.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5081
     components:
     - pos: 23.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5082
     components:
     - pos: 22.5,-11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5083
     components:
     - pos: 22.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5084
     components:
     - pos: 21.5,-12.5
@@ -44807,239 +42317,171 @@ entities:
     - pos: 34.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5146
     components:
     - pos: 35.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5147
     components:
     - pos: 36.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5148
     components:
     - pos: 37.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5149
     components:
     - pos: 38.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5150
     components:
     - pos: 39.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5151
     components:
     - pos: 39.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5152
     components:
     - pos: 39.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5153
     components:
     - pos: 39.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5154
     components:
     - pos: 39.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5155
     components:
     - pos: 39.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5156
     components:
     - pos: 39.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5157
     components:
     - pos: 39.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5158
     components:
     - pos: 39.5,38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5159
     components:
     - pos: 39.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5160
     components:
     - pos: 40.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5161
     components:
     - pos: 41.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5162
     components:
     - pos: 42.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5163
     components:
     - pos: 43.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5164
     components:
     - pos: 44.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5165
     components:
     - pos: 45.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5166
     components:
     - pos: 46.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5167
     components:
     - pos: 47.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5168
     components:
     - pos: 47.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5169
     components:
     - pos: 47.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5170
     components:
     - pos: 47.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5171
     components:
     - pos: 47.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5172
     components:
     - pos: 47.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5173
     components:
     - pos: 47.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5174
     components:
     - pos: 47.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5175
     components:
     - pos: 47.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5176
     components:
     - pos: 11.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5177
     components:
     - pos: 11.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5178
     components:
     - pos: 11.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5179
     components:
     - pos: 11.5,-43.5
@@ -45050,15 +42492,11 @@ entities:
     - pos: 11.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5181
     components:
     - pos: 11.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5182
     components:
     - pos: 12.5,-41.5
@@ -45074,22 +42512,16 @@ entities:
     - pos: 55.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5201
     components:
     - pos: 56.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5202
     components:
     - pos: 57.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5203
     components:
     - pos: 57.5,6.5
@@ -45105,92 +42537,66 @@ entities:
     - pos: 25.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5206
     components:
     - pos: 24.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5207
     components:
     - pos: 23.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5208
     components:
     - pos: 22.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5209
     components:
     - pos: 21.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5210
     components:
     - pos: 20.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5211
     components:
     - pos: 19.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5212
     components:
     - pos: 19.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5213
     components:
     - pos: 19.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5214
     components:
     - pos: 19.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5215
     components:
     - pos: 19.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5216
     components:
     - pos: 19.5,0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5217
     components:
     - pos: 19.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5218
     components:
     - pos: 19.5,-1.5
@@ -45201,8 +42607,6 @@ entities:
     - pos: -25.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5226
     components:
     - pos: -23.5,44.5
@@ -45218,29 +42622,21 @@ entities:
     - pos: -21.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5229
     components:
     - pos: -22.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5230
     components:
     - pos: -22.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5231
     components:
     - pos: -28.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5232
     components:
     - pos: -16.5,39.5
@@ -45281,50 +42677,36 @@ entities:
     - pos: -28.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5241
     components:
     - pos: -27.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5242
     components:
     - pos: -26.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5243
     components:
     - pos: -25.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5244
     components:
     - pos: -24.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5245
     components:
     - pos: -23.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5246
     components:
     - pos: -25.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5247
     components:
     - pos: -18.5,44.5
@@ -45390,8 +42772,6 @@ entities:
     - pos: -29.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5296
     components:
     - pos: -12.5,40.5
@@ -45462,57 +42842,41 @@ entities:
     - pos: -13.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5421
     components:
     - pos: -13.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5422
     components:
     - pos: -15.5,51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5423
     components:
     - pos: -14.5,51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5424
     components:
     - pos: -13.5,51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5425
     components:
     - pos: -12.5,51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5426
     components:
     - pos: -11.5,51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5427
     components:
     - pos: -10.5,51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5499
     components:
     - pos: -20.5,45.5
@@ -45578,8 +42942,6 @@ entities:
     - pos: -33.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5612
     components:
     - pos: -20.5,55.5
@@ -45595,771 +42957,551 @@ entities:
     - pos: -20.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5615
     components:
     - pos: -20.5,58.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5616
     components:
     - pos: -20.5,59.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5617
     components:
     - pos: -20.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5627
     components:
     - pos: -37.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5628
     components:
     - pos: -30.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5629
     components:
     - pos: -21.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5630
     components:
     - pos: -20.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5631
     components:
     - pos: -20.5,62.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5632
     components:
     - pos: -20.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5633
     components:
     - pos: -20.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5634
     components:
     - pos: -21.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5635
     components:
     - pos: -22.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5636
     components:
     - pos: -23.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5637
     components:
     - pos: -24.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5638
     components:
     - pos: -25.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5639
     components:
     - pos: -26.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5640
     components:
     - pos: -27.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5641
     components:
     - pos: -28.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5642
     components:
     - pos: -29.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5643
     components:
     - pos: -30.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5679
     components:
     - pos: -22.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5680
     components:
     - pos: -12.5,83.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5689
     components:
     - pos: -20.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5701
     components:
     - pos: -14.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5702
     components:
     - pos: -25.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5703
     components:
     - pos: -32.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5704
     components:
     - pos: -38.5,83.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5730
     components:
     - pos: -33.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5789
     components:
     - pos: -26.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5799
     components:
     - pos: -24.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5856
     components:
     - pos: -38.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5869
     components:
     - pos: -31.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5870
     components:
     - pos: -13.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5922
     components:
     - pos: -33.5,75.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5927
     components:
     - pos: -38.5,82.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5928
     components:
     - pos: -33.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5929
     components:
     - pos: -15.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5984
     components:
     - pos: -12.5,81.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5985
     components:
     - pos: -17.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5986
     components:
     - pos: -28.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5987
     components:
     - pos: -35.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5988
     components:
     - pos: -38.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5993
     components:
     - pos: -33.5,69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6102
     components:
     - pos: -12.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6103
     components:
     - pos: -16.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6169
     components:
     - pos: -27.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6170
     components:
     - pos: -34.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6171
     components:
     - pos: -38.5,81.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6176
     components:
     - pos: -33.5,74.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6178
     components:
     - pos: -15.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6179
     components:
     - pos: -14.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6180
     components:
     - pos: -13.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6181
     components:
     - pos: -12.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6182
     components:
     - pos: -35.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6183
     components:
     - pos: -36.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6184
     components:
     - pos: -37.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6185
     components:
     - pos: -38.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6186
     components:
     - pos: -38.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6187
     components:
     - pos: -38.5,74.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6188
     components:
     - pos: -38.5,75.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6189
     components:
     - pos: -38.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6190
     components:
     - pos: -38.5,77.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6191
     components:
     - pos: -38.5,78.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6192
     components:
     - pos: -38.5,79.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6218
     components:
     - pos: -23.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6219
     components:
     - pos: -12.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6232
     components:
     - pos: -12.5,79.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6233
     components:
     - pos: -12.5,78.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6234
     components:
     - pos: -12.5,77.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6235
     components:
     - pos: -12.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6236
     components:
     - pos: -12.5,75.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6237
     components:
     - pos: -12.5,74.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6238
     components:
     - pos: -12.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6239
     components:
     - pos: -12.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6240
     components:
     - pos: -12.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6241
     components:
     - pos: -12.5,69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6242
     components:
     - pos: -12.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6243
     components:
     - pos: -12.5,67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6244
     components:
     - pos: -12.5,66.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6245
     components:
     - pos: -12.5,65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6246
     components:
     - pos: -12.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6247
     components:
     - pos: -12.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6248
     components:
     - pos: -12.5,62.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6249
     components:
     - pos: -12.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6250
     components:
     - pos: -12.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6251
     components:
     - pos: -13.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6252
     components:
     - pos: -14.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6253
     components:
     - pos: -15.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6254
     components:
     - pos: -16.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6255
     components:
     - pos: -38.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6256
     components:
     - pos: -38.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6257
     components:
     - pos: -38.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6258
     components:
     - pos: -38.5,69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6259
     components:
     - pos: -38.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6260
     components:
     - pos: -38.5,67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6261
     components:
     - pos: -38.5,66.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6262
     components:
     - pos: -38.5,65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6263
     components:
     - pos: -38.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6264
     components:
     - pos: -38.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6265
     components:
     - pos: -38.5,62.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6266
     components:
     - pos: -38.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6267
     components:
     - pos: -38.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6268
     components:
     - pos: -37.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6269
     components:
     - pos: -36.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6270
     components:
     - pos: -35.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6271
     components:
     - pos: -34.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6272
     components:
     - pos: -33.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6273
     components:
     - pos: -32.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6274
     components:
     - pos: -31.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6936
     components:
     - pos: -28.5,15.5
@@ -46405,43 +43547,31 @@ entities:
     - pos: -41.5,-51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10176
     components:
     - pos: -41.5,-52.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10177
     components:
     - pos: -40.5,-51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10178
     components:
     - pos: -40.5,-50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10179
     components:
     - pos: -40.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10180
     components:
     - pos: -41.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10181
     components:
     - pos: -41.5,-48.5
@@ -46452,99 +43582,71 @@ entities:
     - pos: -42.5,-51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10194
     components:
     - pos: -41.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10195
     components:
     - pos: -58.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10196
     components:
     - pos: -59.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10197
     components:
     - pos: -59.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10198
     components:
     - pos: -59.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10199
     components:
     - pos: -59.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10200
     components:
     - pos: -59.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10201
     components:
     - pos: -59.5,-29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10202
     components:
     - pos: -59.5,-28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10203
     components:
     - pos: -59.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10204
     components:
     - pos: -59.5,-26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10205
     components:
     - pos: -59.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10206
     components:
     - pos: -60.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10207
     components:
     - pos: -61.5,-25.5
@@ -46555,960 +43657,686 @@ entities:
     - pos: -62.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10209
     components:
     - pos: -62.5,-26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10211
     components:
     - pos: -63.5,-26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10212
     components:
     - pos: -64.5,-26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10213
     components:
     - pos: -65.5,-26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10215
     components:
     - pos: -62.5,-24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10216
     components:
     - pos: -65.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10217
     components:
     - pos: -66.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10226
     components:
     - pos: -65.5,-24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10340
     components:
     - pos: -16.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11436
     components:
     - pos: -33.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11505
     components:
     - pos: -36.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11506
     components:
     - pos: -29.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11507
     components:
     - pos: -18.5,84.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11508
     components:
     - pos: -12.5,82.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11752
     components:
     - pos: -75.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11753
     components:
     - pos: -75.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11754
     components:
     - pos: -75.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11755
     components:
     - pos: -75.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11756
     components:
     - pos: -75.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11757
     components:
     - pos: -75.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11758
     components:
     - pos: -75.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11759
     components:
     - pos: -75.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11760
     components:
     - pos: -73.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11761
     components:
     - pos: -73.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11762
     components:
     - pos: -73.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11763
     components:
     - pos: -73.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11764
     components:
     - pos: -73.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11765
     components:
     - pos: -73.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11766
     components:
     - pos: -73.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11767
     components:
     - pos: -73.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11768
     components:
     - pos: -74.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11769
     components:
     - pos: -74.5,10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11770
     components:
     - pos: -74.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11771
     components:
     - pos: -74.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11772
     components:
     - pos: -74.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11773
     components:
     - pos: -75.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11774
     components:
     - pos: -75.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11775
     components:
     - pos: -75.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11776
     components:
     - pos: -75.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11777
     components:
     - pos: -75.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11778
     components:
     - pos: -75.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11779
     components:
     - pos: -75.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11780
     components:
     - pos: -75.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11781
     components:
     - pos: -73.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11782
     components:
     - pos: -73.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11783
     components:
     - pos: -73.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11784
     components:
     - pos: -73.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11785
     components:
     - pos: -73.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11786
     components:
     - pos: -73.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11787
     components:
     - pos: -73.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11788
     components:
     - pos: -73.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11789
     components:
     - pos: -71.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11790
     components:
     - pos: -71.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11791
     components:
     - pos: -71.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11792
     components:
     - pos: -71.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11793
     components:
     - pos: -71.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11794
     components:
     - pos: -71.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11795
     components:
     - pos: -71.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11796
     components:
     - pos: -71.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11797
     components:
     - pos: -70.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11798
     components:
     - pos: -69.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11799
     components:
     - pos: -69.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11800
     components:
     - pos: -69.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11801
     components:
     - pos: -69.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11802
     components:
     - pos: -69.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11803
     components:
     - pos: -69.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11804
     components:
     - pos: -69.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11805
     components:
     - pos: -69.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11806
     components:
     - pos: -67.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11807
     components:
     - pos: -67.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11808
     components:
     - pos: -67.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11809
     components:
     - pos: -67.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11810
     components:
     - pos: -67.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11811
     components:
     - pos: -67.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11812
     components:
     - pos: -67.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11813
     components:
     - pos: -67.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11814
     components:
     - pos: -65.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11815
     components:
     - pos: -65.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11816
     components:
     - pos: -65.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11817
     components:
     - pos: -65.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11818
     components:
     - pos: -65.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11819
     components:
     - pos: -65.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11820
     components:
     - pos: -65.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11821
     components:
     - pos: -65.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11822
     components:
     - pos: -66.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11823
     components:
     - pos: -70.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11824
     components:
     - pos: -70.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11825
     components:
     - pos: -70.5,10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11826
     components:
     - pos: -70.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11827
     components:
     - pos: -71.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11828
     components:
     - pos: -71.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11829
     components:
     - pos: -71.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11830
     components:
     - pos: -71.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11831
     components:
     - pos: -71.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11832
     components:
     - pos: -71.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11833
     components:
     - pos: -71.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11834
     components:
     - pos: -71.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11835
     components:
     - pos: -69.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11836
     components:
     - pos: -69.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11837
     components:
     - pos: -69.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11838
     components:
     - pos: -69.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11839
     components:
     - pos: -69.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11840
     components:
     - pos: -69.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11841
     components:
     - pos: -69.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11842
     components:
     - pos: -69.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11843
     components:
     - pos: -70.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11844
     components:
     - pos: -67.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11845
     components:
     - pos: -67.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11846
     components:
     - pos: -67.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11847
     components:
     - pos: -67.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11848
     components:
     - pos: -67.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11849
     components:
     - pos: -67.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11850
     components:
     - pos: -67.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11851
     components:
     - pos: -67.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11852
     components:
     - pos: -65.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11853
     components:
     - pos: -65.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11854
     components:
     - pos: -65.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11855
     components:
     - pos: -65.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11856
     components:
     - pos: -65.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11857
     components:
     - pos: -65.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11858
     components:
     - pos: -65.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11859
     components:
     - pos: -65.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11860
     components:
     - pos: -66.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11862
     components:
     - pos: -53.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11863
     components:
     - pos: -54.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11864
     components:
     - pos: -55.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11865
     components:
     - pos: -56.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11866
     components:
     - pos: -57.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11867
     components:
     - pos: -58.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11868
     components:
     - pos: -59.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11875
     components:
     - pos: -53.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11876
     components:
     - pos: -52.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11877
     components:
     - pos: -51.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11878
     components:
     - pos: -51.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11879
     components:
     - pos: -50.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12714
     components:
     - pos: 14.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12715
     components:
     - pos: 14.5,-22.5
@@ -47524,57 +44352,41 @@ entities:
     - pos: 15.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12724
     components:
     - pos: 16.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13011
     components:
     - pos: -23.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13149
     components:
     - pos: -22.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13240
     components:
     - pos: -24.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13270
     components:
     - pos: -25.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13378
     components:
     - pos: -17.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13379
     components:
     - pos: -18.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13957
     components:
     - pos: 17.5,-11.5
@@ -47805,8 +44617,6 @@ entities:
     - pos: 19.5,-58.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14269
     components:
     - pos: 19.5,-59.5
@@ -47832,141 +44642,101 @@ entities:
     - pos: 19.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14274
     components:
     - pos: 19.5,-64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14275
     components:
     - pos: 19.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14276
     components:
     - pos: 19.5,-66.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14277
     components:
     - pos: 19.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14278
     components:
     - pos: 19.5,-68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14279
     components:
     - pos: 19.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14280
     components:
     - pos: 19.5,-70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14281
     components:
     - pos: 19.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14282
     components:
     - pos: 19.5,-72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14283
     components:
     - pos: 19.5,-73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14284
     components:
     - pos: 19.5,-74.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14285
     components:
     - pos: 19.5,-75.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14286
     components:
     - pos: 19.5,-76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14287
     components:
     - pos: 19.5,-77.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14288
     components:
     - pos: 19.5,-78.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14289
     components:
     - pos: 19.5,-79.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14290
     components:
     - pos: 19.5,-80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14291
     components:
     - pos: 19.5,-81.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14292
     components:
     - pos: 19.5,-82.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14293
     components:
     - pos: 19.5,-83.5
@@ -48017,8 +44787,6 @@ entities:
     - pos: 29.5,-91.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14313
     components:
     - pos: 13.5,-91.5
@@ -48034,8 +44802,6 @@ entities:
     - pos: 11.5,-91.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15170
     components:
     - pos: -22.5,56.5
@@ -48046,162 +44812,116 @@ entities:
     - pos: -21.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16303
     components:
     - pos: -21.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16435
     components:
     - pos: -30.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16436
     components:
     - pos: -30.5,36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16437
     components:
     - pos: -30.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16438
     components:
     - pos: -30.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16439
     components:
     - pos: -31.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16440
     components:
     - pos: -31.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16441
     components:
     - pos: -30.5,38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16442
     components:
     - pos: -30.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16443
     components:
     - pos: -30.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16444
     components:
     - pos: -30.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16445
     components:
     - pos: -30.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16446
     components:
     - pos: -30.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16447
     components:
     - pos: -30.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16448
     components:
     - pos: -30.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16449
     components:
     - pos: -30.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16450
     components:
     - pos: -30.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16451
     components:
     - pos: -30.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16452
     components:
     - pos: -30.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16453
     components:
     - pos: -30.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16454
     components:
     - pos: -31.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16455
     components:
     - pos: -31.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16456
     components:
     - pos: -31.5,32.5
@@ -48252,162 +44972,116 @@ entities:
     - pos: 40.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17296
     components:
     - pos: 47.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17297
     components:
     - pos: 47.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17314
     components:
     - pos: 47.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17315
     components:
     - pos: 46.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17317
     components:
     - pos: 45.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17318
     components:
     - pos: 44.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17319
     components:
     - pos: 43.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17320
     components:
     - pos: 42.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17321
     components:
     - pos: 41.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17322
     components:
     - pos: 40.5,50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17323
     components:
     - pos: 40.5,49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17324
     components:
     - pos: 40.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17325
     components:
     - pos: 40.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17326
     components:
     - pos: 40.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17327
     components:
     - pos: 45.5,51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17328
     components:
     - pos: 45.5,52.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17329
     components:
     - pos: 45.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17330
     components:
     - pos: 45.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18371
     components:
     - pos: -21.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18372
     components:
     - pos: -20.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18373
     components:
     - pos: -19.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18835
     components:
     - pos: -9.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19054
     components:
     - pos: 20.5,50.5
@@ -48428,22 +45102,16 @@ entities:
     - pos: 20.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19058
     components:
     - pos: 20.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19059
     components:
     - pos: 20.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19060
     components:
     - pos: 19.5,45.5
@@ -48454,92 +45122,66 @@ entities:
     - pos: 18.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19062
     components:
     - pos: 17.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19063
     components:
     - pos: 16.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19064
     components:
     - pos: 15.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19065
     components:
     - pos: 14.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19066
     components:
     - pos: 13.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19067
     components:
     - pos: 12.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19068
     components:
     - pos: 11.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19069
     components:
     - pos: 11.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19070
     components:
     - pos: 10.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19071
     components:
     - pos: 9.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19072
     components:
     - pos: 8.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19073
     components:
     - pos: 7.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19074
     components:
     - pos: -5.5,32.5
@@ -48725,15 +45367,11 @@ entities:
     - pos: -16.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20537
     components:
     - pos: -8.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20538
     components:
     - pos: -8.5,36.5
@@ -48744,1576 +45382,1126 @@ entities:
     - pos: -67.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20917
     components:
     - pos: -68.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20918
     components:
     - pos: -83.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20919
     components:
     - pos: -83.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20920
     components:
     - pos: -83.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20921
     components:
     - pos: -83.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20922
     components:
     - pos: -83.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20923
     components:
     - pos: -83.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20924
     components:
     - pos: -83.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20925
     components:
     - pos: -83.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20926
     components:
     - pos: -81.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20927
     components:
     - pos: -81.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20928
     components:
     - pos: -81.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20929
     components:
     - pos: -81.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20930
     components:
     - pos: -81.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20931
     components:
     - pos: -81.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20932
     components:
     - pos: -81.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20933
     components:
     - pos: -81.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20934
     components:
     - pos: -79.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20935
     components:
     - pos: -79.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20936
     components:
     - pos: -79.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20937
     components:
     - pos: -79.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20938
     components:
     - pos: -79.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20939
     components:
     - pos: -79.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20940
     components:
     - pos: -79.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20941
     components:
     - pos: -79.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20942
     components:
     - pos: -77.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20943
     components:
     - pos: -77.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20944
     components:
     - pos: -77.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20945
     components:
     - pos: -77.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20946
     components:
     - pos: -77.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20947
     components:
     - pos: -77.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20948
     components:
     - pos: -77.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20949
     components:
     - pos: -77.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20950
     components:
     - pos: -75.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20951
     components:
     - pos: -75.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20952
     components:
     - pos: -75.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20953
     components:
     - pos: -75.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20954
     components:
     - pos: -75.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20955
     components:
     - pos: -75.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20956
     components:
     - pos: -75.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20957
     components:
     - pos: -75.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20958
     components:
     - pos: -85.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20959
     components:
     - pos: -84.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20960
     components:
     - pos: -83.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20961
     components:
     - pos: -82.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20962
     components:
     - pos: -82.5,-24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20963
     components:
     - pos: -82.5,-26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20964
     components:
     - pos: -82.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20965
     components:
     - pos: -82.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20966
     components:
     - pos: -83.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20967
     components:
     - pos: -83.5,-28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20968
     components:
     - pos: -83.5,-29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20969
     components:
     - pos: -83.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20970
     components:
     - pos: -83.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20971
     components:
     - pos: -83.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20972
     components:
     - pos: -83.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20973
     components:
     - pos: -83.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20974
     components:
     - pos: -81.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20975
     components:
     - pos: -81.5,-28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20976
     components:
     - pos: -81.5,-29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20977
     components:
     - pos: -81.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20978
     components:
     - pos: -81.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20979
     components:
     - pos: -81.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20980
     components:
     - pos: -81.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20981
     components:
     - pos: -81.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20982
     components:
     - pos: -79.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20983
     components:
     - pos: -79.5,-28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20984
     components:
     - pos: -79.5,-29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20985
     components:
     - pos: -79.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20986
     components:
     - pos: -79.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20987
     components:
     - pos: -79.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20988
     components:
     - pos: -79.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20989
     components:
     - pos: -79.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20990
     components:
     - pos: -77.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20991
     components:
     - pos: -77.5,-28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20992
     components:
     - pos: -77.5,-29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20993
     components:
     - pos: -77.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20994
     components:
     - pos: -77.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20995
     components:
     - pos: -77.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20996
     components:
     - pos: -77.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20997
     components:
     - pos: -77.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20998
     components:
     - pos: -78.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20999
     components:
     - pos: -75.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21000
     components:
     - pos: -75.5,-28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21001
     components:
     - pos: -75.5,-29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21002
     components:
     - pos: -75.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21003
     components:
     - pos: -75.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21004
     components:
     - pos: -75.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21005
     components:
     - pos: -75.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21006
     components:
     - pos: -75.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21007
     components:
     - pos: -73.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21008
     components:
     - pos: -73.5,-28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21009
     components:
     - pos: -73.5,-29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21010
     components:
     - pos: -73.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21011
     components:
     - pos: -73.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21012
     components:
     - pos: -73.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21013
     components:
     - pos: -73.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21014
     components:
     - pos: -73.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21015
     components:
     - pos: -74.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21016
     components:
     - pos: -73.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21017
     components:
     - pos: -73.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21018
     components:
     - pos: -73.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21019
     components:
     - pos: -73.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21020
     components:
     - pos: -73.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21021
     components:
     - pos: -73.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21022
     components:
     - pos: -73.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21023
     components:
     - pos: -73.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21024
     components:
     - pos: -74.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21025
     components:
     - pos: -78.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21252
     components:
     - pos: -41.5,-53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21253
     components:
     - pos: -41.5,-54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21254
     components:
     - pos: -41.5,-55.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21255
     components:
     - pos: -32.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21256
     components:
     - pos: -33.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21257
     components:
     - pos: -34.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21258
     components:
     - pos: -35.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21259
     components:
     - pos: -36.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21260
     components:
     - pos: -37.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21261
     components:
     - pos: -38.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21262
     components:
     - pos: -39.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21263
     components:
     - pos: -32.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21264
     components:
     - pos: -33.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21265
     components:
     - pos: -34.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21266
     components:
     - pos: -35.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21267
     components:
     - pos: -36.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21268
     components:
     - pos: -37.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21269
     components:
     - pos: -38.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21270
     components:
     - pos: -39.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21271
     components:
     - pos: -32.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21272
     components:
     - pos: -33.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21273
     components:
     - pos: -34.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21274
     components:
     - pos: -35.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21275
     components:
     - pos: -36.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21276
     components:
     - pos: -37.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21277
     components:
     - pos: -38.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21278
     components:
     - pos: -39.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21279
     components:
     - pos: -32.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21280
     components:
     - pos: -33.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21281
     components:
     - pos: -34.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21282
     components:
     - pos: -35.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21283
     components:
     - pos: -36.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21284
     components:
     - pos: -37.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21285
     components:
     - pos: -38.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21286
     components:
     - pos: -39.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21287
     components:
     - pos: -32.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21288
     components:
     - pos: -33.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21289
     components:
     - pos: -34.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21290
     components:
     - pos: -35.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21291
     components:
     - pos: -36.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21292
     components:
     - pos: -37.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21293
     components:
     - pos: -38.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21294
     components:
     - pos: -39.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21295
     components:
     - pos: -32.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21296
     components:
     - pos: -33.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21297
     components:
     - pos: -34.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21298
     components:
     - pos: -35.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21299
     components:
     - pos: -36.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21300
     components:
     - pos: -37.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21301
     components:
     - pos: -38.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21302
     components:
     - pos: -39.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21303
     components:
     - pos: -39.5,-70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21304
     components:
     - pos: -40.5,-70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21305
     components:
     - pos: -41.5,-70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21306
     components:
     - pos: -41.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21307
     components:
     - pos: -41.5,-72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21308
     components:
     - pos: -41.5,-73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21309
     components:
     - pos: -50.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21310
     components:
     - pos: -49.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21311
     components:
     - pos: -48.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21312
     components:
     - pos: -47.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21313
     components:
     - pos: -46.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21314
     components:
     - pos: -45.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21315
     components:
     - pos: -44.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21316
     components:
     - pos: -43.5,-71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21317
     components:
     - pos: -50.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21318
     components:
     - pos: -49.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21319
     components:
     - pos: -48.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21320
     components:
     - pos: -47.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21321
     components:
     - pos: -46.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21322
     components:
     - pos: -45.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21323
     components:
     - pos: -44.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21324
     components:
     - pos: -43.5,-69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21325
     components:
     - pos: -43.5,-70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21326
     components:
     - pos: -50.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21327
     components:
     - pos: -49.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21328
     components:
     - pos: -48.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21329
     components:
     - pos: -47.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21330
     components:
     - pos: -46.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21331
     components:
     - pos: -45.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21332
     components:
     - pos: -44.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21333
     components:
     - pos: -43.5,-67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21334
     components:
     - pos: -50.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21335
     components:
     - pos: -49.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21336
     components:
     - pos: -48.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21337
     components:
     - pos: -47.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21338
     components:
     - pos: -46.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21339
     components:
     - pos: -45.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21340
     components:
     - pos: -44.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21341
     components:
     - pos: -43.5,-65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21342
     components:
     - pos: -43.5,-66.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21343
     components:
     - pos: -39.5,-66.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21344
     components:
     - pos: -39.5,-62.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21345
     components:
     - pos: -43.5,-62.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21346
     components:
     - pos: -43.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21347
     components:
     - pos: -44.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21348
     components:
     - pos: -45.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21349
     components:
     - pos: -46.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21350
     components:
     - pos: -47.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21351
     components:
     - pos: -48.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21352
     components:
     - pos: -49.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21353
     components:
     - pos: -50.5,-61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21354
     components:
     - pos: -50.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21355
     components:
     - pos: -49.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21356
     components:
     - pos: -48.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21357
     components:
     - pos: -47.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21358
     components:
     - pos: -46.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21359
     components:
     - pos: -45.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21360
     components:
     - pos: -44.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21361
     components:
     - pos: -43.5,-63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21362
     components:
     - pos: -42.5,-70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21581
     components:
     - pos: -6.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21583
     components:
     - pos: -7.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21584
     components:
     - pos: -8.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21586
     components:
     - pos: -6.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21587
     components:
     - pos: -5.5,5.5
@@ -50324,190 +46512,136 @@ entities:
     - pos: -4.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21646
     components:
     - pos: -17.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22413
     components:
     - pos: -48.5,10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22414
     components:
     - pos: -48.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22415
     components:
     - pos: -48.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22416
     components:
     - pos: -47.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22417
     components:
     - pos: -46.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22418
     components:
     - pos: -45.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22419
     components:
     - pos: -44.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22420
     components:
     - pos: -43.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22421
     components:
     - pos: -42.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22422
     components:
     - pos: -41.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22423
     components:
     - pos: -40.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22424
     components:
     - pos: -39.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22425
     components:
     - pos: -38.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22426
     components:
     - pos: -37.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22427
     components:
     - pos: -36.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22428
     components:
     - pos: -35.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22429
     components:
     - pos: -34.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22430
     components:
     - pos: -31.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22431
     components:
     - pos: -31.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22432
     components:
     - pos: -30.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22433
     components:
     - pos: -29.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22434
     components:
     - pos: -28.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22435
     components:
     - pos: -27.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22436
     components:
     - pos: -26.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22437
     components:
     - pos: -25.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22438
     components:
     - pos: -24.5,9.5
@@ -50518,8 +46652,6 @@ entities:
     - pos: -48.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22440
     components:
     - pos: -49.5,11.5
@@ -50530,57 +46662,41 @@ entities:
     - pos: -32.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22580
     components:
     - pos: -33.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22709
     components:
     - pos: -17.5,75.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22711
     components:
     - pos: -17.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22715
     components:
     - pos: 16.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22719
     components:
     - pos: -33.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22727
     components:
     - pos: -17.5,74.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22728
     components:
     - pos: -17.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22832
     components:
     - pos: -1.5,55.5
@@ -50616,43 +46732,31 @@ entities:
     - pos: 19.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22839
     components:
     - pos: 20.5,31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22840
     components:
     - pos: 20.5,32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22841
     components:
     - pos: 20.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22842
     components:
     - pos: 20.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22843
     components:
     - pos: 20.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22844
     components:
     - pos: 20.5,36.5
@@ -50663,8 +46767,6 @@ entities:
     - pos: 20.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22846
     components:
     - pos: 20.5,38.5
@@ -50675,36 +46777,26 @@ entities:
     - pos: 20.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22848
     components:
     - pos: 20.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22849
     components:
     - pos: 20.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22850
     components:
     - pos: 20.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22851
     components:
     - pos: 20.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22852
     components:
     - pos: 20.5,44.5
@@ -50715,155 +46807,111 @@ entities:
     - pos: 20.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22854
     components:
     - pos: 20.5,29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22855
     components:
     - pos: 20.5,28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22856
     components:
     - pos: 20.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22857
     components:
     - pos: 20.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22858
     components:
     - pos: 20.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22859
     components:
     - pos: 20.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22860
     components:
     - pos: 20.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22861
     components:
     - pos: 20.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22862
     components:
     - pos: 21.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22863
     components:
     - pos: 22.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22864
     components:
     - pos: 25.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22865
     components:
     - pos: 24.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22866
     components:
     - pos: 23.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22867
     components:
     - pos: 23.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22868
     components:
     - pos: 23.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22869
     components:
     - pos: 24.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22870
     components:
     - pos: 25.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22871
     components:
     - pos: 26.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22872
     components:
     - pos: 27.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22873
     components:
     - pos: 28.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22874
     components:
     - pos: 29.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22875
     components:
     - pos: 30.5,20.5
@@ -50889,78 +46937,56 @@ entities:
     - pos: -1.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23045
     components:
     - pos: -1.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23477
     components:
     - pos: -1.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23478
     components:
     - pos: -1.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23479
     components:
     - pos: -1.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23480
     components:
     - pos: -1.5,-18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23481
     components:
     - pos: -1.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23482
     components:
     - pos: -1.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23483
     components:
     - pos: -0.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23484
     components:
     - pos: 0.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23485
     components:
     - pos: 0.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 23486
     components:
     - pos: 0.5,-22.5
@@ -51016,36 +47042,26 @@ entities:
     - pos: -15.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25298
     components:
     - pos: -34.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25299
     components:
     - pos: -35.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25473
     components:
     - pos: -17.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25474
     components:
     - pos: -17.5,69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25494
     components:
     - pos: -29.5,16.5
@@ -51066,8 +47082,6 @@ entities:
     - pos: 20.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25760
     components:
     - pos: 20.5,54.5
@@ -51233,8 +47247,6 @@ entities:
     - pos: 30.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25793
     components:
     - pos: 30.5,77.5
@@ -51304,106 +47316,76 @@ entities:
     - pos: 15.5,-13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 1190
     components:
     - pos: -34.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3869
     components:
     - pos: -11.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3870
     components:
     - pos: -12.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3871
     components:
     - pos: -13.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3872
     components:
     - pos: -14.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3873
     components:
     - pos: -15.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3874
     components:
     - pos: -16.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3875
     components:
     - pos: -16.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3876
     components:
     - pos: -16.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3877
     components:
     - pos: -16.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3878
     components:
     - pos: -16.5,0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3879
     components:
     - pos: -16.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3880
     components:
     - pos: -15.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3881
     components:
     - pos: -14.5,-0.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3882
     components:
     - pos: -14.5,-1.5
@@ -51439,43 +47421,31 @@ entities:
     - pos: -29.5,65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4347
     components:
     - pos: -31.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4348
     components:
     - pos: -33.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4349
     components:
     - pos: -35.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4919
     components:
     - pos: -23.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4921
     components:
     - pos: -15.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5383
     components:
     - pos: -11.5,-4.5
@@ -51491,365 +47461,261 @@ entities:
     - pos: -34.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5645
     components:
     - pos: -33.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5646
     components:
     - pos: -32.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5647
     components:
     - pos: -31.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5648
     components:
     - pos: -30.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5649
     components:
     - pos: -29.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5650
     components:
     - pos: -28.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5651
     components:
     - pos: -27.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5652
     components:
     - pos: -26.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5653
     components:
     - pos: -25.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5654
     components:
     - pos: -24.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5655
     components:
     - pos: -23.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5656
     components:
     - pos: -22.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5657
     components:
     - pos: -21.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5658
     components:
     - pos: -20.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5659
     components:
     - pos: -19.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5660
     components:
     - pos: -18.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5661
     components:
     - pos: -17.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5662
     components:
     - pos: -16.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5663
     components:
     - pos: -15.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5664
     components:
     - pos: -15.5,65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5665
     components:
     - pos: -15.5,66.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5666
     components:
     - pos: -15.5,67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5667
     components:
     - pos: -15.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5668
     components:
     - pos: -15.5,69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5669
     components:
     - pos: -15.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5670
     components:
     - pos: -15.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5671
     components:
     - pos: -15.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5672
     components:
     - pos: -15.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5673
     components:
     - pos: -15.5,74.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5674
     components:
     - pos: -15.5,75.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5675
     components:
     - pos: -15.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5676
     components:
     - pos: -15.5,77.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5677
     components:
     - pos: -15.5,78.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5678
     components:
     - pos: -15.5,79.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5688
     components:
     - pos: -21.5,65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5708
     components:
     - pos: -35.5,79.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5709
     components:
     - pos: -35.5,78.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5710
     components:
     - pos: -35.5,77.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5711
     components:
     - pos: -35.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5712
     components:
     - pos: -35.5,75.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5713
     components:
     - pos: -35.5,74.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5714
     components:
     - pos: -35.5,73.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5715
     components:
     - pos: -35.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5716
     components:
     - pos: -35.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5717
     components:
     - pos: -35.5,70.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5718
     components:
     - pos: -35.5,69.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5719
     components:
     - pos: -35.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5720
     components:
     - pos: -35.5,67.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5721
     components:
     - pos: -35.5,66.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5722
     components:
     - pos: -35.5,65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5723
     components:
     - pos: -35.5,64.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5732
     components:
     - pos: -22.5,56.5
@@ -51890,169 +47756,121 @@ entities:
     - pos: -20.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5740
     components:
     - pos: -20.5,58.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5741
     components:
     - pos: -20.5,59.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5776
     components:
     - pos: -17.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5777
     components:
     - pos: -18.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5778
     components:
     - pos: -26.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5807
     components:
     - pos: -25.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5808
     components:
     - pos: -17.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5833
     components:
     - pos: -16.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5916
     components:
     - pos: -27.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5917
     components:
     - pos: -19.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5918
     components:
     - pos: -34.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5923
     components:
     - pos: -29.5,79.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6063
     components:
     - pos: -34.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6064
     components:
     - pos: -21.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6065
     components:
     - pos: -29.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6196
     components:
     - pos: -33.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6197
     components:
     - pos: -20.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6198
     components:
     - pos: -28.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6209
     components:
     - pos: -32.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6210
     components:
     - pos: -34.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6213
     components:
     - pos: -24.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6214
     components:
     - pos: -16.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6215
     components:
     - pos: -21.5,79.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6738
     components:
     - pos: -23.5,55.5
@@ -52088,43 +47906,31 @@ entities:
     - pos: -23.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6745
     components:
     - pos: -24.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6746
     components:
     - pos: -25.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6747
     components:
     - pos: -26.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6748
     components:
     - pos: -27.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6749
     components:
     - pos: -22.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6911
     components:
     - pos: -1.5,55.5
@@ -52140,8 +47946,6 @@ entities:
     - pos: -2.5,56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6914
     components:
     - pos: -0.5,56.5
@@ -52152,22 +47956,16 @@ entities:
     - pos: -3.5,56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6943
     components:
     - pos: 4.5,56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6944
     components:
     - pos: 3.5,56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6945
     components:
     - pos: 2.5,56.5
@@ -52208,36 +48006,26 @@ entities:
     - pos: -10.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10941
     components:
     - pos: -25.5,65.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10942
     components:
     - pos: -34.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11218
     components:
     - pos: -30.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11220
     components:
     - pos: -22.5,80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12039
     components:
     - pos: 13.5,-41.5
@@ -52253,15 +48041,11 @@ entities:
     - pos: 11.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12042
     components:
     - pos: 11.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12043
     components:
     - pos: 11.5,-43.5
@@ -52272,22 +48056,16 @@ entities:
     - pos: 11.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12045
     components:
     - pos: 11.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12046
     components:
     - pos: 11.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12047
     components:
     - pos: 19.5,-46.5
@@ -52338,8 +48116,6 @@ entities:
     - pos: 11.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12057
     components:
     - pos: 19.5,-45.5
@@ -52495,15 +48271,11 @@ entities:
     - pos: 28.5,-24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12089
     components:
     - pos: 5.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12090
     components:
     - pos: 5.5,-44.5
@@ -52524,99 +48296,71 @@ entities:
     - pos: 5.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12094
     components:
     - pos: 6.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12095
     components:
     - pos: 7.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12096
     components:
     - pos: 8.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12097
     components:
     - pos: 9.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12098
     components:
     - pos: 10.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12099
     components:
     - pos: 11.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12101
     components:
     - pos: 12.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13978
     components:
     - pos: 7.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13979
     components:
     - pos: 6.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13980
     components:
     - pos: 5.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13981
     components:
     - pos: 4.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13982
     components:
     - pos: 3.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13983
     components:
     - pos: 2.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13985
     components:
     - pos: -33.5,-25.5
@@ -52627,15 +48371,11 @@ entities:
     - pos: 0.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13993
     components:
     - pos: -0.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13994
     components:
     - pos: -0.5,-11.5
@@ -52656,127 +48396,91 @@ entities:
     - pos: -0.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13998
     components:
     - pos: 0.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13999
     components:
     - pos: 1.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14000
     components:
     - pos: 2.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14001
     components:
     - pos: 3.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14002
     components:
     - pos: 4.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14003
     components:
     - pos: 5.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14004
     components:
     - pos: 6.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14005
     components:
     - pos: 7.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14006
     components:
     - pos: 8.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14007
     components:
     - pos: 9.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14008
     components:
     - pos: 10.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14009
     components:
     - pos: 11.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14010
     components:
     - pos: 12.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14011
     components:
     - pos: 13.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14012
     components:
     - pos: 14.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14013
     components:
     - pos: 15.5,-8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14014
     components:
     - pos: 15.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14015
     components:
     - pos: 15.5,-10.5
@@ -52792,50 +48496,36 @@ entities:
     - pos: 15.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14018
     components:
     - pos: 14.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14027
     components:
     - pos: 12.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14028
     components:
     - pos: 11.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14029
     components:
     - pos: 10.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14030
     components:
     - pos: 9.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14031
     components:
     - pos: 8.5,-19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14034
     components:
     - pos: 9.5,-18.5
@@ -52861,8 +48551,6 @@ entities:
     - pos: 9.5,-14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14039
     components:
     - pos: 9.5,-13.5
@@ -52898,36 +48586,26 @@ entities:
     - pos: 11.5,-91.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14317
     components:
     - pos: 11.5,-92.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14318
     components:
     - pos: 29.5,-91.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14319
     components:
     - pos: 29.5,-92.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14372
     components:
     - pos: 20.5,-98.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14373
     components:
     - pos: 20.5,-99.5
@@ -53048,8 +48726,6 @@ entities:
     - pos: 11.5,-91.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14397
     components:
     - pos: 30.5,-91.5
@@ -53165,197 +48841,141 @@ entities:
     - pos: 15.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15079
     components:
     - pos: 25.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15080
     components:
     - pos: 24.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15081
     components:
     - pos: 23.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15082
     components:
     - pos: 21.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15083
     components:
     - pos: 22.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15084
     components:
     - pos: 20.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15085
     components:
     - pos: 20.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15086
     components:
     - pos: 20.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15087
     components:
     - pos: 20.5,25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15088
     components:
     - pos: 20.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15089
     components:
     - pos: 20.5,27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15090
     components:
     - pos: 20.5,28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15091
     components:
     - pos: 20.5,29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15092
     components:
     - pos: 20.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15093
     components:
     - pos: 21.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15094
     components:
     - pos: 22.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15095
     components:
     - pos: 23.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15096
     components:
     - pos: 23.5,31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15097
     components:
     - pos: 23.5,32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15098
     components:
     - pos: 23.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15099
     components:
     - pos: 23.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15100
     components:
     - pos: 24.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15101
     components:
     - pos: 25.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15102
     components:
     - pos: 26.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15103
     components:
     - pos: 27.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15104
     components:
     - pos: 28.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15105
     components:
     - pos: 29.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15106
     components:
     - pos: 30.5,20.5
@@ -53411,8 +49031,6 @@ entities:
     - pos: 37.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15118
     components:
     - pos: 38.5,20.5
@@ -53473,8 +49091,6 @@ entities:
     - pos: 44.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15554
     components:
     - pos: 20.5,62.5
@@ -53495,8 +49111,6 @@ entities:
     - pos: -4.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15684
     components:
     - pos: -5.5,5.5
@@ -53507,190 +49121,136 @@ entities:
     - pos: -6.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15686
     components:
     - pos: -6.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15687
     components:
     - pos: -6.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15688
     components:
     - pos: -7.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15689
     components:
     - pos: -8.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15690
     components:
     - pos: -9.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15691
     components:
     - pos: -10.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15692
     components:
     - pos: -10.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15693
     components:
     - pos: -10.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15694
     components:
     - pos: -10.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15695
     components:
     - pos: -10.5,8.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15696
     components:
     - pos: -10.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15697
     components:
     - pos: -10.5,10.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15698
     components:
     - pos: -10.5,11.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15699
     components:
     - pos: -10.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15700
     components:
     - pos: -9.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15701
     components:
     - pos: -8.5,12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15702
     components:
     - pos: -8.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15703
     components:
     - pos: -8.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15704
     components:
     - pos: -8.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15705
     components:
     - pos: -8.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15706
     components:
     - pos: -8.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15707
     components:
     - pos: -8.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15708
     components:
     - pos: -8.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15709
     components:
     - pos: -7.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15710
     components:
     - pos: -6.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15711
     components:
     - pos: -5.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15712
     components:
     - pos: -5.5,18.5
@@ -53721,15 +49281,11 @@ entities:
     - pos: -6.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15992
     components:
     - pos: 25.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15997
     components:
     - pos: 30.5,30.5
@@ -53740,85 +49296,61 @@ entities:
     - pos: 29.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15999
     components:
     - pos: 28.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16000
     components:
     - pos: 27.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16020
     components:
     - pos: 19.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16021
     components:
     - pos: 19.5,4.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16022
     components:
     - pos: 19.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16023
     components:
     - pos: 20.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16024
     components:
     - pos: 21.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16025
     components:
     - pos: 22.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16026
     components:
     - pos: 23.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16027
     components:
     - pos: 24.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16028
     components:
     - pos: 25.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16029
     components:
     - pos: 26.5,3.5
@@ -53844,8 +49376,6 @@ entities:
     - pos: 28.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16034
     components:
     - pos: 28.5,6.5
@@ -53931,8 +49461,6 @@ entities:
     - pos: 23.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16168
     components:
     - pos: -8.5,38.5
@@ -54028,8 +49556,6 @@ entities:
     - pos: -8.5,48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16294
     components:
     - pos: -13.5,40.5
@@ -54095,29 +49621,21 @@ entities:
     - pos: -21.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16309
     components:
     - pos: -22.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16310
     components:
     - pos: -22.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16311
     components:
     - pos: -22.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16312
     components:
     - pos: -22.5,41.5
@@ -54128,8 +49646,6 @@ entities:
     - pos: -22.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16465
     components:
     - pos: -23.5,41.5
@@ -54185,50 +49701,36 @@ entities:
     - pos: -29.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16476
     components:
     - pos: -30.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16477
     components:
     - pos: -30.5,36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16478
     components:
     - pos: -30.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16479
     components:
     - pos: -30.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16480
     components:
     - pos: -31.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16481
     components:
     - pos: -31.5,33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16482
     components:
     - pos: -31.5,32.5
@@ -54329,113 +49831,81 @@ entities:
     - pos: -35.5,26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16670
     components:
     - pos: -10.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16671
     components:
     - pos: -11.5,13.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16881
     components:
     - pos: 7.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16882
     components:
     - pos: 8.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16883
     components:
     - pos: 9.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16884
     components:
     - pos: 10.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16885
     components:
     - pos: 11.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16886
     components:
     - pos: 11.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16887
     components:
     - pos: 12.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16888
     components:
     - pos: 13.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16889
     components:
     - pos: 14.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16890
     components:
     - pos: 15.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16891
     components:
     - pos: 16.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16892
     components:
     - pos: 17.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16893
     components:
     - pos: 18.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16894
     components:
     - pos: 19.5,45.5
@@ -54446,22 +49916,16 @@ entities:
     - pos: 20.5,45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16896
     components:
     - pos: 20.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16897
     components:
     - pos: 20.5,47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16898
     components:
     - pos: 20.5,48.5
@@ -54492,8 +49956,6 @@ entities:
     - pos: 20.5,53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16904
     components:
     - pos: 20.5,54.5
@@ -54529,8 +49991,6 @@ entities:
     - pos: 17.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16911
     components:
     - pos: 20.5,58.5
@@ -54581,36 +50041,26 @@ entities:
     - pos: 21.5,68.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17130
     components:
     - pos: 41.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17131
     components:
     - pos: 41.5,36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17132
     components:
     - pos: 41.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17133
     components:
     - pos: 40.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17335
     components:
     - pos: 57.5,6.5
@@ -54621,36 +50071,26 @@ entities:
     - pos: 57.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17337
     components:
     - pos: 56.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17338
     components:
     - pos: 55.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17339
     components:
     - pos: 54.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17340
     components:
     - pos: 54.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17341
     components:
     - pos: 54.5,5.5
@@ -54801,8 +50241,6 @@ entities:
     - pos: 79.5,1.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17475
     components:
     - pos: 53.5,4.5
@@ -55073,8 +50511,6 @@ entities:
     - pos: 57.5,-20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17530
     components:
     - pos: 55.5,-19.5
@@ -55095,99 +50531,71 @@ entities:
     - pos: 54.5,-21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17534
     components:
     - pos: 54.5,-22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17535
     components:
     - pos: 54.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17536
     components:
     - pos: 54.5,-24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17537
     components:
     - pos: 54.5,-25.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17538
     components:
     - pos: 54.5,-26.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17539
     components:
     - pos: 54.5,-27.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17540
     components:
     - pos: 54.5,-28.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17541
     components:
     - pos: 54.5,-29.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17542
     components:
     - pos: 54.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17543
     components:
     - pos: 54.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17544
     components:
     - pos: 54.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17545
     components:
     - pos: 54.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17546
     components:
     - pos: 54.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17547
     components:
     - pos: 54.5,-35.5
@@ -55198,715 +50606,511 @@ entities:
     - pos: 53.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17611
     components:
     - pos: 53.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17612
     components:
     - pos: 53.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17614
     components:
     - pos: 56.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17615
     components:
     - pos: 56.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17617
     components:
     - pos: 52.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17618
     components:
     - pos: 51.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17619
     components:
     - pos: 50.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17620
     components:
     - pos: 49.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17621
     components:
     - pos: 48.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17622
     components:
     - pos: 47.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17623
     components:
     - pos: 47.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17624
     components:
     - pos: 47.5,-36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17625
     components:
     - pos: 47.5,-37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17626
     components:
     - pos: 47.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17627
     components:
     - pos: 46.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17628
     components:
     - pos: 45.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17629
     components:
     - pos: 44.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17630
     components:
     - pos: 43.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17631
     components:
     - pos: 42.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17632
     components:
     - pos: 41.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17633
     components:
     - pos: 40.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17634
     components:
     - pos: 39.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17636
     components:
     - pos: 37.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17637
     components:
     - pos: 36.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17638
     components:
     - pos: 36.5,-39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17639
     components:
     - pos: 36.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17640
     components:
     - pos: 36.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17641
     components:
     - pos: 36.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17642
     components:
     - pos: 36.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17643
     components:
     - pos: 36.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17644
     components:
     - pos: 36.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17645
     components:
     - pos: 36.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17646
     components:
     - pos: 36.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17647
     components:
     - pos: 36.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17648
     components:
     - pos: 36.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17649
     components:
     - pos: 36.5,-50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17650
     components:
     - pos: 36.5,-51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17651
     components:
     - pos: 36.5,-52.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17652
     components:
     - pos: 36.5,-53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17653
     components:
     - pos: 36.5,-54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17654
     components:
     - pos: 36.5,-55.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17655
     components:
     - pos: 36.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17656
     components:
     - pos: 37.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17657
     components:
     - pos: 38.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17658
     components:
     - pos: 39.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17659
     components:
     - pos: 40.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17660
     components:
     - pos: 41.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17661
     components:
     - pos: 42.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17662
     components:
     - pos: 43.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17663
     components:
     - pos: 44.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17664
     components:
     - pos: 45.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17665
     components:
     - pos: 46.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17666
     components:
     - pos: 47.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17667
     components:
     - pos: 48.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17668
     components:
     - pos: 49.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17669
     components:
     - pos: 50.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17670
     components:
     - pos: 51.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17671
     components:
     - pos: 52.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17672
     components:
     - pos: 53.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17673
     components:
     - pos: 54.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17674
     components:
     - pos: 55.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17675
     components:
     - pos: 56.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17676
     components:
     - pos: 57.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17677
     components:
     - pos: 58.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17678
     components:
     - pos: 59.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17679
     components:
     - pos: 60.5,-56.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17680
     components:
     - pos: 60.5,-55.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17681
     components:
     - pos: 60.5,-54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17682
     components:
     - pos: 60.5,-53.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17683
     components:
     - pos: 60.5,-52.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17684
     components:
     - pos: 60.5,-51.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17685
     components:
     - pos: 60.5,-50.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17686
     components:
     - pos: 60.5,-49.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17687
     components:
     - pos: 60.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17688
     components:
     - pos: 61.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17689
     components:
     - pos: 62.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17690
     components:
     - pos: 63.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17691
     components:
     - pos: 64.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17692
     components:
     - pos: 65.5,-48.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17693
     components:
     - pos: 65.5,-47.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17694
     components:
     - pos: 65.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17695
     components:
     - pos: 65.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17696
     components:
     - pos: 65.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17697
     components:
     - pos: 65.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17698
     components:
     - pos: 65.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17699
     components:
     - pos: 65.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17700
     components:
     - pos: 65.5,-40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17701
     components:
     - pos: 65.5,-39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17702
     components:
     - pos: 65.5,-38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17703
     components:
     - pos: 65.5,-37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17704
     components:
     - pos: 65.5,-36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17705
     components:
     - pos: 65.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17706
     components:
     - pos: 64.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17708
     components:
     - pos: 62.5,-35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17709
     components:
     - pos: 62.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17710
     components:
     - pos: 61.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17711
     components:
     - pos: 60.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17712
     components:
     - pos: 59.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17713
     components:
     - pos: 58.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17714
     components:
     - pos: 57.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17827
     components:
     - pos: 57.5,-6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17910
     components:
     - pos: 40.5,-5.5
@@ -55942,15 +51146,11 @@ entities:
     - pos: 34.5,-5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18187
     components:
     - pos: -14.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18188
     components:
     - pos: -14.5,-32.5
@@ -56096,43 +51296,31 @@ entities:
     - pos: -6.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18217
     components:
     - pos: -7.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18218
     components:
     - pos: -8.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18219
     components:
     - pos: -9.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18220
     components:
     - pos: -10.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18221
     components:
     - pos: -10.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18222
     components:
     - pos: -11.5,-17.5
@@ -56153,22 +51341,16 @@ entities:
     - pos: -14.5,-17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18226
     components:
     - pos: -14.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18227
     components:
     - pos: -14.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18228
     components:
     - pos: -13.5,-15.5
@@ -56179,8 +51361,6 @@ entities:
     - pos: -12.5,-15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18362
     components:
     - pos: 41.5,34.5
@@ -56191,22 +51371,16 @@ entities:
     - pos: 39.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18364
     components:
     - pos: 39.5,38.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18365
     components:
     - pos: 39.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18366
     components:
     - pos: 39.5,36.5
@@ -56222,99 +51396,71 @@ entities:
     - pos: 40.5,37.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18369
     components:
     - pos: 41.5,35.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18374
     components:
     - pos: -25.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18375
     components:
     - pos: -24.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18376
     components:
     - pos: -23.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18377
     components:
     - pos: -22.5,-46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18378
     components:
     - pos: -22.5,-45.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18379
     components:
     - pos: -22.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18380
     components:
     - pos: -23.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18381
     components:
     - pos: -24.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18382
     components:
     - pos: -25.5,-44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18383
     components:
     - pos: -23.5,-43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18384
     components:
     - pos: -23.5,-42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18385
     components:
     - pos: -23.5,-41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18386
     components:
     - pos: -23.5,-40.5
@@ -56380,8 +51526,6 @@ entities:
     - pos: -28.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18481
     components:
     - pos: -27.5,-32.5
@@ -56507,8 +51651,6 @@ entities:
     - pos: -40.5,-36.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18648
     components:
     - pos: -38.5,-32.5
@@ -56584,8 +51726,6 @@ entities:
     - pos: -43.5,-23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18688
     components:
     - pos: -41.5,-32.5
@@ -56651,15 +51791,11 @@ entities:
     - pos: -53.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18790
     components:
     - pos: 26.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18806
     components:
     - pos: 39.5,34.5
@@ -56670,50 +51806,36 @@ entities:
     - pos: 24.5,30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18847
     components:
     - pos: 40.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18848
     components:
     - pos: 44.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18849
     components:
     - pos: 42.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18850
     components:
     - pos: 41.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18851
     components:
     - pos: 43.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18852
     components:
     - pos: 45.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18853
     components:
     - pos: 45.5,38.5
@@ -56759,29 +51881,21 @@ entities:
     - pos: -16.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19454
     components:
     - pos: -15.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20619
     components:
     - pos: -17.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21843
     components:
     - pos: 0.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21844
     components:
     - pos: 0.5,39.5
@@ -56812,120 +51926,86 @@ entities:
     - pos: 5.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21850
     components:
     - pos: 6.5,39.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21851
     components:
     - pos: 6.5,40.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21852
     components:
     - pos: 6.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21853
     components:
     - pos: 7.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21854
     components:
     - pos: 8.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21855
     components:
     - pos: 9.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21856
     components:
     - pos: 10.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21857
     components:
     - pos: 11.5,41.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21858
     components:
     - pos: 11.5,42.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21859
     components:
     - pos: 11.5,43.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21860
     components:
     - pos: 11.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21861
     components:
     - pos: 10.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21862
     components:
     - pos: 9.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21863
     components:
     - pos: 8.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21864
     components:
     - pos: 7.5,44.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21866
     components:
     - pos: -32.5,-9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21867
     components:
     - pos: -32.5,-10.5
@@ -56961,8 +52041,6 @@ entities:
     - pos: -34.5,-16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21874
     components:
     - pos: -33.5,-16.5
@@ -57023,8 +52101,6 @@ entities:
     - pos: -26.5,-12.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 21886
     components:
     - pos: -25.5,-12.5
@@ -57100,8 +52176,6 @@ entities:
     - pos: -33.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22217
     components:
     - pos: -24.5,57.5
@@ -57117,148 +52191,106 @@ entities:
     - pos: 4.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22659
     components:
     - pos: -3.5,57.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22660
     components:
     - pos: -3.5,59.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22661
     components:
     - pos: -3.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22662
     components:
     - pos: -3.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22663
     components:
     - pos: -1.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22664
     components:
     - pos: 0.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22665
     components:
     - pos: 2.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22666
     components:
     - pos: 4.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22667
     components:
     - pos: 4.5,61.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22668
     components:
     - pos: 4.5,59.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22684
     components:
     - pos: -3.5,62.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22685
     components:
     - pos: 3.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22686
     components:
     - pos: 4.5,62.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22687
     components:
     - pos: 4.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22688
     components:
     - pos: 4.5,58.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22783
     components:
     - pos: -3.5,58.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22784
     components:
     - pos: -3.5,60.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22785
     components:
     - pos: -2.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22786
     components:
     - pos: -0.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 22787
     components:
     - pos: 1.5,63.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24163
     components:
     - pos: -13.5,48.5
@@ -57314,50 +52346,36 @@ entities:
     - pos: -15.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24174
     components:
     - pos: -14.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24175
     components:
     - pos: -13.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24176
     components:
     - pos: -12.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24177
     components:
     - pos: -11.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24178
     components:
     - pos: -10.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24179
     components:
     - pos: -9.5,54.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 24180
     components:
     - pos: -9.5,53.5
@@ -57388,29 +52406,21 @@ entities:
     - pos: -25.5,79.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25294
     components:
     - pos: -33.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25295
     components:
     - pos: -16.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25296
     components:
     - pos: -17.5,72.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25624
     components:
     - pos: -28.5,15.5
@@ -57421,22 +52431,16 @@ entities:
     - pos: -28.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25650
     components:
     - pos: -29.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25668
     components:
     - pos: -27.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25686
     components:
     - pos: -28.5,16.5
@@ -57537,8 +52541,6 @@ entities:
     - pos: 30.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25756
     components:
     - pos: 30.5,77.5
@@ -57569,22 +52571,16 @@ entities:
     - pos: -28.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25869
     components:
     - pos: -29.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25870
     components:
     - pos: -27.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25871
     components:
     - pos: -27.5,18.5
@@ -57600,8 +52596,6 @@ entities:
     - pos: -26.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
 - proto: CableMVStack
   entities:
   - uid: 4174
@@ -81441,8 +76435,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 8098
     components:
@@ -81452,8 +76444,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20494
     components:
@@ -81462,8 +76452,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20503
     components:
@@ -81472,8 +76460,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20506
     components:
@@ -81482,8 +76468,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20507
     components:
@@ -81492,8 +76476,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20508
     components:
@@ -81503,8 +76485,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20509
     components:
@@ -81514,8 +76494,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20510
     components:
@@ -81525,8 +76503,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20511
     components:
@@ -81536,8 +76512,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20512
     components:
@@ -81547,8 +76521,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20513
     components:
@@ -81557,8 +76529,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20514
     components:
@@ -81568,8 +76538,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20515
     components:
@@ -81579,8 +76547,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20516
     components:
@@ -81590,8 +76556,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20518
     components:
@@ -81601,8 +76565,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20519
     components:
@@ -81612,8 +76574,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20520
     components:
@@ -81622,8 +76582,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20521
     components:
@@ -81632,8 +76590,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20522
     components:
@@ -81643,8 +76599,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20523
     components:
@@ -81653,8 +76607,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20524
     components:
@@ -81663,8 +76615,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20525
     components:
@@ -81674,8 +76624,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20526
     components:
@@ -81685,8 +76633,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20527
     components:
@@ -81696,8 +76642,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20528
     components:
@@ -81706,8 +76650,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20529
     components:
@@ -81717,8 +76659,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20541
     components:
@@ -81727,8 +76667,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20543
     components:
@@ -81738,8 +76676,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20544
     components:
@@ -81749,8 +76685,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20545
     components:
@@ -81760,8 +76694,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20546
     components:
@@ -81770,8 +76702,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20548
     components:
@@ -81781,8 +76711,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20550
     components:
@@ -81792,8 +76720,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20551
     components:
@@ -81802,8 +76728,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20552
     components:
@@ -81813,8 +76737,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20553
     components:
@@ -81824,8 +76746,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20554
     components:
@@ -81834,8 +76754,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20555
     components:
@@ -81845,8 +76763,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20556
     components:
@@ -81856,8 +76772,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20557
     components:
@@ -81866,8 +76780,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20558
     components:
@@ -81877,8 +76789,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20559
     components:
@@ -81888,8 +76798,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20560
     components:
@@ -81899,8 +76807,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20561
     components:
@@ -81909,8 +76815,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20562
     components:
@@ -81919,8 +76823,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20563
     components:
@@ -81929,8 +76831,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20565
     components:
@@ -81940,8 +76840,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20566
     components:
@@ -81951,8 +76849,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20567
     components:
@@ -81962,8 +76858,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20568
     components:
@@ -81972,8 +76866,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20569
     components:
@@ -81983,8 +76875,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20570
     components:
@@ -81994,8 +76884,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20571
     components:
@@ -82005,8 +76893,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 20572
     components:
@@ -82015,8 +76901,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 21572
     components:
@@ -82026,8 +76910,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 21658
     components:
@@ -82037,8 +76919,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 21660
     components:
@@ -82048,8 +76928,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 21661
     components:
@@ -82059,8 +76937,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 21663
     components:
@@ -82069,8 +76945,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 21946
     components:
@@ -82080,8 +76954,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 22098
     components:
@@ -82091,8 +76963,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 25239
     components:
@@ -82102,8 +76972,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
 - proto: EmergencyRollerBed
   entities:
@@ -86976,50 +81844,36 @@ entities:
     - pos: 0.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 660
     components:
     - pos: 2.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 661
     components:
     - pos: 4.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 662
     components:
     - pos: 6.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 663
     components:
     - pos: 8.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 664
     components:
     - pos: 10.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 665
     components:
     - pos: 12.5,24.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 666
     components:
     - pos: 16.5,24.5
@@ -87027,8 +81881,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 713
     components:
     - rot: 3.141592653589793 rad
@@ -87037,15 +81889,11 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 753
     components:
     - pos: 12.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 758
     components:
     - rot: -1.5707963267948966 rad
@@ -87054,8 +81902,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 815
     components:
     - rot: 1.5707963267948966 rad
@@ -87064,8 +81910,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 818
     components:
     - rot: 3.141592653589793 rad
@@ -87074,8 +81918,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 822
     components:
     - rot: -1.5707963267948966 rad
@@ -87084,8 +81926,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 900
     components:
     - rot: 3.141592653589793 rad
@@ -87102,8 +81942,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 1140
     components:
     - rot: 3.141592653589793 rad
@@ -87130,8 +81968,6 @@ entities:
       pos: 2.5,34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2255
     components:
     - pos: 6.5,34.5
@@ -87139,8 +81975,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 2734
     components:
     - rot: -1.5707963267948966 rad
@@ -87185,8 +82019,6 @@ entities:
       pos: 9.5,71.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8127
     components:
     - rot: 3.141592653589793 rad
@@ -87317,8 +82149,6 @@ entities:
       pos: 21.5,-78.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9872
     components:
     - rot: -1.5707963267948966 rad
@@ -87573,8 +82403,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13212
     components:
     - pos: 10.5,36.5
@@ -87855,8 +82683,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15270
     components:
     - pos: -40.5,-26.5
@@ -87880,8 +82706,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15438
     components:
     - pos: -50.5,-22.5
@@ -87912,8 +82736,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15455
     components:
     - rot: -1.5707963267948966 rad
@@ -87922,8 +82744,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15458
     components:
     - rot: 1.5707963267948966 rad
@@ -87932,8 +82752,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15467
     components:
     - rot: 3.141592653589793 rad
@@ -88056,8 +82874,6 @@ entities:
       pos: 55.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20055
     components:
     - rot: -1.5707963267948966 rad
@@ -88120,8 +82936,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 1858
     components:
     - pos: 18.5,16.5
@@ -88129,8 +82943,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9510
     components:
     - pos: 21.5,16.5
@@ -88339,395 +83151,285 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 382
     components:
     - pos: 0.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 383
     components:
     - pos: 0.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 384
     components:
     - pos: 2.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 385
     components:
     - pos: 2.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 386
     components:
     - pos: 1.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 387
     components:
     - pos: 1.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 388
     components:
     - pos: 7.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 389
     components:
     - pos: 7.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 390
     components:
     - pos: 13.5,3.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 391
     components:
     - pos: 13.5,2.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 398
     components:
     - pos: 6.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 399
     components:
     - pos: 6.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 400
     components:
     - pos: 8.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 401
     components:
     - pos: 8.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 402
     components:
     - pos: 12.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 403
     components:
     - pos: 12.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 404
     components:
     - pos: 14.5,7.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 405
     components:
     - pos: 14.5,6.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 406
     components:
     - pos: 14.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 407
     components:
     - pos: 12.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 408
     components:
     - pos: 8.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 409
     components:
     - pos: 6.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 410
     components:
     - pos: 2.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 411
     components:
     - pos: 0.5,5.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 422
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 423
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 424
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 425
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 426
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 427
     components:
     - rot: 3.141592653589793 rad
       pos: 14.5,9.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 428
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 429
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 430
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 593
     components:
     - pos: 0.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 594
     components:
     - pos: 0.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 595
     components:
     - pos: 0.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 596
     components:
     - pos: 2.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 597
     components:
     - pos: 2.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 598
     components:
     - pos: 2.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 599
     components:
     - pos: 4.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 600
     components:
     - pos: 4.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 601
     components:
     - pos: 4.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 602
     components:
     - pos: 6.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 603
     components:
     - pos: 6.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 604
     components:
     - pos: 6.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 605
     components:
     - pos: 8.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 606
     components:
     - pos: 8.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 607
     components:
     - pos: 8.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 608
     components:
     - pos: 10.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 609
     components:
     - pos: 10.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 610
     components:
     - pos: 10.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 611
     components:
     - pos: 12.5,23.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 612
     components:
     - pos: 12.5,22.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 613
     components:
     - pos: 12.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 614
     components:
     - pos: 16.5,23.5
@@ -88735,8 +83437,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 615
     components:
     - pos: 16.5,22.5
@@ -88744,8 +83444,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 616
     components:
     - pos: 16.5,21.5
@@ -88753,8 +83451,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 617
     components:
     - pos: 15.5,21.5
@@ -88762,246 +83458,176 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 618
     components:
     - pos: 11.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 619
     components:
     - pos: 9.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 620
     components:
     - pos: 7.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 621
     components:
     - pos: 5.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 622
     components:
     - pos: 3.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 623
     components:
     - pos: 1.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 624
     components:
     - pos: -0.5,21.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 626
     components:
     - pos: -0.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 627
     components:
     - pos: -0.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 628
     components:
     - pos: 0.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 629
     components:
     - pos: 1.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 630
     components:
     - pos: 1.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 631
     components:
     - pos: 2.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 632
     components:
     - pos: 2.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 633
     components:
     - pos: 3.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 634
     components:
     - pos: 3.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 635
     components:
     - pos: 4.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 636
     components:
     - pos: 4.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 637
     components:
     - pos: 5.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 638
     components:
     - pos: 5.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 639
     components:
     - pos: 6.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 640
     components:
     - pos: 6.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 641
     components:
     - pos: 7.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 642
     components:
     - pos: 7.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 643
     components:
     - pos: 8.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 644
     components:
     - pos: 8.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 645
     components:
     - pos: 9.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 646
     components:
     - pos: 9.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 647
     components:
     - pos: 10.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 648
     components:
     - pos: 10.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 649
     components:
     - pos: 11.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 650
     components:
     - pos: 11.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 651
     components:
     - pos: 12.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 652
     components:
     - pos: 12.5,19.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 653
     components:
     - pos: 15.5,20.5
@@ -89009,8 +83635,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 654
     components:
     - pos: 15.5,19.5
@@ -89018,8 +83642,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 655
     components:
     - pos: 16.5,20.5
@@ -89027,8 +83649,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 656
     components:
     - pos: 16.5,19.5
@@ -89036,8 +83656,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 657
     components:
     - pos: 16.5,18.5
@@ -89045,8 +83663,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 658
     components:
     - pos: 15.5,18.5
@@ -89054,72 +83670,54 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 667
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 668
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 669
     components:
     - rot: 3.141592653589793 rad
       pos: 0.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 670
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 671
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 672
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 673
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 674
     components:
     - rot: 3.141592653589793 rad
       pos: 10.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 675
     components:
     - rot: 3.141592653589793 rad
@@ -89128,119 +83726,89 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 677
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,17.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 679
     components:
     - pos: -1.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 684
     components:
     - rot: 3.141592653589793 rad
       pos: 1.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 685
     components:
     - rot: 3.141592653589793 rad
       pos: 2.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 686
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 687
     components:
     - rot: 3.141592653589793 rad
       pos: 4.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 688
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 689
     components:
     - rot: 3.141592653589793 rad
       pos: 6.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 690
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 691
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 692
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 693
     components:
     - rot: 3.141592653589793 rad
       pos: 10.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 694
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 695
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,18.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 714
     components:
     - pos: 16.5,16.5
@@ -89248,8 +83816,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 720
     components:
     - pos: 18.5,12.5
@@ -89257,8 +83823,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 722
     components:
     - pos: 18.5,10.5
@@ -89266,112 +83830,84 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 723
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 739
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 740
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 741
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 742
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 743
     components:
     - rot: 3.141592653589793 rad
       pos: 5.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 744
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 745
     components:
     - rot: 3.141592653589793 rad
       pos: 7.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 746
     components:
     - rot: 3.141592653589793 rad
       pos: 9.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 748
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 750
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 751
     components:
     - rot: 1.5707963267948966 rad
       pos: 10.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 752
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 755
     components:
     - rot: -1.5707963267948966 rad
@@ -89380,8 +83916,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 759
     components:
     - rot: 3.141592653589793 rad
@@ -89390,8 +83924,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 765
     components:
     - rot: 3.141592653589793 rad
@@ -89400,8 +83932,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 788
     components:
     - pos: -5.5,18.5
@@ -89415,24 +83945,18 @@ entities:
       pos: 0.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 791
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 792
     components:
     - rot: 1.5707963267948966 rad
       pos: 1.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 793
     components:
     - rot: 1.5707963267948966 rad
@@ -89441,48 +83965,36 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 794
     components:
     - rot: 1.5707963267948966 rad
       pos: 3.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 795
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 796
     components:
     - rot: 1.5707963267948966 rad
       pos: 7.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 797
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 798
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,16.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 816
     components:
     - pos: -1.5,13.5
@@ -89490,8 +84002,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 817
     components:
     - pos: -1.5,12.5
@@ -89499,8 +84009,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 826
     components:
     - rot: 1.5707963267948966 rad
@@ -89509,8 +84017,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 827
     components:
     - pos: 13.5,14.5
@@ -89518,32 +84024,24 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 828
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 829
     components:
     - rot: -1.5707963267948966 rad
       pos: 6.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 830
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 878
     components:
     - rot: -1.5707963267948966 rad
@@ -89552,8 +84050,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 879
     components:
     - rot: -1.5707963267948966 rad
@@ -89562,8 +84058,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 880
     components:
     - rot: -1.5707963267948966 rad
@@ -89572,8 +84066,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 881
     components:
     - rot: -1.5707963267948966 rad
@@ -89582,8 +84074,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 882
     components:
     - rot: -1.5707963267948966 rad
@@ -89592,8 +84082,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 883
     components:
     - rot: -1.5707963267948966 rad
@@ -89602,8 +84090,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 884
     components:
     - rot: -1.5707963267948966 rad
@@ -89612,8 +84098,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 885
     components:
     - rot: -1.5707963267948966 rad
@@ -89622,8 +84106,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 886
     components:
     - rot: -1.5707963267948966 rad
@@ -89632,8 +84114,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 897
     components:
     - rot: -1.5707963267948966 rad
@@ -89642,8 +84122,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 898
     components:
     - rot: -1.5707963267948966 rad
@@ -89652,8 +84130,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 909
     components:
     - rot: -1.5707963267948966 rad
@@ -89662,8 +84138,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 910
     components:
     - rot: -1.5707963267948966 rad
@@ -89672,8 +84146,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 915
     components:
     - pos: -4.5,12.5
@@ -89681,8 +84153,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 930
     components:
     - rot: -1.5707963267948966 rad
@@ -89691,8 +84161,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 948
     components:
     - rot: -1.5707963267948966 rad
@@ -89701,8 +84169,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 952
     components:
     - rot: 1.5707963267948966 rad
@@ -89711,8 +84177,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 953
     components:
     - rot: 1.5707963267948966 rad
@@ -90036,8 +84500,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 1861
     components:
     - rot: -1.5707963267948966 rad
@@ -90046,8 +84508,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 1965
     components:
     - rot: 1.5707963267948966 rad
@@ -90134,8 +84594,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 2261
     components:
     - rot: -1.5707963267948966 rad
@@ -90213,8 +84671,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 3032
     components:
     - pos: -36.5,-37.5
@@ -90330,8 +84786,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 6923
     components:
     - rot: 1.5707963267948966 rad
@@ -90350,8 +84804,6 @@ entities:
       pos: 2.5,46.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7277
     components:
     - rot: 3.141592653589793 rad
@@ -90692,22 +85144,16 @@ entities:
     - pos: 19.5,-80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9725
     components:
     - pos: 19.5,-81.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9726
     components:
     - pos: 19.5,-82.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9727
     components:
     - pos: 19.5,-78.5
@@ -90715,8 +85161,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9728
     components:
     - pos: 19.5,-77.5
@@ -90724,8 +85168,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9729
     components:
     - pos: 19.5,-76.5
@@ -90733,8 +85175,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9730
     components:
     - pos: 19.5,-75.5
@@ -90742,8 +85182,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9731
     components:
     - pos: 19.5,-74.5
@@ -90751,8 +85189,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9732
     components:
     - pos: 19.5,-73.5
@@ -90760,8 +85196,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9733
     components:
     - pos: 19.5,-72.5
@@ -90769,8 +85203,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9734
     components:
     - pos: 19.5,-71.5
@@ -90778,8 +85210,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9735
     components:
     - pos: 19.5,-70.5
@@ -90787,8 +85217,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9736
     components:
     - pos: 19.5,-69.5
@@ -90796,8 +85224,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9737
     components:
     - pos: 19.5,-68.5
@@ -90805,8 +85231,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9738
     components:
     - pos: 19.5,-67.5
@@ -90814,8 +85238,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9739
     components:
     - pos: 19.5,-66.5
@@ -90823,8 +85245,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9740
     components:
     - pos: 19.5,-65.5
@@ -90832,8 +85252,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9741
     components:
     - pos: 19.5,-64.5
@@ -90841,8 +85259,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9742
     components:
     - pos: 19.5,-63.5
@@ -90850,8 +85266,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9743
     components:
     - pos: 19.5,-62.5
@@ -90880,8 +85294,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9748
     components:
     - rot: -1.5707963267948966 rad
@@ -91263,22 +85675,16 @@ entities:
     - pos: 21.5,-82.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9842
     components:
     - pos: 21.5,-81.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9843
     components:
     - pos: 21.5,-80.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9845
     components:
     - rot: 1.5707963267948966 rad
@@ -91538,8 +85944,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10074
     components:
     - rot: 3.141592653589793 rad
@@ -91548,8 +85952,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10075
     components:
     - rot: 3.141592653589793 rad
@@ -91558,8 +85960,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10076
     components:
     - rot: 3.141592653589793 rad
@@ -91568,8 +85968,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10077
     components:
     - rot: 3.141592653589793 rad
@@ -91578,8 +85976,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10078
     components:
     - rot: 3.141592653589793 rad
@@ -91588,8 +85984,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10079
     components:
     - rot: 3.141592653589793 rad
@@ -91598,8 +85992,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10080
     components:
     - rot: 3.141592653589793 rad
@@ -91608,8 +86000,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10081
     components:
     - rot: 3.141592653589793 rad
@@ -91794,8 +86184,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10110
     components:
     - rot: 1.5707963267948966 rad
@@ -91804,8 +86192,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10111
     components:
     - rot: 1.5707963267948966 rad
@@ -91814,8 +86200,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10112
     components:
     - rot: 1.5707963267948966 rad
@@ -91824,8 +86208,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10113
     components:
     - rot: 1.5707963267948966 rad
@@ -91834,8 +86216,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10114
     components:
     - rot: 1.5707963267948966 rad
@@ -91844,8 +86224,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10115
     components:
     - rot: 1.5707963267948966 rad
@@ -91854,8 +86232,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10116
     components:
     - rot: 1.5707963267948966 rad
@@ -91864,8 +86240,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10117
     components:
     - rot: 1.5707963267948966 rad
@@ -91874,8 +86248,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10118
     components:
     - rot: 1.5707963267948966 rad
@@ -91884,8 +86256,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10119
     components:
     - rot: 1.5707963267948966 rad
@@ -92247,8 +86617,6 @@ entities:
     - pos: 0.5,20.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10838
     components:
     - rot: 3.141592653589793 rad
@@ -92325,8 +86693,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 11539
     components:
     - rot: 1.5707963267948966 rad
@@ -92723,8 +87089,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 12609
     components:
     - rot: -1.5707963267948966 rad
@@ -93289,8 +87653,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 12742
     components:
     - rot: 1.5707963267948966 rad
@@ -94421,8 +88783,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 12946
     components:
     - rot: -1.5707963267948966 rad
@@ -95236,8 +89596,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13087
     components:
     - rot: -1.5707963267948966 rad
@@ -95246,8 +89604,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13088
     components:
     - rot: -1.5707963267948966 rad
@@ -95256,8 +89612,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13089
     components:
     - rot: -1.5707963267948966 rad
@@ -95266,8 +89620,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13092
     components:
     - rot: 1.5707963267948966 rad
@@ -95894,8 +90246,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13196
     components:
     - rot: 1.5707963267948966 rad
@@ -96035,8 +90385,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13221
     components:
     - rot: -1.5707963267948966 rad
@@ -96782,8 +91130,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13352
     components:
     - rot: 3.141592653589793 rad
@@ -97820,8 +92166,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13531
     components:
     - rot: -1.5707963267948966 rad
@@ -98255,8 +92599,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13602
     components:
     - rot: 3.141592653589793 rad
@@ -98289,8 +92631,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13607
     components:
     - pos: -33.5,-15.5
@@ -98496,8 +92836,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13640
     components:
     - rot: 3.141592653589793 rad
@@ -98530,8 +92868,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13644
     components:
     - rot: 3.141592653589793 rad
@@ -99155,8 +93491,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13747
     components:
     - pos: 2.5,-13.5
@@ -99356,8 +93690,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13779
     components:
     - rot: 1.5707963267948966 rad
@@ -100303,8 +94635,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13938
     components:
     - rot: 1.5707963267948966 rad
@@ -100360,8 +94690,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13953
     components:
     - rot: -1.5707963267948966 rad
@@ -100526,8 +94854,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14184
     components:
     - pos: 21.5,-59.5
@@ -101809,8 +96135,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14683
     components:
     - pos: 3.5,-36.5
@@ -101881,8 +96205,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14702
     components:
     - rot: 3.141592653589793 rad
@@ -102040,8 +96362,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14730
     components:
     - pos: -10.5,-32.5
@@ -103180,8 +97500,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14960
     components:
     - rot: -1.5707963267948966 rad
@@ -103263,8 +97581,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14979
     components:
     - pos: -39.5,-30.5
@@ -103464,8 +97780,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15429
     components:
     - rot: 3.141592653589793 rad
@@ -103482,8 +97796,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15431
     components:
     - rot: 3.141592653589793 rad
@@ -103524,8 +97836,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15439
     components:
     - rot: -1.5707963267948966 rad
@@ -103534,8 +97844,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15440
     components:
     - rot: -1.5707963267948966 rad
@@ -103544,8 +97852,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15441
     components:
     - rot: -1.5707963267948966 rad
@@ -103593,8 +97899,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15452
     components:
     - rot: -1.5707963267948966 rad
@@ -103603,8 +97907,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15453
     components:
     - rot: -1.5707963267948966 rad
@@ -103613,8 +97915,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15460
     components:
     - pos: -56.5,-23.5
@@ -103622,8 +97922,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15461
     components:
     - pos: -56.5,-24.5
@@ -103659,8 +97957,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15468
     components:
     - rot: 1.5707963267948966 rad
@@ -103685,8 +97981,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15471
     components:
     - rot: 1.5707963267948966 rad
@@ -103790,8 +98084,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 18571
     components:
     - rot: 1.5707963267948966 rad
@@ -105000,8 +99292,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19319
     components:
     - rot: 3.141592653589793 rad
@@ -105010,8 +99300,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19320
     components:
     - rot: 3.141592653589793 rad
@@ -105020,8 +99308,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19321
     components:
     - rot: 3.141592653589793 rad
@@ -105030,8 +99316,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19322
     components:
     - rot: 3.141592653589793 rad
@@ -105040,8 +99324,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19323
     components:
     - rot: 3.141592653589793 rad
@@ -105050,8 +99332,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19324
     components:
     - rot: 3.141592653589793 rad
@@ -105060,8 +99340,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19325
     components:
     - rot: 3.141592653589793 rad
@@ -105070,8 +99348,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19326
     components:
     - rot: 3.141592653589793 rad
@@ -105080,8 +99356,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19327
     components:
     - rot: 3.141592653589793 rad
@@ -105090,8 +99364,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19328
     components:
     - rot: 3.141592653589793 rad
@@ -105100,8 +99372,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19329
     components:
     - rot: 3.141592653589793 rad
@@ -105110,8 +99380,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 19802
     components:
     - pos: 72.5,3.5
@@ -105688,8 +99956,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20013
     components:
     - pos: 54.5,-22.5
@@ -105697,8 +99963,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20014
     components:
     - pos: 54.5,-23.5
@@ -105706,8 +99970,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20015
     components:
     - pos: 54.5,-24.5
@@ -105715,8 +99977,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20016
     components:
     - pos: 54.5,-25.5
@@ -105724,8 +99984,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20017
     components:
     - pos: 54.5,-26.5
@@ -105733,8 +99991,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20018
     components:
     - pos: 54.5,-27.5
@@ -105742,8 +99998,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20019
     components:
     - pos: 54.5,-28.5
@@ -105751,8 +100005,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20020
     components:
     - pos: 54.5,-29.5
@@ -105760,8 +100012,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20021
     components:
     - pos: 54.5,-30.5
@@ -105769,8 +100019,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20022
     components:
     - pos: 54.5,-31.5
@@ -105778,8 +100026,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20023
     components:
     - pos: 54.5,-32.5
@@ -105787,8 +100033,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 20026
     components:
     - pos: 54.5,-35.5
@@ -105904,32 +100148,24 @@ entities:
       pos: 56.5,-30.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20049
     components:
     - rot: 3.141592653589793 rad
       pos: 55.5,-31.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20050
     components:
     - rot: 3.141592653589793 rad
       pos: 55.5,-32.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20051
     components:
     - rot: 3.141592653589793 rad
       pos: 55.5,-33.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 20053
     components:
     - rot: 3.141592653589793 rad
@@ -106177,8 +100413,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 24549
     components:
     - rot: 1.5707963267948966 rad
@@ -106234,15 +100468,11 @@ entities:
     - pos: 29.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25803
     components:
     - pos: 31.5,76.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 25804
     components:
     - pos: 29.5,74.5
@@ -106375,8 +100605,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 736
     components:
     - rot: -1.5707963267948966 rad
@@ -106385,24 +100613,18 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 747
     components:
     - rot: 3.141592653589793 rad
       pos: 11.5,14.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 749
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,15.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 766
     components:
     - rot: -1.5707963267948966 rad
@@ -106411,8 +100633,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 799
     components:
     - pos: 8.5,11.5
@@ -106420,8 +100640,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 800
     components:
     - pos: 6.5,11.5
@@ -106429,8 +100647,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 801
     components:
     - pos: 0.5,11.5
@@ -106438,8 +100654,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 802
     components:
     - pos: 2.5,11.5
@@ -106447,8 +100661,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 809
     components:
     - pos: 12.5,11.5
@@ -106456,8 +100668,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 810
     components:
     - pos: 14.5,11.5
@@ -106465,8 +100675,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 811
     components:
     - rot: 3.141592653589793 rad
@@ -106475,8 +100683,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 812
     components:
     - rot: 3.141592653589793 rad
@@ -106485,8 +100691,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 813
     components:
     - rot: 3.141592653589793 rad
@@ -106495,8 +100699,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 814
     components:
     - rot: 3.141592653589793 rad
@@ -106505,8 +100707,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 819
     components:
     - pos: -0.5,13.5
@@ -106514,8 +100714,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 820
     components:
     - rot: 3.141592653589793 rad
@@ -106524,8 +100722,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 824
     components:
     - pos: 15.5,13.5
@@ -106533,8 +100729,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 873
     components:
     - rot: 3.141592653589793 rad
@@ -106543,8 +100737,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 874
     components:
     - pos: 3.5,13.5
@@ -106552,8 +100744,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 875
     components:
     - pos: 5.5,13.5
@@ -106561,8 +100751,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 876
     components:
     - pos: 11.5,13.5
@@ -106570,8 +100758,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 877
     components:
     - pos: 9.5,13.5
@@ -106579,8 +100765,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 887
     components:
     - rot: 3.141592653589793 rad
@@ -106589,8 +100773,6 @@ entities:
       type: Transform
     - color: '#680285FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 899
     components:
     - pos: -4.5,16.5
@@ -106598,8 +100780,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 902
     components:
     - rot: -1.5707963267948966 rad
@@ -106608,8 +100788,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 903
     components:
     - rot: -1.5707963267948966 rad
@@ -106618,8 +100796,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 1163
     components:
     - pos: 37.5,20.5
@@ -106736,8 +100912,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 1867
     components:
     - rot: 3.141592653589793 rad
@@ -106746,8 +100920,6 @@ entities:
       type: Transform
     - color: '#947507FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 1879
     components:
     - rot: 3.141592653589793 rad
@@ -106756,8 +100928,6 @@ entities:
       type: Transform
     - color: '#03FCD3FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 2540
     components:
     - rot: 1.5707963267948966 rad
@@ -106929,8 +101099,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10082
     components:
     - rot: -1.5707963267948966 rad
@@ -108594,8 +102762,6 @@ entities:
       pos: 54.5,-34.5
       parent: 82
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 19842
     components:
     - pos: 61.5,4.5
@@ -109179,8 +103345,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
   - uid: 377
     components:
     - pos: 2.5,8.5
@@ -109188,8 +103352,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
   - uid: 378
     components:
     - pos: 6.5,8.5
@@ -109197,8 +103359,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
   - uid: 379
     components:
     - pos: 8.5,8.5
@@ -109206,8 +103366,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
   - uid: 380
     components:
     - pos: 12.5,8.5
@@ -109215,8 +103373,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
   - uid: 381
     components:
     - pos: 14.5,8.5
@@ -109224,8 +103380,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
   - uid: 678
     components:
     - pos: -1.5,17.5
@@ -109233,8 +103387,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 763
@@ -109269,8 +103421,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
     - color: '#947507FF'
       type: AtmosPipeColor
   - uid: 1869
@@ -109281,8 +103431,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
     - color: '#947507FF'
       type: AtmosPipeColor
   - uid: 1878
@@ -109293,8 +103441,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
     - color: '#947507FF'
       type: AtmosPipeColor
 - proto: GasVentPump
@@ -109305,8 +103451,6 @@ entities:
       pos: 20.5,11.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1259
@@ -109315,8 +103459,6 @@ entities:
       pos: 28.5,3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1262
@@ -109325,8 +103467,6 @@ entities:
       pos: 32.5,12.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 1263
@@ -109335,8 +103475,6 @@ entities:
       pos: 26.5,8.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 2821
@@ -109348,8 +103486,6 @@ entities:
     - ShutdownSubscribers:
       - 24530
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 5525
@@ -109358,8 +103494,6 @@ entities:
       pos: 27.5,-31.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 7278
@@ -109367,8 +103501,6 @@ entities:
     - pos: 18.5,72.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 7735
@@ -109377,8 +103509,6 @@ entities:
       pos: 72.5,-6.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 7736
@@ -109387,8 +103517,6 @@ entities:
       pos: 85.5,-6.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 7883
@@ -109400,8 +103528,6 @@ entities:
     - ShutdownSubscribers:
       - 24525
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 9709
@@ -109410,71 +103536,53 @@ entities:
       pos: 20.5,-91.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9817
     components:
     - rot: 1.5707963267948966 rad
       pos: 31.5,-89.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9818
     components:
     - pos: 20.5,-86.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9819
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-89.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9820
     components:
     - rot: -1.5707963267948966 rad
       pos: 9.5,-98.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9821
     components:
     - rot: 1.5707963267948966 rad
       pos: 31.5,-98.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9822
     components:
     - rot: 3.141592653589793 rad
       pos: 17.5,-103.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9823
     components:
     - rot: 3.141592653589793 rad
       pos: 23.5,-103.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 12592
     components:
     - rot: 3.141592653589793 rad
       pos: 37.5,19.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12610
@@ -109483,8 +103591,6 @@ entities:
       pos: 40.5,27.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12611
@@ -109493,8 +103599,6 @@ entities:
       pos: 44.5,27.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12617
@@ -109503,8 +103607,6 @@ entities:
       pos: 32.5,26.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12623
@@ -109513,8 +103615,6 @@ entities:
       pos: 12.5,56.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12637
@@ -109523,8 +103623,6 @@ entities:
       pos: 36.5,28.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12657
@@ -109533,8 +103631,6 @@ entities:
       pos: 39.5,33.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12671
@@ -109542,8 +103638,6 @@ entities:
     - pos: 44.5,35.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12685
@@ -109552,8 +103646,6 @@ entities:
       pos: 32.5,44.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12754
@@ -109561,8 +103653,6 @@ entities:
     - pos: 28.5,55.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12755
@@ -109570,8 +103660,6 @@ entities:
     - pos: 23.5,55.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12785
@@ -109579,8 +103667,6 @@ entities:
     - pos: 27.5,64.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12786
@@ -109589,8 +103675,6 @@ entities:
       pos: 25.5,59.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12787
@@ -109599,8 +103683,6 @@ entities:
       pos: 19.5,59.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12818
@@ -109608,8 +103690,6 @@ entities:
     - pos: 22.5,65.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12853
@@ -109618,8 +103698,6 @@ entities:
       pos: 28.5,69.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12859
@@ -109628,8 +103706,6 @@ entities:
       pos: 14.5,64.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12879
@@ -109638,8 +103714,6 @@ entities:
       pos: 23.5,50.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12902
@@ -109648,8 +103722,6 @@ entities:
       pos: 7.5,50.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12968
@@ -109658,8 +103730,6 @@ entities:
       pos: -3.5,50.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 12969
@@ -109668,8 +103738,6 @@ entities:
       pos: 0.5,43.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13006
@@ -109677,8 +103745,6 @@ entities:
     - pos: -13.5,48.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13008
@@ -109687,8 +103753,6 @@ entities:
       pos: -11.5,44.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13009
@@ -109697,8 +103761,6 @@ entities:
       pos: -13.5,38.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13041
@@ -109707,8 +103769,6 @@ entities:
       pos: -19.5,50.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13044
@@ -109717,8 +103777,6 @@ entities:
       pos: -25.5,54.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13058
@@ -109727,8 +103785,6 @@ entities:
       pos: -24.5,48.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13091
@@ -109737,8 +103793,6 @@ entities:
       pos: -26.5,41.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13105
@@ -109747,8 +103801,6 @@ entities:
       pos: -24.5,38.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13117
@@ -109757,8 +103809,6 @@ entities:
       pos: -19.5,38.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13142
@@ -109767,8 +103817,6 @@ entities:
       pos: -20.5,30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13177
@@ -109777,8 +103825,6 @@ entities:
       pos: 5.5,30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13197
@@ -109787,8 +103833,6 @@ entities:
       pos: -0.5,35.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13198
@@ -109797,8 +103841,6 @@ entities:
       pos: -4.5,36.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13214
@@ -109806,8 +103848,6 @@ entities:
     - pos: 9.5,37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13257
@@ -109816,8 +103856,6 @@ entities:
       pos: -41.5,30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13265
@@ -109826,8 +103864,6 @@ entities:
       pos: -40.5,26.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13316
@@ -109835,8 +103871,6 @@ entities:
     - pos: -57.5,54.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13359
@@ -109845,8 +103879,6 @@ entities:
       pos: -24.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13376
@@ -109855,8 +103887,6 @@ entities:
       pos: -58.5,45.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13377
@@ -109865,8 +103895,6 @@ entities:
       pos: -60.5,36.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13405
@@ -109875,8 +103903,6 @@ entities:
       pos: -22.5,20.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13423
@@ -109885,8 +103911,6 @@ entities:
       pos: -15.5,19.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13456
@@ -109895,8 +103919,6 @@ entities:
       pos: -22.5,2.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13466
@@ -109905,8 +103927,6 @@ entities:
       pos: -24.5,-11.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13526
@@ -109914,8 +103934,6 @@ entities:
     - pos: -36.5,-10.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13546
@@ -109924,8 +103942,6 @@ entities:
       pos: -18.5,-12.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13553
@@ -109934,8 +103950,6 @@ entities:
       pos: -31.5,-12.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13595
@@ -109944,8 +103958,6 @@ entities:
       pos: -42.5,-16.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13599
@@ -109954,8 +103966,6 @@ entities:
       pos: -37.5,-7.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13606
@@ -109964,8 +103974,6 @@ entities:
       pos: -41.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13618
@@ -109974,8 +103982,6 @@ entities:
       pos: -27.5,4.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13646
@@ -109983,8 +103989,6 @@ entities:
     - pos: -8.5,1.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13647
@@ -109993,8 +103997,6 @@ entities:
       pos: -7.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13725
@@ -110003,8 +104005,6 @@ entities:
       pos: 19.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13767
@@ -110013,8 +104013,6 @@ entities:
       pos: 4.5,-11.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13768
@@ -110023,8 +104021,6 @@ entities:
       pos: 10.5,-11.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13849
@@ -110032,8 +104028,6 @@ entities:
     - pos: 24.5,-18.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13868
@@ -110042,8 +104036,6 @@ entities:
       pos: 34.5,-19.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13885
@@ -110052,8 +104044,6 @@ entities:
       pos: 19.5,-18.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13943
@@ -110061,8 +104051,6 @@ entities:
     - pos: 27.5,-27.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13947
@@ -110071,8 +104059,6 @@ entities:
       pos: 12.5,-14.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13948
@@ -110081,8 +104067,6 @@ entities:
       pos: 3.5,-15.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 13954
@@ -110091,8 +104075,6 @@ entities:
       pos: 9.5,-17.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14217
@@ -110101,8 +104083,6 @@ entities:
       pos: 20.5,-46.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14218
@@ -110111,8 +104091,6 @@ entities:
       pos: 15.5,-48.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14237
@@ -110121,8 +104099,6 @@ entities:
       pos: 20.5,-61.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14519
@@ -110131,8 +104107,6 @@ entities:
       pos: 23.5,-7.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14576
@@ -110141,8 +104115,6 @@ entities:
       pos: 6.5,-24.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14600
@@ -110151,8 +104123,6 @@ entities:
       pos: -5.5,-25.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14636
@@ -110161,8 +104131,6 @@ entities:
       pos: -4.5,-13.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14691
@@ -110171,8 +104139,6 @@ entities:
       pos: 3.5,-35.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14692
@@ -110181,8 +104147,6 @@ entities:
       pos: 11.5,-35.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14693
@@ -110191,8 +104155,6 @@ entities:
       pos: 6.5,-40.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14724
@@ -110201,8 +104163,6 @@ entities:
       pos: -13.5,-33.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14725
@@ -110210,8 +104170,6 @@ entities:
     - pos: -11.5,-30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14783
@@ -110220,8 +104178,6 @@ entities:
       pos: -5.5,-38.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14793
@@ -110230,8 +104186,6 @@ entities:
       pos: -10.5,-52.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14811
@@ -110240,8 +104194,6 @@ entities:
       pos: -5.5,-60.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14822
@@ -110250,8 +104202,6 @@ entities:
       pos: -17.5,-25.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14836
@@ -110260,8 +104210,6 @@ entities:
       pos: -25.5,-27.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14837
@@ -110273,8 +104221,6 @@ entities:
     - ShutdownSubscribers:
       - 24530
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14854
@@ -110282,8 +104228,6 @@ entities:
     - pos: -17.5,-29.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14907
@@ -110295,8 +104239,6 @@ entities:
     - ShutdownSubscribers:
       - 24525
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14940
@@ -110305,8 +104247,6 @@ entities:
       pos: -35.5,-23.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14941
@@ -110315,8 +104255,6 @@ entities:
       pos: -23.5,-17.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15273
@@ -110328,8 +104266,6 @@ entities:
     - ShutdownSubscribers:
       - 24530
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15410
@@ -110341,8 +104277,6 @@ entities:
     - ShutdownSubscribers:
       - 24530
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15419
@@ -110350,8 +104284,6 @@ entities:
     - pos: -49.5,-28.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15474
@@ -110360,8 +104292,6 @@ entities:
       pos: -55.5,-28.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 18838
@@ -110370,8 +104300,6 @@ entities:
       pos: -13.5,26.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 18843
@@ -110380,8 +104308,6 @@ entities:
       pos: -26.5,26.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19206
@@ -110390,8 +104316,6 @@ entities:
       pos: 44.5,1.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19228
@@ -110399,8 +104323,6 @@ entities:
     - pos: 38.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19229
@@ -110409,8 +104331,6 @@ entities:
       pos: 40.5,0.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19279
@@ -110419,8 +104339,6 @@ entities:
       pos: 37.5,-12.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19286
@@ -110428,8 +104346,6 @@ entities:
     - pos: 50.5,-1.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19287
@@ -110438,8 +104354,6 @@ entities:
       pos: 55.5,-5.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19290
@@ -110447,8 +104361,6 @@ entities:
     - pos: 59.5,-1.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19386
@@ -110457,8 +104369,6 @@ entities:
       pos: 42.5,16.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19841
@@ -110467,8 +104377,6 @@ entities:
       pos: 61.5,3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19843
@@ -110477,8 +104385,6 @@ entities:
       pos: 74.5,3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19888
@@ -110487,8 +104393,6 @@ entities:
       pos: 79.5,9.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19889
@@ -110496,8 +104400,6 @@ entities:
     - pos: 75.5,14.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19890
@@ -110505,8 +104407,6 @@ entities:
     - pos: 82.5,14.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19915
@@ -110515,8 +104415,6 @@ entities:
       pos: 55.5,-15.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 19916
@@ -110525,8 +104423,6 @@ entities:
       pos: 61.5,-18.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 20032
@@ -110535,8 +104431,6 @@ entities:
       pos: 54.5,-37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 20045
@@ -110545,8 +104439,6 @@ entities:
       pos: 46.5,-45.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 20547
@@ -110555,8 +104447,6 @@ entities:
       pos: 11.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 20638
@@ -110568,8 +104458,6 @@ entities:
     - ShutdownSubscribers:
       - 24525
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 22404
@@ -110578,8 +104466,6 @@ entities:
       pos: -57.5,30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 22780
@@ -110588,8 +104474,6 @@ entities:
       pos: 13.5,30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 24481
@@ -110598,8 +104482,6 @@ entities:
       pos: 28.5,24.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 25723
@@ -110607,8 +104489,6 @@ entities:
     - pos: 23.5,74.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 26241
@@ -110617,8 +104497,6 @@ entities:
       pos: -29.5,16.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
 - proto: GasVentScrubber
@@ -110628,30 +104506,22 @@ entities:
     - pos: 1.5,4.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 396
     components:
     - pos: 7.5,4.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 397
     components:
     - pos: 13.5,4.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 1000
     components:
     - rot: 3.141592653589793 rad
       pos: -4.5,11.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 1260
@@ -110659,8 +104529,6 @@ entities:
     - pos: 32.5,3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 1261
@@ -110669,8 +104537,6 @@ entities:
       pos: 27.5,8.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 2852
@@ -110682,8 +104548,6 @@ entities:
     - ShutdownSubscribers:
       - 24525
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 2868
@@ -110694,8 +104558,6 @@ entities:
     - ShutdownSubscribers:
       - 24525
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 3278
@@ -110707,8 +104569,6 @@ entities:
     - ShutdownSubscribers:
       - 24530
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 4455
@@ -110717,8 +104577,6 @@ entities:
       pos: -40.5,-27.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 7337
@@ -110726,8 +104584,6 @@ entities:
     - pos: 19.5,72.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 7738
@@ -110736,8 +104592,6 @@ entities:
       pos: 73.5,-7.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 7739
@@ -110746,8 +104600,6 @@ entities:
       pos: 86.5,-7.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 9896
@@ -110756,70 +104608,52 @@ entities:
       pos: 8.5,-97.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9897
     components:
     - pos: 9.5,-88.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9898
     components:
     - rot: 3.141592653589793 rad
       pos: 16.5,-87.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9899
     components:
     - rot: 3.141592653589793 rad
       pos: 24.5,-87.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9900
     components:
     - pos: 31.5,-88.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9901
     components:
     - rot: -1.5707963267948966 rad
       pos: 32.5,-97.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9902
     components:
     - rot: 3.141592653589793 rad
       pos: 20.5,-100.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 9903
     components:
     - rot: 1.5707963267948966 rad
       pos: 20.5,-105.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 10271
     components:
     - rot: 1.5707963267948966 rad
       pos: 32.5,14.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 10982
@@ -110828,8 +104662,6 @@ entities:
       pos: -58.5,36.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 10985
@@ -110837,8 +104669,6 @@ entities:
     - pos: 26.5,59.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 10989
@@ -110847,8 +104677,6 @@ entities:
       pos: 42.5,15.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 10993
@@ -110856,8 +104684,6 @@ entities:
     - pos: -4.5,-24.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12519
@@ -110866,8 +104692,6 @@ entities:
       pos: 27.5,54.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12558
@@ -110876,8 +104700,6 @@ entities:
       pos: 46.5,14.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12581
@@ -110886,8 +104708,6 @@ entities:
       pos: 44.5,28.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12585
@@ -110896,8 +104716,6 @@ entities:
       pos: 39.5,28.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12591
@@ -110905,8 +104723,6 @@ entities:
     - pos: 36.5,20.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12625
@@ -110915,8 +104731,6 @@ entities:
       pos: 19.5,58.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12630
@@ -110925,8 +104739,6 @@ entities:
       pos: 32.5,25.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12631
@@ -110935,8 +104747,6 @@ entities:
       pos: 36.5,25.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12665
@@ -110944,8 +104754,6 @@ entities:
     - pos: 40.5,33.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12678
@@ -110953,8 +104761,6 @@ entities:
     - pos: 45.5,34.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12684
@@ -110963,8 +104769,6 @@ entities:
       pos: 32.5,42.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12757
@@ -110973,8 +104777,6 @@ entities:
       pos: 24.5,54.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12768
@@ -110983,8 +104785,6 @@ entities:
       pos: 12.5,55.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12817
@@ -110993,8 +104793,6 @@ entities:
       pos: 21.5,64.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12862
@@ -111002,8 +104800,6 @@ entities:
     - pos: 36.5,49.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12903
@@ -111011,8 +104807,6 @@ entities:
     - pos: 6.5,50.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12970
@@ -111020,8 +104814,6 @@ entities:
     - pos: 1.5,44.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12971
@@ -111030,8 +104822,6 @@ entities:
       pos: -4.5,49.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12991
@@ -111040,8 +104830,6 @@ entities:
       pos: -12.5,38.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13005
@@ -111049,8 +104837,6 @@ entities:
     - pos: -12.5,48.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13007
@@ -111058,8 +104844,6 @@ entities:
     - pos: -14.5,44.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13042
@@ -111067,8 +104851,6 @@ entities:
     - pos: -19.5,48.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13043
@@ -111077,8 +104859,6 @@ entities:
       pos: -25.5,53.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13057
@@ -111086,8 +104866,6 @@ entities:
     - pos: -26.5,48.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13103
@@ -111096,8 +104874,6 @@ entities:
       pos: -23.5,41.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13104
@@ -111106,8 +104882,6 @@ entities:
       pos: -24.5,37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13116
@@ -111116,8 +104890,6 @@ entities:
       pos: -19.5,36.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13134
@@ -111126,8 +104898,6 @@ entities:
       pos: -18.5,26.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13141
@@ -111136,8 +104906,6 @@ entities:
       pos: -19.5,30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13178
@@ -111145,8 +104913,6 @@ entities:
     - pos: 4.5,31.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13213
@@ -111155,8 +104921,6 @@ entities:
       pos: 9.5,36.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13258
@@ -111164,8 +104928,6 @@ entities:
     - pos: -39.5,30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13266
@@ -111174,8 +104936,6 @@ entities:
       pos: -39.5,26.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13302
@@ -111184,8 +104944,6 @@ entities:
       pos: -56.5,30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13318
@@ -111193,8 +104951,6 @@ entities:
     - pos: -61.5,54.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13324
@@ -111203,8 +104959,6 @@ entities:
       pos: -62.5,49.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13358
@@ -111212,8 +104966,6 @@ entities:
     - pos: -20.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13375
@@ -111222,8 +104974,6 @@ entities:
       pos: -60.5,45.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13404
@@ -111232,8 +104982,6 @@ entities:
       pos: -22.5,17.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13422
@@ -111242,8 +104990,6 @@ entities:
       pos: -15.5,14.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13455
@@ -111252,8 +104998,6 @@ entities:
       pos: -22.5,3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13504
@@ -111262,8 +105006,6 @@ entities:
       pos: -21.5,-11.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13513
@@ -111272,8 +105014,6 @@ entities:
       pos: -18.5,-16.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13545
@@ -111281,8 +105021,6 @@ entities:
     - pos: -31.5,-13.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13559
@@ -111291,8 +105029,6 @@ entities:
       pos: -36.5,-15.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13596
@@ -111301,8 +105037,6 @@ entities:
       pos: -40.5,-16.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13597
@@ -111310,8 +105044,6 @@ entities:
     - pos: -40.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13598
@@ -111320,8 +105052,6 @@ entities:
       pos: -33.5,-7.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13610
@@ -111330,8 +105060,6 @@ entities:
       pos: -33.5,-18.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13617
@@ -111340,8 +105068,6 @@ entities:
       pos: -28.5,1.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13645
@@ -111349,8 +105075,6 @@ entities:
     - pos: -4.5,2.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13648
@@ -111359,8 +105083,6 @@ entities:
       pos: -5.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13724
@@ -111369,8 +105091,6 @@ entities:
       pos: 19.5,-5.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13769
@@ -111378,8 +105098,6 @@ entities:
     - pos: 2.5,-10.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13770
@@ -111387,8 +105105,6 @@ entities:
     - pos: 12.5,-10.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13848
@@ -111397,8 +105113,6 @@ entities:
       pos: 24.5,-21.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13869
@@ -111407,8 +105121,6 @@ entities:
       pos: 34.5,-20.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13884
@@ -111417,8 +105129,6 @@ entities:
       pos: 19.5,-21.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13934
@@ -111426,8 +105136,6 @@ entities:
     - pos: 27.5,-34.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13942
@@ -111436,8 +105144,6 @@ entities:
       pos: 26.5,-27.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13946
@@ -111446,8 +105152,6 @@ entities:
       pos: 11.5,-15.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13949
@@ -111456,8 +105160,6 @@ entities:
       pos: 2.5,-15.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 13955
@@ -111466,8 +105168,6 @@ entities:
       pos: 12.5,-17.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14223
@@ -111476,8 +105176,6 @@ entities:
       pos: 16.5,-43.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14224
@@ -111485,8 +105183,6 @@ entities:
     - pos: 15.5,-49.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14225
@@ -111495,8 +105191,6 @@ entities:
       pos: 20.5,-45.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14236
@@ -111505,8 +105199,6 @@ entities:
       pos: 20.5,-60.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14520
@@ -111515,8 +105207,6 @@ entities:
       pos: 28.5,-7.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14567
@@ -111524,8 +105214,6 @@ entities:
     - pos: 8.5,-24.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14677
@@ -111533,8 +105221,6 @@ entities:
     - pos: 1.5,-32.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14678
@@ -111542,8 +105228,6 @@ entities:
     - pos: 7.5,-32.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14679
@@ -111551,8 +105235,6 @@ entities:
     - pos: 13.5,-32.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14685
@@ -111561,8 +105243,6 @@ entities:
       pos: -1.5,-37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14686
@@ -111571,8 +105251,6 @@ entities:
       pos: 3.5,-37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14687
@@ -111581,8 +105259,6 @@ entities:
       pos: 11.5,-37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14688
@@ -111591,8 +105267,6 @@ entities:
       pos: 16.5,-37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14689
@@ -111600,8 +105274,6 @@ entities:
     - pos: 0.5,-34.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14690
@@ -111609,8 +105281,6 @@ entities:
     - pos: 14.5,-34.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14694
@@ -111619,8 +105289,6 @@ entities:
       pos: 8.5,-40.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14726
@@ -111628,8 +105296,6 @@ entities:
     - pos: -10.5,-30.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14744
@@ -111638,8 +105304,6 @@ entities:
       pos: -13.5,-42.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14755
@@ -111648,8 +105312,6 @@ entities:
       pos: -5.5,-37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14792
@@ -111657,8 +105319,6 @@ entities:
     - pos: -10.5,-48.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14810
@@ -111667,8 +105327,6 @@ entities:
       pos: -5.5,-61.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14823
@@ -111676,8 +105334,6 @@ entities:
     - pos: -14.5,-25.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14868
@@ -111686,8 +105342,6 @@ entities:
       pos: -25.5,-31.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14880
@@ -111698,8 +105352,6 @@ entities:
     - ShutdownSubscribers:
       - 24530
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14886
@@ -111711,8 +105363,6 @@ entities:
     - ShutdownSubscribers:
       - 24525
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14942
@@ -111721,8 +105371,6 @@ entities:
       pos: -21.5,-17.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15400
@@ -111733,8 +105381,6 @@ entities:
     - ShutdownSubscribers:
       - 24530
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15401
@@ -111743,8 +105389,6 @@ entities:
       pos: -44.5,-27.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15411
@@ -111755,8 +105399,6 @@ entities:
     - ShutdownSubscribers:
       - 24530
       type: DeviceNetwork
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15475
@@ -111765,8 +105407,6 @@ entities:
       pos: -55.5,-31.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15476
@@ -111775,8 +105415,6 @@ entities:
       pos: -55.5,-27.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15503
@@ -111785,8 +105423,6 @@ entities:
       pos: -43.5,-34.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 18842
@@ -111795,8 +105431,6 @@ entities:
       pos: -25.5,26.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19167
@@ -111804,8 +105438,6 @@ entities:
     - pos: 41.5,3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19168
@@ -111814,8 +105446,6 @@ entities:
       pos: 46.5,1.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19226
@@ -111824,8 +105454,6 @@ entities:
       pos: 40.5,-0.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19227
@@ -111833,8 +105461,6 @@ entities:
     - pos: 42.5,-4.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19264
@@ -111843,8 +105469,6 @@ entities:
       pos: 45.5,-11.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19265
@@ -111853,8 +105477,6 @@ entities:
       pos: 48.5,-8.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19285
@@ -111862,8 +105484,6 @@ entities:
     - pos: 53.5,-1.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19289
@@ -111871,8 +105491,6 @@ entities:
     - pos: 61.5,-1.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19840
@@ -111880,8 +105498,6 @@ entities:
     - pos: 59.5,3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19844
@@ -111889,8 +105505,6 @@ entities:
     - pos: 77.5,3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19885
@@ -111899,8 +105513,6 @@ entities:
       pos: 79.5,6.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19891
@@ -111908,8 +105520,6 @@ entities:
     - pos: 76.5,13.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19892
@@ -111917,8 +105527,6 @@ entities:
     - pos: 83.5,13.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 19917
@@ -111927,8 +105535,6 @@ entities:
       pos: 61.5,-20.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 20062
@@ -111937,31 +105543,23 @@ entities:
       pos: 59.5,-37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 20068
     components:
     - rot: 1.5707963267948966 rad
       pos: 52.5,-42.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 20069
     components:
     - rot: -1.5707963267948966 rad
       pos: 58.5,-41.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 20671
     components:
     - pos: 3.5,-3.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 22441
@@ -111970,8 +105568,6 @@ entities:
       pos: 55.5,-16.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 22494
@@ -111979,8 +105575,6 @@ entities:
     - pos: 14.5,31.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 22572
@@ -111988,8 +105582,6 @@ entities:
     - pos: 56.5,-4.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 22593
@@ -111998,8 +105590,6 @@ entities:
       pos: -4.5,34.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 22656
@@ -112008,8 +105598,6 @@ entities:
       pos: -4.5,-12.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 24548
@@ -112017,8 +105605,6 @@ entities:
     - pos: 22.5,50.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 25724
@@ -112026,8 +105612,6 @@ entities:
     - pos: 24.5,74.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 26240
@@ -112035,8 +105619,6 @@ entities:
     - pos: -29.5,19.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
 - proto: GasVolumePump
@@ -125099,8 +118681,6 @@ entities:
     - pos: 15.5,74.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
 - proto: MachineAnomalyVessel
   entities:
   - uid: 3194
@@ -128974,8 +122554,6 @@ entities:
       pos: -29.5,-36.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 3407
     components:
     - rot: 3.141592653589793 rad
@@ -129042,8 +122620,6 @@ entities:
     - pos: 2.5,20.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 7245
     components:
     - rot: 3.141592653589793 rad
@@ -129143,8 +122719,6 @@ entities:
     - pos: 12.5,20.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 11188
     components:
     - rot: 1.5707963267948966 rad
@@ -129174,8 +122748,6 @@ entities:
       pos: -33.5,-44.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 11500
     components:
     - pos: 66.5,-18.5
@@ -129212,24 +122784,18 @@ entities:
       pos: -42.5,-44.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 15520
     components:
     - rot: -1.5707963267948966 rad
       pos: -36.5,-40.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 15912
     components:
     - rot: 1.5707963267948966 rad
       pos: -37.5,-43.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 16944
     components:
     - rot: 1.5707963267948966 rad
@@ -130713,8 +124279,6 @@ entities:
       pos: -39.5,-37.5
       parent: 82
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 22634
     components:
     - rot: -1.5707963267948966 rad
@@ -141336,9 +134900,14 @@ entities:
     - pos: 58.5,-6.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -141347,9 +134916,14 @@ entities:
     - pos: 59.5,-6.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -141359,9 +134933,14 @@ entities:
       pos: 3.5,-19.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141371,9 +134950,14 @@ entities:
       pos: 2.5,-19.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141382,9 +134966,14 @@ entities:
     - pos: 1.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141393,9 +134982,14 @@ entities:
     - pos: 2.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141404,9 +134998,14 @@ entities:
     - pos: 3.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141415,9 +135014,14 @@ entities:
     - pos: 5.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141426,9 +135030,14 @@ entities:
     - pos: 6.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141437,9 +135046,14 @@ entities:
     - pos: 7.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141448,9 +135062,14 @@ entities:
     - pos: 8.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141459,9 +135078,14 @@ entities:
     - pos: 9.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141470,9 +135094,14 @@ entities:
     - pos: 11.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141481,9 +135110,14 @@ entities:
     - pos: 12.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141492,9 +135126,14 @@ entities:
     - pos: 13.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141503,9 +135142,14 @@ entities:
     - pos: 14.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141515,9 +135159,14 @@ entities:
       pos: 16.5,-11.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141527,9 +135176,14 @@ entities:
       pos: 16.5,-10.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141539,9 +135193,14 @@ entities:
       pos: -1.5,-11.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141551,9 +135210,14 @@ entities:
       pos: -1.5,-10.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141563,9 +135227,14 @@ entities:
       pos: 25.5,64.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -401259.6
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25178
       type: DeviceLinkSink
@@ -141598,9 +135267,14 @@ entities:
     - pos: 62.5,-6.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -141609,9 +135283,14 @@ entities:
     - pos: -8.5,32.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -399951.5
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25181
       type: DeviceLinkSink
@@ -141620,9 +135299,14 @@ entities:
     - pos: -9.5,32.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -399951.5
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25181
       type: DeviceLinkSink
@@ -141631,9 +135315,14 @@ entities:
     - pos: -7.5,32.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -399951.5
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25181
       type: DeviceLinkSink
@@ -141643,9 +135332,14 @@ entities:
       pos: -6.5,34.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -399951.5
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25181
       type: DeviceLinkSink
@@ -141655,9 +135349,14 @@ entities:
       pos: -6.5,35.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -399951.5
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25181
       type: DeviceLinkSink
@@ -141666,9 +135365,14 @@ entities:
     - pos: 60.5,-6.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -141678,9 +135382,14 @@ entities:
       pos: 44.5,12.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -89448.695
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 14025
       type: DeviceLinkSink
@@ -141690,9 +135399,14 @@ entities:
       pos: 44.5,13.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -89448.695
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 14025
       type: DeviceLinkSink
@@ -141702,9 +135416,14 @@ entities:
       pos: -46.5,-34.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -392892.66
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25230
       type: DeviceLinkSink
@@ -141714,9 +135433,14 @@ entities:
       pos: 12.5,-19.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141726,9 +135450,14 @@ entities:
       pos: 11.5,-19.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141738,9 +135467,14 @@ entities:
       pos: 10.5,-19.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141750,9 +135484,14 @@ entities:
       pos: 4.5,-19.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141761,9 +135500,14 @@ entities:
     - pos: 0.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -501142.78
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25958
       type: DeviceLinkSink
@@ -141773,9 +135517,14 @@ entities:
       pos: 44.5,14.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -89448.695
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 14025
       type: DeviceLinkSink
@@ -141785,9 +135534,14 @@ entities:
       pos: -6.5,33.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -399951.5
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25181
       type: DeviceLinkSink
@@ -141796,9 +135550,14 @@ entities:
     - pos: -10.5,32.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -399951.5
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25181
       type: DeviceLinkSink
@@ -141808,9 +135567,14 @@ entities:
       pos: 25.5,65.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -401259.6
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25178
       type: DeviceLinkSink
@@ -141819,9 +135583,14 @@ entities:
     - pos: 28.5,67.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -401259.6
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25178
       type: DeviceLinkSink
@@ -141830,9 +135599,14 @@ entities:
     - pos: 27.5,67.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -401259.6
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25178
       type: DeviceLinkSink
@@ -141841,9 +135615,14 @@ entities:
     - pos: 28.5,62.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -401259.6
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25178
       type: DeviceLinkSink
@@ -141852,9 +135631,14 @@ entities:
     - pos: 26.5,62.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -401259.6
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25178
       type: DeviceLinkSink
@@ -141863,9 +135647,14 @@ entities:
     - pos: 27.5,62.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -401259.6
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25178
       type: DeviceLinkSink
@@ -141875,9 +135664,14 @@ entities:
       pos: -6.5,36.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -399951.5
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25181
       type: DeviceLinkSink
@@ -141887,9 +135681,14 @@ entities:
       pos: -46.5,-35.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -392892.66
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25230
       type: DeviceLinkSink
@@ -141898,9 +135697,14 @@ entities:
     - pos: -45.5,-33.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -392892.66
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25230
       type: DeviceLinkSink
@@ -141909,9 +135713,14 @@ entities:
     - pos: -44.5,-33.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -392892.66
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25230
       type: DeviceLinkSink
@@ -141920,9 +135729,14 @@ entities:
     - pos: -42.5,-33.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -392892.66
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25230
       type: DeviceLinkSink
@@ -141931,9 +135745,14 @@ entities:
     - pos: -41.5,-33.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -392892.66
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 25230
       type: DeviceLinkSink
@@ -141942,9 +135761,14 @@ entities:
     - pos: 61.5,-6.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -141954,9 +135778,14 @@ entities:
       pos: 57.5,-7.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -141966,9 +135795,14 @@ entities:
       pos: 57.5,-8.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -141978,9 +135812,14 @@ entities:
       pos: 57.5,-10.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -141990,9 +135829,14 @@ entities:
       pos: 57.5,-11.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -142002,9 +135846,14 @@ entities:
       pos: 57.5,-9.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -142014,9 +135863,14 @@ entities:
       pos: 59.5,-14.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -142026,9 +135880,14 @@ entities:
       pos: 59.5,-15.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -390107.34
-      state: Opening
+    - enabled: False
+      type: Occluder
+    - canCollide: False
+      type: Physics
+    - state: Open
       type: Door
+    - airBlocked: False
+      type: Airtight
     - links:
       - 3190
       type: DeviceLinkSink
@@ -142205,9 +136064,14 @@ entities:
     - pos: -26.5,60.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -445943.38
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 24531
       type: DeviceLinkSink
@@ -142216,9 +136080,14 @@ entities:
     - pos: -24.5,60.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -445943.38
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 24531
       type: DeviceLinkSink
@@ -142227,9 +136096,14 @@ entities:
     - pos: -25.5,60.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -445943.38
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 24531
       type: DeviceLinkSink
@@ -142238,9 +136112,14 @@ entities:
     - pos: -23.5,60.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -445943.38
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 24531
       type: DeviceLinkSink
@@ -142249,9 +136128,14 @@ entities:
     - pos: -27.5,60.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -445943.38
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 24531
       type: DeviceLinkSink
@@ -170814,6 +164698,11 @@ entities:
       type: Transform
 - proto: WindoorSecureMedicalLocked
   entities:
+  - uid: 2867
+    components:
+    - pos: -29.5,-36.5
+      parent: 82
+      type: Transform
   - uid: 2980
     components:
     - rot: 3.141592653589793 rad
@@ -170830,13 +164719,6 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -23.5,-30.5
-      parent: 82
-      type: Transform
-- proto: WindoorSecureParamedicLocked
-  entities:
-  - uid: 2867
-    components:
-    - pos: -29.5,-36.5
       parent: 82
       type: Transform
 - proto: WindoorSecureSalvageLocked
@@ -172523,17 +166405,27 @@ entities:
     - pos: -11.5,17.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -571050.75
-      state: Opening
+    - state: Open
       type: Door
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
+    - enabled: False
+      type: Occluder
   - uid: 4246
     components:
     - pos: -11.5,19.5
       parent: 82
       type: Transform
-    - SecondsUntilStateChange: -571049
-      state: Opening
+    - state: Open
       type: Door
+    - canCollide: False
+      type: Physics
+    - airBlocked: False
+      type: Airtight
+    - enabled: False
+      type: Occluder
   - uid: 8013
     components:
     - pos: -53.5,-2.5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Title implies. Nothing else was changed.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

#20652 -> This implies roundstart paramedics cannot leave their room on the current map.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

This door is affected and was changed:
![image](https://github.com/space-wizards/space-station-14/assets/19798667/943b5fdc-659b-4347-889f-67445393fa8a)



**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
no cl
