### PR TITLE
syndicate snack box

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -269,6 +269,9 @@ uplink-decoy-disk-desc = A piece of plastic with a lenticular printing, made to 
 uplink-cigarettes-name = Syndicate Smokes Packet
 uplink-cigarettes-desc = Elite cigarettes for elite agents. Infused with medicine for when you need to do more than calm your nerves.
 
+uplink-snack-box-name = Syndicate Snack Box
+uplink-snack-box-desc = A box of delicious snacks and drinks to eat alone or with your team. Includes 1 toy you didn't want.
+
 uplink-eshield-name = Energy Shield
 uplink-eshield-desc = Exotic energy shield that reflects almost all laser beams, as well as a little protection from bullets and other physical attacks.
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1126,6 +1126,16 @@
   - UplinkMisc
 
 - type: listing
+  id: UplinkSnackBox
+  name: uplink-snack-box-name
+  description: uplink-snack-box-desc
+  productEntity: HappyHonkNukieSnacks
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkMisc
+
+- type: listing
   id: UplinkEshield
   name: uplink-eshield-name
   description: uplink-eshield-desc

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1131,7 +1131,7 @@
   description: uplink-snack-box-desc
   productEntity: HappyHonkNukieSnacks
   cost:
-    Telecrystal: 4
+    Telecrystal: 1
   categories:
   - UplinkMisc
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -578,6 +578,57 @@
         orGroup: GiftPool
 
 - type: entity
+  parent: HappyHonkNukie
+  id: HappyHonkNukieSnacks
+  suffix: Toy Unsafe, Snacks
+  name: syndicate snack box
+  components:
+  - type: Item
+    size: 60
+  - type: Storage
+    capacity: 60 # need more room for goodies
+  - type: StorageFill
+    contents:
+    # toy
+    - id: C4
+      prob: 0.02
+      orGroup: GiftPool
+    - id: ToyMarauder
+      orGroup: GiftPool
+    - id: ToyMauler
+      orGroup: GiftPool
+    - id: ToyNuke
+      orGroup: GiftPool
+    - id: ToySword
+      orGroup: GiftPool
+    - id: BalloonSyn
+      prob: 0.6
+      orGroup: GiftPool
+    - id: PlushieNuke
+      orGroup: GiftPool
+    # drinks - 4 cans, up to 2 blood-red brews
+    - id: DrinkNukieCan
+      prob: 0.2
+      orGroup: Drink1Pool
+    - id: DrinkColaCan
+      orGroup: Drink1Pool
+    - id: DrinkNukieCan
+      prob: 0.2
+      orGroup: Drink2Pool
+    - id: DrinkColaCan
+      orGroup: Drink2Pool
+    - id: DrinkColaCan
+      amount: 2
+    # food
+    - id: FoodSaladValid
+      prob: 0.05
+      amount: 4
+      orGroup: FoodPool
+    - id: FoodSnackSyndi
+      amount: 4
+      orGroup: FoodPool
+
+- type: entity
   id: HappyHonkCluwne
   parent: HappyHonk
   name: woeful cluwne meal

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -584,9 +584,9 @@
   name: syndicate snack box
   components:
   - type: Item
-    size: 60
+    size: 64
   - type: Storage
-    capacity: 60 # need more room for goodies
+    capacity: 64 # need more room for goodies
   - type: StorageFill
     contents:
     # toy


### PR DESCRIPTION
## About the PR
available for 1tc to syndies and nukies

usually contains:
- a toy
- 4 cans of soda
- 4 syndicakes

rare spawns:
- c4 or balloon, same as the robust nukie meal
- 1-2 blood-red brew cans
- valid salads instead of syndicakes

## Why / Balance
- nukies can eat if they forgot to eat at the outpost
- syndies that are wanted can eat instead of risking going out in public
- valid...
- nukies can buy it and fight over who gets the toy

## Technical details
no

## Media
uplink listing:
![23:26:50](https://github.com/space-wizards/space-station-14/assets/39013340/3be92e0d-8626-4199-8195-e085af9fad86)

6 of them i bought:
![23:32:42](https://github.com/space-wizards/space-station-14/assets/39013340/6f6ae411-939f-45d0-a7df-94f06f551c12)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: The Syndicate's chefs are now offering snack boxes for only 1 tc. Usually contains a toy, drinks and food.
