### PR TITLE
Adds more sources for sheet paper material

### DIFF
--- a/Resources/Locale/en-US/materials/materials.ftl
+++ b/Resources/Locale/en-US/materials/materials.ftl
@@ -18,6 +18,7 @@ materials-durathread = durathread
 materials-plasma = plasma
 materials-plastic = plastic
 materials-wood = wood
+materials-paper = paper
 materials-uranium = uranium
 materials-bananium = bananium
 materials-meat = meat

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-materials.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-materials.ftl
@@ -19,6 +19,9 @@ ent-MaterialPlasma = { ent-CrateMaterialPlasma }
 ent-CardboardMaterial = { ent-CrateMaterialCardboard }
     .desc = { ent-CrateMaterialCardboard.desc }
 
+ent-PaperMaterial = { ent-CrateMaterialPaper }
+    .desc = { ent-CrateMaterialPaper.desc }
+
 ent-MaterialFuelTank = { ent-WeldingFuelTankFull }
     .desc = { ent-WeldingFuelTankFull.desc }
 

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/materials-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/materials-crates.ftl
@@ -21,3 +21,6 @@ ent-CrateMaterialPlasma = Solid plasma crate
 
 ent-CrateMaterialCardboard = Cardboard crate
     .desc = 60 pieces of cardboard.
+
+ent-CrateMaterialPaper = Paper crate
+    .desc = 90 sheets of paper.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -69,6 +69,16 @@
   group: market
 
 - type: cargoProduct
+  id: PaperMaterial
+  icon:
+    sprite: Objects/Materials/Sheets/other.rsi
+    state: paper_3
+  product: CrateMaterialPaper
+  cost: 1000
+  category: Materials
+  group: market
+
+- type: cargoProduct
   id: MaterialFuelTank
   icon:
     sprite: Structures/Storage/tanks.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -70,6 +70,15 @@
       - id: MaterialCardboard
         amount: 2
 
+- type: entity
+  id: CrateMaterialPaper
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: SheetPaper
+        amount: 3
+
 #- type: entity
 #  id: CrateMaterialHFuelTank
 #  name:  fueltank crate

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -37,6 +37,10 @@
     - paper
     - paper_2
     - paper_3
+  - type: Material
+  - type: PhysicalComposition
+    materialComposition:
+      Paper: 100
   - type: Sprite
     state: paper_3
     layers:

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -237,6 +237,11 @@
   - type: Appearance
   - type: Item
     heldPrefix: wood
+  - type: Tag
+    tags:
+    - Wooden
+    - DroneUsable
+    - RawMaterial
 
 - type: entity
   parent: MaterialWoodPlank

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -887,9 +887,11 @@
     whitelist:
       tags:
       - Raw
+      - Wooden
   - type: Lathe
     idleState: base_machine
     runningState: base_machine_processing
     canEjectStoredMaterials: false
     staticRecipes:
     - MaterialSheetMeat
+    - SheetPaper

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -35,6 +35,14 @@
   price: 0.15 # 1-1 mix of plastic and cloth.
 
 - type: material
+  id: Paper
+  stackEntity: SheetPaper1
+  name: materials-paper
+  icon: { sprite: Objects/Materials/Sheets/other.rsi, state: paper }
+  color: "#d9d9d9"
+  price: 0.05 #same as wood
+
+- type: material
   id: Plasma
   stackEntity: SheetPlasma1
   name: materials-plasma

--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -139,3 +139,10 @@
   completetime: 6.4
   materials:
     Meaterial: 200
+
+- type: latheRecipe
+  id: SheetPaper
+  result: SheetPaper1
+  completetime: 1
+  materials:
+    Wood: 50

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -157,7 +157,6 @@
   cost: 5000
   recipeUnlocks:
   - FatExtractorMachineCircuitboard
-  - SheetifierMachineCircuitboard
 
 - type: technology
   id: HONKMech

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -1,4 +1,4 @@
-﻿# Tier 1
+# Tier 1
 
 - type: technology
   id: SalvageEquipment
@@ -54,6 +54,7 @@
   - AutolatheMachineCircuitboard
   - CircuitImprinterMachineCircuitboard
   - MaterialReclaimerMachineCircuitboard
+  - SheetifierMachineCircuitboard
 
 - type: technology
   id: PowerGeneration


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- Adds a paper sheet crate to the cargo catalog
- Adds a paper sheet lathe recipe to the sheetifier
- Moves the sheetifier research unlock from civilian services to industrial 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There was chat of giving the sheetifier more use, so considering that I already had the yaml work done for this, I thought Id make it a PR. Sheetifiers being an industrial unlock and paper being more acquirable might see more use out of both of them in future content additions (I anticipate itll benefit something of mine, personally).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![lathable](https://github.com/space-wizards/space-station-14/assets/138547931/5681200b-3e6e-498a-9eee-a7de24fd12cd)
![researchable](https://github.com/space-wizards/space-station-14/assets/138547931/3a41b80d-909b-49e8-a684-7c5ac55c2927)
![purchasable](https://github.com/space-wizards/space-station-14/assets/138547931/e82b5a2a-93a3-4445-935b-d3fc2ca6cae3)



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: RiceMar
- add: Paper is now lathable from the sheet-meister 2000.
- add: Crates of paper can now be purchased from the cargo request computer.
- tweak: The sheet-meister 2000 research unlock has moved from the civilian services tree to the industrial tree. 