### PR TITLE
add impersonate traitor objective

### DIFF
--- a/Content.Server/Objectives/Components/AntisocialObjectiveComponent.cs
+++ b/Content.Server/Objectives/Components/AntisocialObjectiveComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server.Objectives.Components;
+
+/// <summary>
+/// Marker component for antisocial objectives and social objectives to be mutually exclusive.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AntiSocialObjectiveComponent : Component
+{
+}

--- a/Content.Server/Objectives/Components/ImpersonateConditionComponent.cs
+++ b/Content.Server/Objectives/Components/ImpersonateConditionComponent.cs
@@ -3,7 +3,7 @@ using Content.Server.Objectives.Systems;
 namespace Content.Server.Objectives.Components;
 
 /// <summary>
-/// Requires that your identity be the same as a target.
+/// Requires that you have the same identity a target for a certain length of time before the round ends.
 /// Obviously the agent id will work for this, but it's assumed that you will kill the target to prevent suspicion.
 /// Depends on <see cref="TargetObjectiveComponent"/> to function.
 /// </summary>
@@ -18,4 +18,24 @@ public sealed partial class ImpersonateConditionComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string? Name;
+
+    /// <summary>
+    /// Mind this objective got assigned to, used to continiously checkd impersonation.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public EntityUid? MindId;
+
+    /// <summary>
+    /// How long you have to impersonate the target for a greentext.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan Duration = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// How long you have impersonated the target for.
+    /// Increases when your identity is the same, and decreases when it isn't.
+    /// Will only increase up to <see cref="Duration"/> so you can't invest time then stop impersonating on evac.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan TimeImpersonated = TimeSpan.Zero;
 }

--- a/Content.Server/Objectives/Components/ImpersonateConditionComponent.cs
+++ b/Content.Server/Objectives/Components/ImpersonateConditionComponent.cs
@@ -1,0 +1,21 @@
+using Content.Server.Objectives.Systems;
+
+namespace Content.Server.Objectives.Components;
+
+/// <summary>
+/// Requires that your identity be the same as a target.
+/// Obviously the agent id will work for this, but it's assumed that you will kill the target to prevent suspicion.
+/// Depends on <see cref="TargetObjectiveComponent"/> to function.
+/// </summary>
+[RegisterComponent, Access(typeof(ImpersonateConditionSystem))]
+public sealed partial class ImpersonateConditionComponent : Component
+{
+    /// <summary>
+    /// Name that must match your identity for greentext.
+    /// This is stored once after the objective is assigned:
+    /// 1. to be a tiny bit more efficient
+    /// 2. to prevent the name possibly changing when borging or anything else and messing you up
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string? Name;
+}

--- a/Content.Server/Objectives/Components/SocialObjectiveComponent.cs
+++ b/Content.Server/Objectives/Components/SocialObjectiveComponent.cs
@@ -1,7 +1,7 @@
 namespace Content.Server.Objectives.Components;
 
 /// <summary>
-/// Marker component for social objectives and kill objectives to be mutually exclusive.
+/// Marker component for social objectives and antisocial objectives to be mutually exclusive.
 /// </summary>
 [RegisterComponent]
 public sealed partial class SocialObjectiveComponent : Component

