### PR TITLE
Add new chemical Valoderm

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -1,6 +1,9 @@
 reagent-name-cryptobiolin = cryptobiolin
 reagent-desc-cryptobiolin = Causes confusion and dizziness. This is essential to make Spaceacillin.
 
+reagent-name-cryptobiolin = valoderm
+reagent-desc-cryptobiolin = Has an adverse reaction within the body causing major jittering. While not useful on it's own, it can be used to produce a small variety of chemicals.
+
 reagent-name-dylovene = dylovene
 reagent-desc-dylovene = A broad-spectrum anti-toxin, which treats toxin damage in the blood stream. Overdosing will cause vomiting, dizzyness and pain.
 

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -36,8 +36,6 @@
       - !type:MovespeedModifier
         walkSpeedModifier: 0.8
         sprintSpeedModifier: 0.8
-        - !type:ReagentThreshold
-          min: 5
 
 - type: reagent
   id: Dylovene

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -36,6 +36,8 @@
       - !type:MovespeedModifier
         walkSpeedModifier: 0.8
         sprintSpeedModifier: 0.8
+        - !type:ReagentThreshold
+          min: 5
 
 - type: reagent
   id: Dylovene

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -19,6 +19,25 @@
         boozePower: 20
 
 - type: reagent
+  id: Valoderm
+  name: reagent-name-valoderm
+  group: Medicine
+  desc: reagent-desc-valoderm
+  physicalDesc: reagent-physical-desc-shiny
+  flavor: medicine
+  color: "#435166"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:Jitter
+        conditions:
+        - !type:ReagentThreshold
+          min: 5
+      - !type:MovespeedModifier
+        walkSpeedModifier: 0.8
+        sprintSpeedModifier: 0.8
+
+- type: reagent
   id: Dylovene
   name: reagent-name-dylovene
   group: Medicine

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -186,15 +186,15 @@
 - type: reaction
   id: Leporazine
   reactants:
+    Valoderm:
+      amount: 2
     Silicon:
-      amount: 1
-    Copper:
       amount: 1
     Plasma:
       amount: 1
       catalyst: true
   products:
-    Leporazine: 2
+    Leporazine: 3
 
 - type: reaction
   id: Phalanximine
@@ -236,7 +236,7 @@
   reactants:
     Lithium:
       amount: 1
-    Sugar:
+    Valoderm:
       amount: 1
     Water:
       amount: 1
@@ -269,9 +269,9 @@
   reactants:
     Mercury:
       amount: 1
-    Oxygen:
-      amount: 1
     Water:
+      amount: 1
+    Valoderm:
       amount: 1
   products:
     Impedrezene: 1
@@ -396,3 +396,15 @@
       amount: 1
   products:
     Saline: 5
+
+- type: reaction
+  id: Valoderm
+  reactants:
+    Mercury:
+      amount: 1
+    Hydrogen:
+      amount: 1
+    Water:
+      amount: 1
+  products:
+    Valoderm: 3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This chemical is the summation of two changes i feel would either add some more uniqueness to what a chemist can create, along with adding more interactions to some chemicals that i feel are way too simple for their effects. This is my personal opinion as someone who is a crackhead at chem and absolutely love the job gameplay.

For an example, even though alcohol and space drugs are all great for making for a trippy experience; there is still ONE effect that can hardly be recreated.. jittering! Your only choice for jittering is overdose or space medipen, which is way too little. In short, this is just cryptobiolin v2.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

It requires a 1:1:1 ratio of hydrogen, water and mercury to create, and produces 3 Valoderm. I have tweaked the recipes of Leporazine, Impedredizine and Synaptizine to require Valoderm. Causes Jittering and slower movement on consumption, at a minimum of 5u.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Ubaser
- add: Added a new "filler" chemical, Valoderm.
