### PR TITLE
Change ThrownItemComponent to be removed after flytime

### DIFF
--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -1,7 +1,6 @@
 using System.Numerics;
 using Content.Shared.Gravity;
 using Content.Shared.Interaction;
-using Content.Shared.Movement.Components;
 using Content.Shared.Projectiles;
 using Content.Shared.Tag;
 using Robust.Shared.Map;
@@ -24,6 +23,7 @@ public sealed class ThrowingSystem : EntitySystem
     /// </summary>
     public const float FlyTime = 0.15f;
 
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly SharedGravitySystem _gravity = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
@@ -112,6 +112,13 @@ public sealed class ThrowingSystem : EntitySystem
 
         var comp = EnsureComp<ThrownItemComponent>(uid);
         comp.Thrower = user;
+
+        // Estimate time to arrival so we can apply OnGround status and slow it much faster.
+        var time = direction.Length() / strength;
+        comp.ThrownTime = _gameTiming.CurTime;
+        comp.LandTime = time < FlyTime ? default : comp.ThrownTime + TimeSpan.FromSeconds(time - FlyTime);
+        comp.PlayLandSound = playSound;
+
         ThrowingAngleComponent? throwingAngle = null;
 
         // Give it a l'il spin.
@@ -134,24 +141,13 @@ public sealed class ThrowingSystem : EntitySystem
         var impulseVector = direction.Normalized() * strength * physics.Mass;
         _physics.ApplyLinearImpulse(uid, impulseVector, body: physics);
 
-        // Estimate time to arrival so we can apply OnGround status and slow it much faster.
-        var time = direction.Length() / strength;
-
-        if (time < FlyTime)
+        if (comp.LandTime <= TimeSpan.Zero)
         {
             _thrownSystem.LandComponent(uid, comp, physics, playSound);
         }
         else
         {
             _physics.SetBodyStatus(physics, BodyStatus.InAir);
-
-            Timer.Spawn(TimeSpan.FromSeconds(time - FlyTime), () =>
-            {
-                if (physics.Deleted)
-                    return;
-
-                _thrownSystem.LandComponent(uid, comp, physics, playSound);
-            });
         }
 
         // Give thrower an impulse in the other direction

--- a/Content.Shared/Throwing/ThrownItemComponent.cs
+++ b/Content.Shared/Throwing/ThrownItemComponent.cs
@@ -1,13 +1,41 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Throwing
 {
-    [RegisterComponent, NetworkedComponent]
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class ThrownItemComponent : Component
     {
-        [ViewVariables(VVAccess.ReadWrite), DataField("thrower")]
+        /// <summary>
+        ///     The entity that threw this entity.
+        /// </summary>
+        [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
         public EntityUid? Thrower { get; set; }
+
+        /// <summary>
+        ///     The <see cref="IGameTiming.CurTime"/> timestamp at which this entity was thrown.
+        /// </summary>
+        [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+        public TimeSpan? ThrownTime { get; set; }
+
+        /// <summary>
+        ///     Compared to <see cref="IGameTiming.CurTime"/> to land this entity, if any.
+        /// </summary>
+        [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+        public TimeSpan? LandTime { get; set; }
+
+        /// <summary>
+        ///     Whether or not this entity was already landed.
+        /// </summary>
+        [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+        public bool Landed { get; set; }
+
+        /// <summary>
+        ///     Whether or not to play a sound when the entity lands.
+        /// </summary>
+        [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+        public bool PlayLandSound { get; set; }
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedTetherGunSystem.cs
@@ -259,6 +259,7 @@ public abstract partial class SharedTetherGunSystem : EntitySystem
             {
                 var thrown = EnsureComp<ThrownItemComponent>(component.Tethered.Value);
                 _thrown.LandComponent(component.Tethered.Value, thrown, targetPhysics, true);
+                _thrown.StopThrow(component.Tethered.Value, thrown);
             }
 
             _physics.SetBodyStatus(targetPhysics, BodyStatus.OnGround);


### PR DESCRIPTION
## About the PR
This also makes spears (DamageOnHit), stun batons and cream pies more consistent since they can take effect at close range and when the item has landed but is still sliding.
Also throwing doesn't use a timer anymore.

## Media
https://github.com/space-wizards/space-station-14/assets/10968691/bca49f54-57b2-4399-985d-70f4df45640e

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed not being able to throw items into disposals from close up.