--- a/Content.Server/Objectives/Components/TargetObjectiveComponent.cs
+++ b/Content.Server/Objectives/Components/TargetObjectiveComponent.cs
@@ -6,11 +6,18 @@ namespace Content.Server.Objectives.Components;
 public sealed partial class TargetObjectiveComponent : Component
 {
     /// <summary>
-    /// Locale id for the objective title.
+    /// Optional locale id for the objective title.
     /// It is passed "targetName" and "job" arguments.
     /// </summary>
-    [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
-    public string Title = string.Empty;
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId? Title;
+
+    /// <summary>
+    /// Optional locale id for the objective description.
+    /// It is passed "targetName" and "job" arguments.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId? Description;
 
     /// <summary>
     /// Mind entity id of the target.

--- a/Content.Server/Objectives/Systems/ImpersonateConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/ImpersonateConditionSystem.cs
@@ -1,0 +1,47 @@
+using Content.Server.Objectives.Components;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Components;
+
+namespace Content.Server.Objectives.Systems;
+
+/// <summary>
+/// Handles kill person condition logic and picking random kill targets.
+/// </summary>
+public sealed class ImpersonateConditionSystem : EntitySystem
+{
+    [Dependency] private readonly TargetObjectiveSystem _target = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ImpersonateConditionComponent, ObjectiveAfterAssignEvent>(OnAfterAssign);
+        SubscribeLocalEvent<ImpersonateConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
+    }
+
+    private void OnAfterAssign(EntityUid uid, ImpersonateConditionComponent comp, ref ObjectiveAfterAssignEvent args)
+    {
+        if (!_target.GetTarget(uid, out var target))
+            return;
+
+        if (!TryComp<MindComponent>(target, out var targetMind) || targetMind.CharacterName == null)
+            return;
+
+        comp.Name = targetMind.CharacterName;
+    }
+
+    private void OnGetProgress(EntityUid uid, ImpersonateConditionComponent comp, ref ObjectiveGetProgressEvent args)
+    {
+        args.Progress = GetProgress(args.Mind, comp.Name);
+    }
+
+    private float GetProgress(MindComponent mind, string? name)
+    {
+        if (mind.OwnedEntity == null || name == null)
+            return 0;
+
+        var uid = mind.OwnedEntity.Value;
+        return Identity.Name(uid, EntityManager).Equals(name) ? 1 : 0;
+    }
+}

--- a/Content.Server/Objectives/Systems/TargetObjectiveSystem.cs
+++ b/Content.Server/Objectives/Systems/TargetObjectiveSystem.cs
@@ -27,7 +27,11 @@ public sealed class TargetObjectiveSystem : EntitySystem
         if (!GetTarget(uid, out var target, comp))
             return;
 
-        _metaData.SetEntityName(uid, GetTitle(target.Value, comp.Title), args.Meta);
+        if (comp.Title != null)
+            _metaData.SetEntityName(uid, Format(target.Value, comp.Title.Value), args.Meta);
+
+        if (comp.Description != null)
+        _metaData.SetEntityDescription(uid, Format(target.Value, comp.Description.Value), args.Meta);
     }
 
     /// <summary>
@@ -53,7 +57,10 @@ public sealed class TargetObjectiveSystem : EntitySystem
         return target != null;
     }
 
-    private string GetTitle(EntityUid target, string title)
+    /// <summary>
+    /// Format either a title or description.
+    /// </summary>
+    private string Format(EntityUid target, LocId fmt)
     {
         var targetName = "Unknown";
         if (TryComp<MindComponent>(target, out var mind) && mind.CharacterName != null)
@@ -62,7 +69,7 @@ public sealed class TargetObjectiveSystem : EntitySystem
         }
 
         var jobName = _job.MindTryGetJobName(target);
-        return Loc.GetString(title, ("targetName", targetName), ("job", jobName));
+        return Loc.GetString(fmt, ("targetName", targetName), ("job", jobName));
     }
 
 }

--- a/Resources/Locale/en-US/objectives/conditions/impersonate.ftl
+++ b/Resources/Locale/en-US/objectives/conditions/impersonate.ftl
@@ -1,0 +1,2 @@
+objective-condition-impersonate-title = Impersonate {$targetName}, {CAPITALIZE($job)}
+objective-condition-impersonate-description = Assume the identity of {$targetName} by wearing their ID and presumably the rest of their clothes.

--- a/Resources/Prototypes/Objectives/base_objectives.yml
+++ b/Resources/Prototypes/Objectives/base_objectives.yml
@@ -60,6 +60,23 @@
       state: icon
   - type: KillPersonCondition
 
+# requires that the player impersonate someone
+- type: entity
+  abstract: true
+  parent: BaseAntiSocialObjective
+  id: BaseImpersonateObjective
+  components:
+  - type: Objective
+    icon:
+      sprite: Clothing/Mask/gas.rsi
+      state: icon
+  - type: ObjectiveBlacklistRequirement
+    blacklist:
+      components:
+      - SocialObjective
+      - DieCondition
+  - type: ImpersonateCondition
+
 # requires that the player interact socially with someone
 # disables antisocial objectives and is disabled by antisocial objectives
 - type: entity

--- a/Resources/Prototypes/Objectives/base_objectives.yml
+++ b/Resources/Prototypes/Objectives/base_objectives.yml
@@ -35,11 +35,22 @@
   components:
   - type: TargetObjective
 
