### PR TITLE
more balanced constructing and unscrewing for metal objects

### DIFF
--- a/Content.IntegrationTests/Tests/Construction/Interaction/ComputerContruction.cs
+++ b/Content.IntegrationTests/Tests/Construction/Interaction/ComputerContruction.cs
@@ -51,7 +51,7 @@ public sealed class ComputerConstruction : InteractionTest
             Screw,
             Pry,
             Wrench,
-            Weld);
+            Screw);
 
         // construction finished, entity no longer exists.
         AssertDeleted();

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/meatspike.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/meatspike.yml
@@ -13,7 +13,7 @@
           steps:
             - material: Steel
               amount: 15
-              doAfter: 10
+              doAfter: 2
     - node: MeatSpike
       entity: KitchenSpike
       edges:
@@ -22,9 +22,6 @@
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 15
-          conditions:
-            - !type:EntityAnchored
-              anchored: false
           steps:
-            - tool: Welding
-              doAfter: 10
+            - tool: Screwing
+              doAfter: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/rack.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/rack.yml
@@ -22,9 +22,6 @@
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 2
-          conditions:
-            - !type:EntityAnchored
-              anchored: false
           steps:
             - tool: Screwing
               doAfter: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
@@ -11,6 +11,7 @@
           steps:
             - material: Steel
               amount: 5
+              doAfter: 2.5
 
     - node: frameUnsecured
       actions:
@@ -29,16 +30,13 @@
                 state: "id_mod"
 
         - to: start
-          conditions:
-            - !type:EntityAnchored
-              anchored: false
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 5
             - !type:DeleteEntity {}
           steps:
-            - tool: Welding
+            - tool: Screwing
               doAfter: 2
 
     - node: boardUnsecured

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
@@ -33,9 +33,6 @@
           steps:
             - material: Cable
         - to: start
-          conditions:
-            - !type:EntityAnchored
-              anchored: false
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1


### PR DESCRIPTION
## About the PR
- computer frame, machine frame, rack and meatspike can be deconstructed while anchored by screwing
- Computer frames now need time to be constructed.
- it now takes a reasonable time (2s) to make a meatspike.


## Why / Balance
If you can assembly something by hand, you shouldn't need to unweld it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Nanotrasen has added screw holes to some metal constructions. (computer frame, machine frame, rack and meat spike are now deconstructed by screwing, also while unanchored.)

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
