### PR TITLE
buff bicar to heal 3 of each damage per unit

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -143,8 +143,10 @@
       effects:
       - !type:HealthChange
         damage:
-          groups:
-            Brute: -2
+          types:
+            Blunt: -1.5
+            Slash: -1.5
+            Piercing: -1.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
## About the PR
change bicar to heal 3/u per brute type instead of a group

## Why / Balance
- group healing is annoying
- healing brute damage with bicar is a fit faster since it can do 45 healing per type without overdose
- makes it easier to give patients a specific dose since just divide the highest damage by 3
- consistent with derma which heals every type except caustic

## Technical details
no

## Media
injured urist
![16:59:47](https://github.com/space-wizards/space-station-14/assets/39013340/6d82d0ce-8a2a-49ce-911d-0c3ae1ec87b4)

urist after 15u bicar
![17:00:33](https://github.com/space-wizards/space-station-14/assets/39013340/57db4439-1fce-479a-a5f0-05464278c7de)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Bicaridine now heals 3 damage per type instead of 4 over the whole group.
