### PR TITLE
Incendiary bullets no longer deal cold, acid, or shock damage 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -39,5 +39,6 @@
   components:
   - type: Projectile
     damage:
-      groups:
-        Burn: 17
+      types:
+        Blunt: 3
+        Heat: 16

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -41,9 +41,10 @@
   components:
   - type: Projectile
     damage:
-      groups:
-        Burn: 32
-
+      types:
+        Blunt: 3
+        Heat: 32
+        
 - type: entity
   id: BulletMagnumAP
   name: bullet (.45 magnum armor-piercing)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -39,5 +39,6 @@
   components:
   - type: Projectile
     damage:
-      groups:
-        Burn: 14
+      types:
+        Blunt: 2
+        Heat: 14

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -39,5 +39,7 @@
   components:
   - type: Projectile
     damage:
-      groups:
-        Burn: 15
+      types:
+        Blunt: 2
+        Heat: 15
+        

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -53,8 +53,9 @@
     state: buckshot-flare
   - type: Projectile
     damage:
-      groups:
-        Burn: 7
+      types:
+        Blunt: 1
+        Heat: 7
 
 - type: entity
   id: PelletShotgunPractice


### PR DESCRIPTION
## About the PR
Burn damage has been replaced by heat and blunt damage (because those rounds still hit on their own).

## Why / Balance
There are no armor stats in the game that protect against electrical or cold damage. Thus, incendiary bullets ignore absolutely any armor, becoming more advanced than armor-piercing (AP) bullets.

- [ ] This PR does not require an ingame showcase

**Changelog**
fix: Incendiary bullets no longer deal cold, acid, or shock damage that ignores all armor.
