### PR TITLE
add flash and dash sounds to paracusia

### DIFF
--- a/Resources/Prototypes/SoundCollections/traits.yml
+++ b/Resources/Prototypes/SoundCollections/traits.yml
@@ -41,9 +41,11 @@
   - /Audio/Machines/phasein.ogg
   - /Audio/Machines/vending_restock_start.ogg
   - /Audio/Machines/vending_restock_done.ogg
+  - /Audio/Magic/blink.ogg
   - /Audio/Magic/disintegrate.ogg
   - /Audio/Magic/staff_animation.ogg
   - /Audio/Weapons/ebladeon.ogg
+  - /Audio/Weapons/flash.ogg
   - /Audio/Weapons/smash.ogg
   - /Audio/Weapons/bladeslice.ogg
   - /Audio/Weapons/punch1.ogg


### PR DESCRIPTION
## About the PR
title

## Why / Balance
some people like hearing noises so when they hear flashing or katana/wizard teleport they might pause before yelling REVS IN CARGO / NINJA IN SEC MAINTS

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun