### PR TITLE
add craft rollerbed & wheelchair

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -114,6 +114,10 @@
       - FoodPlateSmallPlastic
       - SprayBottle
       - PowerCellSmall
+      - VehicleWheelchairFolded
+      - RollerBedSpawnFolded
+      - CheapRollerBedSpawnFolded
+      - EmergencyRollerBedSpawnFolded
       - MicroManipulatorStockPart
       - MatterBinStockPart
       - CapacitorStockPart

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -667,6 +667,10 @@
       - PillCanister
       - BodyBag
       - ChemistryEmptyBottle01
+      - VehicleWheelchairFolded
+      - RollerBedSpawnFolded
+      - CheapRollerBedSpawnFolded
+      - EmergencyRollerBedSpawnFolded
       - Medkit
       - MedkitBurn
       - MedkitToxin

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -203,3 +203,36 @@
   completetime: 4
   materials:
     Plastic: 400
+
+- type: latheRecipe
+  id: VehicleWheelchairFolded
+  result: VehicleWheelchairFolded
+  completetime: 1
+  materials:
+    Steel: 500
+    Plastic: 300
+    
+- type: latheRecipe
+  id: RollerBedSpawnFolded
+  result: RollerBedSpawnFolded
+  completetime: 1
+  materials:
+    Steel: 600
+    Plastic: 300
+
+- type: latheRecipe
+  id: CheapRollerBedSpawnFolded
+  result: CheapRollerBedSpawnFolded
+  completetime: 1
+  materials:
+    Steel: 600
+    Plastic: 300
+
+- type: latheRecipe
+  id: EmergencyRollerBedSpawnFolded
+  result: EmergencyRollerBedSpawnFolded
+  completetime: 1
+  materials:
+    Steel: 600
+    Plastic: 300
+


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Adding craft wheelchair and rollerbed.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I don't understand why there was initially crafting of these items. Wheelchairs are stolen from poor disabled people and they cannot move.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Added lathe printing for rollerbed & wheelchairs.


