### PR TITLE
Monkey's can wear gas masks now. 

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -13,6 +13,7 @@
   - type: IdentityBlocker
   - type: Tag
     tags:
+    - MonkeyWearable
     - HamsterWearable
     - WhitelistChameleon
 

--- a/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
@@ -24,6 +24,7 @@
     displayName: Mask
     whitelist:
       tags:
+        - MonkeyWearable
         - PetWearable
       components:
         - Smokable

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -766,6 +766,9 @@
   id: PetWearable
 
 - type: Tag
+  id: MonkeyWearable
+
+- type: Tag
   id: Pickaxe
 
 - type: Tag


### PR DESCRIPTION
## About the PR
Monkeys are capable of wearing gas mask's now.
Fixes #20676

## Why / Balance
Syndicate monkey's were not able to equip the syndicate gas mask previously

## Media
![imgur](https://i.imgur.com/uxNOZlg.png)
- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame 

**Changelog**
:cl:
- add:  Monkey's now are able to equip gas masks.

