### PR TITLE
Fix thrown items not registering the tile they stop by colliding with a hard surface

### DIFF
--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -99,6 +99,7 @@ namespace Content.Shared.Throwing
             if (TryComp<PhysicsComponent>(uid, out var physics))
             {
                 _physics.SetBodyStatus(physics, BodyStatus.OnGround);
+                _broadphase.RegenerateContacts(uid, physics);
             }
 
             if (EntityManager.TryGetComponent(uid, out FixturesComponent? manager))


### PR DESCRIPTION
## About the PR
I noticed when throwing the rubber ducky onto a moving conveyor belt that only sometimes it would land and get picked up by the belt, and other times it would just stop moving. I found it was specifically when the item collided with a wall and believe it was caused by `StopThrow()` setting the item's `BodyStatus` to `OnGround` which also disables its collision until awoken by something else. Making the entity regenerate its contacts right after ensures that if the throw ends or stops for any reason then the entity will reassess its surroundings 

## Technical details
Items should now always interact with tiles and objects where they land instead of some of the time.

## Media
Before:

https://github.com/space-wizards/space-station-14/assets/46236974/5c2e3f5a-fd83-4131-b9cb-822bbf9fd8c1

After:

https://github.com/space-wizards/space-station-14/assets/46236974/976a8521-7869-46d0-9ac9-1464075a40bd



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl:
- fix: Fixed thrown entities physics being set to sleep if the throw was stopped by colliding with something

