### PR TITLE
Reenable kudzu.

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -37,7 +37,7 @@ public sealed class MutationSystem : EntitySystem
         }
 
         // Add up everything in the bits column and put the number here.
-        const int totalbits = 265;
+        const int totalbits = 270;
 
         // Tolerances (55)
         MutateFloat(ref seed.NutrientConsumption  , 0.05f, 1.2f, 5, totalbits, severity);
@@ -69,8 +69,7 @@ public sealed class MutationSystem : EntitySystem
         MutateBool(ref seed.Sentient      , true , 10, totalbits, severity);
         MutateBool(ref seed.Ligneous      , true , 10, totalbits, severity);
         MutateBool(ref seed.Bioluminescent, true , 10, totalbits, severity);
-        // Kudzu disabled until superkudzu bug is fixed
-        // MutateBool(ref seed.TurnIntoKudzu , true , 10, totalbits, severity);
+        MutateBool(ref seed.TurnIntoKudzu , true , 10, totalbits, severity);
         MutateBool(ref seed.CanScream     , true , 10, totalbits, severity);
         seed.BioluminescentColor = RandomColor(seed.BioluminescentColor, 10, totalbits, severity);
 
@@ -119,7 +118,7 @@ public sealed class MutationSystem : EntitySystem
         CrossBool(ref result.Sentient, a.Sentient);
         CrossBool(ref result.Ligneous, a.Ligneous);
         CrossBool(ref result.Bioluminescent, a.Bioluminescent);
-        // CrossBool(ref result.TurnIntoKudzu, a.TurnIntoKudzu);
+        CrossBool(ref result.TurnIntoKudzu, a.TurnIntoKudzu);
         CrossBool(ref result.CanScream, a.CanScream);
 
         CrossGasses(ref result.ExudeGasses, a.ExudeGasses);

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -132,18 +132,18 @@
     startDelay: 20
   - type: GasLeakRule
 
-#- type: entity
-#  id: KudzuGrowth
-#  parent: BaseGameRule
-#  noSpawn: true
-#  components:
-#  - type: StationEvent
-#    earliestStart: 15
-#    minimumPlayers: 15
-#    weight: 5
-#    startDelay: 50
-#    duration: 240
-#  - type: KudzuGrowthRule
+- type: entity
+  id: KudzuGrowth
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    earliestStart: 15
+    minimumPlayers: 15
+    weight: 5
+    startDelay: 50
+    duration: 240
+  - type: KudzuGrowthRule
 
 - type: entity
   id: MeteorSwarm


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Since spreader code underwent a pretty massive rewrite recently, it's fair to say that it's pretty likely that this bug got fixed. Even if it didn't, nobody can reproduce this locally so turning it back on is really the only way to tell.

the joys of playtesting.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase



## LE CHANGELOG
:cl:
- add: Kudzu has been reenabled.
