### PR TITLE
Minor food fixes and tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -618,6 +618,8 @@
   id: FoodBurgerMcrib
   description: An elusive rib shaped burger with limited availablity across the galaxy. Not as good as you remember it.
   components:
+  - type: Food
+    trash: FoodKebabSkewer
   - type: FlavorProfile
     flavors:
       - bun

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -428,19 +428,6 @@
     node: flat
 
 - type: entity
-  name: bun
-  parent: FoodBakingBase
-  id: FoodDoughBun
-  description: A base for any self-respecting burger.
-  components:
-  - type: FlavorProfile
-    flavors:
-      - bun
-  - type: Sprite
-    sprite: Objects/Consumable/Food/burger.rsi
-    state: bun
-
-- type: entity
   name: raw pastry base
   parent: FoodBakingBase
   id: FoodDoughPastryBaseRaw

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -326,6 +326,8 @@
   id: FoodMealRibs
   description: BBQ ribs, slathered in a healthy coating of BBQ sauce. The least vegan thing to ever exist.
   components:
+  - type: Food
+    trash: FoodKebabSkewer
   - type: FlavorProfile
     flavors:
       - meaty

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -24,7 +24,7 @@
   time: 10
   solids:
     FoodBreadBun: 1
-    FoodMeatCutlet: 3 #replace with bacon
+    FoodMeatBacon: 1
     FoodCheeseSlice: 2
 
 - type: microwaveMealRecipe
@@ -186,7 +186,7 @@
   time: 10
   solids:
     FoodBreadBun: 1
-    ClothingOuterGhostSheet: 1 #replace with ectoplasm once added
+    Ectoplasm: 1
 
 - type: microwaveMealRecipe
   id: RecipeHumanBurger

--- a/Resources/Prototypes/Recipes/Reactions/food.yml
+++ b/Resources/Prototypes/Recipes/Reactions/food.yml
@@ -148,6 +148,7 @@
       amount: 30
     Enzyme:
       amount: 5
+      catalyst: true
   effects:
     - !type:CreateEntityReactionEffect
       entity: FoodTofu
@@ -158,11 +159,11 @@
   id: CookingKetchup
   reactants:
     JuiceTomato:
-      amount: 10
+      amount: 2
     Sugar:
-      amount: 5
+      amount: 1
   products:
-    Ketchup: 15
+    Ketchup: 3
 
 - type: reaction
   id: CookingMayoVinegar
@@ -203,67 +204,67 @@
   id: CookingKetchunaise
   reactants:
     Ketchup:
-      amount: 5
+      amount: 1
     Mayo:
-      amount: 5
+      amount: 1
   products:
-    Ketchunaise: 10
+    Ketchunaise: 2
 
 - type: reaction
   id: CookingBbqSauce
   reactants:
     Ketchup:
-      amount: 5
+      amount: 1
     Vinegar:
-      amount: 5
+      amount: 1
     Sugar:
-      amount: 5
+      amount: 1
   products:
-    BbqSauce: 15
+    BbqSauce: 3
 
 - type: reaction
   id: CookingHotsauce
   reactants:
     JuiceTomato:
-      amount: 5
+      amount: 1
     TableSalt:
-      amount: 5
+      amount: 1
     CapsaicinOil:
-      amount: 5
+      amount: 1
   products:
-    Hotsauce: 15
+    Hotsauce: 3
 
 - type: reaction
   id: CookingVinegar
   reactants:
     Ethanol:
-      amount: 5
+      amount: 1
     Oxygen:
-      amount: 5
+      amount: 1
   products:
-    Vinegar: 10
+    Vinegar: 2
 
 - type: reaction
   id: CookingSoysauce
   reactants:
     MilkSoy:
-      amount: 10
+      amount: 2
     SulfuricAcid:
-      amount: 5
+      amount: 1
   products:
-    Soysauce: 15
+    Soysauce: 3
 
 - type: reaction
   id: CookingVinaigrette
   reactants:
     Vinegar:
-      amount: 5
+      amount: 1
     OilOlive:
-      amount: 5
+      amount: 1
     Blackpepper:
-      amount: 5
+      amount: 1
   products:
-    Vinaigrette: 15
+    Vinaigrette: 3
 
 - type: reaction
   id: CreateMeatball


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Combed through the foods that require bowls / skewers that don't return them and fixed that. Recipes that had placeholder items that have since been added have been updated to use the correct item. Removed an unused duplicate bun item. Tofu recipe no longer consumes the enzyme. Tweaked food reagent recipes that aren't quantized so that they use the least amount of reagents but keep the ratio (ie a reaction that takes 5 of one chem and 10 of another to produce 15 of a third is reduced to 1:2:3 respectively).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes limited stock cooking utensils getting deleted for seemingly no reason. Makes recipes make more sense (didn't tweak the clown tears recipe as microwave recipes don't work well with stacks). Unused duplicate items are bad. Tofu recipe is the only recipe that consumes the enzyme which feels unintended and can catch cooks off guard if they are expecting it to be like other recipes that don't consume it. Reducing reagent counts to the least amount that keeps the ratio makes it more consistent with other reactions. I can make these into separate PRs if preferred.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- tweak: Bacon burgers require 1 bacon instead of 3 cutlets
- tweak: Ghost burgers require 1 ectoplasm instead of 1 ghost sheet
- tweak: Tofu creation no longer consumes the enzyme
- fix: Ribs and Mcribs now give back skewers when eaten
