### PR TITLE
Increase carbon dioxide poisoning damage

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -135,7 +135,9 @@
         damage:
           types:
             Poison:
-              0.2
+              0.8
+      - !type:Oxygenate # carbon dioxide displaces oxygen from the bloodstream, causing asphyxiation
+        factor: -4
       # Cant be added until I add metabolism effects on reagent removal
       #- !type:AdjustAlert
       #  alertType: CarbonDioxide

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -137,6 +137,10 @@
             Poison:
               0.8
       - !type:Oxygenate # carbon dioxide displaces oxygen from the bloodstream, causing asphyxiation
+        conditions:
+        - !type:OrganType
+          type: Plant
+          shouldHave: false
         factor: -4
       # Cant be added until I add metabolism effects on reagent removal
       #- !type:AdjustAlert


### PR DESCRIPTION
## About the PR
Increases CO2 damage such that a non-Diona player without internals dies from CO2 poisoning after 2:30 minutes of exposure to >30% CO2 under standard atmospheric conditions.

## Why / Balance
According to the US National Institute of Health, [carbon dioxide above 50% leads to death in under 1 minute for animals](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5380556/). However, Space Station 14 players can be in very high CO2 environments and survive for 15+ minutes. This makes it almost nearly a non-issue, but when it is an issue it is hard to diagnose.

This was inspired by this [Discord conversation](https://discord.com/channels/310555209753690112/675078881425752124/1161842702665658459).

This PR:

1. Increases the poison damage.
2. Adds a negative Oxygenate factor so that players start visibly gasping and get the O2 warning when exposed to high levels of CO2, which aids detection. This balances the faster poison damage by strongly cueing players in to what they need to do to rectify the situation, instead of silently killing them.

## Media
This real-time video demonstrates the speed of CO2 poisoning for a non-Diona character after the changes in this PR:

https://github.com/space-wizards/space-station-14/assets/3229565/981b2904-4e5f-4684-85c8-5b93b59261fe

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl: notafet
- tweak: Carbon dioxide poisoning is now more deadly. Victims of carbon dioxide poisoning now gasp visibly.