### PR TITLE
Fix shuttle planet FTL overlapping markers

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -553,6 +553,9 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
 
                 foreach (var node in nodes)
                 {
+                    if (modified.Contains(node))
+                        continue;
+
                     // Need to ensure the tile under it has loaded for anchoring.
                     if (TryGetBiomeTile(node, component.Layers, component.Noise, grid, out var tile))
                     {


### PR DESCRIPTION
:cl:
- fix: Fix shuttles sometimes clipping planet marker entities such as ore.