### PR TITLE
Tweaked secret weights

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,8 +1,8 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.15
-    Traitor: 0.60
+    Nukeops: 0.20
+    Traitor: 0.50
     Zombie: 0.10
-    Revolutionary: 0.15
+    Revolutionary: 0.20
     


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
traitor chance is now 50%
nukies and revs chance is now 20%
zombies stays at 10%

with discussion these could change
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
1. Without dynamic mode, other modes are just going to get less and less likely to happen as more are added
2. The other modes are more fun, most people wont be effected by traitors which sucks when the entire point of the game is mass chaos
3. revs aren't rolled very often, ive only seen it once
## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: JoeHammad
- tweak: traitor gamemode is rarer, nukies and revs are more common
