### PR TITLE
Jittering System Fix + Cleanup

### DIFF
--- a/Content.Client/Jittering/JitteringSystem.cs
+++ b/Content.Client/Jittering/JitteringSystem.cs
@@ -1,13 +1,7 @@
-using System;
-using System.Collections.Immutable;
 using System.Numerics;
 using Content.Shared.Jittering;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
-using Robust.Shared.Animations;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 using Robust.Shared.Random;
 
 namespace Content.Client.Jittering
@@ -15,6 +9,7 @@ namespace Content.Client.Jittering
     public sealed class JitteringSystem : SharedJitteringSystem
     {
         [Dependency] private readonly IRobustRandom _random = default!;
+        [Dependency] private readonly AnimationPlayerSystem _animationPlayerSystem = default!;
 
         private readonly float[] _sign = { -1, 1 };
         private readonly string _jitterAnimationKey = "jittering";
@@ -35,13 +30,13 @@ namespace Content.Client.Jittering
 
             var animationPlayer = EntityManager.EnsureComponent<AnimationPlayerComponent>(uid);
 
-            animationPlayer.Play(GetAnimation(jittering, sprite), _jitterAnimationKey);
+            _animationPlayerSystem.Play(animationPlayer, GetAnimation(jittering, sprite), _jitterAnimationKey);
         }
 
         private void OnShutdown(EntityUid uid, JitteringComponent jittering, ComponentShutdown args)
         {
             if (EntityManager.TryGetComponent(uid, out AnimationPlayerComponent? animationPlayer))
-                animationPlayer.Stop(_jitterAnimationKey);
+                _animationPlayerSystem.Stop(animationPlayer, _jitterAnimationKey);
 
             if (EntityManager.TryGetComponent(uid, out SpriteComponent? sprite))
                 sprite.Offset = Vector2.Zero;
@@ -52,9 +47,9 @@ namespace Content.Client.Jittering
             if(args.Key != _jitterAnimationKey)
                 return;
 
-            if(EntityManager.TryGetComponent(uid, out AnimationPlayerComponent? animationPlayer)
+            if (EntityManager.TryGetComponent(uid, out AnimationPlayerComponent? animationPlayer)
             && EntityManager.TryGetComponent(uid, out SpriteComponent? sprite))
-                animationPlayer.Play(GetAnimation(jittering, sprite), _jitterAnimationKey);
+                _animationPlayerSystem.Play(animationPlayer, GetAnimation(jittering, sprite), _jitterAnimationKey);
         }
 
         private Animation GetAnimation(JitteringComponent jittering, SpriteComponent sprite)
@@ -77,8 +72,10 @@ namespace Content.Client.Jittering
                     offset.Y *= -1;
             }
 
-            // Animation length shouldn't be too high so we will cap it at 2 seconds...
-            var length = Math.Min((1f/jittering.Frequency), 2f);
+            var length = 0f;
+            // avoid dividing by 0 so animations don't try to be infinitely long
+            if (jittering.Frequency > 0)
+                length = 1f / jittering.Frequency;
 
             jittering.LastJitter = offset;
 

--- a/Content.Client/Jittering/JitteringSystem.cs
+++ b/Content.Client/Jittering/JitteringSystem.cs
@@ -9,7 +9,7 @@ namespace Content.Client.Jittering
     public sealed class JitteringSystem : SharedJitteringSystem
     {
         [Dependency] private readonly IRobustRandom _random = default!;
-        [Dependency] private readonly AnimationPlayerSystem _animationPlayerSystem = default!;
+        [Dependency] private readonly AnimationPlayerSystem _animationPlayer = default!;
 
         private readonly float[] _sign = { -1, 1 };
         private readonly string _jitterAnimationKey = "jittering";
@@ -30,13 +30,13 @@ namespace Content.Client.Jittering
 
             var animationPlayer = EntityManager.EnsureComponent<AnimationPlayerComponent>(uid);
 
-            _animationPlayerSystem.Play(animationPlayer, GetAnimation(jittering, sprite), _jitterAnimationKey);
+            _animationPlayer.Play(animationPlayer, GetAnimation(jittering, sprite), _jitterAnimationKey);
         }
 
         private void OnShutdown(EntityUid uid, JitteringComponent jittering, ComponentShutdown args)
         {
             if (EntityManager.TryGetComponent(uid, out AnimationPlayerComponent? animationPlayer))
-                _animationPlayerSystem.Stop(animationPlayer, _jitterAnimationKey);
+                _animationPlayer.Stop(animationPlayer, _jitterAnimationKey);
 
             if (EntityManager.TryGetComponent(uid, out SpriteComponent? sprite))
                 sprite.Offset = Vector2.Zero;
@@ -49,7 +49,7 @@ namespace Content.Client.Jittering
 
             if (EntityManager.TryGetComponent(uid, out AnimationPlayerComponent? animationPlayer)
             && EntityManager.TryGetComponent(uid, out SpriteComponent? sprite))
-                _animationPlayerSystem.Play(animationPlayer, GetAnimation(jittering, sprite), _jitterAnimationKey);
+                _animationPlayer.Play(animationPlayer, GetAnimation(jittering, sprite), _jitterAnimationKey);
         }
 
         private Animation GetAnimation(JitteringComponent jittering, SpriteComponent sprite)

--- a/Content.Shared/Jittering/SharedJitteringSystem.cs
+++ b/Content.Shared/Jittering/SharedJitteringSystem.cs
@@ -72,7 +72,7 @@ namespace Content.Shared.Jittering
             var jitter = EnsureComp<JitteringComponent>(uid);
             jitter.Amplitude = amplitude;
             jitter.Frequency = frequency;
-            Dirty(jitter);
+            Dirty(uid, jitter);
         }
     }
 }


### PR DESCRIPTION
## About the PR
This fixes a bug with the jittering system where the length of a jittering animation would be infinite (capped to 2 seconds) when the frequency was 0. That can happen during the first jitter of a new component, causing an initial 2 second jitter that shouldn't be there.

I originally found and fixed this while working on #20375 but since I haven't finished that PR and don't know when I will, I thought I'd open the fix as a separate PR to get it merged sooner.

## Why / Balance
Because a call to SharedJitteringSystem.AddJitter should start jittering at the desired frequency right away without potentially being delayed by an initial 2 second animation that shouldn't be there.

## Technical details
This also removes the maximum 2 second limit for jittering animations since it seemed pointless and arbitrary. (and potentially like a bandaid fix for this bug?)
If there's a good reason to keep it, I can put it back in though.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
no
