### PR TITLE
Prevent Returning to Speaking Ghost Roles after Ghosting

### DIFF
--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Atmos.EntitySystems;
 using Content.Server.Botany.Components;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Fluids.Components;
+using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Kitchen.Components;
 using Content.Server.Popups;
@@ -41,6 +42,7 @@ public sealed class PlantHolderSystem : EntitySystem
     [Dependency] private readonly SolutionContainerSystem _solutionSystem = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly GhostRoleSystem _ghostRoleSystem = default!;
 
 
     public const float HydroponicsSpeedMultiplier = 1f;
@@ -623,10 +625,11 @@ public sealed class PlantHolderSystem : EntitySystem
 
         if (component.Seed.Sentient)
         {
-            var ghostRole = EnsureComp<GhostRoleComponent>(uid);
+            EnsureComp<GhostRoleComponent>(uid);
             EnsureComp<GhostTakeoverAvailableComponent>(uid);
-            ghostRole.RoleName = MetaData(uid).EntityName;
-            ghostRole.RoleDescription = Loc.GetString("station-event-random-sentience-role-description", ("name", ghostRole.RoleName));
+            var roleName = MetaData(uid).EntityName;
+            var roleDescription = Loc.GetString("station-event-random-sentience-role-description", ("name", roleName));
+            _ghostRoleSystem.SetInformation(uid, roleName, roleDescription);
         }
 
         if (component.UpdateSpriteAfterUpdate)

--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -1,3 +1,4 @@
+using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Speech.Components;
 using Content.Shared.Chemistry.Reagent;
@@ -8,6 +9,8 @@ namespace Content.Server.Chemistry.ReagentEffects;
 
 public sealed partial class MakeSentient : ReagentEffect
 {
+    [Dependency] private readonly GhostRoleSystem _ghostRoleSystem = default!;
+
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("reagent-effect-guidebook-make-sentient", ("chance", Probability));
 
@@ -34,11 +37,10 @@ public sealed partial class MakeSentient : ReagentEffect
             return;
         }
 
-        ghostRole = entityManager.AddComponent<GhostRoleComponent>(uid);
+        entityManager.AddComponent<GhostRoleComponent>(uid);
         entityManager.EnsureComponent<GhostTakeoverAvailableComponent>(uid);
 
         var entityData = entityManager.GetComponent<MetaDataComponent>(uid);
-        ghostRole.RoleName = entityData.EntityName;
-        ghostRole.RoleDescription = Loc.GetString("ghost-role-information-cognizine-description");
+        _ghostRoleSystem.SetInformation(uid, entityData.EntityName, Loc.GetString("ghost-role-information-cognizine-description"));
     }
 }

--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -238,7 +238,8 @@ namespace Content.Server.GameTicking
 
             // Ok, so, this is the master place for the logic for if ghosting is "too cheaty" to allow returning.
             // There's no reason at this time to move it to any other place, especially given that the 'side effects required' situations would also have to be moved.
-            // + If CharacterDeadPhysically applies, we're physically dead. Therefore, ghosting OK, and we can return (this is critical for gibbing)
+            // + If CharacterDeadPhysically applies, we're physically dead, or if we cannot be physically dead (e.g. vending machines) we're unable to communicate.
+            //   Therefore, ghosting OK, and we can return (this is critical for gibbing)
             //   Note that we could theoretically be ICly dead and still physically alive and vice versa.
             //   (For example, a zombie could be dead ICly, but may retain memories and is definitely physically active)
             // + If we're in a mob that is critical, and we're supposed to be able to return if possible,

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
 using Content.Server.Communications;
 using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Ghost.Roles.Events;
 using Content.Server.Humanoid;
