### PR TITLE
Fix thrusters starting disabled

### DIFF
--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -16,7 +16,7 @@ namespace Content.Server.Shuttles.Components
         /// Whether the thruster has been force to be enabled / disabled (e.g. VV, interaction, etc.)
         /// </summary>
         [DataField, ViewVariables(VVAccess.ReadWrite)]
-        public bool Enabled { get; set; }
+        public bool Enabled { get; set; } = true;
 
         /// <summary>
         /// This determines whether the thruster is actually enabled for the purposes of thrust


### PR DESCRIPTION
## About the PR
## Media
https://github.com/space-wizards/space-station-14/assets/10968691/7862ae10-258e-456e-8d5b-d9285da50cb6

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed shuttle thrusters and gyroscopes being disabled by default.
