### PR TITLE
Return of spam pointing (lowers pointing cooldown)

### DIFF
--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -41,7 +41,7 @@ namespace Content.Server.Pointing.EntitySystems
         [Dependency] private readonly SharedMindSystem _minds = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
 
-        private static readonly TimeSpan PointDelay = TimeSpan.FromSeconds(0.5f);
+        private static readonly TimeSpan PointDelay = TimeSpan.FromSeconds(0.15f);
 
         /// <summary>
         ///     A dictionary of players to the last time that they


### PR DESCRIPTION
## About the PR
Makes the pointing cooldown much, much lower. Probably somewhere roughly similar to the cooldown SS13 had, at least to my memory.

## Why / Balance
It's a really funny faucet of player expression that is direly missed in SS14. It buffs passive-aggressively pointing at someone because they're taking too long and also lets you soyjack pointing image "HOLY SHIT LOOK. LOOK AT THE THING! LOOK!"

Not really abusable because pointing is obviously temporary, not really annoying because of the previous thing + the fact that most players will have to spam the fuck out of their middle mouse button. In the absolute worst-case scenario where someone DOES actually spam the ever living shit out of it with a normal key, it will probably just be more funny then anything since it barely affects anything.

## Technical details
Changes a single line in PointingSystem.cs, lowing the PointDelay from 0.5 to 0.15.

## Media
https://imgur.com/a/hnYQNYl

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Drastically lowered the pointing cooldown.
