### PR TITLE
Some mild item size balancing + fixes

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -180,14 +180,13 @@ namespace Content.Server.Chemistry.EntitySystems
             var user = message.Session.AttachedEntity;
             var maybeContainer = _itemSlotsSystem.GetItemOrNull(chemMaster, SharedChemMaster.OutputSlotName);
             if (maybeContainer is not { Valid: true } container
-                || !TryComp(container, out StorageComponent? storage)
-                || storage.Container is null)
+                || !TryComp(container, out StorageComponent? storage))
             {
                 return; // output can't fit pills
             }
 
             // Ensure the number is valid.
-            if (message.Number == 0 || _storageSystem.HasSpace((chemMaster, storage)))
+            if (message.Number == 0 || !_storageSystem.HasSpace((container, storage)))
                 return;
 
             // Ensure the amount is valid.

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -267,6 +267,11 @@
   name: syndicate hardsuit bundle
   description: "Contains the Syndicate's signature blood red hardsuit."
   components:
+  - type: Storage
+    maxItemSize: Huge
+    whitelist: #to snub 'dem metagamers
+      components:
+      - Clothing
   - type: StorageFill
     contents:
       - id: ClothingOuterHardsuitSyndie

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -86,9 +86,16 @@
   suffix: Filled
   parent: ToolboxSyndicate
   components:
+  - type: Storage
+    maxSlots: 8
   - type: StorageFill
     contents:
-      - id: ClothingBeltUtilityEngineering
+      - id: Crowbar
+      - id: Wrench
+      - id: Screwdriver
+      - id: Wirecutter
+      - id: Welder
+      - id: Multitool
       - id: ClothingHandsGlovesCombat
       - id: ClothingMaskGasSyndicate
 

--- a/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
@@ -25,7 +25,7 @@
     maxSlots: 7
     maxItemSize: Normal
   - type: Item
-    size: Large
+    size: Huge
   - type: ContainerContainer
     containers:
       storagebase: !type:Container

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -15,7 +15,7 @@
   id: ClothingOuterBaseLarge
   components:
   - type: Item
-    size: Normal
+    size: Large
   - type: Clothing
     slots:
     - outerClothing
@@ -28,8 +28,6 @@
   parent: ClothingOuterBase
   id: ClothingOuterStorageBase
   components:
-  - type: Item
-    size: Normal
   - type: Storage
     maxSlots: 3
   - type: ContainerContainer
@@ -72,7 +70,7 @@
     walkModifier: 0.4
     sprintModifier: 0.6
   - type: Item
-    size: Large
+    size: Huge
   - type: Armor
     modifiers:
       coefficients:
@@ -107,7 +105,7 @@
     walkModifier: 0.8
     sprintModifier: 0.8
   - type: Item
-    size: Normal
+    size: Large
 
 - type: entity
   parent: ClothingOuterBase
@@ -130,7 +128,7 @@
   id: ClothingOuterBaseMedium
   components:
   - type: Item
-    size: Normal
+    size: Large
   - type: Clothing
     slots:
     - outerClothing

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -16,7 +16,7 @@
   - type: Item
     size: Huge
   - type: Storage
-    maxSlots: 12
+    maxSlots: 5
     maxItemSize: Normal
     quickInsert: true
     areaInsert: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- hardsuits are now all large/huge instead of normal/large
- fixed pill creation
- storage belts are now huge instead of large
- ore bag nerfed to something actually reasonable. CRAZY!

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Adjusted the sizes of space suits and belts.
- tweak: Reduced the slot count in the ore bag.
- fix: Fixed not being to create pills at the ChemMaster 5000.
