### PR TITLE
Thicken thindow bounds

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -125,7 +125,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.39,0.49,-0.36"
+          bounds: "-0.49,-0.49,0.49,-0.36"
         density: 1500
         mask:
         - FullTileMask


### PR DESCRIPTION
This is as thick as you can get it while still being able to move through with a 0.35 radius body. This will significantly reduce instances of tunneling.

:cl:
- tweak: Made thindows slightly thicker (0.03m to 0.13m) to reduce instances of tunneling through them at high speeds. This only affects the outer edge so you can still move through two parallel thindows on the same tile.