### PR TITLE
simple space mobs cant be flashed

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -53,7 +53,6 @@
   - type: Body
     prototype: Animal
   - type: Climbing
-  - type: Flashable
   - type: NameIdentifier
     group: GenericNumber
   - type: SlowOnDamage


### PR DESCRIPTION
## About the PR
all simple space mobs are immune to flashing now

fixes #20783

## Why / Balance
flash shouldnt work on fishe and dragon

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun