### PR TITLE
Mind tweaks & fixes

### DIFF
--- a/Content.Client/Mind/MindSystem.cs
+++ b/Content.Client/Mind/MindSystem.cs
@@ -4,4 +4,24 @@ namespace Content.Client.Mind;
 
 public sealed class MindSystem : SharedMindSystem
 {
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<MindComponent, AfterAutoHandleStateEvent>(OnHandleState);
+    }
+
+    private void OnHandleState(EntityUid uid, MindComponent component, ref AfterAutoHandleStateEvent args)
+    {
+        // Because minds are generally not networked, there might be weird situations were a client thinks multiple
+        // users share a mind? E.g., if an admin periodical gets sent all minds via some PVS override, but doesn't get
+        // sent intermediate states? Not sure if this is actually possible, but better to be safe.
+        foreach (var (user, mind) in UserMinds)
+        {
+            if (mind == uid)
+                UserMinds.Remove(user);
+        }
+
+        if (component.UserId != null)
+            UserMinds[component.UserId.Value] = uid;
+    }
 }

--- a/Content.IntegrationTests/Tests/Minds/MindTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.cs
@@ -67,13 +67,12 @@ public sealed partial class MindTests
             var entity = entMan.SpawnEntity(null, new MapCoordinates());
             var mindComp = entMan.EnsureComponent<MindContainerComponent>(entity);
 
-            var mindId = mindSystem.CreateMind(null);
-            var mind = entMan.GetComponent<MindComponent>(mindId);
+            var mind = mindSystem.CreateMind(null);
 
-            Assert.That(mind.UserId, Is.EqualTo(null));
+            Assert.That(mind.Comp.UserId, Is.EqualTo(null));
 
-            mindSystem.TransferTo(mindId, entity, mind: mind);
-            Assert.That(mindSystem.GetMind(entity, mindComp), Is.EqualTo(mindId));
+            mindSystem.TransferTo(mind, entity, mind: mind);
+            Assert.That(mindSystem.GetMind(entity, mindComp), Is.EqualTo(mind.Owner));
         });
 
         await pair.CleanReturnAsync();
@@ -94,11 +93,11 @@ public sealed partial class MindTests
             var entity = entMan.SpawnEntity(null, new MapCoordinates());
             var mindComp = entMan.EnsureComponent<MindContainerComponent>(entity);
 
-            var mindId = mindSystem.CreateMind(null);
+            var mindId = mindSystem.CreateMind(null).Owner;
             mindSystem.TransferTo(mindId, entity);
             Assert.That(mindSystem.GetMind(entity, mindComp), Is.EqualTo(mindId));
 
-            var mind2 = mindSystem.CreateMind(null);
+            var mind2 = mindSystem.CreateMind(null).Owner;
             mindSystem.TransferTo(mind2, entity);
             Assert.Multiple(() =>
             {
@@ -184,7 +183,7 @@ public sealed partial class MindTests
             var mindComp = entMan.EnsureComponent<MindContainerComponent>(entity);
             entMan.EnsureComponent<MindContainerComponent>(targetEntity);
 
-            var mind = mindSystem.CreateMind(null);
+            var mind = mindSystem.CreateMind(null).Owner;
 
             mindSystem.TransferTo(mind, entity);
 
@@ -276,7 +275,7 @@ public sealed partial class MindTests
             var entity = entMan.SpawnEntity(null, new MapCoordinates());
             var mindComp = entMan.EnsureComponent<MindContainerComponent>(entity);
 
-            var mindId = mindSystem.CreateMind(null);
+            var mindId = mindSystem.CreateMind(null).Owner;
             var mind = entMan.EnsureComponent<MindComponent>(mindId);
 
             Assert.That(mind.UserId, Is.EqualTo(null));
@@ -334,7 +333,7 @@ public sealed partial class MindTests
     public async Task TestPlayerCanGhost()
     {
         // Client is needed to spawn session
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true, DummyTicker = false });
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();

--- a/Content.Server/Administration/Commands/ControlMob.cs
+++ b/Content.Server/Administration/Commands/ControlMob.cs
@@ -1,5 +1,5 @@
+using Content.Server.Mind;
 using Content.Shared.Administration;
-using Content.Shared.Mind;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 
@@ -42,14 +42,7 @@ namespace Content.Server.Administration.Commands
                 return;
             }
 
