### PR TITLE
microwave can be turned on with signal

### DIFF
--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Construction.Prototypes;
+using Content.Shared.DeviceLinking;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
@@ -36,6 +37,9 @@ namespace Content.Server.Kitchen.Components
 
         [ViewVariables]
         public bool Broken;
+
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public ProtoId<SinkPortPrototype> OnPort = "On";
 
         /// <summary>
         /// This is a fixed offset of 5.

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -54,7 +54,7 @@ namespace Content.Server.Kitchen.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<MicrowaveComponent, ComponentInit>(OnInit);
+            SubscribeLocalEvent<MicrowaveComponent, MapInitEvent>(OnInit);
             SubscribeLocalEvent<MicrowaveComponent, SolutionChangedEvent>(OnSolutionChange);
             SubscribeLocalEvent<MicrowaveComponent, InteractUsingEvent>(OnInteractUsing, after: new[] { typeof(AnchorableSystem) });
             SubscribeLocalEvent<MicrowaveComponent, BreakageEventArgs>(OnBreak);
@@ -180,10 +180,10 @@ namespace Content.Server.Kitchen.EntitySystems
             }
         }
 
-        private void OnInit(EntityUid uid, MicrowaveComponent component, ComponentInit ags)
+        private void OnInit(Entity<MicrowaveComponent> ent, ref MapInitEvent args)
         {
-            component.Storage = _container.EnsureContainer<Container>(uid, "microwave_entity_container");
-            _deviceLink.EnsureSinkPorts(uid, component.OnPort);
+            ent.Comp.Storage = _container.EnsureContainer<Container>(ent, "microwave_entity_container");
+            _deviceLink.EnsureSinkPorts(ent, ent.Comp.OnPort);
         }
 
         private void OnSuicide(EntityUid uid, MicrowaveComponent component, SuicideEvent args)

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -54,7 +54,8 @@ namespace Content.Server.Kitchen.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<MicrowaveComponent, MapInitEvent>(OnInit);
+            SubscribeLocalEvent<MicrowaveComponent, ComponentInit>(OnInit);
+            SubscribeLocalEvent<MicrowaveComponent, MapInitEvent>(OnMapInit);
             SubscribeLocalEvent<MicrowaveComponent, SolutionChangedEvent>(OnSolutionChange);
             SubscribeLocalEvent<MicrowaveComponent, InteractUsingEvent>(OnInteractUsing, after: new[] { typeof(AnchorableSystem) });
             SubscribeLocalEvent<MicrowaveComponent, BreakageEventArgs>(OnBreak);
@@ -180,9 +181,14 @@ namespace Content.Server.Kitchen.EntitySystems
             }
         }
 
-        private void OnInit(Entity<MicrowaveComponent> ent, ref MapInitEvent args)
+        private void OnInit(Entity<MicrowaveComponent> ent, ref ComponentInit args)
         {
+            // this really does have to be in ComponentInit
             ent.Comp.Storage = _container.EnsureContainer<Container>(ent, "microwave_entity_container");
+        }
+
+        private void OnMapInit(Entity<MicrowaveComponent> ent, ref MapInitEvent args)
+        {
             _deviceLink.EnsureSinkPorts(ent, ent.Comp.OnPort);
         }
 

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -1,9 +1,13 @@
 using System.Linq;
 using Content.Server.Body.Systems;
 using Content.Server.Construction;
+using Content.Server.DeviceLinking.Events;
+using Content.Server.DeviceLinking.Systems;
+using Content.Server.DeviceNetwork;
 using Content.Server.Hands.Systems;
 using Content.Server.Kitchen.Components;
 using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
 using Content.Server.Temperature.Components;
 using Content.Server.Temperature.Systems;
 using Content.Shared.Body.Components;
@@ -33,7 +37,9 @@ namespace Content.Server.Kitchen.EntitySystems
     {
         [Dependency] private readonly BodySystem _bodySystem = default!;
         [Dependency] private readonly ContainerSystem _container = default!;
+        [Dependency] private readonly DeviceLinkSystem _deviceLink = default!;
         [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+        [Dependency] private readonly PowerReceiverSystem _power = default!;
         [Dependency] private readonly RecipeManager _recipeManager = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -56,6 +62,8 @@ namespace Content.Server.Kitchen.EntitySystems
             SubscribeLocalEvent<MicrowaveComponent, SuicideEvent>(OnSuicide);
             SubscribeLocalEvent<MicrowaveComponent, RefreshPartsEvent>(OnRefreshParts);
             SubscribeLocalEvent<MicrowaveComponent, UpgradeExamineEvent>(OnUpgradeExamine);
+
+            SubscribeLocalEvent<MicrowaveComponent, SignalReceivedEvent>(OnSignalReceived);
 
             SubscribeLocalEvent<MicrowaveComponent, MicrowaveStartCookMessage>((u, c, m) => Wzhzhzh(u, c, m.Session.AttachedEntity));
             SubscribeLocalEvent<MicrowaveComponent, MicrowaveEjectMessage>(OnEjectMessage);
@@ -175,6 +183,7 @@ namespace Content.Server.Kitchen.EntitySystems
         private void OnInit(EntityUid uid, MicrowaveComponent component, ComponentInit ags)
         {
             component.Storage = _container.EnsureContainer<Container>(uid, "microwave_entity_container");
+            _deviceLink.EnsureSinkPorts(uid, component.OnPort);
         }
 
         private void OnSuicide(EntityUid uid, MicrowaveComponent component, SuicideEvent args)
@@ -275,6 +284,17 @@ namespace Content.Server.Kitchen.EntitySystems
         private void OnUpgradeExamine(EntityUid uid, MicrowaveComponent component, UpgradeExamineEvent args)
         {
             args.AddPercentageUpgrade("microwave-component-upgrade-cook-time", component.CookTimeMultiplier);
+        }
+
+        private void OnSignalReceived(Entity<MicrowaveComponent> ent, ref SignalReceivedEvent args)
+        {
+            if (args.Port != ent.Comp.OnPort)
+                return;
+
+            if (ent.Comp.Broken || !_power.IsPowered(ent))
+                return;
+
+            Wzhzhzh(ent.Owner, ent.Comp, null);
         }
 
         public void UpdateUserInterfaceState(EntityUid uid, MicrowaveComponent component)

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -33,6 +33,14 @@
           False: { visible: false }
   - type: ActivatableUI
     key: enum.MicrowaveUiKey.Key
+  - type: DeviceLinkSink
+    ports:
+    - On
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
   - type: UserInterface
     interfaces:
     - key: enum.MicrowaveUiKey.Key


### PR DESCRIPTION
## About the PR
title

## Why / Balance
- lets you automate kitchen a little bit, e.g. with #20026 have a 15s timer control a clock that activates a 10s microwave to get an efficient breab pipeline, 5s window to put in new dough rinse and repeat
- let sussy/rev make remotely activated microwave bombs real

## Technical details
simple

## Media

hampter roulette + battery bomb

https://github.com/space-wizards/space-station-14/assets/39013340/b1c53475-3ada-4f8d-9739-2a07c3a2109a


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun