### PR TITLE
Fix sorting admin player tab playtime alphabetically

### DIFF
--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
@@ -150,7 +150,7 @@ namespace Content.Client.Administration.UI.Tabs.PlayerTab
                 Header.Character => Compare(x.CharacterName, y.CharacterName),
                 Header.Job => Compare(x.StartingJob, y.StartingJob),
                 Header.Antagonist => x.Antag.CompareTo(y.Antag),
-                Header.Playtime => Compare(x.PlaytimeString, y.PlaytimeString),
+                Header.Playtime => TimeSpan.Compare(x.OverallPlaytime ?? default, y.OverallPlaytime ?? default),
                 _ => 1
             };
         }

--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -41,3 +41,8 @@ Entries:
   - {message: 'Fixed not being able to sort the F7 players tab by playtime.', type: Fix}
   id: 6
   time: '2023-10-14T23:52:00.0000000+00:00'
+- author: DrSmugleaf
+  changes:
+  - {message: 'Fixed playtime being sorted incorrectly in the F7 players tab.', type: Fix}
+  id: 7
+  time: '2023-10-16T04:23:00.0000000+00:00'


### PR DESCRIPTION
## About the PR
## Media
![Content Client_3w9FzMCSho](https://github.com/space-wizards/space-station-14/assets/10968691/ea331223-6dda-4819-81b7-629591339ef3)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase