### PR TITLE
fix hand examine when cuffed

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -182,7 +182,9 @@ public abstract partial class SharedHandsSystem : EntitySystem
     //TODO: Actually shows all items/clothing/etc.
     private void HandleExamined(EntityUid uid, HandsComponent handsComp, ExaminedEvent args)
     {
-        var held = EnumerateHeld(uid, handsComp).ToList();
+        var held = EnumerateHeld(uid, handsComp)
+            .Where(x => !HasComp<HandVirtualItemComponent>(x)).ToList();
+
         if (!held.Any())
         {
             args.PushText(Loc.GetString("comp-hands-examine-empty",
@@ -191,7 +193,6 @@ public abstract partial class SharedHandsSystem : EntitySystem
         }
 
         var heldList = ContentLocalizationManager.FormatList(held
-            .Where(x => !HasComp<HandVirtualItemComponent>(x))
             .Select(x => Loc.GetString("comp-hands-examine-wrapper",
                 ("item", Identity.Entity(x, EntityManager)))).ToList());
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #21304

The examine logic would still try and read out the held items if they were all virtual. This basically only happens when someone is cuffed.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
no cl no fun
