### PR TITLE
Fix for a bug that prevents the hacking UI from opening on non-airlock entities

### DIFF
--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -152,10 +152,12 @@ public sealed class AirlockSystem : SharedAirlockSystem
     {
         if (TryComp<WiresPanelComponent>(uid, out var panel) &&
             panel.Open &&
-            TryComp<WiresPanelSecurityComponent>(uid, out var wiresPanelSecurity) &&
-            wiresPanelSecurity.WiresAccessible &&
             TryComp<ActorComponent>(args.User, out var actor))
         {
+            if (TryComp<WiresPanelSecurityComponent>(uid, out var wiresPanelSecurity) &&
+                !wiresPanelSecurity.WiresAccessible)
+                return;
+
             _wiresSystem.OpenUserInterface(uid, actor.PlayerSession);
             args.Handled = true;
             return;

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -463,11 +463,13 @@ public sealed class WiresSystem : SharedWiresSystem
             return;
 
         if (panel.Open &&
-            TryComp<WiresPanelSecurityComponent>(uid, out var wiresPanelSecurity) &&
-            wiresPanelSecurity.WiresAccessible &&
             (_toolSystem.HasQuality(args.Used, "Cutting", tool) ||
             _toolSystem.HasQuality(args.Used, "Pulsing", tool)))
         {
+            if (TryComp<WiresPanelSecurityComponent>(uid, out var wiresPanelSecurity) &&
+                !wiresPanelSecurity.WiresAccessible)
+                return;
+
             if (TryComp(args.User, out ActorComponent? actor))
             {
                 _uiSystem.TryOpen(uid, WiresUiKey.Key, actor.PlayerSession);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes a bug that prevents the hacking UI from opening on non-airlock entities

This will close #20787

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
See above

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
If a WiresPanelSecurityComponent was not found, a call to open the UI would not trigger. Changed the position of the check so it doesn't matter if entities have a WiresPanelSecurityComponent  or not

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Proof bomb wires can be now be accessed
![wires_bomb](https://github.com/space-wizards/space-station-14/assets/50505512/34f8cea4-0865-4381-8ede-5cb9fbd1a798)

Proof vending machine wires can now be accessed
![wires_vending](https://github.com/space-wizards/space-station-14/assets/50505512/0ab16eab-4a52-4458-8fff-d6697700bc19)

Proof that door wires can still be accessed
![wires_door](https://github.com/space-wizards/space-station-14/assets/50505512/6b74d0a4-99f6-46e7-9fdf-b71c040e2369)

I have also checked that having door protections in place prevent you from accessing the wires until you remove them

Before adding plates
![wires_door_before](https://github.com/space-wizards/space-station-14/assets/50505512/a3e72b83-df1a-4f37-a46e-4db9b0155329)

After adding plates (no UI pops after normal interaction or interaction with wire cutters)
![wires_door_during](https://github.com/space-wizards/space-station-14/assets/50505512/35bc79de-6fb8-4a9e-9310-fe0bc05ab576)

After removing the plates
![wires_door_after](https://github.com/space-wizards/space-station-14/assets/50505512/c92d6dcd-c9b1-4333-966c-97b2cf1d1ebe)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed wire panels on bombs and vending machines not opening correctly.