### PR TITLE
Update yaml sequence option in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -338,5 +338,8 @@ dotnet_naming_symbols.type_parameters_symbols.applicable_kinds = type_parameter
 resharper_braces_for_ifelse = required_for_multiline
 resharper_keep_existing_attribute_arrangement = true
 
-[*.{csproj,xml,yml,dll.config,msbuildproj,targets}]
+[*.{csproj,xml,yml,yaml,dll.config,msbuildproj,targets}]
 indent_size = 2
+
+[{*.yaml,*.yml}]
+ij_yaml_indent_sequence_value = false


### PR DESCRIPTION
Option should mean that rider defaults using our current yaml convention for sequences, i.e.
```yaml
a:
- b
- c
```
instead of
```yaml
a:
  - b
  - c
```