### PR TITLE
Fix 0-length climbs

### DIFF
--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -257,15 +257,25 @@ public sealed partial class ClimbSystem : VirtualController
          // Need direction relative to climber's parent.
          var localDirection = (-parentRot).RotateVec(worldDirection);
 
-         climbing.IsClimbing = true;
-         var climbDuration = TimeSpan.FromSeconds(distance / climbing.TransitionRate);
-         climbing.NextTransition = _timing.CurTime + climbDuration;
+         // On top of it already so just do it in place.
+         if (localDirection.LengthSquared() < 0.01f)
+         {
+             climbing.NextTransition = null;
+         }
+         // VirtualController over to the thing.
+         else
+         {
+             var climbDuration = TimeSpan.FromSeconds(distance / climbing.TransitionRate);
+             climbing.NextTransition = _timing.CurTime + climbDuration;
 
-         climbing.Direction = localDirection.Normalized() * climbing.TransitionRate;
+             climbing.Direction = localDirection.Normalized() * climbing.TransitionRate;
+             _actionBlockerSystem.UpdateCanMove(uid);
+         }
+
+         climbing.IsClimbing = true;
          Dirty(uid, climbing);
 
          _audio.PlayPredicted(comp.FinishClimbSound, climbable, user);
-         _actionBlockerSystem.UpdateCanMove(uid);
 
          var startEv = new StartClimbEvent(climbable);
          var climbedEv = new ClimbedOnEvent(uid, user);


### PR DESCRIPTION
Supercedes https://github.com/space-wizards/space-station-14/pull/21071

Main issue in that pr was nexttransition being used regardless of whether the climb was valid which we shouldn't do.

:cl:
- fix: Fix climbing in the same position (e.g. exiting from medical scanners) sending you to the farplanes.