-            var mindSystem = _entities.System<SharedMindSystem>();
-            if (!mindSystem.TryGetMind(target, out var mindId, out var mind))
-            {
-                shell.WriteLine(Loc.GetString("shell-entity-is-not-mob"));
-                return;
-            }
-
-            mindSystem.TransferTo(mindId, target, mind: mind);
+            _entities.System<MindSystem>().ControlMob(player.UserId, target);
         }
     }
 }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Disposal.Tube;
 using Content.Server.Disposal.Tube.Components;
 using Content.Server.EUI;
 using Content.Server.Ghost.Roles;
+using Content.Server.Mind;
 using Content.Server.Mind.Commands;
 using Content.Server.Prayer;
 using Content.Server.Xenoarchaeology.XenoArtifacts;
@@ -18,7 +19,6 @@ using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Inventory;
-using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
@@ -56,7 +56,7 @@ namespace Content.Server.Administration.Systems
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
         [Dependency] private readonly PrayerSystem _prayerSystem = default!;
         [Dependency] private readonly EuiManager _eui = default!;
-        [Dependency] private readonly SharedMindSystem _mindSystem = default!;
+        [Dependency] private readonly MindSystem _mindSystem = default!;
         [Dependency] private readonly ToolshedManager _toolshed = default!;
         [Dependency] private readonly RejuvenateSystem _rejuvenate = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -277,12 +277,7 @@ namespace Content.Server.Administration.Systems
                     // TODO VERB ICON control mob icon
                     Act = () =>
                     {
-                        MakeSentientCommand.MakeSentient(args.Target, EntityManager);
-
-                        if (!_minds.TryGetMind(player, out var mindId, out var mind))
-                            return;
-
-                        _mindSystem.TransferTo(mindId, args.Target, ghostCheckOverride: true, mind: mind);
+                        _mindSystem.ControlMob(args.User, args.Target);
                     },
                     Impact = LogImpact.High,
                     ConfirmationPopup = true
@@ -358,7 +353,7 @@ namespace Content.Server.Administration.Systems
                         var message = ExamineSystemShared.InRangeUnOccluded(args.User, args.Target)
                             ? Loc.GetString("in-range-unoccluded-verb-on-activate-not-occluded")
                             : Loc.GetString("in-range-unoccluded-verb-on-activate-occluded");
-                        
+
                         _popup.PopupEntity(message, args.Target, args.User);
                     }
                 };

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -360,8 +360,7 @@ namespace Content.Server.GameTicking
                 else if (mind.CurrentEntity != null && TryName(mind.CurrentEntity.Value, out var icName))
                     playerIcName = icName;
 
-                var entity = mind.OriginalOwnedEntity;
-                if (Exists(entity))
+                if (TryGetEntity(mind.OriginalOwnedEntity, out var entity))
                     _pvsOverride.AddGlobalOverride(entity.Value, recursive: true);
 
                 var roles = _roles.MindGetAllRoles(mindId);

--- a/Content.Server/Mind/Commands/RenameCommand.cs
+++ b/Content.Server/Mind/Commands/RenameCommand.cs
@@ -54,6 +54,7 @@ public sealed class RenameCommand : IConsoleCommand
         {
             // Mind
             mind.CharacterName = name;
+            _entManager.Dirty(mindId, mind);
         }
 
         // Id Cards

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -245,6 +245,11 @@ public sealed class MindSystem : SharedMindSystem
         }
         else if (createGhost)
         {
+            // TODO remove this option.
+            // Transfer-to-null should just detach a mind.
+            // If people want to create a ghost, that should be done explicitly via some TransferToGhost() method, not
+            // not implicitly via optional arguments.
+
             var position = Deleted(mind.OwnedEntity)
                 ? _gameTicker.GetObserverSpawnPoint().ToMap(EntityManager, _transform)
                 : Transform(mind.OwnedEntity.Value).MapPosition;
@@ -259,14 +264,13 @@ public sealed class MindSystem : SharedMindSystem
         if (TryComp(oldEntity, out MindContainerComponent? oldContainer))
         {
             oldContainer.Mind = null;
+            mind.OwnedEntity = null;
             Entity<MindComponent> mindEnt = (mindId, mind);
             Entity<MindContainerComponent> containerEnt = (oldEntity.Value, oldContainer);
             RaiseLocalEvent(oldEntity.Value, new MindRemovedMessage(mindEnt, containerEnt));
             RaiseLocalEvent(mindId, new MindGotRemovedEvent(mindEnt, containerEnt));
             Dirty(oldEntity.Value, oldContainer);
         }
-
-        SetOwnedEntity(mind, entity, component);
 
         // Don't do the full deletion cleanup if we're transferring to our VisitingEntity
         if (alreadyAttached)
@@ -295,6 +299,7 @@ public sealed class MindSystem : SharedMindSystem
         if (entity != null)
         {
             component!.Mind = mindId;
+            mind.OwnedEntity = entity;
             mind.OriginalOwnedEntity ??= mind.OwnedEntity;
             Entity<MindComponent> mindEnt = (mindId, mind);
             Entity<MindContainerComponent> containerEnt = (entity.Value, component);

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -170,7 +170,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         if (component.AntagonistRole == null)
             return;
 
-        _roles.MindTryRemoveRole<SubvertedSiliconRoleComponent>(args.OldMindId);
+        _roles.MindTryRemoveRole<SubvertedSiliconRoleComponent>(args.Mind);
     }
 
     private void EnsureEmaggedRole(EntityUid uid, EmagSiliconLawComponent component)

--- a/Content.Shared/Mind/Components/MindContainerComponent.cs
+++ b/Content.Shared/Mind/Components/MindContainerComponent.cs
@@ -39,23 +39,59 @@ namespace Content.Shared.Mind.Components
         public bool GhostOnShutdown { get; set; } = true;
     }
 
-    public sealed class MindRemovedMessage : EntityEventArgs
+    public abstract class MindEvent : EntityEventArgs
     {
         public readonly Entity<MindComponent> Mind;
+        public readonly Entity<MindContainerComponent> Container;
 
-        public MindRemovedMessage(Entity<MindComponent> mind)
+        public MindEvent(Entity<MindComponent> mind, Entity<MindContainerComponent> container)
         {
             Mind = mind;
+            Container = container;
         }
     }
 
-    public sealed class MindAddedMessage : EntityEventArgs
+    /// <summary>
+    /// Event raised directed at a mind-container when a mind gets removed.
+    /// </summary>
+    public sealed class MindRemovedMessage : MindEvent
     {
-        public readonly Entity<MindComponent> Mind;
-
-        public MindAddedMessage(Entity<MindComponent> mind)
+        public MindRemovedMessage(Entity<MindComponent> mind, Entity<MindContainerComponent> container)
+            : base(mind, container)
         {
-            Mind = mind;
+        }
+    }
+
+    /// <summary>
+    /// Event raised directed at a mind when it gets removed from a mind-container.
+    /// </summary>
+    public sealed class MindGotRemovedEvent : MindEvent
+    {
+        public MindGotRemovedEvent(Entity<MindComponent> mind, Entity<MindContainerComponent> container)
+            : base(mind, container)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event raised directed at a mind-container when a mind gets added.
+    /// </summary>
+    public sealed class MindAddedMessage : MindEvent
+    {
+        public MindAddedMessage(Entity<MindComponent> mind, Entity<MindContainerComponent> container)
+            : base(mind, container)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event raised directed at a mind when it gets added to a mind-container.
+    /// </summary>
+    public sealed class MindGotAddedEvent : MindEvent
+    {
+        public MindGotAddedEvent(Entity<MindComponent> mind, Entity<MindContainerComponent> container)
+            : base(mind, container)
+        {
         }
     }
 }

--- a/Content.Shared/Mind/Components/MindContainerComponent.cs
+++ b/Content.Shared/Mind/Components/MindContainerComponent.cs
@@ -1,24 +1,25 @@
 using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Mind.Components
 {
     /// <summary>
-    ///     Stores a <see cref="MindComponent"/> on a mob.
+    /// This component indicates that this entity may have mind, which is simply an entity with a <see cref="MindComponent"/>.
+    /// The mind entity is not actually stored in a "container", but is simply stored in nullspace.
     /// </summary>
-    [RegisterComponent, Access(typeof(SharedMindSystem))]
+    [RegisterComponent, Access(typeof(SharedMindSystem)), NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class MindContainerComponent : Component
     {
         /// <summary>
         ///     The mind controlling this mob. Can be null.
         /// </summary>
-        [ViewVariables]
+        [DataField, AutoNetworkedField]
         [Access(typeof(SharedMindSystem), Other = AccessPermissions.ReadWriteExecute)] // FIXME Friends
         public EntityUid? Mind { get; set; }
 
         /// <summary>
         ///     True if we have a mind, false otherwise.
         /// </summary>
-        [ViewVariables]
         [MemberNotNullWhen(true, nameof(Mind))]
         public bool HasMind => Mind != null;
 
@@ -26,7 +27,7 @@ namespace Content.Shared.Mind.Components
         ///     Whether examining should show information about the mind or not.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("showExamineInfo")]
+        [DataField("showExamineInfo"), AutoNetworkedField]
         public bool ShowExamineInfo { get; set; }
 
         /// <summary>
@@ -40,17 +41,21 @@ namespace Content.Shared.Mind.Components
 
     public sealed class MindRemovedMessage : EntityEventArgs
     {
-        public EntityUid OldMindId;
-        public MindComponent OldMind;
+        public readonly Entity<MindComponent> Mind;
 
-        public MindRemovedMessage(EntityUid oldMindId, MindComponent oldMind)
+        public MindRemovedMessage(Entity<MindComponent> mind)
         {
-            OldMindId = oldMindId;
-            OldMind = oldMind;
+            Mind = mind;
         }
     }
 
     public sealed class MindAddedMessage : EntityEventArgs
     {
+        public readonly Entity<MindComponent> Mind;
+
+        public MindAddedMessage(Entity<MindComponent> mind)
+        {
+            Mind = mind;
+        }
     }
 }

--- a/Content.Shared/Mind/MindComponent.cs
+++ b/Content.Shared/Mind/MindComponent.cs
@@ -1,84 +1,84 @@
 ﻿using Content.Shared.GameTicking;
 using Content.Shared.Mind.Components;
+using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Players;
 
 namespace Content.Shared.Mind
 {
     /// <summary>
-    ///     This is added as a component to mind entities, not to player entities.
-    ///     <see cref="MindContainerComponent"/> for the one that is added to players.
-    ///     A mind represents the IC "mind" of a player.
-    ///     Roles are attached as components to its owning entity.
+    ///     This component stores information about a player/mob mind. The component will be attached to a mind-entity
+    ///     which is stored in null-space. The entity that is currently "possessed" by the mind will have a
+    ///     <see cref="MindContainerComponent"/>.
     /// </summary>
     /// <remarks>
+    ///     Roles are attached as components on the mind-entity entity.
     ///     Think of it like this: if a player is supposed to have their memories,
     ///     their mind follows along.
     ///
     ///     Things such as respawning do not follow, because you're a new character.
     ///     Getting borged, cloned, turned into a catbeast, etc... will keep it following you.
+    ///
+    ///     Minds are stored in null-space, and are thus generally not set to players unless that player is the owner
+    ///     of the mind. As a result it should be safe to network "secret" information like roles & objectives
     /// </remarks>
-    [RegisterComponent]
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class MindComponent : Component
     {
-        internal readonly List<EntityUid> Objectives = new();
+        [DataField, AutoNetworkedField]
+        public List<EntityUid> Objectives = new();
 
         /// <summary>
         ///     The session ID of the player owning this mind.
         /// </summary>
-        [ViewVariables, Access(typeof(SharedMindSystem))]
+        [DataField, AutoNetworkedField, Access(typeof(SharedMindSystem))]
         public NetUserId? UserId { get; set; }
 
         /// <summary>
         ///     The session ID of the original owner, if any.
         ///     May end up used for round-end information (as the owner may have abandoned Mind since)
         /// </summary>
-        [ViewVariables, Access(typeof(SharedMindSystem))]
+        [DataField, AutoNetworkedField, Access(typeof(SharedMindSystem))]
         public NetUserId? OriginalOwnerUserId { get; set; }
 
         /// <summary>
         ///     Entity UID for the first entity that this mind controlled. Used for round end.
         ///     Might be relevant if the player has ghosted since.
         /// </summary>
-        [ViewVariables] public EntityUid? OriginalOwnedEntity;
+
+        [DataField, AutoNetworkedField]
+        public EntityUid? OriginalOwnedEntity;
 
         [ViewVariables]
         public bool IsVisitingEntity => VisitingEntity != null;
 
-        [ViewVariables, Access(typeof(SharedMindSystem))]
+        [DataField, AutoNetworkedField, Access(typeof(SharedMindSystem))]
         public EntityUid? VisitingEntity { get; set; }
 
         [ViewVariables]
         public EntityUid? CurrentEntity => VisitingEntity ?? OwnedEntity;
 
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
         public string? CharacterName { get; set; }
 
         /// <summary>
         ///     The time of death for this Mind.
         ///     Can be null - will be null if the Mind is not considered "dead".
         /// </summary>
-        [ViewVariables]
+        [DataField]
         public TimeSpan? TimeOfDeath { get; set; }
-
-        /// <summary>
-        ///     The component currently owned by this mind.
-        ///     Can be null.
-        /// </summary>
-        [ViewVariables] public MindContainerComponent? OwnedComponent;
 
         /// <summary>
         ///     The entity currently owned by this mind.
         ///     Can be null.
         /// </summary>
-        [ViewVariables, Access(typeof(SharedMindSystem))]
+        [DataField, AutoNetworkedField, Access(typeof(SharedMindSystem))]
         public EntityUid? OwnedEntity { get; set; }
 
-        // TODO move objectives out of mind component
         /// <summary>
         ///     An enumerable over all the objective entities this mind has.
         /// </summary>
-        [ViewVariables]
+        [ViewVariables, Obsolete("Use Objectives field")]
         public IEnumerable<EntityUid> AllObjectives => Objectives;
 
         /// <summary>
@@ -100,6 +100,7 @@ namespace Content.Shared.Mind
         ///     Can be null, in which case the player is currently not logged in.
         /// </summary>
         [ViewVariables, Access(typeof(SharedMindSystem), typeof(SharedGameTicker))]
+        // TODO remove this after moving IPlayerManager functions to shared
         public ICommonSession? Session { get; set; }
     }
 }

--- a/Content.Shared/Mind/MindComponent.cs
+++ b/Content.Shared/Mind/MindComponent.cs
@@ -22,7 +22,7 @@ namespace Content.Shared.Mind
     ///     Minds are stored in null-space, and are thus generally not set to players unless that player is the owner
     ///     of the mind. As a result it should be safe to network "secret" information like roles & objectives
     /// </remarks>
-    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
     public sealed partial class MindComponent : Component
     {
         [DataField, AutoNetworkedField]

--- a/Content.Shared/Mind/MindComponent.cs
+++ b/Content.Shared/Mind/MindComponent.cs
@@ -42,12 +42,14 @@ namespace Content.Shared.Mind
         public NetUserId? OriginalOwnerUserId { get; set; }
 
         /// <summary>
-        ///     Entity UID for the first entity that this mind controlled. Used for round end.
+        ///     The first entity that this mind controlled. Used for round end information.
         ///     Might be relevant if the player has ghosted since.
         /// </summary>
-
         [DataField, AutoNetworkedField]
-        public EntityUid? OriginalOwnedEntity;
+        public NetEntity? OriginalOwnedEntity;
+        // This is a net entity, because this field currently ddoes not get set to null when this entity is deleted.
+        // This is a lazy way to ensure that people check that the entity still exists.
+        // TODO MIND Fix this properly by adding an OriginalMindContainerComponent or something like that.
 
         [ViewVariables]
         public bool IsVisitingEntity => VisitingEntity != null;

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -446,20 +446,6 @@ public abstract class SharedMindSystem : EntitySystem
     }
 
     /// <summary>
-    /// Sets the Mind's OwnedComponent and OwnedEntity
-    /// </summary>
-    /// <param name="mind">Mind to set OwnedComponent and OwnedEntity on</param>
-    /// <param name="uid">Entity owned by <paramref name="mind"/></param>
-    /// <param name="mindContainerComponent">MindContainerComponent owned by <paramref name="mind"/></param>
-    protected void SetOwnedEntity(MindComponent mind, EntityUid? uid, MindContainerComponent? mindContainerComponent)
-    {
-        if (uid != null)
-            Resolve(uid.Value, ref mindContainerComponent);
-
-        mind.OwnedEntity = uid;
-    }
-
-    /// <summary>
     /// Sets the Mind's UserId, Session, and updates the player's PlayerData. This should have no direct effect on the
     /// entity that any mind is connected to, except as a side effect of the fact that it may change a player's
     /// attached entity. E.g., ghosts get deleted.

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -54,9 +54,11 @@ public abstract class SharedMindSystem : EntitySystem
         if (UserMinds.TryAdd(component.UserId.Value, uid))
             return;
 
-        var old = UserMinds[component.UserId.Value];
+        var existing = UserMinds[component.UserId.Value];
+        if (existing == uid)
+            return;
 
-        if (!Exists(old))
+        if (!Exists(existing))
         {
             Log.Error($"Found deleted entity in mind dictionary while initializing mind {ToPrettyString(uid)}");
             UserMinds[component.UserId.Value] = uid;

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -26,7 +26,7 @@ public abstract class SharedMindSystem : EntitySystem
     [Dependency] private readonly SharedPlayerSystem _player = default!;
     [Dependency] private readonly MetaDataSystem _metadata = default!;
 
-    // This is dictionary is required to track the minds of disconnected players that may have had their entity deleted.
+    [ViewVariables]
     protected readonly Dictionary<NetUserId, EntityUid> UserMinds = new();
 
     public override void Initialize()


### PR DESCRIPTION
- Fixed a bug where mind-removed events were using the wrong entity uid.
- Fixed a bug where the mind PVS override would sometimes get incorrectly cleared.
- Fixed `ControlMob` command not working
- Moved some logic from the control mob command & verb into a new method on mind system.
- Added new mind-added & mind-removed events that get directed at the mind entity.
- Added `DataField` & `AutoNetworkedField` attributes to various mind & mind container fields.