### PR TITLE
Adds thermal insulation to flannel jackets

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -289,6 +289,8 @@
         color: "#670a09"
       - state: equipped-OUTERCLOTHING-lines
         color: "#000000"
+  - type: TemperatureProtection
+    coefficient: 0.3
 
 - type: entity
   parent: ClothingOuterBase
@@ -323,6 +325,8 @@
         color: "#3232a6"
       - state: equipped-OUTERCLOTHING-lines
         color: "#000000"
+  - type: TemperatureProtection
+    coefficient: 0.3
 
 - type: entity
   parent: ClothingOuterBase
@@ -357,3 +361,5 @@
         color: "#164d0f"
       - state: equipped-OUTERCLOTHING-lines
         color: "#000000"
+  - type: TemperatureProtection
+    coefficient: 0.3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds 0.3 thermal insulation to flannel jackets, allowing them to stay warm in colder environments.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Flannel jackets are objectively worse than winter coats as they lack thermal insulation and storage slots, so this shouldn't effect balance too much. Also flannel IRL keeps you warm so it adds to the realism I guess.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Flannel jackets now keep you warm.
