### PR TITLE
Cleanup more follower leaks

### DIFF
--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -138,7 +138,17 @@ public sealed class FollowerSystem : EntitySystem
             targetXform = Transform(targetXform.ParentUid);
         }
 
-        var followerComp = EnsureComp<FollowerComponent>(follower);
+        // Cleanup old following.
+        if (TryComp<FollowerComponent>(follower, out var followerComp))
+        {
+            // Already following you goob
+            if (followerComp.Following == entity)
+                return;
+
+            StopFollowingEntity(follower, followerComp.Following, deparent: false);
+        }
+
+        followerComp = AddComp<FollowerComponent>(follower);
         followerComp.Following = entity;
 
         var followedComp = EnsureComp<FollowedComponent>(entity);
@@ -167,7 +177,7 @@ public sealed class FollowerSystem : EntitySystem
 
         RaiseLocalEvent(follower, followerEv);
         RaiseLocalEvent(entity, entityEv);
-        Dirty(followedComp);
+        Dirty(entity, followedComp);
     }
 
     /// <summary>

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -145,10 +145,13 @@ public sealed class FollowerSystem : EntitySystem
             if (followerComp.Following == entity)
                 return;
 
-            StopFollowingEntity(follower, followerComp.Following, deparent: false);
+            StopFollowingEntity(follower, followerComp.Following, deparent: false, removeComp: false);
         }
-
-        followerComp = AddComp<FollowerComponent>(follower);
+        else
+        {
+            followerComp = AddComp<FollowerComponent>(follower);
+        }
+        
         followerComp.Following = entity;
 
         var followedComp = EnsureComp<FollowedComponent>(entity);
@@ -184,7 +187,7 @@ public sealed class FollowerSystem : EntitySystem
     ///     Forces an entity to stop following another entity, if it is doing so.
     /// </summary>
     /// <param name="deparent">Should the entity deparent itself</param>
-    public void StopFollowingEntity(EntityUid uid, EntityUid target, FollowedComponent? followed = null, bool deparent = true)
+    public void StopFollowingEntity(EntityUid uid, EntityUid target, FollowedComponent? followed = null, bool deparent = true, bool removeComp = true)
     {
         if (!Resolve(target, ref followed, false))
             return;
@@ -196,8 +199,12 @@ public sealed class FollowerSystem : EntitySystem
         if (followed.Following.Count == 0)
             RemComp<FollowedComponent>(target);
 
-        RemComp<FollowerComponent>(uid);
-        RemComp<OrbitVisualsComponent>(uid);
+        if (removeComp)
+        {
+            RemComp<FollowerComponent>(uid);
+            RemComp<OrbitVisualsComponent>(uid);
+        }
+
         var uidEv = new StoppedFollowingEntityEvent(target, uid);
         var targetEv = new EntityStoppedFollowingEvent(target, uid);
 


### PR DESCRIPTION
Rather than check stop everywhere we'll just check it on start and cleanup the old following. If someone were already following and followed something new the FollowedComponent would never get cleaned up and would never have its ref to the entity removed.

Should fix the remaining pvs logs for followingcomp.