### PR TITLE
Fix anomaly locators frantically beeping when entering detection range.

### DIFF
--- a/Content.Server/Pinpointer/ProximityBeeperSystem.cs
+++ b/Content.Server/Pinpointer/ProximityBeeperSystem.cs
@@ -73,7 +73,11 @@ public sealed class ProximityBeeperSystem : EntitySystem
         }
 
         if (closestDistance is not { } distance)
+        {
+            // If we don't reset the timer here walking into range will result in the beeper beeping frantically as it catches up.
+            component.NextBeepTime = _timing.CurTime + component.MaxBeepInterval;
             return;
+        }
 
         if (playBeep)
             _audio.PlayPvs(component.BeepSound, uid);

--- a/Content.Server/Pinpointer/ProximityBeeperSystem.cs
+++ b/Content.Server/Pinpointer/ProximityBeeperSystem.cs
@@ -73,18 +73,17 @@ public sealed class ProximityBeeperSystem : EntitySystem
         }
 
         if (closestDistance is not { } distance)
-        {
-            // If we don't reset the timer here walking into range will result in the beeper beeping frantically as it catches up.
-            component.NextBeepTime = _timing.CurTime + component.MaxBeepInterval;
             return;
-        }
 
         if (playBeep)
             _audio.PlayPvs(component.BeepSound, uid);
 
         var scalingFactor = distance / component.MaximumDistance;
         var interval = (component.MaxBeepInterval - component.MinBeepInterval) * scalingFactor + component.MinBeepInterval;
+
         component.NextBeepTime += interval;
+        if (component.NextBeepTime < _timing.CurTime) // Prevents spending time out of range accumulating a deficit which causes a series of very rapid beeps when comeing into range.
+            component.NextBeepTime = _timing.CurTime + interval;
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Prevents anomaly locators frantically beeping when they enter detection range for an anomaly.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The frantic beeping whenever an anomaly enters detection range was a bit disconcerting.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
If the anomaly locator now updates the next check time regardless of whether it detects any anomalies in range.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.

-->
:cl:
- fix: Fixed anomaly locators frantically beeping when they first enter detection range for an anomaly.