### PR TITLE
Fix bola stam damage, bring back old construction requirements

### DIFF
--- a/Content.Server/Ensnaring/EnsnareableSystem.Ensnaring.cs
+++ b/Content.Server/Ensnaring/EnsnareableSystem.Ensnaring.cs
@@ -1,8 +1,9 @@
 using System.Linq;
 using Content.Server.Body.Systems;
 using Content.Shared.Alert;
-using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Ensnaring;
 using Content.Shared.Ensnaring.Components;
@@ -17,6 +18,7 @@ public sealed partial class EnsnareableSystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly BodySystem _body = default!;
+    [Dependency] private readonly StaminaSystem _stamina = default!;
 
     public void InitializeEnsnaring()
     {
@@ -71,6 +73,15 @@ public sealed partial class EnsnareableSystem
 
         if (freeLegs <= 0)
             return;
+
+        // Apply stamina damage to target if they weren't ensnared before.
+        if (ensnareable.IsEnsnared != true)
+        {
+            if (TryComp<StaminaComponent>(target, out var stamina))
+            {
+                _stamina.TakeStaminaDamage(target, component.StaminaDamage, with: ensnare);
+            }
+        }
 
         component.Ensnared = target;
         ensnareable.Container.Insert(ensnare);

--- a/Content.Shared/Ensnaring/Components/EnsnaringComponent.cs
+++ b/Content.Shared/Ensnaring/Components/EnsnaringComponent.cs
@@ -37,6 +37,13 @@ public sealed partial class EnsnaringComponent : Component
     public float SprintSpeed = 0.9f;
 
     /// <summary>
+    /// How much stamina does the ensnare sap
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("staminaDamage")]
+    public float StaminaDamage = 55f;
+
+    /// <summary>
     /// Should this ensnare someone when thrown?
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -45,4 +45,5 @@
     sprintSpeed: 0.7
     staminaDamage: 55 # Sudden weight increase sapping stamina
     canThrowTrigger: true
+    canMoveBreakout: true
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -37,7 +37,7 @@
   - type: DamageOnLand
     damage:
       types:
-        Blunt: 3
+        Blunt: 5
   - type: Ensnaring
     freeTime: 2.0
     breakoutTime: 3.5 #all bola should generally be fast to remove

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -13,8 +13,6 @@
     sound: /Audio/Weapons/bolathrow.ogg
   - type: EmitSoundOnLand
     sound: /Audio/Effects/snap.ogg
-  - type: StaminaDamageOnCollide
-    damage: 80
   - type: Construction
     graph: Bola
     node: bola
@@ -45,5 +43,6 @@
     breakoutTime: 3.5 #all bola should generally be fast to remove
     walkSpeed: 0.7 #makeshift bola shouldn't slow too much
     sprintSpeed: 0.7
+    staminaDamage: 55 # Sudden weight increase sapping stamina
     canThrowTrigger: true
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/bola.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/bola.yml
@@ -6,9 +6,12 @@
       edges:
         - to: bola
           steps:
-            - material: Cable
-              amount: 5
-              doAfter: 2
+            - tag: Handcuffs
+              icon:
+                sprite: Objects/Misc/cablecuffs.rsi
+                state: cuff
+                color: red
+              name: cuffs
             - material: Steel
               amount: 6
               doAfter: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Reverts #18998, trumps #21334, implements [KeronSHB's second suggestion](https://github.com/space-wizards/space-station-14/pull/21334#issuecomment-1784200894)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bola bad.
Drops stamina damage on ensnare from 80 to 55.
**Bola does not deal STAM if target is already ensnared.**
Reverts to old crafting recipe.
You can break out of a bola while moving.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes a new field for EnsnaringComponent, staminaDamage - this dictates the amount of STAM dealt to the target.
Moves StamDamageOnCollide to staminaDamage in Ensnaring.
Checks if target is already ensnared: if they are - don't apply staminaDamage.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
rev meta broke

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Bolas no longer deal stamina damage if you're already ensnared.
- tweak: Returned old bola recipe
- tweak: Nerfed bola stamina damage from 80 to 55
- tweak: You can break out of bolas while moving.
