### PR TITLE
Removes unnecessary message for defibbing a patient which has ghosted

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -230,8 +230,6 @@ public sealed class DefibrillatorSystem : EntitySystem
                 // notify them they're being revived.
                 if (mind.CurrentEntity != target)
                 {
-                    _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-ghosted"),
-                        InGameICChatType.Speak, true);
                     _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind), session);
                 }
             }

--- a/Resources/Locale/en-US/medical/components/defibrillator.ftl
+++ b/Resources/Locale/en-US/medical/components/defibrillator.ftl
@@ -1,4 +1,3 @@
 ﻿defibrillator-not-on = The defibrillator isn't turned on.
 defibrillator-no-mind = No intelligence pattern can be detected in patient's brain. Further attempts futile.
-defibrillator-ghosted = Resuscitation failed - Mental interface error. Further attempts may be successful.
 defibrillator-rotten = Body decomposition detected: resuscitation failed.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
As per title, removes an unnecessary message for defibbing a patient which has ghosted.


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

That was a message for the defib operator which showed up for ghosted dead patients. The message was

> Resuscitation failed - Mental interface error. Further attempts may be successful.

It was probably meant to inform them that the patient doesn't have a consciousness since it's ghosted but maybe no message is really the right way to go here because it may have succeeded and that would be what would happen had the defib attempt succeeded - no message.

Also when the patient's ghost return to body they will be alive as long as the body is still alive, so telling the operator to defib again may be wrong.

It is confusing mostly because the body may be alive. Users end up using defib multiple times and just deal burn damage to a patient which is or was alive.

When defib attempts fail on bodies which aren't rotten and still have a mind attached to them - like the deadly poisoned - it also displays no message. The only difference is what sound effect is played.

If the patient is ghosted and afk and never returns or just chooses "no", then the doctor will probably figure the body misses a player by the message that shows up by examining them, which they will probably do soon after defibbing. This is already the most reliable way to tell if it worked.

Finally, in most cases the player will return, and in those cases it will be better anyway if alive people can't tell whether the person getting resuscitated ghosted or not.

I don't think the other PR fields apply so just removed those.

Cheers