### PR TITLE
Fix PDA notifications when creating a news entry using the Mass-Media console.

### DIFF
--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -211,7 +211,6 @@ public sealed class NewsSystem : EntitySystem
                 continue;
 
             _ringer.RingerPlayRingtone(uid, ringer);
-            break;
         }
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes the PDA notification that is supposed to sound when a new news article gets created.

## Media
https://github.com/space-wizards/space-station-14/assets/63975668/816123d5-f613-47e0-8600-1f20f7e39789
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: The PDA will now ring again, when a new station article gets published. Reporters rejoice!
