### PR TITLE
Revert "Disable SSD indicators on LRP"

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/salamander.toml
+++ b/Resources/ConfigPresets/WizardsDen/salamander.toml
@@ -25,7 +25,6 @@ enable_during_round = true
 
 [ic]
 flavor_text = true
-show_ssd_indicator = true
 
 [hub]
 tags = "lang:en,region:am_n_w,rp:med"

--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -28,6 +28,3 @@ limit = 10.0
 [admin]
 see_own_notes = true
 deadmin_on_join = true
-
-[ic]
-show_ssd_indicator = false


### PR DESCRIPTION
Reverts space-wizards/space-station-14#20021

It's client only, causes the servers to not start.