### PR TITLE
aspid cargo expansion :trollface:

### DIFF
--- a/Resources/Maps/aspid.yml
+++ b/Resources/Maps/aspid.yml
@@ -120,11 +120,11 @@ entities:
           version: 6
         -3,-1:
           ind: -3,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAKQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAKQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWAAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAYAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAHwAAAAACUwAAAAAAWAAAAAAAcAAAAAAAWAAAAAAAcAAAAAAAHwAAAAACHwAAAAACRwAAAAAARwAAAAAAHwAAAAACHwAAAAACcAAAAAAAcAAAAAAAcAAAAAAAYAAAAAAAGgAAAAAAUwAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAHwAAAAADHwAAAAACRwAAAAAARwAAAAAAHwAAAAABHwAAAAAAcAAAAAAAYAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAACcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAHwAAAAACHwAAAAADRwAAAAAARwAAAAAAHwAAAAAAHwAAAAAAcAAAAAAAGgAAAAADGgAAAAABGgAAAAABcAAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAHwAAAAABHwAAAAADRwAAAAAARwAAAAAAHwAAAAABHwAAAAADcAAAAAAAGgAAAAACGgAAAAACGgAAAAACHwAAAAADUwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAHwAAAAABHwAAAAADcAAAAAAAcAAAAAAAcAAAAAAAGgAAAAACGgAAAAACGgAAAAAAcAAAAAAAUwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAUwAAAAAAUwAAAAABUwAAAAADUwAAAAAAUwAAAAACWwAAAAACcAAAAAAAGgAAAAACGgAAAAAAGgAAAAACUwAAAAADUwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAUwAAAAADUwAAAAACUwAAAAADUwAAAAACHwAAAAACGgAAAAADGgAAAAABGgAAAAADUwAAAAABUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAUwAAAAAAUwAAAAADUwAAAAABUwAAAAACUwAAAAABUwAAAAACcAAAAAAAGgAAAAAAGgAAAAADGgAAAAAAcAAAAAAAUwAAAAAC
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAKQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAKQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWAAAAAAAcAAAAAAAXwAAAAAAXwAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAYAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAHwAAAAACUwAAAAAAWAAAAAAAcAAAAAAAWAAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAYAAAAAAAGgAAAAAAUwAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAUwAAAAAAcAAAAAAAYAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAACcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAUwAAAAAAcAAAAAAAGgAAAAADGgAAAAABGgAAAAABcAAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAcAAAAAAAGgAAAAACGgAAAAACGgAAAAACHwAAAAADUwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWwAAAAAAWwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGgAAAAACGgAAAAACGgAAAAAAcAAAAAAAUwAAAAACAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAUwAAAAAAUwAAAAABUwAAAAADUwAAAAAAUwAAAAACWwAAAAACcAAAAAAAGgAAAAACGgAAAAAAGgAAAAACUwAAAAADUwAAAAADAAAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAUwAAAAADUwAAAAACUwAAAAADUwAAAAACHwAAAAACGgAAAAADGgAAAAABGgAAAAADUwAAAAABUwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAUwAAAAAAUwAAAAADUwAAAAABUwAAAAACUwAAAAABUwAAAAACcAAAAAAAGgAAAAAAGgAAAAADGgAAAAAAcAAAAAAAUwAAAAAC
           version: 6
         -3,0:
           ind: -3,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWwAAAAADUwAAAAADUwAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWwAAAAABWwAAAAABUwAAAAADUwAAAAABUwAAAAAAUwAAAAAAUwAAAAACcAAAAAAAUwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWwAAAAABUwAAAAACUwAAAAADUwAAAAACUwAAAAAAUwAAAAABUwAAAAAAcAAAAAAAUwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAABUwAAAAACUwAAAAACUwAAAAACcAAAAAAAWwAAAAACcAAAAAAAcAAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWwAAAAABUwAAAAADUwAAAAADUwAAAAACcAAAAAAAUwAAAAACUwAAAAABWwAAAAABUwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWwAAAAADWwAAAAABUwAAAAACUwAAAAADcAAAAAAAWwAAAAADUwAAAAACWwAAAAACUwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWwAAAAABUwAAAAADUwAAAAADUwAAAAABUwAAAAACUwAAAAACUwAAAAABWwAAAAACUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAbQAAAAADbQAAAAACcAAAAAAAUwAAAAADUwAAAAAAUwAAAAACUwAAAAADUwAAAAADUwAAAAADUwAAAAAAWwAAAAAAUwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAbQAAAAACbQAAAAABcAAAAAAAUwAAAAAAUwAAAAADUwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAbQAAAAADbQAAAAACWwAAAAABUwAAAAABUwAAAAAAUwAAAAAAcAAAAAAAGgAAAAABGgAAAAABGgAAAAAAcAAAAAAAUwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAbQAAAAABbQAAAAAAcAAAAAAAUwAAAAACUwAAAAAAUwAAAAADHwAAAAABGgAAAAABGgAAAAABGgAAAAAAcAAAAAAAUwAAAAACcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbQAAAAACbQAAAAADcAAAAAAAUwAAAAABUwAAAAABUwAAAAACcAAAAAAAGgAAAAABGgAAAAAAGgAAAAACcAAAAAAAUwAAAAAAUwAAAAADUwAAAAACWwAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAcAAAAAAAcAAAAAAAUwAAAAABUwAAAAABUwAAAAABUwAAAAAAUwAAAAADUwAAAAAAUwAAAAACUwAAAAADUwAAAAAAUwAAAAAAUwAAAAADUwAAAAABUwAAAAACUwAAAAAAUwAAAAABUwAAAAADUwAAAAAAUwAAAAABUwAAAAABUwAAAAAAUwAAAAAAUwAAAAACUwAAAAAAUwAAAAABUwAAAAADUwAAAAACUwAAAAADUwAAAAACUwAAAAADUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAACUwAAAAABUwAAAAACUwAAAAADUwAAAAACUwAAAAACUwAAAAADUwAAAAADUwAAAAAAUwAAAAADUwAAAAADUwAAAAABUwAAAAABUwAAAAAAUwAAAAABUwAAAAADUwAAAAAD
+          tiles: cAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAUwAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAUwAAAAADUwAAAAABUwAAAAAAUwAAAAAAUwAAAAACcAAAAAAAUwAAAAACcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAUwAAAAADUwAAAAACUwAAAAAAUwAAAAABUwAAAAAAcAAAAAAAUwAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAUwAAAAACUwAAAAACcAAAAAAAWwAAAAACcAAAAAAAcAAAAAAAUwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAUwAAAAADUwAAAAACcAAAAAAAUwAAAAACUwAAAAABWwAAAAABUwAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAACUwAAAAADcAAAAAAAWwAAAAADUwAAAAACWwAAAAACUwAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAUwAAAAADUwAAAAADUwAAAAABUwAAAAACUwAAAAACUwAAAAABWwAAAAACUwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAbQAAAAADbQAAAAACcAAAAAAAUwAAAAADUwAAAAAAUwAAAAACUwAAAAADUwAAAAADUwAAAAADUwAAAAAAWwAAAAAAUwAAAAADAAAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAbQAAAAACbQAAAAABcAAAAAAAUwAAAAAAUwAAAAADUwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAbwAAAAAAcAAAAAAAbQAAAAADbQAAAAACWwAAAAABUwAAAAABUwAAAAAAUwAAAAAAcAAAAAAAGgAAAAABGgAAAAABGgAAAAAAcAAAAAAAUwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAbQAAAAABbQAAAAAAcAAAAAAAUwAAAAACUwAAAAAAUwAAAAADHwAAAAABGgAAAAABGgAAAAABGgAAAAAAcAAAAAAAUwAAAAACcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbQAAAAACbQAAAAADcAAAAAAAUwAAAAABUwAAAAABUwAAAAACcAAAAAAAGgAAAAABGgAAAAAAGgAAAAACcAAAAAAAUwAAAAAAUwAAAAADUwAAAAACWwAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAWwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAUwAAAAAAcAAAAAAAcAAAAAAAUwAAAAABUwAAAAABUwAAAAABUwAAAAAAUwAAAAADUwAAAAAAUwAAAAACUwAAAAADUwAAAAAAUwAAAAAAUwAAAAADUwAAAAABUwAAAAACUwAAAAAAUwAAAAABUwAAAAADUwAAAAAAUwAAAAABUwAAAAABUwAAAAAAUwAAAAAAUwAAAAACUwAAAAAAUwAAAAABUwAAAAADUwAAAAACUwAAAAADUwAAAAACUwAAAAADUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAACUwAAAAABUwAAAAACUwAAAAADUwAAAAACUwAAAAACUwAAAAADUwAAAAADUwAAAAAAUwAAAAADUwAAAAADUwAAAAABUwAAAAABUwAAAAAAUwAAAAABUwAAAAADUwAAAAAD
           version: 6
         -3,1:
           ind: -3,1
@@ -272,7 +272,7 @@ entities:
           version: 6
         -1,-3:
           ind: -1,-3
-          tiles: cAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAHwAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGgAAAAACGgAAAAADGgAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAYAAAAAAAGgAAAAADGgAAAAABGgAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAGgAAAAACGgAAAAADGgAAAAACcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAGgAAAAADGgAAAAABGgAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAGgAAAAACGgAAAAACGgAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAGgAAAAABGgAAAAACGgAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAA
+          tiles: cAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAHwAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAGgAAAAACGgAAAAADGgAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAcAAAAAAAYAAAAAAAGgAAAAADGgAAAAABGgAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAGgAAAAACGgAAAAADGgAAAAACcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAGgAAAAADGgAAAAABGgAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAGgAAAAACGgAAAAACGgAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAXwAAAAAAcAAAAAAAGgAAAAABGgAAAAACGgAAAAADcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAcAAAAAAAcAAAAAAAcAAAAAAA
           version: 6
         -2,-3:
           ind: -2,-3
@@ -449,28 +449,6 @@ entities:
           decals:
             5129: -41,24
             5130: -41,22
-        - node:
-            color: '#FFFFFFFF'
-            id: Box
-          decals:
-            1988: -41,6
-            1989: -41,0
-            1990: -44,-5
-            1991: -44,-6
-            1992: -44,-7
-            1993: -44,-8
-            1994: -43,-8
-            1995: -43,-7
-            1996: -43,-6
-            1997: -43,-5
-            1998: -39,-5
-            1999: -39,-6
-            2000: -39,-7
-            2001: -39,-8
-            2002: -40,-8
-            2003: -40,-7
-            2004: -40,-6
-            2005: -40,-5
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkBox
@@ -1088,6 +1066,7 @@ entities:
             1360: -8,-12
             1759: 4,19
             1798: -45,41
+            5280: -40,-6
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelCornerNw
@@ -1104,6 +1083,7 @@ entities:
             2067: -36,7
             2112: -4,57
             2328: 26,18
+            5279: -43,-6
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelCornerSe
@@ -1112,6 +1092,7 @@ entities:
             1318: -10,-15
             1341: 11,-15
             2322: 23,20
+            5282: -40,-7
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelCornerSw
@@ -1123,6 +1104,7 @@ entities:
             1340: 8,-15
             2068: -36,4
             2107: -4,52
+            5281: -43,-7
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelEndN
@@ -1245,6 +1227,8 @@ entities:
             2071: -34,7
             2113: -3,57
             2327: 27,18
+            5283: -41,-6
+            5284: -42,-6
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineS
@@ -1270,6 +1254,8 @@ entities:
             2106: -3,52
             2325: 21,20
             2339: 22,20
+            5285: -42,-7
+            5286: -41,-7
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineW
@@ -1319,7 +1305,6 @@ entities:
             2041: -41,9
             2042: -41,10
             2043: -41,11
-            2044: -41,3
             2069: -36,6
             2108: -4,53
             2109: -4,54
@@ -2145,7 +2130,6 @@ entities:
             2060: -41,9
             2061: -41,8
             2062: -41,7
-            2063: -41,3
             2064: -44,-1
             2065: -44,-2
             2066: -44,-3
@@ -2162,6 +2146,7 @@ entities:
             5120: -43,23
             5121: -43,22
             5122: -43,21
+            5288: -41,6
         - node:
             color: '#D381C996'
             id: BrickTileWhiteLineW
@@ -2515,13 +2500,6 @@ entities:
             1277: -13,-28
             1278: -13,-27
         - node:
-            angle: 1.5707963267948966 rad
-            color: '#FFFFFFFF'
-            id: Delivery
-          decals:
-            1986: -41,2
-            1987: -41,4
-        - node:
             color: '#52B4E996'
             id: DeliveryGreyscale
           decals:
@@ -2733,10 +2711,7 @@ entities:
             2569: -36,2
             2570: -37,2
             2571: -39,2
-            2572: -41,1
-            2573: -41,0
             2574: -40,0
-            2575: -40,1
             2576: -42,2
             2577: -43,2
             2578: -44,2
@@ -2757,19 +2732,6 @@ entities:
             2593: -41,-1
             2594: -42,-3
             2595: -41,-3
-            2596: -42,-4
-            2597: -41,-4
-            2598: -42,-5
-            2599: -42,-6
-            2600: -41,-7
-            2601: -42,-8
-            2602: -44,-8
-            2603: -43,-6
-            2604: -40,-6
-            2605: -39,-6
-            2606: -39,-8
-            2607: -41,-8
-            2608: -39,-5
             2609: -42,-2
             2610: -42,-1
             2611: -39,-2
@@ -4283,18 +4245,11 @@ entities:
             4469: -36,15
             4470: -36,15
             4471: -35,15
-            4472: -40,5
             4473: -39,4
             4474: -40,3
-            4475: -41,3
             4476: -40,2
-            4477: -40,1
-            4478: -41,0
             4479: -40,0
             4480: -40,-1
-            4481: -42,-5
-            4482: -42,-7
-            4483: -41,-7
             4484: -41,-1
             4485: -41,-2
             4486: -42,-2
@@ -4696,10 +4651,6 @@ entities:
             4509: -39,4
             4510: -39,5
             4511: -40,2
-            4512: -40,1
-            4513: -41,2
-            4514: -41,4
-            4515: -41,4
             4538: -38,6
             4539: -39,4
             4540: -38,3
@@ -5662,14 +5613,19 @@ entities:
           decals:
             2082: -36,5
         - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            5277: -43,1
+        - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
-            1984: -40,1
-            1985: -40,5
             5127: -42,24
             5128: -42,22
+            5276: -43,5
         - node:
             angle: -1.5707963267948966 rad
             color: '#52B4E996'
@@ -6414,8 +6370,6 @@ entities:
             1979: -42,9
             1980: -38,10
             1981: -36,3
-            1982: -42,-4
-            1983: -41,-4
             2319: -20,-13
             2320: -21,-13
             4969: -40,12
@@ -6498,6 +6452,7 @@ entities:
             1653: 8,-39
             2295: -22,-16
             5073: -14,35
+            5264: -40,4
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerNW
@@ -6506,6 +6461,7 @@ entities:
             2294: -24,-16
             5078: -16,35
             5104: 25,31
+            5263: -42,4
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSE
@@ -6513,6 +6469,7 @@ entities:
             1058: -14,32
             1651: 8,-42
             2293: -22,-18
+            5265: -40,0
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSW
@@ -6523,6 +6480,7 @@ entities:
             5094: -7,-18
             5096: 13,-34
             5105: 27,34
+            5262: -42,0
         - node:
             angle: 4.71238898038469 rad
             color: '#FFFFFFFF'
@@ -6572,10 +6530,6 @@ entities:
             1649: 8,-41
             1921: 12,-18
             1922: 12,-19
-            2006: -41,-5
-            2007: -41,-6
-            2008: -41,-7
-            2009: -41,-8
             2297: -22,-17
             5007: 20,-12
             5008: 20,-13
@@ -6585,6 +6539,9 @@ entities:
             5101: 23,31
             5141: -45,27
             5142: -45,28
+            5270: -40,1
+            5271: -40,2
+            5272: -40,3
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
@@ -6613,6 +6570,8 @@ entities:
             5095: -6,-18
             5106: -29,49
             5107: -28,49
+            5268: -41,0
+            5269: -41,0
         - node:
             color: '#FFFFFFFF'
             id: WarnLineS
@@ -6629,10 +6588,6 @@ entities:
             1646: 5,-40
             1919: 11,-19
             1920: 11,-18
-            2010: -42,-5
-            2011: -42,-6
-            2012: -42,-7
-            2013: -42,-8
             2259: 19,-35
             2260: 19,-34
             2261: 19,-36
@@ -6646,6 +6601,9 @@ entities:
             5124: -43,28
             5143: -46,28
             5144: -46,27
+            5273: -42,1
+            5274: -42,2
+            5275: -42,3
         - node:
             color: '#FFA500FF'
             id: WarnLineW
@@ -6666,6 +6624,7 @@ entities:
             5074: -15,35
             5102: 27,31
             5103: 26,31
+            5266: -41,4
         - node:
             color: '#E7B795FF'
             id: WoodTrimThinCornerNe
@@ -10494,6 +10453,16 @@ entities:
       type: Transform
 - proto: AirlockCargoGlassLocked
   entities:
+  - uid: 255
+    components:
+    - pos: -40.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 4141
+    components:
+    - pos: -41.5,-3.5
+      parent: 1
+      type: Transform
   - uid: 9354
     components:
     - rot: 1.5707963267948966 rad
@@ -10884,14 +10853,14 @@ entities:
       type: Transform
 - proto: AirlockExternalGlassCargoLocked
   entities:
-  - uid: 6636
+  - uid: 2971
     components:
-    - pos: -41.5,2.5
+    - pos: -44.5,2.5
       parent: 1
       type: Transform
-  - uid: 6637
+  - uid: 4162
     components:
-    - pos: -41.5,4.5
+    - pos: -44.5,4.5
       parent: 1
       type: Transform
   - uid: 7814
@@ -11031,18 +11000,6 @@ entities:
       pos: 52.5,13.5
       parent: 1
       type: Transform
-  - uid: 111
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -44.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 112
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -44.5,4.5
-      parent: 1
-      type: Transform
   - uid: 467
     components:
     - rot: -1.5707963267948966 rad
@@ -11087,6 +11044,18 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -53.5,38.5
+      parent: 1
+      type: Transform
+  - uid: 1766
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -47.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 2070
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -47.5,4.5
       parent: 1
       type: Transform
   - uid: 2145
@@ -12858,6 +12827,26 @@ entities:
     - pos: 51.5,-14.5
       parent: 1
       type: Transform
+  - uid: 2606
+    components:
+    - pos: -47.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 2609
+    components:
+    - pos: -47.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 4137
+    components:
+    - pos: -44.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 4148
+    components:
+    - pos: -44.5,2.5
+      parent: 1
+      type: Transform
   - uid: 6771
     components:
     - pos: 52.5,13.5
@@ -12952,18 +12941,6 @@ entities:
       pos: 3.5,-1.5
       parent: 8756
       type: Transform
-  - uid: 17635
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -44.5,4.5
-      parent: 1
-      type: Transform
-  - uid: 17636
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -44.5,2.5
-      parent: 1
-      type: Transform
   - uid: 17637
     components:
     - rot: 3.141592653589793 rad
@@ -13026,6 +13003,21 @@ entities:
       type: Transform
 - proto: AtmosFixBlockerMarker
   entities:
+  - uid: 2706
+    components:
+    - pos: -3.5,-44.5
+      parent: 1
+      type: Transform
+  - uid: 2716
+    components:
+    - pos: -3.5,-43.5
+      parent: 1
+      type: Transform
+  - uid: 2729
+    components:
+    - pos: -3.5,-45.5
+      parent: 1
+      type: Transform
   - uid: 7045
     components:
     - pos: -1.5,-25.5
@@ -14065,40 +14057,105 @@ entities:
     - links:
       - 4305
       type: DeviceLinkSink
+- proto: BlastDoorExterior3Open
+  entities:
+  - uid: 9639
+    components:
+    - pos: -19.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9640
+    components:
+    - pos: -18.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9641
+    components:
+    - pos: -16.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9642
+    components:
+    - pos: -15.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9643
+    components:
+    - pos: -13.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9644
+    components:
+    - pos: -12.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9645
+    components:
+    - pos: -9.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9646
+    components:
+    - pos: -10.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9647
+    components:
+    - pos: -6.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9648
+    components:
+    - pos: -7.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9649
+    components:
+    - pos: -3.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9650
+    components:
+    - pos: -4.5,39.5
+      parent: 1
+      type: Transform
+  - uid: 9651
+    components:
+    - pos: -3.5,48.5
+      parent: 1
+      type: Transform
+  - uid: 9652
+    components:
+    - pos: -3.5,49.5
+      parent: 1
+      type: Transform
+  - uid: 9653
+    components:
+    - pos: -3.5,50.5
+      parent: 1
+      type: Transform
+  - uid: 9654
+    components:
+    - pos: -4.5,53.5
+      parent: 1
+      type: Transform
+  - uid: 9655
+    components:
+    - pos: -4.5,54.5
+      parent: 1
+      type: Transform
+  - uid: 9656
+    components:
+    - pos: -4.5,56.5
+      parent: 1
+      type: Transform
+  - uid: 9657
+    components:
+    - pos: -4.5,57.5
+      parent: 1
+      type: Transform
 - proto: BlastDoorOpen
   entities:
-  - uid: 109
-    components:
-    - pos: -44.5,5.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9363
-      type: DeviceLinkSink
-  - uid: 110
-    components:
-    - pos: -44.5,1.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9363
-      type: DeviceLinkSink
-  - uid: 286
-    components:
-    - pos: -41.5,1.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9363
-      type: DeviceLinkSink
-  - uid: 287
-    components:
-    - pos: -41.5,5.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9363
-      type: DeviceLinkSink
   - uid: 1048
     components:
     - pos: -6.5,27.5
@@ -14107,14 +14164,51 @@ entities:
     - links:
       - 8572
       type: DeviceLinkSink
+  - uid: 2129
+    components:
+    - pos: -44.5,5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 2291
+      type: DeviceLinkSink
+  - uid: 2130
+    components:
+    - pos: -47.5,1.5
+      parent: 1
+      type: Transform
+    - links:
+      - 2128
+      type: DeviceLinkSink
+  - uid: 2607
+    components:
+    - pos: -44.5,1.5
+      parent: 1
+      type: Transform
+    - links:
+      - 2291
+      type: DeviceLinkSink
+  - uid: 2610
+    components:
+    - pos: -47.5,5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 2612
+      type: DeviceLinkSink
   - uid: 2813
     components:
     - pos: -11.5,-26.5
       parent: 1
       type: Transform
-    - SecondsUntilStateChange: -66676.36
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 8738
       type: DeviceLinkSink
@@ -14123,9 +14217,14 @@ entities:
     - pos: -11.5,-27.5
       parent: 1
       type: Transform
-    - SecondsUntilStateChange: -66676.36
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 8738
       type: DeviceLinkSink
@@ -14134,9 +14233,14 @@ entities:
     - pos: -11.5,-28.5
       parent: 1
       type: Transform
-    - SecondsUntilStateChange: -66676.36
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 8738
       type: DeviceLinkSink
@@ -14145,9 +14249,14 @@ entities:
     - pos: -11.5,-29.5
       parent: 1
       type: Transform
-    - SecondsUntilStateChange: -66676.36
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 8738
       type: DeviceLinkSink
@@ -14188,9 +14297,14 @@ entities:
     - pos: 19.5,-38.5
       parent: 1
       type: Transform
-    - SecondsUntilStateChange: -65669.61
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 17649
       type: DeviceLinkSink
@@ -14199,9 +14313,14 @@ entities:
     - pos: 14.5,-23.5
       parent: 1
       type: Transform
-    - SecondsUntilStateChange: -65692.28
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
+    - airBlocked: True
+      type: Airtight
     - links:
       - 17648
       type: DeviceLinkSink
@@ -14531,6 +14650,13 @@ entities:
     - pos: -0.5525799,82.65699
       parent: 1
       type: Transform
+- proto: BoxFolderClipboard
+  entities:
+  - uid: 9636
+    components:
+    - pos: -38.639683,-6.348105
+      parent: 1
+      type: Transform
 - proto: BoxFolderGrey
   entities:
   - uid: 3446
@@ -14792,13 +14918,6 @@ entities:
       pos: -8.5,43.5
       parent: 1
       type: Transform
-- proto: Brutepack
-  entities:
-  - uid: 7815
-    components:
-    - pos: -42.603355,21.659529
-      parent: 1
-      type: Transform
 - proto: Bucket
   entities:
   - uid: 9006
@@ -14825,8 +14944,6 @@ entities:
     - pos: 51.5,-7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 168
     components:
     - pos: 48.5,-12.5
@@ -14862,8 +14979,6 @@ entities:
     - pos: 51.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2038
     components:
     - pos: 48.5,-13.5
@@ -14884,18 +14999,19 @@ entities:
     - pos: 50.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2059
     components:
     - pos: 50.5,-7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2060
     components:
     - pos: 46.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 2622
+    components:
+    - pos: -42.5,1.5
       parent: 1
       type: Transform
   - uid: 2635
@@ -14908,20 +15024,21 @@ entities:
     - pos: -17.5,31.5
       parent: 1
       type: Transform
+  - uid: 5533
+    components:
+    - pos: -42.5,0.5
+      parent: 1
+      type: Transform
   - uid: 6000
     components:
     - pos: -29.5,-17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6022
     components:
     - pos: -18.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6521
     components:
     - pos: 48.5,-10.5
@@ -14952,8 +15069,6 @@ entities:
     - pos: 26.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7652
     components:
     - pos: -27.5,-28.5
@@ -14989,57 +15104,41 @@ entities:
     - pos: -43.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7942
     components:
     - pos: -44.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7943
     components:
     - pos: -45.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7944
     components:
     - pos: -45.5,21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8009
     components:
     - pos: -45.5,20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8140
     components:
     - pos: -43.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8141
     components:
     - pos: -44.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8142
     components:
     - pos: -45.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8143
     components:
     - pos: -42.5,27.5
@@ -15095,13 +15194,41 @@ entities:
     - pos: -2.5,1.5
       parent: 1
       type: Transform
+  - uid: 8518
+    components:
+    - pos: -44.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 8598
+    components:
+    - pos: -45.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 8599
+    components:
+    - pos: -46.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 8600
+    components:
+    - pos: -45.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 8601
+    components:
+    - pos: -46.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 8701
+    components:
+    - pos: -44.5,4.5
+      parent: 1
+      type: Transform
   - uid: 8830
     components:
     - pos: 1.5,-5.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8831
     components:
     - pos: 1.5,-4.5
@@ -15117,8 +15244,6 @@ entities:
     - pos: 1.5,-2.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8834
     components:
     - pos: 1.5,-1.5
@@ -15129,8 +15254,6 @@ entities:
     - pos: 1.5,-0.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8836
     components:
     - pos: 1.5,0.5
@@ -15146,8 +15269,6 @@ entities:
     - pos: 0.5,1.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8839
     components:
     - pos: 0.5,2.5
@@ -15178,8 +15299,6 @@ entities:
     - pos: -1.5,1.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8845
     components:
     - pos: -1.5,0.5
@@ -15195,8 +15314,6 @@ entities:
     - pos: -2.5,-0.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8848
     components:
     - pos: -2.5,-1.5
@@ -15207,8 +15324,6 @@ entities:
     - pos: -2.5,-2.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8850
     components:
     - pos: -2.5,-3.5
@@ -15224,8 +15339,6 @@ entities:
     - pos: -2.5,-5.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8853
     components:
     - pos: -1.5,-5.5
@@ -15246,8 +15359,6 @@ entities:
     - pos: 1.5,-5.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9620
     components:
     - pos: 19.5,28.5
@@ -15263,8 +15374,6 @@ entities:
     - pos: -22.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9738
     components:
     - pos: -22.5,-18.5
