### PR TITLE
Automatic internals toggle

### DIFF
--- a/Content.Server/Body/Components/InternalsComponent.cs
+++ b/Content.Server/Body/Components/InternalsComponent.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 namespace Content.Server.Body.Components
 {
     /// <summary>
@@ -16,5 +16,13 @@ namespace Content.Server.Body.Components
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("delay")]
         public float Delay = 3;
+
+        /// <summary>
+        /// Whether the mob should automatically attempt to activate its internals after spawning.
+        /// Intended for respirator mobs that may spawn in space or a spaced area.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("auto")]
+        public bool Auto = false;
     }
 }

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -143,6 +143,11 @@ public sealed class InternalsSystem : EntitySystem
             // TODO: Should listen to gas tank updates instead I guess?
             _alerts.ShowAlert(uid, AlertType.Internals, GetSeverity(component));
         }
+        else if (component.Auto)
+        {
+            ToggleInternals(uid, uid, true, component);
+            component.Auto = false;
+        }
     }
     public void DisconnectBreathTool(InternalsComponent component)
     {

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2173,8 +2173,10 @@
     interactSuccessSpawn: EffectHearts
     interactSuccessSound:
       path: /Audio/Animals/cat_meow.ogg
-  - type: Respirator #It just works?
-    minSaturation: 5.0
+  - type: Internals
+    auto: true
+  - type: Loadout
+    prototypes: [SpacePet]
 
 - type: entity
   name: caracal cat

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -79,3 +79,5 @@
     nameSegments:
     - names_ninja_title
     - names_ninja
+  - type: Internals
+    auto: true

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -350,3 +350,10 @@
     back: SpearBone
     head: ClothingHeadHelmetBone
     shoes: ClothingShoesCult
+
+#Space pets
+- type: startingGear
+  id: SpacePet
+  equipment:
+    suitstorage: OxygenTankFilled
+    mask: ClothingMaskBreath


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Mobs may now automatically attempt to activate their internals after spawning, in order to prevent any unfortunate suffocation-related accidents.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
* The ninja spawns out in the middle of space with internals deactivated, and a newer player may be overwhelmed checking out their gear, objectives etc. and end up forgetting to turn their air on.
* The space cat not needing to breathe air at all practically rendered its mask and gas tank slots redundant, so now it just knows how to activate its internals by itself. Smart kitty!
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added the `Auto` field to the internals component, false by default.
When the mob attempts to breathe, `Auto` is true and internals aren't activated, they will automatically be toggled on. `Auto` will be changed to false afterwards, to avoid repeatedly turning on the internals if the player purposely wants them to be off, or spamming toggle attempts if the mob did not spawn with the necessary equipment.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Space ninjas (and cats) automatically turn on their internals after spawning.