### PR TITLE
make bloodred large size

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -264,11 +264,6 @@
   name: syndicate hardsuit bundle
   description: "Contains the Syndicate's signature blood red hardsuit."
   components:
-  - type: Storage
-    maxItemSize: Huge
-    whitelist: #to snub 'dem metagamers
-      components:
-      - Clothing
   - type: StorageFill
     contents:
       - id: ClothingOuterHardsuitSyndie

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -430,6 +430,8 @@
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
+  - type: Item
+    size: Large
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
   - type: PressureProtection


### PR DESCRIPTION
## About the PR
made validsuit large instead of huge and made its bag same as other duffels

## Why / Balance
lilten suggested in video and i agree

## Technical details
no

## Media
![16:07:29](https://github.com/space-wizards/space-station-14/assets/39013340/379e3b36-dd8e-4dca-9f0f-fd177eced756)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun