### PR TITLE
Fix not being able to sort by playtime in the F7 players tab

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace Content.Client.Administration.UI.Bwoink
 
                     if (sel.OverallPlaytime != null)
                     {
-                        Title += $" | {Loc.GetString("generic-playtime-title")}: {sel.PlaytimeString()}";
+                        Title += $" | {Loc.GetString("generic-playtime-title")}: {sel.PlaytimeString}";
                     }
                 }
             };

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
@@ -121,7 +121,7 @@ namespace Content.Client.Administration.UI.Tabs.PlayerTab
                     player.Antag ? "YES" : "NO",
                     new StyleBoxFlat(useAltColor ? _altColor : _defaultColor),
                     player.Connected,
-                    player.PlaytimeString());
+                    player.PlaytimeString);
                 entry.PlayerEntity = player.NetEntity;
                 entry.OnPressed += args => OnEntryPressed?.Invoke(args);
                 entry.ToolTip = Loc.GetString("player-tab-entry-tooltip");
@@ -150,6 +150,7 @@ namespace Content.Client.Administration.UI.Tabs.PlayerTab
                 Header.Character => Compare(x.CharacterName, y.CharacterName),
                 Header.Job => Compare(x.StartingJob, y.StartingJob),
                 Header.Antagonist => x.Antag.CompareTo(y.Antag),
+                Header.Playtime => Compare(x.PlaytimeString, y.PlaytimeString),
                 _ => 1
             };
         }

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabHeader.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabHeader.xaml.cs
@@ -19,6 +19,7 @@ public sealed partial class PlayerTabHeader : ContainerButton
         CharacterLabel.OnKeyBindDown += CharacterClicked;
         JobLabel.OnKeyBindDown += JobClicked;
         AntagonistLabel.OnKeyBindDown += AntagonistClicked;
+        PlaytimeLabel.OnKeyBindDown += PlaytimeClicked;
     }
 
     public Label GetHeader(Header header)
@@ -29,6 +30,7 @@ public sealed partial class PlayerTabHeader : ContainerButton
             Header.Character => CharacterLabel,
             Header.Job => JobLabel,
             Header.Antagonist => AntagonistLabel,
+            Header.Playtime => PlaytimeLabel,
             _ => throw new ArgumentOutOfRangeException(nameof(header), header, null)
         };
     }
@@ -39,6 +41,7 @@ public sealed partial class PlayerTabHeader : ContainerButton
         CharacterLabel.Text = Loc.GetString("player-tab-character");
         JobLabel.Text = Loc.GetString("player-tab-job");
         AntagonistLabel.Text = Loc.GetString("player-tab-antagonist");
+        PlaytimeLabel.Text = Loc.GetString("player-tab-playtime");
     }
 
     private void HeaderClicked(GUIBoundKeyEventArgs args, Header header)
@@ -72,16 +75,22 @@ public sealed partial class PlayerTabHeader : ContainerButton
         HeaderClicked(args, Header.Antagonist);
     }
 
+    private void PlaytimeClicked(GUIBoundKeyEventArgs args)
+    {
+        HeaderClicked(args, Header.Playtime);
+    }
+
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
 
         if (disposing)
         {
-            UsernameLabel.OnKeyBindDown += UsernameClicked;
-            CharacterLabel.OnKeyBindDown += CharacterClicked;
-            JobLabel.OnKeyBindDown += JobClicked;
-            AntagonistLabel.OnKeyBindDown += AntagonistClicked;
+            UsernameLabel.OnKeyBindDown -= UsernameClicked;
+            CharacterLabel.OnKeyBindDown -= CharacterClicked;
+            JobLabel.OnKeyBindDown -= JobClicked;
+            AntagonistLabel.OnKeyBindDown -= AntagonistClicked;
+            PlaytimeLabel.OnKeyBindDown -= PlaytimeClicked;
         }
     }
 
@@ -90,6 +99,7 @@ public sealed partial class PlayerTabHeader : ContainerButton
         Username,
         Character,
         Job,
-        Antagonist
+        Antagonist,
+        Playtime
     }
 }

--- a/Content.Shared/Administration/PlayerInfo.cs
+++ b/Content.Shared/Administration/PlayerInfo.cs
@@ -16,9 +16,9 @@ namespace Content.Shared.Administration
         bool ActiveThisRound,
         TimeSpan? OverallPlaytime)
     {
-        public string PlaytimeString()
-        {
-            return OverallPlaytime?.ToString("%d':'hh':'mm") ?? Loc.GetString("generic-unknown-title");
-        }
+        private string? _playtimeString;
+
+        public string PlaytimeString => _playtimeString ??=
+            OverallPlaytime?.ToString("%d':'hh':'mm") ?? Loc.GetString("generic-unknown-title");
     }
 }

--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -36,3 +36,8 @@ Entries:
   - {message: 'Add pop sound effect when using the erase admin verb.', type: Tweak}
   id: 5
   time: '2023-10-14T09:47:00.0000000+00:00'
+- author: DrSmugleaf
+  changes:
+  - {message: 'Fixed not being able to sort the F7 players tab by playtime.', type: Fix}
+  id: 6
+  time: '2023-10-14T23:52:00.0000000+00:00'


### PR DESCRIPTION
## About the PR
Replacing the enum with a method in the control someday, specially the day we stop needing to write Access="Public" in every single control

## Media
https://github.com/space-wizards/space-station-14/assets/10968691/54b01013-9667-4fbb-9dca-00b7f059675a

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase