### PR TITLE
Fix salvage faction non-determinism

### DIFF
--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -48,6 +48,7 @@ public abstract class SharedSalvageSystem : EntitySystem
         var air = GetBiomeMod<SalvageAirMod>(biome.ID, rand, ref modifierBudget);
         var dungeon = GetBiomeMod<SalvageDungeonModPrototype>(biome.ID, rand, ref modifierBudget);
         var factionProtos = _proto.EnumeratePrototypes<SalvageFactionPrototype>().ToList();
+        factionProtos.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
         var faction = factionProtos[rand.Next(factionProtos.Count)];
 
         var mods = new List<string>();


### PR DESCRIPTION
Sorting moment

:cl:
- fix: Fix expedition faction sometimes not aligning with the mission faction.
