### PR TITLE
Reduce C4 and C4 Bundle Price

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -189,7 +189,7 @@
   description: uplink-c4-desc
   productEntity: C4
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - UplinkExplosives
 
@@ -214,7 +214,7 @@
   description: uplink-c4-bundle-desc
   productEntity: ClothingBackpackDuffelSyndicateC4tBundle
   cost:
-    Telecrystal: 20
+    Telecrystal: 12 #you're buying bulk so its a 25% discount
   categories:
   - UplinkExplosives
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
C4 is reduced to 2 from 4 and the bundle to 12 from 20 in the traitor/nukeops uplink.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Because C4 is bad, 4TC is overpriced and makes the item not worth it for the opportunity cost.

C4 was originally changed to 4TC in some Emisse PR several months ago, along with the bundle to 20TC, Emisse then later allowed C4 to be changed back to 2TC (and the bundle retroactively) and Flareguy said he'd PR this but I forgot where that went.

Cheaper C4 should put it back as a good option in the uplink and make tots blow shit up more rather than chew on wires or do some other boring sabotage activity, nukeops don't buy c4 often because they start with some c4 in the shuttle and they don't need a lot before it loses value, or they buy a fireaxe and troll walls with it.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
webedit pr, i didn't test this bich!!! repoban 'em all 2004
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: BurninDreamer
- tweak: C4 now costs 2 TC instead of 4TC, the bundle costs 12TC instead of 20TC
