### PR TITLE
gives a suffix to the strictly human spawning syndicate agent

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -9,6 +9,7 @@
   parent: MobHuman
   id: MobHumanSyndicateAgent
   name: Syndicate Agent
+  suffix: Human
   components:
     - type: Loadout
       prototypes: [SyndicateOperativeGearExtremelyBasic]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Gives a suffix to the syndicate agent entity, which can only spawn a human. The other two being one with the suffix of nukeops, which spawns with the nukeop component, and the other being supposedly the same syndicate agent entity, but it can spawn a random species and has no suffix. I couldn't find that entity for some reason.