### PR TITLE
Bump med stack sizes to standard

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -6,7 +6,7 @@
   - type: Sprite
     sprite: Objects/Specific/Medical/medical.rsi
   - type: Item
-    size: 10
+    size: 30
     sprite: Objects/Specific/Medical/medical.rsi
     heldPrefix: ointment
   # Inherited
@@ -55,7 +55,7 @@
     stackType: Ointment
     count: 1
   - type: Item
-    size: 1
+    size: 3
 
 - type: entity
   id: Ointment10Lingering
@@ -106,7 +106,7 @@
     stackType: RegenerativeMesh
     count: 1
   - type: Item
-    size: 1
+    size: 3
 
 - type: entity
   name: bruise pack
@@ -145,7 +145,7 @@
     stackType: Brutepack
     count: 1
   - type: Item
-    size: 1
+    size: 3
 
 - type: entity
   id: Brutepack10Lingering
@@ -194,7 +194,7 @@
     stackType: MedicatedSuture
     count: 1
   - type: Item
-    size: 1
+    size: 3
 
 - type: entity
   name: blood pack
@@ -274,7 +274,7 @@
   - type: Stack
     count: 1
   - type: Item
-    size: 1
+    size: 3
 
 - type: entity
   id: Gauze10Lingering

--- a/Resources/Prototypes/Stacks/medical_stacks.yml
+++ b/Resources/Prototypes/Stacks/medical_stacks.yml
@@ -12,7 +12,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Hydroponics/aloe.rsi", state: cream }
   spawn: AloeCream
   maxCount: 10
-  itemSize: 1
+  itemSize: 3
 
 - type: stack
   id: Gauze

--- a/Resources/Prototypes/Stacks/medical_stacks.yml
+++ b/Resources/Prototypes/Stacks/medical_stacks.yml
@@ -4,7 +4,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: ointment }
   spawn: Ointment
   maxCount: 10
-  itemSize: 1
+  itemSize: 3
 
 - type: stack
   id: AloeCream
@@ -20,7 +20,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Gauze
   maxCount: 10
-  itemSize: 1
+  itemSize: 3
 
 - type: stack
   id: Brutepack
@@ -28,7 +28,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Brutepack
   maxCount: 10
-  itemSize: 1
+  itemSize: 3
 
 - type: stack
   id: Bloodpack
@@ -36,7 +36,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: bloodpack }
   spawn: Bloodpack
   maxCount: 10
-  itemSize: 1
+  itemSize: 3
 
 - type: stack
   id: MedicatedSuture
@@ -44,7 +44,7 @@
   icon: {sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: medicated-suture }
   spawn: MedicatedSuture
   maxCount: 10
-  itemSize: 1
+  itemSize: 3
 
 - type: stack
   id: RegenerativeMesh
@@ -52,6 +52,6 @@
   icon: {sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: regenerative-mesh}
   spawn: RegenerativeMesh
   maxCount: 10
-  itemSize: 1
+  itemSize: 3
 
 


### PR DESCRIPTION
Most things are size 30 so this just stops you carrying 100x healing items in an average backpack

:cl:
- tweak: Med item sizes changed from 1 to 3 so they standardise at 30 per stack.
