### PR TITLE
Remove "mk --> mmm, okay" and "u --> you" to chatsan anti slang

### DIFF
--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -114,3 +114,6 @@ chatsan-replacement-41 = for your information
 
 chatsan-word-42 = wyd
 chatsan-replacement-42 = what you doing
+
+chatsan-word-43 = ofc
+chatsan-replacement-43 = of course

--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -109,11 +109,8 @@ chatsan-word-39 = etc
 chatsan-word-40 = etc.
 chatsan-replacement-etcetera = etcetera
 
-chatsan-word-41 = fyi
-chatsan-replacement-41 = for your information
+chatsan-word-41 = wyd
+chatsan-replacement-41 = what you doing
 
-chatsan-word-42 = wyd
-chatsan-replacement-42 = what you doing
-
-chatsan-word-43 = ofc
-chatsan-replacement-43 = of course
+chatsan-word-42 = ofc
+chatsan-replacement-42 = of course

--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -110,7 +110,7 @@ chatsan-word-40 = etc.
 chatsan-replacement-etcetera = etcetera
 
 chatsan-word-41 = wyd
-chatsan-replacement-41 = what you doing
+chatsan-replacement-41 = what are you doing
 
 chatsan-word-42 = ofc
 chatsan-replacement-42 = of course

--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -10,8 +10,8 @@ chatsan-replacement-3 = on god
 chatsan-word-4 = wtf
 chatsan-replacement-4 = what the fuck
 
-chatsan-word-5 = ffs
-chatsan-replacement-5 = for fuck's sake
+chatsan-word-5 = wth
+chatsan-replacement-5 = what the heck
 
 chatsan-word-6 = tf
 chatsan-replacement-6 = the fuck
@@ -37,8 +37,8 @@ chatsan-replacement-13 = let me know
 chatsan-word-14 = ur
 chatsan-replacement-14 = your
 
-chatsan-word-15 = mk
-chatsan-replacement-15 = mmm, okay
+chatsan-word-15 = ffs
+chatsan-replacement-15 = for fuck's sake
 
 chatsan-word-16 = iirc
 chatsan-replacement-16 = if i remember correctly

--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -31,8 +31,8 @@ chatsan-replacement-10 = i don't care
 chatsan-word-12 = tbh
 chatsan-replacement-12 = to be honest
 
-chatsan-word-13 = u
-chatsan-replacement-13 = you
+chatsan-word-13 = lmk
+chatsan-replacement-13 = let me know
 
 chatsan-word-14 = ur
 chatsan-replacement-14 = your

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -536,4 +536,3 @@
     chatsan-word-40: chatsan-replacement-etcetera
     chatsan-word-41: chatsan-replacement-41
     chatsan-word-42: chatsan-replacement-42
-    chatsan-word-43: chatsan-replacement-43

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -536,3 +536,4 @@
     chatsan-word-40: chatsan-replacement-etcetera
     chatsan-word-41: chatsan-replacement-41
     chatsan-word-42: chatsan-replacement-42
+    chatsan-word-43: chatsan-replacement-43


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Replaces mmm, okay and the "u" letter in speech-chatsan.ftl with 'lmk' and 'wth'
Removed fyi --> for your information
Also adds ofc --> of course

## Why / Balance
mk becomes 'mmm, okay' but mk is also the name of the MK-58
u is the cargo radio's radio letter and blacklisting an entire letter is probably not good either
fyi is an actual thing people say

## Technical details
0

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**

:cl:
- tweak: The anti-slang system allows for more leeway with certain phrases now.
- fix: The supply radio channel can be used with ":u" again.
