### PR TITLE
Add pipe pressure damage

### DIFF
--- a/Content.Server/NodeContainer/NodeGroups/PipeNet.cs
+++ b/Content.Server/NodeContainer/NodeGroups/PipeNet.cs
@@ -3,6 +3,7 @@ using Content.Server.Atmos;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.NodeContainer.Nodes;
 using Content.Shared.Atmos;
+using Content.Shared.Damage;
 using Robust.Shared.Utility;
 
 namespace Content.Server.NodeContainer.NodeGroups
@@ -21,6 +22,7 @@ namespace Content.Server.NodeContainer.NodeGroups
         [ViewVariables] public GasMixture Air { get; set; } = new() {Temperature = Atmospherics.T20C};
 
         [ViewVariables] private AtmosphereSystem? _atmosphereSystem;
+        [ViewVariables] private DamageableSystem? _damage;
 
         public EntityUid? Grid { get; private set; }
 
@@ -38,11 +40,39 @@ namespace Content.Server.NodeContainer.NodeGroups
 
             _atmosphereSystem = entMan.EntitySysManager.GetEntitySystem<AtmosphereSystem>();
             _atmosphereSystem.AddPipeNet(Grid.Value, this);
+            _damage = entMan.EntitySysManager.GetEntitySystem<DamageableSystem>();
+        }
+
+        /// <summary>
+        /// Calculate pressure damage for pipe. There is no damage if the pressure is below MaxPressure,
+        /// and damage scales exponentially beyond that.
+        /// </summary>
+        private int PressureDamage(PipeNode pipe)
+        {
+            const float tau = 10; // number of atmos ticks to break pipe at nominal overpressure
+            var diff = pipe.Air.Pressure - pipe.MaxPressure;
+            const float alpha = 100/tau;
+            return diff > 0 ? (int)(alpha*float.Exp(diff / pipe.MaxPressure)) : 0;
         }
 
         public void Update()
         {
             _atmosphereSystem?.React(Air, this);
+
+            // Check each pipe node for overpressure and apply damage if needed
+            foreach (var node in Nodes)
+            {
+                if (node is PipeNode pipe && pipe.MaxPressure > 0)
+                {
+                    int dam = PressureDamage(pipe);
+                    if (dam > 0)
+                    {
+                        var dspec = new DamageSpecifier();
+                        dspec.DamageDict.Add("Structural", dam);
+                        _damage?.TryChangeDamage(pipe.Owner, dspec);
+                    }
+                }
+            }
         }
 
         public override void LoadNodes(List<Node> groupNodes)

--- a/Content.Server/NodeContainer/Nodes/PipeNode.cs
+++ b/Content.Server/NodeContainer/Nodes/PipeNode.cs
@@ -102,6 +102,12 @@ namespace Content.Server.NodeContainer.Nodes
 
         private const float DefaultVolume = 200f;
 
+        /// <summary>
+        ///     Pressure beyond which this pipe node starts taking damage. Set to zero for no pressure damage.
+        /// </summary>
+        [DataField]
+        public float MaxPressure = 0;
+
         public override void Initialize(EntityUid owner, IEntityManager entMan)
         {
             base.Initialize(owner, entMan);

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -100,6 +100,7 @@
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: Longitudinal
+        maxPressure: 6750
   - type: Sprite
     layers:
       - state: pipeStraight
@@ -137,6 +138,7 @@
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: SWBend
+        maxPressure: 6750
   - type: Sprite
     layers:
       - state: pipeBend
@@ -181,6 +183,7 @@
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: TSouth
+        maxPressure: 6750
   - type: Sprite
     layers:
       - state: pipeTJunction
@@ -223,6 +226,7 @@
         !type:PipeNode
         nodeGroupID: Pipe
         pipeDirection: Fourway
+        maxPressure: 6750
   - type: Sprite
     layers:
       - state: pipeFourway


### PR DESCRIPTION
## About the PR
This adds pipe pressure damage, which damages pipes when the internal pressure exceeds some threshold. In other words, pipes now explode from pressure.

## Why / Balance
It doesn't make sense that pipes can hold an infinite amount of pressure without bursting, especially because canisters can explode. Most people agree that pipes should have an upper limit, so the rest of this is dedicated to discussing what that limit should actually be.

The pressure chosen in this PR is intended to demonstrate this code (see screenshots below), and not as the final number. For the final number, we turn to the community for feedback. *Please contribute to the discussion by commenting below.*

The number chosen in this PR is 1.5 × `Atmospherics.MaxOutputPressure`. This means that pressure pumps can never cause a pipe to burst, but misusing a volume pump will. This adds risk to using the volume pump. I didn't think to hard about this number since we're leaving this number to be determined by the community.

## Technical details
Adds a pressure check to all pipe nodes in a `PipeNet` after each `PipeNet` `Update()`. Deal damage that scales exponentially with pressure.

## Media
https://github.com/space-wizards/space-station-14/assets/3229565/52e4bed3-03db-40e9-a4d8-ece2a32e396c

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: notafet
- add: Gas pipes now burst at very high pressures.