### PR TITLE
1984 supermatter bomb

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -37,7 +37,7 @@ uplink-mini-bomb-name = Minibomb
 uplink-mini-bomb-desc = A low-yield, high-impact precision sabotage explosive with a five-second long fuse. Perfect for quickly destroying a machine, dead body, or whatever else needs to go.
 
 uplink-supermatter-grenade-name = Supermatter Grenade
-uplink-supermatter-grenade-desc = Grenade that simulates delamination of a suppermatter engine, generates powerful gravity well. Explosion comparable to a Mini Bomb.
+uplink-supermatter-grenade-desc = Grenade that simulates delamination of a suppermatter engine, generates powerful gravity well.
 
 uplink-whitehole-grenade-name = Whitehole Grenade
 uplink-whitehole-grenade-desc = Grenade that are repulses everything around for about 10 seconds. Very useful in small rooms and for chasing someone.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -154,7 +154,7 @@
   description: uplink-supermatter-grenade-desc
   productEntity: SupermatterGrenade
   cost:
-    Telecrystal: 6
+    Telecrystal: 8
   categories:
     - UplinkExplosives
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -137,9 +137,10 @@
         volume: -5
   - type: Explosive
     explosionType: Default
-    totalIntensity: 200
-    intensitySlope: 30
-    maxIntensity: 120
+    totalIntensity: 50
+    intensitySlope: 5
+    maxIntensity: 20
+    canCreateVacuum: false
   - type: SoundOnTrigger
     removeOnTrigger: true
     sound:
@@ -158,7 +159,7 @@
           path: /Audio/Effects/Grenades/Supermatter/supermatter_loop.ogg
       - type: GravityWell
         maxRange: 8
-        baseRadialAcceleration: 145
+        baseRadialAcceleration: 100
         baseTangentialAcceleration: 5
         gravPulsePeriod: 0.01
       - type: SingularityDistortion


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Massivly nerfs supermatters

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Copypaste from #21171

This cost EXACTLY the same as a minibomb and acts like one but pulls people into it. I have only seen this being used on the shuttle last second for someone to get their kill objective or destroying a mass amount of items dragged into it. The gravity pull is also very hard to escape especially if you have a decently high ping or have items preventing you from. Thus making it certain you would at least be going to crit.

This makes the gravity pull WAY easier to escape but still can be a challenge. Makes it a few telecrystals more expensive and made its explosion able to at most crit someone if they happen to be in the center as it explodes.

Why make it more expensive? It can still crit A LOT of people easily. Ensure unconscious people die. Get rid of some items etc
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


https://github.com/space-wizards/space-station-14/assets/34938708/6e11b6a9-ce70-4311-8bed-c5f61220f72a



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Vasilis
- tweak: 1984'd supermatter grenades. It's easier to escape its gravitational pull, they cant gib or space rooms anymore but can get someone to crit still. And costs 8TC