### PR TITLE
Replace string data fields with LocId where relevant

### DIFF
--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsComponent.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsComponent.cs
@@ -1,11 +1,4 @@
-using System;
 using Content.Shared.Chemistry;
-using JetBrains.Annotations;
-using Robust.Client.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
-using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
 
 namespace Content.Client.Chemistry.Visualizers
@@ -13,40 +6,40 @@ namespace Content.Client.Chemistry.Visualizers
     [RegisterComponent]
     public sealed partial class SolutionContainerVisualsComponent : Component
     {
-        [DataField("maxFillLevels")]
+        [DataField]
         public int MaxFillLevels = 0;
-        [DataField("fillBaseName")]
+        [DataField]
         public string? FillBaseName = null;
-        [DataField("layer")]
-        public SolutionContainerLayers FillLayer = SolutionContainerLayers.Fill;
-        [DataField("baseLayer")]
+        [DataField]
+        public SolutionContainerLayers Layer = SolutionContainerLayers.Fill;
+        [DataField]
         public SolutionContainerLayers BaseLayer = SolutionContainerLayers.Base;
-        [DataField("overlayLayer")]
+        [DataField]
         public SolutionContainerLayers OverlayLayer = SolutionContainerLayers.Overlay;
-        [DataField("changeColor")]
+        [DataField]
         public bool ChangeColor = true;
-        [DataField("emptySpriteName")]
+        [DataField]
         public string? EmptySpriteName = null;
-        [DataField("emptySpriteColor")]
+        [DataField]
         public Color EmptySpriteColor = Color.White;
-        [DataField("metamorphic")]
+        [DataField]
         public bool Metamorphic = false;
-        [DataField("metamorphicDefaultSprite")]
+        [DataField]
         public SpriteSpecifier? MetamorphicDefaultSprite;
-        [DataField("metamorphicNameFull")]
-        public string MetamorphicNameFull = "transformable-container-component-glass";
+        [DataField]
+        public LocId MetamorphicNameFull = "transformable-container-component-glass";
 
         /// <summary>
         /// Which solution of the SolutionContainerManagerComponent to represent.
         /// If not set, will work as default.
         /// </summary>
-        [DataField("solutionName")]
+        [DataField]
         public string? SolutionName;
 
-        [DataField("initialName")]
+        [DataField]
         public string InitialName = string.Empty;
 
-        [DataField("initialDescription")]
+        [DataField]
         public string InitialDescription = string.Empty;
     }
 }

--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -41,7 +41,7 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
         if (args.Sprite == null)
             return;
 
-        if (!args.Sprite.LayerMapTryGet(component.FillLayer, out var fillLayer))
+        if (!args.Sprite.LayerMapTryGet(component.Layer, out var fillLayer))
             return;
 
         // Currently some solution methods such as overflowing will try to update appearance with a

--- a/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
+++ b/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
@@ -1,18 +1,17 @@
 #nullable enable
 using System.Collections.Generic;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
-using Content.Server.Storage.Components;
 using Content.Server.VendingMachines;
+using Content.Server.Wires;
 using Content.Shared.Cargo.Prototypes;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
-using Content.Shared.VendingMachines;
-using Content.Shared.Wires;
-using Content.Server.Wires;
 using Content.Shared.Prototypes;
 using Content.Shared.Storage.Components;
+using Content.Shared.VendingMachines;
+using Content.Shared.Wires;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests
 {
@@ -96,7 +95,7 @@ namespace Content.IntegrationTests.Tests
   name: Test Ramen
   components:
   - type: Wires
-    LayoutId: Vending
+    layoutId: Vending
   - type: VendingMachine
     pack: TestInventory
   - type: Sprite

--- a/Content.Server/Chemistry/Components/SolutionSpikerComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionSpikerComponent.cs
@@ -7,24 +7,24 @@ public sealed partial class SolutionSpikerComponent : Component
     ///     The source solution to take the reagents from in order
     ///     to spike the other solution container.
     /// </summary>
-    [DataField("sourceSolution")]
+    [DataField]
     public string SourceSolution { get; private set; } = string.Empty;
 
     /// <summary>
     ///     If spiking with this entity should ignore empty containers or not.
     /// </summary>
-    [DataField("ignoreEmpty")]
+    [DataField]
     public bool IgnoreEmpty { get; private set; }
 
     /// <summary>
     ///     What should pop up when spiking with this entity.
     /// </summary>
-    [DataField("popup")]
-    public string Popup { get; private set; } = "spike-solution-generic";
+    [DataField]
+    public LocId Popup { get; private set; } = "spike-solution-generic";
 
     /// <summary>
     ///     What should pop up when spiking fails because the container was empty.
     /// </summary>
-    [DataField("popupEmpty")]
-    public string PopupEmpty { get; private set; } = "spike-solution-empty-generic";
+    [DataField]
+    public LocId PopupEmpty { get; private set; } = "spike-solution-empty-generic";
 }

--- a/Content.Server/Communications/CommunicationsConsoleComponent.cs
+++ b/Content.Server/Communications/CommunicationsConsoleComponent.cs
@@ -1,6 +1,5 @@
 using Content.Server.UserInterface;
 using Content.Shared.Communications;
-using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 
 namespace Content.Server.Communications
@@ -21,41 +20,41 @@ namespace Content.Server.Communications
         /// If a Fluent ID isn't found, just uses the raw string
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("title", required: true)]
-        public string AnnouncementDisplayName = "comms-console-announcement-title-station";
+        [DataField(required: true)]
+        public LocId Title = "comms-console-announcement-title-station";
 
         /// <summary>
         /// Announcement color
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("color")]
-        public Color AnnouncementColor = Color.Gold;
+        [DataField]
+        public Color Color = Color.Gold;
 
         /// <summary>
         /// Time in seconds between announcement delays on a per-console basis
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("delay")]
-        public int DelayBetweenAnnouncements = 90;
+        [DataField]
+        public int Delay = 90;
 
         /// <summary>
         /// Can call or recall the shuttle
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("canShuttle")]
-        public bool CanCallShuttle = true;
+        [DataField]
+        public bool CanShuttle = true;
 
         /// <summary>
         /// Announce on all grids (for nukies)
         /// </summary>
-        [DataField("global")]
-        public bool AnnounceGlobal = false;
+        [DataField]
+        public bool Global = false;
 
         /// <summary>
         /// Announce sound file path
         /// </summary>
-        [DataField("sound")]
-        public SoundSpecifier AnnouncementSound = new SoundPathSpecifier("/Audio/Announcements/announce.ogg");
+        [DataField]
+        public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/Announcements/announce.ogg");
 
         public PlayerBoundUserInterface? UserInterface => Owner.GetUIOrNull(CommunicationsConsoleUiKey.Key);
     }

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -188,7 +188,7 @@ namespace Content.Server.Communications
 
             // Calling shuttle checks
             if (_roundEndSystem.ExpectedCountdownEnd is null)
