### PR TITLE
mops go in jani belt

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -210,6 +210,7 @@
         - HolosignProjector
       components:
         - LightReplacer
+        - Absorbent
   - type: ItemMapper
     mapLayers:
       bottle:


### PR DESCRIPTION
## About the PR
lets mops and damp rags be put in jani belts

with sprites soon

## Why / Balance
jani belt has plenty of space to hold a 15 size mop, why not

## Technical details
no

## Media

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Mops and damp rags can now be put in janitor belts.