### PR TITLE
Make bluespace beakers hold 1000u

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -234,7 +234,7 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 300
+        maxVol: 1000
         canMix: true
 
 - type: entity


### PR DESCRIPTION
These are criminally underpowered.

Also mobile pr ate the fucking template son of a bitch

:cl:
- tweak: Bluespace beakers can now hold up to 1000u.