### PR TITLE
Preliminary scrubber buff

### DIFF
--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
         public bool IgnoreAlarms { get; set; } = false;
         public HashSet<Gas> FilterGases { get; set; } = new(DefaultFilterGases);
         public ScrubberPumpDirection PumpDirection { get; set; } = ScrubberPumpDirection.Scrubbing;
-        public float VolumeRate { get; set; } = 200f;
+        public float VolumeRate { get; set; } = 12500f;
         public bool WideNet { get; set; } = false;
 
         public static HashSet<Gas> DefaultFilterGases = new()
@@ -32,7 +32,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Enabled = true,
             FilterGases = new(GasVentScrubberData.DefaultFilterGases),
             PumpDirection = ScrubberPumpDirection.Scrubbing,
-            VolumeRate = 200f,
+            VolumeRate = 12500f,
             WideNet = false
         };
 
@@ -41,7 +41,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Enabled = true,
             FilterGases = new(GasVentScrubberData.DefaultFilterGases),
             PumpDirection = ScrubberPumpDirection.Scrubbing,
-            VolumeRate = 200f,
+            VolumeRate = 12500f,
             WideNet = true
         };
 
@@ -51,7 +51,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Dirty = true,
             FilterGases = new(GasVentScrubberData.DefaultFilterGases),
             PumpDirection = ScrubberPumpDirection.Scrubbing,
-            VolumeRate = 200f,
+            VolumeRate = 4000f,
             WideNet = false
         };
 
@@ -61,7 +61,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Dirty = true,
             FilterGases = new(GasVentScrubberData.DefaultFilterGases),
             PumpDirection = ScrubberPumpDirection.Siphoning,
-            VolumeRate = 200f,
+            VolumeRate = 12500f,
             WideNet = false
         };
 
@@ -72,7 +72,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Dirty = true,
             FilterGases = new(GasVentScrubberData.DefaultFilterGases),
             PumpDirection = ScrubberPumpDirection.Siphoning,
-            VolumeRate = 200f,
+            VolumeRate = 12500f,
             WideNet = false
         };
     }

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
         public bool IgnoreAlarms { get; set; } = false;
         public HashSet<Gas> FilterGases { get; set; } = new(DefaultFilterGases);
         public ScrubberPumpDirection PumpDirection { get; set; } = ScrubberPumpDirection.Scrubbing;
-        public float VolumeRate { get; set; } = 12500f;
+        public float VolumeRate { get; set; } = 4000f;
         public bool WideNet { get; set; } = false;
 
         public static HashSet<Gas> DefaultFilterGases = new()
@@ -32,7 +32,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Enabled = true,
             FilterGases = new(GasVentScrubberData.DefaultFilterGases),
             PumpDirection = ScrubberPumpDirection.Scrubbing,
-            VolumeRate = 12500f,
+            VolumeRate = 4000f,
             WideNet = false
         };
 
@@ -41,7 +41,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Enabled = true,
             FilterGases = new(GasVentScrubberData.DefaultFilterGases),
             PumpDirection = ScrubberPumpDirection.Scrubbing,
-            VolumeRate = 12500f,
+            VolumeRate = 4000f,
             WideNet = true
         };
 
@@ -61,7 +61,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Dirty = true,
             FilterGases = new(GasVentScrubberData.DefaultFilterGases),
             PumpDirection = ScrubberPumpDirection.Siphoning,
-            VolumeRate = 12500f,
+            VolumeRate = 4000f,
             WideNet = false
         };
 
@@ -72,7 +72,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Dirty = true,
             FilterGases = new(GasVentScrubberData.DefaultFilterGases),
             PumpDirection = ScrubberPumpDirection.Siphoning,
-            VolumeRate = 12500f,
+            VolumeRate = 4000f,
             WideNet = false
         };
     }

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -170,7 +170,7 @@
             Welded: { state: scrub_welded }
     - type: AtmosDevice
     - type: GasVentScrubber
-      maxTransferRate: 12500
+      maxTransferRate: 4000
     - type: Construction
       graph: GasUnary
       node: ventscrubber

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -170,6 +170,7 @@
             Welded: { state: scrub_welded }
     - type: AtmosDevice
     - type: GasVentScrubber
+      maxTransferRate: 12500
     - type: Construction
       graph: GasUnary
       node: ventscrubber


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Scrubbers have been buffed from 200 L/s to 4000 L/s. This value shouldn't be final (i.e. gas leaks possibly not being a problem), but it's a decent start.
I believe that the value should be anywhere from 1000L/s to 4000L/s for single scrubbers - 1000L/s because of 5 would-be scrubber layers and 4000L/s to mostly preserve atmos setups.
This PR can be closed freely should a more complete atmos balance rework happen.

## Why / Balance
Response to #20917.

## Technical details
Air alarm presets have been changed. Scrubbers have a higher `maxTransferRate` defined in their prototype.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: router
- tweak: Scrubbers have been buffed to 4000L/s to account for slow radiators. This change is temporary, more balance feedback is needed for a proper scrubber balance level.