### PR TITLE
add rainbow fish

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -129,6 +129,18 @@
       proto: robot
 
 - type: entity
+  parent: MobCarp
+  id: MobCarpRainbow
+  name: rainbow carp
+  description: Wow such a shiny fishie!
+  components:
+  - type: PointLight
+    radius: 1.5
+    energy: 0.5
+  - type: RgbLightController
+    layers: [ 0 ]
+
+- type: entity
   id: MobCarpSalvage
   parent: MobCarp
   suffix: "Salvage Ruleset"

--- a/Resources/Prototypes/Procedural/salvage_factions.yml
+++ b/Resources/Prototypes/Procedural/salvage_factions.yml
@@ -33,6 +33,9 @@
     #- proto: MobCarpMagic
     #  cost: 5
     #  prob: 0.1
+    - proto: MobCarpRainbow # carp version of rouny...
+      cost: 3
+      prob: 0.05
     - proto: MobDragonDungeon
       cost: 10
       prob: 0.02


### PR DESCRIPTION
## About the PR
add MobCarpRainbow rainbow fish and added as a rare exped spawn

## Why / Balance
carp equivalent of rouny for exped, the second luxury cogni pet for salv

## Technical details
rgbee copypaste job but less energy

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/72f9cc3c-15a8-4849-b1da-68faef460e75


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
sneaky fish