### PR TITLE
organs edible to lizards, and make their food contents uncooked proteins

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -14,11 +14,14 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: FlavorProfile
     flavors:
       - chicken # everything kinda tastes like chicken
+  - type: Tag
+    tags:
+      - Meat
 
 
 - type: entity
@@ -49,7 +52,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
 
 - type: entity
@@ -68,7 +71,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Stomach
   - type: Metabolizer

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -19,8 +19,11 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
+  - type: Tag
+    tags:
+      - Meat
 
 - type: entity
   id: OrganArachnidStomach
@@ -40,7 +43,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Metabolizer
     updateFrequency: 1.5
@@ -77,7 +80,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
 
 - type: entity

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -19,7 +19,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: FlavorProfile
     flavors:
@@ -46,7 +46,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Brain
   - type: Lung #lungs in they head. why they there tho?
@@ -85,7 +85,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Stomach
   - type: Metabolizer

--- a/Resources/Prototypes/Body/Organs/dwarf.yml
+++ b/Resources/Prototypes/Body/Organs/dwarf.yml
@@ -29,7 +29,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Stomach
   - type: Metabolizer

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -40,6 +40,10 @@
     context: "ghost"
   - type: Brain
   - type: BlockMovement
+  - type: BadFood
+  - type: Tag
+    tags:
+      - Meat
 
 - type: entity
   id: OrganHumanEyes

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -18,11 +18,14 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: FlavorProfile
     flavors:
       - people
+  - type: Tag
+    tags:
+      - Meat
 
 - type: entity
   id: OrganHumanBrain
@@ -109,7 +112,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
 
 - type: entity
@@ -146,7 +149,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Stomach
   # The stomach metabolizes stuff like foods and drinks.

--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -14,7 +14,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Metabolizer
     maxReagents: 3

--- a/Resources/Prototypes/Body/Organs/rat.yml
+++ b/Resources/Prototypes/Body/Organs/rat.yml
@@ -18,7 +18,7 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Sprite
     state: stomach

--- a/Resources/Prototypes/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/Body/Organs/reptilian.yml
@@ -16,5 +16,5 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -27,7 +27,7 @@
         food:
           maxVol: 5
           reagents:
-          - ReagentId: Nutriment
+          - ReagentId: UncookedAnimalProteins
             Quantity: 5
 
 
@@ -63,5 +63,5 @@
       food:
         maxVol: 5
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: UncookedAnimalProteins
           Quantity: 5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added the meat tag to organs so lizards can consume them with their whitelisted stomach.
Changed nutriment within organs to uncooked protein so only animals can safely consume them without cooking.
resolves #20881

NPC mobs will also avoid eating brains to make player's lives just a tiny bit better.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Food.
You can get round removed by a random mouse interrupting borging.


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Nothing complex, added tag.
Changed nutriment to uncooked protein.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Whisper
- fix: Lizards can eat organs again!
- tweak: Organs now contain uncooked proteins instead of edible nutriment. Animals will be able to consume this.