-# requires that the player kill someone
 # disables social objectives and is disabled by social objectives
 - type: entity
   abstract: true
   parent: BaseTargetObjective
+  id: BaseAntiSocialObjective
+  components:
+  - type: ObjectiveBlacklistRequirement
+    blacklist:
+      components:
+      - SocialObjective
+  - type: AntiSocialObjective
+
+# requires that the player kill someone
+- type: entity
+  abstract: true
+  parent: BaseAntiSocialObjective
   id: BaseKillObjective
   components:
   - type: Objective
@@ -47,14 +58,10 @@
     icon:
       sprite: Objects/Weapons/Guns/Pistols/viper.rsi
       state: icon
-  - type: ObjectiveBlacklistRequirement
-    blacklist:
-      components:
-      - SocialObjective
   - type: KillPersonCondition
 
 # requires that the player interact socially with someone
-# disables kill objectives and is disabled by kill objectives
+# disables antisocial objectives and is disabled by antisocial objectives
 - type: entity
   abstract: true
   parent: BaseTargetObjective
@@ -65,7 +72,7 @@
   - type: ObjectiveBlacklistRequirement
     blacklist:
       components:
-      - KillPersonCondition
+      - AntiSocialObjective
   - type: SocialObjective
 
 # requires that the target survives the round

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -3,7 +3,7 @@
   id: TraitorObjectiveGroups
   weights:
     TraitorObjectiveGroupSteal: 1
-    TraitorObjectiveGroupKill: 1
+    TraitorObjectiveGroupAntisocial: 1 # kill someone, or get to work after theyve been killed
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
 
@@ -22,10 +22,11 @@
     SecretDocumentsStealObjective: 0.5
 
 - type: weightedRandom
-  id: TraitorObjectiveGroupKill
+  id: TraitorObjectiveGroupAntisocial
   weights:
     KillRandomPersonObjective: 1
     KillRandomHeadObjective: 0.25
+    ImpersonateRandomPersonObjective: 0.5
 
 - type: weightedRandom
   id: TraitorObjectiveGroupState

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -62,9 +62,10 @@
       components:
       - EscapeShuttleCondition
       - StealCondition
+      - ImpersonateCondition
   - type: DieCondition
 
-# kill
+# antisocial
 
 - type: entity
   noSpawn: true
@@ -97,6 +98,20 @@
     # don't count missing evac as killing as heads are higher profile, so you really need to do the dirty work
     # if ce flies a shittle to centcom you better find a way onto it
     requireDead: true
+
+- type: entity
+  noSpawn: true
+  parent: [BaseTraitorObjective, BaseImpersonateObjective]
+  id: ImpersonateRandomPersonObjective
+  components:
+  - type: Objective
+    difficulty: 2.0
+    # physically not able to impersonate multiple people
+    unique: true
+  - type: TargetObjective
+    title: objective-condition-impersonate-title
+    description: objective-condition-impersonate-description
+  - type: PickRandomPerson
 
 # social
 


### PR DESCRIPTION
## About the PR
new objective that requires you to have the same identity as the target for 10 minutes straight before round ends, so id + wear a mask.
presumably youd have to kill them too to avoid any "why is this guy running around with my id pretending to be me"

## Why / Balance
cool new objective to spice up rounds a bit from the boring mostly just stealing and killing.

## Technical details
- impersonate logic requires you to have the same identity as the target for 10 minutes before round ends
- made TargetObjective's Title optional and added description so its more customizable.
- added AntiSocialObjective marker component since it makes it easier to maintain social's blacklist with kill and impersonation and anything else in the future that would fit in.

## Media
silly urist
![18:26:41](https://github.com/space-wizards/space-station-14/assets/39013340/2123957a-9a4d-4920-bdd0-b9a8337a51e4)

i am the captain now
![18:27:39](https://github.com/space-wizards/space-station-14/assets/39013340/7a62f3e1-a0d9-4968-873a-6ec128700f67)

le epic greentext
![18:27:53](https://github.com/space-wizards/space-station-14/assets/39013340/b548b635-7dc7-42fb-9a05-3d771d62448c)

we must wait
![19:41:42](https://github.com/space-wizards/space-station-14/assets/39013340/2f6c24a9-ab87-4cd7-94a7-cab18a0b4205)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: The Syndicate may now assign operatives the goal of assuming the identity of crewmembers.