### PR TITLE
Kill `ComponentExt`

### DIFF
--- a/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
@@ -63,11 +63,11 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             await server.WaitAssertion(() =>
             {
                 user = sEntities.SpawnEntity(null, coords);
-                user.EnsureComponent<HandsComponent>();
+                sEntities.EnsureComponent<HandsComponent>(user);
                 handSys.AddHand(user, "hand", HandLocation.Left);
                 target = sEntities.SpawnEntity(null, coords);
                 item = sEntities.SpawnEntity(null, coords);
-                item.EnsureComponent<ItemComponent>();
+                sEntities.EnsureComponent<ItemComponent>(item);
             });
 
             await server.WaitRunTicks(1);
@@ -134,11 +134,11 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             await server.WaitAssertion(() =>
             {
                 user = sEntities.SpawnEntity(null, coords);
-                user.EnsureComponent<HandsComponent>();
+                sEntities.EnsureComponent<HandsComponent>(user);
                 handSys.AddHand(user, "hand", HandLocation.Left);
                 target = sEntities.SpawnEntity(null, new MapCoordinates(new Vector2(1.9f, 0), mapId));
                 item = sEntities.SpawnEntity(null, coords);
-                item.EnsureComponent<ItemComponent>();
+                sEntities.EnsureComponent<ItemComponent>(item);
                 wall = sEntities.SpawnEntity("DummyDebugWall", new MapCoordinates(new Vector2(1, 0), sEntities.GetComponent<TransformComponent>(user).MapID));
             });
 
@@ -204,11 +204,11 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             await server.WaitAssertion(() =>
             {
                 user = sEntities.SpawnEntity(null, coords);
-                user.EnsureComponent<HandsComponent>();
+                sEntities.EnsureComponent<HandsComponent>(user);
                 handSys.AddHand(user, "hand", HandLocation.Left);
                 target = sEntities.SpawnEntity(null, new MapCoordinates(new Vector2(SharedInteractionSystem.InteractionRange - 0.1f, 0), mapId));
                 item = sEntities.SpawnEntity(null, coords);
-                item.EnsureComponent<ItemComponent>();
+                sEntities.EnsureComponent<ItemComponent>(item);
             });
 
             await server.WaitRunTicks(1);
@@ -274,11 +274,11 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             await server.WaitAssertion(() =>
             {
                 user = sEntities.SpawnEntity(null, coords);
-                user.EnsureComponent<HandsComponent>();
+                sEntities.EnsureComponent<HandsComponent>(user);
                 handSys.AddHand(user, "hand", HandLocation.Left);
                 target = sEntities.SpawnEntity(null, new MapCoordinates(new Vector2(SharedInteractionSystem.InteractionRange + 0.01f, 0), mapId));
                 item = sEntities.SpawnEntity(null, coords);
-                item.EnsureComponent<ItemComponent>();
+                sEntities.EnsureComponent<ItemComponent>(item);
             });
 
             await server.WaitRunTicks(1);
@@ -346,11 +346,11 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             await server.WaitAssertion(() =>
             {
                 user = sEntities.SpawnEntity(null, coords);
-                user.EnsureComponent<HandsComponent>();
+                sEntities.EnsureComponent<HandsComponent>(user);
                 handSys.AddHand(user, "hand", HandLocation.Left);
                 target = sEntities.SpawnEntity(null, coords);
                 item = sEntities.SpawnEntity(null, coords);
-                item.EnsureComponent<ItemComponent>();
+                sEntities.EnsureComponent<ItemComponent>(item);
                 containerEntity = sEntities.SpawnEntity(null, coords);
                 container = conSystem.EnsureContainer<Container>(containerEntity, "InteractionTestContainer");
             });

--- a/Content.Server/Chemistry/EntitySystems/SolutionInjectOnCollideSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionInjectOnCollideSystem.cs
@@ -22,14 +22,7 @@ namespace Content.Server.Chemistry.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<SolutionInjectOnCollideComponent, ComponentInit>(HandleInit);
             SubscribeLocalEvent<SolutionInjectOnCollideComponent, StartCollideEvent>(HandleInjection);
-        }
-
-        private void HandleInit(EntityUid uid, SolutionInjectOnCollideComponent component, ComponentInit args)
-        {
-            component.Owner
-                .EnsureComponentWarn<SolutionContainerManagerComponent>($"{nameof(SolutionInjectOnCollideComponent)} requires a SolutionContainerManager on {component.Owner}!");
         }
 
         private void HandleInjection(EntityUid uid, SolutionInjectOnCollideComponent component, ref StartCollideEvent args)

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -343,7 +343,7 @@ namespace Content.Server.Ghost.Roles
             if (ghostRole.MakeSentient)
                 MakeSentientCommand.MakeSentient(mob, EntityManager, ghostRole.AllowMovement, ghostRole.AllowSpeech);
 