-                return comp.CanCallShuttle;
+                return comp.CanShuttle;
 
             // Recalling shuttle checks
             var recallThreshold = _cfg.GetCVar(CCVars.EmergencyRecallTurningPoint);
@@ -256,27 +256,27 @@ namespace Content.Server.Communications
                 }
             }
 
-            comp.AnnouncementCooldownRemaining = comp.DelayBetweenAnnouncements;
+            comp.AnnouncementCooldownRemaining = comp.Delay;
             UpdateCommsConsoleInterface(uid, comp);
 
             var ev = new CommunicationConsoleAnnouncementEvent(uid, comp, msg, message.Session.AttachedEntity);
             RaiseLocalEvent(ref ev);
 
             // allow admemes with vv
-            Loc.TryGetString(comp.AnnouncementDisplayName, out var title);
-            title ??= comp.AnnouncementDisplayName;
+            Loc.TryGetString(comp.Title, out var title);
+            title ??= comp.Title;
 
             msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author;
-            if (comp.AnnounceGlobal)
+            if (comp.Global)
             {
-                _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.AnnouncementSound, colorOverride: comp.AnnouncementColor);
+                _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color);
 
                 if (message.Session.AttachedEntity != null)
                     _adminLogger.Add(LogType.Chat, LogImpact.Low, $"{ToPrettyString(message.Session.AttachedEntity.Value):player} has sent the following global announcement: {msg}");
 
                 return;
             }
-            _chatSystem.DispatchStationAnnouncement(uid, msg, title, colorOverride: comp.AnnouncementColor);
+            _chatSystem.DispatchStationAnnouncement(uid, msg, title, colorOverride: comp.Color);
 
             if (message.Session.AttachedEntity != null)
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"{ToPrettyString(message.Session.AttachedEntity.Value):player} has sent the following station announcement: {msg}");

--- a/Content.Server/Forensics/Components/FiberComponent.cs
+++ b/Content.Server/Forensics/Components/FiberComponent.cs
@@ -7,10 +7,10 @@ namespace Content.Server.Forensics
     [RegisterComponent]
     public sealed partial class FiberComponent : Component
     {
-        [DataField("fiberMaterial")]
-        public string FiberMaterial = "fibers-synthetic";
+        [DataField]
+        public LocId FiberMaterial = "fibers-synthetic";
 
-        [DataField("fiberColor")]
+        [DataField]
         public string? FiberColor;
     }
 }

--- a/Content.Server/Nuke/NukeLabelComponent.cs
+++ b/Content.Server/Nuke/NukeLabelComponent.cs
@@ -9,6 +9,6 @@ namespace Content.Server.Nuke;
 [RegisterComponent]
 public sealed partial class NukeLabelComponent : Component
 {
-    [DataField("prefix")] public string NukeLabel = "nuke-label-nanotrasen";
-    [DataField("serialLength")] public int SerialLength = 6;
+    [DataField] public LocId Prefix = "nuke-label-nanotrasen";
+    [DataField] public int SerialLength = 6;
 }

--- a/Content.Server/Nuke/NukeLabelSystem.cs
+++ b/Content.Server/Nuke/NukeLabelSystem.cs
@@ -16,7 +16,7 @@ public sealed class NukeLabelSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, NukeLabelComponent nuke, MapInitEvent args)
     {
-        var label = Loc.GetString(nuke.NukeLabel, ("serial", _nuke.GenerateRandomNumberString(nuke.SerialLength)));
+        var label = Loc.GetString(nuke.Prefix, ("serial", _nuke.GenerateRandomNumberString(nuke.SerialLength)));
         var meta = MetaData(uid);
         _metaData.SetEntityName(uid, $"{meta.EntityName} ({label})", meta);
     }

--- a/Content.Server/NukeOps/WarDeclaratorComponent.cs
+++ b/Content.Server/NukeOps/WarDeclaratorComponent.cs
@@ -12,37 +12,37 @@ public sealed partial class WarDeclaratorComponent : Component
     /// Custom war declaration message. If empty, use default.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("message")]
+    [DataField]
     public string Message;
 
     /// <summary>
     /// Permission to customize message text
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("allowEditingMessage")]
+    [DataField]
     public bool AllowEditingMessage = true;
 
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("maxMessageLength")]
+    [DataField]
     public int MaxMessageLength = 512;
 
     /// <summary>
     /// War declarement text color
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("color")]
-    public Color DeclarementColor = Color.Red;
+    [DataField]
+    public Color Color = Color.Red;
 
     /// <summary>
     /// War declarement sound file path
     /// </summary>
-    [DataField("sound")]
-    public SoundSpecifier DeclarementSound = new SoundPathSpecifier("/Audio/Announcements/war.ogg");
+    [DataField]
+    public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/Announcements/war.ogg");
 
     /// <summary>
     /// Fluent ID for the declarement title
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("title")]
-    public string DeclarementTitle = "comms-console-announcement-title-nukie";
+    [DataField]
+    public LocId Title = "comms-console-announcement-title-nukie";
 }

--- a/Content.Server/NukeOps/WarDeclaratorSystem.cs
+++ b/Content.Server/NukeOps/WarDeclaratorSystem.cs
@@ -76,9 +76,9 @@ public sealed class WarDeclaratorSystem : EntitySystem
         {
             message = Loc.GetString("war-declarator-default-message");
         }
-        var title = Loc.GetString(component.DeclarementTitle);
+        var title = Loc.GetString(component.Title);
 
-        _nukeopsRuleSystem.DeclareWar(args.Session.AttachedEntity.Value, message, title, component.DeclarementSound, component.DeclarementColor);
+        _nukeopsRuleSystem.DeclareWar(args.Session.AttachedEntity.Value, message, title, component.Sound, component.Color);
 
         if (args.Session.AttachedEntity != null)
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"{ToPrettyString(args.Session.AttachedEntity.Value):player} has declared war with this text: {message}");

--- a/Content.Server/Nutrition/Components/FoodComponent.cs
+++ b/Content.Server/Nutrition/Components/FoodComponent.cs
@@ -1,10 +1,8 @@
 using Content.Server.Body.Components;
-using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Nutrition.Components;
 
@@ -17,8 +15,8 @@ public sealed partial class FoodComponent : Component
     [DataField]
     public SoundSpecifier UseSound = new SoundPathSpecifier("/Audio/Items/eatfood.ogg");
 
-    [DataField("trash")]
-    public EntProtoId? TrashPrototype;
+    [DataField]
+    public EntProtoId? Trash;
 
     [DataField]
     public FixedPoint2? TransferAmount = FixedPoint2.New(5);
@@ -55,7 +53,7 @@ public sealed partial class FoodComponent : Component
     /// The localization identifier for the eat message. Needs a "food" entity argument passed to it.
     /// </summary>
     [DataField]
-    public string EatMessage = "food-nom";
+    public LocId EatMessage = "food-nom";
 
     /// <summary>
     /// How long it takes to eat the food personally.

