### PR TITLE
Stun baton tweak

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -10,7 +10,7 @@
     - state: stunbaton_off
       map: [ "enum.ToggleVisuals.Layer" ]
   - type: Stunbaton
-    energyPerUse: 100
+    energyPerUse: 50
   - type: MeleeWeapon
     damage:
       types:
@@ -19,10 +19,10 @@
     angle: 60
     animation: WeaponArcSlash
   - type: StaminaDamageOnHit
-    damage: 55
+    damage: 35
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
-    damage: 55
+    damage: 35
     sound: /Audio/Weapons/egloves.ogg
   - type: Battery
     maxCharge: 1000


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
stun batons now take 3 hits to stun someone (35 per swing, so two to slow) and their battery use has been dropped by half
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Metal gear sloth wanted it (cant find their drafted PR)
should give syndies and other victims more leeway when attacked by so surprise baton has like a second more time to react

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: JoeHammad
- tweak: Stun batons now take three hits to stun and have had their battery use dropped by half
