### PR TITLE
 uncloak ninja after attacking

### DIFF
--- a/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
@@ -96,12 +96,15 @@ public abstract class SharedNinjaSuitSystem : EntitySystem
     /// <summary>
     /// Force uncloaks the user and disables suit abilities.
     /// </summary>
-    public void RevealNinja(EntityUid uid, EntityUid user, NinjaSuitComponent? comp = null, StealthClothingComponent? stealthClothing = null)
+    public void RevealNinja(EntityUid uid, EntityUid user, bool disable = true, NinjaSuitComponent? comp = null, StealthClothingComponent? stealthClothing = null)
     {
         if (!Resolve(uid, ref comp, ref stealthClothing))
             return;
 
         if (!StealthClothing.SetEnabled(uid, user, false, stealthClothing))
+            return;
+
+        if (!disable)
             return;
 
         // previously cloaked, disable abilities for a short time

--- a/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
@@ -19,6 +19,7 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<SpaceNinjaComponent, AttackedEvent>(OnNinjaAttacked);
+        SubscribeLocalEvent<SpaceNinjaComponent, MeleeAttackEvent>(OnNinjaAttack);
         SubscribeLocalEvent<SpaceNinjaComponent, ShotAttemptedEvent>(OnShotAttempted);
     }
 
@@ -74,7 +75,19 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
     {
         if (comp.Suit != null && TryComp<StealthClothingComponent>(comp.Suit, out var stealthClothing) && stealthClothing.Enabled)
         {
-            Suit.RevealNinja(comp.Suit.Value, uid, null, stealthClothing);
+            Suit.RevealNinja(comp.Suit.Value, uid, true, null, stealthClothing);
+        }
+    }
+
+    /// <summary>
+    /// Handle revealing ninja if cloaked when attacking.
+    /// Only reveals, there is no cooldown.
+    /// </summary>
+    private void OnNinjaAttack(EntityUid uid, SpaceNinjaComponent comp, ref MeleeAttackEvent args)
+    {
+        if (comp.Suit != null && TryComp<StealthClothingComponent>(comp.Suit, out var stealthClothing) && stealthClothing.Enabled)
+        {
+            Suit.RevealNinja(comp.Suit.Value, uid, false, null, stealthClothing);
         }
     }
 

--- a/Content.Shared/Weapons/Melee/Events/MeleeAttackEvent.cs
+++ b/Content.Shared/Weapons/Melee/Events/MeleeAttackEvent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared.Weapons.Melee.Events;
+
+/// <summary>
+/// Event raised on the user after attacking with a melee weapon, regardless of whether it hit anything.
+/// </summary>
+[ByRefEvent]
+public record struct MeleeAttackEvent(EntityUid Weapon);

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -426,6 +426,9 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             DoLungeAnimation(user, weapon.Angle, GetCoordinates(attack.Coordinates).ToMap(EntityManager, TransformSystem), weapon.Range, animation);
         }
 
+        var attackEv = new MeleeAttackEvent(weaponUid);
+        RaiseLocalEvent(user, ref attackEv);
+
         weapon.Attacking = true;
         return true;
     }


### PR DESCRIPTION
## About the PR
made ninja lose invis after swinging a weapon to reduce trolling (#20490) and also to not have to micromanage turning cloak off when fighting to prevent getting abilities put on 

## Why / Balance
good

## Technical details
added `MeleeAttackEvent` raised on the user when stabbing/swinging a melee weapon


## Media
uncloak after attacking:

https://github.com/space-wizards/space-station-14/assets/39013340/69047186-a43f-4148-83fc-8853c0ab9ae6

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Ninja uncloak after attacking with melee weapons.