--- a/Content.Server/Nutrition/Components/OpenableComponent.cs
+++ b/Content.Server/Nutrition/Components/OpenableComponent.cs
@@ -28,7 +28,7 @@ public sealed partial class OpenableComponent : Component
     /// Text shown when examining and its open.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public string ExamineText = "drink-component-on-examine-is-opened";
+    public LocId ExamineText = "drink-component-on-examine-is-opened";
 
     /// <summary>
     /// The locale id for the popup shown when IsClosed is called and closed. Needs a "owner" entity argument passed to it.
@@ -36,7 +36,7 @@ public sealed partial class OpenableComponent : Component
     /// It's still generic enough that you should change it if you make openable non-drinks, i.e. unwrap it first, peel it first.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public string ClosedPopup = "drink-component-try-use-drink-not-open";
+    public LocId ClosedPopup = "drink-component-try-use-drink-not-open";
 
     /// <summary>
     /// Sound played when opening.

--- a/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
@@ -45,9 +45,9 @@ namespace Content.Server.Nutrition.EntitySystems
                 {
                     _puddle.TrySpillAt(uid, solution, out _, false);
                 }
-                if (!string.IsNullOrEmpty(foodComp.TrashPrototype))
+                if (!string.IsNullOrEmpty(foodComp.Trash))
                 {
-                    EntityManager.SpawnEntity(foodComp.TrashPrototype, Transform(uid).Coordinates);
+                    EntityManager.SpawnEntity(foodComp.Trash, Transform(uid).Coordinates);
                 }
             }
             ActivatePayload(uid);

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Server.Chemistry.EntitySystems;
@@ -22,13 +21,12 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nutrition;
-using Content.Shared.Verbs;
 using Content.Shared.Stacks;
+using Content.Shared.Storage;
+using Content.Shared.Verbs;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
-using Content.Shared.Tag;
-using Content.Shared.Storage;
 
 namespace Content.Server.Nutrition.EntitySystems;
 
@@ -309,7 +307,7 @@ public sealed class FoodSystem : EntitySystem
         if (ev.Cancelled)
             return;
 
-        if (string.IsNullOrEmpty(component.TrashPrototype))
+        if (string.IsNullOrEmpty(component.Trash))
             QueueDel(uid);
         else
             DeleteAndSpawnTrash(component, uid, args.User);