@@ -57,6 +58,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 {
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly EmergencyShuttleSystem _emergency = default!;
+    [Dependency] private readonly GhostRoleSystem _ghostRoleSystem = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
@@ -956,10 +958,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
             else if (addSpawnPoints)
             {
                 var spawnPoint = Spawn(component.GhostSpawnPointProto, _random.Pick(spawns));
-                var ghostRole = EnsureComp<GhostRoleComponent>(spawnPoint);
+                EnsureComp<GhostRoleComponent>(spawnPoint);
                 EnsureComp<GhostRoleMobSpawnerComponent>(spawnPoint);
-                ghostRole.RoleName = Loc.GetString(nukeOpsAntag.Name);
-                ghostRole.RoleDescription = Loc.GetString(nukeOpsAntag.Objective);
+                _ghostRoleSystem.SetInformation(spawnPoint, Loc.GetString(nukeOpsAntag.Name), Loc.GetString(nukeOpsAntag.Objective));
 
                 var nukeOpSpawner = EnsureComp<NukeOperativeSpawnerComponent>(spawnPoint);
                 nukeOpSpawner.OperativeName = spawnDetails.Name;

--- a/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Mind.Commands;
+using Content.Server.Mind.Commands;
 using Content.Shared.Roles;
 
 namespace Content.Server.Ghost.Roles.Components
@@ -32,7 +32,7 @@ namespace Content.Server.Ghost.Roles.Components
         // We do this so updating RoleName and RoleDescription in VV updates the open EUIs.
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [Access(typeof(GhostRoleSystem), Other = AccessPermissions.ReadWriteExecute)] // FIXME Friends
+        [Access(typeof(GhostRoleSystem))]
         public string RoleName
         {
             get => Loc.GetString(_roleName);
@@ -44,7 +44,7 @@ namespace Content.Server.Ghost.Roles.Components
         }
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [Access(typeof(GhostRoleSystem), Other = AccessPermissions.ReadWriteExecute)] // FIXME Friends
+        [Access(typeof(GhostRoleSystem))]
         public string RoleDescription
         {
             get => Loc.GetString(_roleDescription);
@@ -56,7 +56,7 @@ namespace Content.Server.Ghost.Roles.Components
         }
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [Access(typeof(GhostRoleSystem), Other = AccessPermissions.ReadWriteExecute)] // FIXME Friends
+        [Access(typeof(GhostRoleSystem))]
         public string RoleRules
         {
             get => Loc.GetString(_roleRules);
@@ -69,10 +69,12 @@ namespace Content.Server.Ghost.Roles.Components
 
         [DataField("allowSpeech")]
         [ViewVariables(VVAccess.ReadWrite)]
+        [Access(typeof(GhostRoleSystem))]
         public bool AllowSpeech { get; set; } = true;
 
         [DataField("allowMovement")]
         [ViewVariables(VVAccess.ReadWrite)]
+        [Access(typeof(GhostRoleSystem))]
         public bool AllowMovement { get; set; }
 
         [ViewVariables(VVAccess.ReadOnly)]

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -246,6 +246,21 @@ namespace Content.Server.Ghost.Roles
             return roles.ToArray();
         }
 
+        public void SetInformation(EntityUid roleUid, string name, string description, string rules = "", bool allowSpeech = true, bool allowMovement = false, GhostRoleComponent? role = null)
+        {
+            if (!Resolve(roleUid, ref role))
+                return;
+
+            role.RoleName = name;
+            role.RoleDescription = description;
+            if (rules == "")
+                role.RoleRules = Loc.GetString("ghost-role-component-default-rules");
+            else
+                role.RoleRules = rules;
+            role.AllowSpeech = allowSpeech;
+            role.AllowMovement = allowMovement;
+        }
+
         private void OnPlayerAttached(PlayerAttachedEvent message)
         {
             // Close the session of any player that has a ghost roles window open and isn't a ghost anymore.

--- a/Content.Server/Ghost/Roles/MakeGhostRoleCommand.cs
+++ b/Content.Server/Ghost/Roles/MakeGhostRoleCommand.cs
@@ -13,11 +13,11 @@ namespace Content.Server.Ghost.Roles
 
         public string Command => "makeghostrole";
         public string Description => "Turns an entity into a ghost role.";
-        public string Help => $"Usage: {Command} <entity uid> <name> <description> [<rules>]";
+        public string Help => $"Usage: {Command} <entity uid> <name> <description> [rules] [allowMovement = false] [allowSpeech = true]";
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            if (args.Length < 3 || args.Length > 4)
+            if (args.Length < 3 || args.Length > 6)
             {
                 shell.WriteLine($"Invalid amount of arguments.\n{Help}");
                 return;
@@ -44,7 +44,19 @@ namespace Content.Server.Ghost.Roles
 
             var name = args[1];
             var description = args[2];
-            var rules = args.Length >= 4 ? args[3] : Loc.GetString("ghost-role-component-default-rules");
+            var rules = (args.Length >= 4 && args[3] != String.Empty) ? args[3] : Loc.GetString("ghost-role-component-default-rules");
+            var allowMovement = false;
+            var allowSpeech = true;
+            if(args.Length >= 5 && !bool.TryParse(args[4], out allowMovement))
+            {
+                shell.WriteLine($"Optional argument 5 \"allowMovement\" must be \"true\" or \"false\".\n{Help}");
+                return;
+            }
+            if (args.Length >= 6 && !bool.TryParse(args[5], out allowSpeech))
+            {
+                shell.WriteLine($"Optional argument 6 \"allowSpeech\" must be \"true\" or \"false\".\n{Help}");
+                return;
+            }
 
             if (_entManager.TryGetComponent(uid, out GhostRoleComponent? ghostRole))
             {
@@ -63,7 +75,7 @@ namespace Content.Server.Ghost.Roles
             _entManager.TrySystem(out GhostRoleSystem? ghostRoleSystem);
             if (ghostRoleSystem != null)
             {
-                ghostRoleSystem.SetInformation(uid.Value, name, description, rules);
+                ghostRoleSystem.SetInformation(uid.Value, name, description, rules, allowSpeech, allowMovement);
             }
 
             shell.WriteLine($"Made entity {metaData.EntityName} a ghost role.");

--- a/Content.Server/Ghost/Roles/MakeGhostRoleCommand.cs
+++ b/Content.Server/Ghost/Roles/MakeGhostRoleCommand.cs
@@ -58,11 +58,13 @@ namespace Content.Server.Ghost.Roles
                 return;
             }
 
-            ghostRole = _entManager.AddComponent<GhostRoleComponent>(uid.Value);
+            _entManager.AddComponent<GhostRoleComponent>(uid.Value);
             _entManager.AddComponent<GhostTakeoverAvailableComponent>(uid.Value);
-            ghostRole.RoleName = name;
-            ghostRole.RoleDescription = description;
-            ghostRole.RoleRules = rules;
+            _entManager.TrySystem(out GhostRoleSystem? ghostRoleSystem);
+            if (ghostRoleSystem != null)
+            {
+                ghostRoleSystem.SetInformation(uid.Value, name, description, rules);
+            }
 
             shell.WriteLine($"Made entity {metaData.EntityName} a ghost role.");
         }

--- a/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Shared.Examine;
 using Content.Shared.Interaction.Events;
@@ -13,6 +14,7 @@ namespace Content.Server.Ghost.Roles;
 /// </summary>
 public sealed class ToggleableGhostRoleSystem : EntitySystem
 {
+    [Dependency] private readonly GhostRoleSystem _ghostRoleSystem = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
@@ -49,10 +51,9 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
 
         UpdateAppearance(uid, ToggleableGhostRoleStatus.Searching);
 
-        var ghostRole = EnsureComp<GhostRoleComponent>(uid);
+        EnsureComp<GhostRoleComponent>(uid);
         EnsureComp<GhostTakeoverAvailableComponent>(uid);
-        ghostRole.RoleName = Loc.GetString(component.RoleName);
-        ghostRole.RoleDescription = Loc.GetString(component.RoleDescription);
+        _ghostRoleSystem.SetInformation(uid, Loc.GetString(component.RoleName), Loc.GetString(component.RoleDescription));
     }
 
     private void OnExamined(EntityUid uid, ToggleableGhostRoleComponent component, ExaminedEvent args)

--- a/Content.Server/Mind/Commands/MakeSentientCommand.cs
+++ b/Content.Server/Mind/Commands/MakeSentientCommand.cs
@@ -16,13 +16,13 @@ namespace Content.Server.Mind.Commands
 
         public string Command => "makesentient";
         public string Description => "Makes an entity sentient (able to be controlled by a player)";
-        public string Help => "makesentient <entity id>";
+        public string Help => "makesentient <entity id> [allowMovement = false] [allowSpeech = true]";
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            if (args.Length != 1)
+            if (args.Length < 1 || args.Length > 3)
             {
-                shell.WriteLine("Wrong number of arguments.");
+                shell.WriteLine($"Wrong number of arguments.\n{Help}");
                 return;
             }
 
@@ -38,7 +38,20 @@ namespace Content.Server.Mind.Commands
                 return;
             }
 
-            MakeSentient(entId.Value, _entManager, true, true);
+            var allowMovement = false;
+            var allowSpeech = true;
+            if (args.Length >= 2 && !bool.TryParse(args[1], out allowMovement))
+            {
+                shell.WriteLine($"Optional argument 2 \"allowMovement\" must be \"true\" or \"false\".\n{Help}");
+                return;
+            }
+            if (args.Length >= 3 && !bool.TryParse(args[2], out allowSpeech))
+            {
+                shell.WriteLine($"Optional argument 3 \"allowSpeech\" must be \"true\" or \"false\".\n{Help}");
+                return;
+            }
+
+            MakeSentient(entId.Value, _entManager, allowMovement, allowSpeech);
         }
 
         public static void MakeSentient(EntityUid uid, IEntityManager entityManager, bool allowMovement = true, bool allowSpeech = true)

--- a/Content.Server/Puppet/VentriloquistPuppetSystem.cs
+++ b/Content.Server/Puppet/VentriloquistPuppetSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Popups;
 using Content.Shared.Interaction.Events;
@@ -10,6 +11,7 @@ namespace Content.Server.Puppet
 {
     public sealed class VentriloquistPuppetSystem : SharedVentriloquistPuppetSystem
     {
+        [Dependency] private readonly GhostRoleSystem _ghostRoleSystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
 
         public override void Initialize()
@@ -49,9 +51,8 @@ namespace Content.Server.Puppet
             if (!HasComp<GhostTakeoverAvailableComponent>(uid))
             {
                 AddComp<GhostTakeoverAvailableComponent>(uid);
-                var ghostRole = EnsureComp<GhostRoleComponent>(uid);
-                ghostRole.RoleName = Loc.GetString("ventriloquist-puppet-role-name");
-                ghostRole.RoleDescription = Loc.GetString("ventriloquist-puppet-role-description");
+                EnsureComp<GhostRoleComponent>(uid);
+                _ghostRoleSystem.SetInformation(uid, Loc.GetString("ventriloquist-puppet-role-name"), Loc.GetString("ventriloquist-puppet-role-description"));
             }
 
             args.Handled = true;

--- a/Content.Server/StationEvents/Events/RandomSentienceRule.cs
+++ b/Content.Server/StationEvents/Events/RandomSentienceRule.cs
@@ -1,6 +1,7 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Components;
@@ -9,6 +10,8 @@ namespace Content.Server.StationEvents.Events;
 
 public sealed class RandomSentienceRule : StationEventSystem<RandomSentienceRuleComponent>
 {
+    [Dependency] private readonly GhostRoleSystem _ghostRoleSystem = default!;
+
     protected override void Started(EntityUid uid, RandomSentienceRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         HashSet<EntityUid> stationsToNotify = new();
@@ -26,10 +29,11 @@ public sealed class RandomSentienceRule : StationEventSystem<RandomSentienceRule
                 break;
 
             RemComp<SentienceTargetComponent>(target.Owner);
-            var ghostRole = EnsureComp<GhostRoleComponent>(target.Owner);
+            EnsureComp<GhostRoleComponent>(target.Owner);
             EnsureComp<GhostTakeoverAvailableComponent>(target.Owner);
-            ghostRole.RoleName = MetaData(target.Owner).EntityName;
-            ghostRole.RoleDescription = Loc.GetString("station-event-random-sentience-role-description", ("name", ghostRole.RoleName));
+            var roleName = MetaData(target.Owner).EntityName;
+            var roleDescription = Loc.GetString("station-event-random-sentience-role-description", ("name", roleName));
+            _ghostRoleSystem.SetInformation(target.Owner, roleName, roleDescription);
             groups.Add(Loc.GetString(target.FlavorKind));
         }
 

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -2,6 +2,7 @@ using Content.Server.Atmos.Components;
 using Content.Server.Body.Components;
 using Content.Server.Chat;
 using Content.Server.Chat.Managers;
+using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Humanoid;
 using Content.Server.IdentityManagement;
@@ -56,6 +57,7 @@ namespace Content.Server.Zombies
         [Dependency] private readonly SharedRoleSystem _roles = default!;
         [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
+        [Dependency] private readonly GhostRoleSystem _ghostRoleSystem = default!;
 
         /// <summary>
         /// Handles an entity turning into a zombie when they die or go into crit
@@ -241,11 +243,9 @@ namespace Content.Server.Zombies
             if (!HasComp<GhostRoleMobSpawnerComponent>(target) && !hasMind) //this specific component gives build test trouble so pop off, ig
             {
                 //yet more hardcoding. Visit zombie.ftl for more information.
-                var ghostRole = EnsureComp<GhostRoleComponent>(target);
+                EnsureComp<GhostRoleComponent>(target);
                 EnsureComp<GhostTakeoverAvailableComponent>(target);
-                ghostRole.RoleName = Loc.GetString("zombie-generic");
-                ghostRole.RoleDescription = Loc.GetString("zombie-role-desc");
-                ghostRole.RoleRules = Loc.GetString("zombie-role-rules");
+                _ghostRoleSystem.SetInformation(target, Loc.GetString("zombie-generic"), Loc.GetString("zombie-role-desc"), Loc.GetString("zombie-role-rules"));
             }
 
             if (TryComp<HandsComponent>(target, out var handsComp))


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR adds more restrictions to the Return to Body action after Ghosting, which previously only properly checked things with a `MobStateComponent`. Now, when you Ghost out of a non-mob, we determine if you were able to communicate (currently checking Speech or Emote, let me know if this list should change) and prevent Returning if so.

I also did a bit of variable scoping and extended the `makeghostrole` and `makesentient` commands to take bools for `allowMovement`/`allowSpeech`. I initially added these as new checkboxes in the Ghost Role creator UI, but all they actually do is ensure the components (and I didn't want to change the MakeSentient behavior itself), so e.g. `allowMovement=true` doesn't help things with Static physics bodies and `allowSpeech=false` doesn't prevent things that can already speak. Happy to re-add if desired.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Primary fix is to resolve #8888, preventing metagaming via non-mob ghost roles like sentient vendors. Previously you could hop out, talk in Ghost chat, then Return since they had no `MobStateComponent` to be considered "alive".

Besides that, the command changes provide nominal benefits to ghost role / sentience creation options for admins, and the `GhostRoleComponent` variable scoping changes ensure better ownership and access protections as per the [Component Access Restrictions](https://docs.spacestation14.com/en/general-development/codebase-info/conventions.html#component-access-restrictions) conventions. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Important change is to `SharedMindSystem::IsCharacterDeadPhysically(...)`, which now returns `false` if the entity had no `MobStateComponent` but _was_ able to communicate with crew. This does not impact Kill/Escape conditions for Ghost Roles (since they create new minds), nor for things like Zombies/Borgs which have their own callbacks via `IsCharacterDeadIc(...)`. Intent is to impact Return rules exclusively.
- The members of `GhostRoleComponent` have been removed from global `ReadWriteExecute` permissions and can now be modified via `GhostRoleSystem::SetInformation(...)` instead. All relevant callsites updated.
- `makeghostrole` and `makesentient` commands have been updated to parse for optional allowSpeech and allowMovement arguments

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/69610864/4cda0dbe-090f-4f3a-a56b-3ae65473e49a


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
- 
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Players can no longer Return to speaking Ghost Roles such as sentient vending machines after ghosting
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
