### PR TITLE
Make minigun weigh more

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -33,6 +33,7 @@
       map: ["enum.GunVisualLayers.Base"]
   - type: Item
     sprite: Objects/Weapons/Guns/HMGs/minigun.rsi
+    size: 90
   - type: Gun
     fireRate: 15
     soundGunshot:


### PR DESCRIPTION
## About the PR
Miniguns weigh 90 volume units instead of 5 now, causing storing them in pockets to be impossible.

## Why / Balance
I don't think this needs ANY fucking description.
I chose 90 because the next best thing, the L6 SAW being a LMG, takes up 60 space. Not entirely out of reach of ERT/squaddies, but prohibitive for normal crew.
The fact that balance like this wasn't made for a fucking year now is deplorable, but such is the rot, to consume.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
