### PR TITLE
actually add jug to medfab + cheaper

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -685,6 +685,7 @@
       - Hemostat
       - BluespaceBeaker
       - SyringeBluespace
+      - Jug
   - type: Machine
     board: MedicalTechFabCircuitboard
 

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -202,4 +202,4 @@
   result: Jug
   completetime: 4
   materials:
-    Plastic: 700
+    Plastic: 400

--- a/Resources/Prototypes/Research/biochemical.yml
+++ b/Resources/Prototypes/Research/biochemical.yml
@@ -15,6 +15,7 @@
   - HotplateMachineCircuitboard
   - ChemicalPayload
   - ClothingEyesGlassesChemical
+  - Jug
 
 - type: technology
   id: SurgicalTools


### PR DESCRIPTION
## About the PR
actually added the recipe to the medfab and in the chemistry tech
made it 4 plastic instead of 7

## Why / Balance
large beaker is 2 glass
jug has double capacity and is plastic so 4 plastic

## Technical details
no

## Media
![14:38:50](https://github.com/space-wizards/space-station-14/assets/39013340/82e1adf7-ae95-4bce-a78a-bba0bd65070c)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
theres a cl from 2 months ago im sure people remember it
