### PR TITLE
Make gibbing drop items again

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -111,7 +111,7 @@ public sealed class BodySystem : SharedBodySystem
         _humanoidSystem.SetLayersVisibility(bodyUid, layers, false, true, humanoid);
     }
 
-    public override HashSet<EntityUid> GibBody(EntityUid bodyId, bool gibOrgans = false, BodyComponent? body = null, bool deleteItems = false)
+    public override HashSet<EntityUid> GibBody(EntityUid bodyId, bool gibOrgans = false, BodyComponent? body = null, bool deleteItems = false, bool deleteBrain = false)
     {
         if (!Resolve(bodyId, ref body, false))
             return new HashSet<EntityUid>();
@@ -123,7 +123,7 @@ public sealed class BodySystem : SharedBodySystem
         if (xform.MapUid == null)
             return new HashSet<EntityUid>();
 
-        var gibs = base.GibBody(bodyId, gibOrgans, body, deleteItems);
+        var gibs = base.GibBody(bodyId, gibOrgans, body, deleteItems, deleteBrain);
 
         var coordinates = xform.Coordinates;
         var filter = Filter.Pvs(bodyId, entityManager: EntityManager);
@@ -135,7 +135,10 @@ public sealed class BodySystem : SharedBodySystem
         {
             if (deleteItems)
             {
-                QueueDel(entity);
+                if(TryComp<BrainComponent>(entity, out _) == false || deleteBrain == true)
+                {
+                    QueueDel(entity);
+                }
             }
             else
             {

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -135,7 +135,7 @@ public sealed class BodySystem : SharedBodySystem
         {
             if (deleteItems)
             {
-                if(TryComp<BrainComponent>(entity, out _) == false || deleteBrain == true)
+                if (!HasComp<BrainComponent>(entity) || deleteBrain)
                 {
                     QueueDel(entity);
                 }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -148,7 +148,7 @@ namespace Content.Server.Explosion.EntitySystems
             if (!TryComp<TransformComponent>(uid, out var xform))
                 return;
 
-            _body.GibBody(xform.ParentUid, deleteItems: component.DeleteItems);
+            _body.GibBody(xform.ParentUid, true, deleteItems: component.DeleteItems);
 
             args.Handled = true;
         }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -267,7 +267,7 @@ public partial class SharedBodySystem
     }
 
     public virtual HashSet<EntityUid> GibBody(EntityUid bodyId, bool gibOrgans = false,
-        BodyComponent? body = null, bool deleteItems = false)
+        BodyComponent? body = null, bool deleteItems = false, bool deleteBrain = false)
     {
         var gibs = new HashSet<EntityUid>();
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -5,6 +5,8 @@ using Content.Shared.Body.Organ;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Prototypes;
 using Content.Shared.DragDrop;
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 
@@ -18,6 +20,8 @@ public partial class SharedBodySystem
      * - On MapInit we spawn the root entity in the prototype and spawn all connections outwards from here
      * - Each "connection" is a body part (e.g. arm, hand, etc.) and each part can also contain organs.
      */
+
+    [Dependency] private readonly InventorySystem _inventory = default!;
 
     private void InitializeBody()
     {
@@ -287,7 +291,14 @@ public partial class SharedBodySystem
                 gibs.Add(organ.Id);
             }
         }
-
+        if(TryComp<InventoryComponent>(bodyId, out var inventory))
+        {
+            foreach (var item in _inventory.GetHandOrInventoryEntities(bodyId))
+            {
+                SharedTransform.AttachToGridOrMap(item);
+                gibs.Add(item);
+            }
+        }
         return gibs;
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #21045 
Edit: Fixes #21038 too now :trollface: 
Edit 2: It fixes #20426 too, or at least should (if a nukie with microbomb dies with the disk uh, skill issue)
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It's a bug as far as I'm told, and I believe being able to completely erase evidence/objective items so easily is not balanced either.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Modified the shared `GibBody` method to also look for all inventory items and drop them along with the organs. (since they're all processed together, items will still get deleted when `deleteItems` is true, such as when activating a microbomb.)
Made `deleteItems` ignore the brain unless specifically told to delete it too via `deleteBrain`
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Gib moment](https://github.com/space-wizards/space-station-14/assets/75124791/c002f597-f3b5-408c-bade-17179049d361)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Being gibbed through normal means will no longer delete all items on the body.