@@ -319,7 +317,7 @@ public sealed class FoodSystem : EntitySystem
     {
         //We're empty. Become trash.
         var position = Transform(food).MapPosition;
-        var finisher = Spawn(component.TrashPrototype, position);
+        var finisher = Spawn(component.Trash, position);
 
         // If the user is holding the item
         if (user != null && _hands.IsHolding(user.Value, food, out var hand))

--- a/Content.Server/StationEvents/Components/CargoGiftsRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/CargoGiftsRuleComponent.cs
@@ -1,8 +1,6 @@
 ﻿using Content.Server.StationEvents.Events;
 using Content.Shared.Cargo.Prototypes;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 
 namespace Content.Server.StationEvents.Components;
 
@@ -15,43 +13,43 @@ public sealed partial class CargoGiftsRuleComponent : Component
     /// <summary>
     /// The base announcement string (which then incorporates the strings below)
     /// </summary>
-    [DataField("announce"), ViewVariables(VVAccess.ReadWrite)]
-    public string Announce = "cargo-gifts-event-announcement";
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId Announce = "cargo-gifts-event-announcement";
 
     /// <summary>
     /// What is being sent
     /// </summary>
-    [DataField("description"), ViewVariables(VVAccess.ReadWrite)]
-    public string Description = "cargo-gift-default-description";
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId Description = "cargo-gift-default-description";
 
     /// <summary>
     /// Sender of the gifts
     /// </summary>
-    [DataField("sender"), ViewVariables(VVAccess.ReadWrite)]
-    public string Sender = "cargo-gift-default-sender";
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId Sender = "cargo-gift-default-sender";
 
     /// <summary>
     /// Destination of the gifts (who they get sent to on the station)
     /// </summary>
-    [DataField("dest"), ViewVariables(VVAccess.ReadWrite)]
-    public string Dest = "cargo-gift-default-dest";
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId Dest = "cargo-gift-default-dest";
 
     /// <summary>
     /// Cargo that you would like gifted to the station, with the quantity for each
     /// Use Ids from cargoProduct Prototypes
     /// </summary>
-    [DataField("gifts", required: true, customTypeSerializer:typeof(PrototypeIdDictionarySerializer<int, CargoProductPrototype>)), ViewVariables(VVAccess.ReadWrite)]
-    public Dictionary<string, int> Gifts = new();
+    [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
+    public Dictionary<ProtoId<CargoProductPrototype>, int> Gifts = new();
 
     /// <summary>
     /// How much space (minimum) you want to leave in the order database for supply to actually do their work
     /// </summary>
-    [DataField("orderSpaceToLeave"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public int OrderSpaceToLeave = 5;
 
     /// <summary>
     /// Time until we consider next lot of gifts (if supply is overflowing with orders)
     /// </summary>
-    [DataField("timeUntilNextGifts"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float TimeUntilNextGifts = 10.0f;
 }

--- a/Content.Server/StationEvents/Events/CargoGiftsRule.cs
+++ b/Content.Server/StationEvents/Events/CargoGiftsRule.cs
@@ -4,7 +4,6 @@ using Content.Server.Cargo.Systems;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.StationEvents.Components;
-using Content.Shared.Cargo.Prototypes;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.StationEvents.Events;
@@ -56,7 +55,7 @@ public sealed class CargoGiftsRule : StationEventSystem<CargoGiftsRuleComponent>
             var (productId, qty) = component.Gifts.First();
             component.Gifts.Remove(productId);
 
-            var product = _prototypeManager.Index<CargoProductPrototype>(productId);
+            var product = _prototypeManager.Index(productId);
 
             if (!_cargoSystem.AddAndApproveOrder(
                     station!.Value,

--- a/Content.Server/Storage/Components/PickRandomComponent.cs
+++ b/Content.Server/Storage/Components/PickRandomComponent.cs
@@ -14,18 +14,18 @@ public sealed partial class PickRandomComponent : Component
     /// <summary>
     /// Whitelist for potential picked items.
     /// </summary>
-    [DataField("whitelist"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public EntityWhitelist? Whitelist;
 
     /// <summary>
     /// Locale id for the pick verb text.
     /// </summary>
-    [DataField("verbText"), ViewVariables(VVAccess.ReadWrite)]
-    public string VerbText = "comp-pick-random-verb-text";
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId VerbText = "comp-pick-random-verb-text";
 
     /// <summary>
     /// Locale id for the empty storage message.
     /// </summary>
-    [DataField("emptyText"), ViewVariables(VVAccess.ReadWrite)]
-    public string EmptyText = "comp-pick-random-empty";
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId EmptyText = "comp-pick-random-empty";
 }

--- a/Content.Server/Tabletop/Components/TabletopGameComponent.cs
+++ b/Content.Server/Tabletop/Components/TabletopGameComponent.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using Vector2 = System.Numerics.Vector2;
 
 namespace Content.Server.Tabletop.Components
 {
@@ -12,25 +11,25 @@ namespace Content.Server.Tabletop.Components
         /// <summary>
         /// The localized name of the board. Shown in the UI.
         /// </summary>
-        [DataField("boardName")]
-        public string BoardName { get; private set; } = "tabletop-default-board-name";
+        [DataField]
+        public LocId BoardName { get; private set; } = "tabletop-default-board-name";
 
         /// <summary>
         /// The type of method used to set up a tabletop.
         /// </summary>
-        [DataField("setup", required: true)]
+        [DataField(required: true)]
         public TabletopSetup Setup { get; private set; } = new TabletopChessSetup();
 
         /// <summary>
         /// The size of the viewport being opened. Must match the board dimensions otherwise you'll get the space parallax (unless that's what you want).
         /// </summary>
-        [DataField("size")]
+        [DataField]
         public Vector2i Size { get; private set; } = (300, 300);
 
         /// <summary>
         /// The zoom of the viewport camera.
         /// </summary>
-        [DataField("cameraZoom")]
+        [DataField]
         public Vector2 CameraZoom { get; private set; } = Vector2.One;
 
         /// <summary>

--- a/Content.Server/UserInterface/ActivatableUIComponent.cs
+++ b/Content.Server/UserInterface/ActivatableUIComponent.cs
@@ -1,4 +1,3 @@
-using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Reflection;
 using Robust.Shared.Serialization;
@@ -15,21 +14,21 @@ namespace Content.Server.UserInterface
         [ViewVariables] public PlayerBoundUserInterface? UserInterface => (Key != null) ? Owner.GetUIOrNull(Key) : null;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("inHandsOnly")]
+        [DataField]
         public bool InHandsOnly { get; set; } = false;
 
-        [DataField("singleUser")]
+        [DataField]
         public bool SingleUser { get; set; } = false;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("adminOnly")]
+        [DataField]
         public bool AdminOnly { get; set; } = false;
 
         [DataField("key", required: true)]
         private string _keyRaw = default!;
 
-        [DataField("verbText")]
-        public string VerbText = "ui-verb-toggle-open";
+        [DataField]
+        public LocId VerbText = "ui-verb-toggle-open";
 
         /// <summary>
         ///     Whether you need a hand to operate this UI. The hand does not need to be free, you just need to have one.
@@ -39,28 +38,28 @@ namespace Content.Server.UserInterface
         ///     more generic interaction / configuration that might not require hands.
         /// </remarks>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("requireHands")]
+        [DataField]
         public bool RequireHands = true;
 
         /// <summary>
         ///     Whether you can activate this ui with activateinhand or not
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("rightClickOnly")]
+        [DataField]
         public bool rightClickOnly = false;
 
         /// <summary>
         ///     Whether spectators (non-admin ghosts) should be allowed to view this UI.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("allowSpectator")]
+        [DataField]
         public bool AllowSpectator = true;
 
         /// <summary>
         ///     Whether the UI should close when the item is deselected due to a hand swap or drop
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("closeOnHandDeselect")]
+        [DataField]
         public bool CloseOnHandDeselect = true;
 
         /// <summary>

--- a/Content.Server/Wires/WiresComponent.cs
+++ b/Content.Server/Wires/WiresComponent.cs
@@ -8,13 +8,13 @@ public sealed partial class WiresComponent : Component
     /// <summary>
     ///     The name of this entity's internal board.
     /// </summary>
-    [DataField("BoardName")]
-    public string BoardName { get; set; } = "wires-board-name-default";
+    [DataField]
+    public LocId BoardName { get; set; } = "wires-board-name-default";
 
     /// <summary>
     ///     The layout ID of this entity's wires.
     /// </summary>
-    [DataField("LayoutId", required: true)]
+    [DataField(required: true)]
     public string LayoutId { get; set; } = default!;
 
     /// <summary>
@@ -47,7 +47,7 @@ public sealed partial class WiresComponent : Component
     ///     If this should follow the layout saved the first time the layout dictated by the
     ///     layout ID is generated, or if a new wire order should be generated every time.
     /// </summary>
-    [DataField("alwaysRandomize")]
+    [DataField]
     public bool AlwaysRandomize { get; private set; }
 
     /// <summary>
@@ -64,6 +64,6 @@ public sealed partial class WiresComponent : Component
     [ViewVariables]
     public Dictionary<object, object> StateData { get; } = new();
 
-    [DataField("pulseSound")]
+    [DataField]
     public SoundSpecifier PulseSound = new SoundPathSpecifier("/Audio/Effects/multitool_pulse.ogg");
 }

--- a/Content.Shared/Bed/Sleep/SleepEmitSoundComponent.cs
+++ b/Content.Shared/Bed/Sleep/SleepEmitSoundComponent.cs
@@ -8,24 +8,24 @@ public sealed partial class SleepEmitSoundComponent : Component
     /// <summary>
     /// Sound to play when sleeping
     /// </summary>
-    [DataField("snore"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier Snore = new SoundCollectionSpecifier("Snores", AudioParams.Default.WithVariation(0.2f));
 
     /// <summary>
     /// Interval between snore attempts in seconds
     /// </summary>
-    [DataField("interval"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float Interval = 5f;
 
     /// <summary>
     /// Chance for snore attempt to succeed
     /// </summary>
-    [DataField("chance"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float Chance = 0.33f;
 
     /// <summary>
     /// Popup for snore (e.g. Zzz...)
     /// </summary>
-    [DataField("popUp"), ViewVariables(VVAccess.ReadWrite)]
-    public string PopUp = "sleep-onomatopoeia";
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId PopUp = "sleep-onomatopoeia";
 }

--- a/Content.Shared/CartridgeLoader/CartridgeComponent.cs
+++ b/Content.Shared/CartridgeLoader/CartridgeComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.CartridgeLoader;
 public sealed partial class CartridgeComponent : Component
 {
     [DataField(required: true)]
-    public string ProgramName = "default-program-name";
+    public LocId ProgramName = "default-program-name";
 
     [DataField]
     public SpriteSpecifier? Icon;

--- a/Content.Shared/Chemistry/Reaction/ReactionMixerComponent.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionMixerComponent.cs
@@ -9,15 +9,15 @@ public sealed partial class ReactionMixerComponent : Component
     ///     A list of IDs for categories of reactions that can be mixed (i.e. HOLY for a bible, DRINK for a spoon)
     /// </summary>
     [ViewVariables]
-    [DataField("reactionTypes")]
+    [DataField]
     public List<string> ReactionTypes = default!;
 
     /// <summary>
     ///     A string which identifies the string to be sent when successfully mixing a solution
     /// </summary>
     [ViewVariables]
-    [DataField("mixMessage")]
-    public string MixMessage = "default-mixing-success";
+    [DataField]
+    public LocId MixMessage = "default-mixing-success";
 }
 
 [ByRefEvent]

--- a/Content.Shared/Construction/Steps/PartAssemblyConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/PartAssemblyConstructionGraphStep.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Construction.Components;
 using Content.Shared.Examine;
-using JetBrains.Annotations;
 
 namespace Content.Shared.Construction.Steps;
 
@@ -10,14 +9,14 @@ public sealed partial class PartAssemblyConstructionGraphStep : ConstructionGrap
     /// <summary>
     /// A valid ID on <see cref="PartAssemblyComponent"/>'s dictionary of strings to part lists.
     /// </summary>
-    [DataField("assemblyId")]
+    [DataField]
     public string AssemblyId = string.Empty;
 
     /// <summary>
-    /// A localization string used for
+    /// A localization string used when examining and for the guidebook.
     /// </summary>
-    [DataField("guideString")]
-    public string GuideString = "construction-guide-condition-part-assembly";
+    [DataField]
+    public LocId GuideString = "construction-guide-condition-part-assembly";
 
     public bool Condition(EntityUid uid, IEntityManager entityManager)
     {

--- a/Content.Shared/Examine/ExamineSystemShared.Group.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.Group.cs
@@ -1,5 +1,5 @@
-using Robust.Shared.Utility;
 using Content.Shared.Verbs;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Examine
 {
@@ -23,7 +23,7 @@ namespace Content.Shared.Examine
         /// </summary>
         private void OnGroupExamineVerb(EntityUid uid, GroupExamineComponent component, GetVerbsEvent<ExamineVerb> args)
         {
-            foreach (var group in component.ExamineGroups)
+            foreach (var group in component.Group)
             {
                 if (!EntityHasComponent(uid, group.Components))
                     continue;
@@ -116,7 +116,7 @@ namespace Content.Shared.Examine
                 // Make sure we have the component name as a string
                 var componentName = _componentFactory.GetComponentName(component.GetType());
 
-                foreach (var examineGroup in groupExamine.ExamineGroups)
+                foreach (var examineGroup in groupExamine.Group)
                 {
                     // If any of the examine groups list of components contain this componentname
                     if (examineGroup.Components.Contains(componentName))
@@ -124,7 +124,7 @@ namespace Content.Shared.Examine
                         foreach (var entry in examineGroup.Entries)
                         {
                             // If any of the entries already are from your component, dont do anything else - no doubles!
-                            if (entry.ComponentName == componentName)
+                            if (entry.Component == componentName)
                                 return;
                         }
 

--- a/Content.Shared/Examine/GroupExamineComponent.cs
+++ b/Content.Shared/Examine/GroupExamineComponent.cs
@@ -12,8 +12,8 @@ namespace Content.Shared.Examine
         /// <summary>
         ///     A list of ExamineGroups.
         /// </summary>
-        [DataField("group")]
-        public List<ExamineGroup> ExamineGroups = new()
+        [DataField]
+        public List<ExamineGroup> Group = new()
         {
             // TODO Remove hardcoded component names.
             new ExamineGroup()
@@ -33,14 +33,14 @@ namespace Content.Shared.Examine
         /// <summary>
         ///     The title of the Examine Group. Localized string that gets added to the examine tooltip.
         /// </summary>
-        [DataField("title")]
+        [DataField]
         [ViewVariables(VVAccess.ReadWrite)]
         public string? Title;
 
         /// <summary>
         ///     A list of ExamineEntries, containing which component it belongs to, which priority it has, and what FormattedMessage it holds.
         /// </summary>
-        [DataField("entries")]
+        [DataField]
         public List<ExamineEntry> Entries = new();
 
         // TODO custom type serializer, or just make this work via some other automatic grouping process that doesn't
@@ -48,25 +48,25 @@ namespace Content.Shared.Examine
         /// <summary>
         ///     A list of all components this ExamineGroup encompasses.
         /// </summary>
-        [DataField("components")]
+        [DataField]
         public List<string> Components = new();
 
         /// <summary>
         ///     The icon path for the Examine Group.
         /// </summary>
-        [DataField("icon")]
+        [DataField]
         public SpriteSpecifier Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/examine-star.png"));
 
         /// <summary>
         ///     The text shown in the context verb menu.
         /// </summary>
-        [DataField("contextText")]
-        public string ContextText = "verb-examine-group-other";
+        [DataField]
+        public LocId ContextText = "verb-examine-group-other";
 
         /// <summary>
         ///     Details shown when hovering over the button.
         /// </summary>
-        [DataField("hoverMessage")]
+        [DataField]
         public string HoverMessage = string.Empty;
     }
 
@@ -79,25 +79,25 @@ namespace Content.Shared.Examine
         /// <summary>
         ///     Which component does this entry relate to?
         /// </summary>
-        [DataField("component", required: true)]
-        public string ComponentName;
+        [DataField(required: true)]
+        public string Component;
 
         /// <summary>
         ///     What priority has this entry - entries are sorted high to low.
         /// </summary>
-        [DataField("priority")]
+        [DataField]
         public float Priority = 0f;
 
         /// <summary>
         ///     The FormattedMessage of this entry.
         /// </summary>
-        [DataField("message", required: true)]
+        [DataField(required: true)]
         public FormattedMessage Message;
 
-        /// <param name="componentName">Should be set to _componentFactory.GetComponentName(component.GetType()) to properly function.</param>
-        public ExamineEntry(string componentName, float priority, FormattedMessage message)
+        /// <param name="component">Should be set to _componentFactory.GetComponentName(component.GetType()) to properly function.</param>
+        public ExamineEntry(string component, float priority, FormattedMessage message)
         {
-            ComponentName = componentName;
+            Component = component;
             Priority = priority;
             Message = message;
         }
@@ -106,7 +106,7 @@ namespace Content.Shared.Examine
         {
             // parameterless ctor is required for data-definition serialization
             Message = default!;
-            ComponentName = default!;
+            Component = default!;
         }
     }
 

--- a/Content.Shared/Implants/Components/RattleComponent.cs
+++ b/Content.Shared/Implants/Components/RattleComponent.cs
@@ -1,6 +1,6 @@
 using Content.Shared.Radio;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Implants.Components;
 
@@ -8,14 +8,14 @@ namespace Content.Shared.Implants.Components;
 public sealed partial class RattleComponent : Component
 {
     // The radio channel the message will be sent to
-    [DataField("radioChannel", customTypeSerializer: typeof(PrototypeIdSerializer<RadioChannelPrototype>))]
-    public string RadioChannel = "Syndicate";
+    [DataField]
+    public ProtoId<RadioChannelPrototype> RadioChannel = "Syndicate";
 
     // The message that the implant will send when crit
-    [DataField("critMessage")]
-    public string CritMessage = "deathrattle-implant-critical-message";
+    [DataField]
+    public LocId CritMessage = "deathrattle-implant-critical-message";
 
     // The message that the implant will send when dead
     [DataField("deathMessage")]
-    public string DeathMessage = "deathrattle-implant-dead-message";
+    public LocId DeathMessage = "deathrattle-implant-dead-message";
 }

--- a/Content.Shared/Materials/MaterialPrototype.cs
+++ b/Content.Shared/Materials/MaterialPrototype.cs
@@ -1,7 +1,6 @@
 using Robust.Shared.Prototypes;
-using Robust.Shared.Utility;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Materials
 {
@@ -17,7 +16,7 @@ namespace Content.Shared.Materials
         public string[]? Parents { get; }
 
         [ViewVariables]
-        [AbstractDataFieldAttribute]
+        [AbstractDataField]
         public bool Abstract { get; } = false;
 
         [ViewVariables]
@@ -29,10 +28,10 @@ namespace Content.Shared.Materials
         ///     between the material and physical entities you can carry,
         ///     include which stack we should spawn by default.
         /// </summary>
-        [DataField("stackEntity", customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
-        public string? StackEntity;
+        [DataField]
+        public ProtoId<EntityPrototype>? StackEntity;
 
-        [DataField("name")]
+        [DataField]
         public string Name = string.Empty;
 
         /// <summary>
@@ -40,22 +39,22 @@ namespace Content.Shared.Materials
         /// Lathe recipe tooltips and material storage display use this to let you change a material to sound nicer.
         /// For example, 5 bars of gold is better than 5 sheets of gold.
         /// </summary>
-        [DataField("unit")]
-        public string Unit = "materials-unit-sheet";
+        [DataField]
+        public LocId Unit = "materials-unit-sheet";
 
-        [DataField("color")]
+        [DataField]
         public Color Color { get; private set; } = Color.Gray;
 
         /// <summary>
         ///     An icon used to represent the material in graphic interfaces.
         /// </summary>
-        [DataField("icon")]
+        [DataField]
         public SpriteSpecifier Icon { get; private set; } = SpriteSpecifier.Invalid;
 
         /// <summary>
         /// The price per cm3.
         /// </summary>
-        [DataField("price", required: true)]
+        [DataField(required: true)]
         public double Price = 0;
     }
 }

--- a/Content.Shared/Nutrition/AnimalHusbandry/ReproductiveComponent.cs
+++ b/Content.Shared/Nutrition/AnimalHusbandry/ReproductiveComponent.cs
@@ -1,5 +1,4 @@
-﻿using Content.Shared.Nutrition.Components;
-using Content.Shared.Storage;
+﻿using Content.Shared.Storage;
 using Content.Shared.Whitelist;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -16,93 +15,93 @@ public sealed partial class ReproductiveComponent : Component
     /// <summary>
     /// The next time when breeding will be attempted.
     /// </summary>
-    [DataField("nextBreedAttempt", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan NextBreedAttempt;
 
     /// <summary>
     /// Minimum length between each attempt to breed.
     /// </summary>
-    [DataField("minBreedAttemptInterval"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan MinBreedAttemptInterval = TimeSpan.FromSeconds(45);
 
     /// <summary>
     /// Maximum length between each attempt to breed.
     /// </summary>
-    [DataField("maxBreedAttemptInterval"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan MaxBreedAttemptInterval = TimeSpan.FromSeconds(60);
 
     /// <summary>
     /// How close to a partner an entity must be in order to breed.
     /// Unrealistically long.
     /// </summary>
-    [DataField("breedRange"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float BreedRange = 3f;
 
     /// <summary>
     /// How many other entities with this component are allowed in range before we stop.
     /// </summary>
-    [DataField("capacity"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public int Capacity = 6;
 
     /// <summary>
     /// The chance that, on a given attempt,
     /// for each valid partner, the entity will breed.
     /// </summary>
-    [DataField("breedChance"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float BreedChance = 0.15f;
 
     /// <summary>
     /// Entity prototypes for what type of
     /// offspring can be produced by this entity.
     /// </summary>
-    [DataField("offspring", required: true)]
+    [DataField(required: true)]
     public List<EntitySpawnEntry> Offspring = default!;
 
     /// <summary>
     /// Whether or not this entity has bred successfully
     /// and will produce offspring imminently
     /// </summary>
-    [DataField("gestating")]
+    [DataField]
     public bool Gestating;
 
     /// <summary>
     /// When gestation will end.
     /// Null if <see cref="Gestating"/> is false
     /// </summary>
-    [DataField("gestationEndTime"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan? GestationEndTime;
 
     /// <summary>
     /// How long it takes the entity after breeding
     /// to produce offspring
     /// </summary>
-    [DataField("gestationDuration"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan GestationDuration = TimeSpan.FromMinutes(1.5);
 
     /// <summary>
     /// How much hunger is consumed when an entity
     /// gives birth. A balancing tool to require feeding.
     /// </summary>
-    [DataField("hungerPerBirth"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float HungerPerBirth = 75f;
 
     /// <summary>
     /// Popup shown when an entity gives birth.
     /// Configurable for things like laying eggs.
     /// </summary>
-    [DataField("birthPopup"), ViewVariables(VVAccess.ReadWrite)]
-    public string BirthPopup = "reproductive-birth-popup";
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public LocId BirthPopup = "reproductive-birth-popup";
 
     /// <summary>
     /// Whether or not the offspring should be made into "infants".
     /// </summary>
-    [DataField("makeOffspringInfant"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool MakeOffspringInfant = true;
 
     /// <summary>
     /// An entity whitelist for what entities
     /// can be this one's partner.
     /// </summary>
-    [DataField("partnerWhitelist", required: true)]
+    [DataField(required: true)]
     public EntityWhitelist PartnerWhitelist = default!;
 }

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -94,7 +94,7 @@
   - type: WiresPanel
   - type: ActivatableUIRequiresPanel
   - type: Wires
-    LayoutId: Borg
+    layoutId: Borg
   - type: NameIdentifier
     group: Silicon
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -61,7 +61,7 @@
         toggleAction: ActionAGhostShowStationRecords
   - type: SolarControlConsole # look ma i AM the computer!
   - type: CommunicationsConsole
-    title: communicationsconsole-announcement-title-centcom
+    title: comms-console-announcement-title-centcom
     color: "#228b22"
   - type: RadarConsole
   - type: CargoOrderConsole

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
@@ -164,8 +164,8 @@
   - type: WiresVisuals
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-dawinstrument
-    LayoutId: DawInstrument
+    boardName: wires-board-name-dawinstrument
+    layoutId: DawInstrument
   - type: Machine
     board: DawInstrumentMachineCircuitboard
   - type: Instrument

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -54,8 +54,8 @@
   - type: Clickable
   - type: WiresPanel
   - type: Wires #we just want the panel
-    BoardName: wires-board-name-mech
-    LayoutId: Mech
+    boardName: wires-board-name-mech
+    layoutId: Mech
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -17,8 +17,8 @@
   - type: Machine
     board: BoozeDispenserMachineCircuitboard
   - type: Wires
-    BoardName: wires-board-name-booze
-    LayoutId: BoozeDispenser
+    boardName: wires-board-name-booze
+    layoutId: BoozeDispenser
   - type: GuideHelp
     guides:
     - Bartender

--- a/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
@@ -26,8 +26,8 @@
   - type: Machine
     board: ChemDispenserMachineCircuitboard
   - type: Wires
-    BoardName: wires-board-name-chemdispenser
-    LayoutId: ChemDispenser
+    boardName: wires-board-name-chemdispenser
+    layoutId: ChemDispenser
   - type: UpgradePowerDraw
     powerDrawMultiplier: 0.75
     scaling: Exponential

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -17,8 +17,8 @@
   - type: Machine
     board: SodaDispenserMachineCircuitboard
   - type: Wires
-    BoardName: wires-board-name-soda
-    LayoutId: SodaDispenser
+    boardName: wires-board-name-soda
+    layoutId: SodaDispenser
   - type: GuideHelp
     guides:
     - Bartender

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -207,7 +207,7 @@
   - type: AccessReader
     access: [["Command"]]
   - type: Wires
-    LayoutId: AirlockCommand
+    layoutId: AirlockCommand
 
 - type: entity
   parent: AirlockCommand
@@ -273,7 +273,7 @@
   - type: AccessReader
     access: [["Security"]]
   - type: Wires
-    LayoutId: AirlockSecurity
+    layoutId: AirlockSecurity
 
 - type: entity
   parent: AirlockSecurity
@@ -283,7 +283,7 @@
   - type: AccessReader
     access: [["Detective"]]
   - type: Wires
-    LayoutId: AirlockSecurity
+    layoutId: AirlockSecurity
 
 - type: entity
   parent: AirlockSecurity
@@ -293,7 +293,7 @@
   - type: AccessReader
     access: [["Brig"]]
   - type: Wires
-    LayoutId: AirlockSecurity
+    layoutId: AirlockSecurity
 
 - type: entity
   parent: AirlockSecurity
@@ -303,7 +303,7 @@
   - type: AccessReader
     access: [["Armory"]]
   - type: Wires
-    LayoutId: AirlockArmory
+    layoutId: AirlockArmory
 
 - type: entity
   parent: AirlockSecurity

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -76,8 +76,8 @@
   - type: WiresPanel
   - type: WiresPanelSecurity
   - type: Wires
-    BoardName: wires-board-name-airlock
-    LayoutId: Airlock
+    boardName: wires-board-name-airlock
+    layoutId: Airlock
   - type: DoorSignalControl
   - type: DeviceNetwork
     deviceNetId: Wireless
@@ -134,7 +134,7 @@
     price: 150
   - type: Tag
     tags:
-      - Airlock 
+      - Airlock
       # This tag is used to nagivate the Airlock construction graph. It's needed because the construction graph is shared between Airlock, AirlockGlass, and HighSecDoor
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -70,8 +70,8 @@
   - type: WiresPanelSecurity
     securityLevel: maxSecurity
   - type: Wires
-    BoardName: wires-board-name-highsec
-    LayoutId: HighSec
+    boardName: wires-board-name-highsec
+    layoutId: HighSec
     alwaysRandomize: true
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -43,7 +43,7 @@
     - state: panel_open
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: Wires
-    LayoutId: Docking
+    layoutId: Docking
   - type: Door
     bumpOpen: false
     closeTimeTwo: 0.4

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -84,8 +84,8 @@
     - type: WiresVisuals
     - type: WiresPanel
     - type: Wires
-      BoardName: wires-board-name-firelock
-      LayoutId: Firelock
+      boardName: wires-board-name-firelock
+      layoutId: Firelock
     - type: UserInterface
       interfaces:
         - key: enum.WiresUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -118,8 +118,8 @@
     usesApcPower: true
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-windoor
-    LayoutId: Airlock
+    boardName: wires-board-name-windoor
+    layoutId: Airlock
   - type: UserInterface
     interfaces:
     - key: enum.WiresUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -87,8 +87,8 @@
     - PlushieHampter
   - type: WiresPanel
   - type: Wires
-    LayoutId: Arcade
-    BoardName: wires-board-name-arcade
+    layoutId: Arcade
+    boardName: wires-board-name-arcade
   - type: ActivatableUI
     key: enum.SpaceVillainArcadeUiKey.Key
   - type: ActivatableUIRequiresPower
@@ -129,8 +129,8 @@
   - type: ActivatableUIRequiresPower
   - type: WiresPanel
   - type: Wires
-    LayoutId: Arcade
-    BoardName: wires-board-name-arcade
+    layoutId: Arcade
+    boardName: wires-board-name-arcade
   - type: UserInterface
     interfaces:
       - key: enum.BlockGameUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -51,8 +51,8 @@
   - type: WiresVisuals
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-cryopod
-    LayoutId: CryoPod
+    boardName: wires-board-name-cryopod
+    layoutId: CryoPod
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -38,8 +38,8 @@
   - type: Appearance
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-vessel
-    LayoutId: Vessel
+    boardName: wires-board-name-vessel
+    layoutId: Vessel
   - type: AmbientSound
     enabled: false
     range: 3
@@ -175,8 +175,8 @@
   - type: WiresPanel
   - type: WiresVisuals
   - type: Wires
-    BoardName: wires-board-name-ape
-    LayoutId: Ape
+    boardName: wires-board-name-ape
+    layoutId: Ape
   - type: GenericVisualizer
     visuals:
       enum.PowerDeviceVisuals.Powered:
@@ -264,8 +264,8 @@
     doAfterDelay: 5
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-anomalygenerator
-    LayoutId: AnomalyGenerator
+    boardName: wires-board-name-anomalygenerator
+    layoutId: AnomalyGenerator
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -13,7 +13,7 @@
         - key: enum.WiresUiKey.Key
           type: WiresBoundUserInterface
     - type: Wires
-      LayoutId: Defusable
+      layoutId: Defusable
       alwaysRandomize: true
     - type: Defusable
     - type: Rotatable
@@ -56,7 +56,7 @@
   description: A bomb for dummies, manual not included.
   components:
     - type: Wires
-      LayoutId: Defusable
+      layoutId: Defusable
       alwaysRandomize: true
     - type: Sprite
       sprite: Structures/Machines/bomb.rsi

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -61,8 +61,8 @@
   # Machine / Construction stuff
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-chemmaster
-    LayoutId: chem_master
+    boardName: wires-board-name-chemmaster
+    layoutId: chem_master
   - type: Machine
     board: ChemMasterMachineCircuitboard
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
@@ -61,8 +61,8 @@
     - Biomass
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-cloningpod
-    LayoutId: CloningPod
+    boardName: wires-board-name-cloningpod
+    layoutId: CloningPod
   - type: ApcPowerReceiver
     powerLoad: 200 #Receives most of its power from the console
   - type: Appearance

--- a/Resources/Prototypes/Entities/Structures/Machines/fatextractor.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fatextractor.yml
@@ -96,8 +96,8 @@
     board: FatExtractorMachineCircuitboard
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-fatextractor
-    LayoutId: FatExtractor
+    boardName: wires-board-name-fatextractor
+    layoutId: FatExtractor
   - type: Appearance
   - type: Speech
     speechVerb: Robotic

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -121,8 +121,8 @@
             max: 1
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-minigravitygenerator
-    LayoutId: MiniGravityGenerator
+    boardName: wires-board-name-minigravitygenerator
+    layoutId: MiniGravityGenerator
   - type: Machine
     board: MiniGravityGeneratorCircuitboard
   - type: ApcPowerReceiver

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -31,8 +31,8 @@
         acts: ["Destruction"]
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-autolathe
-    LayoutId: Autolathe
+    boardName: wires-board-name-autolathe
+    layoutId: Autolathe
   - type: ActivatableUI
     key: enum.LatheUiKey.Key
   - type: ActivatableUIRequiresPower
@@ -187,8 +187,8 @@
   - type: Machine
     board: ProtolatheMachineCircuitboard
   - type: Wires
-    BoardName: wires-board-name-protolathe
-    LayoutId: Protolathe
+    boardName: wires-board-name-protolathe
+    layoutId: Protolathe
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
@@ -59,8 +59,8 @@
     board: MaterialReclaimerMachineCircuitboard
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-reclaimer
-    LayoutId: Reclaimer
+    boardName: wires-board-name-reclaimer
+    layoutId: Reclaimer
   - type: MaterialReclaimer
     whitelist:
       components:

--- a/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
@@ -78,8 +78,8 @@
     board: MedicalScannerMachineCircuitboard
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-medicalscanner
-    LayoutId: MedicalScanner
+    boardName: wires-board-name-medicalscanner
+    layoutId: MedicalScanner
   - type: Appearance
   - type: Climbable
   - type: ApcPowerReceiver

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -24,7 +24,7 @@
   - type: ExtensionCableReceiver
   - type: WiresPanel
   - type: Wires
-    LayoutId: rndserver
+    layoutId: rndserver
   - type: WiresVisuals
   - type: Machine
     board: ResearchAndDevelopmentServerMachineCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -49,8 +49,8 @@
     board: TelecomServerCircuitboard
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-telecomserver
-    LayoutId: TelecomServer
+    boardName: wires-board-name-telecomserver
+    layoutId: TelecomServer
   - type: Transform
     anchored: true
   - type: Pullable

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -64,8 +64,8 @@
       type: WiresBoundUserInterface
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-vendingmachine
-    LayoutId: Vending
+    boardName: wires-board-name-vendingmachine
+    layoutId: Vending
   - type: Anchorable
   - type: TypingIndicator
     proto: robot

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -241,8 +241,8 @@
       key: enum.ThermomachineUiKey.Key
     - type: WiresPanel
     - type: Wires
-      BoardName: wires-board-name-thermomachine
-      LayoutId: Thermomachine
+      boardName: wires-board-name-thermomachine
+      layoutId: Thermomachine
     - type: WiresVisuals
     - type: NodeContainer
       nodes:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -23,8 +23,8 @@
       type: WiresBoundUserInterface
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-pa
-    LayoutId: ParticleAccelerator
+    boardName: wires-board-name-pa
+    layoutId: ParticleAccelerator
 
 # Unfinished
 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -43,8 +43,8 @@
     # Construction, interaction
     - type: WiresPanel
     - type: Wires
-      BoardName: wires-board-name-generator
-      LayoutId: Generator
+      boardName: wires-board-name-generator
+      layoutId: Generator
     - type: UserInterface
       interfaces:
         - key: enum.GeneratorComponentUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -91,8 +91,8 @@
   - type: WallMount
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-apc
-    LayoutId: APC
+    boardName: wires-board-name-apc
+    layoutId: APC
   - type: WiresVisuals
   - type: Damageable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -213,7 +213,7 @@
     - machine_board
     - entity_storage
   - type: Wires
-    LayoutId: borgcharger
+    layoutId: borgcharger
   - type: WiresPanel
   - type: WiresVisuals
   - type: Machine

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -63,8 +63,8 @@
       castShadows: false
     - type: WiresPanel
     - type: Wires
-      BoardName: wires-board-name-smes
-      LayoutId: SMES
+      boardName: wires-board-name-smes
+      layoutId: SMES
     - type: Machine
       board: SMESMachineCircuitboard
     - type: StationInfiniteBatteryTarget

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -87,8 +87,8 @@
     totalIntensity: 200
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-substation
-    LayoutId: Substation
+    boardName: wires-board-name-substation
+    layoutId: Substation
   - type: Machine
     board: SubstationMachineCircuitboard
   - type: StationInfiniteBatteryTarget

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -59,8 +59,8 @@
       type: WiresBoundUserInterface
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-airalarm
-    LayoutId: AirAlarm
+    boardName: wires-board-name-airalarm
+    layoutId: AirAlarm
   - type: AccessReader
     access: [["Atmospherics"]]
   - type: ContainerFill

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -66,8 +66,8 @@
       type: WiresBoundUserInterface
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-firealarm
-    LayoutId: FireAlarm
+    boardName: wires-board-name-firealarm
+    layoutId: FireAlarm
   - type: Sprite
     sprite: Structures/Wallmounts/air_monitors.rsi
     layers:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
@@ -50,8 +50,8 @@
     anchored: true
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-intercom
-    LayoutId: Intercom
+    boardName: wires-board-name-intercom
+    layoutId: Intercom
   - type: ActivatableUIRequiresPower
   - type: ActivatableUI
     key: enum.IntercomUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -23,7 +23,7 @@
   - type: WiresPanel
   - type: Wires
     alwaysRandomize: true
-    LayoutId: SurveillanceCamera
+    layoutId: SurveillanceCamera
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Entities/Structures/hydro_tray.yml
+++ b/Resources/Prototypes/Entities/Structures/hydro_tray.yml
@@ -79,8 +79,8 @@
     board: HydroponicsTrayMachineCircuitboard
   - type: WiresPanel
   - type: Wires
-    BoardName: wires-board-name-hydroponicstray
-    LayoutId: HydroponicsTray
+    boardName: wires-board-name-hydroponicstray
+    layoutId: HydroponicsTray
   - type: AmbientSound
     volume: -9
     range: 5


### PR DESCRIPTION
## About the PR
This makes them automatically linted by the YAML linter for missing or invalid localizations.
Any changed files also had the rest of their data fields updated.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Renamed code fields to be consistent with their YAML names:
SolutionContainerVisualsComponent FillLayer -> Layer
CommunicationsConsoleComponent
- AnnouncementDisplayName -> Title
- AnnouncementColor -> Color
- DelayBetweenAnnouncements -> Delay
- CanCallShuttle -> CanShuttle
- AnnounceGlobal -> Global
- AnnouncementSound -> Sound

NukeLabelComponent
- NukeLabel -> Prefix

WarDeclaratorComponent
- DeclarementColor -> Color
- DeclarementSound -> Sound
- DeclarementTitle -> Title

FoodComponent
- TrashPrototype -> Trash

GroupExamineComponent
- ExamineGroups -> Group
- ComponentName -> Component

