### PR TITLE
Make keybind screen inputs unique

### DIFF
--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -405,6 +405,15 @@ namespace Content.Client.Options.UI.Tabs
                 CanRepeat = false
             };
 
+            // Remove existing binding if found.
+            if (_inputManager.TryGetBindings(registration, out var bindings))
+            {
+                foreach (var bind in bindings)
+                {
+                    _inputManager.RemoveBinding(bind);
+                }
+            }
+
             _inputManager.RegisterBinding(registration);
             // OnKeyBindModified will cause _currentlyRebinding to be reset and the UI to update.
             _inputManager.SaveToUserData();


### PR DESCRIPTION
Will clear any existing ones that exist on the same key. No warning atm as mainly want to fix the existing abuse.

Obviously this breaks if for example shuttle movement is rebound though I think for most people it will stop bug abuse.

Requires https://github.com/space-wizards/RobustToolbox/pull/4524

:cl:
- tweak: Keybinds on the rebind screen are unique and can't be duplicated.