### PR TITLE
Fix not removing RevolutionaryRoleComponent from minds on mindshield application

### DIFF
--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -48,8 +48,7 @@ public sealed class MindShieldSystem : EntitySystem
     /// </summary>
     public void MindShieldRemovalCheck(EntityUid implanted, EntityUid implant)
     {
-        if (HasComp<RevolutionaryComponent>(implanted) &&
-            !HasComp<HeadRevolutionaryComponent>(implanted))
+        if (HasComp<HeadRevolutionaryComponent>(implanted))
         {
             _popupSystem.PopupEntity(Loc.GetString("head-rev-break-mindshield"), implanted);
             QueueDel(implant);

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -1,13 +1,13 @@
-using Content.Shared.Mindshield.Components;
-using Content.Shared.Revolutionary.Components;
-using Content.Server.Popups;
-using Content.Shared.Database;
 using Content.Server.Administration.Logs;
 using Content.Server.Mind;
-using Content.Shared.Implants;
-using Content.Shared.Tag;
+using Content.Server.Popups;
 using Content.Server.Roles;
+using Content.Shared.Database;
+using Content.Shared.Implants;
 using Content.Shared.Implants.Components;
+using Content.Shared.Mindshield.Components;
+using Content.Shared.Revolutionary.Components;
+using Content.Shared.Tag;
 
 namespace Content.Server.Mindshield;
 
@@ -39,25 +39,26 @@ public sealed class MindShieldSystem : EntitySystem
         if (_tag.HasTag(ev.Implant, MindShieldTag) && ev.Implanted != null)
         {
             EnsureComp<MindShieldComponent>(ev.Implanted.Value);
-            MindShieldRemovalCheck(ev.Implanted, ev.Implant);
+            MindShieldRemovalCheck(ev.Implanted.Value, ev.Implant);
         }
     }
 
     /// <summary>
     /// Checks if the implanted person was a Rev or Head Rev and remove role or destroy mindshield respectively.
     /// </summary>
-    public void MindShieldRemovalCheck(EntityUid? implanted, EntityUid implant)
+    public void MindShieldRemovalCheck(EntityUid implanted, EntityUid implant)
     {
-        if (HasComp<RevolutionaryComponent>(implanted) && !HasComp<HeadRevolutionaryComponent>(implanted))
+        if (HasComp<RevolutionaryComponent>(implanted))
         {
-            _mindSystem.TryGetMind(implanted.Value, out var mindId, out _);
-            _adminLogManager.Add(LogType.Mind, LogImpact.Medium, $"{ToPrettyString(implanted.Value)} was deconverted due to being implanted with a Mindshield.");
-            _roleSystem.MindTryRemoveRole<RevolutionaryRoleComponent>(mindId);
-        }
-        else if (HasComp<RevolutionaryComponent>(implanted))
-        {
-            _popupSystem.PopupEntity(Loc.GetString("head-rev-break-mindshield"), implanted.Value);
+            _popupSystem.PopupEntity(Loc.GetString("head-rev-break-mindshield"), implanted);
             QueueDel(implant);
+            return;
+        }
+
+        if (_mindSystem.TryGetMind(implanted, out var mindId, out _) &&
+            _roleSystem.MindTryRemoveRole<RevolutionaryRoleComponent>(mindId))
+        {
+            _adminLogManager.Add(LogType.Mind, LogImpact.Medium, $"{ToPrettyString(implanted)} was deconverted due to being implanted with a Mindshield.");
         }
     }
 }

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -48,7 +48,8 @@ public sealed class MindShieldSystem : EntitySystem
     /// </summary>
     public void MindShieldRemovalCheck(EntityUid implanted, EntityUid implant)
     {
-        if (HasComp<RevolutionaryComponent>(implanted))
+        if (HasComp<RevolutionaryComponent>(implanted) &&
+            !HasComp<HeadRevolutionaryComponent>(implanted))
         {
             _popupSystem.PopupEntity(Loc.GetString("head-rev-break-mindshield"), implanted);
             QueueDel(implant);

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -1,7 +1,7 @@
-using Content.Shared.Revolutionary.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Popups;
+using Content.Shared.Revolutionary.Components;
 using Content.Shared.Stunnable;
 
 namespace Content.Shared.Revolutionary;
@@ -22,17 +22,19 @@ public sealed class SharedRevolutionarySystem : EntitySystem
     /// </summary>
     private void MindShieldImplanted(EntityUid uid, MindShieldComponent comp, MapInitEvent init)
     {
-        if (HasComp<RevolutionaryComponent>(uid) && !HasComp<HeadRevolutionaryComponent>(uid))
+        if (HasComp<HeadRevolutionaryComponent>(uid))
+        {
+            RemCompDeferred<MindShieldComponent>(uid);
+            return;
+        }
+
+        if (HasComp<RevolutionaryComponent>(uid))
         {
             var stunTime = TimeSpan.FromSeconds(4);
             var name = Identity.Entity(uid, EntityManager);
             RemComp<RevolutionaryComponent>(uid);
             _sharedStun.TryParalyze(uid, stunTime, true);
             _popupSystem.PopupEntity(Loc.GetString("rev-break-control", ("name", name)), uid);
-        }
-        else if (HasComp<HeadRevolutionaryComponent>(uid))
-        {
-            RemCompDeferred<MindShieldComponent>(uid);
         }
     }
 }


### PR DESCRIPTION
## About the PR
Fixes https://github.com/space-wizards/space-station-14/issues/20830
Revolutionary and RevolutionaryRole components should probably be merged at some point.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

