### PR TITLE
Rev and Zombie icon visibility to ghosts are now determined by a CCVar

### DIFF
--- a/Content.Client/Antag/AntagStatusIconSystem.cs
+++ b/Content.Client/Antag/AntagStatusIconSystem.cs
@@ -1,7 +1,9 @@
+using Content.Shared.CCVar;
 using Content.Shared.Ghost;
 using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
 using Robust.Client.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.Antag;
@@ -14,6 +16,17 @@ public abstract class AntagStatusIconSystem<T> : SharedStatusIconSystem
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private bool GhostAntagStatusIndicatorVisible {get; set;}
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _cfg.OnValueChanged(CCVars.GhostAntagStatusIndicatorVisible, value => GhostAntagStatusIndicatorVisible =  value, true);
+
+    }
 
     /// <summary>
     /// Will check if the local player has the same component as the one who called it and give the status icon.
@@ -24,8 +37,12 @@ public abstract class AntagStatusIconSystem<T> : SharedStatusIconSystem
     {
         var ent = _player.LocalPlayer?.ControlledEntity;
 
-        if (!HasComp<T>(ent) && !HasComp<GhostComponent>(ent))
-            return;
+        if (!HasComp<T>(ent))
+        {
+            // We still want admin ghosts to see the icons even if normal ghosts can't.
+            if (!TryComp<GhostComponent>(ent, out var comp) || (!GhostAntagStatusIndicatorVisible && !comp.CanGhostInteract))
+                return;
+        }
 
         args.StatusIcons.Add(_prototype.Index<StatusIconPrototype>(antagStatusIcon));
     }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -655,7 +655,7 @@ namespace Content.Shared.CCVar
         /// Whether ghosts can see antagonist icons on antagonists such as Revolutionaries. Aghosts still get to see them.
         /// </summary>
         public static readonly CVarDef<bool> GhostAntagStatusIndicatorVisible =
-            CVarDef.Create("hud.ghost_antag_status_indicator_visible", true, CVar.ARCHIVE);
+            CVarDef.Create("hud.ghost_antag_status_indicator_visible", true, CVar.ARCHIVE | CVar.SERVER | CVar.REPLICATED);
 
         /*
          * NPCs

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -651,6 +651,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> HudFpsCounterVisible =
             CVarDef.Create("hud.fps_counter_visible", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+        /// <summary>
+        /// Whether ghosts can see antagonist icons on antagonists such as Revolutionaries. Aghosts still get to see them.
+        /// </summary>
+        public static readonly CVarDef<bool> GhostAntagStatusIndicatorVisible =
+            CVarDef.Create("hud.ghost_antag_status_indicator_visible", true, CVar.ARCHIVE);
+
         /*
          * NPCs
          */


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
Currently waiting on #21260.
## About the PR
<!-- What did you change in this PR? -->
This PR makes a new CCVar that determines whether ghosts can see stuff such as the Rev, headrev, and zombie icons. Admin ghosts and the actual antagonists will be able to view these icons regardless of what the ccvar is set to. The ccvar defaults to true.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
See #21201. The ability for ghosts to see whether for example someone is a head rev or a rev can and has resulted in them immediately relaying this information the moment they are revived or brought back in the round in some other way. This is obviously problematic. This PR however does not actually make it so ghosts can't see antag icons on wizden servers, but just gives us the option of doing it along with any other downstream servers that want to as well.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
A new CCVar was added which the AntagStatusIconSystem.cs subscribes to. If it is set to false then people who do not have the relevant antag component will not see the icon except for aghosts. The way the system checks if the player is an aghost is checking whether they have the ghost component and can interact, the same method that the actual aghost command uses.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/32041239/ac40d761-561e-44ef-899a-511414b9f291


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun