### PR TITLE
Action bugfixes

### DIFF
--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -213,6 +213,9 @@ public sealed class ActionContainerSystem : EntitySystem
 
     private void OnShutdown(EntityUid uid, ActionsContainerComponent component, ComponentShutdown args)
     {
+        if (_timing.ApplyingState && component.NetSyncEnabled)
+            return; // The game state should handle the container removal & action deletion.
+
         component.Container.Shutdown();
     }
 

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -621,7 +621,10 @@ public abstract class SharedActionsSystem : EntitySystem
 
         if (action.AttachedEntity != performer)
         {
-            Log.Error($"Attempted to remove an action {ToPrettyString(actionId)} from an entity that it was never attached to: {ToPrettyString(performer)}");
+            DebugTools.Assert(!Resolve(performer, ref comp, false) || !comp.Actions.Contains(actionId.Value));
+
+            if (!GameTiming.ApplyingState)
+                Log.Error($"Attempted to remove an action {ToPrettyString(actionId)} from an entity that it was never attached to: {ToPrettyString(performer)}");
             return;
         }
 

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -36,6 +36,8 @@ public abstract class SharedActionsSystem : EntitySystem
         SubscribeLocalEvent<ActionsComponent, DidUnequipEvent>(OnDidUnequip);
         SubscribeLocalEvent<ActionsComponent, DidUnequipHandEvent>(OnHandUnequipped);
 
+        SubscribeLocalEvent<ActionsComponent, ComponentShutdown>(OnShutdown);
+
         SubscribeLocalEvent<ActionsComponent, ComponentGetState>(OnActionsGetState);
 
         SubscribeLocalEvent<InstantActionComponent, ComponentGetState>(OnInstantGetState);
@@ -47,6 +49,14 @@ public abstract class SharedActionsSystem : EntitySystem
         SubscribeLocalEvent<WorldTargetActionComponent, GetActionDataEvent>(OnGetActionData);
 
         SubscribeAllEvent<RequestPerformActionEvent>(OnActionRequest);
+    }
+
+    private void OnShutdown(EntityUid uid, ActionsComponent component, ComponentShutdown args)
+    {
+        foreach (var act in component.Actions)
+        {
+            RemoveAction(uid, act, component);
+        }
     }
 
     private void OnInstantGetState(EntityUid uid, InstantActionComponent component, ref ComponentGetState args)


### PR DESCRIPTION
Ensures that an action's attached entity gets cleared when the entity gets deleted. This should fix one of the debug asserts that get triggered while scrubbing through replays.