### PR TITLE
Bug fix for missing notifications when prying open a powered or bolted airlock

### DIFF
--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -179,7 +179,7 @@ public sealed class AirlockSystem : SharedAirlockSystem
     {
         if (this.IsPowered(uid, EntityManager) && !args.PryPowered)
         {
-            Popup.PopupClient(Loc.GetString("airlock-component-cannot-pry-is-powered-message"), uid, args.User);
+            Popup.PopupEntity(Loc.GetString("airlock-component-cannot-pry-is-powered-message"), uid, args.User);
             args.Cancelled = true;
         }
     }

--- a/Content.Shared/Doors/Systems/SharedDoorBoltSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorBoltSystem.cs
@@ -25,7 +25,7 @@ public abstract class SharedDoorBoltSystem : EntitySystem
     {
         if (component.BoltsDown && !args.Force)
         {
-            Popup.PopupClient(Loc.GetString("airlock-component-cannot-pry-is-bolted-message"), uid, args.User);
+            Popup.PopupEntity(Loc.GetString("airlock-component-cannot-pry-is-bolted-message"), uid, args.User);
             args.Cancelled = true;
         }
     }


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes a bug so that when you try to pry open a powered or bolted airlock, a notification will pop up again

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
See above

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changed 'Popup.Client' to 'Popup.PopupEntity'

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/50505512/6f06a7f1-22b2-4072-a06c-1173f8d1d27e

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
