### PR TITLE
Street light fix for mapping

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -124,6 +124,8 @@
     damage:
       types:
         Heat: 20
+  - type: PointLight
+    enabled: true
   - type: StaticPrice
     price: 25
   - type: AmbientOnPowered


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

streetlights now glow on mapping

## Why / Balance
need me for mapping. it's illogical that wall lamps glow on mapping, but street lights don't. And it also just makes it hard to appreciate how well the light is positioned

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no
