### PR TITLE
Fix uncuffing for zombies

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
+using Content.Shared.Atmos.Piping.Unary.Components;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Cuffs.Components;
 using Content.Shared.Damage;
@@ -85,6 +86,7 @@ namespace Content.Shared.Cuffs
             SubscribeLocalEvent<HandcuffComponent, AfterInteractEvent>(OnCuffAfterInteract);
             SubscribeLocalEvent<HandcuffComponent, MeleeHitEvent>(OnCuffMeleeHit);
             SubscribeLocalEvent<HandcuffComponent, AddCuffDoAfterEvent>(OnAddCuffDoAfter);
+            SubscribeLocalEvent<HandcuffComponent, VirtualItemDeletedEvent>(OnCuffVirtualItemDeleted);
         }
 
         private void OnUncuffAttempt(ref UncuffAttemptEvent args)
@@ -163,7 +165,7 @@ namespace Content.Shared.Cuffs
                 return;
 
             component.CanStillInteract = canInteract;
-            Dirty(component);
+            Dirty(uid, component);
             _actionBlocker.UpdateCanMove(uid);
 
             if (component.CanStillInteract)
@@ -350,7 +352,11 @@ namespace Content.Shared.Cuffs
                         ("otherName", Identity.Name(user, EntityManager, target))), target, target);
                 }
             }
+        }
 
+        private void OnCuffVirtualItemDeleted(EntityUid uid, HandcuffComponent component, VirtualItemDeletedEvent args)
+        {
+            Uncuff(args.User, null, uid, cuff: component);
         }
 
         /// <summary>
@@ -543,7 +549,7 @@ namespace Content.Shared.Cuffs
             {
                 if (!cuffable.Container.ContainedEntities.Contains(cuffsToRemove.Value))
                 {
-                    Logger.Warning("A user is trying to remove handcuffs that aren't in the owner's container. This should never happen!");
+                    Log.Warning("A user is trying to remove handcuffs that aren't in the owner's container. This should never happen!");
                 }
             }
 
@@ -608,20 +614,22 @@ namespace Content.Shared.Cuffs
             _audio.PlayPredicted(isOwner ? cuff.StartBreakoutSound : cuff.StartUncuffSound, target, user);
         }
 
-        public void Uncuff(EntityUid target, EntityUid user, EntityUid cuffsToRemove, CuffableComponent? cuffable = null, HandcuffComponent? cuff = null)
+        public void Uncuff(EntityUid target, EntityUid? user, EntityUid cuffsToRemove, CuffableComponent? cuffable = null, HandcuffComponent? cuff = null)
         {
             if (!Resolve(target, ref cuffable) || !Resolve(cuffsToRemove, ref cuff))
                 return;
 
-            var attempt = new UncuffAttemptEvent(user, target);
-            RaiseLocalEvent(user, ref attempt);
-            if (attempt.Cancelled)
-                return;
+            if (user != null)
+            {
+                var attempt = new UncuffAttemptEvent(user.Value, target);
+                RaiseLocalEvent(user.Value, ref attempt);
+                if (attempt.Cancelled)
+                    return;
+            }
 
             _audio.PlayPredicted(cuff.EndUncuffSound, target, user);
 
             cuffable.Container.Remove(cuffsToRemove);
-
 
             if (_net.IsServer)
             {
@@ -640,12 +648,13 @@ namespace Content.Shared.Cuffs
                 // Only play popups on server because popups suck
                 if (cuffable.CuffedHandCount == 0)
                 {
-                    _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-success-message"), user, user);
+                    if (user != null)
+                        _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-success-message"), user.Value, user.Value);
 
-                    if (target != user)
+                    if (target != user && user != null)
                     {
                         _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-by-other-success-message",
-                            ("otherName", Identity.Name(user, EntityManager, user))), target, target);
+                            ("otherName", Identity.Name(user.Value, EntityManager, user))), target, target);
                         _adminLog.Add(LogType.Action, LogImpact.Medium,
                             $"{ToPrettyString(user):player} has successfully uncuffed {ToPrettyString(target):player}");
                     }
@@ -655,22 +664,22 @@ namespace Content.Shared.Cuffs
                             $"{ToPrettyString(user):player} has successfully uncuffed themselves");
                     }
                 }
-                else
+                else if (user != null)
                 {
                     if (user != target)
                     {
                         _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
                             ("cuffedHandCount", cuffable.CuffedHandCount),
-                            ("otherName", Identity.Name(user, EntityManager, user))), user, user);
+                            ("otherName", Identity.Name(user.Value, EntityManager, user.Value))), user.Value, user.Value);
                         _popup.PopupEntity(Loc.GetString(
                             "cuffable-component-remove-cuffs-by-other-partial-success-message",
-                            ("otherName", Identity.Name(user, EntityManager, user)),
+                            ("otherName", Identity.Name(user.Value, EntityManager, user.Value)),
                             ("cuffedHandCount", cuffable.CuffedHandCount)), target, target);
                     }
                     else
                     {
                         _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
-                            ("cuffedHandCount", cuffable.CuffedHandCount)), user, user);
+                            ("cuffedHandCount", cuffable.CuffedHandCount)), user.Value, user.Value);
                     }
                 }
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
when someone gets zombified, they lose all their hands. This is cool and all but since the cuff virtual items get removed, they get in a permanent state of being cuffed. This PR fixes it by updating the cuffs when the virtual item is deleted

Fixes #18529 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fixed being permanently cuffed if you transformed into a zombie with cuffs on.