### PR TITLE
Increase containment field connection duration

### DIFF
--- a/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
+++ b/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
@@ -53,7 +53,7 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     /// How many seconds should the generators wait before losing power?
     /// </summary>
     [DataField("threshold")]
-    public float Threshold = 10f;
+    public float Threshold = 20f;
 
     /// <summary>
     /// How many tiles should this field check before giving up?


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This pr doubles the amount of time containment fields stay connected without power.

## Why / Balance
One of the most common ways to loose a singularity right now is to simply cut one mv cable. Many stations only have a single mv wire powering all of the emitters, and cutting one wire or unanchoring the substation will cause a singuloose in 90 seconds. Even if an engi instantly notices the emitters stop firing, they have 90 seconds to fix the wire, or turn the PA off. However, the fields don't last long enough to prevent the singularity from escaping due to it taking more than 90 seconds to die. This PR makes it so you have 180 seconds from the second the emitters lose their power to either fix the problem, or kill the singularity. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Increased containment field duration after power loss. 

