### PR TITLE
allow network payload data to inherit nullability

### DIFF
--- a/Content.Server/DeviceNetwork/NetworkPayload.cs
+++ b/Content.Server/DeviceNetwork/NetworkPayload.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Content.Server.DeviceNetwork
 {
-    public sealed class NetworkPayload : Dictionary<string, object>
+    public sealed class NetworkPayload : Dictionary<string, object?>
     {
         /// <summary>
         /// Tries to get a value from the payload and checks if that value is of type  T.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
just a simple `?` in the definition of `NetworkPayload`

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
because data in `NetworkPacketEvent`s is already "nullably" accessed through `TryGetValue`, this lets receivers handle null cases for more code flexibility

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