@@ -15320,22 +15429,16 @@ entities:
     - pos: -22.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9749
     components:
     - pos: -22.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9750
     components:
     - pos: -22.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9751
     components:
     - pos: -22.5,-23.5
@@ -15351,8 +15454,6 @@ entities:
     - pos: -20.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9754
     components:
     - pos: -20.5,-21.5
@@ -15373,8 +15474,6 @@ entities:
     - pos: -20.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9758
     components:
     - pos: -23.5,-20.5
@@ -15390,15 +15489,11 @@ entities:
     - pos: -24.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9761
     components:
     - pos: -24.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9762
     components:
     - pos: -24.5,-23.5
@@ -15409,15 +15504,11 @@ entities:
     - pos: -24.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9776
     components:
     - pos: -31.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9777
     components:
     - pos: -31.5,-14.5
@@ -15428,36 +15519,26 @@ entities:
     - pos: -31.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9779
     components:
     - pos: -31.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9780
     components:
     - pos: -30.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9781
     components:
     - pos: -29.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9782
     components:
     - pos: -28.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9783
     components:
     - pos: -27.5,-16.5
@@ -15468,183 +15549,131 @@ entities:
     - pos: -26.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9785
     components:
     - pos: -25.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9786
     components:
     - pos: -25.5,-17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9787
     components:
     - pos: -25.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9788
     components:
     - pos: -29.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9789
     components:
     - pos: -29.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9790
     components:
     - pos: -28.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9791
     components:
     - pos: -27.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9792
     components:
     - pos: -27.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9793
     components:
     - pos: -27.5,-12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9794
     components:
     - pos: -27.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9795
     components:
     - pos: -32.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9796
     components:
     - pos: -33.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9797
     components:
     - pos: -34.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9798
     components:
     - pos: -35.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9799
     components:
     - pos: -35.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9800
     components:
     - pos: -35.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9801
     components:
     - pos: -35.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9802
     components:
     - pos: -35.5,-12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9803
     components:
     - pos: -35.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9804
     components:
     - pos: -35.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9805
     components:
     - pos: -35.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9806
     components:
     - pos: -35.5,-8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9807
     components:
     - pos: -35.5,-7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9808
     components:
     - pos: -36.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9809
     components:
     - pos: -37.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9810
     components:
     - pos: -38.5,-11.5
@@ -15665,15 +15694,11 @@ entities:
     - pos: -40.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9814
     components:
     - pos: -40.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9818
     components:
     - pos: -44.5,-9.5
@@ -15684,8 +15709,6 @@ entities:
     - pos: -45.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9820
     components:
     - pos: -46.5,-9.5
@@ -15696,106 +15719,76 @@ entities:
     - pos: -47.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9822
     components:
     - pos: -48.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9823
     components:
     - pos: -49.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9824
     components:
     - pos: -50.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9825
     components:
     - pos: -51.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9826
     components:
     - pos: -52.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9827
     components:
     - pos: -49.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9828
     components:
     - pos: -49.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9829
     components:
     - pos: -47.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9830
     components:
     - pos: -47.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9831
     components:
     - pos: -50.5,-8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9832
     components:
     - pos: -50.5,-7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9833
     components:
     - pos: -51.5,-7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9834
     components:
     - pos: -52.5,-7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9835
     components:
     - pos: -49.5,-7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9836
     components:
     - pos: -48.5,-7.5
@@ -15811,8 +15804,6 @@ entities:
     - pos: -46.5,-7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9839
     components:
     - pos: -45.5,-7.5
@@ -15823,92 +15814,66 @@ entities:
     - pos: -45.5,-8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9990
     components:
     - pos: -29.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9991
     components:
     - pos: -29.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9992
     components:
     - pos: -29.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9993
     components:
     - pos: -29.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9994
     components:
     - pos: -29.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9995
     components:
     - pos: -29.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9996
     components:
     - pos: -30.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9997
     components:
     - pos: -31.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9998
     components:
     - pos: -31.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9999
     components:
     - pos: -31.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10000
     components:
     - pos: -31.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10001
     components:
     - pos: -31.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10002
     components:
     - pos: -32.5,-19.5
@@ -15929,148 +15894,106 @@ entities:
     - pos: -28.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10006
     components:
     - pos: -27.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10007
     components:
     - pos: -26.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10008
     components:
     - pos: -29.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10009
     components:
     - pos: -29.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10010
     components:
     - pos: -29.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10011
     components:
     - pos: -28.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10012
     components:
     - pos: -27.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10013
     components:
     - pos: -26.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10014
     components:
     - pos: -25.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10015
     components:
     - pos: -24.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10016
     components:
     - pos: -23.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10017
     components:
     - pos: -22.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10018
     components:
     - pos: -21.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10019
     components:
     - pos: -20.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10020
     components:
     - pos: -20.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10021
     components:
     - pos: -20.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10022
     components:
     - pos: -20.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10023
     components:
     - pos: -20.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10024
     components:
     - pos: -20.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10025
     components:
     - pos: -19.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10026
     components:
     - pos: -19.5,-32.5
@@ -16086,15 +16009,11 @@ entities:
     - pos: -19.5,-34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10029
     components:
     - pos: -19.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10030
     components:
     - pos: -19.5,-36.5
@@ -16135,141 +16054,101 @@ entities:
     - pos: -16.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10038
     components:
     - pos: -16.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10039
     components:
     - pos: -16.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10040
     components:
     - pos: -16.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10041
     components:
     - pos: -17.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10042
     components:
     - pos: -18.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10043
     components:
     - pos: -18.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10044
     components:
     - pos: -18.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10045
     components:
     - pos: -18.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10046
     components:
     - pos: -18.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10047
     components:
     - pos: -18.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10049
     components:
     - pos: -17.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10050
     components:
     - pos: -16.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10051
     components:
     - pos: -16.5,-32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10052
     components:
     - pos: -16.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10053
     components:
     - pos: -16.5,-34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10054
     components:
     - pos: -16.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10055
     components:
     - pos: -16.5,-36.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10056
     components:
     - pos: -16.5,-37.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10057
     components:
     - pos: -16.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10058
     components:
     - pos: -16.5,-39.5
@@ -16285,8 +16164,6 @@ entities:
     - pos: 29.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10165
     components:
     - pos: 29.5,-13.5
@@ -16327,127 +16204,91 @@ entities:
     - pos: 29.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10173
     components:
     - pos: 28.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10174
     components:
     - pos: 27.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10175
     components:
     - pos: 26.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10176
     components:
     - pos: 25.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10177
     components:
     - pos: 24.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10178
     components:
     - pos: 24.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10179
     components:
     - pos: 24.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10180
     components:
     - pos: 24.5,-12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10181
     components:
     - pos: 24.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10182
     components:
     - pos: 24.5,-17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10183
     components:
     - pos: 24.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10184
     components:
     - pos: 24.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10185
     components:
     - pos: 24.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10186
     components:
     - pos: 24.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10187
     components:
     - pos: 24.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10188
     components:
     - pos: 24.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10189
     components:
     - pos: 24.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10190
     components:
     - pos: 23.5,-24.5
@@ -16463,127 +16304,91 @@ entities:
     - pos: 22.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10193
     components:
     - pos: 22.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10194
     components:
     - pos: 22.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10195
     components:
     - pos: 21.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10196
     components:
     - pos: 21.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10197
     components:
     - pos: 21.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10198
     components:
     - pos: 20.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10199
     components:
     - pos: 19.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10200
     components:
     - pos: 18.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10201
     components:
     - pos: 17.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10202
     components:
     - pos: 16.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10203
     components:
     - pos: 15.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10204
     components:
     - pos: 15.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10205
     components:
     - pos: 15.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10206
     components:
     - pos: 15.5,-32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10207
     components:
     - pos: 15.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10208
     components:
     - pos: 15.5,-34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10209
     components:
     - pos: 15.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10210
     components:
     - pos: 16.5,-34.5
@@ -16624,8 +16429,6 @@ entities:
     - pos: 19.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10218
     components:
     - pos: 15.5,-36.5
@@ -16656,162 +16459,116 @@ entities:
     - pos: 30.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10224
     components:
     - pos: 31.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10225
     components:
     - pos: 32.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10226
     components:
     - pos: 32.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10227
     components:
     - pos: 32.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10228
     components:
     - pos: 32.5,-12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10229
     components:
     - pos: 32.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10230
     components:
     - pos: 33.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10231
     components:
     - pos: 34.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10232
     components:
     - pos: 35.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10233
     components:
     - pos: 36.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10234
     components:
     - pos: 37.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10235
     components:
     - pos: 38.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10236
     components:
     - pos: 39.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10237
     components:
     - pos: 30.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10238
     components:
     - pos: 30.5,-17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10239
     components:
     - pos: 30.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10240
     components:
     - pos: 30.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10241
     components:
     - pos: 30.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10242
     components:
     - pos: 30.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10243
     components:
     - pos: 30.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10244
     components:
     - pos: 30.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10245
     components:
     - pos: 30.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10246
     components:
     - pos: 29.5,-19.5
@@ -16822,64 +16579,46 @@ entities:
     - pos: 28.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10248
     components:
     - pos: 27.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10249
     components:
     - pos: 26.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10250
     components:
     - pos: 29.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10251
     components:
     - pos: 28.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10252
     components:
     - pos: 27.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10253
     components:
     - pos: 26.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10254
     components:
     - pos: 25.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10255
     components:
     - pos: 31.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10256
     components:
     - pos: 32.5,-20.5
@@ -16890,8 +16629,6 @@ entities:
     - pos: 33.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10258
     components:
     - pos: 34.5,-20.5
@@ -16902,29 +16639,21 @@ entities:
     - pos: 35.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10261
     components:
     - pos: 37.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10262
     components:
     - pos: 37.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10263
     components:
     - pos: 37.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10264
     components:
     - pos: 37.5,-16.5
@@ -16940,8 +16669,6 @@ entities:
     - pos: 36.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10267
     components:
     - pos: 35.5,-15.5
@@ -16957,15 +16684,11 @@ entities:
     - pos: 34.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10270
     components:
     - pos: 31.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10271
     components:
     - pos: 32.5,-24.5
@@ -16976,8 +16699,6 @@ entities:
     - pos: -41.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10310
     components:
     - pos: -42.5,7.5
@@ -16993,22 +16714,16 @@ entities:
     - pos: -44.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10313
     components:
     - pos: -44.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10314
     components:
     - pos: -44.5,9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10315
     components:
     - pos: -43.5,9.5
@@ -17099,8 +16814,6 @@ entities:
     - pos: -36.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10333
     components:
     - pos: -37.5,4.5
@@ -17256,43 +16969,31 @@ entities:
     - pos: -41.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10364
     components:
     - pos: -42.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10365
     components:
     - pos: -43.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10366
     components:
     - pos: -42.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10367
     components:
     - pos: -43.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10368
     components:
     - pos: -41.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10369
     components:
     - pos: -41.5,-1.5
@@ -17368,8 +17069,6 @@ entities:
     - pos: 16.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10444
     components:
     - pos: 17.5,-21.5
@@ -17380,15 +17079,11 @@ entities:
     - pos: 17.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10446
     components:
     - pos: 18.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10447
     components:
     - pos: 17.5,-22.5
@@ -17414,15 +17109,11 @@ entities:
     - pos: 17.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10452
     components:
     - pos: 18.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10453
     components:
     - pos: 18.5,-23.5
@@ -17433,22 +17124,16 @@ entities:
     - pos: 19.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10455
     components:
     - pos: 19.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10456
     components:
     - pos: 19.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10457
     components:
     - pos: 16.5,-23.5
@@ -17459,15 +17144,11 @@ entities:
     - pos: 5.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10471
     components:
     - pos: 5.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10472
     components:
     - pos: 5.5,-29.5
@@ -17478,29 +17159,21 @@ entities:
     - pos: 5.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10474
     components:
     - pos: 6.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10475
     components:
     - pos: 7.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10476
     components:
     - pos: 8.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10477
     components:
     - pos: 8.5,-29.5
@@ -17511,15 +17184,11 @@ entities:
     - pos: 8.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10479
     components:
     - pos: 7.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10480
     components:
     - pos: 7.5,-31.5
@@ -17555,29 +17224,21 @@ entities:
     - pos: 7.5,-37.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10487
     components:
     - pos: 7.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10488
     components:
     - pos: 7.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10489
     components:
     - pos: 7.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10490
     components:
     - pos: 6.5,-36.5
@@ -17703,64 +17364,46 @@ entities:
     - pos: 12.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10515
     components:
     - pos: 12.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10516
     components:
     - pos: 12.5,-41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10517
     components:
     - pos: 12.5,-42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10518
     components:
     - pos: 12.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10519
     components:
     - pos: 12.5,-44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10520
     components:
     - pos: 12.5,-45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10521
     components:
     - pos: 12.5,-46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10522
     components:
     - pos: 12.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10523
     components:
     - pos: 13.5,-34.5
@@ -17806,8 +17449,6 @@ entities:
     - pos: 10.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10532
     components:
     - pos: 9.5,-29.5
@@ -17858,8 +17499,6 @@ entities:
     - pos: 10.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10550
     components:
     - pos: 10.5,-20.5
@@ -17970,8 +17609,6 @@ entities:
     - pos: 10.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10572
     components:
     - pos: 9.5,-20.5
@@ -18092,8 +17729,6 @@ entities:
     - pos: 6.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10597
     components:
     - pos: 6.5,-15.5
@@ -18244,36 +17879,26 @@ entities:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10627
     components:
     - pos: 3.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10628
     components:
     - pos: 2.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10629
     components:
     - pos: 1.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10630
     components:
     - pos: 0.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10648
     components:
     - pos: 21.5,-11.5
@@ -18329,15 +17954,11 @@ entities:
     - pos: 19.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10660
     components:
     - pos: 18.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10661
     components:
     - pos: 20.5,-15.5
@@ -18358,8 +17979,6 @@ entities:
     - pos: -11.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10725
     components:
     - pos: -11.5,-37.5
@@ -18385,575 +18004,411 @@ entities:
     - pos: -13.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10730
     components:
     - pos: -13.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10731
     components:
     - pos: -13.5,-41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10732
     components:
     - pos: -13.5,-42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10733
     components:
     - pos: -13.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10734
     components:
     - pos: -13.5,-44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10735
     components:
     - pos: -13.5,-45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10736
     components:
     - pos: -13.5,-46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10737
     components:
     - pos: -13.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10738
     components:
     - pos: -12.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10739
     components:
     - pos: -11.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10740
     components:
     - pos: -10.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10741
     components:
     - pos: -9.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10742
     components:
     - pos: -8.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10743
     components:
     - pos: -7.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10744
     components:
     - pos: -6.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10745
     components:
     - pos: -5.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10746
     components:
     - pos: -4.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10747
     components:
     - pos: -3.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10748
     components:
     - pos: -10.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10749
     components:
     - pos: -9.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10750
     components:
     - pos: -8.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10751
     components:
     - pos: -7.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10752
     components:
     - pos: -6.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10753
     components:
     - pos: -5.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10754
     components:
     - pos: -4.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10755
     components:
     - pos: -4.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10756
     components:
     - pos: -4.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10757
     components:
     - pos: -4.5,-41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10758
     components:
     - pos: -4.5,-37.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10759
     components:
     - pos: -4.5,-36.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10760
     components:
     - pos: -4.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10761
     components:
     - pos: -4.5,-34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10762
     components:
     - pos: -4.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10763
     components:
     - pos: -4.5,-32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10764
     components:
     - pos: -4.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10765
     components:
     - pos: -4.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10766
     components:
     - pos: -4.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10767
     components:
     - pos: -4.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10768
     components:
     - pos: -4.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10769
     components:
     - pos: -4.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10770
     components:
     - pos: -4.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10771
     components:
     - pos: -4.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10772
     components:
     - pos: -4.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10773
     components:
     - pos: -4.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10774
     components:
     - pos: -4.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10775
     components:
     - pos: -4.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10776
     components:
     - pos: -4.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10777
     components:
     - pos: -4.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10778
     components:
     - pos: -3.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10779
     components:
     - pos: -2.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10780
     components:
     - pos: -1.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10781
     components:
     - pos: -0.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10782
     components:
     - pos: 0.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10783
     components:
     - pos: 1.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10784
     components:
     - pos: 1.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10785
     components:
     - pos: 1.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10786
     components:
     - pos: 1.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10787
     components:
     - pos: 1.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10788
     components:
     - pos: 1.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10789
     components:
     - pos: 1.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10790
     components:
     - pos: 1.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10791
     components:
     - pos: 1.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10792
     components:
     - pos: 1.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10793
     components:
     - pos: 1.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10794
     components:
     - pos: 1.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10795
     components:
     - pos: 1.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10796
     components:
     - pos: 1.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10797
     components:
     - pos: 1.5,-32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10798
     components:
     - pos: 1.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10799
     components:
     - pos: 1.5,-34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10800
     components:
     - pos: 1.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10801
     components:
     - pos: 1.5,-36.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10802
     components:
     - pos: 1.5,-37.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10803
     components:
     - pos: 1.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10804
     components:
     - pos: 1.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10805
     components:
     - pos: 1.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10806
     components:
     - pos: 1.5,-41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10807
     components:
     - pos: 1.5,-42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10808
     components:
     - pos: -4.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10809
     components:
     - pos: -4.5,-41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10810
     components:
     - pos: -4.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10811
     components:
     - pos: -11.5,-36.5
@@ -18989,8 +18444,6 @@ entities:
     - pos: -11.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10818
     components:
     - pos: -11.5,-29.5
@@ -19016,8 +18469,6 @@ entities:
     - pos: -11.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10823
     components:
     - pos: -11.5,-24.5
@@ -19043,8 +18494,6 @@ entities:
     - pos: -7.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10828
     components:
     - pos: -7.5,-15.5
@@ -19080,36 +18529,26 @@ entities:
     - pos: -5.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10835
     components:
     - pos: -4.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10836
     components:
     - pos: -3.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10837
     components:
     - pos: -2.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10838
     components:
     - pos: -1.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10839
     components:
     - pos: -6.5,-12.5
@@ -19270,8 +18709,6 @@ entities:
     - pos: 44.5,-6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10993
     components:
     - pos: 45.5,-6.5
@@ -19462,8 +18899,6 @@ entities:
     - pos: 23.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11111
     components:
     - pos: 22.5,-3.5
@@ -19509,22 +18944,16 @@ entities:
     - pos: 18.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11120
     components:
     - pos: 18.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11121
     components:
     - pos: 18.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11122
     components:
     - pos: 18.5,1.5
@@ -19535,8 +18964,6 @@ entities:
     - pos: 18.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11124
     components:
     - pos: 18.5,-4.5
@@ -19712,8 +19139,6 @@ entities:
     - pos: 25.5,-6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11159
     components:
     - pos: 25.5,-5.5
@@ -19804,8 +19229,6 @@ entities:
     - pos: 22.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11177
     components:
     - pos: 23.5,5.5
@@ -19856,99 +19279,71 @@ entities:
     - pos: 21.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11187
     components:
     - pos: 21.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11188
     components:
     - pos: 21.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11189
     components:
     - pos: 21.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11190
     components:
     - pos: 21.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11191
     components:
     - pos: 21.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11192
     components:
     - pos: 21.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11193
     components:
     - pos: 20.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11194
     components:
     - pos: 19.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11195
     components:
     - pos: 18.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11196
     components:
     - pos: 18.5,9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11197
     components:
     - pos: 18.5,10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11198
     components:
     - pos: 18.5,11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11199
     components:
     - pos: 21.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11200
     components:
     - pos: 23.5,6.5
@@ -20099,22 +19494,16 @@ entities:
     - pos: 26.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11231
     components:
     - pos: 26.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11232
     components:
     - pos: 26.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11233
     components:
     - pos: 24.5,3.5
@@ -20130,8 +19519,6 @@ entities:
     - pos: 16.5,9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11246
     components:
     - pos: 15.5,9.5
@@ -20312,127 +19699,91 @@ entities:
     - pos: 13.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11290
     components:
     - pos: 14.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11291
     components:
     - pos: 14.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11292
     components:
     - pos: 14.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11293
     components:
     - pos: 14.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11294
     components:
     - pos: 14.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11295
     components:
     - pos: 14.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11296
     components:
     - pos: 14.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11297
     components:
     - pos: 14.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11298
     components:
     - pos: 14.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11299
     components:
     - pos: 15.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11300
     components:
     - pos: 16.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11301
     components:
     - pos: 17.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11302
     components:
     - pos: 18.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11303
     components:
     - pos: 14.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11304
     components:
     - pos: 14.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11305
     components:
     - pos: 14.5,-4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11306
     components:
     - pos: 15.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11307
     components:
     - pos: 12.5,-1.5
@@ -20598,8 +19949,6 @@ entities:
     - pos: 6.5,75.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11426
     components:
     - pos: 6.5,74.5
@@ -20635,22 +19984,16 @@ entities:
     - pos: 8.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11433
     components:
     - pos: 8.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11434
     components:
     - pos: 8.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11435
     components:
     - pos: 5.5,74.5
@@ -20676,120 +20019,86 @@ entities:
     - pos: 1.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11440
     components:
     - pos: 2.5,75.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11441
     components:
     - pos: 3.5,75.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11442
     components:
     - pos: 1.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11443
     components:
     - pos: 1.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11444
     components:
     - pos: 1.5,71.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11445
     components:
     - pos: 1.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11446
     components:
     - pos: 1.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11447
     components:
     - pos: 2.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11448
     components:
     - pos: 3.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11449
     components:
     - pos: 4.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11450
     components:
     - pos: 5.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11451
     components:
     - pos: 6.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11452
     components:
     - pos: 7.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11453
     components:
     - pos: 8.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11454
     components:
     - pos: 8.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11455
     components:
     - pos: 8.5,71.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11456
     components:
     - pos: 8.5,68.5
@@ -20950,8 +20259,6 @@ entities:
     - pos: -3.5,75.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11488
     components:
     - pos: -3.5,76.5
@@ -21152,57 +20459,41 @@ entities:
     - pos: -0.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11528
     components:
     - pos: -1.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11529
     components:
     - pos: -2.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11530
     components:
     - pos: -3.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11531
     components:
     - pos: 0.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11532
     components:
     - pos: 1.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11533
     components:
     - pos: 2.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11534
     components:
     - pos: -4.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11535
     components:
     - pos: -5.5,74.5
@@ -21253,22 +20544,16 @@ entities:
     - pos: -9.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11545
     components:
     - pos: -10.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11546
     components:
     - pos: -10.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11547
     components:
     - pos: -7.5,72.5
@@ -21294,36 +20579,26 @@ entities:
     - pos: -30.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11612
     components:
     - pos: -30.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11613
     components:
     - pos: -31.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11614
     components:
     - pos: -32.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11615
     components:
     - pos: -33.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11616
     components:
     - pos: -34.5,56.5
@@ -21339,29 +20614,21 @@ entities:
     - pos: -35.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11619
     components:
     - pos: -35.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11620
     components:
     - pos: -35.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11621
     components:
     - pos: -35.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11622
     components:
     - pos: -34.5,52.5
@@ -21372,8 +20639,6 @@ entities:
     - pos: -33.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11624
     components:
     - pos: -32.5,52.5
@@ -21384,22 +20649,16 @@ entities:
     - pos: -31.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11626
     components:
     - pos: -30.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11627
     components:
     - pos: -29.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11628
     components:
     - pos: -28.5,52.5
@@ -21410,8 +20669,6 @@ entities:
     - pos: -27.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11630
     components:
     - pos: -27.5,53.5
@@ -21422,8 +20679,6 @@ entities:
     - pos: -27.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11632
     components:
     - pos: -27.5,55.5
@@ -21434,71 +20689,51 @@ entities:
     - pos: -27.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11634
     components:
     - pos: -28.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11635
     components:
     - pos: -29.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11636
     components:
     - pos: -27.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11637
     components:
     - pos: -26.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11638
     components:
     - pos: -25.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11639
     components:
     - pos: -24.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11640
     components:
     - pos: -24.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11641
     components:
     - pos: -24.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11642
     components:
     - pos: -24.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11643
     components:
     - pos: -24.5,53.5
@@ -21509,57 +20744,41 @@ entities:
     - pos: -24.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11645
     components:
     - pos: -24.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11646
     components:
     - pos: -36.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11647
     components:
     - pos: -37.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11648
     components:
     - pos: -38.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11649
     components:
     - pos: -38.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11650
     components:
     - pos: -38.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11651
     components:
     - pos: -38.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11652
     components:
     - pos: -42.5,44.5
@@ -21575,85 +20794,61 @@ entities:
     - pos: -43.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11655
     components:
     - pos: -43.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11656
     components:
     - pos: -43.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11657
     components:
     - pos: -43.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11658
     components:
     - pos: -43.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11659
     components:
     - pos: -43.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11660
     components:
     - pos: -43.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11661
     components:
     - pos: -42.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11662
     components:
     - pos: -41.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11663
     components:
     - pos: -44.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11665
     components:
     - pos: -46.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11666
     components:
     - pos: -47.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11667
     components:
     - pos: -42.5,43.5
@@ -21739,8 +20934,6 @@ entities:
     - pos: -49.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11684
     components:
     - pos: -50.5,38.5
@@ -21756,8 +20949,6 @@ entities:
     - pos: -52.5,38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11687
     components:
     - pos: -50.5,36.5
@@ -21773,8 +20964,6 @@ entities:
     - pos: -52.5,36.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11690
     components:
     - pos: -48.5,36.5
@@ -21795,8 +20984,6 @@ entities:
     - pos: -47.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11694
     components:
     - pos: -46.5,36.5
@@ -21987,8 +21174,6 @@ entities:
     - pos: -24.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11732
     components:
     - pos: -24.5,48.5
@@ -22124,57 +21309,41 @@ entities:
     - pos: -26.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11759
     components:
     - pos: -26.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11760
     components:
     - pos: -26.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11761
     components:
     - pos: -30.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11762
     components:
     - pos: -31.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11763
     components:
     - pos: -32.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11764
     components:
     - pos: -34.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11765
     components:
     - pos: -35.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11766
     components:
     - pos: -31.5,43.5
@@ -22220,15 +21389,11 @@ entities:
     - pos: -39.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11775
     components:
     - pos: -39.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11776
     components:
     - pos: -35.5,46.5
@@ -22264,22 +21429,16 @@ entities:
     - pos: -39.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11783
     components:
     - pos: -39.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11784
     components:
     - pos: -20.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11785
     components:
     - pos: -19.5,50.5
@@ -22435,15 +21594,11 @@ entities:
     - pos: -12.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11816
     components:
     - pos: -13.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11817
     components:
     - pos: -13.5,44.5
@@ -22494,36 +21649,26 @@ entities:
     - pos: -17.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11827
     components:
     - pos: -18.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11828
     components:
     - pos: -19.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11829
     components:
     - pos: -16.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11830
     components:
     - pos: -15.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11831
     components:
     - pos: -18.5,44.5
@@ -22569,8 +21714,6 @@ entities:
     - pos: -7.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11865
     components:
     - pos: -8.5,56.5
@@ -22711,22 +21854,16 @@ entities:
     - pos: -8.5,61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11893
     components:
     - pos: -9.5,61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11894
     components:
     - pos: -7.5,60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11895
     components:
     - pos: -6.5,56.5
@@ -22942,15 +22079,11 @@ entities:
     - pos: -9.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11939
     components:
     - pos: -10.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11940
     components:
     - pos: -6.5,43.5
@@ -22996,22 +22129,16 @@ entities:
     - pos: -6.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11949
     components:
     - pos: -7.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11950
     components:
     - pos: -3.5,39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11951
     components:
     - pos: -3.5,40.5
@@ -23052,15 +22179,11 @@ entities:
     - pos: -3.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11959
     components:
     - pos: -4.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11960
     components:
     - pos: -23.5,47.5
