### PR TITLE
Fix item drop mispredicts

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -104,6 +104,8 @@ public abstract partial class SharedHandsSystem
 
         var target = targetDropLocation.Value.ToMap(EntityManager, TransformSystem);
         TransformSystem.SetWorldPosition(itemXform, GetFinalDropCoordinates(uid, userXform.MapPosition, target));
+        // TODO: Temporary measure until we get engine method for setworldpos nolerp.
+        TransformSystem.DeactivateLerp(itemXform);
         return true;
     }
 


### PR DESCRIPTION
Client is trying to lerp it across parents which the old method didn't do.

:cl:
- fix: Fix item drops mispredicting.