### PR TITLE
mild syndicate bundle additions

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -38,6 +38,7 @@
   components:
   - type: StorageFill
     contents:
+      - id: MMI
       - id: Hemostat
       - id: SawAdvanced
       - id: Drill
@@ -225,6 +226,8 @@
       contents:
         - id: C4
           amount: 8
+        - id: Multitool
+        - id: RemoteSignaller
 
 - type: entity
   parent: ClothingBackpackChameleon


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
adds an MMI to the syndicate surgery duffel bag
adds a multitool and remote signaller to the syndicate C4 bundle
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
surgery bag - fun, you can gib someone and keep them as a morbid pAI or borg them, whatever
C-4 bundle - so you can have more flexibility and adds more value to the bundle
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl: JoeHammad
- tweak: syndicate surgery bundles now contain an MMI
- tweak: syndicate C-4 bundles now contain a multitool and remote signaller