@@ -23081,288 +22204,206 @@ entities:
     - pos: -21.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11964
     components:
     - pos: -21.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11965
     components:
     - pos: -21.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11966
     components:
     - pos: -21.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11967
     components:
     - pos: -21.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11968
     components:
     - pos: -21.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11969
     components:
     - pos: -21.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11970
     components:
     - pos: -20.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11971
     components:
     - pos: -19.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11972
     components:
     - pos: -19.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11973
     components:
     - pos: -19.5,59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11974
     components:
     - pos: -19.5,60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11975
     components:
     - pos: -19.5,61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11976
     components:
     - pos: -19.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11977
     components:
     - pos: -18.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11978
     components:
     - pos: -17.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11979
     components:
     - pos: -16.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11980
     components:
     - pos: -15.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11981
     components:
     - pos: -14.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11982
     components:
     - pos: -13.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11983
     components:
     - pos: -13.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11984
     components:
     - pos: -13.5,64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11985
     components:
     - pos: -13.5,65.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11986
     components:
     - pos: -13.5,66.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11987
     components:
     - pos: -13.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11988
     components:
     - pos: -13.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11989
     components:
     - pos: -13.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11990
     components:
     - pos: -13.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11991
     components:
     - pos: -12.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11992
     components:
     - pos: -11.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11993
     components:
     - pos: -10.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11994
     components:
     - pos: -9.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11995
     components:
     - pos: -8.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11996
     components:
     - pos: -7.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11997
     components:
     - pos: -6.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11998
     components:
     - pos: -5.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11999
     components:
     - pos: -4.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12000
     components:
     - pos: -4.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12001
     components:
     - pos: -4.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12002
     components:
     - pos: -4.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12003
     components:
     - pos: -3.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12004
     components:
     - pos: -1.5,47.5
@@ -23423,43 +22464,31 @@ entities:
     - pos: -21.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12016
     components:
     - pos: -21.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12017
     components:
     - pos: -21.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12018
     components:
     - pos: -21.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12019
     components:
     - pos: -21.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12060
     components:
     - pos: -12.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12061
     components:
     - pos: -11.5,32.5
@@ -23490,15 +22519,11 @@ entities:
     - pos: -7.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12067
     components:
     - pos: -6.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12068
     components:
     - pos: -6.5,32.5
@@ -23509,36 +22534,26 @@ entities:
     - pos: -6.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12070
     components:
     - pos: -6.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12071
     components:
     - pos: -6.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12072
     components:
     - pos: -6.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12073
     components:
     - pos: -6.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12074
     components:
     - pos: -9.5,31.5
@@ -23614,22 +22629,16 @@ entities:
     - pos: -20.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12089
     components:
     - pos: -20.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12090
     components:
     - pos: -20.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12091
     components:
     - pos: -20.5,28.5
@@ -23655,8 +22664,6 @@ entities:
     - pos: -20.5,35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12096
     components:
     - pos: -20.5,36.5
@@ -23857,8 +22864,6 @@ entities:
     - pos: -17.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12137
     components:
     - pos: -17.5,25.5
@@ -24089,78 +23094,56 @@ entities:
     - pos: -20.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12183
     components:
     - pos: -21.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12184
     components:
     - pos: -22.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12185
     components:
     - pos: -23.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12186
     components:
     - pos: -23.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12187
     components:
     - pos: -23.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12188
     components:
     - pos: -23.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12189
     components:
     - pos: -23.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12190
     components:
     - pos: -23.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12191
     components:
     - pos: -23.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12192
     components:
     - pos: -23.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12193
     components:
     - pos: -23.5,35.5
@@ -24171,127 +23154,91 @@ entities:
     - pos: -23.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12195
     components:
     - pos: -23.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12196
     components:
     - pos: -24.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12197
     components:
     - pos: -25.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12198
     components:
     - pos: -26.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12199
     components:
     - pos: -27.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12200
     components:
     - pos: -27.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12201
     components:
     - pos: -27.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12202
     components:
     - pos: -27.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12203
     components:
     - pos: -27.5,21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12204
     components:
     - pos: -27.5,20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12205
     components:
     - pos: -27.5,19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12206
     components:
     - pos: -27.5,18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12207
     components:
     - pos: -27.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12208
     components:
     - pos: -26.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12209
     components:
     - pos: -25.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12210
     components:
     - pos: -28.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12211
     components:
     - pos: -25.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12212
     components:
     - pos: -26.5,32.5
@@ -24417,8 +23364,6 @@ entities:
     - pos: -8.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12247
     components:
     - pos: -7.5,23.5
@@ -24459,8 +23404,6 @@ entities:
     - pos: -5.5,20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12255
     components:
     - pos: -5.5,19.5
@@ -24641,8 +23584,6 @@ entities:
     - pos: -35.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12327
     components:
     - pos: -36.5,25.5
@@ -24828,8 +23769,6 @@ entities:
     - pos: -52.5,15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12367
     components:
     - pos: -51.5,15.5
@@ -24845,8 +23784,6 @@ entities:
     - pos: -49.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12370
     components:
     - pos: -47.5,16.5
@@ -24857,8 +23794,6 @@ entities:
     - pos: -47.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12372
     components:
     - pos: -49.5,14.5
@@ -24884,8 +23819,6 @@ entities:
     - pos: -52.5,13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12377
     components:
     - pos: -36.5,15.5
@@ -24911,162 +23844,116 @@ entities:
     - pos: -35.5,18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12382
     components:
     - pos: -35.5,19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12383
     components:
     - pos: -35.5,20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12384
     components:
     - pos: -35.5,21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12385
     components:
     - pos: -34.5,21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12386
     components:
     - pos: -34.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12387
     components:
     - pos: -34.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12388
     components:
     - pos: -34.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12389
     components:
     - pos: -34.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12390
     components:
     - pos: -34.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12391
     components:
     - pos: -34.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12392
     components:
     - pos: -34.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12393
     components:
     - pos: -34.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12394
     components:
     - pos: -34.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12395
     components:
     - pos: -34.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12396
     components:
     - pos: -34.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12397
     components:
     - pos: -34.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12398
     components:
     - pos: -35.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12399
     components:
     - pos: -36.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12400
     components:
     - pos: -37.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12401
     components:
     - pos: -38.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12402
     components:
     - pos: -38.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12543
     components:
     - pos: 41.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12544
     components:
     - pos: 41.5,42.5
@@ -25167,8 +24054,6 @@ entities:
     - pos: 48.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12564
     components:
     - pos: 47.5,36.5
@@ -25259,71 +24144,51 @@ entities:
     - pos: 34.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12582
     components:
     - pos: 35.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12583
     components:
     - pos: 36.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12584
     components:
     - pos: 37.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12585
     components:
     - pos: 38.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12586
     components:
     - pos: 39.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12587
     components:
     - pos: 39.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12588
     components:
     - pos: 39.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12589
     components:
     - pos: 39.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12590
     components:
     - pos: 39.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12591
     components:
     - pos: 40.5,43.5
@@ -25334,36 +24199,26 @@ entities:
     - pos: 38.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12593
     components:
     - pos: 38.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12594
     components:
     - pos: 38.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12595
     components:
     - pos: 38.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12596
     components:
     - pos: 38.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12597
     components:
     - pos: 39.5,48.5
@@ -25469,8 +24324,6 @@ entities:
     - pos: 46.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12618
     components:
     - pos: 50.5,36.5
@@ -25481,15 +24334,11 @@ entities:
     - pos: 51.5,36.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12620
     components:
     - pos: 51.5,38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12621
     components:
     - pos: 50.5,38.5
@@ -25510,8 +24359,6 @@ entities:
     - pos: 27.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12625
     components:
     - pos: 27.5,50.5
@@ -25657,22 +24504,16 @@ entities:
     - pos: 31.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12654
     components:
     - pos: 32.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12655
     components:
     - pos: 32.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12656
     components:
     - pos: 32.5,53.5
@@ -25718,106 +24559,76 @@ entities:
     - pos: 33.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12665
     components:
     - pos: 34.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12666
     components:
     - pos: 35.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12667
     components:
     - pos: 36.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12668
     components:
     - pos: 36.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12669
     components:
     - pos: 36.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12670
     components:
     - pos: 36.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12671
     components:
     - pos: 36.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12672
     components:
     - pos: 36.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12673
     components:
     - pos: 36.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12674
     components:
     - pos: 36.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12675
     components:
     - pos: 36.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12676
     components:
     - pos: 36.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12677
     components:
     - pos: 36.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12678
     components:
     - pos: 36.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12679
     components:
     - pos: 30.5,42.5
@@ -25923,155 +24734,111 @@ entities:
     - pos: 22.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12700
     components:
     - pos: 22.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12701
     components:
     - pos: 22.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12702
     components:
     - pos: 22.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12703
     components:
     - pos: 22.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12704
     components:
     - pos: 22.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12705
     components:
     - pos: 22.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12706
     components:
     - pos: 23.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12707
     components:
     - pos: 24.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12708
     components:
     - pos: 25.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12709
     components:
     - pos: 26.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12710
     components:
     - pos: 27.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12711
     components:
     - pos: 28.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12712
     components:
     - pos: 28.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12713
     components:
     - pos: 28.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12714
     components:
     - pos: 28.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12715
     components:
     - pos: 28.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12716
     components:
     - pos: 28.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12717
     components:
     - pos: 29.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12718
     components:
     - pos: 29.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12719
     components:
     - pos: 30.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12720
     components:
     - pos: 24.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12721
     components:
     - pos: 23.5,42.5
@@ -26112,141 +24879,101 @@ entities:
     - pos: 25.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12729
     components:
     - pos: 25.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12730
     components:
     - pos: 25.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12731
     components:
     - pos: 25.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12732
     components:
     - pos: 24.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12733
     components:
     - pos: 23.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12734
     components:
     - pos: 22.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12735
     components:
     - pos: 22.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12736
     components:
     - pos: 22.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12737
     components:
     - pos: 22.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12738
     components:
     - pos: 22.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12739
     components:
     - pos: 21.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12740
     components:
     - pos: 20.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12741
     components:
     - pos: 19.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12742
     components:
     - pos: 18.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12743
     components:
     - pos: 17.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12744
     components:
     - pos: 16.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12745
     components:
     - pos: 16.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12746
     components:
     - pos: 16.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12747
     components:
     - pos: 16.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12748
     components:
     - pos: 17.5,52.5
@@ -26257,43 +24984,31 @@ entities:
     - pos: 18.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12750
     components:
     - pos: 19.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12751
     components:
     - pos: 20.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12752
     components:
     - pos: 20.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12753
     components:
     - pos: 15.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12754
     components:
     - pos: 15.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12755
     components:
     - pos: 15.5,48.5
@@ -26364,15 +25079,11 @@ entities:
     - pos: 20.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12769
     components:
     - pos: 21.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12770
     components:
     - pos: 14.5,44.5
@@ -26418,162 +25129,116 @@ entities:
     - pos: 14.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12779
     components:
     - pos: 13.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12780
     components:
     - pos: 12.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12781
     components:
     - pos: 11.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12782
     components:
     - pos: 10.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12783
     components:
     - pos: 9.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12784
     components:
     - pos: 9.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12785
     components:
     - pos: 9.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12786
     components:
     - pos: 9.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12787
     components:
     - pos: 9.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12788
     components:
     - pos: 9.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12789
     components:
     - pos: 9.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12790
     components:
     - pos: 9.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12791
     components:
     - pos: 9.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12792
     components:
     - pos: 9.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12793
     components:
     - pos: 8.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12794
     components:
     - pos: 7.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12795
     components:
     - pos: 6.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12796
     components:
     - pos: 5.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12797
     components:
     - pos: 4.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12798
     components:
     - pos: 3.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12799
     components:
     - pos: 2.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12800
     components:
     - pos: 6.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12801
     components:
     - pos: 5.5,46.5
@@ -26669,64 +25334,46 @@ entities:
     - pos: 5.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12826
     components:
     - pos: 36.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12827
     components:
     - pos: 37.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12828
     components:
     - pos: 37.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12829
     components:
     - pos: 37.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12830
     components:
     - pos: 37.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12831
     components:
     - pos: 37.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12832
     components:
     - pos: 37.5,59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12833
     components:
     - pos: 37.5,60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12834
     components:
     - pos: 17.5,41.5
@@ -26902,8 +25549,6 @@ entities:
     - pos: 8.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12930
     components:
     - pos: 9.5,31.5
@@ -27039,8 +25684,6 @@ entities:
     - pos: 5.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12957
     components:
     - pos: 6.5,26.5
@@ -27231,8 +25874,6 @@ entities:
     - pos: 17.5,19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12995
     components:
     - pos: 16.5,19.5
@@ -27438,22 +26079,16 @@ entities:
     - pos: 19.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13036
     components:
     - pos: 19.5,18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13037
     components:
     - pos: 19.5,19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13038
     components:
     - pos: 18.5,19.5
@@ -27464,8 +26099,6 @@ entities:
     - pos: 20.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13040
     components:
     - pos: 20.5,31.5
@@ -27566,22 +26199,16 @@ entities:
     - pos: 24.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13061
     components:
     - pos: 24.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13062
     components:
     - pos: 24.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13063
     components:
     - pos: 24.5,30.5
@@ -27642,29 +26269,21 @@ entities:
     - pos: 24.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13075
     components:
     - pos: 24.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13076
     components:
     - pos: 24.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13077
     components:
     - pos: 25.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13078
     components:
     - pos: 26.5,25.5
@@ -28130,15 +26749,11 @@ entities:
     - pos: 15.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13228
     components:
     - pos: 14.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13229
     components:
     - pos: 14.5,23.5
@@ -28149,36 +26764,26 @@ entities:
     - pos: 14.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13231
     components:
     - pos: 15.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13232
     components:
     - pos: 16.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13234
     components:
     - pos: 16.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13235
     components:
     - pos: 17.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13236
     components:
     - pos: 28.5,26.5
@@ -28204,36 +26809,26 @@ entities:
     - pos: 23.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13241
     components:
     - pos: 22.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13242
     components:
     - pos: 21.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13243
     components:
     - pos: 20.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13244
     components:
     - pos: 19.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13245
     components:
     - pos: 24.5,17.5
@@ -28354,8 +26949,6 @@ entities:
     - pos: 51.5,15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13269
     components:
     - pos: 48.5,15.5
@@ -28371,8 +26964,6 @@ entities:
     - pos: 48.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13272
     components:
     - pos: 46.5,15.5
@@ -28388,8 +26979,6 @@ entities:
     - pos: 46.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13275
     components:
     - pos: 49.5,13.5
@@ -28405,8 +26994,6 @@ entities:
     - pos: 51.5,13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13278
     components:
     - pos: 46.5,13.5
@@ -28517,15 +27104,11 @@ entities:
     - pos: -21.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13535
     components:
     - pos: -21.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13536
     components:
     - pos: -22.5,-2.5
@@ -28536,169 +27119,121 @@ entities:
     - pos: -23.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13538
     components:
     - pos: -24.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13539
     components:
     - pos: -25.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13540
     components:
     - pos: -20.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13541
     components:
     - pos: -19.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13542
     components:
     - pos: -19.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13543
     components:
     - pos: -19.5,-4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13544
     components:
     - pos: -19.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13545
     components:
     - pos: -20.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13546
     components:
     - pos: -21.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13547
     components:
     - pos: -22.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13548
     components:
     - pos: -23.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13549
     components:
     - pos: -24.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13550
     components:
     - pos: -25.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13551
     components:
     - pos: -26.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13552
     components:
     - pos: -27.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13553
     components:
     - pos: -27.5,-4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13554
     components:
     - pos: -27.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13555
     components:
     - pos: -27.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13556
     components:
     - pos: -27.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13557
     components:
     - pos: -27.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13558
     components:
     - pos: -27.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13559
     components:
     - pos: -27.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13560
     components:
     - pos: -28.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13561
     components:
     - pos: -29.5,1.5
@@ -28929,134 +27464,96 @@ entities:
     - pos: -19.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13607
     components:
     - pos: -19.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13608
     components:
     - pos: -19.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13609
     components:
     - pos: -19.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13610
     components:
     - pos: -19.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13611
     components:
     - pos: -19.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13612
     components:
     - pos: -19.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13613
     components:
     - pos: -19.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13614
     components:
     - pos: -19.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13615
     components:
     - pos: -19.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13616
     components:
     - pos: -18.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13617
     components:
     - pos: -17.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13618
     components:
     - pos: -16.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13619
     components:
     - pos: -15.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13620
     components:
     - pos: -15.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13621
     components:
     - pos: -15.5,9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13622
     components:
     - pos: -15.5,10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13623
     components:
     - pos: -15.5,11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13624
     components:
     - pos: -21.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13625
     components:
     - pos: -22.5,8.5
@@ -29152,8 +27649,6 @@ entities:
     - pos: -22.5,12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13645
     components:
     - pos: -22.5,13.5
@@ -29289,8 +27784,6 @@ entities:
     - pos: -11.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13672
     components:
     - pos: -11.5,4.5
@@ -29506,22 +27999,16 @@ entities:
     - pos: -12.5,11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13715
     components:
     - pos: -13.5,11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13716
     components:
     - pos: -13.5,10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13717
     components:
     - pos: -7.5,11.5
@@ -30197,43 +28684,31 @@ entities:
     - pos: 10.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13888
     components:
     - pos: 10.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13889
     components:
     - pos: 9.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13890
     components:
     - pos: 8.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13891
     components:
     - pos: 7.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13892
     components:
     - pos: 7.5,64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13893
     components:
     - pos: 7.5,65.5
@@ -30544,106 +29019,76 @@ entities:
     - pos: 16.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13955
     components:
     - pos: 17.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13956
     components:
     - pos: 18.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13957
     components:
     - pos: 18.5,59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13958
     components:
     - pos: 18.5,60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13959
     components:
     - pos: 18.5,61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13960
     components:
     - pos: 18.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13961
     components:
     - pos: 18.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13962
     components:
     - pos: 17.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13963
     components:
     - pos: 16.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13964
     components:
     - pos: 15.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13965
     components:
     - pos: 14.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13966
     components:
     - pos: 13.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13967
     components:
     - pos: 12.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13968
     components:
     - pos: 11.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13969
     components:
     - pos: 14.5,55.5
@@ -30734,57 +29179,41 @@ entities:
     - pos: 19.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13987
     components:
     - pos: 19.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13988
     components:
     - pos: 19.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13989
     components:
     - pos: 18.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13990
     components:
     - pos: 17.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13991
     components:
     - pos: 16.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13992
     components:
     - pos: 16.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13993
     components:
     - pos: 16.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14446
     components:
     - pos: 32.5,6.5
@@ -30795,8 +29224,6 @@ entities:
     - pos: -35.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 15387
     components:
     - pos: -35.5,9.5
@@ -30862,50 +29289,36 @@ entities:
     - pos: -33.5,10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16385
     components:
     - pos: -12.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16386
     components:
     - pos: -11.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16387
     components:
     - pos: -10.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16388
     components:
     - pos: 11.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16389
     components:
     - pos: 10.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 16390
     components:
     - pos: 9.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17312
     components:
     - pos: 5.5,80.5
@@ -30946,8 +29359,6 @@ entities:
     - pos: 21.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18069
     components:
     - pos: -17.5,-40.5
@@ -30988,22 +29399,16 @@ entities:
     - pos: -33.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18134
     components:
     - pos: -23.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18135
     components:
     - pos: -22.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18197
     components:
     - pos: 34.5,4.5
@@ -31019,15 +29424,11 @@ entities:
     - pos: 35.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18200
     components:
     - pos: 36.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18201
     components:
     - pos: 34.5,1.5
@@ -31038,15 +29439,11 @@ entities:
     - pos: 35.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18203
     components:
     - pos: 36.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18204
     components:
     - pos: 34.5,6.5
@@ -31067,8 +29464,6 @@ entities:
     - pos: -19.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18319
     components:
     - pos: -19.5,64.5
@@ -31079,8 +29474,6 @@ entities:
     - pos: 16.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18468
     components:
     - pos: 16.5,-11.5
@@ -31098,11 +29491,6 @@ entities:
       type: Transform
 - proto: CableApcStack
   entities:
-  - uid: 1766
-    components:
-    - pos: -42.50212,21.737055
-      parent: 1
-      type: Transform
   - uid: 7462
     components:
     - pos: 22.493486,-23.113226
@@ -31157,22 +29545,16 @@ entities:
     - pos: -44.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 177
     components:
     - pos: -43.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 179
     components:
     - pos: -45.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 1224
     components:
     - pos: -20.5,28.5
@@ -31188,29 +29570,21 @@ entities:
     - pos: -40.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3249
     components:
     - pos: -35.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3460
     components:
     - pos: 13.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3566
     components:
     - pos: 38.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3805
     components:
     - pos: 15.5,-12.5
@@ -31221,1086 +29595,776 @@ entities:
     - pos: 5.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3834
     components:
     - pos: 7.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4595
     components:
     - pos: -6.5,-70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4596
     components:
     - pos: -6.5,-69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4597
     components:
     - pos: -6.5,-68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4598
     components:
     - pos: -6.5,-67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4599
     components:
     - pos: -6.5,-66.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4600
     components:
     - pos: -6.5,-65.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4601
     components:
     - pos: -6.5,-64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4602
     components:
     - pos: -8.5,-70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4603
     components:
     - pos: -8.5,-69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4604
     components:
     - pos: -8.5,-68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4605
     components:
     - pos: -8.5,-67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4606
     components:
     - pos: -8.5,-66.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4607
     components:
     - pos: -8.5,-65.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4608
     components:
     - pos: -8.5,-64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4609
     components:
     - pos: -7.5,-64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4610
     components:
     - pos: -7.5,-63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4611
     components:
     - pos: -7.5,-62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4612
     components:
     - pos: -7.5,-61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4613
     components:
     - pos: -7.5,-60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4614
     components:
     - pos: -7.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4615
     components:
     - pos: -7.5,-58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4616
     components:
     - pos: -7.5,-57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4617
     components:
     - pos: -7.5,-56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4618
     components:
     - pos: -7.5,-55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4619
     components:
     - pos: -7.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4620
     components:
     - pos: -8.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4621
     components:
     - pos: -9.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4622
     components:
     - pos: -9.5,-53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4623
     components:
     - pos: -9.5,-52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4624
     components:
     - pos: -9.5,-51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4625
     components:
     - pos: -9.5,-50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4626
     components:
     - pos: -9.5,-49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4627
     components:
     - pos: -9.5,-48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4628
     components:
     - pos: -9.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4629
     components:
     - pos: -10.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4630
     components:
     - pos: -11.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4631
     components:
     - pos: -12.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4632
     components:
     - pos: -13.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4633
     components:
     - pos: -14.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4634
     components:
     - pos: -15.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4635
     components:
     - pos: -15.5,-46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4636
     components:
     - pos: -15.5,-45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4637
     components:
     - pos: -15.5,-44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4638
     components:
     - pos: -15.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4639
     components:
     - pos: -10.5,-51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4640
     components:
     - pos: -11.5,-51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4641
     components:
     - pos: -11.5,-50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4642
     components:
     - pos: -12.5,-50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4643
     components:
     - pos: -12.5,-49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4644
     components:
     - pos: -10.5,-53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4645
     components:
     - pos: -10.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4646
     components:
     - pos: -10.5,-55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4647
     components:
     - pos: -10.5,-56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4648
     components:
     - pos: -9.5,-56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4649
     components:
     - pos: -9.5,-57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4650
     components:
     - pos: -9.5,-58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4651
     components:
     - pos: -9.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4652
     components:
     - pos: -8.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4653
     components:
     - pos: -8.5,-60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4654
     components:
     - pos: -8.5,-61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4655
     components:
     - pos: -8.5,-62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4656
     components:
     - pos: -6.5,-62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4657
     components:
     - pos: -5.5,-62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4658
     components:
     - pos: -5.5,-61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4659
     components:
     - pos: -5.5,-60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4660
     components:
     - pos: -5.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4661
     components:
     - pos: -4.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4662
     components:
     - pos: -4.5,-58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4663
     components:
     - pos: -4.5,-57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4664
     components:
     - pos: -4.5,-56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4665
     components:
     - pos: -4.5,-55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4666
     components:
     - pos: -4.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4667
     components:
     - pos: -4.5,-53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4668
     components:
     - pos: 3.5,-53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4669
     components:
     - pos: 3.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4670
     components:
     - pos: 3.5,-55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4671
     components:
     - pos: 3.5,-56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4672
     components:
     - pos: 3.5,-57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4673
     components:
     - pos: 3.5,-58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4674
     components:
     - pos: 3.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4675
     components:
     - pos: 4.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4676
     components:
     - pos: 4.5,-60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4677
     components:
     - pos: 4.5,-61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4678
     components:
     - pos: 4.5,-62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4679
     components:
     - pos: 5.5,-62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4680
     components:
     - pos: 6.5,-64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4681
     components:
     - pos: 6.5,-63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4682
     components:
     - pos: 6.5,-62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4683
     components:
     - pos: 6.5,-61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4684
     components:
     - pos: 6.5,-60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4685
     components:
     - pos: 6.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4686
     components:
     - pos: 6.5,-58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4687
     components:
     - pos: 6.5,-57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4688
     components:
     - pos: 6.5,-56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4689
     components:
     - pos: 6.5,-55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4690
     components:
     - pos: 6.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4691
     components:
     - pos: -8.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4692
     components:
     - pos: -7.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4693
     components:
     - pos: -6.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4694
     components:
     - pos: -5.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4695
     components:
     - pos: -4.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4696
     components:
     - pos: -3.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4697
     components:
     - pos: -3.5,-48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4698
     components:
     - pos: -3.5,-49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4704
     components:
     - pos: 2.5,-49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4705
     components:
     - pos: 2.5,-48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4706
     components:
     - pos: 2.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4707
     components:
     - pos: 3.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4708
     components:
     - pos: 4.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4709
     components:
     - pos: 5.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4710
     components:
     - pos: 6.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4711
     components:
     - pos: 7.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4712
     components:
     - pos: 8.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4713
     components:
     - pos: 8.5,-48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4714
     components:
     - pos: 8.5,-49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4715
     components:
     - pos: 8.5,-50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4716
     components:
     - pos: 8.5,-51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4717
     components:
     - pos: 8.5,-52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4718
     components:
     - pos: 8.5,-53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4719
     components:
     - pos: 8.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4720
     components:
     - pos: 7.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4721
     components:
     - pos: 9.5,-53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4722
     components:
     - pos: 9.5,-54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4723
     components:
     - pos: 9.5,-55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4724
     components:
     - pos: 9.5,-56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4725
     components:
     - pos: 8.5,-56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4726
     components:
     - pos: 8.5,-57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4727
     components:
     - pos: 8.5,-58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4728
     components:
     - pos: 8.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4729
     components:
     - pos: 7.5,-59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4730
     components:
     - pos: 7.5,-60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4731
     components:
     - pos: 7.5,-61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4732
     components:
     - pos: 7.5,-62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4733
     components:
     - pos: 9.5,-51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4734
     components:
     - pos: 10.5,-51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4735
     components:
     - pos: 10.5,-50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4736
     components:
     - pos: 11.5,-50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4737
     components:
     - pos: 11.5,-49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4738
     components:
     - pos: 13.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4739
     components:
     - pos: 14.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4740
     components:
     - pos: 14.5,-46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4741
     components:
     - pos: 14.5,-45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4742
     components:
     - pos: 14.5,-44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4743
     components:
     - pos: 14.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4744
     components:
     - pos: 12.5,-47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4745
     components:
     - pos: 12.5,-46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4746
     components:
     - pos: 12.5,-45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4747
     components:
     - pos: 12.5,-44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4748
     components:
     - pos: 12.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4749
     components:
     - pos: 12.5,-42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4750
     components:
     - pos: 12.5,-41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4751
     components:
     - pos: 12.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4752
     components:
     - pos: 12.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4753
     components:
     - pos: 12.5,-38.5
