### PR TITLE
Fix fast kudzu

### DIFF
--- a/Content.Server/Spreader/SpreaderGridComponent.cs
+++ b/Content.Server/Spreader/SpreaderGridComponent.cs
@@ -1,10 +1,8 @@
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
-
 namespace Content.Server.Spreader;
 
 [RegisterComponent]
 public sealed partial class SpreaderGridComponent : Component
 {
-    [DataField("nextUpdate", customTypeSerializer:typeof(TimeOffsetSerializer))]
-    public TimeSpan NextUpdate = TimeSpan.Zero;
+    [DataField]
+    public float UpdateAccumulator = SpreaderSystem.SpreadCooldownSeconds;
 }

--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -9,7 +9,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Spreader;
@@ -19,12 +18,9 @@ namespace Content.Server.Spreader;
 /// </summary>
 public sealed class SpreaderSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
-
-    private static readonly TimeSpan SpreadCooldown = TimeSpan.FromSeconds(SpreadCooldownSeconds);
 
     /// <summary>
     /// Cached maximum number of updates per spreader prototype. This is applied per-grid.
@@ -36,7 +32,7 @@ public sealed class SpreaderSystem : EntitySystem
     /// </summary>
     private Dictionary<EntityUid, Dictionary<string, int>> _gridUpdates = new();
 
-    private const float SpreadCooldownSeconds = 1;
+    public const float SpreadCooldownSeconds = 1;
 
     [ValidatePrototypeId<TagPrototype>]
     private const string IgnoredTag = "SpreaderIgnore";
@@ -46,8 +42,6 @@ public sealed class SpreaderSystem : EntitySystem
     {
         SubscribeLocalEvent<AirtightChanged>(OnAirtightChanged);
         SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
-
-        SubscribeLocalEvent<SpreaderGridComponent, EntityUnpausedEvent>(OnGridUnpaused);
 
         SubscribeLocalEvent<EdgeSpreaderComponent, EntityTerminatingEvent>(OnTerminating);
         SetupPrototypes();
@@ -87,15 +81,9 @@ public sealed class SpreaderSystem : EntitySystem
         }
     }
 
-    private void OnGridUnpaused(EntityUid uid, SpreaderGridComponent component, ref EntityUnpausedEvent args)
-    {
-        component.NextUpdate += args.PausedTime;
-    }
-
     private void OnGridInit(GridInitializeEvent ev)
     {
-        var grid = EnsureComp<SpreaderGridComponent>(ev.EntityUid);
-        grid.NextUpdate = _timing.CurTime + SpreadCooldown;
+        EnsureComp<SpreaderGridComponent>(ev.EntityUid);
     }
 
     private void OnTerminating(EntityUid uid, EdgeSpreaderComponent component, ref EntityTerminatingEvent args)
@@ -112,19 +100,18 @@ public sealed class SpreaderSystem : EntitySystem
     /// <inheritdoc/>
     public override void Update(float frameTime)
     {
-        var curTime = _timing.CurTime;
-
         // Check which grids are valid for spreading
         var spreadGrids = EntityQueryEnumerator<SpreaderGridComponent>();
 
         _gridUpdates.Clear();
         while (spreadGrids.MoveNext(out var uid, out var grid))
         {
-            if (grid.NextUpdate > curTime)
+            grid.UpdateAccumulator -= frameTime;
+            if (grid.UpdateAccumulator > 0)
                 continue;
 
             _gridUpdates[uid] = _prototypeUpdates.ShallowClone();
-            grid.NextUpdate += SpreadCooldown;
+            grid.UpdateAccumulator += SpreadCooldownSeconds;
         }
 
         if (_gridUpdates.Count == 0)

--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -94,7 +94,8 @@ public sealed class SpreaderSystem : EntitySystem
 
     private void OnGridInit(GridInitializeEvent ev)
     {
-        EnsureComp<SpreaderGridComponent>(ev.EntityUid);
+        var grid = EnsureComp<SpreaderGridComponent>(ev.EntityUid);
+        grid.NextUpdate = _timing.CurTime + SpreadCooldown;
     }
 
     private void OnTerminating(EntityUid uid, EdgeSpreaderComponent component, ref EntityTerminatingEvent args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
from discord:
KUDZU BUG EXPLAINED:
The core of this comes down to how the updates are tracked per each grid. Each grid, when created, gets initialized with a component that keeps track of the next time when an update will occur. In Update(), this is checked against the current time and, if it is less than the current time, a spread update occurs and one second is **directly accumulated** to this timer.

The issue occurs when a new grid is added. The datafield has the TimeOffsetSerializer, but the component isn't deserialized, it's added directly through the GridInitializeEvent. The value of the NextSecond is never set, so it defaults to 0. 

As a result, when the check occurs every Update(), it will be less than CurTime, and therefore spread will increase and the time will be accumulated by a single second. However, since this value is so far below the current time, this will repeat many times until the grid timer catches up to the current time. On dev builds, this is trivial, since the CurTime rarely exceeds a few minutes, and with a second being added every tick, the difference is made up quickly.

On the servers though, this difference is MUCH greater, and so grids can be trapper in this "rapid update state" for extended periods of time. This is what causes the bug.

The solution...? Simply set the next update to the current time + 1 when we add the component.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed kudzu, foam, smoke, and puddles spreading at extremely high rates.
