### PR TITLE
use percentage for storage ui

### DIFF
--- a/Content.Client/Storage/UI/StorageWindow.cs
+++ b/Content.Client/Storage/UI/StorageWindow.cs
@@ -67,8 +67,7 @@ namespace Content.Client.Storage.UI
                 VerticalAlignment = VAlignment.Center
             };
             _information.SetMessage(Loc.GetString("comp-storage-window-volume",
-                ("itemCount", 0),
-                ("maxCount", 0),
+                ("percent", 0),
                 ("size", SharedItemSystem.GetItemSizeLocale(ItemSize.Normal))));
 
             vBox.AddChild(_information);
@@ -111,19 +110,9 @@ namespace Content.Client.Storage.UI
 
         private void SetStorageInformation(Entity<StorageComponent> uid)
         {
-            if (uid.Comp.MaxSlots != uid.Comp.Container.ContainedEntities.Count
-                && _storage.GetCumulativeItemSizes(uid, uid.Comp) == _storage.GetMaxTotalWeight((uid, uid.Comp)))
-            {
-                _information.SetMarkup(Loc.GetString("comp-storage-window-volume-full",
-                    ("size", SharedItemSystem.GetItemSizeLocale(_storage.GetMaxItemSize((uid, uid.Comp))))));
-            }
-            else
-            {
-                _information.SetMarkup(Loc.GetString("comp-storage-window-volume",
-                    ("itemCount", uid.Comp.Container.ContainedEntities.Count),
-                    ("maxCount", uid.Comp.MaxSlots),
-                    ("size", SharedItemSystem.GetItemSizeLocale(_storage.GetMaxItemSize((uid, uid.Comp))))));
-            }
+            _information.SetMarkup(Loc.GetString("comp-storage-window-volume",
+                ("percent", _storage.GetStorageFillPercentage((uid, uid.Comp)) * 100f),
+                ("size", SharedItemSystem.GetItemSizeLocale(_storage.GetMaxItemSize((uid, uid.Comp))))));
         }
 
         /// <summary>

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.CombatMode;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Destructible;
 using Content.Shared.DoAfter;
+using Content.Shared.FixedPoint;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Implants.Components;
@@ -663,6 +664,17 @@ public abstract class SharedStorageSystem : EntitySystem
             return uid.Comp.MaxTotalWeight.Value;
 
         return uid.Comp.MaxSlots * SharedItemSystem.GetItemSizeWeight(GetMaxItemSize(uid));
+    }
+
+    public FixedPoint2 GetStorageFillPercentage(Entity<StorageComponent?> uid)
+    {
+        if (!Resolve(uid, ref uid.Comp))
+            return 0;
+
+        var slotPercent = FixedPoint2.New(uid.Comp.Container.ContainedEntities.Count) / uid.Comp.MaxSlots;
+        var weightPercent = FixedPoint2.New(GetCumulativeItemSizes(uid)) / GetMaxTotalWeight(uid);
+
+        return FixedPoint2.Max(slotPercent, weightPercent);
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/components/storage-component.ftl
+++ b/Resources/Locale/en-US/components/storage-component.ftl
@@ -6,5 +6,4 @@ comp-storage-invalid-container = This doesn't go in there!
 comp-storage-anchored-failure = Can't insert an anchored item.
 comp-storage-cant-drop = You can't let go of { THE($entity) }!
 comp-storage-window-title = Storage Item
-comp-storage-window-volume = Items: { $itemCount }/{ $maxCount }, Max Size: {$size}
-comp-storage-window-volume-full = [color=orange][bold]FULL[/bold][/color], Max Size: {$size}
+comp-storage-window-volume = Fill: { $percent }%, Max Size: {$size}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
show percentage fill in storage ui.

hides "slots" from the player and makes the weight system more obvious.
better solution than the "FULL" text.

still might go through some more revisions but idk.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/ab97062a-810f-452e-b19c-f9c522e4f5cc)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Storage UI now shows a percentage fill instead of a fraction of slots.
