### PR TITLE
uranium crab enhancement

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -185,7 +185,8 @@
     factions:
       - SimpleHostile
   - type: RadiationSource
-    intensity: 0.3
+    intensity: 2
+    slope: 0.3
   - type: Destructible
     thresholds:
     - trigger:
@@ -198,8 +199,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           UraniumOre1:
-            min: 4
-            max: 6
+            min: 8
+            max: 10
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: PointLight


### PR DESCRIPTION
## About the PR
The uranium crab has become more radioactive. It emits 2 rads 6 tiles away from itself.
A character being close to a crab receives 100 radiation damage in 52 seconds, while being on the 5th tile from a crab the character will receive 100 damage in 3:35 minutes.
Due to the increase in radiation damage, the amount of uranium dropped from the crab has been increased, up to 10.

## Why / Balance
Early crabs emitted 0.3 rad and only on the same tile as the crab itself. The uranium crab does not attack anyone, which turns it into a "punching bag".
Increasing radius and radiation damage will allow the uranium crab to be something of a support for its stone counterparts.

## Technical details
I reduced slope to increase the radius of radiation, and intensity to increase damage. I think that maybe the crab has become too strong, so I increased the reward for it to 10 uranium.

- [X] This PR does not require an ingame showcase

**Changelog**
:cl: Lomcastar
- tweak: Uranium crabs are more radioactive!
