### PR TITLE
Revert "Northstar Gloves dmg reduced from 8 -> 7"

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -339,7 +339,7 @@
     attackRate: 4
     damage:
       types:
-       Blunt: 7
+       Blunt: 8
     soundHit:
       collection: Punch
     animation: WeaponArcFist


### PR DESCRIPTION
Reverts space-wizards/space-station-14#19570

the 25% damage bonus for clicks was removed so it should go back up to 8

:cl: JoeHammad
tweak: the north star gloves have had their damage changed back to 8, as was originally intended