@@ -32376,43 +30440,31 @@ entities:
     - pos: 7.5,-37.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4768
     components:
     - pos: 7.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4769
     components:
     - pos: 7.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4770
     components:
     - pos: 7.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4771
     components:
     - pos: 6.5,-40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4772
     components:
     - pos: 6.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4773
     components:
     - pos: 7.5,-32.5
@@ -32428,29 +30480,21 @@ entities:
     - pos: 7.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4776
     components:
     - pos: 6.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4777
     components:
     - pos: 5.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4778
     components:
     - pos: 8.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4783
     components:
     - pos: 5.5,-29.5
@@ -32481,8 +30525,6 @@ entities:
     - pos: 10.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4789
     components:
     - pos: 11.5,-29.5
@@ -32618,78 +30660,56 @@ entities:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4816
     components:
     - pos: 3.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4817
     components:
     - pos: 2.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4818
     components:
     - pos: 1.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4819
     components:
     - pos: 0.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4820
     components:
     - pos: -0.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4821
     components:
     - pos: -1.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4822
     components:
     - pos: -2.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4823
     components:
     - pos: -3.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4824
     components:
     - pos: -4.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4825
     components:
     - pos: -5.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4826
     components:
     - pos: -6.5,-15.5
@@ -32775,15 +30795,11 @@ entities:
     - pos: -12.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4843
     components:
     - pos: -13.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4844
     components:
     - pos: -12.5,-26.5
@@ -32809,15 +30825,11 @@ entities:
     - pos: -12.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4849
     components:
     - pos: -13.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4850
     components:
     - pos: -12.5,-31.5
@@ -32863,162 +30875,116 @@ entities:
     - pos: -15.5,-36.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4859
     components:
     - pos: -16.5,-36.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4860
     components:
     - pos: -16.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4861
     components:
     - pos: -16.5,-34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4862
     components:
     - pos: -16.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4863
     components:
     - pos: -16.5,-32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4864
     components:
     - pos: -16.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4865
     components:
     - pos: -17.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4866
     components:
     - pos: -18.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4867
     components:
     - pos: -18.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4868
     components:
     - pos: -18.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4869
     components:
     - pos: -18.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4870
     components:
     - pos: -18.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4871
     components:
     - pos: -18.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4872
     components:
     - pos: -18.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4873
     components:
     - pos: -18.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4874
     components:
     - pos: -19.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4875
     components:
     - pos: -20.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4876
     components:
     - pos: -17.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4877
     components:
     - pos: -16.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4878
     components:
     - pos: -16.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4879
     components:
     - pos: -16.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4880
     components:
     - pos: -16.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4881
     components:
     - pos: -16.5,-20.5
@@ -33129,176 +31095,126 @@ entities:
     - pos: -20.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4903
     components:
     - pos: -20.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4904
     components:
     - pos: -20.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4905
     components:
     - pos: -20.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4906
     components:
     - pos: -20.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4907
     components:
     - pos: -21.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4908
     components:
     - pos: -22.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4909
     components:
     - pos: -23.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4910
     components:
     - pos: -24.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4911
     components:
     - pos: -25.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4912
     components:
     - pos: -26.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4913
     components:
     - pos: -27.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4914
     components:
     - pos: -28.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4915
     components:
     - pos: -29.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4916
     components:
     - pos: -29.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4917
     components:
     - pos: -29.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4918
     components:
     - pos: -29.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4919
     components:
     - pos: -29.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4920
     components:
     - pos: -29.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4921
     components:
     - pos: -29.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4922
     components:
     - pos: -29.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4923
     components:
     - pos: -29.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4924
     components:
     - pos: -29.5,-17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4925
     components:
     - pos: -29.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4926
     components:
     - pos: -28.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4927
     components:
     - pos: -27.5,-16.5
@@ -33309,15 +31225,11 @@ entities:
     - pos: -26.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4929
     components:
     - pos: -25.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4930
     components:
     - pos: -25.5,-15.5
@@ -33328,22 +31240,16 @@ entities:
     - pos: -3.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4933
     components:
     - pos: -3.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4934
     components:
     - pos: -3.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4935
     components:
     - pos: -3.5,71.5
@@ -33354,36 +31260,26 @@ entities:
     - pos: -3.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4937
     components:
     - pos: -4.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4938
     components:
     - pos: -4.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4939
     components:
     - pos: -4.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4940
     components:
     - pos: -4.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4941
     components:
     - pos: -3.5,67.5
@@ -33404,232 +31300,166 @@ entities:
     - pos: -5.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4945
     components:
     - pos: -6.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4946
     components:
     - pos: -7.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4947
     components:
     - pos: -8.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4948
     components:
     - pos: -9.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4949
     components:
     - pos: -10.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4950
     components:
     - pos: -11.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4951
     components:
     - pos: -12.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4952
     components:
     - pos: -13.5,67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4953
     components:
     - pos: -13.5,66.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4954
     components:
     - pos: -13.5,65.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4955
     components:
     - pos: -13.5,64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4956
     components:
     - pos: -13.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4957
     components:
     - pos: -13.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4958
     components:
     - pos: -14.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4959
     components:
     - pos: -15.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4960
     components:
     - pos: -16.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4961
     components:
     - pos: -17.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4962
     components:
     - pos: -18.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4963
     components:
     - pos: -19.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4964
     components:
     - pos: -19.5,61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4965
     components:
     - pos: -19.5,60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4966
     components:
     - pos: -19.5,59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4967
     components:
     - pos: -19.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4968
     components:
     - pos: -19.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4969
     components:
     - pos: -20.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4970
     components:
     - pos: -21.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4971
     components:
     - pos: -21.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4972
     components:
     - pos: -21.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4973
     components:
     - pos: -21.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4974
     components:
     - pos: -21.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4975
     components:
     - pos: -21.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4976
     components:
     - pos: -21.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4977
     components:
     - pos: -21.5,50.5
@@ -33665,36 +31495,26 @@ entities:
     - pos: -21.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4984
     components:
     - pos: -21.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4985
     components:
     - pos: -21.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4986
     components:
     - pos: -21.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4987
     components:
     - pos: -21.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4988
     components:
     - pos: -21.5,39.5
@@ -33720,43 +31540,31 @@ entities:
     - pos: -22.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4993
     components:
     - pos: -23.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4994
     components:
     - pos: -24.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4995
     components:
     - pos: -24.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4996
     components:
     - pos: -24.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4997
     components:
     - pos: -24.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4998
     components:
     - pos: -24.5,53.5
@@ -33767,22 +31575,16 @@ entities:
     - pos: -24.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5000
     components:
     - pos: -24.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5001
     components:
     - pos: -24.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5002
     components:
     - pos: -0.5,67.5
@@ -33843,323 +31645,231 @@ entities:
     - pos: 7.5,64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5014
     components:
     - pos: 7.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5015
     components:
     - pos: 8.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5016
     components:
     - pos: 9.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5017
     components:
     - pos: 10.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5018
     components:
     - pos: 11.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5019
     components:
     - pos: 12.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5020
     components:
     - pos: 13.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5021
     components:
     - pos: 14.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5022
     components:
     - pos: 15.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5023
     components:
     - pos: 16.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5024
     components:
     - pos: 17.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5025
     components:
     - pos: 18.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5026
     components:
     - pos: 18.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5027
     components:
     - pos: 18.5,61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5028
     components:
     - pos: 18.5,60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5029
     components:
     - pos: 18.5,59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5030
     components:
     - pos: 18.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5031
     components:
     - pos: 19.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5032
     components:
     - pos: 19.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5033
     components:
     - pos: 19.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5034
     components:
     - pos: 18.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5035
     components:
     - pos: 17.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5036
     components:
     - pos: 16.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5037
     components:
     - pos: 20.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5038
     components:
     - pos: 21.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5039
     components:
     - pos: 22.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5040
     components:
     - pos: 22.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5041
     components:
     - pos: 22.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5042
     components:
     - pos: 22.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5043
     components:
     - pos: 22.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5044
     components:
     - pos: 22.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5045
     components:
     - pos: 22.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5046
     components:
     - pos: 22.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5047
     components:
     - pos: 22.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5048
     components:
     - pos: 22.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5049
     components:
     - pos: 22.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5050
     components:
     - pos: 22.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5051
     components:
     - pos: 23.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5052
     components:
     - pos: 24.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5053
     components:
     - pos: 25.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5054
     components:
     - pos: 25.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5055
     components:
     - pos: 25.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5056
     components:
     - pos: 25.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5057
     components:
     - pos: 25.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5058
     components:
     - pos: 25.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5059
     components:
     - pos: 25.5,39.5
@@ -34185,36 +31895,26 @@ entities:
     - pos: 16.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5064
     components:
     - pos: 16.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5065
     components:
     - pos: 16.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5066
     components:
     - pos: 16.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5067
     components:
     - pos: 16.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5068
     components:
     - pos: 17.5,52.5
@@ -34225,36 +31925,26 @@ entities:
     - pos: 18.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5070
     components:
     - pos: 19.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5071
     components:
     - pos: 20.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5072
     components:
     - pos: 20.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5073
     components:
     - pos: 20.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5074
     components:
     - pos: -20.5,36.5
@@ -34785,127 +32475,91 @@ entities:
     - pos: 24.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5180
     components:
     - pos: 24.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5181
     components:
     - pos: 24.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5182
     components:
     - pos: 24.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5183
     components:
     - pos: 24.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5184
     components:
     - pos: 24.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5185
     components:
     - pos: 23.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5186
     components:
     - pos: 22.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5187
     components:
     - pos: 21.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5188
     components:
     - pos: 20.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5189
     components:
     - pos: 19.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5190
     components:
     - pos: 19.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5191
     components:
     - pos: 19.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5192
     components:
     - pos: 19.5,21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5193
     components:
     - pos: 19.5,20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5194
     components:
     - pos: 19.5,19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5195
     components:
     - pos: 19.5,18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5196
     components:
     - pos: 19.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5197
     components:
     - pos: 19.5,16.5
@@ -34931,36 +32585,26 @@ entities:
     - pos: 18.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5202
     components:
     - pos: 17.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5203
     components:
     - pos: 16.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5204
     components:
     - pos: 15.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5205
     components:
     - pos: 14.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5206
     components:
     - pos: 14.5,23.5
@@ -34971,8 +32615,6 @@ entities:
     - pos: 14.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5208
     components:
     - pos: 14.5,25.5
@@ -35388,148 +33030,106 @@ entities:
     - pos: 18.5,11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5291
     components:
     - pos: 18.5,10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5292
     components:
     - pos: 18.5,9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5293
     components:
     - pos: 18.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5294
     components:
     - pos: 18.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5295
     components:
     - pos: 18.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5296
     components:
     - pos: 17.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5297
     components:
     - pos: 16.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5298
     components:
     - pos: 15.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5299
     components:
     - pos: 14.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5300
     components:
     - pos: 14.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5301
     components:
     - pos: 14.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5302
     components:
     - pos: 14.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5303
     components:
     - pos: 14.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5304
     components:
     - pos: 14.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5305
     components:
     - pos: 14.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5306
     components:
     - pos: 14.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5307
     components:
     - pos: 14.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5308
     components:
     - pos: 14.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5309
     components:
     - pos: 14.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5310
     components:
     - pos: 14.5,-4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5311
     components:
     - pos: 14.5,-5.5
@@ -35545,43 +33145,31 @@ entities:
     - pos: 15.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5314
     components:
     - pos: 16.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5315
     components:
     - pos: 17.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5316
     components:
     - pos: 18.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5317
     components:
     - pos: 18.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5318
     components:
     - pos: 18.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5319
     components:
     - pos: 18.5,1.5
@@ -35592,22 +33180,16 @@ entities:
     - pos: 18.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5321
     components:
     - pos: 18.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5322
     components:
     - pos: 18.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5323
     components:
     - pos: 17.5,4.5
@@ -36378,204 +33960,146 @@ entities:
     - pos: -26.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5479
     components:
     - pos: -25.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5480
     components:
     - pos: -24.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5481
     components:
     - pos: -23.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5482
     components:
     - pos: -22.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5483
     components:
     - pos: -21.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5484
     components:
     - pos: -20.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5485
     components:
     - pos: -19.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5486
     components:
     - pos: -19.5,-4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5487
     components:
     - pos: -19.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5488
     components:
     - pos: -19.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5489
     components:
     - pos: -19.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5490
     components:
     - pos: -19.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5491
     components:
     - pos: -19.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5492
     components:
     - pos: -19.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5493
     components:
     - pos: -19.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5494
     components:
     - pos: -19.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5495
     components:
     - pos: -19.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5496
     components:
     - pos: -19.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5497
     components:
     - pos: -19.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5498
     components:
     - pos: -19.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5499
     components:
     - pos: -18.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5500
     components:
     - pos: -17.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5501
     components:
     - pos: -16.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5502
     components:
     - pos: -15.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5503
     components:
     - pos: -15.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5504
     components:
     - pos: -15.5,9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5505
     components:
     - pos: -15.5,10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5506
     components:
     - pos: -15.5,11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5507
     components:
     - pos: -15.5,12.5
@@ -36586,15 +34110,11 @@ entities:
     - pos: -20.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5509
     components:
     - pos: -21.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5510
     components:
     - pos: -22.5,-2.5
@@ -36605,29 +34125,21 @@ entities:
     - pos: -23.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5512
     components:
     - pos: -24.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5513
     components:
     - pos: -25.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5514
     components:
     - pos: -25.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5515
     components:
     - pos: -25.5,-0.5
@@ -36643,204 +34155,146 @@ entities:
     - pos: -23.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5518
     components:
     - pos: -23.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5519
     components:
     - pos: -23.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5520
     components:
     - pos: -23.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5521
     components:
     - pos: -23.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5522
     components:
     - pos: -23.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5523
     components:
     - pos: -23.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5524
     components:
     - pos: -23.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5525
     components:
     - pos: -23.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5526
     components:
     - pos: -23.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5527
     components:
     - pos: -22.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5528
     components:
     - pos: -21.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5529
     components:
     - pos: -20.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5536
     components:
     - pos: -21.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5537
     components:
     - pos: -21.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5538
     components:
     - pos: -24.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5539
     components:
     - pos: -25.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5540
     components:
     - pos: -26.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5541
     components:
     - pos: -27.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5542
     components:
     - pos: -27.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5543
     components:
     - pos: -27.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5544
     components:
     - pos: -27.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5545
     components:
     - pos: -27.5,21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5546
     components:
     - pos: -27.5,20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5547
     components:
     - pos: -27.5,19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5548
     components:
     - pos: -27.5,18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5549
     components:
     - pos: -27.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5550
     components:
     - pos: -26.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5551
     components:
     - pos: -25.5,17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5552
     components:
     - pos: -25.5,15.5
@@ -36856,8 +34310,6 @@ entities:
     - pos: -28.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5558
     components:
     - pos: -29.5,23.5
@@ -36868,155 +34320,111 @@ entities:
     - pos: 39.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5560
     components:
     - pos: 37.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5561
     components:
     - pos: 36.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5562
     components:
     - pos: 35.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5563
     components:
     - pos: 34.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5564
     components:
     - pos: 33.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5565
     components:
     - pos: 32.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5566
     components:
     - pos: 32.5,-12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5567
     components:
     - pos: 32.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5568
     components:
     - pos: 32.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5569
     components:
     - pos: 32.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5570
     components:
     - pos: 31.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5571
     components:
     - pos: 30.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5572
     components:
     - pos: 30.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5573
     components:
     - pos: 30.5,-17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5574
     components:
     - pos: 30.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5575
     components:
     - pos: 30.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5576
     components:
     - pos: 30.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5577
     components:
     - pos: 30.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5578
     components:
     - pos: 30.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5579
     components:
     - pos: 30.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5580
     components:
     - pos: 30.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5581
     components:
     - pos: 29.5,-19.5
@@ -37027,22 +34435,16 @@ entities:
     - pos: 28.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5583
     components:
     - pos: 27.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5584
     components:
     - pos: 26.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5585
     components:
     - pos: 26.5,-18.5
@@ -37088,106 +34490,76 @@ entities:
     - pos: 15.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5595
     components:
     - pos: 15.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5596
     components:
     - pos: 15.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5599
     components:
     - pos: 15.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5600
     components:
     - pos: 16.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5601
     components:
     - pos: 17.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5602
     components:
     - pos: 18.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5603
     components:
     - pos: 19.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5604
     components:
     - pos: 20.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5605
     components:
     - pos: 21.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5606
     components:
     - pos: 21.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5607
     components:
     - pos: 21.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5608
     components:
     - pos: 22.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5609
     components:
     - pos: 22.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5610
     components:
     - pos: 22.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5611
     components:
     - pos: 22.5,-24.5
@@ -37203,50 +34575,36 @@ entities:
     - pos: 24.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5614
     components:
     - pos: 25.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5615
     components:
     - pos: 26.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5616
     components:
     - pos: 27.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5617
     components:
     - pos: 28.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5618
     components:
     - pos: 29.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5706
     components:
     - pos: -32.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5936
     components:
     - pos: -25.5,14.5
@@ -37257,211 +34615,151 @@ entities:
     - pos: -20.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5957
     components:
     - pos: 5.5,-64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5958
     components:
     - pos: 5.5,-65.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5959
     components:
     - pos: 5.5,-66.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5960
     components:
     - pos: 5.5,-67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5961
     components:
     - pos: 5.5,-68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5962
     components:
     - pos: 5.5,-69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5963
     components:
     - pos: 5.5,-70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5964
     components:
     - pos: 7.5,-70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5965
     components:
     - pos: 7.5,-69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5966
     components:
     - pos: 7.5,-68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5967
     components:
     - pos: 7.5,-67.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5968
     components:
     - pos: 7.5,-66.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5969
     components:
     - pos: 7.5,-65.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5970
     components:
     - pos: 7.5,-64.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5971
     components:
     - pos: -30.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5972
     components:
     - pos: -31.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5973
     components:
     - pos: -32.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5974
     components:
     - pos: -33.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5975
     components:
     - pos: -34.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5976
     components:
     - pos: -35.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5977
     components:
     - pos: -35.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5978
     components:
     - pos: -35.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5979
     components:
     - pos: -35.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5980
     components:
     - pos: -35.5,-12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5981
     components:
     - pos: -35.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5982
     components:
     - pos: -35.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5983
     components:
     - pos: -35.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5984
     components:
     - pos: -35.5,-8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5985
     components:
     - pos: -35.5,-7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 5986
     components:
     - pos: -34.5,-7.5
@@ -37502,22 +34800,16 @@ entities:
     - pos: 15.5,-34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6079
     components:
     - pos: 15.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6080
     components:
     - pos: 15.5,-32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6102
     components:
     - pos: 25.5,34.5
@@ -37528,8 +34820,6 @@ entities:
     - pos: 7.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6409
     components:
     - pos: 7.5,-17.5
@@ -37550,64 +34840,46 @@ entities:
     - pos: -27.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6441
     components:
     - pos: -27.5,-4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6442
     components:
     - pos: -27.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6443
     components:
     - pos: -27.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6444
     components:
     - pos: -27.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6445
     components:
     - pos: -27.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6446
     components:
     - pos: -27.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6447
     components:
     - pos: -27.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6448
     components:
     - pos: -28.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6449
     components:
     - pos: -29.5,1.5
@@ -37633,127 +34905,91 @@ entities:
     - pos: -44.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6520
     components:
     - pos: -42.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6527
     components:
     - pos: -46.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6529
     components:
     - pos: -40.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6539
     components:
     - pos: -45.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6540
     components:
     - pos: -47.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6541
     components:
     - pos: -46.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6548
     components:
     - pos: -36.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6572
     components:
     - pos: -41.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6573
     components:
     - pos: -47.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6574
     components:
     - pos: -43.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6576
     components:
     - pos: 6.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6577
     components:
     - pos: 8.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6579
     components:
     - pos: 6.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6580
     components:
     - pos: 7.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6708
     components:
     - pos: -35.5,21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6709
     components:
     - pos: -35.5,20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6710
     components:
     - pos: -35.5,19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6711
     components:
     - pos: -32.5,23.5
@@ -37804,134 +35040,96 @@ entities:
     - pos: -35.5,18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6734
     components:
     - pos: -34.5,21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6738
     components:
     - pos: -34.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6739
     components:
     - pos: -34.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6740
     components:
     - pos: -34.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6741
     components:
     - pos: -34.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6742
     components:
     - pos: -34.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6743
     components:
     - pos: -34.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6744
     components:
     - pos: -34.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6745
     components:
     - pos: -34.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6746
     components:
     - pos: -34.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6747
     components:
     - pos: -34.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6748
     components:
     - pos: -34.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6749
     components:
     - pos: -34.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6750
     components:
     - pos: -35.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6751
     components:
     - pos: -36.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6752
     components:
     - pos: -37.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6753
     components:
     - pos: -38.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6754
     components:
     - pos: -38.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6755
     components:
     - pos: -38.5,35.5
@@ -37982,232 +35180,166 @@ entities:
     - pos: -41.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 6768
     components:
     - pos: -42.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7209
     components:
     - pos: 21.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7210
     components:
     - pos: 20.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7211
     components:
     - pos: 19.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7212
     components:
     - pos: 18.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7213
     components:
     - pos: 17.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7214
     components:
     - pos: 16.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7215
     components:
     - pos: 16.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7216
     components:
     - pos: 16.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7217
     components:
     - pos: 15.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7218
     components:
     - pos: 14.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7219
     components:
     - pos: 13.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7220
     components:
     - pos: 12.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7221
     components:
     - pos: 11.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7222
     components:
     - pos: 10.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7223
     components:
     - pos: 9.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7224
     components:
     - pos: 9.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7225
     components:
     - pos: 9.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7226
     components:
     - pos: 9.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7227
     components:
     - pos: 9.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7228
     components:
     - pos: 9.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7229
     components:
     - pos: 9.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7230
     components:
     - pos: 9.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7231
     components:
     - pos: 9.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7232
     components:
     - pos: 9.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7233
     components:
     - pos: 8.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7234
     components:
     - pos: 7.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7235
     components:
     - pos: 6.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7236
     components:
     - pos: 5.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7237
     components:
     - pos: 4.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7238
     components:
     - pos: 3.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7239
     components:
     - pos: 2.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7240
     components:
     - pos: 1.5,41.5
@@ -38228,106 +35360,76 @@ entities:
     - pos: 29.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7295
     components:
     - pos: 28.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7296
     components:
     - pos: 27.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7297
     components:
     - pos: 26.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7298
     components:
     - pos: 25.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7299
     components:
     - pos: 24.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7300
     components:
     - pos: 24.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7301
     components:
     - pos: 24.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7322
     components:
     - pos: 24.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7323
     components:
     - pos: 24.5,-17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7324
     components:
     - pos: 24.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7325
     components:
     - pos: 24.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7326
     components:
     - pos: 24.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7327
     components:
     - pos: 24.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7328
     components:
     - pos: 24.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7336
     components:
     - pos: -31.5,23.5
@@ -38338,22 +35440,16 @@ entities:
     - pos: 24.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7338
     components:
     - pos: 24.5,-12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7339
     components:
     - pos: 24.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7340
     components:
     - pos: 24.5,-10.5
@@ -38364,8 +35460,6 @@ entities:
     - pos: 36.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7347
     components:
     - pos: 33.5,36.5
@@ -38396,1219 +35490,871 @@ entities:
     - pos: 34.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7353
     components:
     - pos: 34.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7354
     components:
     - pos: 35.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7355
     components:
     - pos: 36.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7356
     components:
     - pos: 36.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7357
     components:
     - pos: 36.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7358
     components:
     - pos: 36.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7359
     components:
     - pos: 36.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7360
     components:
     - pos: 36.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7361
     components:
     - pos: 36.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7362
     components:
     - pos: 36.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7363
     components:
     - pos: 36.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7364
     components:
     - pos: 36.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7365
     components:
     - pos: 36.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7366
     components:
     - pos: 35.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7367
     components:
     - pos: 34.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7368
     components:
     - pos: 33.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7369
     components:
     - pos: 32.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7370
     components:
     - pos: 31.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7371
     components:
     - pos: 30.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7372
     components:
     - pos: 29.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7373
     components:
     - pos: 29.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7374
     components:
     - pos: 28.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7375
     components:
     - pos: 28.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7376
     components:
     - pos: 28.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7377
     components:
     - pos: 28.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7378
     components:
     - pos: 28.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7379
     components:
     - pos: 28.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7380
     components:
     - pos: 27.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7381
     components:
     - pos: 26.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7382
     components:
     - pos: 25.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7383
     components:
     - pos: 24.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7384
     components:
     - pos: 23.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7385
     components:
     - pos: 22.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7546
     components:
     - pos: 37.5,60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7547
     components:
     - pos: 37.5,59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7548
     components:
     - pos: 37.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7549
     components:
     - pos: 37.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7550
     components:
     - pos: 37.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7551
     components:
     - pos: 37.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7552
     components:
     - pos: 36.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7553
     components:
     - pos: 35.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7554
     components:
     - pos: 35.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7555
     components:
     - pos: 34.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7556
     components:
     - pos: 33.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7557
     components:
     - pos: 32.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7558
     components:
     - pos: 31.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7559
     components:
     - pos: 30.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7560
     components:
     - pos: 29.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7561
     components:
     - pos: 28.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7562
     components:
     - pos: 35.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7563
     components:
     - pos: 34.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7564
     components:
     - pos: 33.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7565
     components:
     - pos: 32.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7566
     components:
     - pos: 31.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7567
     components:
     - pos: 30.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7568
     components:
     - pos: 29.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7569
     components:
     - pos: 28.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7570
     components:
     - pos: 38.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7571
     components:
     - pos: 39.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7572
     components:
     - pos: 39.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7573
     components:
     - pos: 40.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7574
     components:
     - pos: 41.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7575
     components:
     - pos: 42.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7576
     components:
     - pos: 43.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7577
     components:
     - pos: 44.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7578
     components:
     - pos: 45.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7579
     components:
     - pos: 46.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7580
     components:
     - pos: 39.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7581
     components:
     - pos: 40.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7582
     components:
     - pos: 41.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7583
     components:
     - pos: 42.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7584
     components:
     - pos: 43.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7585
     components:
     - pos: 44.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7586
     components:
     - pos: 45.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7587
     components:
     - pos: 46.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7588
     components:
     - pos: 38.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7589
     components:
     - pos: 39.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7590
     components:
     - pos: 39.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7591
     components:
     - pos: 40.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7592
     components:
     - pos: 41.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7593
     components:
     - pos: 42.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7594
     components:
     - pos: 43.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7595
     components:
     - pos: 44.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7596
     components:
     - pos: 45.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7597
     components:
     - pos: 46.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7598
     components:
     - pos: 39.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7599
     components:
     - pos: 40.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7600
     components:
     - pos: 41.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7601
     components:
     - pos: 42.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7602
     components:
     - pos: 43.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7603
     components:
     - pos: 44.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7604
     components:
     - pos: 45.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7605
     components:
     - pos: 46.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7606
     components:
     - pos: 36.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7607
     components:
     - pos: 35.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7608
     components:
     - pos: 35.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7609
     components:
     - pos: 34.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7610
     components:
     - pos: 33.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7611
     components:
     - pos: 32.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7612
     components:
     - pos: 31.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7613
     components:
     - pos: 30.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7614
     components:
     - pos: 29.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7615
     components:
     - pos: 28.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7616
     components:
     - pos: 35.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7617
     components:
     - pos: 34.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7618
     components:
     - pos: 33.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7619
     components:
     - pos: 32.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7620
     components:
     - pos: 31.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7621
     components:
     - pos: 30.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7622
     components:
     - pos: 29.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7623
     components:
     - pos: 28.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7830
     components:
     - pos: -37.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7831
     components:
     - pos: -39.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7832
     components:
     - pos: -39.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7833
     components:
     - pos: -37.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7834
     components:
     - pos: -36.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7835
     components:
     - pos: -36.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7836
     components:
     - pos: -40.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7837
     components:
     - pos: -40.5,69.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7838
     components:
     - pos: -40.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7839
     components:
     - pos: -41.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7840
     components:
     - pos: -42.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7841
     components:
     - pos: -43.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7842
     components:
     - pos: -44.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7843
     components:
     - pos: -45.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7844
     components:
     - pos: -46.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7845
     components:
     - pos: -47.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7846
     components:
     - pos: -40.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7847
     components:
     - pos: -41.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7848
     components:
     - pos: -42.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7849
     components:
     - pos: -43.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7850
     components:
     - pos: -44.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7851
     components:
     - pos: -45.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7852
     components:
     - pos: -46.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7853
     components:
     - pos: -47.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7854
     components:
     - pos: -36.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7855
     components:
     - pos: -35.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7856
     components:
     - pos: -34.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7857
     components:
     - pos: -33.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7858
     components:
     - pos: -32.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7859
     components:
     - pos: -31.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7860
     components:
     - pos: -30.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7861
     components:
     - pos: -29.5,70.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7862
     components:
     - pos: -36.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7863
     components:
     - pos: -35.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7864
     components:
     - pos: -34.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7865
     components:
     - pos: -33.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7866
     components:
     - pos: -32.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7867
     components:
     - pos: -31.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7868
     components:
     - pos: -30.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7869
     components:
     - pos: -29.5,68.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7871
     components:
     - pos: -38.5,59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7872
     components:
     - pos: -38.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7873
     components:
     - pos: -38.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7874
     components:
     - pos: -38.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7875
     components:
     - pos: -38.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7883
     components:
     - pos: -35.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7896
     components:
     - pos: -34.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7897
     components:
     - pos: -30.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7903
     components:
     - pos: -31.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7904
     components:
     - pos: -33.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7905
     components:
     - pos: -29.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7906
     components:
     - pos: -36.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7907
     components:
     - pos: -34.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7908
     components:
     - pos: -33.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7909
     components:
     - pos: -32.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7910
     components:
     - pos: -31.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7911
     components:
     - pos: -30.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 7912
     components:
     - pos: -29.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8012
     components:
     - pos: -25.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8013
     components:
     - pos: -26.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8014
     components:
     - pos: -27.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8015
     components:
     - pos: -27.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8016
     components:
     - pos: -27.5,55.5
