### PR TITLE
Slimes no longer laugh / scream from Nitrous Oxide

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -261,6 +261,9 @@
         - !type:ReagentThreshold
           reagent: NitrousOxide
           min: 0.2
+        - !type:OrganType
+          type: Slime
+          shouldHave: false
         emote: Laugh
         showInChat: true
         probability: 0.1
@@ -269,6 +272,9 @@
         - !type:ReagentThreshold
           reagent: NitrousOxide
           min: 0.2
+        - !type:OrganType
+          type: Slime
+          shouldHave: false
         emote: Scream
         showInChat: true
         probability: 0.01


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Slimes are already immune to every other effect of N2O and this would cause them to constantly be laughing when inside a locker. 

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Lank
- fix: Slimes are fully immune to Nitrous Oxide again.

