### PR TITLE
Remove noRot from asteroids

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -18,7 +18,6 @@
   - type: SmoothEdge
   - type: Sprite
     sprite: Structures/Walls/rock.rsi
-    noRot: true
     layers:
       - state: rock_asteroid
       - map: [ "enum.EdgeLayer.South" ]
@@ -77,7 +76,6 @@
   components:
   - type: Sprite
     sprite: Structures/Walls/rock.rsi
-    noRot: true
     layers:
       - state: rock_asteroid_ore
       - map: [ "enum.EdgeLayer.South" ]
@@ -98,7 +96,6 @@
   components:
   - type: Sprite
     sprite: Structures/Walls/rock.rsi
-    noRot: true
     layers:
       - state: rock_asteroid_ore1
       - map: [ "enum.EdgeLayer.South" ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
See images. Makes the asteroids rotate with the grid they're parented to, rather than always facing the player view.

## With noRot
![image](https://github.com/space-wizards/space-station-14/assets/121047731/b1319249-afdb-465e-b9bf-b0dd0fe7043a)
![image](https://github.com/space-wizards/space-station-14/assets/121047731/22630ed9-af39-4034-b80f-5c71192a3b03)
## Without noRot
![image](https://github.com/space-wizards/space-station-14/assets/121047731/aed8a875-2644-483f-b85d-a6521d5915d2)