@@ -39619,8 +36365,6 @@ entities:
     - pos: -27.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8018
     components:
     - pos: -27.5,53.5
@@ -39631,8 +36375,6 @@ entities:
     - pos: -27.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8020
     components:
     - pos: -28.5,52.5
@@ -39643,22 +36385,16 @@ entities:
     - pos: -29.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8022
     components:
     - pos: -30.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8023
     components:
     - pos: -31.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8024
     components:
     - pos: -32.5,52.5
@@ -39669,8 +36405,6 @@ entities:
     - pos: -33.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8026
     components:
     - pos: -34.5,52.5
@@ -39681,113 +36415,81 @@ entities:
     - pos: -35.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8028
     components:
     - pos: -36.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8029
     components:
     - pos: -37.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8030
     components:
     - pos: -38.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8031
     components:
     - pos: -39.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8032
     components:
     - pos: -40.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8033
     components:
     - pos: -40.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8034
     components:
     - pos: -41.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8035
     components:
     - pos: -42.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8036
     components:
     - pos: -43.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8037
     components:
     - pos: -43.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8038
     components:
     - pos: -43.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8039
     components:
     - pos: -43.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8040
     components:
     - pos: -43.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8041
     components:
     - pos: -43.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8042
     components:
     - pos: -43.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8043
     components:
     - pos: -43.5,44.5
@@ -39858,22 +36560,16 @@ entities:
     - pos: -39.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8058
     components:
     - pos: -39.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8059
     components:
     - pos: -39.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8821
     components:
     - pos: 0.5,-5.5
@@ -39894,8 +36590,6 @@ entities:
     - pos: -2.5,-5.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9727
     components:
     - pos: -17.5,-18.5
@@ -39936,15 +36630,11 @@ entities:
     - pos: 36.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10147
     components:
     - pos: 36.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10541
     components:
     - pos: 7.5,-41.5
@@ -39955,22 +36645,16 @@ entities:
     - pos: 7.5,-42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10543
     components:
     - pos: 6.5,-42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10544
     components:
     - pos: 5.5,-42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10663
     components:
     - pos: 15.5,-11.5
@@ -40046,22 +36730,16 @@ entities:
     - pos: -25.5,-17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13179
     components:
     - pos: -25.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14045
     components:
     - pos: 36.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14634
     components:
     - pos: -32.5,-8.5
@@ -40087,8 +36765,6 @@ entities:
     - pos: 16.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18458
     components:
     - pos: 16.5,-11.5
@@ -40143,8 +36819,6 @@ entities:
     - pos: -2.5,-5.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 8826
     components:
     - pos: -1.5,-5.5
@@ -40165,8 +36839,6 @@ entities:
     - pos: 1.5,-5.5
       parent: 8756
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9079
     components:
     - pos: 8.5,-17.5
@@ -40192,8 +36864,6 @@ entities:
     - pos: -22.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9765
     components:
     - pos: -25.5,-15.5
@@ -40204,15 +36874,11 @@ entities:
     - pos: -25.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9767
     components:
     - pos: -26.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9768
     components:
     - pos: -27.5,-16.5
@@ -40223,36 +36889,26 @@ entities:
     - pos: -28.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9770
     components:
     - pos: -29.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9771
     components:
     - pos: -30.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9772
     components:
     - pos: -31.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9773
     components:
     - pos: -31.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9774
     components:
     - pos: -31.5,-14.5
@@ -40263,8 +36919,6 @@ entities:
     - pos: -31.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10124
     components:
     - pos: -24.5,36.5
@@ -40280,22 +36934,16 @@ entities:
     - pos: 26.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10154
     components:
     - pos: 27.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10155
     components:
     - pos: 28.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10156
     components:
     - pos: 29.5,-19.5
@@ -40306,162 +36954,116 @@ entities:
     - pos: 30.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10158
     components:
     - pos: 30.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10159
     components:
     - pos: 30.5,-17.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10160
     components:
     - pos: 30.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10161
     components:
     - pos: 30.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10162
     components:
     - pos: 29.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10163
     components:
     - pos: 29.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10272
     components:
     - pos: -32.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10273
     components:
     - pos: -33.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10274
     components:
     - pos: -34.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10275
     components:
     - pos: -35.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10276
     components:
     - pos: -35.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10277
     components:
     - pos: -35.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10278
     components:
     - pos: -35.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10279
     components:
     - pos: -35.5,-12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10280
     components:
     - pos: -35.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10281
     components:
     - pos: -35.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10282
     components:
     - pos: -35.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10283
     components:
     - pos: -36.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10284
     components:
     - pos: -37.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10285
     components:
     - pos: -38.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10286
     components:
     - pos: -39.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10287
     components:
     - pos: -40.5,-9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10288
     components:
     - pos: -40.5,-8.5
@@ -40562,85 +37164,61 @@ entities:
     - pos: -41.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10386
     components:
     - pos: 30.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10387
     components:
     - pos: 30.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10388
     components:
     - pos: 30.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10389
     components:
     - pos: 30.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10390
     components:
     - pos: 30.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10391
     components:
     - pos: 29.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10392
     components:
     - pos: 28.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10393
     components:
     - pos: 27.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10394
     components:
     - pos: 26.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10395
     components:
     - pos: 25.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10396
     components:
     - pos: 24.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10397
     components:
     - pos: 23.5,-24.5
@@ -40656,120 +37234,86 @@ entities:
     - pos: 22.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10400
     components:
     - pos: 22.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10401
     components:
     - pos: 22.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10402
     components:
     - pos: 21.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10403
     components:
     - pos: 21.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10404
     components:
     - pos: 21.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10405
     components:
     - pos: 20.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10406
     components:
     - pos: 19.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10407
     components:
     - pos: 18.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10408
     components:
     - pos: 17.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10409
     components:
     - pos: 16.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10410
     components:
     - pos: 15.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10411
     components:
     - pos: 15.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10412
     components:
     - pos: 15.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10413
     components:
     - pos: 15.5,-32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10414
     components:
     - pos: 15.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10415
     components:
     - pos: 15.5,-34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10416
     components:
     - pos: 8.5,-18.5
@@ -40895,8 +37439,6 @@ entities:
     - pos: 16.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10459
     components:
     - pos: 12.5,-34.5
@@ -40952,8 +37494,6 @@ entities:
     - pos: 5.5,-31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10546
     components:
     - pos: 11.5,-20.5
@@ -40969,71 +37509,51 @@ entities:
     - pos: 10.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10631
     components:
     - pos: 28.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10632
     components:
     - pos: 27.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10633
     components:
     - pos: 26.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10634
     components:
     - pos: 25.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10635
     components:
     - pos: 24.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10636
     components:
     - pos: 24.5,-14.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10637
     components:
     - pos: 24.5,-13.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10638
     components:
     - pos: 24.5,-12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10639
     components:
     - pos: 24.5,-11.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10640
     components:
     - pos: 24.5,-10.5
@@ -41054,8 +37574,6 @@ entities:
     - pos: 22.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10667
     components:
     - pos: 7.5,-18.5
@@ -41096,8 +37614,6 @@ entities:
     - pos: 6.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10675
     components:
     - pos: 7.5,-17.5
@@ -41108,8 +37624,6 @@ entities:
     - pos: 7.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10677
     components:
     - pos: 7.5,-15.5
@@ -41130,78 +37644,56 @@ entities:
     - pos: 4.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10681
     components:
     - pos: 3.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10682
     components:
     - pos: 2.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10683
     components:
     - pos: 1.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10684
     components:
     - pos: 0.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10685
     components:
     - pos: -0.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10686
     components:
     - pos: -1.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10687
     components:
     - pos: -2.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10688
     components:
     - pos: -3.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10689
     components:
     - pos: -4.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10690
     components:
     - pos: -5.5,-15.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10691
     components:
     - pos: -6.5,-15.5
@@ -41287,8 +37779,6 @@ entities:
     - pos: -12.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10709
     components:
     - pos: -12.5,-26.5
@@ -41314,8 +37804,6 @@ entities:
     - pos: -12.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10714
     components:
     - pos: -12.5,-31.5
@@ -41361,8 +37849,6 @@ entities:
     - pos: -11.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10968
     components:
     - pos: 25.5,-9.5
@@ -41473,8 +37959,6 @@ entities:
     - pos: 44.5,-6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11084
     components:
     - pos: 17.5,4.5
@@ -41485,22 +37969,16 @@ entities:
     - pos: 18.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11086
     components:
     - pos: 18.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11087
     components:
     - pos: 18.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11088
     components:
     - pos: 18.5,1.5
@@ -41511,78 +37989,56 @@ entities:
     - pos: 18.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11090
     components:
     - pos: 19.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11091
     components:
     - pos: 20.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11092
     components:
     - pos: 21.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11093
     components:
     - pos: 21.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11094
     components:
     - pos: 21.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11095
     components:
     - pos: 21.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11096
     components:
     - pos: 21.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11097
     components:
     - pos: 21.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11098
     components:
     - pos: 22.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11099
     components:
     - pos: 22.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11100
     components:
     - pos: 23.5,0.5
@@ -41628,15 +38084,11 @@ entities:
     - pos: 23.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11236
     components:
     - pos: 16.5,9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11237
     components:
     - pos: 17.5,9.5
@@ -41647,120 +38099,86 @@ entities:
     - pos: 18.5,9.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11239
     components:
     - pos: 18.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11240
     components:
     - pos: 19.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11241
     components:
     - pos: 20.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11242
     components:
     - pos: 21.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11243
     components:
     - pos: 21.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11244
     components:
     - pos: 21.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11282
     components:
     - pos: 13.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11283
     components:
     - pos: 14.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11284
     components:
     - pos: 15.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11285
     components:
     - pos: 16.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11286
     components:
     - pos: 17.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11287
     components:
     - pos: 18.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11288
     components:
     - pos: 18.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11378
     components:
     - pos: -4.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11379
     components:
     - pos: -3.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11380
     components:
     - pos: -3.5,75.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11381
     components:
     - pos: -3.5,76.5
@@ -41796,295 +38214,211 @@ entities:
     - pos: -9.5,76.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11388
     components:
     - pos: -9.5,77.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11389
     components:
     - pos: -9.5,78.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11390
     components:
     - pos: -8.5,78.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11391
     components:
     - pos: -8.5,79.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11392
     components:
     - pos: -8.5,80.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11393
     components:
     - pos: -8.5,81.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11394
     components:
     - pos: -7.5,81.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11395
     components:
     - pos: -7.5,82.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11396
     components:
     - pos: -7.5,83.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11397
     components:
     - pos: -6.5,83.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11398
     components:
     - pos: -5.5,83.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11399
     components:
     - pos: -4.5,83.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11400
     components:
     - pos: -4.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11401
     components:
     - pos: -3.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11402
     components:
     - pos: -2.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11403
     components:
     - pos: -1.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11404
     components:
     - pos: -0.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11405
     components:
     - pos: 0.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11406
     components:
     - pos: 1.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11407
     components:
     - pos: 2.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11408
     components:
     - pos: 3.5,84.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11409
     components:
     - pos: 3.5,83.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11410
     components:
     - pos: 4.5,83.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11411
     components:
     - pos: 5.5,83.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11412
     components:
     - pos: 6.5,83.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11413
     components:
     - pos: 6.5,82.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11414
     components:
     - pos: 6.5,81.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11415
     components:
     - pos: 7.5,81.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11416
     components:
     - pos: 7.5,80.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11417
     components:
     - pos: 7.5,79.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11418
     components:
     - pos: 7.5,78.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11419
     components:
     - pos: 8.5,78.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11420
     components:
     - pos: 8.5,77.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11421
     components:
     - pos: 8.5,76.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11422
     components:
     - pos: 8.5,75.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11423
     components:
     - pos: 7.5,75.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11424
     components:
     - pos: 6.5,75.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11553
     components:
     - pos: -24.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11554
     components:
     - pos: -24.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11555
     components:
     - pos: -24.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11556
     components:
     - pos: -24.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11557
     components:
     - pos: -24.5,53.5
@@ -42095,92 +38429,66 @@ entities:
     - pos: -24.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11559
     components:
     - pos: -24.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11560
     components:
     - pos: -24.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11561
     components:
     - pos: -24.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11562
     components:
     - pos: -23.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11563
     components:
     - pos: -22.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11564
     components:
     - pos: -21.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11565
     components:
     - pos: -21.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11566
     components:
     - pos: -21.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11567
     components:
     - pos: -21.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11568
     components:
     - pos: -21.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11569
     components:
     - pos: -21.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11570
     components:
     - pos: -21.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11571
     components:
     - pos: -21.5,50.5
@@ -42191,8 +38499,6 @@ entities:
     - pos: -20.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11574
     components:
     - pos: -42.5,44.5
@@ -42208,113 +38514,81 @@ entities:
     - pos: -43.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11577
     components:
     - pos: -43.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11578
     components:
     - pos: -43.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11579
     components:
     - pos: -43.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11580
     components:
     - pos: -43.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11581
     components:
     - pos: -43.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11582
     components:
     - pos: -43.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11583
     components:
     - pos: -41.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11584
     components:
     - pos: -42.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11585
     components:
     - pos: -40.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11586
     components:
     - pos: -40.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11587
     components:
     - pos: -39.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11588
     components:
     - pos: -38.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11589
     components:
     - pos: -37.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11590
     components:
     - pos: -36.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11591
     components:
     - pos: -35.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11592
     components:
     - pos: -34.5,52.5
@@ -42325,8 +38599,6 @@ entities:
     - pos: -33.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11594
     components:
     - pos: -32.5,52.5
@@ -42337,22 +38609,16 @@ entities:
     - pos: -31.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11596
     components:
     - pos: -30.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11597
     components:
     - pos: -29.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11598
     components:
     - pos: -28.5,52.5
@@ -42363,8 +38629,6 @@ entities:
     - pos: -27.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11600
     components:
     - pos: -27.5,53.5
@@ -42375,8 +38639,6 @@ entities:
     - pos: -27.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11602
     components:
     - pos: -27.5,55.5
@@ -42387,50 +38649,36 @@ entities:
     - pos: -27.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11604
     components:
     - pos: -27.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11605
     components:
     - pos: -30.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11606
     components:
     - pos: -30.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11607
     components:
     - pos: -29.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11608
     components:
     - pos: -26.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11609
     components:
     - pos: -25.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 11839
     components:
     - pos: -21.5,49.5
@@ -42551,43 +38799,31 @@ entities:
     - pos: -7.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12020
     components:
     - pos: -28.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12028
     components:
     - pos: -21.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12029
     components:
     - pos: -20.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12030
     components:
     - pos: -20.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12031
     components:
     - pos: -20.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12032
     components:
     - pos: -20.5,28.5
@@ -42598,8 +38834,6 @@ entities:
     - pos: -20.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12034
     components:
     - pos: -20.5,26.5
@@ -42630,8 +38864,6 @@ entities:
     - pos: -17.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12040
     components:
     - pos: -16.5,25.5
@@ -42687,8 +38919,6 @@ entities:
     - pos: -8.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12051
     components:
     - pos: -10.5,26.5
@@ -42734,64 +38964,46 @@ entities:
     - pos: -12.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12236
     components:
     - pos: -21.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12237
     components:
     - pos: -22.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12238
     components:
     - pos: -23.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12239
     components:
     - pos: -23.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12240
     components:
     - pos: -23.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12241
     components:
     - pos: -23.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12242
     components:
     - pos: -23.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12243
     components:
     - pos: -23.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12244
     components:
     - pos: -24.5,32.5
@@ -42802,22 +39014,16 @@ entities:
     - pos: -25.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12290
     components:
     - pos: -23.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12291
     components:
     - pos: -23.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12292
     components:
     - pos: -23.5,35.5
@@ -42908,141 +39114,101 @@ entities:
     - pos: -38.5,34.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12311
     components:
     - pos: -38.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12312
     components:
     - pos: -37.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12313
     components:
     - pos: -36.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12314
     components:
     - pos: -35.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12315
     components:
     - pos: -34.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12316
     components:
     - pos: -34.5,32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12317
     components:
     - pos: -34.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12318
     components:
     - pos: -34.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12319
     components:
     - pos: -34.5,29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12320
     components:
     - pos: -34.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12321
     components:
     - pos: -34.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12322
     components:
     - pos: -34.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12323
     components:
     - pos: -34.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12324
     components:
     - pos: -35.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12409
     components:
     - pos: 20.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12410
     components:
     - pos: 20.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12411
     components:
     - pos: 20.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12412
     components:
     - pos: 19.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12413
     components:
     - pos: 18.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12414
     components:
     - pos: 17.5,52.5
@@ -43053,323 +39219,231 @@ entities:
     - pos: 16.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12416
     components:
     - pos: 16.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12417
     components:
     - pos: 16.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12418
     components:
     - pos: 16.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12419
     components:
     - pos: 16.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12420
     components:
     - pos: 17.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12421
     components:
     - pos: 18.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12422
     components:
     - pos: 19.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12423
     components:
     - pos: 19.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12424
     components:
     - pos: 19.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12425
     components:
     - pos: 18.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12426
     components:
     - pos: 18.5,59.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12427
     components:
     - pos: 18.5,60.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12428
     components:
     - pos: 18.5,61.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12429
     components:
     - pos: 18.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12430
     components:
     - pos: 18.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12431
     components:
     - pos: 17.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12432
     components:
     - pos: 16.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12433
     components:
     - pos: 15.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12434
     components:
     - pos: 14.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12435
     components:
     - pos: 13.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12436
     components:
     - pos: 12.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12437
     components:
     - pos: 11.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12438
     components:
     - pos: 10.5,63.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12439
     components:
     - pos: 10.5,62.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12440
     components:
     - pos: 16.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12441
     components:
     - pos: 16.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12442
     components:
     - pos: 16.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12443
     components:
     - pos: 17.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12444
     components:
     - pos: 18.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12445
     components:
     - pos: 19.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12446
     components:
     - pos: 20.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12447
     components:
     - pos: 21.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12448
     components:
     - pos: 22.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12449
     components:
     - pos: 22.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12450
     components:
     - pos: 22.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12451
     components:
     - pos: 22.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12452
     components:
     - pos: 22.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12453
     components:
     - pos: 23.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12454
     components:
     - pos: 24.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12455
     components:
     - pos: 25.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12456
     components:
     - pos: 25.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12457
     components:
     - pos: 25.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12458
     components:
     - pos: 25.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12459
     components:
     - pos: 24.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12461
     components:
     - pos: 6.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12462
     components:
     - pos: 5.5,46.5
@@ -43520,8 +39594,6 @@ entities:
     - pos: 5.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12492
     components:
     - pos: 14.5,54.5
@@ -43557,295 +39629,211 @@ entities:
     - pos: 16.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12499
     components:
     - pos: 17.5,58.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12500
     components:
     - pos: 20.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12501
     components:
     - pos: 21.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12502
     components:
     - pos: 22.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12503
     components:
     - pos: 22.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12504
     components:
     - pos: 23.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12505
     components:
     - pos: 24.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12506
     components:
     - pos: 25.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12507
     components:
     - pos: 26.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12508
     components:
     - pos: 27.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12509
     components:
     - pos: 28.5,57.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12510
     components:
     - pos: 28.5,56.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12511
     components:
     - pos: 28.5,55.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12512
     components:
     - pos: 28.5,54.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12513
     components:
     - pos: 28.5,53.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12514
     components:
     - pos: 28.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12515
     components:
     - pos: 28.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12516
     components:
     - pos: 27.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12517
     components:
     - pos: 29.5,52.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12518
     components:
     - pos: 29.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12519
     components:
     - pos: 30.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12520
     components:
     - pos: 31.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12521
     components:
     - pos: 32.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12522
     components:
     - pos: 33.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12523
     components:
     - pos: 34.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12524
     components:
     - pos: 35.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12525
     components:
     - pos: 36.5,51.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12526
     components:
     - pos: 36.5,50.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12527
     components:
     - pos: 36.5,49.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12528
     components:
     - pos: 36.5,48.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12529
     components:
     - pos: 36.5,47.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12530
     components:
     - pos: 36.5,46.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12531
     components:
     - pos: 36.5,45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12532
     components:
     - pos: 36.5,44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12533
     components:
     - pos: 36.5,43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12534
     components:
     - pos: 36.5,42.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12535
     components:
     - pos: 36.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12536
     components:
     - pos: 36.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12537
     components:
     - pos: 37.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12538
     components:
     - pos: 38.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12539
     components:
     - pos: 39.5,40.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12540
     components:
     - pos: 40.5,40.5
@@ -43861,8 +39849,6 @@ entities:
     - pos: 41.5,41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12866
     components:
     - pos: 16.5,25.5
@@ -43883,8 +39869,6 @@ entities:
     - pos: 14.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12870
     components:
     - pos: 14.5,23.5
@@ -43895,64 +39879,46 @@ entities:
     - pos: 14.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12872
     components:
     - pos: 15.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12873
     components:
     - pos: 16.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12874
     components:
     - pos: 17.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12875
     components:
     - pos: 18.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12876
     components:
     - pos: 19.5,22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12877
     components:
     - pos: 19.5,21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12878
     components:
     - pos: 19.5,20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12879
     components:
     - pos: 19.5,19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12880
     components:
     - pos: 18.5,19.5
@@ -43963,85 +39929,61 @@ entities:
     - pos: 17.5,19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12882
     components:
     - pos: 19.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12883
     components:
     - pos: 19.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12884
     components:
     - pos: 20.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12885
     components:
     - pos: 21.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12886
     components:
     - pos: 22.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12887
     components:
     - pos: 23.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12888
     components:
     - pos: 24.5,24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12889
     components:
     - pos: 24.5,23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12890
     components:
     - pos: 24.5,25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12891
     components:
     - pos: 24.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12892
     components:
     - pos: 24.5,27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12893
     components:
     - pos: 23.5,27.5
@@ -44077,8 +40019,6 @@ entities:
     - pos: 20.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12902
     components:
     - pos: 17.5,28.5
@@ -44154,8 +40094,6 @@ entities:
     - pos: 5.5,26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 12917
     components:
     - pos: 15.5,21.5
@@ -44186,15 +40124,11 @@ entities:
     - pos: 8.5,31.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13491
     components:
     - pos: -7.5,-16.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13497
     components:
     - pos: -25.5,-0.5
@@ -44205,29 +40139,21 @@ entities:
     - pos: -25.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13499
     components:
     - pos: -25.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13500
     components:
     - pos: -24.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13501
     components:
     - pos: -23.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13502
     components:
     - pos: -22.5,-2.5
@@ -44238,99 +40164,71 @@ entities:
     - pos: -21.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13504
     components:
     - pos: -20.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13505
     components:
     - pos: -19.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13506
     components:
     - pos: -19.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13507
     components:
     - pos: -19.5,-0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13508
     components:
     - pos: -19.5,0.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13509
     components:
     - pos: -19.5,1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13510
     components:
     - pos: -19.5,2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13511
     components:
     - pos: -19.5,3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13512
     components:
     - pos: -19.5,4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13513
     components:
     - pos: -19.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13514
     components:
     - pos: -19.5,6.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13515
     components:
     - pos: -19.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13516
     components:
     - pos: -20.5,7.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13517
     components:
     - pos: -21.5,7.5
@@ -44341,8 +40239,6 @@ entities:
     - pos: -21.5,8.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13519
     components:
     - pos: -18.5,-0.5
@@ -44413,15 +40309,11 @@ entities:
     - pos: -11.5,5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 13533
     components:
     - pos: -21.5,-1.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 14379
     components:
     - pos: 28.5,-9.5
@@ -44442,29 +40334,21 @@ entities:
     - pos: -9.5,74.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18341
     components:
     - pos: -9.5,73.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18342
     components:
     - pos: -9.5,72.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18343
     components:
     - pos: -9.5,75.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18451
     components:
     - pos: 20.5,-11.5
@@ -44490,8 +40374,6 @@ entities:
     - pos: 16.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18474
     components:
     - pos: 15.5,-11.5
@@ -44502,8 +40384,6 @@ entities:
     - pos: 15.5,-10.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
 - proto: CableMVStack
   entities:
   - uid: 9125
@@ -48480,6 +44360,26 @@ entities:
     - pos: 12.5,-41.5
       parent: 1
       type: Transform
+  - uid: 9200
+    components:
+    - pos: -45.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 9201
+    components:
+    - pos: -46.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 9202
+    components:
+    - pos: -45.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 9308
+    components:
+    - pos: -46.5,2.5
+      parent: 1
+      type: Transform
   - uid: 9600
     components:
     - pos: 15.5,-34.5
@@ -49257,6 +45157,17 @@ entities:
   - uid: 9594
     components:
     - pos: 15.5,15.5
+      parent: 1
+      type: Transform
+  - uid: 9626
+    components:
+    - pos: -38.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 9627
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -38.5,-7.5
       parent: 1
       type: Transform
   - uid: 9719
@@ -53332,6 +49243,13 @@ entities:
     - pos: 15.602159,8.388835
       parent: 1
       type: Transform
+- proto: ClothingBeltUtility
+  entities:
+  - uid: 9621
+    components:
+    - pos: -43.50088,-2.459965
+      parent: 1
+      type: Transform
 - proto: ClothingBeltUtilityFilled
   entities:
   - uid: 4702
@@ -54614,6 +50532,42 @@ entities:
       type: Transform
 - proto: ConveyorBelt
   entities:
