### PR TITLE
start of persistence support

### DIFF
--- a/Content.Server/Administration/Commands/PersistenceSaveCommand.cs
+++ b/Content.Server/Administration/Commands/PersistenceSaveCommand.cs
@@ -1,0 +1,60 @@
+using Content.Server.GameTicking;
+using Content.Server.Ghost.Components;
+using Content.Server.Players;
+using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Content.Shared.Ghost;
+using Robust.Server.GameObjects;
+using Robust.Server.Player;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+using Robust.Shared.Map;
+using System.Linq;
+
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Server)]
+public sealed class PersistenceSave : IConsoleCommand
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly IEntityManager _entities = default!;
+    [Dependency] private readonly IEntitySystemManager _system = default!;
+    [Dependency] private readonly IMapManager _map = default!;
+
+    public string Command => "persistencesave";
+    public string Description => "Saves server data to a persistence file to be loaded later.";
+    public string Help => "persistencesave [mapId] [filePath - default: game.map (CCVar) ]";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length < 1 || args.Length > 2)
+        {
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
+        }
+
+        if (!int.TryParse(args[0], out var intMapId))
+        {
+            shell.WriteError(Loc.GetString("cmd-parse-failure-integer", ("arg", args[0])));
+            return;
+        }
+
+        var mapId = new MapId(intMapId);
+        if (!_map.MapExists(mapId))
+        {
+            shell.WriteError(Loc.GetString("cmd-savemap-not-exist"));
+            return;
+        }
+
+        var saveFilePath = (args.Length > 1 ? args[1] : null) ?? _config.GetCVar(CCVars.GameMap);
+        if (string.IsNullOrWhiteSpace(saveFilePath))
+        {
+            shell.WriteError(Loc.GetString("cmd-persistencesave-no-path", ("cvar", nameof(CCVars.GameMap))));
+            return;
+        }
+
+        var mapLoader = _system.GetEntitySystem<MapLoaderSystem>();
+        mapLoader.SaveMap(mapId, saveFilePath);
+        shell.WriteLine(Loc.GetString("cmd-savemap-success"));
+    }
+}

--- a/Content.Server/Maps/GameMapPrototype.cs
+++ b/Content.Server/Maps/GameMapPrototype.cs
@@ -40,4 +40,18 @@ public sealed partial class GameMapPrototype : IPrototype
     /// The stations this map contains. The names should match with the BecomesStation components.
     /// </summary>
     public IReadOnlyDictionary<string, StationConfig> Stations => _stations;
+
+    /// <summary>
+    /// Performs a shallow clone of this map prototype, replacing <c>MapPath</c> with the argument.
+    /// </summary>
+    public GameMapPrototype Persistence(ResPath mapPath)
+    {
+        return new()
+        {
+            ID = ID,
+            MapName = MapName,
+            MapPath = mapPath,
+            _stations = _stations
+        };
+    }
 }

--- a/Content.Server/Station/Components/StationMemberComponent.cs
+++ b/Content.Server/Station/Components/StationMemberComponent.cs
@@ -11,6 +11,6 @@ public sealed partial class StationMemberComponent : Component
     /// <summary>
     /// Station that this grid is a part of.
     /// </summary>
-    [ViewVariables]
+    [DataField]
     public EntityUid Station = EntityUid.Invalid;
 }

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -331,7 +331,7 @@ public sealed class StationSystem : EntitySystem
         if (!string.IsNullOrEmpty(name))
             _metaData.SetEntityName(mapGrid, name);
 
-        var stationMember = AddComp<StationMemberComponent>(mapGrid);
+        var stationMember = EnsureComp<StationMemberComponent>(mapGrid);
         stationMember.Station = station;
         stationData.Grids.Add(mapGrid);
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -187,6 +187,19 @@ namespace Content.Shared.CCVar
             GameMap = CVarDef.Create("game.map", string.Empty, CVar.SERVERONLY);
 
         /// <summary>
+        ///     Controls whether to use world persistence or not.
+        /// </summary>
+        public static readonly CVarDef<bool>
+            UsePersistence = CVarDef.Create("game.usepersistence", false, CVar.ARCHIVE);
+
+        /// <summary>
+        ///     If world persistence is used, what map prototype should be initially loaded.
+        ///     If the save file exists, it replaces MapPath but everything else stays the same (station name and such).
+        /// </summary>
+        public static readonly CVarDef<string>
+            PersistenceMap = CVarDef.Create("game.persistencemap", "Empty", CVar.ARCHIVE);
+
+        /// <summary>
         ///     Prototype to use for map pool.
         /// </summary>
         public static readonly CVarDef<string>

--- a/Resources/Locale/en-US/persistence/command.ftl
+++ b/Resources/Locale/en-US/persistence/command.ftl
@@ -1,0 +1,1 @@
+cmd-persistencesave-no-path = filePath was not specified and CCVar {$cvar} is not set. Manually set the filePath param in order to save the map.


### PR DESCRIPTION
## About the PR
mini revival of #14740
lets maps be loaded from persistence saves and adds `persistencesave` command

this pr doesnt change any components to reserialize properly nor does it add the save load test as that wouldn't work at all.

more data will be saved in future prs piece by piece until eventually the test can be added and boom persistence can be used live.

## Why / Balance
good

## Technical details
the bool cvar `game.usepersistence` is used as before to control persistence being used at all.
with persistence enabled `game.persistencestartmap` map prototype is loaded.

with persistence `game.map` is no longer a prototype id but a path to a save file in the userdata directory.
if it exists, the MapPath on the start map prototype is replaced with this.

## Media
a modified empty map saved and loaded on a fresh server
a few things are serialized properly :) like ame jar being in the controller, nodegroups probably and the akms bolt being closed.
![23:07:02](https://github.com/space-wizards/space-station-14/assets/39013340/98932147-d489-4870-8926-2ba5bc6a25f1)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun