### PR TITLE
Add GrantContainedActions()

### DIFF
--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -494,6 +494,9 @@ public abstract class SharedActionsSystem : EntitySystem
                           (TryComp(action.Container, out ActionsContainerComponent? containerComp)
                            && containerComp.Container.Contains(actionId)));
 
+        if (action.AttachedEntity != null)
+            RemoveAction(action.AttachedEntity.Value, actionId, action: action);
+
         DebugTools.AssertOwner(performer, comp);
         comp ??= EnsureComp<ActionsComponent>(performer);
         action.AttachedEntity = performer;
@@ -529,6 +532,26 @@ public abstract class SharedActionsSystem : EntitySystem
         foreach (var actionId in actions)
         {
             AddAction(performer, actionId, container, comp, containerComp: containerComp);
+        }
+    }
+
+    /// <summary>
+    ///     Grants all actions currently contained in some action-container. If the target entity has no action
+    /// component, this will give them one.
+    /// </summary>
+    /// <param name="performer">Entity to receive the actions</param>
+    /// <param name="container">The entity that contains thee actions.</param>
+    public void GrantContainedActions(Entity<ActionsComponent?> performer, Entity<ActionsContainerComponent?> container)
+    {
+        if (!Resolve(container, ref container.Comp))
+            return;
+
+        performer.Comp ??= EnsureComp<ActionsComponent>(performer);
+
+        foreach (var actionId in container.Comp.Container.ContainedEntities)
+        {
+            if (TryGetActionData(actionId, out var action))
+                AddActionDirect(performer, actionId, performer.Comp, action);
         }
     }
 


### PR DESCRIPTION
Adds a new convenience method to SharedActionsSystem. Currently unused, but will probably be used in some WIP PRs.

Also adds a check to `AddActionDirect()` to ensure that actions don't get added twice.