### PR TITLE
Give Slimes stronger passive regen

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -74,6 +74,16 @@
       types:
         Asphyxiation: -1.0
     maxSaturation: 15
+  - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 9 damage a minute or 4 for poison.
+    allowedStates:
+    - Alive
+    - Critical
+    damage:
+      types:
+        Heat: -0.15
+        Poison: -0.07
+      groups:
+        Brute: -0.15
 
 - type: entity
   parent: MobHumanDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -74,7 +74,7 @@
       types:
         Asphyxiation: -1.0
     maxSaturation: 15
-  - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute or 4 for poison.
+  - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
     allowedStates:
     - Alive
     - Critical

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -80,10 +80,9 @@
     - Critical
     damage:
       types:
-        Heat: -0.15
-        Poison: -0.07
+        Heat: -0.07
       groups:
-        Brute: -0.15
+        Brute: -0.07
 
 - type: entity
   parent: MobHumanDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -74,7 +74,7 @@
       types:
         Asphyxiation: -1.0
     maxSaturation: 15
-  - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 9 damage a minute or 4 for poison.
+  - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute or 4 for poison.
     allowedStates:
     - Alive
     - Critical


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Gave slimes stronger passive regen, without a cap ~~and about twice as fast~~. Part of my Species Rework. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Slimes have very little going for them at the moment. This should hopefully be an interesting upside that also isn't completely gamebreaking as it's relatively slow (only 4 damage a minute). Makes sense that slimes can regenerate, too, so there's that. 


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Changelog

:cl: Lank
- tweak: Slimepeople are now capable of regenerating damage at stronger than average levels.