### PR TITLE
Restore Leviathan's 80 pop cap

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/leviathan.toml
+++ b/Resources/ConfigPresets/WizardsDen/leviathan.toml
@@ -4,7 +4,7 @@
 
 [game]
 hostname = "[EN] Wizard's Den Leviathan [US East 1]"
-soft_max_players = 60
+soft_max_players = 80
 
 [hub]
 tags = "lang:en,region:am_n_e,rp:low"


### PR DESCRIPTION
Reverts space-wizards/space-station-14#19589

General feedback from players seemed to be:
1. It did not improve things
2. Many of the maps minimum player caps are too low, resulting in empty feeling stations

General feedback from admins was mixed, with some seeing improvement while others didn't. Some seemed to agree with players that minimum pop caps were too low.

Imo, the best option atm is to restore the original server pop cap and try again in a few months or something if maps have been adjusted.