### PR TITLE
give revs briefing

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -58,6 +58,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         SubscribeLocalEvent<CommandStaffComponent, MobStateChangedEvent>(OnCommandMobStateChanged);
         SubscribeLocalEvent<HeadRevolutionaryComponent, MobStateChangedEvent>(OnHeadRevMobStateChanged);
         SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndText);
+        SubscribeLocalEvent<RevolutionaryRoleComponent, GetBriefingEvent>(OnGetBriefing);
         SubscribeLocalEvent<HeadRevolutionaryComponent, AfterFlashedEvent>(OnPostFlash);
     }
 
@@ -116,6 +117,15 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             }
             break;
         }
+    }
+
+    private void OnGetBriefing(EntityUid uid, RevolutionaryRoleComponent comp, ref GetBriefingEvent args)
+    {
+        if (!TryComp<MindComponent>(uid, out var mind) || mind.OwnedEntity == null)
+            return;
+
+        var head = HasComp<HeadRevolutionaryComponent>(mind.OwnedEntity);
+        args.Append(Loc.GetString(head ? "head-rev-briefing" : "rev-briefing"));
     }
 
     private void OnStartAttempt(RoundStartAttemptEvent ev)

--- a/Content.Server/Roles/RoleBriefingSystem.cs
+++ b/Content.Server/Roles/RoleBriefingSystem.cs
@@ -11,15 +11,6 @@ public sealed class RoleBriefingSystem : EntitySystem
 
     private void OnGetBriefing(EntityUid uid, RoleBriefingComponent comp, ref GetBriefingEvent args)
     {
-        if (args.Briefing == null)
-        {
-            // no previous briefing so just set it
-            args.Briefing = comp.Briefing;
-        }
-        else
-        {
-            // there is a previous briefing so append to it
-            args.Briefing += "\n" + comp.Briefing;
-        }
+        args.Append(comp.Briefing);
     }
 }

--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -35,4 +35,28 @@ public sealed class RoleSystem : SharedRoleSystem
 /// Handlers can either replace or append to the briefing, whichever is more appropriate.
 /// </summary>
 [ByRefEvent]
-public record struct GetBriefingEvent(string? Briefing = null);
+public sealed class GetBriefingEvent
+{
+    public string? Briefing;
+
+    public GetBriefingEvent(string? briefing = null)
+    {
+        Briefing = briefing;
+    }
+
+    /// <summary>
+    /// If there is no briefing, sets it to the string.
+    /// If there is a briefing, adds a new line to separate it from the appended string.
+    /// </summary>
+    public void Append(string text)
+    {
+        if (Briefing == null)
+        {
+            Briefing = text;
+        }
+        else
+        {
+            Briefing += "\n" + text;
+        }
+    }
+}

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -10,6 +10,10 @@ head-rev-role-greeting =
     Beware, this won't work on Security, Command, or those wearing sunglasses.
     Viva la revolución!
 
+head-rev-briefing =
+    Use flashes to convert people to your cause.
+    Kill all heads to take over the station.
+
 head-rev-initial-name = [color=#5e9cff]{$name}[/color] was one of the Head Revolutionaries.
 head-rev-initial-name-user = [color=#5e9cff]{$name}[/color] ([color=gray]{$username}[/color]) was one of the Head Revolutionaries.
 
@@ -32,6 +36,8 @@ rev-role-greeting =
     You are tasked with taking over the station and protecting the Head Revolutionaries.
     Eliminate all of the command staff.
     Viva la revolución!
+
+rev-briefing = Help your head revolutionaries kill every head to take over the station.
 
 ## General
 


### PR DESCRIPTION
## About the PR
gives rev and headrev a briefing in character menu

## Why / Balance
help new players figure it out

## Technical details
GetBriefingEvent for rev role yep

## Media

headrev briefing
![12:35:23](https://github.com/space-wizards/space-station-14/assets/39013340/858a247f-8452-42b7-9edb-79bfc29fa9a6)

rev briefing on a dragon!!!!
even compatible with other role's briefings
![12:32:30](https://github.com/space-wizards/space-station-14/assets/39013340/d63b3324-a6b9-4d78-9808-f8e313e6bcb1)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun