### PR TITLE
Fix action-granting items not being predicted

### DIFF
--- a/Content.Server/Bed/BedSystem.cs
+++ b/Content.Server/Bed/BedSystem.cs
@@ -44,6 +44,7 @@ namespace Content.Server.Bed
                 AddComp<HealOnBuckleHealingComponent>(uid);
                 component.NextHealTime = _timing.CurTime + TimeSpan.FromSeconds(component.HealTime);
                 _actionsSystem.AddAction(args.BuckledEntity, ref component.SleepAction, SleepingSystem.SleepActionId, uid);
+                Dirty(uid, component);
                 return;
             }
 

--- a/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
+++ b/Content.Server/Light/EntitySystems/UnpoweredFlashlightSystem.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+        [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
         [Dependency] private readonly SharedPointLightSystem _light = default!;
@@ -31,6 +32,13 @@ namespace Content.Server.Light.EntitySystems
             SubscribeLocalEvent<UnpoweredFlashlightComponent, ToggleActionEvent>(OnToggleAction);
             SubscribeLocalEvent<UnpoweredFlashlightComponent, MindAddedMessage>(OnMindAdded);
             SubscribeLocalEvent<UnpoweredFlashlightComponent, GotEmaggedEvent>(OnGotEmagged);
+            SubscribeLocalEvent<UnpoweredFlashlightComponent, MapInitEvent>(OnMapInit);
+        }
+
+        private void OnMapInit(EntityUid uid, UnpoweredFlashlightComponent component, MapInitEvent args)
+        {
+            _actionContainer.EnsureAction(uid, ref component.ToggleActionEntity, component.ToggleAction);
+            Dirty(uid, component);
         }
 
         private void OnToggleAction(EntityUid uid, UnpoweredFlashlightComponent component, ToggleActionEvent args)

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -27,6 +27,7 @@ public sealed partial class BlockingSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+    [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly FixtureSystem _fixtureSystem = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
@@ -51,11 +52,19 @@ public sealed partial class BlockingSystem : EntitySystem
         SubscribeLocalEvent<BlockingComponent, ComponentShutdown>(OnShutdown);
 
         SubscribeLocalEvent<BlockingComponent, GetVerbsEvent<ExamineVerb>>(OnVerbExamine);
+        SubscribeLocalEvent<BlockingComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, BlockingComponent component, MapInitEvent args)
+    {
+        _actionContainer.EnsureAction(uid, ref component.BlockingToggleActionEntity, component.BlockingToggleAction);
+        Dirty(uid, component);
     }
 
     private void OnEquip(EntityUid uid, BlockingComponent component, GotEquippedHandEvent args)
     {
         component.User = args.User;
+        Dirty(uid, component);
 
         //To make sure that this bodytype doesn't get set as anything but the original
         if (TryComp<PhysicsComponent>(args.User, out var physicsComponent) && physicsComponent.BodyType != BodyType.Static && !HasComp<BlockingUserComponent>(args.User))
@@ -201,6 +210,7 @@ public sealed partial class BlockingSystem : EntitySystem
         }
 
         component.IsBlocking = true;
+        Dirty(item, component);
 
         return true;
     }
@@ -254,6 +264,7 @@ public sealed partial class BlockingSystem : EntitySystem
         }
 
         component.IsBlocking = false;
+        Dirty(item, component);
 
         return true;
     }

--- a/Content.Shared/Blocking/Components/BlockingComponent.cs
+++ b/Content.Shared/Blocking/Components/BlockingComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Damage;
 using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -9,19 +10,19 @@ namespace Content.Shared.Blocking;
 /// <summary>
 /// This component goes on an item that you want to use to block
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class BlockingComponent : Component
 {
     /// <summary>
     /// The entity that's blocking
     /// </summary>
-    [ViewVariables]
+    [ViewVariables, AutoNetworkedField]
     public EntityUid? User;
 
     /// <summary>
     /// Is it currently blocking?
     /// </summary>
-    [ViewVariables]
+    [ViewVariables, AutoNetworkedField]
     public bool IsBlocking;
 
     /// <summary>
@@ -50,7 +51,7 @@ public sealed partial class BlockingComponent : Component
     [DataField("blockingToggleAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string BlockingToggleAction = "ActionToggleBlock";
 
-    [DataField("blockingToggleActionEntity")]
+    [DataField, AutoNetworkedField]
     public EntityUid? BlockingToggleActionEntity;
 
     /// <summary>

--- a/Content.Shared/Clothing/Components/StealthClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/StealthClothingComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class StealthClothingComponent : Component
     /// <summary>
     /// The action for enabling and disabling stealth.
     /// </summary>
-    [DataField("toggleActionEntity")] public EntityUid? ToggleActionEntity;
+    [DataField, AutoNetworkedField] public EntityUid? ToggleActionEntity;
 }
 
 /// <summary>

--- a/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/StealthClothingSystem.cs
@@ -12,6 +12,7 @@ namespace Content.Shared.Clothing.EntitySystems;
 public sealed class StealthClothingSystem : EntitySystem
 {
     [Dependency] private readonly SharedStealthSystem _stealth = default!;
+    [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
 
     public override void Initialize()
     {
@@ -21,6 +22,13 @@ public sealed class StealthClothingSystem : EntitySystem
         SubscribeLocalEvent<StealthClothingComponent, ToggleStealthEvent>(OnToggleStealth);
         SubscribeLocalEvent<StealthClothingComponent, AfterAutoHandleStateEvent>(OnHandleState);
         SubscribeLocalEvent<StealthClothingComponent, GotUnequippedEvent>(OnUnequipped);
+        SubscribeLocalEvent<StealthClothingComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, StealthClothingComponent component, MapInitEvent args)
+    {
+        _actionContainer.EnsureAction(uid, ref component.ToggleActionEntity, component.ToggleAction);
+        Dirty(uid, component);
     }
 
     /// <summary>

--- a/Content.Shared/Clothing/SharedMagbootsSystem.cs
+++ b/Content.Shared/Clothing/SharedMagbootsSystem.cs
@@ -15,6 +15,7 @@ public abstract class SharedMagbootsSystem : EntitySystem
     [Dependency] private readonly ClothingSystem _clothing = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedActionsSystem _sharedActions = default!;
+    [Dependency] private readonly SharedActionsSystem _actionContainer = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedContainerSystem _sharedContainer = default!;
     [Dependency] private readonly SharedItemSystem _item = default!;
@@ -27,6 +28,13 @@ public abstract class SharedMagbootsSystem : EntitySystem
         SubscribeLocalEvent<MagbootsComponent, InventoryRelayedEvent<SlipAttemptEvent>>(OnSlipAttempt);
         SubscribeLocalEvent<MagbootsComponent, GetItemActionsEvent>(OnGetActions);
         SubscribeLocalEvent<MagbootsComponent, ToggleMagbootsEvent>(OnToggleMagboots);
+        SubscribeLocalEvent<MagbootsComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, MagbootsComponent component, MapInitEvent args)
+    {
+        _actionContainer.AddAction(uid, ref component.ToggleActionEntity, component.ToggleAction);
+        Dirty(uid, component);
     }
 
     private void OnToggleMagboots(EntityUid uid, MagbootsComponent component, ToggleMagbootsEvent args)
@@ -55,7 +63,7 @@ public abstract class SharedMagbootsSystem : EntitySystem
 
         _appearance.SetData(uid, ToggleVisuals.Toggled, magboots.On);
         OnChanged(uid, magboots);
-        Dirty(magboots);
+        Dirty(uid, magboots);
     }
 
     protected virtual void UpdateMagbootEffects(EntityUid parent, EntityUid uid, bool state, MagbootsComponent? component) { }

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -27,6 +27,7 @@ public abstract class SharedCombatModeSystem : EntitySystem
     private void OnMapInit(EntityUid uid, CombatModeComponent component, MapInitEvent args)
     {
         _actionsSystem.AddAction(uid, ref component.CombatToggleActionEntity, component.CombatToggleAction);
+        Dirty(uid, component);
     }
 
     private void OnShutdown(EntityUid uid, CombatModeComponent component, ComponentShutdown args)

--- a/Content.Shared/Movement/Components/JetpackComponent.cs
+++ b/Content.Shared/Movement/Components/JetpackComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Movement.Components;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class JetpackComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("moleUsage")]
@@ -12,7 +12,7 @@ public sealed partial class JetpackComponent : Component
 
     [DataField] public EntProtoId ToggleAction = "ActionToggleJetpack";
 
-    [DataField("toggleActionEntity")] public EntityUid? ToggleActionEntity;
+    [DataField, AutoNetworkedField] public EntityUid? ToggleActionEntity;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("acceleration")]
     public float Acceleration = 1f;

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -19,6 +19,7 @@ public abstract class SharedJetpackSystem : EntitySystem
     [Dependency] private   readonly SharedMoverController _mover = default!;
     [Dependency] private   readonly SharedPopupSystem _popup = default!;
     [Dependency] private   readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
 
     public override void Initialize()
     {
@@ -32,6 +33,13 @@ public abstract class SharedJetpackSystem : EntitySystem
         SubscribeLocalEvent<JetpackUserComponent, EntParentChangedMessage>(OnJetpackUserEntParentChanged);
 
         SubscribeLocalEvent<GravityChangedEvent>(OnJetpackUserGravityChanged);
+        SubscribeLocalEvent<JetpackComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, JetpackComponent component, MapInitEvent args)
+    {
+        _actionContainer.EnsureAction(uid, ref component.ToggleActionEntity, component.ToggleAction);
+        Dirty(uid, component);
     }
 
     private void OnJetpackCanWeightlessMove(EntityUid uid, JetpackComponent component, ref CanWeightlessMoveEvent args)

--- a/Content.Shared/Ninja/Components/DashAbilityComponent.cs
+++ b/Content.Shared/Ninja/Components/DashAbilityComponent.cs
@@ -3,7 +3,6 @@ using Content.Shared.Ninja.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Ninja.Components;
 
@@ -16,8 +15,8 @@ public sealed partial class DashAbilityComponent : Component
     /// <summary>
     /// The action id for dashing.
     /// </summary>
-    [DataField("dashAction", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>)), ViewVariables(VVAccess.ReadWrite)]
-    public string DashAction = string.Empty;
+    [DataField]
+    public EntProtoId DashAction = "ActionEnergyKatanaDash";
 
     [DataField, AutoNetworkedField]
     public EntityUid? DashActionEntity;

--- a/Content.Shared/Ninja/Components/DashAbilityComponent.cs
+++ b/Content.Shared/Ninja/Components/DashAbilityComponent.cs
@@ -5,10 +5,12 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
+namespace Content.Shared.Ninja.Components;
+
 /// <summary>
 /// Adds an action to dash, teleport to clicked position, when this item is held.
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(DashAbilitySystem))]
+[RegisterComponent, NetworkedComponent, Access(typeof(DashAbilitySystem)), AutoGenerateComponentState]
 public sealed partial class DashAbilityComponent : Component
 {
     /// <summary>
@@ -17,7 +19,7 @@ public sealed partial class DashAbilityComponent : Component
     [DataField("dashAction", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>)), ViewVariables(VVAccess.ReadWrite)]
     public string DashAction = string.Empty;
 
-    [DataField("dashActionEntity")]
+    [DataField, AutoNetworkedField]
     public EntityUid? DashActionEntity;
 
     /// <summary>

