### PR TITLE
Add Paramedic access and airlocks

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -65,6 +65,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "Kitchen",
         "Maintenance",
         "Medical",
+        "Paramedic",
         "Quartermaster",
         "Research",
         "ResearchDirector",

--- a/Resources/Prototypes/Access/medical.yml
+++ b/Resources/Prototypes/Access/medical.yml
@@ -20,3 +20,4 @@
   - ChiefMedicalOfficer
   - Medical
   - Chemistry
+  - Paramedic

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -15,6 +15,7 @@
   - Brig
   - Engineering
   - Medical
+  - Paramedic
   - Quartermaster
   - Salvage
   - Cargo

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -40,6 +40,7 @@
       - Kitchen
       - Maintenance
       - Medical
+      - Paramedic
       - Quartermaster
       - Research
       - ResearchDirector

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -168,6 +168,14 @@
     access: [["Medical"]]
 
 - type: entity
+  parent: AirlockMedical
+  id: AirlockParamedicLocked
+  suffix: Paramedic, Locked
+  components:
+  - type: AccessReader
+    access: [["Paramedic"]]
+
+- type: entity
   parent: AirlockVirology
   id: AirlockVirologyLocked
   suffix: Virology, Locked
@@ -449,6 +457,14 @@
   components:
   - type: AccessReader
     access: [["Medical"]]
+
+- type: entity
+  parent: AirlockMedicalGlass
+  id: AirlockParamedicGlassLocked
+  suffix: Paramedic, Locked
+  components:
+  - type: AccessReader
+    access: [["Paramedic"]]
 
 - type: entity
   parent: AirlockVirologyGlass

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -223,7 +223,7 @@
     stateDoorOpen: paramed_open
     stateDoorClosed: paramed_door
   - type: AccessReader
-    access: [ [ "Medical" ] ]
+    access: [ [ "Paramedic" ] ]
 
 
 # Chemical

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -14,6 +14,8 @@
   - Medical
   - Chemistry
   - Maintenance
+  extendedAccess:
+  - Paramedic
 
 - type: startingGear
   id: ChemistGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -28,6 +28,7 @@
   - Command
   - Maintenance
   - Chemistry
+  - Paramedic
   - ChiefMedicalOfficer
   special:
   - !type:AddImplantSpecial

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -15,6 +15,7 @@
   - Maintenance
   extendedAccess:
   - Chemistry
+  - Paramedic
 
 - type: startingGear
   id: DoctorGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -16,6 +16,7 @@
   - Medical
   - Maintenance
   - External
+  - Paramedic
   extendedAccess:
   - Chemistry
 

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -20,6 +20,7 @@
   - Medical
   - Maintenance
   - Chemistry
+  - Paramedic
 
 - type: startingGear
   id: SeniorPhysicianGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

I added the Paramedic access to the ID card console, as well as on some ID cards. I also added two airlocks with the "Paramedic" access: one opaque, one glass.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Fixes https://github.com/space-wizards/space-station-14/issues/20652
The paramedic secure windoor is in the game, but it's half-implemented; the access isn't actually there. Adding this means that mappers can make paramedic rooms and the like.

## Media

![image](https://github.com/space-wizards/space-station-14/assets/113523727/b11699ce-5158-4f66-b529-1831ec5b5a87)

![image](https://github.com/space-wizards/space-station-14/assets/113523727/063b2a85-3551-4abe-8d06-1d800f6eaf9b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Paramedics now have their own access. Their voidsuits are now safe from the interns!