### PR TITLE
To weld the secret door

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -35,6 +35,8 @@
     openingAnimationTime: 1.2
     closingAnimationTime: 1.2
   - type: Appearance
+  - type: Weldable
+    time: 2
   - type: Airtight
     fixVacuum: true
   - type: Damageable


### PR DESCRIPTION
## About the PR

Less meta with Secret Doors, now they won't be "accidentally" opened in tech tunnels. Just weld the doors and they will not react to click in any way.

## Why / Balance
Secret Doors are too easy to open, and too many people just click on all the walls in techs looking for secret rooms. This will now be avoided.

## Technical details

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: Nimfar11

- add: Now the Secret Doors can be welded shut.
