### PR TITLE
Small Liquid Anomaly Patch

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
@@ -305,6 +305,7 @@
     solution: anomaly
   - type: InjectionAnomaly
     solution: anomaly
+    superCriticalInjectRadius: 10
   - type: ReagentProducerAnomaly
     solution: anomaly
     needRecolor: true
@@ -354,6 +355,7 @@
     - Cognizine
     - Beer
     - SpaceGlue
+    - SpaceLube
     - CogChamp
     - Honk
     - Carpetium


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
A small edit to the liquid anomaly. Reduced injection radius at supercritical collapse, added space lube to the list of possible reagents.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
15 radius of injection tiles by default is too high. As practice has shown, an anomaly explosion close to the center of the map can kill 3/4 crew.

Space lube is fun. It should be in the anomaly.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- add: Added Space Lube to Liquid Anomaly!
- tweak: Reduced supercritical injection radius of liquid anomaly from 15 to 10 tiles!
