### PR TITLE
Remove foam event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -245,21 +245,21 @@
     lightBreakChancePerSecond: 0.0003
     doorToggleChancePerSecond: 0.001
 
-- type: entity
-  id: VentClog
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-vent-clog-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    earliestStart: 15
-    minimumPlayers: 15
-    weight: 5
-    startDelay: 50
-    duration: 60
-  - type: VentClogRule
+#- type: entity
+#  id: VentClog
+#  parent: BaseGameRule
+#  noSpawn: true
+#  components:
+#  - type: StationEvent
+#    startAnnouncement: station-event-vent-clog-start-announcement
+#    startAudio:
+#      path: /Audio/Announcements/attention.ogg
+#    earliestStart: 15
+#    minimumPlayers: 15
+#    weight: 5
+#    startDelay: 50
+#    duration: 60
+#  - type: VentClogRule
 
 - type: entity
   id: VentCritters


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Temporarily removing the foam, otherwise known as vent clog event because of the removal of foam chemical effects. All it does now is slips you if you move and blocks up your view for a few seconds, a minor annoyance and simply unfun. Doesn't hurt you, or cause chaos around the station.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: Ubaser
- remove: Vent clog event is temporarily removed.

