### PR TITLE
emitter bolts can mine

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -300,6 +300,8 @@
     damage:
       types:
         Heat: 14
+  # mining laser real
+  - type: GatheringProjectile
   - type: Tag
     tags:
     - EmitterBolt


### PR DESCRIPTION
## About the PR
instead of 20 shots for the heat damage to break it, emitter bolts are now just gathering projectiles
this means you can properly use them for epic laser mining

## Why / Balance
with stock parts its much slower than just using a pick, mostly to just be cool

## Technical details
no

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/3f8461ac-8248-4102-a85e-a5b7082a00c7

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Emitters now destroy rocks in 1 hit like crushers and PKAs, you can use them for laser mining. 
