### PR TITLE
ProtectedGridComponent Logic Change

### DIFF
--- a/Content.Server/Maps/TileSystem.cs
+++ b/Content.Server/Maps/TileSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Maps;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Random;
+using Content.Shared.Tiles;
 
 namespace Content.Server.Maps;
 
@@ -95,6 +96,11 @@ public sealed class TileSystem : EntitySystem
             return false;
 
         var mapGrid = _mapManager.GetGrid(tileRef.GridUid);
+        var ev = new FloorTileAttemptEvent();
+        RaiseLocalEvent(mapGrid);
+
+        if ((HasComp<ProtectedGridComponent>(tileRef.GridUid) || ev.Cancelled) && tileDef.ID == "Plating")
+            return false;
 
         const float margin = 0.1f;
         var bounds = mapGrid.TileSize - margin * 2;

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -165,7 +165,7 @@ public sealed class RCDSystem : EntitySystem
         {
             //Floor mode just needs the tile to be a space tile (subFloor)
             case RcdMode.Floors:
-                if (!_floors.CanPlaceTile(gridId.Value, mapGrid, out var reason))
+                if (!_floors.CanPlaceTile(gridId.Value, mapGrid, null, out var reason))
                 {
                     _popup.PopupClient(reason, user, user);
                     return;


### PR DESCRIPTION
## About the PR
Changes to how "ProtectedGridComponent" working.

1. Placing plating and floor tiles on lattice allowed (To fix spacing from small bombs and damage).
2. Placing lattice is still blocked (Cannot extend platform or fix minibombs holes).
3. Cannot remove plating with tools like axe (RCD still works, i can also fix this if needed)

## Why / Balance
Allow basic repair and protection to safe grids.

## Technical details
C#
Added a lookup for "ProtectedGridComponent" in DeconstructTile to block tools removing plating.
Added a lookup in CanPlaceTile for any tile that isnt Lattice (rods) to allow fixing of tiles without adding new tiles.

Im not sure about my code skills, so please let me know about issues in formatting, I did test the code in game to make sure there is no issues with it, this code is based on a working version of the code that was made for Frontier fork, also by me.

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame,

## Breaking changes
Evac shuttle can be fixed now on a basic level, but at the same time you cannot space it with an axe, 
this PR is up as a draft for now to allow us to talk about this.

**Changelog**
no cl no fun.
