### PR TITLE
uncomment cl template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,13 +31,11 @@ List any breaking changes, including namespace, public class/method/field change
 **Changelog**
 <!--
 Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
--->
 
-<!--
-Make sure to take this Changelog template out of the comment block in order for it to show up.
+Be sure to change the template with whatever entries you want.
+--!>
 :cl:
 - add: Added fun!
 - remove: Removed fun!
 - tweak: Changed fun!
 - fix: Fixed fun!
--->


### PR DESCRIPTION
## About the PR
uncomment the changelog template :trollface:

## Why / Balance
pros keep leaving out :cl: or not formatting it right

## Technical details
no

## Media
merge and open new pr :trollface:
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
