### PR TITLE
Increase Ninja Suit Weight

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -92,7 +92,7 @@
   - type: GroupExamine
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterBaseLarge
   id: ClothingOuterSuitSpaceNinja
   name: space ninja suit
   description: This black technologically advanced, cybernetically-enhanced suit provides many abilities like invisibility or teleportation.


### PR DESCRIPTION
## About the PR
Changes the Ninja's space suit to 80 weight instead of 5.

## Why / Balance
Has no right to be 5 weight and was likely an oversight. 80 to match with the paramedic's void suit.

**Changelog**
No requirement.