### PR TITLE
Block opening storage UIs that are nested inside another

### DIFF
--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Content.Server.Administration.Managers;
 using Content.Shared.Administration;
 using Content.Shared.Ghost;
@@ -105,6 +106,9 @@ public sealed partial class StorageSystem : SharedStorageSystem
     public override void OpenStorageUI(EntityUid uid, EntityUid entity, StorageComponent? storageComp = null, bool silent = false)
     {
         if (!Resolve(uid, ref storageComp) || !TryComp(entity, out ActorComponent? player))
+            return;
+
+        if (!CanOpenUI(uid, storageComp, entity))
             return;
 
         // prevent spamming bag open / honkerton honk sound

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1809,5 +1809,16 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<string> ReplayAutoRecordTempDir =
             CVarDef.Create("replay.auto_record_temp_dir", "", CVar.SERVERONLY);
+
+
+        /*
+         * Storage
+         */
+
+        /// <summary>
+        /// Whether players can access nested storage UIs.
+        /// </summary>
+        public static readonly CVarDef<bool> NestedStorageUIAccessEnabled =
+            CVarDef.Create("storage.nested_ui_access", true, CVar.REPLICATED);
     }
 }

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -75,6 +75,8 @@ public abstract class SharedStorageSystem : EntitySystem
         SubscribeLocalEvent<StorageComponent, AreaPickupDoAfterEvent>(OnDoAfter);
 
         SubscribeLocalEvent<StorageComponent, StorageInteractWithItemEvent>(OnInteractWithItem);
+
+        // TODO close UI when inserted into another storage component.
     }
 
     private void OnComponentInit(EntityUid uid, StorageComponent storageComp, ComponentInit args)
@@ -343,6 +345,7 @@ public abstract class SharedStorageSystem : EntitySystem
     /// </summary>
     private void OnInteractWithItem(EntityUid uid, StorageComponent storageComp, StorageInteractWithItemEvent args)
     {
+        // TODO Disable interaction when nested.
         if (args.Session.AttachedEntity is not { } player)
             return;
 

--- a/Resources/Locale/en-US/components/storage-component.ftl
+++ b/Resources/Locale/en-US/components/storage-component.ftl
@@ -8,3 +8,4 @@ comp-storage-cant-drop = You can't let go of { THE($entity) }!
 comp-storage-window-title = Storage Item
 comp-storage-window-volume = Items: { $itemCount }/{ $maxCount }, Max Size: {$size}
 comp-storage-window-volume-full = [color=orange][bold]FULL[/bold][/color], Max Size: {$size}
+comp-storage-cant-open-nested = You can't open the {$item} inside the {$parent}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Disables opening storage UIs if they are inside another storage UI.
Added a CVar for the nested container access.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This makes storage a choice between more inventory space or faster access.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Can't open nested](https://github.com/space-wizards/space-station-14/assets/10494922/4da53579-55e9-4081-b73f-036a47a6009f)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

- add: Added a server setting to disable accessing nested storage UIs.