### PR TITLE
Adding Mantles to Head Lockers until loadouts is merged

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -21,6 +21,7 @@
       - id: RubberStampQm
       - id: ClothingHeadsetAltCargo
       - id: BoxEncryptionKeyCargo
+      - id: ClothingNeckMantleQM
 
 - type: entity
   id: LockerCaptainFilledHardsuit
@@ -56,6 +57,7 @@
       - id: JetpackCaptainFilled
       - id: MedalCase
       - id: ClothingHeadHatCapcap
+      - id: ClothingNeckMantleCap
 
 - type: entity
   id: LockerCaptainFilled
@@ -89,6 +91,7 @@
       - id: JetpackCaptainFilled
       - id: MedalCase
       - id: ClothingHeadHatCapcap
+      - id: ClothingNeckMantleCap
 
 - type: entity
   id: LockerHeadOfPersonnelFilled
@@ -119,6 +122,7 @@
       - id: ClothingBackpackIan
         prob: 0.5
       - id: AccessConfigurator
+      - id: ClothingNeckMantleHOP
 
 - type: entity
   id: LockerChiefEngineerFilledHardsuit
@@ -147,6 +151,7 @@
       - id: ClothingHeadsetAltEngineering
       - id: BoxEncryptionKeyEngineering
       - id: AccessConfigurator
+      - id: ClothingNeckMantleCE
 
 - type: entity
   id: LockerChiefEngineerFilled
@@ -169,6 +174,7 @@
       - id: ClothingHeadsetAltEngineering
       - id: BoxEncryptionKeyEngineering
       - id: AccessConfigurator
+      - id: ClothingNeckMantleCE
 
 - type: entity
   id: LockerChiefMedicalOfficerFilledHardsuit
@@ -193,6 +199,7 @@
       - id: RubberStampCMO
       - id: MedicalTechFabCircuitboard
       - id: BoxEncryptionKeyMedical
+      - id: ClothingNeckMantleCMO
 
 - type: entity
   id: LockerChiefMedicalOfficerFilled
@@ -216,6 +223,7 @@
       - id: RubberStampCMO
       - id: MedicalTechFabCircuitboard
       - id: BoxEncryptionKeyMedical
+      - id: ClothingNeckMantleCMO
 
 - type: entity
   id: LockerResearchDirectorFilledHardsuit
@@ -238,6 +246,7 @@
       - id: RubberStampRd
       - id: ClothingHeadsetAltScience
       - id: BoxEncryptionKeyScience
+      - id: ClothingNeckMantleRD
 
 - type: entity
   id: LockerResearchDirectorFilled
@@ -259,6 +268,7 @@
       - id: RubberStampRd
       - id: ClothingHeadsetAltScience
       - id: BoxEncryptionKeyScience
+      - id: ClothingNeckMantleRD
 
 - type: entity
   id: LockerHeadOfSecurityFilledHardsuit
@@ -292,6 +302,7 @@
       - id: BoxEncryptionKeySecurity
       - id: HoloprojectorSecurity
       - id: BookSecretDocuments
+      - id: ClothingNeckMantleHOS
 
 - type: entity
   id: LockerHeadOfSecurityFilled
@@ -322,3 +333,4 @@
       - id: BoxEncryptionKeySecurity
       - id: HoloprojectorSecurity
       - id: BookSecretDocuments
+      - id: ClothingNeckMantleHOS


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? --> All head mantles have been added to their respective lockers. (Yes... QM included)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. --> I did this change as a temporary fun little change for mantle lovers until loadouts can get merged.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog

:cl:
--> tweak: All Head Lockers are now stocked with their respective mantles! have fun!