-            mob.EnsureComponent<MindContainerComponent>();
+            EnsureComp<MindContainerComponent>(mob);
 
             GhostRoleInternalCreateMindAndTransfer(args.Player, uid, mob, ghostRole);
 

--- a/Content.Server/Tabletop/TabletopSystem.Session.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Session.cs
@@ -81,7 +81,7 @@ namespace Content.Server.Tabletop
                 CloseSessionFor(player, gamer.Tabletop, false);
 
             // Set the entity as an absolute GAMER.
-            attachedEntity.EnsureComponent<TabletopGamerComponent>().Tabletop = uid;
+            EnsureComp<TabletopGamerComponent>(attachedEntity).Tabletop = uid;
 
             // Create a camera for the gamer to use
             var camera = CreateCamera(tabletop, player);
@@ -139,7 +139,7 @@ namespace Content.Server.Tabletop
             var camera = EntityManager.SpawnEntity(null, session.Position.Offset(offset));
 
             // Add an eye component and disable FOV
-            var eyeComponent = camera.EnsureComponent<EyeComponent>();
+            var eyeComponent = EnsureComp<EyeComponent>(camera);
             _eye.SetDrawFov(camera, false, eyeComponent);
             _eye.SetZoom(camera, tabletop.CameraZoom, eyeComponent);
 

--- a/Content.Shared/Singularity/Components/SingularityDistortionComponent.cs
+++ b/Content.Shared/Singularity/Components/SingularityDistortionComponent.cs
@@ -8,10 +8,10 @@ namespace Content.Shared.Singularity.Components
     [Access(typeof(SharedSingularitySystem))]
     public sealed partial class SingularityDistortionComponent : Component
     {
-        [DataField]
+        [DataField, AutoNetworkedField, VVAccess(VVAccess.ReadWrite)]
         public float Intensity = 31.25f;
 
-        [DataField]
+        [DataField, AutoNetworkedField, VVAccess(VVAccess.ReadWrite)]
         public float FalloffPower = MathF.Sqrt(2f);
     }
 }

--- a/Content.Shared/Singularity/Components/SingularityDistortionComponent.cs
+++ b/Content.Shared/Singularity/Components/SingularityDistortionComponent.cs
@@ -8,10 +8,10 @@ namespace Content.Shared.Singularity.Components
     [Access(typeof(SharedSingularitySystem))]
     public sealed partial class SingularityDistortionComponent : Component
     {
-        [DataField, AutoNetworkedField, VVAccess(VVAccess.ReadWrite)]
+        [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
         public float Intensity = 31.25f;
 
-        [DataField, AutoNetworkedField, VVAccess(VVAccess.ReadWrite)]
+        [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
         public float FalloffPower = MathF.Sqrt(2f);
     }
 }

--- a/Content.Shared/Singularity/Components/SingularityDistortionComponent.cs
+++ b/Content.Shared/Singularity/Components/SingularityDistortionComponent.cs
@@ -1,31 +1,17 @@
+using Content.Shared.Singularity.EntitySystems;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Singularity.Components
 {
     [RegisterComponent, NetworkedComponent]
     [AutoGenerateComponentState]
+    [Access(typeof(SharedSingularitySystem))]
     public sealed partial class SingularityDistortionComponent : Component
     {
-        // TODO: use access and remove this funny stuff
-        [DataField("intensity")]
-        private float _intensity = 31.25f;
+        [DataField]
+        public float Intensity = 31.25f;
 
-        [DataField("falloffPower")]
-        private float _falloffPower = MathF.Sqrt(2f);
-
-        [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-        public float Intensity
-        {
-            get => _intensity;
-            set => this.SetAndDirtyIfChanged(ref _intensity, value);
-        }
-
-        [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-        public float FalloffPower
-        {
-            get => _falloffPower;
-            set => this.SetAndDirtyIfChanged(ref _falloffPower, value);
-        }
+        [DataField]
+        public float FalloffPower = MathF.Sqrt(2f);
     }
 }

--- a/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedSingularitySystem.cs
@@ -312,6 +312,7 @@ public abstract class SharedSingularitySystem : EntitySystem
 
         comp.FalloffPower = newFalloffPower;
         comp.Intensity = newIntensity;
+        Dirty(uid, comp);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

only remaining stuff was uid ensurecomps so killed all

sing stuff just changed to use access since all sets went through the system already anyway and vv dirties so it doesnt matter