+  - uid: 252
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -43.5,1.5
+      parent: 1
+      type: Transform
+    - links:
+      - 7815
+      type: DeviceLinkSink
+  - uid: 459
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -46.5,5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 8179
+      type: DeviceLinkSink
+  - uid: 460
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -45.5,5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 8179
+      type: DeviceLinkSink
+  - uid: 461
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -44.5,5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 8179
+      type: DeviceLinkSink
   - uid: 1767
     components:
     - rot: 1.5707963267948966 rad
@@ -54623,6 +50577,33 @@ entities:
     - links:
       - 7918
       - 7808
+      type: DeviceLinkSink
+  - uid: 2127
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -43.5,5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 8179
+      type: DeviceLinkSink
+  - uid: 2722
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -47.5,5.5
+      parent: 1
+      type: Transform
+    - links:
+      - 8179
+      type: DeviceLinkSink
+  - uid: 2723
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -44.5,1.5
+      parent: 1
+      type: Transform
+    - links:
+      - 7815
       type: DeviceLinkSink
   - uid: 3830
     components:
@@ -54746,87 +50727,6 @@ entities:
       - 7918
       - 7808
       type: DeviceLinkSink
-  - uid: 4137
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -44.5,1.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9362
-      type: DeviceLinkSink
-  - uid: 4138
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -43.5,1.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9362
-      type: DeviceLinkSink
-  - uid: 4139
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -42.5,1.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9362
-      type: DeviceLinkSink
-  - uid: 4140
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -41.5,1.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9362
-      type: DeviceLinkSink
-  - uid: 4141
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -44.5,5.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9362
-      type: DeviceLinkSink
-  - uid: 4142
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -43.5,5.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9362
-      type: DeviceLinkSink
-  - uid: 4143
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -42.5,5.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9362
-      type: DeviceLinkSink
-  - uid: 4144
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -41.5,5.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9362
-      type: DeviceLinkSink
-  - uid: 4145
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -40.5,5.5
-      parent: 1
-      type: Transform
-    - links:
-      - 9362
-      type: DeviceLinkSink
   - uid: 4146
     components:
     - rot: 1.5707963267948966 rad
@@ -54845,14 +50745,32 @@ entities:
     - links:
       - 9364
       type: DeviceLinkSink
-  - uid: 4148
+  - uid: 7254
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -40.5,1.5
+    - rot: -1.5707963267948966 rad
+      pos: -45.5,1.5
       parent: 1
       type: Transform
     - links:
-      - 9362
+      - 7815
+      type: DeviceLinkSink
+  - uid: 7291
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -46.5,1.5
+      parent: 1
+      type: Transform
+    - links:
+      - 7815
+      type: DeviceLinkSink
+  - uid: 7704
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -47.5,1.5
+      parent: 1
+      type: Transform
+    - links:
+      - 7815
       type: DeviceLinkSink
   - uid: 7818
     components:
@@ -54930,44 +50848,24 @@ entities:
     - pos: -20.5,9.5
       parent: 1
       type: Transform
-  - uid: 9314
-    components:
-    - pos: -38.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 9315
-    components:
-    - pos: -38.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 9316
-    components:
-    - pos: -39.5,-7.5
-      parent: 1
-      type: Transform
   - uid: 9317
     components:
-    - pos: -39.5,-5.5
+    - pos: -41.5,0.5
       parent: 1
       type: Transform
   - uid: 9318
     components:
-    - pos: -43.5,-4.5
+    - pos: -39.5,0.5
       parent: 1
       type: Transform
   - uid: 9319
     components:
-    - pos: -42.5,-5.5
+    - pos: -39.5,1.5
       parent: 1
       type: Transform
   - uid: 9320
     components:
-    - pos: -43.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 9390
-    components:
-    - pos: -40.5,0.5
+    - pos: -40.5,1.5
       parent: 1
       type: Transform
   - uid: 9448
@@ -55254,17 +51152,32 @@ entities:
       type: Transform
   - uid: 9311
     components:
-    - pos: -39.5,-6.5
+    - pos: -40.5,0.5
       parent: 1
       type: Transform
   - uid: 9312
     components:
-    - pos: -42.5,-4.5
+    - pos: -41.5,1.5
       parent: 1
       type: Transform
   - uid: 9313
     components:
-    - pos: -40.5,6.5
+    - pos: -41.5,2.5
+      parent: 1
+      type: Transform
+  - uid: 9314
+    components:
+    - pos: -39.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 9315
+    components:
+    - pos: -39.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 9316
+    components:
+    - pos: -40.5,4.5
       parent: 1
       type: Transform
 - proto: CrateFreezer
@@ -55294,34 +51207,23 @@ entities:
       type: EntityStorage
 - proto: CrateFunArtSupplies
   entities:
-  - uid: 9308
+  - uid: 9363
     components:
-    - pos: -38.5,-7.5
+    - pos: -40.5,3.5
       parent: 1
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 3.4430928
-        - 12.952587
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
 - proto: CrateMedicalSurgery
   entities:
   - uid: 1663
     components:
     - pos: 18.5,26.5
+      parent: 1
+      type: Transform
+- proto: CrateMindShieldImplants
+  entities:
+  - uid: 256
+    components:
+    - pos: -8.5,64.5
       parent: 1
       type: Transform
 - proto: CrateNPCCow
@@ -55349,56 +51251,13 @@ entities:
         - 0
         - 0
       type: EntityStorage
-- proto: CrateServiceBooks
-  entities:
-  - uid: 9309
-    components:
-    - pos: -43.5,-5.5
-      parent: 1
-      type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 3.4430928
-        - 12.952587
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
 - proto: CrateServiceBureaucracy
   entities:
-  - uid: 9310
+  - uid: 9321
     components:
-    - pos: -38.5,-4.5
+    - pos: -40.5,2.5
       parent: 1
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 3.4430928
-        - 12.952587
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
 - proto: CrateServiceJanitorialSupplies
   entities:
   - uid: 9378
@@ -60485,6 +56344,16 @@ entities:
     - pos: 5.67161,57.67581
       parent: 1
       type: Transform
+  - uid: 9632
+    components:
+    - pos: -42.65752,-7.2487845
+      parent: 1
+      type: Transform
+  - uid: 9633
+    components:
+    - pos: -42.641895,-7.3894095
+      parent: 1
+      type: Transform
 - proto: DrinkWineGlass
   entities:
   - uid: 8368
@@ -60519,8 +56388,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11341
     components:
@@ -60529,8 +56396,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11342
     components:
@@ -60539,8 +56404,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11343
     components:
@@ -60549,8 +56412,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11344
     components:
@@ -60560,8 +56421,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11345
     components:
@@ -60571,8 +56430,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11346
     components:
@@ -60581,8 +56438,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11347
     components:
@@ -60592,8 +56447,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11348
     components:
@@ -60602,8 +56455,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11349
     components:
@@ -60613,8 +56464,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11350
     components:
@@ -60624,8 +56473,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11351
     components:
@@ -60635,8 +56482,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11352
     components:
@@ -60646,8 +56491,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11353
     components:
@@ -60657,8 +56500,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11354
     components:
@@ -60667,8 +56508,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11355
     components:
@@ -60677,8 +56516,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11356
     components:
@@ -60688,8 +56525,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11357
     components:
@@ -60699,8 +56534,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11358
     components:
@@ -60710,8 +56543,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11359
     components:
@@ -60721,8 +56552,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11360
     components:
@@ -60731,8 +56560,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11361
     components:
@@ -60742,8 +56569,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11362
     components:
@@ -60752,8 +56577,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11363
     components:
@@ -60762,8 +56585,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11364
     components:
@@ -60772,8 +56593,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11366
     components:
@@ -60783,8 +56602,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11367
     components:
@@ -60794,8 +56611,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11369
     components:
@@ -60805,8 +56620,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11370
     components:
@@ -60815,8 +56628,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11371
     components:
@@ -60826,8 +56637,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11372
     components:
@@ -60836,8 +56645,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11373
     components:
@@ -60847,8 +56654,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 11374
     components:
@@ -60858,8 +56663,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 13994
     components:
@@ -60868,8 +56671,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 13995
     components:
@@ -60879,8 +56680,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 13996
     components:
@@ -60890,8 +56689,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 14091
     components:
@@ -60901,8 +56698,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 14219
     components:
@@ -60912,8 +56707,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18156
     components:
@@ -60923,8 +56716,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18157
     components:
@@ -60933,8 +56724,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18158
     components:
@@ -60944,8 +56733,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18159
     components:
@@ -60955,8 +56742,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18160
     components:
@@ -60965,8 +56750,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18161
     components:
@@ -60975,8 +56758,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18162
     components:
@@ -60985,8 +56766,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18163
     components:
@@ -60996,8 +56775,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18164
     components:
@@ -61007,8 +56784,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18165
     components:
@@ -61018,8 +56793,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18166
     components:
@@ -61028,8 +56801,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18167
     components:
@@ -61039,8 +56810,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18168
     components:
@@ -61050,8 +56819,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18169
     components:
@@ -61060,8 +56827,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
   - uid: 18170
     components:
@@ -61071,8 +56836,6 @@ entities:
       type: Transform
     - enabled: True
       type: PointLight
-    - enabled: True
-      type: AmbientSound
     - type: ActiveEmergencyLight
 - proto: Emitter
   entities:
@@ -61171,6 +56934,11 @@ entities:
       type: Transform
 - proto: ExtinguisherCabinetFilled
   entities:
+  - uid: 5532
+    components:
+    - pos: -37.5,0.5
+      parent: 1
+      type: Transform
   - uid: 18367
     components:
     - rot: -1.5707963267948966 rad
@@ -61271,12 +57039,6 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -33.5,-5.5
-      parent: 1
-      type: Transform
-  - uid: 18385
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -41.5,0.5
       parent: 1
       type: Transform
   - uid: 18386
@@ -64528,6 +60290,23 @@ entities:
     - pos: -35.421543,-26.464243
       parent: 1
       type: Transform
+- proto: FoodBanana
+  entities:
+  - uid: 9661
+    components:
+    - pos: -16.203074,-0.3446604
+      parent: 1
+      type: Transform
+  - uid: 9662
+    components:
+    - pos: -16.203074,-0.3446604
+      parent: 1
+      type: Transform
+  - uid: 9663
+    components:
+    - pos: -16.203074,-0.3446604
+      parent: 1
+      type: Transform
 - proto: FoodBowlBig
   entities:
   - uid: 8268
@@ -64555,6 +60334,13 @@ entities:
   - uid: 10112
     components:
     - pos: 18.107027,-35.953514
+      parent: 1
+      type: Transform
+- proto: FoodBoxDonkpocket
+  entities:
+  - uid: 9631
+    components:
+    - pos: -42.173145,-7.3112845
       parent: 1
       type: Transform
 - proto: FoodBoxDonut
@@ -64595,6 +60381,20 @@ entities:
   - uid: 8372
     components:
     - pos: 32.526695,49.610416
+      parent: 1
+      type: Transform
+- proto: FoodBurgerBig
+  entities:
+  - uid: 2726
+    components:
+    - pos: -38.561558,-5.6145735
+      parent: 1
+      type: Transform
+- proto: FoodBurgerCrazy
+  entities:
+  - uid: 9637
+    components:
+    - pos: -18.525078,-21.779133
       parent: 1
       type: Transform
 - proto: FoodCakeBirthdaySlice
@@ -65006,24 +60806,6 @@ entities:
       pos: -1.5,-33.5
       parent: 1
       type: Transform
-  - uid: 2711
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-43.5
-      parent: 1
-      type: Transform
-  - uid: 2712
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-44.5
-      parent: 1
-      type: Transform
-  - uid: 2713
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -2.5,-45.5
-      parent: 1
-      type: Transform
 - proto: GasPassiveVent
   entities:
   - uid: 450
@@ -65150,78 +60932,73 @@ entities:
       type: Transform
 - proto: GasPipeBend
   entities:
+  - uid: 2346
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,-43.5
+      parent: 1
+      type: Transform
+    - color: '#FF1212FF'
+      type: AtmosPipeColor
   - uid: 2572
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2573
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2574
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2575
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2576
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2577
     components:
     - rot: -1.5707963267948966 rad
       pos: 0.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 2703
+  - uid: 2611
+    components:
+    - pos: -6.5,-43.5
+      parent: 1
+      type: Transform
+    - color: '#03FCD3FF'
+      type: AtmosPipeColor
+  - uid: 2717
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -9.5,-45.5
+      parent: 1
+      type: Transform
+    - color: '#FF1212FF'
+      type: AtmosPipeColor
+  - uid: 2730
     components:
     - rot: 3.141592653589793 rad
-      pos: -6.5,-44.5
+      pos: -7.5,-45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 2706
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -4.5,-43.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 2707
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -4.5,-45.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
+    - color: '#03FCD3FF'
+      type: AtmosPipeColor
   - uid: 2744
     components:
     - rot: 1.5707963267948966 rad
@@ -65242,16 +61019,28 @@ entities:
     - pos: 3.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2960
     components:
     - rot: -1.5707963267948966 rad
       pos: 4.5,-45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
+  - uid: 4140
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-45.5
+      parent: 1
+      type: Transform
+    - color: '#03FCD3FF'
+      type: AtmosPipeColor
+  - uid: 4142
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -10.5,-45.5
+      parent: 1
+      type: Transform
+    - color: '#FF1212FF'
+      type: AtmosPipeColor
   - uid: 6372
     components:
     - rot: -1.5707963267948966 rad
@@ -65270,8 +61059,6 @@ entities:
       pos: -7.5,33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9031
     components:
     - rot: 3.141592653589793 rad
@@ -65294,8 +61081,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10881
     components:
     - rot: -1.5707963267948966 rad
@@ -65304,8 +61089,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10885
     components:
     - pos: 30.5,-15.5
@@ -65313,8 +61096,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10891
     components:
     - rot: 3.141592653589793 rad
@@ -65323,8 +61104,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13857
     components:
     - rot: -1.5707963267948966 rad
@@ -65333,8 +61112,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13859
     components:
     - rot: 1.5707963267948966 rad
@@ -65343,8 +61120,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13862
     components:
     - rot: 3.141592653589793 rad
@@ -65353,8 +61128,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13868
     components:
     - pos: 22.5,49.5
@@ -65362,8 +61135,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13872
     components:
     - rot: 3.141592653589793 rad
@@ -65372,8 +61143,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13875
     components:
     - pos: 25.5,45.5
@@ -65381,8 +61150,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14301
     components:
     - pos: 12.5,-12.5
@@ -65429,8 +61196,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14400
     components:
     - rot: -1.5707963267948966 rad
@@ -65639,8 +61404,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15053
     components:
     - pos: 44.5,43.5
@@ -65664,8 +61427,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15081
     components:
     - rot: -1.5707963267948966 rad
@@ -65674,8 +61435,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15092
     components:
     - rot: -1.5707963267948966 rad
@@ -66115,31 +61874,23 @@ entities:
       pos: -23.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18144
     components:
     - pos: -19.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18147
     components:
     - rot: -1.5707963267948966 rad
       pos: -19.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18154
     components:
     - rot: 1.5707963267948966 rad
       pos: -26.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18477
     components:
     - rot: -1.5707963267948966 rad
@@ -66161,15 +61912,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
-  - uid: 2705
-    components:
-    - pos: -4.5,-44.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2736
     components:
     - pos: -12.5,-18.5
@@ -66353,400 +62095,294 @@ entities:
       pos: -0.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2543
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2544
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2545
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2546
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-20.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2547
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2548
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2549
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2550
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2551
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-22.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2552
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2553
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2554
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2555
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2556
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-24.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2557
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2558
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2559
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2560
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2561
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-26.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2562
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2563
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2564
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2565
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2566
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2567
     components:
     - rot: -1.5707963267948966 rad
       pos: -0.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2568
     components:
     - rot: -1.5707963267948966 rad
       pos: -1.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2569
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2570
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2571
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2578
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2579
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2580
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-29.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2581
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2582
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2583
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-27.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2584
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2585
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2586
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-25.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2587
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2588
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2589
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-23.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2590
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2591
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2592
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-21.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2593
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2594
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2595
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-19.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 2622
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -5.5,-44.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2626
     components:
     - rot: 1.5707963267948966 rad
       pos: -4.5,-32.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2647
     components:
     - rot: 3.141592653589793 rad
@@ -66755,8 +62391,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 2649
     components:
     - rot: 3.141592653589793 rad
@@ -66787,124 +62421,64 @@ entities:
       pos: -4.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2664
     components:
     - rot: 1.5707963267948966 rad
       pos: -3.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2665
     components:
     - rot: 1.5707963267948966 rad
       pos: -2.5,-39.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2674
     components:
     - pos: 0.5,-36.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2675
     components:
     - pos: 0.5,-38.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2677
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2678
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2679
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-33.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2681
     components:
     - rot: -1.5707963267948966 rad
       pos: -2.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2682
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2683
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-35.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 2701
-    components:
-    - pos: -6.5,-42.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 2702
-    components:
-    - pos: -6.5,-43.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 2708
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-43.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 2709
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-44.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
-  - uid: 2710
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -3.5,-45.5
-      parent: 1
-      type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2732
     components:
     - rot: -1.5707963267948966 rad
@@ -66913,8 +62487,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 2733
     components:
     - rot: -1.5707963267948966 rad
@@ -66963,8 +62535,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 2743
     components:
     - rot: 1.5707963267948966 rad
@@ -67217,56 +62787,42 @@ entities:
       pos: 2.5,-43.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2954
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2955
     components:
     - rot: 1.5707963267948966 rad
       pos: 2.5,-45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3540
     components:
     - rot: -1.5707963267948966 rad
       pos: -7.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3541
     components:
     - rot: -1.5707963267948966 rad
       pos: -8.5,30.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3542
     components:
     - rot: -1.5707963267948966 rad
       pos: -7.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3543
     components:
     - rot: -1.5707963267948966 rad
       pos: -8.5,28.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 3544
     components:
     - rot: -1.5707963267948966 rad
@@ -67346,8 +62902,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 9035
     components:
     - pos: 10.5,29.5
@@ -67361,32 +62915,24 @@ entities:
       pos: -2.5,-41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9197
     components:
     - rot: -1.5707963267948966 rad
       pos: -3.5,-41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9198
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-41.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 9725
     components:
     - rot: -1.5707963267948966 rad
       pos: -4.5,-18.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 10880
     components:
     - rot: 1.5707963267948966 rad
@@ -67403,8 +62949,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10883
     components:
     - rot: 3.141592653589793 rad
@@ -67413,8 +62957,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10884
     components:
     - rot: 3.141592653589793 rad
@@ -67423,8 +62965,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10886
     components:
     - rot: -1.5707963267948966 rad
@@ -67433,8 +62973,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10887
     components:
     - rot: -1.5707963267948966 rad
@@ -67443,8 +62981,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10888
     components:
     - rot: -1.5707963267948966 rad
@@ -67453,8 +62989,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10889
     components:
     - rot: -1.5707963267948966 rad
@@ -67463,8 +62997,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10890
     components:
     - rot: -1.5707963267948966 rad
@@ -67473,8 +63005,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10892
     components:
     - rot: 3.141592653589793 rad
@@ -67483,8 +63013,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10893
     components:
     - rot: 3.141592653589793 rad
@@ -67493,8 +63021,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10894
     components:
     - rot: 3.141592653589793 rad
@@ -67503,8 +63029,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10895
     components:
     - rot: 3.141592653589793 rad
@@ -67513,8 +63037,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 10896
     components:
     - rot: 3.141592653589793 rad
@@ -67744,8 +63266,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13861
     components:
     - pos: 16.5,50.5
@@ -67753,8 +63273,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13863
     components:
     - rot: 1.5707963267948966 rad
@@ -67763,8 +63281,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13864
     components:
     - rot: 1.5707963267948966 rad
@@ -67773,8 +63289,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13865
     components:
     - rot: 1.5707963267948966 rad
@@ -67783,8 +63297,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13866
     components:
     - rot: 1.5707963267948966 rad
@@ -67793,8 +63305,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13867
     components:
     - rot: 1.5707963267948966 rad
@@ -67803,8 +63313,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13869
     components:
     - pos: 22.5,48.5
@@ -67812,8 +63320,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13870
     components:
     - pos: 22.5,47.5
@@ -67821,8 +63327,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13871
     components:
     - pos: 22.5,46.5
@@ -67830,8 +63334,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13873
     components:
     - rot: 1.5707963267948966 rad
@@ -67840,8 +63342,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13874
     components:
     - rot: 1.5707963267948966 rad
@@ -67850,8 +63350,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13876
     components:
     - pos: 25.5,44.5
@@ -67859,8 +63357,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13877
     components:
     - pos: 25.5,43.5
@@ -67868,8 +63364,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13878
     components:
     - pos: 25.5,42.5
@@ -67877,8 +63371,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13879
     components:
     - pos: 25.5,41.5
@@ -67886,8 +63378,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13880
     components:
     - pos: 25.5,40.5
@@ -67895,8 +63385,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 13881
     components:
     - pos: 25.5,39.5
@@ -68584,8 +64072,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14337
     components:
     - rot: -1.5707963267948966 rad
@@ -69976,8 +65462,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14568
     components:
     - pos: -18.5,-14.5
@@ -70598,8 +66082,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14681
     components:
     - rot: -1.5707963267948966 rad
@@ -70654,8 +66136,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14693
     components:
     - rot: -1.5707963267948966 rad
@@ -70725,8 +66205,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14706
     components:
     - rot: 1.5707963267948966 rad
@@ -70981,8 +66459,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14758
     components:
     - rot: 3.141592653589793 rad
@@ -71020,8 +66496,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14766
     components:
     - rot: 1.5707963267948966 rad
@@ -71413,8 +66887,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14834
     components:
     - rot: -1.5707963267948966 rad
@@ -71527,8 +66999,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 14854
     components:
     - rot: -1.5707963267948966 rad
@@ -72424,8 +67894,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15023
     components:
     - rot: 1.5707963267948966 rad
@@ -72442,8 +67910,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15026
     components:
     - pos: 24.5,49.5
@@ -72746,8 +68212,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15083
     components:
     - rot: 3.141592653589793 rad
@@ -72969,8 +68433,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15127
     components:
     - rot: 1.5707963267948966 rad
@@ -72979,8 +68441,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15128
     components:
     - rot: 1.5707963267948966 rad
@@ -72989,8 +68449,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15136
     components:
     - pos: 15.5,43.5
@@ -73623,8 +69081,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15243
     components:
     - rot: 3.141592653589793 rad
@@ -73641,8 +69097,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15245
     components:
     - rot: 3.141592653589793 rad
@@ -73659,8 +69113,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15248
     components:
     - rot: 3.141592653589793 rad
@@ -73739,8 +69191,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15260
     components:
     - pos: -20.5,36.5
@@ -73779,8 +69229,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15275
     components:
     - rot: 3.141592653589793 rad
@@ -73867,8 +69315,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15292
     components:
     - rot: 1.5707963267948966 rad
@@ -73917,8 +69363,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15302
     components:
     - rot: 1.5707963267948966 rad
@@ -73972,8 +69416,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15312
     components:
     - pos: -4.5,21.5
@@ -73988,8 +69430,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15318
     components:
     - pos: -1.5,33.5
@@ -74623,8 +70063,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15445
     components:
     - rot: -1.5707963267948966 rad
@@ -74953,8 +70391,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15505
     components:
     - rot: 3.141592653589793 rad
@@ -75254,8 +70690,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15561
     components:
     - pos: 19.5,31.5
@@ -75303,8 +70737,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15571
     components:
     - rot: -1.5707963267948966 rad
@@ -75329,8 +70761,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15574
     components:
     - rot: -1.5707963267948966 rad
@@ -75371,8 +70801,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15583
     components:
     - rot: 3.141592653589793 rad
@@ -75397,8 +70825,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15586
     components:
     - rot: 3.141592653589793 rad
@@ -75981,8 +71407,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15673
     components:
     - rot: 3.141592653589793 rad
@@ -76179,8 +71603,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15714
     components:
     - rot: 1.5707963267948966 rad
@@ -76330,8 +71752,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15741
     components:
     - pos: -35.5,-1.5
@@ -76415,8 +71835,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15756
     components:
     - rot: 1.5707963267948966 rad
@@ -76484,8 +71902,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15769
     components:
     - rot: 1.5707963267948966 rad
@@ -77775,8 +73191,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 15996
     components:
     - pos: -8.5,62.5
@@ -77816,8 +73230,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16003
     components:
     - rot: -1.5707963267948966 rad
@@ -77917,8 +73329,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16026
     components:
     - rot: 3.141592653589793 rad
@@ -77957,8 +73367,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16034
     components:
     - rot: -1.5707963267948966 rad
@@ -77999,8 +73407,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16041
     components:
     - rot: -1.5707963267948966 rad
@@ -78033,8 +73439,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16045
     components:
     - rot: -1.5707963267948966 rad
@@ -78250,8 +73654,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16085
     components:
     - rot: 3.141592653589793 rad
@@ -78283,8 +73685,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16091
     components:
     - pos: -18.5,42.5
@@ -78316,8 +73716,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16098
     components:
     - rot: 3.141592653589793 rad
@@ -78374,8 +73772,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16105
     components:
     - rot: 3.141592653589793 rad
@@ -78432,8 +73828,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16112
     components:
     - rot: 3.141592653589793 rad
@@ -78757,8 +74151,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16178
     components:
     - rot: 3.141592653589793 rad
@@ -79036,8 +74428,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16235
     components:
     - rot: -1.5707963267948966 rad
@@ -79532,8 +74922,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16324
     components:
     - pos: -6.5,74.5
@@ -79612,8 +75000,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16344
     components:
     - rot: 3.141592653589793 rad
@@ -79645,8 +75031,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16351
     components:
     - pos: 28.5,-11.5
@@ -79717,8 +75101,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16364
     components:
     - rot: -1.5707963267948966 rad
@@ -79727,8 +75109,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16366
     components:
     - rot: -1.5707963267948966 rad
@@ -79753,8 +75133,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16369
     components:
     - rot: -1.5707963267948966 rad
@@ -79771,8 +75149,6 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 16371
     components:
     - rot: -1.5707963267948966 rad
@@ -79906,8 +75282,6 @@ entities:
       pos: -22.5,12.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 17478
     components:
     - rot: 3.141592653589793 rad
@@ -79926,78 +75300,58 @@ entities:
       pos: -21.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18143
     components:
     - rot: 1.5707963267948966 rad
       pos: -20.5,-2.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18145
     components:
     - pos: -19.5,-3.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18146
     components:
     - pos: -19.5,-4.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18148
     components:
     - rot: -1.5707963267948966 rad
       pos: -20.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18149
     components:
     - rot: -1.5707963267948966 rad
       pos: -21.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18150
     components:
     - rot: -1.5707963267948966 rad
       pos: -22.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18151
     components:
     - rot: -1.5707963267948966 rad
       pos: -23.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18152
     components:
     - rot: -1.5707963267948966 rad
       pos: -24.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18153
     components:
     - rot: -1.5707963267948966 rad
       pos: -25.5,-5.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 18155
     components:
     - pos: -26.5,-6.5
@@ -80017,6 +75371,14 @@ entities:
       type: Transform
 - proto: GasPipeTJunction
   entities:
+  - uid: 2300
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -9.5,-43.5
+      parent: 1
+      type: Transform
+    - color: '#FF1212FF'
+      type: AtmosPipeColor
   - uid: 2630
     components:
     - pos: -6.5,-18.5
@@ -80024,8 +75386,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-    - enabled: True
-      type: AmbientSound
   - uid: 2748
     components:
     - rot: -1.5707963267948966 rad
@@ -80108,16 +75468,12 @@ entities:
       pos: 3.5,-44.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 2958
     components:
     - rot: 3.141592653589793 rad
       pos: 3.5,-45.5
       parent: 1
       type: Transform
-    - enabled: True
-      type: AmbientSound
   - uid: 4418
     components:
     - rot: 3.141592653589793 rad
@@ -80145,6 +75501,14 @@ entities:
       parent: 1
       type: Transform
     - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 9390
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-43.5
+      parent: 1
+      type: Transform
+    - color: '#03FCD3FF'
       type: AtmosPipeColor
   - uid: 10899
     components:
@@ -82068,16 +77432,6 @@ entities:
       type: Transform
 - proto: GasPort
   entities:
-  - uid: 2609
-    components:
-    - pos: -9.5,-40.5
-      parent: 1
-      type: Transform
-  - uid: 2610
-    components:
-    - pos: -10.5,-40.5
-      parent: 1
-      type: Transform
   - uid: 2876
     components:
     - rot: 1.5707963267948966 rad
@@ -82118,6 +77472,18 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: -11.5,30.5
+      parent: 1
+      type: Transform
+  - uid: 4143
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -9.5,-38.5
+      parent: 1
+      type: Transform
+  - uid: 4144
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -9.5,-39.5
       parent: 1
       type: Transform
   - uid: 6369
@@ -82169,11 +77535,6 @@ entities:
       type: AtmosPipeColor
 - proto: GasPressurePump
   entities:
-  - uid: 2606
-    components:
-    - pos: -6.5,-41.5
-      parent: 1
-      type: Transform
   - uid: 2615
     components:
     - rot: 1.5707963267948966 rad
@@ -82337,10 +77698,10 @@ entities:
       type: Transform
 - proto: GasThermoMachineFreezer
   entities:
-  - uid: 2612
+  - uid: 2710
     components:
-    - rot: 3.141592653589793 rad
-      pos: -10.5,-41.5
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,-38.5
       parent: 1
       type: Transform
   - uid: 2769
@@ -82374,10 +77735,10 @@ entities:
       type: Transform
 - proto: GasThermoMachineHeater
   entities:
-  - uid: 2611
+  - uid: 2709
     components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-41.5
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,-39.5
       parent: 1
       type: Transform
   - uid: 2768
@@ -82402,8 +77763,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 2676
@@ -82413,8 +77772,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
   - uid: 2959
     components:
     - rot: 3.141592653589793 rad
@@ -82423,8 +77780,6 @@ entities:
       type: Transform
     - open: False
       type: GasValve
-    - enabled: False
-      type: AmbientSound
 - proto: GasVentPump
   entities:
   - uid: 2737
@@ -82433,8 +77788,6 @@ entities:
       pos: -7.5,-17.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 2745
@@ -82443,8 +77796,6 @@ entities:
       pos: -11.5,-18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 2760
@@ -82453,8 +77804,6 @@ entities:
       pos: -10.5,-13.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 2773
@@ -82463,8 +77812,6 @@ entities:
       pos: -4.5,-12.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 8694
@@ -82473,8 +77820,6 @@ entities:
       pos: -11.5,23.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 9036
@@ -82482,8 +77827,6 @@ entities:
     - pos: 11.5,31.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 10903
@@ -82492,8 +77835,6 @@ entities:
       pos: 20.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 11931
@@ -82502,8 +77843,6 @@ entities:
       pos: 17.5,-23.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14224
@@ -82512,8 +77851,6 @@ entities:
       pos: 3.5,-12.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14254
@@ -82522,8 +77859,6 @@ entities:
       pos: 9.5,-13.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14286
@@ -82532,8 +77867,6 @@ entities:
       pos: 18.5,-15.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14295
@@ -82541,8 +77874,6 @@ entities:
     - pos: 19.5,-5.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14318
@@ -82551,8 +77882,6 @@ entities:
       pos: 11.5,-17.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14332
@@ -82560,24 +77889,18 @@ entities:
     - pos: 6.5,-19.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14345
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-22.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14389
     components:
     - rot: 3.141592653589793 rad
       pos: 12.5,-37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14405
@@ -82586,31 +77909,23 @@ entities:
       pos: 5.5,-33.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14415
     components:
     - pos: 6.5,-30.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14417
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14457
     components:
     - rot: 3.141592653589793 rad
       pos: 35.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14570
@@ -82619,8 +77934,6 @@ entities:
       pos: -17.5,-15.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14571
@@ -82629,8 +77942,6 @@ entities:
       pos: -20.5,-15.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14633
@@ -82639,8 +77950,6 @@ entities:
       pos: -3.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14636
@@ -82649,8 +77958,6 @@ entities:
       pos: -3.5,9.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14659
@@ -82658,8 +77965,6 @@ entities:
     - pos: -6.5,7.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14682
@@ -82668,8 +77973,6 @@ entities:
       pos: -16.5,3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14685
@@ -82678,8 +77981,6 @@ entities:
       pos: -16.5,0.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14696
@@ -82688,8 +77989,6 @@ entities:
       pos: -11.5,0.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14712
@@ -82698,8 +77997,6 @@ entities:
       pos: -16.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14720
@@ -82708,8 +78005,6 @@ entities:
       pos: 10.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14748
@@ -82717,8 +78012,6 @@ entities:
     - pos: 10.5,7.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14751
@@ -82727,8 +78020,6 @@ entities:
       pos: 0.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14761
@@ -82736,8 +78027,6 @@ entities:
     - pos: 25.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14772
@@ -82746,8 +78035,6 @@ entities:
       pos: 27.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14793
@@ -82756,8 +78043,6 @@ entities:
       pos: 48.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14807
@@ -82766,8 +78051,6 @@ entities:
       pos: 35.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14815
@@ -82776,8 +78059,6 @@ entities:
       pos: 31.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14827
@@ -82786,8 +78067,6 @@ entities:
       pos: 31.5,2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14840
@@ -82796,8 +78075,6 @@ entities:
       pos: 24.5,3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14844
@@ -82806,8 +78083,6 @@ entities:
       pos: 31.5,8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14856
@@ -82816,8 +78091,6 @@ entities:
       pos: 25.5,9.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14880
@@ -82826,8 +78099,6 @@ entities:
       pos: 48.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14900
@@ -82836,8 +78107,6 @@ entities:
       pos: 31.5,19.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14906
@@ -82845,8 +78114,6 @@ entities:
     - pos: 25.5,20.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14917
@@ -82855,8 +78122,6 @@ entities:
       pos: 27.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14929
@@ -82865,8 +78130,6 @@ entities:
       pos: 17.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14954
@@ -82875,8 +78138,6 @@ entities:
       pos: 31.5,32.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 14988
@@ -82885,8 +78146,6 @@ entities:
       pos: 31.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15002
@@ -82895,8 +78154,6 @@ entities:
       pos: 29.5,47.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15030
@@ -82904,8 +78161,6 @@ entities:
     - pos: 24.5,51.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15036
@@ -82914,8 +78169,6 @@ entities:
       pos: 36.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15065
@@ -82923,8 +78176,6 @@ entities:
     - pos: 43.5,42.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15066
@@ -82933,8 +78184,6 @@ entities:
       pos: 46.5,38.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15075
@@ -82943,8 +78192,6 @@ entities:
       pos: 26.5,33.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15095
@@ -82953,15 +78200,11 @@ entities:
       pos: 21.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 15101
     components:
     - pos: 22.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15133
@@ -82970,8 +78213,6 @@ entities:
       pos: 14.5,45.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15146
@@ -82980,8 +78221,6 @@ entities:
       pos: 17.5,45.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15147
@@ -82990,8 +78229,6 @@ entities:
       pos: 12.5,44.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15148
@@ -83000,8 +78237,6 @@ entities:
       pos: 12.5,42.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15154
@@ -83010,8 +78245,6 @@ entities:
       pos: 11.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15172
@@ -83020,8 +78253,6 @@ entities:
       pos: 5.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15200
@@ -83030,8 +78261,6 @@ entities:
       pos: -8.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15225
@@ -83040,8 +78269,6 @@ entities:
       pos: -13.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15263
@@ -83050,8 +78277,6 @@ entities:
       pos: -17.5,32.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15266
@@ -83060,8 +78285,6 @@ entities:
       pos: -14.5,28.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15284
@@ -83070,8 +78293,6 @@ entities:
       pos: -10.5,29.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15295
@@ -83079,8 +78300,6 @@ entities:
     - pos: -9.5,18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15317
@@ -83088,8 +78307,6 @@ entities:
     - pos: -4.5,22.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15325
@@ -83098,8 +78315,6 @@ entities:
       pos: -0.5,32.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15351
@@ -83108,8 +78323,6 @@ entities:
       pos: -0.5,20.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15382
@@ -83118,8 +78331,6 @@ entities:
       pos: 9.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15452
@@ -83128,8 +78339,6 @@ entities:
       pos: -24.5,22.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15457
@@ -83138,8 +78347,6 @@ entities:
       pos: -21.5,22.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15460
@@ -83148,8 +78355,6 @@ entities:
       pos: -16.5,19.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15480
@@ -83158,8 +78363,6 @@ entities:
       pos: -10.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15499
@@ -83167,8 +78370,6 @@ entities:
     - pos: 7.5,18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15524
@@ -83176,8 +78377,6 @@ entities:
     - pos: 4.5,23.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15544
@@ -83185,8 +78384,6 @@ entities:
     - pos: 7.5,31.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15558
@@ -83194,8 +78391,6 @@ entities:
     - pos: 20.5,29.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15566
@@ -83204,8 +78399,6 @@ entities:
       pos: 22.5,28.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15579
@@ -83214,8 +78407,6 @@ entities:
       pos: 9.5,27.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15582
@@ -83223,8 +78414,6 @@ entities:
     - pos: 15.5,31.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15609
@@ -83233,8 +78422,6 @@ entities:
       pos: -22.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15669
@@ -83243,8 +78430,6 @@ entities:
       pos: -47.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15681
@@ -83253,8 +78438,6 @@ entities:
       pos: -38.5,28.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15695
@@ -83263,8 +78446,6 @@ entities:
       pos: -31.5,9.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15700
@@ -83273,8 +78454,6 @@ entities:
       pos: -34.5,6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15710
@@ -83283,8 +78462,6 @@ entities:
       pos: -39.5,6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15713
@@ -83293,8 +78470,6 @@ entities:
       pos: -42.5,8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15728
@@ -83303,8 +78478,6 @@ entities:
       pos: -40.5,-6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15743
@@ -83313,8 +78486,6 @@ entities:
       pos: -36.5,-2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15774
@@ -83323,8 +78494,6 @@ entities:
       pos: -16.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15775
@@ -83333,8 +78502,6 @@ entities:
       pos: -25.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15778
@@ -83343,8 +78510,6 @@ entities:
       pos: -31.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15826
@@ -83353,8 +78518,6 @@ entities:
       pos: -27.5,30.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15827
@@ -83363,8 +78526,6 @@ entities:
       pos: -31.5,31.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15828
@@ -83373,8 +78534,6 @@ entities:
       pos: -31.5,19.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15860
@@ -83383,8 +78542,6 @@ entities:
       pos: -22.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15909
@@ -83393,8 +78550,6 @@ entities:
       pos: -49.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15910
@@ -83402,8 +78557,6 @@ entities:
     - pos: -43.5,42.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15911
@@ -83412,8 +78565,6 @@ entities:
       pos: -37.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15921
@@ -83422,8 +78573,6 @@ entities:
       pos: -0.5,42.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15944
@@ -83432,8 +78581,6 @@ entities:
       pos: 5.5,47.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 15982
@@ -83442,8 +78589,6 @@ entities:
       pos: -0.5,54.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16007
@@ -83452,8 +78597,6 @@ entities:
       pos: -12.5,48.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16018
@@ -83462,8 +78605,6 @@ entities:
       pos: -10.5,54.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16024
@@ -83471,8 +78612,6 @@ entities:
     - pos: -6.5,56.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16037
@@ -83481,8 +78620,6 @@ entities:
       pos: -5.5,63.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16040
@@ -83491,8 +78628,6 @@ entities:
       pos: -6.5,60.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16049
@@ -83501,8 +78636,6 @@ entities:
       pos: -13.5,59.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16094
@@ -83511,8 +78644,6 @@ entities:
       pos: -16.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16141
@@ -83521,8 +78652,6 @@ entities:
       pos: -17.5,45.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16157
@@ -83531,8 +78660,6 @@ entities:
       pos: -31.5,44.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16158
@@ -83541,8 +78668,6 @@ entities:
       pos: -28.5,47.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16175
@@ -83551,8 +78676,6 @@ entities:
       pos: -25.5,47.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16183
@@ -83561,8 +78684,6 @@ entities:
       pos: -3.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16184
@@ -83571,8 +78692,6 @@ entities:
       pos: -6.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16185
@@ -83581,8 +78700,6 @@ entities:
       pos: -9.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16186
@@ -83591,8 +78708,6 @@ entities:
       pos: -12.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16195
@@ -83601,8 +78716,6 @@ entities:
       pos: 6.5,55.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16206
@@ -83610,8 +78723,6 @@ entities:
     - pos: 8.5,59.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16239
@@ -83620,8 +78731,6 @@ entities:
       pos: 3.5,63.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16240
@@ -83630,8 +78739,6 @@ entities:
       pos: -0.5,64.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16284
@@ -83640,8 +78747,6 @@ entities:
       pos: 10.5,68.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16285
@@ -83650,8 +78755,6 @@ entities:
       pos: -0.5,70.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16286
@@ -83660,8 +78763,6 @@ entities:
       pos: -0.5,73.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16327
@@ -83669,8 +78770,6 @@ entities:
     - pos: -6.5,79.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16328
@@ -83678,8 +78777,6 @@ entities:
     - pos: 5.5,79.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16334
@@ -83688,8 +78785,6 @@ entities:
       pos: -7.5,73.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16348
@@ -83698,8 +78793,6 @@ entities:
       pos: 6.5,74.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16359
@@ -83708,8 +78801,6 @@ entities:
       pos: 29.5,-12.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 16374
@@ -83718,8 +78809,6 @@ entities:
       pos: 18.5,-34.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 17402
@@ -83728,24 +78817,18 @@ entities:
       pos: 31.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 17480
     components:
     - rot: -1.5707963267948966 rad
       pos: -27.5,10.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 18353
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-25.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
 - proto: GasVentScrubber
   entities:
   - uid: 566
@@ -83753,8 +78836,6 @@ entities:
     - pos: -7.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 2740
@@ -83763,8 +78844,6 @@ entities:
       pos: -12.5,-21.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 2741
@@ -83773,8 +78852,6 @@ entities:
       pos: -13.5,-18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 2759
@@ -83783,8 +78860,6 @@ entities:
       pos: -11.5,-13.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 2774
@@ -83793,8 +78868,6 @@ entities:
       pos: -4.5,-11.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 5390
@@ -83803,8 +78876,6 @@ entities:
       pos: 2.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 9037
@@ -83812,8 +78883,6 @@ entities:
     - pos: 10.5,31.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 12901
@@ -83822,8 +78891,6 @@ entities:
       pos: 18.5,29.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14225
@@ -83832,8 +78899,6 @@ entities:
       pos: 3.5,-11.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14285
@@ -83842,8 +78907,6 @@ entities:
       pos: 19.5,-15.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14296
@@ -83851,8 +78914,6 @@ entities:
     - pos: 21.5,-5.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14298
@@ -83860,8 +78921,6 @@ entities:
     - pos: 17.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14312
@@ -83870,8 +78929,6 @@ entities:
       pos: 10.5,-13.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14319
@@ -83880,8 +78937,6 @@ entities:
       pos: 12.5,-18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14333
@@ -83889,46 +78944,34 @@ entities:
     - pos: 5.5,-19.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14344
     components:
     - rot: -1.5707963267948966 rad
       pos: 12.5,-23.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14366
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-24.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14404
     components:
     - pos: 7.5,-30.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14416
     components:
     - rot: 3.141592653589793 rad
       pos: 8.5,-33.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 14569
     components:
     - pos: -17.5,-17.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14572
@@ -83937,8 +78980,6 @@ entities:
       pos: -20.5,-18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14635
@@ -83947,8 +78988,6 @@ entities:
       pos: 2.5,9.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14660
@@ -83956,8 +78995,6 @@ entities:
     - pos: -8.5,7.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14672
@@ -83965,8 +79002,6 @@ entities:
     - pos: -11.5,2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14683
@@ -83975,8 +79010,6 @@ entities:
       pos: -16.5,4.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14697
@@ -83985,8 +79018,6 @@ entities:
       pos: -16.5,1.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14711
@@ -83995,8 +79026,6 @@ entities:
       pos: -16.5,-4.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14717
@@ -84004,8 +79033,6 @@ entities:
     - pos: 11.5,1.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14718
@@ -84014,8 +79041,6 @@ entities:
       pos: 10.5,-1.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14749
@@ -84023,8 +79048,6 @@ entities:
     - pos: 6.5,7.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14750
@@ -84032,8 +79055,6 @@ entities:
     - pos: -1.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14760
@@ -84041,8 +79062,6 @@ entities:
     - pos: 26.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14771
@@ -84050,8 +79069,6 @@ entities:
     - pos: 29.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14792
@@ -84059,8 +79076,6 @@ entities:
     - pos: 46.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14808
@@ -84068,8 +79083,6 @@ entities:
     - pos: 36.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14816
@@ -84078,8 +79091,6 @@ entities:
       pos: 31.5,-2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14826
@@ -84088,8 +79099,6 @@ entities:
       pos: 31.5,3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14841
@@ -84098,8 +79107,6 @@ entities:
       pos: 24.5,6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14842
@@ -84108,8 +79115,6 @@ entities:
       pos: 31.5,9.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14857
@@ -84118,8 +79123,6 @@ entities:
       pos: 25.5,10.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14875
@@ -84127,8 +79130,6 @@ entities:
     - pos: 36.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14879
@@ -84136,8 +79137,6 @@ entities:
     - pos: 46.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14899
@@ -84146,8 +79145,6 @@ entities:
       pos: 31.5,20.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14907
@@ -84156,8 +79153,6 @@ entities:
       pos: 23.5,18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14916
@@ -84165,8 +79160,6 @@ entities:
     - pos: 28.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14928
@@ -84174,8 +79167,6 @@ entities:
     - pos: 15.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14955
@@ -84184,8 +79175,6 @@ entities:
       pos: 31.5,31.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14983
@@ -84194,8 +79183,6 @@ entities:
       pos: 31.5,36.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 14987
@@ -84204,8 +79191,6 @@ entities:
       pos: 30.5,40.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15001
@@ -84214,8 +79199,6 @@ entities:
       pos: 32.5,47.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15028
@@ -84224,8 +79207,6 @@ entities:
       pos: 24.5,49.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15029
@@ -84234,8 +79215,6 @@ entities:
       pos: 24.5,47.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15031
@@ -84243,8 +79222,6 @@ entities:
     - pos: 25.5,51.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15037
@@ -84252,8 +79229,6 @@ entities:
     - pos: 35.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15054
@@ -84262,8 +79237,6 @@ entities:
       pos: 43.5,43.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15067
@@ -84271,8 +79244,6 @@ entities:
     - pos: 46.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15076
@@ -84281,8 +79252,6 @@ entities:
       pos: 25.5,33.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15084
@@ -84290,8 +79259,6 @@ entities:
     - pos: 32.5,54.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15094
@@ -84300,8 +79267,6 @@ entities:
       pos: 19.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15102
@@ -84309,8 +79274,6 @@ entities:
     - pos: 18.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15129
@@ -84319,8 +79282,6 @@ entities:
       pos: 12.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15130
@@ -84329,8 +79290,6 @@ entities:
       pos: 12.5,45.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15131
@@ -84339,8 +79298,6 @@ entities:
       pos: 17.5,46.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15132
@@ -84349,8 +79306,6 @@ entities:
       pos: 15.5,43.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15155
@@ -84358,8 +79313,6 @@ entities:
     - pos: 10.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15173
@@ -84367,8 +79320,6 @@ entities:
     - pos: 4.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15226
@@ -84376,8 +79327,6 @@ entities:
     - pos: -15.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15264
@@ -84386,8 +79335,6 @@ entities:
       pos: -16.5,32.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15265
@@ -84396,8 +79343,6 @@ entities:
       pos: -14.5,27.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15283
@@ -84405,8 +79350,6 @@ entities:
     - pos: -10.5,31.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15294
@@ -84415,8 +79358,6 @@ entities:
       pos: -7.5,18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15316
@@ -84424,8 +79365,6 @@ entities:
     - pos: -6.5,22.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15326
@@ -84434,8 +79373,6 @@ entities:
       pos: -0.5,31.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15352
@@ -84444,8 +79381,6 @@ entities:
       pos: -0.5,19.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15381
@@ -84453,8 +79388,6 @@ entities:
     - pos: 8.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15411
@@ -84463,8 +79396,6 @@ entities:
       pos: -11.5,22.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15447
@@ -84472,8 +79403,6 @@ entities:
     - pos: -24.5,21.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15458
@@ -84482,8 +79411,6 @@ entities:
       pos: -20.5,21.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15459
@@ -84492,8 +79419,6 @@ entities:
       pos: -16.5,18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15479
@@ -84501,8 +79426,6 @@ entities:
     - pos: -9.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15500
@@ -84511,8 +79434,6 @@ entities:
       pos: 15.5,18.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15525
@@ -84520,8 +79441,6 @@ entities:
     - pos: 3.5,23.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15537
@@ -84530,8 +79449,6 @@ entities:
       pos: 11.5,23.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15550
@@ -84540,8 +79457,6 @@ entities:
       pos: 4.5,30.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15562
@@ -84549,8 +79464,6 @@ entities:
     - pos: 19.5,32.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15578
@@ -84559,8 +79472,6 @@ entities:
       pos: 22.5,27.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15587
@@ -84568,8 +79479,6 @@ entities:
     - pos: 14.5,32.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15610
@@ -84577,8 +79486,6 @@ entities:
     - pos: -19.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15668
@@ -84586,8 +79493,6 @@ entities:
     - pos: -49.5,14.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15680
@@ -84596,8 +79501,6 @@ entities:
       pos: -38.5,23.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15696
@@ -84606,8 +79509,6 @@ entities:
       pos: -31.5,8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15701
@@ -84615,8 +79516,6 @@ entities:
     - pos: -34.5,5.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15729
@@ -84625,8 +79524,6 @@ entities:
       pos: -41.5,-6.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15742
@@ -84635,8 +79532,6 @@ entities:
       pos: -35.5,-2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15757
@@ -84644,8 +79539,6 @@ entities:
     - pos: -39.5,0.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15768
@@ -84654,8 +79547,6 @@ entities:
       pos: -42.5,9.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15771
@@ -84664,8 +79555,6 @@ entities:
       pos: -35.5,10.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15773
@@ -84674,8 +79563,6 @@ entities:
       pos: -18.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15776
@@ -84683,8 +79570,6 @@ entities:
     - pos: -28.5,-8.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15777
@@ -84693,8 +79578,6 @@ entities:
       pos: -31.5,-2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15829
@@ -84703,8 +79586,6 @@ entities:
       pos: -31.5,20.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15830
@@ -84713,8 +79594,6 @@ entities:
       pos: -31.5,32.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15831
@@ -84723,8 +79602,6 @@ entities:
       pos: -27.5,33.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15859
@@ -84732,8 +79609,6 @@ entities:
     - pos: -24.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15906
@@ -84741,8 +79616,6 @@ entities:
     - pos: -36.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15907
@@ -84750,8 +79623,6 @@ entities:
     - pos: -47.5,37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15908
@@ -84759,8 +79630,6 @@ entities:
     - pos: -48.5,42.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15922
@@ -84769,8 +79638,6 @@ entities:
       pos: -0.5,43.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15945
@@ -84779,8 +79646,6 @@ entities:
       pos: 5.5,46.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15981
@@ -84789,8 +79654,6 @@ entities:
       pos: -0.5,55.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15998
@@ -84799,8 +79662,6 @@ entities:
       pos: -6.5,59.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 15999
@@ -84808,8 +79669,6 @@ entities:
     - pos: -8.5,63.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16006
@@ -84818,8 +79677,6 @@ entities:
       pos: -12.5,50.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16017
@@ -84828,8 +79685,6 @@ entities:
       pos: -9.5,53.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16025
@@ -84837,8 +79692,6 @@ entities:
     - pos: -6.5,53.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16050
@@ -84847,8 +79700,6 @@ entities:
       pos: -14.5,58.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16095
@@ -84857,8 +79708,6 @@ entities:
       pos: -18.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16142
@@ -84867,8 +79716,6 @@ entities:
       pos: -17.5,46.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16143
@@ -84876,8 +79723,6 @@ entities:
     - pos: -24.5,48.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16155
@@ -84885,8 +79730,6 @@ entities:
     - pos: -27.5,48.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16156
@@ -84895,8 +79738,6 @@ entities:
       pos: -30.5,45.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16169
@@ -84905,8 +79746,6 @@ entities:
       pos: -37.5,48.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16170
@@ -84915,16 +79754,12 @@ entities:
       pos: -37.5,45.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 16171
     components:
     - rot: 1.5707963267948966 rad
       pos: -37.5,43.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16187
@@ -84933,8 +79768,6 @@ entities:
       pos: -13.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16188
@@ -84943,8 +79776,6 @@ entities:
       pos: -10.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16189
@@ -84953,8 +79784,6 @@ entities:
       pos: -7.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16191
@@ -84963,8 +79792,6 @@ entities:
       pos: -4.5,41.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16196
@@ -84972,8 +79799,6 @@ entities:
     - pos: 6.5,54.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16214
@@ -84982,8 +79807,6 @@ entities:
       pos: 13.5,59.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16238
@@ -84991,8 +79814,6 @@ entities:
     - pos: 4.5,62.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16241
@@ -85001,8 +79822,6 @@ entities:
       pos: -0.5,65.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16283
@@ -85010,8 +79829,6 @@ entities:
     - pos: 11.5,67.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16287
@@ -85020,8 +79837,6 @@ entities:
       pos: -0.5,71.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16288
@@ -85030,8 +79845,6 @@ entities:
       pos: -0.5,74.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16331
@@ -85040,8 +79853,6 @@ entities:
       pos: 5.5,77.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16332
@@ -85050,8 +79861,6 @@ entities:
       pos: -6.5,77.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16339
@@ -85059,8 +79868,6 @@ entities:
     - pos: -8.5,73.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16340
@@ -85069,8 +79876,6 @@ entities:
       pos: -8.5,70.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16349
@@ -85079,8 +79884,6 @@ entities:
       pos: 3.5,74.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16358
@@ -85089,8 +79892,6 @@ entities:
       pos: 27.5,-12.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 16365
@@ -85099,8 +79900,6 @@ entities:
       pos: 18.5,-35.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
     - color: '#990000FF'
       type: AtmosPipeColor
   - uid: 17481
@@ -85109,16 +79908,29 @@ entities:
       pos: -23.5,10.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 18354
     components:
     - rot: -1.5707963267948966 rad
       pos: 8.5,-37.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
+- proto: GasVolumePump
+  entities:
+  - uid: 2718
+    components:
+    - pos: -10.5,-44.5
+      parent: 1
+      type: Transform
+    - color: '#FF1212FF'
+      type: AtmosPipeColor
+  - uid: 2731
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-44.5
+      parent: 1
+      type: Transform
+    - color: '#03FCD3FF'
+      type: AtmosPipeColor
 - proto: Gauze1
   entities:
   - uid: 8684
@@ -85425,6 +80237,16 @@ entities:
     - pos: 41.5,-10.5
       parent: 1
       type: Transform
+  - uid: 109
+    components:
+    - pos: -45.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 111
+    components:
+    - pos: -46.5,3.5
+      parent: 1
+      type: Transform
   - uid: 116
     components:
     - rot: -1.5707963267948966 rad
@@ -85675,12 +80497,7 @@ entities:
       type: Transform
   - uid: 237
     components:
-    - pos: -43.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 238
-    components:
-    - pos: -42.5,3.5
+    - pos: -44.5,3.5
       parent: 1
       type: Transform
   - uid: 274
@@ -85895,6 +80712,12 @@ entities:
   - uid: 456
     components:
     - pos: -37.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 462
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -47.5,3.5
       parent: 1
       type: Transform
   - uid: 465
@@ -87287,11 +82110,6 @@ entities:
     - pos: -4.5,-40.5
       parent: 1
       type: Transform
-  - uid: 2070
-    components:
-    - pos: -3.5,-43.5
-      parent: 1
-      type: Transform
   - uid: 2071
     components:
     - pos: -4.5,-41.5
@@ -87300,16 +82118,6 @@ entities:
   - uid: 2073
     components:
     - pos: 2.5,-43.5
-      parent: 1
-      type: Transform
-  - uid: 2074
-    components:
-    - pos: -3.5,-44.5
-      parent: 1
-      type: Transform
-  - uid: 2075
-    components:
-    - pos: -3.5,-45.5
       parent: 1
       type: Transform
   - uid: 2076
@@ -87421,16 +82229,6 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 35.5,-0.5
-      parent: 1
-      type: Transform
-  - uid: 2129
-    components:
-    - pos: -7.5,-42.5
-      parent: 1
-      type: Transform
-  - uid: 2130
-    components:
-    - pos: -6.5,-42.5
       parent: 1
       type: Transform
   - uid: 2140
@@ -87618,11 +82416,6 @@ entities:
     - pos: -4.5,-30.5
       parent: 1
       type: Transform
-  - uid: 2291
-    components:
-    - pos: -8.5,-42.5
-      parent: 1
-      type: Transform
   - uid: 2293
     components:
     - pos: 7.5,-42.5
@@ -87724,6 +82517,24 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 26.5,4.5
+      parent: 1
+      type: Transform
+  - uid: 2699
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -9.5,-46.5
+      parent: 1
+      type: Transform
+  - uid: 2704
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-46.5
+      parent: 1
+      type: Transform
+  - uid: 2720
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-46.5
       parent: 1
       type: Transform
   - uid: 2798
@@ -87872,6 +82683,12 @@ entities:
   - uid: 2927
     components:
     - pos: 35.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 3046
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-46.5
       parent: 1
       type: Transform
   - uid: 3062
@@ -90857,9 +85674,12 @@ entities:
       pos: 11.5,46.5
       parent: 1
       type: Transform
-    - SecondsUntilStateChange: -484053.5
-      state: Closing
+    - state: Closed
       type: Door
+    - enabled: True
+      type: Occluder
+    - canCollide: True
+      type: Physics
   - uid: 8393
     components:
     - rot: 1.5707963267948966 rad
@@ -91599,6 +86419,11 @@ entities:
     - pos: 10.5,-32.5
       parent: 1
       type: Transform
+  - uid: 9629
+    components:
+    - pos: -41.5,-7.5
+      parent: 1
+      type: Transform
 - proto: KitchenReagentGrinder
   entities:
   - uid: 4048
@@ -92279,6 +87104,14 @@ entities:
         - 0
         - 0
       type: EntityStorage
+  - uid: 9638
+    components:
+    - desc: For confiscated weapons and gadgets.
+      name: contraband locker
+      type: MetaData
+    - pos: -5.5,64.5
+      parent: 1
+      type: Transform
 - proto: LockerFreezer
   entities:
   - uid: 6633
@@ -92860,8 +87693,6 @@ entities:
     - pos: -16.5,21.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
 - proto: MachineAnomalyVessel
   entities:
   - uid: 5534
@@ -93540,6 +88371,11 @@ entities:
       type: Transform
 - proto: MedkitFilled
   entities:
+  - uid: 286
+    components:
+    - pos: -42.513187,21.685522
+      parent: 1
+      type: Transform
   - uid: 8523
     components:
     - pos: 12.53402,24.033106
@@ -93569,6 +88405,11 @@ entities:
   - uid: 8526
     components:
     - pos: 12.548221,23.167448
+      parent: 1
+      type: Transform
+  - uid: 9664
+    components:
+    - pos: -10.990924,34.60699
       parent: 1
       type: Transform
 - proto: MicrophoneInstrument
@@ -94567,29 +89408,24 @@ entities:
       type: Transform
 - proto: PlasticFlapsAirtightClear
   entities:
-  - uid: 459
+  - uid: 112
     components:
     - pos: -44.5,1.5
       parent: 1
       type: Transform
-  - uid: 460
-    components:
-    - pos: -41.5,1.5
-      parent: 1
-      type: Transform
-  - uid: 461
+  - uid: 113
     components:
     - pos: -44.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 462
-    components:
-    - pos: -41.5,5.5
       parent: 1
       type: Transform
   - uid: 463
     components:
     - pos: -36.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2724
+    components:
+    - pos: -47.5,5.5
       parent: 1
       type: Transform
   - uid: 3113
@@ -94600,6 +89436,11 @@ entities:
   - uid: 4114
     components:
     - pos: -43.5,22.5
+      parent: 1
+      type: Transform
+  - uid: 4157
+    components:
+    - pos: -47.5,1.5
       parent: 1
       type: Transform
   - uid: 7819
@@ -95602,6 +90443,29 @@ entities:
       type: Transform
     - powerLoad: 0
       type: ApcPowerReceiver
+  - uid: 2705
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,-44.5
+      parent: 1
+      type: Transform
+  - uid: 2719
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-42.5
+      parent: 1
+      type: Transform
+  - uid: 2725
+    components:
+    - pos: -41.5,5.5
+      parent: 1
+      type: Transform
+  - uid: 2728
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -43.5,0.5
+      parent: 1
+      type: Transform
   - uid: 3733
     components:
     - rot: -1.5707963267948966 rad
@@ -95615,55 +90479,41 @@ entities:
     - pos: 8.5,20.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 4032
     components:
     - pos: 3.5,34.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 4063
     components:
     - rot: 1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 4360
     components:
     - rot: 1.5707963267948966 rad
       pos: 9.5,-22.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 4361
     components:
     - rot: 1.5707963267948966 rad
       pos: 11.5,-35.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 6085
     components:
     - rot: -1.5707963267948966 rad
       pos: 12.5,-2.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 6382
     components:
     - rot: -1.5707963267948966 rad
       pos: 12.5,23.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 6517
     components:
     - rot: 1.5707963267948966 rad
@@ -95678,53 +90528,39 @@ entities:
       pos: 4.5,28.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 6706
     components:
     - pos: 14.5,20.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 7809
     components:
     - rot: -1.5707963267948966 rad
       pos: -44.5,20.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 7811
     components:
     - rot: 3.141592653589793 rad
       pos: -46.5,30.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 7813
     components:
     - rot: 3.141592653589793 rad
       pos: -38.5,17.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 7935
     components:
     - pos: -46.5,25.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 8161
     components:
     - pos: -40.5,28.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 8641
     components:
     - rot: -1.5707963267948966 rad
@@ -95793,8 +90629,6 @@ entities:
     - pos: 11.5,15.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
   - uid: 8876
     components:
     - rot: 3.141592653589793 rad
@@ -95840,8 +90674,18 @@ entities:
     - pos: 8.5,28.5
       parent: 1
       type: Transform
-    - enabled: False
-      type: AmbientSound
+  - uid: 9634
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -43.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 9635
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -38.5,-5.5
+      parent: 1
+      type: Transform
   - uid: 14073
     components:
     - rot: -1.5707963267948966 rad
@@ -95907,13 +90751,6 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: -39.5,-2.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
-  - uid: 14082
-    components:
-    - pos: -39.5,-4.5
       parent: 1
       type: Transform
     - powerLoad: 0
@@ -96862,13 +91699,6 @@ entities:
       type: Transform
     - powerLoad: 0
       type: ApcPowerReceiver
-  - uid: 17651
-    components:
-    - pos: -10.5,-43.5
-      parent: 1
-      type: Transform
-    - powerLoad: 0
-      type: ApcPowerReceiver
   - uid: 17860
     components:
     - pos: 22.5,-32.5
@@ -97139,10 +91969,15 @@ entities:
       pos: -22.5,10.5
       parent: 1
       type: Transform
-  - uid: 3726
+  - uid: 2074
     components:
     - rot: 3.141592653589793 rad
-      pos: -42.5,1.5
+      pos: -45.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 2608
+    components:
+    - pos: -45.5,5.5
       parent: 1
       type: Transform
   - uid: 4066
@@ -99548,9 +94383,30 @@ entities:
       type: Transform
 - proto: RandomPosterLegit
   entities:
+  - uid: 4138
+    components:
+    - pos: -37.5,-6.5
+      parent: 1
+      type: Transform
   - uid: 8252
     components:
     - pos: -3.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 9310
+    components:
+    - pos: -44.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 9630
+    components:
+    - pos: -44.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 9659
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,19.5
       parent: 1
       type: Transform
   - uid: 17938
@@ -99808,6 +94664,11 @@ entities:
     - pos: 16.5,-40.5
       parent: 1
       type: Transform
+  - uid: 9660
+    components:
+    - pos: -15.5,5.5
+      parent: 1
+      type: Transform
   - uid: 10100
     components:
     - pos: -16.5,-40.5
@@ -99992,6 +94853,11 @@ entities:
     - pos: -26.5,-22.5
       parent: 1
       type: Transform
+  - uid: 6690
+    components:
+    - pos: -40.5,11.5
+      parent: 1
+      type: Transform
   - uid: 8418
     components:
     - pos: -48.5,44.5
@@ -100029,9 +94895,21 @@ entities:
       type: Transform
 - proto: RandomVendingDrinks
   entities:
+  - uid: 3725
+    components:
+    - pos: -42.5,-4.5
+      parent: 1
+      type: Transform
   - uid: 8591
     components:
     - pos: -27.5,11.5
+      parent: 1
+      type: Transform
+- proto: RandomVendingSnacks
+  entities:
+  - uid: 3726
+    components:
+    - pos: -43.5,-4.5
       parent: 1
       type: Transform
 - proto: RCD
@@ -100176,21 +95054,6 @@ entities:
   - uid: 2970
     components:
     - pos: 1.5,-41.5
-      parent: 1
-      type: Transform
-  - uid: 2971
-    components:
-    - pos: -3.5,-43.5
-      parent: 1
-      type: Transform
-  - uid: 2972
-    components:
-    - pos: -3.5,-44.5
-      parent: 1
-      type: Transform
-  - uid: 2973
-    components:
-    - pos: -3.5,-45.5
       parent: 1
       type: Transform
   - uid: 2974
@@ -100576,6 +95439,12 @@ entities:
     - pos: 51.5,-8.5
       parent: 1
       type: Transform
+  - uid: 238
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -47.5,3.5
+      parent: 1
+      type: Transform
   - uid: 240
     components:
     - pos: -44.5,-2.5
@@ -100620,14 +95489,7 @@ entities:
       type: Transform
   - uid: 251
     components:
-    - rot: 1.5707963267948966 rad
-      pos: -42.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 252
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -43.5,3.5
+    - pos: -45.5,3.5
       parent: 1
       type: Transform
   - uid: 257
@@ -100638,6 +95500,11 @@ entities:
   - uid: 259
     components:
     - pos: -37.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 287
+    components:
+    - pos: -46.5,3.5
       parent: 1
       type: Transform
   - uid: 317
@@ -102307,24 +97174,9 @@ entities:
     - pos: -4.5,-41.5
       parent: 1
       type: Transform
-  - uid: 2300
-    components:
-    - pos: -8.5,-42.5
-      parent: 1
-      type: Transform
   - uid: 2334
     components:
     - pos: 5.5,-11.5
-      parent: 1
-      type: Transform
-  - uid: 2345
-    components:
-    - pos: -7.5,-42.5
-      parent: 1
-      type: Transform
-  - uid: 2346
-    components:
-    - pos: -6.5,-42.5
       parent: 1
       type: Transform
   - uid: 2347
@@ -102456,6 +97308,30 @@ entities:
   - uid: 2540
     components:
     - pos: 33.5,9.5
+      parent: 1
+      type: Transform
+  - uid: 2698
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-46.5
+      parent: 1
+      type: Transform
+  - uid: 2701
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-46.5
+      parent: 1
+      type: Transform
+  - uid: 2708
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-46.5
+      parent: 1
+      type: Transform
+  - uid: 2711
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -9.5,-46.5
       parent: 1
       type: Transform
   - uid: 2888
@@ -102918,6 +97794,11 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: -43.5,16.5
+      parent: 1
+      type: Transform
+  - uid: 4139
+    components:
+    - pos: -44.5,3.5
       parent: 1
       type: Transform
   - uid: 4216
@@ -103634,22 +98515,6 @@ entities:
     - links:
       - 2873
       type: DeviceLinkSink
-  - uid: 5828
-    components:
-    - pos: -41.5,-3.5
-      parent: 1
-      type: Transform
-    - links:
-      - 17634
-      type: DeviceLinkSink
-  - uid: 6653
-    components:
-    - pos: -40.5,-3.5
-      parent: 1
-      type: Transform
-    - links:
-      - 17634
-      type: DeviceLinkSink
   - uid: 6808
     components:
     - rot: -1.5707963267948966 rad
@@ -104012,6 +98877,37 @@ entities:
       type: Transform
 - proto: SignalButton
   entities:
+  - uid: 2128
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -46.5,0.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        2130:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 2291
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -44.5,3.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        2129:
+        - Pressed: Toggle
+        2607:
+        - Pressed: Toggle
+      type: DeviceLinkSource
+  - uid: 2612
+    components:
+    - pos: -46.5,6.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        2610:
+        - Pressed: Toggle
+      type: DeviceLinkSource
   - uid: 2873
     components:
     - rot: 3.141592653589793 rad
@@ -104181,22 +99077,6 @@ entities:
       pos: -44.5,10.5
       parent: 1
       type: Transform
-  - uid: 9363
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -41.5,3.5
-      parent: 1
-      type: Transform
-    - linkedPorts:
-        110:
-        - Pressed: Toggle
-        286:
-        - Pressed: Toggle
-        109:
-        - Pressed: Toggle
-        287:
-        - Pressed: Toggle
-      type: DeviceLinkSource
   - uid: 9404
     components:
     - pos: -20.5,-14.5
@@ -104204,18 +99084,6 @@ entities:
       type: Transform
     - linkedPorts:
         9406:
-        - Pressed: Toggle
-      type: DeviceLinkSource
-  - uid: 17634
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -39.5,-3.5
-      parent: 1
-      type: Transform
-    - linkedPorts:
-        6653:
-        - Pressed: Toggle
-        5828:
         - Pressed: Toggle
       type: DeviceLinkSource
   - uid: 17647
@@ -104274,6 +99142,17 @@ entities:
         4304:
         - Pressed: Toggle
       type: DeviceLinkSource
+- proto: SignalButtonExt3
+  entities:
+  - uid: 9658
+    components:
+    - desc: Press in case of grey tide.
+      name: emergency security lockdown
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: -11.5,47.5
+      parent: 1
+      type: Transform
 - proto: SignalButtonWindows
   entities:
   - uid: 17612
@@ -104364,9 +99243,9 @@ entities:
       type: Transform
 - proto: SignCargoDock
   entities:
-  - uid: 4157
+  - uid: 9309
     components:
-    - pos: -44.5,3.5
+    - pos: -47.5,3.5
       parent: 1
       type: Transform
   - uid: 18055
@@ -107306,19 +102185,19 @@ entities:
       type: Transform
 - proto: SpawnVendingMachineRestockFoodDrink
   entities:
-  - uid: 9321
-    components:
-    - pos: -43.5,-7.5
-      parent: 1
-      type: Transform
   - uid: 9322
     components:
-    - pos: -39.5,-4.5
+    - pos: -39.5,2.5
       parent: 1
       type: Transform
   - uid: 9323
     components:
-    - pos: -42.5,-6.5
+    - pos: -41.5,3.5
+      parent: 1
+      type: Transform
+  - uid: 9362
+    components:
+    - pos: -41.5,4.5
       parent: 1
       type: Transform
 - proto: Spear
@@ -107537,14 +102416,14 @@ entities:
       type: Transform
 - proto: StorageCanister
   entities:
-  - uid: 2607
+  - uid: 2712
     components:
-    - pos: -9.5,-40.5
+    - pos: -9.5,-38.5
       parent: 1
       type: Transform
-  - uid: 2608
+  - uid: 2713
     components:
-    - pos: -10.5,-40.5
+    - pos: -9.5,-39.5
       parent: 1
       type: Transform
   - uid: 3024
@@ -108147,17 +103026,6 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AME Room
-      type: SurveillanceCamera
-  - uid: 16384
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -9.5,-43.5
-      parent: 1
-      type: Transform
-    - setupAvailableNetworks:
-      - SurveillanceCameraEngineering
-      nameSet: True
-      id: Port Thruster Exterior
       type: SurveillanceCamera
   - uid: 16391
     components:
@@ -109543,6 +104411,18 @@ entities:
       pos: 9.5,30.5
       parent: 1
       type: Transform
+  - uid: 9622
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -38.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 9623
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -38.5,-5.5
+      parent: 1
+      type: Transform
   - uid: 9703
     components:
     - pos: -35.5,9.5
@@ -110370,6 +105250,18 @@ entities:
     - pos: 26.5,-13.5
       parent: 1
       type: Transform
+  - uid: 9624
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -41.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 9625
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -42.5,-7.5
+      parent: 1
+      type: Transform
   - uid: 10643
     components:
     - pos: 8.5,-3.5
@@ -110893,6 +105785,31 @@ entities:
     - pos: -16.5,-2.5
       parent: 1
       type: Transform
+- proto: TegCenter
+  entities:
+  - uid: 2703
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,-44.5
+      parent: 1
+      type: Transform
+- proto: TegCirculator
+  entities:
+  - uid: 2700
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -9.5,-44.5
+      parent: 1
+      type: Transform
+    - color: '#FF3300FF'
+      type: PointLight
+  - uid: 2702
+    components:
+    - pos: -7.5,-44.5
+      parent: 1
+      type: Transform
+    - color: '#FF3300FF'
+      type: PointLight
 - proto: TelecomServer
   entities:
   - uid: 3583
@@ -111462,6 +106379,33 @@ entities:
         - Right: Reverse
         - Middle: Off
       type: DeviceLinkSource
+  - uid: 7815
+    components:
+    - pos: -43.5,0.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        252:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        2723:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        7254:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        7291:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        7704:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+      type: DeviceLinkSource
   - uid: 7918
     components:
     - pos: -44.5,23.5
@@ -111501,49 +106445,29 @@ entities:
         - Right: Reverse
         - Middle: Off
       type: DeviceLinkSource
-  - uid: 9362
+  - uid: 8179
     components:
-    - pos: -40.5,3.5
+    - pos: -41.5,5.5
       parent: 1
       type: Transform
     - linkedPorts:
-        4141:
+        2127:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        4142:
+        461:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        4143:
+        460:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        4144:
+        459:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        4145:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        4137:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        4138:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        4139:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        4140:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        4148:
+        2722:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
@@ -112586,10 +107510,9 @@ entities:
     - pos: -51.5,-10.5
       parent: 1
       type: Transform
-  - uid: 113
+  - uid: 110
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -44.5,3.5
+    - pos: -47.5,0.5
       parent: 1
       type: Transform
   - uid: 114
@@ -112818,16 +107741,6 @@ entities:
   - uid: 247
     components:
     - pos: -33.5,-6.5
-      parent: 1
-      type: Transform
-  - uid: 255
-    components:
-    - pos: -41.5,3.5
-      parent: 1
-      type: Transform
-  - uid: 256
-    components:
-    - pos: -41.5,0.5
       parent: 1
       type: Transform
   - uid: 260
@@ -115468,6 +110381,11 @@ entities:
     - pos: 2.5,-46.5
       parent: 1
       type: Transform
+  - uid: 2075
+    components:
+    - pos: -47.5,6.5
+      parent: 1
+      type: Transform
   - uid: 2078
     components:
     - pos: -3.5,-42.5
@@ -115578,16 +110496,6 @@ entities:
   - uid: 2126
     components:
     - pos: -11.5,-42.5
-      parent: 1
-      type: Transform
-  - uid: 2127
-    components:
-    - pos: -10.5,-42.5
-      parent: 1
-      type: Transform
-  - uid: 2128
-    components:
-    - pos: -9.5,-42.5
       parent: 1
       type: Transform
   - uid: 2131
@@ -116778,6 +111686,46 @@ entities:
     - pos: 33.5,-2.5
       parent: 1
       type: Transform
+  - uid: 2696
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-46.5
+      parent: 1
+      type: Transform
+  - uid: 2697
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -10.5,-46.5
+      parent: 1
+      type: Transform
+  - uid: 2707
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-46.5
+      parent: 1
+      type: Transform
+  - uid: 2714
+    components:
+    - pos: -46.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 2715
+    components:
+    - pos: -46.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 2721
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -11.5,-46.5
+      parent: 1
+      type: Transform
+  - uid: 2727
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -11.5,-44.5
+      parent: 1
+      type: Transform
   - uid: 2804
     components:
     - rot: -1.5707963267948966 rad
@@ -117087,6 +112035,23 @@ entities:
   - uid: 2950
     components:
     - pos: 40.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 2972
+    components:
+    - pos: -45.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 2973
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-43.5
+      parent: 1
+      type: Transform
+  - uid: 3045
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -11.5,-45.5
       parent: 1
       type: Transform
   - uid: 3078
@@ -117858,11 +112823,6 @@ entities:
     - pos: 23.5,30.5
       parent: 1
       type: Transform
-  - uid: 3725
-    components:
-    - pos: -43.5,0.5
-      parent: 1
-      type: Transform
   - uid: 3737
     components:
     - pos: 21.5,-26.5
@@ -118169,6 +113129,12 @@ entities:
     - pos: -43.5,23.5
       parent: 1
       type: Transform
+  - uid: 4145
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -11.5,-43.5
+      parent: 1
+      type: Transform
   - uid: 4151
     components:
     - rot: 3.141592653589793 rad
@@ -118183,6 +113149,11 @@ entities:
   - uid: 4202
     components:
     - pos: -13.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 4339
+    components:
+    - pos: -45.5,0.5
       parent: 1
       type: Transform
   - uid: 4342
@@ -118210,9 +113181,21 @@ entities:
     - pos: -39.5,-14.5
       parent: 1
       type: Transform
+  - uid: 4534
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-45.5
+      parent: 1
+      type: Transform
   - uid: 5530
     components:
     - pos: -19.5,29.5
+      parent: 1
+      type: Transform
+  - uid: 5531
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-44.5
       parent: 1
       type: Transform
   - uid: 5695
@@ -118390,11 +113373,6 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 35.5,2.5
-      parent: 1
-      type: Transform
-  - uid: 6690
-    components:
-    - pos: -42.5,0.5
       parent: 1
       type: Transform
   - uid: 6780
@@ -123234,61 +118212,12 @@ entities:
       type: EntityStorage
 - proto: WarpPoint
   entities:
-  - uid: 6670
-    components:
-    - pos: 30.5,4.5
-      parent: 1
-      type: Transform
-    - location: HoP
-      type: WarpPoint
-  - uid: 17617
-    components:
-    - pos: 10.5,26.5
-      parent: 1
-      type: Transform
-    - location: Medbay
-      type: WarpPoint
   - uid: 17618
     components:
     - pos: -16.5,25.5
       parent: 1
       type: Transform
     - location: Science
-      type: WarpPoint
-  - uid: 17619
-    components:
-    - pos: -37.5,24.5
-      parent: 1
-      type: Transform
-    - location: Salvage
-      type: WarpPoint
-  - uid: 17620
-    components:
-    - pos: -38.5,3.5
-      parent: 1
-      type: Transform
-    - location: Cargo
-      type: WarpPoint
-  - uid: 17621
-    components:
-    - pos: -0.5,2.5
-      parent: 1
-      type: Transform
-    - location: Bar
-      type: WarpPoint
-  - uid: 17622
-    components:
-    - pos: -8.5,-26.5
-      parent: 1
-      type: Transform
-    - location: Atmos
-      type: WarpPoint
-  - uid: 17623
-    components:
-    - pos: 12.5,-26.5
-      parent: 1
-      type: Transform
-    - location: Engineering
       type: WarpPoint
   - uid: 17624
     components:
@@ -123311,26 +118240,12 @@ entities:
       type: Transform
     - location: Vault
       type: WarpPoint
-  - uid: 17628
-    components:
-    - pos: -13.5,48.5
-      parent: 1
-      type: Transform
-    - location: Security
-      type: WarpPoint
   - uid: 17629
     components:
     - pos: 10.5,58.5
       parent: 1
       type: Transform
     - location: Courtroom
-      type: WarpPoint
-  - uid: 17630
-    components:
-    - pos: -0.5,79.5
-      parent: 1
-      type: Transform
-    - location: Bridge
       type: WarpPoint
   - uid: 18176
     components:
@@ -123339,13 +118254,80 @@ entities:
       type: Transform
     - location: Captain's Private Shuttle
       type: WarpPoint
-- proto: WaterCooler
+- proto: WarpPointBombing
   entities:
-  - uid: 4162
+  - uid: 2345
     components:
-    - pos: -40.5,11.5
+    - pos: 24.5,5.5
       parent: 1
       type: Transform
+    - location: HoP Office
+      type: WarpPoint
+  - uid: 5828
+    components:
+    - pos: 18.5,-14.5
+      parent: 1
+      type: Transform
+    - location: Telecomms
+      type: WarpPoint
+  - uid: 6362
+    components:
+    - pos: 10.5,27.5
+      parent: 1
+      type: Transform
+    - location: Medbay
+      type: WarpPoint
+  - uid: 6458
+    components:
+    - pos: -39.5,25.5
+      parent: 1
+      type: Transform
+    - location: Salvage
+      type: WarpPoint
+  - uid: 6600
+    components:
+    - pos: -38.5,2.5
+      parent: 1
+      type: Transform
+    - location: Cargo
+      type: WarpPoint
+  - uid: 6629
+    components:
+    - pos: -0.5,2.5
+      parent: 1
+      type: Transform
+    - location: Bar
+      type: WarpPoint
+  - uid: 6636
+    components:
+    - pos: -8.5,-26.5
+      parent: 1
+      type: Transform
+    - location: Atmospherics
+      type: WarpPoint
+  - uid: 6637
+    components:
+    - pos: 12.5,-26.5
+      parent: 1
+      type: Transform
+    - location: Engineering
+      type: WarpPoint
+  - uid: 6653
+    components:
+    - pos: -13.5,49.5
+      parent: 1
+      type: Transform
+    - location: Security
+      type: WarpPoint
+  - uid: 6670
+    components:
+    - pos: -0.5,79.5
+      parent: 1
+      type: Transform
+    - location: Bridge
+      type: WarpPoint
+- proto: WaterCooler
+  entities:
   - uid: 6948
     components:
     - pos: 26.5,23.5
@@ -123374,6 +118356,11 @@ entities:
   - uid: 9090
     components:
     - pos: 4.5,-32.5
+      parent: 1
+      type: Transform
+  - uid: 9628
+    components:
+    - pos: -43.5,-7.5
       parent: 1
       type: Transform
 - proto: WaterTankFull


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- expanded cargo department, remade the previous cargo holding area into a break room
- added a mindshield crate and contraband locker to the armory
- bombing targets in the bridge, cargo, salvage, security, telecomms, atmos, hop office ect
- emergency lockdown button in the wardens office, which will close blast doors on the windows
- TEG in atmos

minor additions:
first aid kit in salvage (so they can stop bothering medbay)
CRAZY HAMBURGER
random soap spawner in mime room
bananas in clown room
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
the cargo hold was pretty out of the way and not really used, cargo in general was also pretty cramped

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/130668733/b085252b-0a04-4086-87d1-303298b05013)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: JoeHammad
- tweak: Aspid station has had its cargo department expanded.
