### PR TITLE
Fix missing toggle fullscreen loc string

### DIFF
--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -147,6 +147,7 @@ ui-options-function-escape-context = Close recent window or toggle game menu
 
 ui-options-function-take-screenshot = Take screenshot
 ui-options-function-take-screenshot-no-ui = Take screenshot (without UI)
+ui-options-function-toggle-fullscreen = Toggle fullscreen
 
 ui-options-function-editor-place-object = Place object
 ui-options-function-editor-cancel-place = Cancel placement


### PR DESCRIPTION
Somebody forgot to add the loc string when adding fullscreen toggle button. Whisper found it.
![image](https://github.com/space-wizards/space-station-14/assets/46868845/c83147ba-c857-4456-9737-efafa4180164)
