### PR TITLE
Tag tinned peaches and meat with Fruit and Meat, respectively

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -89,6 +89,9 @@
     - funny
   - type: Food
     trash: FoodTinPeachesTrash
+  - type: Tag
+    tags:
+    - Fruit
 
 - type: entity
   parent: FoodTinBaseTrash
@@ -174,6 +177,9 @@
     - cheap
   - type: Food
     trash: FoodTinMRETrash
+  - type: Tag
+    tags:
+    - Meat
 
 - type: entity
   parent: FoodTinBaseTrash


### PR DESCRIPTION
## About the PR
As of the lizard rework (#20328), lizards can only eat fruit and meat. Tinned peaches and tinned meat were not tagged as fruit or meat, but it literally says on the tin!

## Why / Balance
lizard need eat
🍑🥩🦎

## Technical details
Add the Fruit and Meat tags to tinned peaches (regular and maintenance) and tinned meat, respectively.

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**  
not needed, just a bugfix