### PR TITLE
Fix revolutionaries not being considered antags for events

### DIFF
--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -13,6 +13,7 @@ public sealed class RoleSystem : SharedRoleSystem
         SubscribeAntagEvents<InitialInfectedRoleComponent>();
         SubscribeAntagEvents<NinjaRoleComponent>();
         SubscribeAntagEvents<NukeopsRoleComponent>();
+        SubscribeAntagEvents<RevolutionaryRoleComponent>();
         SubscribeAntagEvents<SubvertedSiliconRoleComponent>();
         SubscribeAntagEvents<TraitorRoleComponent>();
         SubscribeAntagEvents<ZombieRoleComponent>();


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/20738

## About the PR
Fixes the player not showing as antag in the overlay and admin player list.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
