### PR TITLE
Allow Hand-Prying Most Unpowered Airlocks

### DIFF
--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -92,7 +92,7 @@ public sealed class PryingSystem : EntitySystem
             // to be marked as handled as a popup would be generated on failure.
             return true;
 
-        return StartPry(target, user, null, 1.0f, out id);
+        return StartPry(target, user, null, 0.1f, out id); // hand-prying is much slower
     }
 
     private bool CanPry(EntityUid target, EntityUid user, PryingComponent? comp = null)

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -136,6 +136,7 @@
     tags:
       - Airlock
       # This tag is used to nagivate the Airlock construction graph. It's needed because the construction graph is shared between Airlock, AirlockGlass, and HighSecDoor
+  - type: PryUnpowered
   placement:
     mode: SnapgridCenter
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
All airlocks except high security doors can now be pried open by hand when they're unpowered, albeit at a 10x slower rate than using a crowbar. That means you can open an unpowered airlock by hand in 15 seconds versus 1.5 seconds with a crowbar.

## Why / Balance
Right now, unless you carry a crowbar on you at all times, the game becomes incredibly unfun and nigh-unplayable whenever the station loses power, as you can easily get trapped in a tiny room somewhere with nobody coming to help you.

This gives players without crowbars a chance to escape and navigate the station, while still keeping crowbars relevant by allowing them to open airlocks much faster. The delay is long enough to discourage people from just running around the station trying to open every door.

High security doors don't inherit from the base Airlock and are not impacted by this PR at all.

## Media

Crowbar vs hand-prying showcase:

https://streamable.com/j2i2v7

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: All non-high-security airlocks can now be pried open by hand when unpowered, albeit much slower than using a crowbar

