### PR TITLE
Fix popup messages appearing when someone tries to open a door without a tool.

### DIFF
--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -184,8 +184,7 @@ public sealed class AirlockSystem : SharedAirlockSystem
         if (!this.IsPowered(uid, EntityManager) || args.PryPowered)
             return;
 
-        if (!args.Silent)
-            Popup.PopupEntity(Loc.GetString("airlock-component-cannot-pry-is-powered-message"), uid, args.User);
+        args.Message = "airlock-component-cannot-pry-is-powered-message";
 
         args.Cancelled = true;
 

--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -178,11 +178,17 @@ public sealed class AirlockSystem : SharedAirlockSystem
 
     private void OnBeforePry(EntityUid uid, AirlockComponent component, ref BeforePryEvent args)
     {
-        if (this.IsPowered(uid, EntityManager) && !args.PryPowered)
-        {
+        if (args.Cancelled)
+            return;
+
+        if (!this.IsPowered(uid, EntityManager) || args.PryPowered)
+            return;
+
+        if (!args.Silent)
             Popup.PopupEntity(Loc.GetString("airlock-component-cannot-pry-is-powered-message"), uid, args.User);
-            args.Cancelled = true;
-        }
+
+        args.Cancelled = true;
+
     }
 
     public bool CanChangeState(EntityUid uid, AirlockComponent component)

--- a/Content.Shared/Doors/Systems/SharedDoorBoltSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorBoltSystem.cs
@@ -29,8 +29,8 @@ public abstract class SharedDoorBoltSystem : EntitySystem
         if (!component.BoltsDown || args.Force)
             return;
 
-        if (!args.Silent)
-            Popup.PopupEntity(Loc.GetString("airlock-component-cannot-pry-is-bolted-message"), uid, args.User);
+        args.Message = "airlock-component-cannot-pry-is-bolted-message";
+
         args.Cancelled = true;
     }
 

--- a/Content.Shared/Doors/Systems/SharedDoorBoltSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorBoltSystem.cs
@@ -23,11 +23,15 @@ public abstract class SharedDoorBoltSystem : EntitySystem
 
     private void OnDoorPry(EntityUid uid, DoorBoltComponent component, ref BeforePryEvent args)
     {
-        if (component.BoltsDown && !args.Force)
-        {
+        if (args.Cancelled)
+            return;
+
+        if (!component.BoltsDown || args.Force)
+            return;
+
+        if (!args.Silent)
             Popup.PopupEntity(Loc.GetString("airlock-component-cannot-pry-is-bolted-message"), uid, args.User);
-            args.Cancelled = true;
-        }
+        args.Cancelled = true;
     }
 
     private void OnBeforeDoorOpened(EntityUid uid, DoorBoltComponent component, BeforeDoorOpenedEvent args)

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -43,7 +43,7 @@ public sealed partial class PryingComponent : Component
 /// Cancel to stop the entity from being pried open.
 /// </summary>
 [ByRefEvent]
-public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force, bool Silent)
+public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force)
 {
     public readonly EntityUid User = User;
 
@@ -51,10 +51,7 @@ public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force,
 
     public readonly bool Force = Force;
 
-    /// <summary>
-    /// Whether to suppress popup messages.
-    /// </summary>
-    public readonly bool Silent = Silent;
+    public string? Message;
 
     public bool Cancelled;
 }

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -43,13 +43,18 @@ public sealed partial class PryingComponent : Component
 /// Cancel to stop the entity from being pried open.
 /// </summary>
 [ByRefEvent]
-public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force)
+public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force, bool Silent)
 {
     public readonly EntityUid User = User;
 
     public readonly bool PryPowered = PryPowered;
 
     public readonly bool Force = Force;
+
+    /// <summary>
+    /// Whether to supress popup messages.
+    /// </summary>
+    public readonly bool Silent = Silent;
 
     public bool Cancelled;
 }

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -52,7 +52,7 @@ public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force,
     public readonly bool Force = Force;
 
     /// <summary>
-    /// Whether to supress popup messages.
+    /// Whether to suppress popup messages.
     /// </summary>
     public readonly bool Silent = Silent;
 

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Database;
 using Content.Shared.Doors.Components;
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Interaction;
+using Content.Shared.Popups;
 using PryUnpoweredComponent = Content.Shared.Prying.Components.PryUnpoweredComponent;
 
 namespace Content.Shared.Prying.Systems;
@@ -19,6 +20,7 @@ public sealed class PryingSystem : EntitySystem
     [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    [Dependency] private readonly SharedPopupSystem Popup = default!;
 
     public override void Initialize()
     {
@@ -68,10 +70,12 @@ public sealed class PryingSystem : EntitySystem
         if (!comp.Enabled)
             return false;
 
-        if (!CanPry(target, user, comp))
+        if (!CanPry(target, user, out var message, comp))
         {
+            if (message != null)
+                Popup.PopupEntity(Loc.GetString(message), target, user);
             // If we have reached this point we want the event that caused this
-            // to be marked as handled as a popup would be generated on failure.
+            // to be marked as handled.
             return true;
         }
 
@@ -87,34 +91,39 @@ public sealed class PryingSystem : EntitySystem
     {
         id = null;
 
-        if (!CanPry(target, user))
+        // We don't care about displaying a message if no tool was used.
+        if (!CanPry(target, user, out _))
             // If we have reached this point we want the event that caused this
-            // to be marked as handled as a popup would be generated on failure.
+            // to be marked as handled.
             return true;
 
         return StartPry(target, user, null, 0.1f, out id); // hand-prying is much slower
     }
 
-    private bool CanPry(EntityUid target, EntityUid user, PryingComponent? comp = null)
+    private bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null)
     {
         BeforePryEvent canev;
 
         if (comp != null)
         {
-            canev = new BeforePryEvent(user, comp.PryPowered, comp.Force, false);
+            canev = new BeforePryEvent(user, comp.PryPowered, comp.Force);
         }
         else
         {
             if (!TryComp<PryUnpoweredComponent>(target, out _))
+            {
+                message = null;
                 return false;
-            canev = new BeforePryEvent(user, false, false, true);
+            }
+
+            canev = new BeforePryEvent(user, false, false);
         }
 
         RaiseLocalEvent(target, ref canev);
 
-        if (canev.Cancelled)
-            return false;
-        return true;
+        message = canev.Message;
+
+        return !canev.Cancelled;
     }
 
     private bool StartPry(EntityUid target, EntityUid user, EntityUid? tool, float toolModifier, [NotNullWhen(true)] out DoAfterId? id)

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -101,13 +101,13 @@ public sealed class PryingSystem : EntitySystem
 
         if (comp != null)
         {
-            canev = new BeforePryEvent(user, comp.PryPowered, comp.Force);
+            canev = new BeforePryEvent(user, comp.PryPowered, comp.Force, false);
         }
         else
         {
             if (!TryComp<PryUnpoweredComponent>(target, out _))
                 return false;
-            canev = new BeforePryEvent(user, false, false);
+            canev = new BeforePryEvent(user, false, false, true);
         }
 
         RaiseLocalEvent(target, ref canev);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This pr makes it so you no longer get popup messages for the door being powered, or bolts being down when trying to open them without any tools just like it was before you could pry open unpowered doors without tools. Trying to pry open doors with tools like the crowbar will still show these popup messages.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The messages are annoying and make it seem like you are trying to furiously pry open every door you don't have access to. The door denied sound and the flashing red lights are more than enough to indicate that you can't open that door.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Systems that check for the event can put a message to be displayed on failure. The message will be shown by the prying system depending on if the user is using a tool or not.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
no cl no fun
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
