### PR TITLE
unidentified corpses have normal inventory

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -64,8 +64,6 @@
         Asphyxiation: 76
         Slash: 56
         Blunt: 19
-  - type: Inventory
-    templateId: corpse
 
 - type: entity
   parent: MobHuman


### PR DESCRIPTION
## About the PR
title

didnt remove the layout incase downstream uses it idk

## Why / Balance
if you revive an unidentified corpse it should be able to wear a bag headset and id

## Technical details
no

## Media
one with loot
![00:04:33](https://github.com/space-wizards/space-station-14/assets/39013340/93490234-a2f0-468c-9ea6-c381a81c2840)

one with no loot
![00:04:39](https://github.com/space-wizards/space-station-14/assets/39013340/846e74a6-1226-478a-9045-e4ec6f2959fd)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun