### PR TITLE
Disable OOC during round on Salamander

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/salamander.toml
+++ b/Resources/ConfigPresets/WizardsDen/salamander.toml
@@ -21,7 +21,7 @@ emergency_early_launch_allowed = true
 easy_mode = false
 
 [ooc]
-enable_during_round = true
+enable_during_round = false
 
 [ic]
 flavor_text = true


### PR DESCRIPTION
## About the PR
Disabled the OOC being on by default on Salamader config.

## Why / Balance
After a discussion in Admin/PM thread a decision was made to disable OOC on salamander due to excessive misuse.

## Technical details
Just a flag in the salamander config.

## Media
N/A

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
OOC disabled on salamander.
