### PR TITLE
Less charges for Sci flash

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -2,7 +2,7 @@
   id: RoboticsInventory
   startingInventory:
     CableApcStack: 4
-    Flash: 4
+    SyntheticFlash: 4
     ProximitySensor: 3
     RemoteSignaller: 3
     HandheldHealthAnalyzer: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -2,7 +2,7 @@
   id: RoboticsInventory
   startingInventory:
     CableApcStack: 4
-    SyntheticFlash: 4
+    SciFlash: 4
     ProximitySensor: 3
     RemoteSignaller: 3
     HandheldHealthAnalyzer: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -139,10 +139,9 @@
       - Security
 
 - type: entity
-  name: synthetic flash
+  name: flash
   parent: Flash
-  id: SyntheticFlash
-  description: Not a standard issue Nanotrasen flash but it'll get the job done.
+  id: SciFlash
   components:
     - type: LimitedCharges
       maxCharges: 2

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -139,6 +139,16 @@
       - Security
 
 - type: entity
+  name: synthetic flash
+  parent: Flash
+  id: SyntheticFlash
+  description: Not a standard issue Nanotrasen flash but it'll get the job done.
+  components:
+    - type: LimitedCharges
+      maxCharges: 2
+      charges: 2
+
+- type: entity
   name: portable flasher
   parent: BaseStructure
   id: PortableFlasher

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -397,7 +397,7 @@
     staticRecipes:
     - MMI
     - PositronicBrain
-    - Flash
+    - SyntheticFlash
     - BorgModuleCable
     - BorgModuleFireExtinguisher
     - BorgModuleGPS

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -397,7 +397,7 @@
     staticRecipes:
     - MMI
     - PositronicBrain
-    - SyntheticFlash
+    - SciFlash
     - BorgModuleCable
     - BorgModuleFireExtinguisher
     - BorgModuleGPS

--- a/Resources/Prototypes/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/robotics.yml
@@ -7,8 +7,8 @@
     Glass: 300
 
 - type: latheRecipe
-  id: SyntheticFlash
-  result: SyntheticFlash
+  id: SciFlash
+  result: SciFlash
   completetime: 2
   materials:
     Glass: 100

--- a/Resources/Prototypes/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/robotics.yml
@@ -7,6 +7,15 @@
     Glass: 300
 
 - type: latheRecipe
+  id: SyntheticFlash
+  result: SyntheticFlash
+  completetime: 2
+  materials:
+    Glass: 100
+    Plastic: 200
+    Steel: 100
+
+- type: latheRecipe
   id: CyborgEndoskeleton
   result: CyborgEndoskeleton
   completetime: 3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Sci now prints two charge flashes instead of five charge flashes.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I've heard many complaints about Revs steamrolling because of high conversion rates because they literally only raid Sci and now I've lowered the charges in the flash because Revs should go other places, see the world man. While it may not fix the problem overall, I hope it'll help a little, and if not we are going to one charge. RIP plant-based flashes. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