--- a/Content.Shared/Ninja/Components/NinjaGlovesComponent.cs
+++ b/Content.Shared/Ninja/Components/NinjaGlovesComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class NinjaGlovesComponent : Component
     [DataField("toggleAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string ToggleAction = "ActionToggleNinjaGloves";
 
-    [DataField("toggleActionEntity")]
+    [DataField, AutoNetworkedField]
     public EntityUid? ToggleActionEntity;
 
     /// <summary>

--- a/Content.Shared/Ninja/Components/NinjaSuitComponent.cs
+++ b/Content.Shared/Ninja/Components/NinjaSuitComponent.cs
@@ -47,7 +47,7 @@ public sealed partial class NinjaSuitComponent : Component
     [DataField("createThrowingStarAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string CreateThrowingStarAction = "ActionCreateThrowingStar";
 
-    [DataField("createThrowingStarActionEntity")]
+    [DataField, AutoNetworkedField]
     public EntityUid? CreateThrowingStarActionEntity;
 
     /// <summary>
@@ -68,7 +68,7 @@ public sealed partial class NinjaSuitComponent : Component
     [DataField("recallKatanaAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string RecallKatanaAction = "ActionRecallKatana";
 
-    [DataField("recallKatanaActionEntity")]
+    [DataField, AutoNetworkedField]
     public EntityUid? RecallKatanaActionEntity;
 
     /// <summary>
@@ -84,7 +84,7 @@ public sealed partial class NinjaSuitComponent : Component
     [DataField("empAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string EmpAction = "ActionNinjaEmp";
 
-    [DataField("empActionEntity")]
+    [DataField, AutoNetworkedField]
     public EntityUid? EmpActionEntity;
 
     /// <summary>

--- a/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
+++ b/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
@@ -6,8 +6,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Ninja.Components;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
-using Robust.Shared.Audio;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.Ninja.Systems;
@@ -24,6 +22,7 @@ public sealed class DashAbilitySystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
 
     public override void Initialize()
     {
@@ -31,6 +30,13 @@ public sealed class DashAbilitySystem : EntitySystem
 
         SubscribeLocalEvent<DashAbilityComponent, GetItemActionsEvent>(OnGetItemActions);
         SubscribeLocalEvent<DashAbilityComponent, DashEvent>(OnDash);
+        SubscribeLocalEvent<DashAbilityComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, DashAbilityComponent component, MapInitEvent args)
+    {
+        _actionContainer.EnsureAction(uid, ref component.DashActionEntity, component.DashAction);
+        Dirty(uid, component);
     }
 
     private void OnGetItemActions(EntityUid uid, DashAbilityComponent comp, GetItemActionsEvent args)

--- a/Content.Shared/Ninja/Systems/SharedNinjaGlovesSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedNinjaGlovesSystem.cs
@@ -1,11 +1,8 @@
 using Content.Shared.Actions;
 using Content.Shared.CombatMode;
 using Content.Shared.Communications;
-using Content.Shared.Doors.Components;
-using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Hands.Components;
-using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Ninja.Components;
@@ -14,7 +11,6 @@ using Content.Shared.Research.Components;
 using Content.Shared.Timing;
 using Content.Shared.Toggleable;
 using Robust.Shared.Timing;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Content.Shared.Ninja.Systems;
 
@@ -26,11 +22,10 @@ public abstract class SharedNinjaGlovesSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
     [Dependency] private readonly SharedCombatModeSystem _combatMode = default!;
-    [Dependency] protected readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] protected readonly SharedInteractionSystem Interaction = default!;
-    [Dependency] private readonly SharedSpaceNinjaSystem _ninja = default!;
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
+    [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
 
     public override void Initialize()
     {
@@ -39,6 +34,13 @@ public abstract class SharedNinjaGlovesSystem : EntitySystem
         SubscribeLocalEvent<NinjaGlovesComponent, GetItemActionsEvent>(OnGetItemActions);
         SubscribeLocalEvent<NinjaGlovesComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<NinjaGlovesComponent, GotUnequippedEvent>(OnUnequipped);
+        SubscribeLocalEvent<NinjaGlovesComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, NinjaGlovesComponent component, MapInitEvent args)
+    {
+        _actionContainer.EnsureAction(uid, ref component.ToggleActionEntity, component.ToggleAction);
+        Dirty(uid, component);
     }
 
     /// <summary>

--- a/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
@@ -4,10 +4,6 @@ using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Ninja.Components;
 using Content.Shared.Timing;
-using Robust.Shared.Audio;
-using Robust.Shared.Network;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Ninja.Systems;
 
@@ -21,6 +17,7 @@ public abstract class SharedNinjaSuitSystem : EntitySystem
     [Dependency] protected readonly SharedSpaceNinjaSystem _ninja = default!;
     [Dependency] protected readonly StealthClothingSystem StealthClothing = default!;
     [Dependency] protected readonly UseDelaySystem UseDelay = default!;
+    [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
 
     public override void Initialize()
     {
@@ -30,6 +27,15 @@ public abstract class SharedNinjaSuitSystem : EntitySystem
         SubscribeLocalEvent<NinjaSuitComponent, GetItemActionsEvent>(OnGetItemActions);
         SubscribeLocalEvent<NinjaSuitComponent, AddStealthActionEvent>(OnAddStealthAction);
         SubscribeLocalEvent<NinjaSuitComponent, GotUnequippedEvent>(OnUnequipped);
+        SubscribeLocalEvent<NinjaSuitComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, NinjaSuitComponent component, MapInitEvent args)
+    {
+        _actionContainer.EnsureAction(uid, ref component.RecallKatanaActionEntity, component.RecallKatanaAction);
+        _actionContainer.EnsureAction(uid, ref component.CreateThrowingStarActionEntity, component.CreateThrowingStarAction);
+        _actionContainer.EnsureAction(uid, ref component.EmpActionEntity, component.EmpAction);
+        Dirty(uid, component);
     }
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -18,7 +18,7 @@
   - type: Reflect
     enabled: true
     reflectProb: .5
-    spread: 90        
+    spread: 90
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/captain_sabre.rsi
@@ -69,7 +69,6 @@
     sprite: Objects/Weapons/Melee/energykatana.rsi
   - type: EnergyKatana
   - type: DashAbility
-    dashAction: ActionEnergyKatanaDash
   - type: LimitedCharges
     maxCharges: 3
     charges: 3


### PR DESCRIPTION
This gets rid of the delay between when an item gets picked up or  equipped and the action appearing in the sidebar.