### PR TITLE
Make secure crate weldable

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
@@ -21,6 +21,8 @@
             - tool: Screwing
               doAfter: 5
           conditions:
+            - !type:StorageWelded
+              welded: false
             - !type:Locked
               locked: false
           completed:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The secure crate is now weldabale.

## Why / Balance
Steel crates should be all weldable.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->


https://github.com/space-wizards/space-station-14/assets/74560659/8df4f013-e7f9-48d5-9111-9b414817d9f1


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
this is technically a breaking change

**Changelog**
:cl:
- fix: Secure crates are now weldable!

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
