### PR TITLE
Make all prototype types partial

### DIFF
--- a/Content.Client/Parallax/Data/ParallaxPrototype.cs
+++ b/Content.Client/Parallax/Data/ParallaxPrototype.cs
@@ -1,9 +1,4 @@
-using System.Collections.Generic;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
-using Robust.Shared.Utility;
 
 namespace Content.Client.Parallax.Data;
 
@@ -11,7 +6,7 @@ namespace Content.Client.Parallax.Data;
 /// Prototype data for a parallax.
 /// </summary>
 [Prototype("parallax")]
-public sealed class ParallaxPrototype : IPrototype
+public sealed partial class ParallaxPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Server/Advertisements/AdvertisementsPackPrototype.cs
+++ b/Content.Server/Advertisements/AdvertisementsPackPrototype.cs
@@ -3,7 +3,7 @@
 namespace Content.Server.Advertisements
 {
     [Serializable, Prototype("advertisementsPack")]
-    public sealed class AdvertisementsPackPrototype : IPrototype
+    public sealed partial class AdvertisementsPackPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Server/AlertLevel/AlertLevelPrototype.cs
+++ b/Content.Server/AlertLevel/AlertLevelPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.AlertLevel;
 
 [Prototype("alertLevels")]
-public sealed class AlertLevelPrototype : IPrototype
+public sealed partial class AlertLevelPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Server/Announcements/RoundAnnouncementPrototype.cs
+++ b/Content.Server/Announcements/RoundAnnouncementPrototype.cs
@@ -1,7 +1,5 @@
-using Content.Server.GameTicking.Presets;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
 namespace Content.Server.Announcements;
 
@@ -9,7 +7,7 @@ namespace Content.Server.Announcements;
 /// Used for any announcements on the start of a round.
 /// </summary>
 [Prototype("roundAnnouncement")]
-public sealed class RoundAnnouncementPrototype : IPrototype
+public sealed partial class RoundAnnouncementPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
+++ b/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
@@ -18,7 +18,7 @@ namespace Content.Server.Atmos.Reactions
     }
 
     [Prototype("gasReaction")]
-    public sealed class GasReactionPrototype : IPrototype
+    public sealed partial class GasReactionPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
+++ b/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Server.GameTicking.Presets
     ///     A round-start setup preset, such as which antagonists to spawn.
     /// </summary>
     [Prototype("gamePreset")]
-    public sealed class GamePresetPrototype : IPrototype
+    public sealed partial class GamePresetPrototype : IPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = default!;

--- a/Content.Server/GameTicking/Prototypes/LobbyBackgroundPrototype.cs
+++ b/Content.Server/GameTicking/Prototypes/LobbyBackgroundPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Server.GameTicking.Prototypes;
 /// Prototype for a lobby background the game can choose.
 /// </summary>
 [Prototype("lobbyBackground")]
-public sealed class LobbyBackgroundPrototype : IPrototype
+public sealed partial class LobbyBackgroundPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Server/GameTicking/Rules/GameRulePrototype.cs
+++ b/Content.Server/GameTicking/Rules/GameRulePrototype.cs
@@ -4,7 +4,7 @@ namespace Content.Server.GameTicking.Rules;
 
 /*
 [Prototype("gameRule")]
-public sealed class GameRulePrototype : IPrototype
+public sealed partial class GameRulePrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Server/Holiday/HolidayPrototype.cs
+++ b/Content.Server/Holiday/HolidayPrototype.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.Holiday
 {
     [Prototype("holiday")]
-    public sealed class HolidayPrototype : IPrototype
+    public sealed partial class HolidayPrototype : IPrototype
     {
         [DataField("name")] public string Name { get; private set; } = string.Empty;
 

--- a/Content.Server/Maps/GameMapPoolPrototype.cs
+++ b/Content.Server/Maps/GameMapPoolPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Server.Maps;
 /// Prototype that holds a pool of maps that can be indexed based on the map pool CCVar.
 /// </summary>
 [Prototype("gameMapPool"), PublicAPI]
-public sealed class GameMapPoolPrototype : IPrototype
+public sealed partial class GameMapPoolPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Server/NPC/Components/NpcFactionPrototype.cs
+++ b/Content.Server/NPC/Components/NpcFactionPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Server.NPC.Components
     /// Contains data about this faction's relations with other factions.
     /// </summary>
     [Prototype("npcFaction")]
-    public sealed class NpcFactionPrototype : IPrototype
+    public sealed partial class NpcFactionPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Server/NPC/HTN/HTNCompoundPrototype.cs
+++ b/Content.Server/NPC/HTN/HTNCompoundPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Server.NPC.HTN;
 /// Represents a network of multiple tasks. This gets expanded out to its relevant nodes.
 /// </summary>
 [Prototype("htnCompound")]
-public sealed class HTNCompoundPrototype : IPrototype
+public sealed partial class HTNCompoundPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = string.Empty;
 

--- a/Content.Server/NPC/Queries/Curves/UtilityCurvePresetPrototype.cs
+++ b/Content.Server/NPC/Queries/Curves/UtilityCurvePresetPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.NPC.Queries.Curves;
 
 [Prototype("utilityCurvePreset")]
-public sealed class UtilityCurvePresetPrototype : IPrototype
+public sealed partial class UtilityCurvePresetPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = string.Empty;
 

--- a/Content.Server/NPC/Queries/UtilityQueryPrototype.cs
+++ b/Content.Server/NPC/Queries/UtilityQueryPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Server.NPC.Queries;
 /// These results are then run through the considerations.
 /// </summary>
 [Prototype("utilityQuery")]
-public sealed class UtilityQueryPrototype : IPrototype
+public sealed partial class UtilityQueryPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Server/Salvage/SalvageMapPrototype.cs
+++ b/Content.Server/Salvage/SalvageMapPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Utility;
 namespace Content.Server.Salvage;
 
 [Prototype("salvageMap")]
-public sealed class SalvageMapPrototype : IPrototype
+public sealed partial class SalvageMapPrototype : IPrototype
 {
     [ViewVariables] [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Server/Speech/Components/ReplacementAccentComponent.cs
+++ b/Content.Server/Speech/Components/ReplacementAccentComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.Speech.Components
 {
     [Prototype("accent")]
-    public sealed class ReplacementAccentPrototype : IPrototype
+    public sealed partial class ReplacementAccentPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Server/Wires/WireLayout.cs
+++ b/Content.Server/Wires/WireLayout.cs
@@ -1,5 +1,4 @@
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
 
 namespace Content.Server.Wires;
@@ -12,7 +11,7 @@ namespace Content.Server.Wires;
 ///     WiresSystem as a functional wire set.
 /// </summary>
 [Prototype("wireLayout")]
-public sealed class WireLayoutPrototype : IPrototype, IInheritingPrototype
+public sealed partial class WireLayoutPrototype : IPrototype, IInheritingPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Worldgen.Prototypes;
 ///     of noise channels at that location.
 /// </summary>
 [Prototype("spaceBiome")]
-public sealed class BiomePrototype : IPrototype, IInheritingPrototype
+public sealed partial class BiomePrototype : IPrototype, IInheritingPrototype
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<EntityPrototype>))]

--- a/Content.Server/Worldgen/Prototypes/WorldgenConfigPrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/WorldgenConfigPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Server.Worldgen.Prototypes;
 ///     The components included are applied to the map that world generation is configured on.
 /// </summary>
 [Prototype("worldgenConfig")]
-public sealed class WorldgenConfigPrototype : IPrototype
+public sealed partial class WorldgenConfigPrototype : IPrototype
 {
     /// <inheritdoc />
     [IdDataField]

--- a/Content.Shared/Access/AccessGroupPrototype.cs
+++ b/Content.Shared/Access/AccessGroupPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Access;
 ///     Used by <see cref="AccessComponent"/> to avoid boilerplate.
 /// </summary>
 [Prototype("accessGroup")]
-public sealed class AccessGroupPrototype : IPrototype
+public sealed partial class AccessGroupPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Access/AccessLevelPrototype.cs
+++ b/Content.Shared/Access/AccessLevelPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Access
     ///     Defines a single access level that can be stored on ID cards and checked for.
     /// </summary>
     [Prototype("accessLevel")]
-    public sealed class AccessLevelPrototype : IPrototype
+    public sealed partial class AccessLevelPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Alert/AlertPrototype.cs
+++ b/Content.Shared/Alert/AlertPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Alert
     /// An alert popup with associated icon, tooltip, and other data.
     /// </summary>
     [Prototype("alert")]
-    public sealed class AlertPrototype : IPrototype, ISerializationHooks
+    public sealed partial class AlertPrototype : IPrototype, ISerializationHooks
     {
         [ViewVariables]
         string IPrototype.ID => AlertType.ToString();

--- a/Content.Shared/Atmos/Monitor/AtmosAlarmThreshold.cs
+++ b/Content.Shared/Atmos/Monitor/AtmosAlarmThreshold.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Atmos.Monitor;
 
 
 [Prototype("alarmThreshold")]
-public sealed class AtmosAlarmThresholdPrototype : IPrototype
+public sealed partial class AtmosAlarmThresholdPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Atmos/Prototypes/GasPrototype.cs
+++ b/Content.Shared/Atmos/Prototypes/GasPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.Atmos.Prototypes
 {
     [Prototype("gas")]
-    public sealed class GasPrototype : IPrototype
+    public sealed partial class GasPrototype : IPrototype
     {
         [DataField("name")] public string Name { get; set; } = "";
 

--- a/Content.Shared/Audio/AmbientMusicPrototype.cs
+++ b/Content.Shared/Audio/AmbientMusicPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Audio;
 /// Attaches a rules prototype to sound files to play ambience.
 /// </summary>
 [Prototype("ambientMusic")]
-public sealed class AmbientMusicPrototype : IPrototype
+public sealed partial class AmbientMusicPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = string.Empty;
 

--- a/Content.Shared/BarSign/BarSignPrototype.cs
+++ b/Content.Shared/BarSign/BarSignPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.BarSign
 {
     [Prototype("barSign")]
-    public sealed class BarSignPrototype : IPrototype
+    public sealed partial class BarSignPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Body/Prototypes/BodyPrototype.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Body.Prototypes;
 
 [Prototype("body")]
-public sealed class BodyPrototype : IPrototype
+public sealed partial class BodyPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Body/Prototypes/MetabolismGroupPrototype.cs
+++ b/Content.Shared/Body/Prototypes/MetabolismGroupPrototype.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared.Body.Prototypes
 {
     [Prototype("metabolismGroup")]
-    public sealed class MetabolismGroupPrototype : IPrototype
+    public sealed partial class MetabolismGroupPrototype : IPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = default!;

--- a/Content.Shared/Body/Prototypes/MetabolizerTypePrototype.cs
+++ b/Content.Shared/Body/Prototypes/MetabolizerTypePrototype.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared.Body.Prototypes
 {
     [Prototype("metabolizerType")]
-    public sealed class MetabolizerTypePrototype : IPrototype
+    public sealed partial class MetabolizerTypePrototype : IPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = default!;

--- a/Content.Shared/Cargo/Prototypes/CargoBountyPrototype.cs
+++ b/Content.Shared/Cargo/Prototypes/CargoBountyPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Cargo.Prototypes;
 /// to receive a monetary reward.
 /// </summary>
 [Prototype("cargoBounty"), Serializable, NetSerializable]
-public sealed class CargoBountyPrototype : IPrototype
+public sealed partial class CargoBountyPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Shared/Cargo/Prototypes/CargoProductPrototype.cs
+++ b/Content.Shared/Cargo/Prototypes/CargoProductPrototype.cs
@@ -1,12 +1,11 @@
 ﻿using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Cargo.Prototypes
 {
     [Prototype("cargoProduct")]
-    public sealed class CargoProductPrototype : IPrototype
+    public sealed partial class CargoProductPrototype : IPrototype
     {
         [DataField("name")] private string _name = string.Empty;
 

--- a/Content.Shared/Chat/Prototypes/AutoEmotePrototype.cs
+++ b/Content.Shared/Chat/Prototypes/AutoEmotePrototype.cs
@@ -1,10 +1,10 @@
-namespace Content.Shared.Chat.Prototypes;
-
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
+namespace Content.Shared.Chat.Prototypes;
+
 [Prototype("autoEmote")]
-public sealed class AutoEmotePrototype : IPrototype
+public sealed partial class AutoEmotePrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Shared/Chat/Prototypes/EmotePrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmotePrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Chat.Prototypes;
 ///     Entities can activate emotes by chat input or code.
 /// </summary>
 [Prototype("emote")]
-public sealed class EmotePrototype : IPrototype
+public sealed partial class EmotePrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Chat.Prototypes;
 ///     Different entities may use different sounds collections.
 /// </summary>
 [Prototype("emoteSounds")]
-public sealed class EmoteSoundsPrototype : IPrototype
+public sealed partial class EmoteSoundsPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Chat/TypingIndicator/TypingIndicatorPrototype.cs
+++ b/Content.Shared/Chat/TypingIndicator/TypingIndicatorPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Chat.TypingIndicator;
 ///     Prototype to store chat typing indicator visuals.
 /// </summary>
 [Prototype("typingIndicator")]
-public sealed class TypingIndicatorPrototype : IPrototype
+public sealed partial class TypingIndicatorPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Chemistry/Dispenser/ReagentDispenserInventoryPrototype.cs
+++ b/Content.Shared/Chemistry/Dispenser/ReagentDispenserInventoryPrototype.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Chemistry.Dispenser
     /// machines define their inventory.
     /// </summary>
     [Serializable, NetSerializable, Prototype("reagentDispenserInventory")]
-    public sealed class ReagentDispenserInventoryPrototype : IPrototype
+    public sealed partial class ReagentDispenserInventoryPrototype : IPrototype
     {
         // TODO use ReagentId
         [DataField("inventory", customTypeSerializer: typeof(PrototypeIdListSerializer<ReagentPrototype>))]

--- a/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Chemistry.Reaction
     /// Prototype for chemical reaction definitions
     /// </summary>
     [Prototype("reaction")]
-    public sealed class ReactionPrototype : IPrototype, IComparable<ReactionPrototype>
+    public sealed partial class ReactionPrototype : IPrototype, IComparable<ReactionPrototype>
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Chemistry/Reaction/ReactiveGroupPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactiveGroupPrototype.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared.Chemistry.Reaction;
 
 [Prototype("reactiveGroup")]
-public sealed class ReactiveGroupPrototype : IPrototype
+public sealed partial class ReactiveGroupPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Communications/CommsHackerComponent.cs
+++ b/Content.Shared/Communications/CommsHackerComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class CommsHackerComponent : Component
 /// You wouldn't do that, right?
 /// </summary>
 [Prototype("ninjaHackingThreat")]
-public sealed class NinjaHackingThreatPrototype : IPrototype
+public sealed partial class NinjaHackingThreatPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Construction/Prototypes/ConstructionGraphPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionGraphPrototype.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Construction.Prototypes
 {
     [Prototype("constructionGraph")]
-    public sealed class ConstructionGraphPrototype : IPrototype, ISerializationHooks
+    public sealed partial class ConstructionGraphPrototype : IPrototype, ISerializationHooks
     {
         private readonly Dictionary<string, ConstructionGraphNode> _nodes = new();
         private readonly Dictionary<(string, string), ConstructionGraphNode[]?> _paths = new();

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Construction.Prototypes;
 
 [Prototype("construction")]
-public sealed class ConstructionPrototype : IPrototype
+public sealed partial class ConstructionPrototype : IPrototype
 {
     [DataField("conditions")] private List<IConstructionCondition> _conditions = new();
 

--- a/Content.Shared/Construction/Prototypes/MachinePartPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/MachinePartPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Construction.Prototypes;
 /// different types of machine parts.
 /// </summary>
 [Prototype("machinePart")]
-public sealed class MachinePartPrototype : IPrototype
+public sealed partial class MachinePartPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Shared/Damage/Prototypes/DamageContainerPrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageContainerPrototype.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.Damage.Prototypes
     /// </remarks>
     [Prototype("damageContainer")]
     [Serializable, NetSerializable]
-    public sealed class DamageContainerPrototype : IPrototype
+    public sealed partial class DamageContainerPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Damage/Prototypes/DamageGroupPrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageGroupPrototype.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Damage.Prototypes
     /// </remarks>
     [Prototype("damageGroup", 2)]
     [Serializable, NetSerializable]
-    public sealed class DamageGroupPrototype : IPrototype
+    public sealed partial class DamageGroupPrototype : IPrototype
     {
         [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Damage/Prototypes/DamageTypePrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageTypePrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Damage.Prototypes
     ///     A single damage type. These types are grouped together in <see cref="DamageGroupPrototype"/>s.
     /// </summary>
     [Prototype("damageType")]
-    public sealed class DamageTypePrototype : IPrototype
+    public sealed partial class DamageTypePrototype : IPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = default!;

--- a/Content.Shared/Damage/Prototypes/ExaminableDamagePrototype.cs
+++ b/Content.Shared/Damage/Prototypes/ExaminableDamagePrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Damage.Prototypes;
 ///     Prototype for examinable damage messages.
 /// </summary>
 [Prototype("examinableDamage")]
-public sealed class ExaminableDamagePrototype : IPrototype
+public sealed partial class ExaminableDamagePrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Dataset/DatasetPrototype.cs
+++ b/Content.Shared/Dataset/DatasetPrototype.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared.Dataset
 {
     [Prototype("dataset")]
-    public sealed class DatasetPrototype : IPrototype
+    public sealed partial class DatasetPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Decals/ColorPalettePrototype.cs
+++ b/Content.Shared/Decals/ColorPalettePrototype.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared.Decals;
 
 [Prototype("palette")]
-public sealed class ColorPalettePrototype : IPrototype
+public sealed partial class ColorPalettePrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = null!;
     [DataField("name")] public string Name { get; private set; } = null!;

--- a/Content.Shared/Decals/DecalPrototype.cs
+++ b/Content.Shared/Decals/DecalPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Decals
 {
     [Prototype("decal")]
-    public sealed class DecalPrototype : IPrototype
+    public sealed partial class DecalPrototype : IPrototype
     {
         [IdDataField] public string ID { get; } = null!;
         [DataField("sprite")] public SpriteSpecifier Sprite { get; private set; } = SpriteSpecifier.Invalid;

--- a/Content.Shared/DeviceNetwork/DeviceFrequencyPrototype.cs
+++ b/Content.Shared/DeviceNetwork/DeviceFrequencyPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.DeviceNetwork;
 /// </summary>
 [Prototype("deviceFrequency")]
 [Serializable, NetSerializable]
-public sealed class DeviceFrequencyPrototype : IPrototype
+public sealed partial class DeviceFrequencyPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/EntityList/EntityListPrototype.cs
+++ b/Content.Shared/EntityList/EntityListPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.EntityList
 {
     [Prototype("entityList")]
-    public sealed class EntityListPrototype : IPrototype
+    public sealed partial class EntityListPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/EntityList/EntityLootTablePrototype.cs
+++ b/Content.Shared/EntityList/EntityLootTablePrototype.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Random;
 namespace Content.Shared.EntityList;
 
 [Prototype("entityLootTable")]
-public sealed class EntityLootTablePrototype : IPrototype
+public sealed partial class EntityLootTablePrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Explosion/ExplosionPrototype.cs
+++ b/Content.Shared/Explosion/ExplosionPrototype.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.Explosion;
 ///     that map of airtight entities. This could be done, but is just not yet implemented.
 /// </remarks>
 [Prototype("explosion")]
-public sealed class ExplosionPrototype : IPrototype
+public sealed partial class ExplosionPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/HUD/HudThemePrototype.cs
+++ b/Content.Shared/HUD/HudThemePrototype.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared.HUD
 {
     [Prototype("hudTheme")]
-    public sealed class HudThemePrototype : IPrototype
+    public sealed partial class HudThemePrototype : IPrototype
     {
         [DataField("name", required: true)]
         public string Name { get; private set; } = string.Empty;

--- a/Content.Shared/Humanoid/Markings/MarkingPoints.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPoints.cs
@@ -35,7 +35,7 @@ public sealed partial class MarkingPoints
 }
 
 [Prototype("markingPoints")]
-public sealed class MarkingPointsPrototype : IPrototype
+public sealed partial class MarkingPointsPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Humanoid.Markings
 {
     [Prototype("marking")]
-    public sealed class MarkingPrototype : IPrototype
+    public sealed partial class MarkingPrototype : IPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = "uwu";

--- a/Content.Shared/Humanoid/Prototypes/HumanoidProfilePrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/HumanoidProfilePrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Humanoid.Prototypes;
 
 [Prototype("humanoidProfile")]
-public sealed class HumanoidProfilePrototype : IPrototype
+public sealed partial class HumanoidProfilePrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Humanoid/Prototypes/HumanoidSpritePrototypes.cs
+++ b/Content.Shared/Humanoid/Prototypes/HumanoidSpritePrototypes.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Humanoid.Markings;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -9,7 +8,7 @@ namespace Content.Shared.Humanoid.Prototypes;
 ///     or settings per layer)
 /// </summary>
 [Prototype("speciesBaseSprites")]
-public sealed class HumanoidSpeciesBaseSpritesPrototype : IPrototype
+public sealed partial class HumanoidSpeciesBaseSpritesPrototype : IPrototype
 {
      [IdDataField]
      public string ID { get; private set; } = default!;
@@ -30,7 +29,7 @@ public sealed class HumanoidSpeciesBaseSpritesPrototype : IPrototype
 ///     that sprite (or at least, the layer this sprite is on).
 /// </summary>
 [Prototype("humanoidBaseSprite")]
-public sealed class HumanoidSpeciesSpriteLayer : IPrototype
+public sealed partial class HumanoidSpeciesSpriteLayer : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Humanoid/Prototypes/RandomHumanoidSettingsPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/RandomHumanoidSettingsPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Humanoid.Prototypes;
 ///     This is what is used to change a humanoid spawned by RandomHumanoidSystem in Content.Server.
 /// </summary>
 [Prototype("randomHumanoidSettings")]
-public sealed class RandomHumanoidSettingsPrototype : IPrototype, IInheritingPrototype
+public sealed partial class RandomHumanoidSettingsPrototype : IPrototype, IInheritingPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.Humanoid.Prototypes;
 
 [Prototype("species")]
-public sealed class SpeciesPrototype : IPrototype
+public sealed partial class SpeciesPrototype : IPrototype
 {
     /// <summary>
     /// Prototype ID of the species.

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Inventory;
 
 [Prototype("inventoryTemplate")]
-public sealed class InventoryTemplatePrototype : IPrototype
+public sealed partial class InventoryTemplatePrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = string.Empty;
 

--- a/Content.Shared/Kitchen/MicrowaveMealRecipePrototype.cs
+++ b/Content.Shared/Kitchen/MicrowaveMealRecipePrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Kitchen
     ///    A recipe for space microwaves.
     /// </summary>
     [Prototype("microwaveMealRecipe")]
-    public sealed class FoodRecipePrototype : IPrototype
+    public sealed partial class FoodRecipePrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -10,7 +10,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Maps
 {
     [Prototype("tile")]
-    public sealed class ContentTileDefinition : IPrototype, IInheritingPrototype, ITileDefinition
+    public sealed partial class ContentTileDefinition : IPrototype, IInheritingPrototype, ITileDefinition
     {
         public const string SpaceID = "Space";
 

--- a/Content.Shared/Materials/MaterialPrototype.cs
+++ b/Content.Shared/Materials/MaterialPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Materials
     ///     Properties should be intrinsic (or at least as much is necessary for game purposes).
     /// </summary>
     [Prototype("material")]
-    public sealed class MaterialPrototype : IPrototype, IInheritingPrototype
+    public sealed partial class MaterialPrototype : IPrototype, IInheritingPrototype
     {
         [ViewVariables]
         [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<MaterialPrototype>))]

--- a/Content.Shared/Mining/OrePrototype.cs
+++ b/Content.Shared/Mining/OrePrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Mining;
 /// This is a prototype for defining ores that generate in rock
 /// </summary>
 [Prototype("ore")]
-public sealed class OrePrototype : IPrototype
+public sealed partial class OrePrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Shared/NameIdentifier/NameIdentifierGroupPrototype.cs
+++ b/Content.Shared/NameIdentifier/NameIdentifierGroupPrototype.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared.NameIdentifier;
 
 [Prototype("nameIdentifierGroup")]
-public sealed class NameIdentifierGroupPrototype : IPrototype
+public sealed partial class NameIdentifierGroupPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Nutrition/Flavor.cs
+++ b/Content.Shared/Nutrition/Flavor.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Nutrition;
 
 [Prototype("flavor")]
-public sealed class FlavorPrototype : IPrototype
+public sealed partial class FlavorPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Parallax/Biomes/BiomeTemplatePrototype.cs
+++ b/Content.Shared/Parallax/Biomes/BiomeTemplatePrototype.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Parallax.Biomes.Layers;
-using Robust.Shared.Noise;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Parallax.Biomes;
@@ -8,7 +7,7 @@ namespace Content.Shared.Parallax.Biomes;
 /// A preset group of biome layers to be used for a <see cref="BiomeComponent"/>
 /// </summary>
 [Prototype("biomeTemplate")]
-public sealed class BiomeTemplatePrototype : IPrototype
+public sealed partial class BiomeTemplatePrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Players/PlayTimeTracking/PlayTimeTrackerPrototype.cs
+++ b/Content.Shared/Players/PlayTimeTracking/PlayTimeTrackerPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Players.PlayTimeTracking;
 /// Given to a role to specify its ID for role-timer tracking purposes. That's it.
 /// </summary>
 [Prototype("playTimeTracker")]
-public sealed class PlayTimeTrackerPrototype : IPrototype
+public sealed partial class PlayTimeTrackerPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 }

--- a/Content.Shared/Procedural/DungeonConfigPrototype.cs
+++ b/Content.Shared/Procedural/DungeonConfigPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Procedural;
 
 [Prototype("dungeonConfig")]
-public sealed class DungeonConfigPrototype : IPrototype
+public sealed partial class DungeonConfigPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Procedural/DungeonPresetPrototype.cs
+++ b/Content.Shared/Procedural/DungeonPresetPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Procedural;
 
 [Prototype("dungeonPreset")]
-public sealed class DungeonPresetPrototype : IPrototype
+public sealed partial class DungeonPresetPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Procedural/DungeonRoomPackPrototype.cs
+++ b/Content.Shared/Procedural/DungeonRoomPackPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Procedural;
 
 [Prototype("dungeonRoomPack")]
-public sealed class DungeonRoomPackPrototype : IPrototype
+public sealed partial class DungeonRoomPackPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = string.Empty;

--- a/Content.Shared/Procedural/DungeonRoomPrototype.cs
+++ b/Content.Shared/Procedural/DungeonRoomPrototype.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Procedural;
 
 [Prototype("dungeonRoom")]
-public sealed class DungeonRoomPrototype : IPrototype
+public sealed partial class DungeonRoomPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = string.Empty;
 

--- a/Content.Shared/Procedural/Loot/SalvageLootPrototype.cs
+++ b/Content.Shared/Procedural/Loot/SalvageLootPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Procedural.Loot;
 /// Spawned inside of a salvage mission.
 /// </summary>
 [Prototype("salvageLoot")]
-public sealed class SalvageLootPrototype : IPrototype
+public sealed partial class SalvageLootPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Procedural/SalvageDifficultyPrototype.cs
+++ b/Content.Shared/Procedural/SalvageDifficultyPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Procedural;
 
 [Prototype("salvageDifficulty")]
-public sealed class SalvageDifficultyPrototype : IPrototype
+public sealed partial class SalvageDifficultyPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = string.Empty;
 

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Radio;
 
 [Prototype("radioChannel")]
-public sealed class RadioChannelPrototype : IPrototype
+public sealed partial class RadioChannelPrototype : IPrototype
 {
     /// <summary>
     /// Human-readable name for the channel.
@@ -30,7 +30,7 @@ public sealed class RadioChannelPrototype : IPrototype
     public string ID { get; } = default!;
 
     /// <summary>
-    /// If channel is long range it doesn't require telecommunication server 
+    /// If channel is long range it doesn't require telecommunication server
     /// and messages can be sent across different stations
     /// </summary>
     [DataField("longRange"), ViewVariables]

--- a/Content.Shared/Random/RulesPrototype.cs
+++ b/Content.Shared/Random/RulesPrototype.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Random;
 /// e.g. "choose maintenance audio if 90% of tiles nearby are maintenance tiles"
 /// </summary>
 [Prototype("rules")]
-public sealed class RulesPrototype : IPrototype
+public sealed partial class RulesPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = string.Empty;
 

--- a/Content.Shared/Random/WeightedRandomFillSolutionPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomFillSolutionPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Random;
 ///     Random weighting dataset for solutions, able to specify reagents quantity.
 /// </summary>
 [Prototype("weightedRandomFillSolution")]
-public sealed class WeightedRandomFillSolutionPrototype : IPrototype
+public sealed partial class WeightedRandomFillSolutionPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
+++ b/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Research.Prototypes
 {
     [NetSerializable, Serializable, Prototype("latheRecipe")]
-    public sealed class LatheRecipePrototype : IPrototype
+    public sealed partial class LatheRecipePrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Research/Prototypes/TechDisciplinePrototype.cs
+++ b/Content.Shared/Research/Prototypes/TechDisciplinePrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Research.Prototypes;
 /// that governs how <see cref="TechnologyPrototype"/>s are unlocked.
 /// </summary>
 [Prototype("techDiscipline")]
-public sealed class TechDisciplinePrototype : IPrototype
+public sealed partial class TechDisciplinePrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Shared/Research/Prototypes/TechnologyPrototype.cs
+++ b/Content.Shared/Research/Prototypes/TechnologyPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Research.Prototypes;
 /// This is a prototype for a technology that can be unlocked.
 /// </summary>
 [Prototype("technology")]
-public sealed class TechnologyPrototype : IPrototype
+public sealed partial class TechnologyPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Roles;
 /// </summary>
 [Prototype("antag")]
 [Serializable, NetSerializable]
-public sealed class AntagPrototype : IPrototype
+public sealed partial class AntagPrototype : IPrototype
 {
     [ViewVariables]
     [IdDataField]

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -1,11 +1,10 @@
-using System.Linq;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
 namespace Content.Shared.Roles;
 
 [Prototype("department")]
-public sealed class DepartmentPrototype : IPrototype
+public sealed partial class DepartmentPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Roles
     ///     Describes information for a single job on the station.
     /// </summary>
     [Prototype("job")]
-    public sealed class JobPrototype : IPrototype
+    public sealed partial class JobPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Roles/StartingGearPrototype.cs
+++ b/Content.Shared/Roles/StartingGearPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Roles
 {
     [Prototype("startingGear")]
-    public sealed class StartingGearPrototype : IPrototype
+    public sealed partial class StartingGearPrototype : IPrototype
     {
         [DataField]
         public Dictionary<string, EntProtoId> Equipment = new();

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageAirMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageAirMod.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 /// Which one is selected depends on the mission difficulty, different weightedRandoms are picked from.
 /// </summary>
 [Prototype("salvageAirMod")]
-public sealed class SalvageAirMod : IPrototype, IBiomeSpecificMod
+public sealed partial class SalvageAirMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageBiomeModPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageBiomeModPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 /// Affects the biome to be used for salvage.
 /// </summary>
 [Prototype("salvageBiomeMod")]
-public sealed class SalvageBiomeModPrototype : IPrototype, ISalvageMod
+public sealed partial class SalvageBiomeModPrototype : IPrototype, ISalvageMod
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageDungeonModPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageDungeonModPrototype.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
 [Prototype("salvageDungeonMod")]
-public sealed class SalvageDungeonModPrototype : IPrototype, IBiomeSpecificMod
+public sealed partial class SalvageDungeonModPrototype : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageLightMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageLightMod.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
 [Prototype("salvageLightMod")]
-public sealed class SalvageLightMod : IPrototype, IBiomeSpecificMod
+public sealed partial class SalvageLightMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageMod.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 /// Generic modifiers with no additional data
 /// </summary>
 [Prototype("salvageMod")]
-public sealed class SalvageMod : IPrototype, ISalvageMod
+public sealed partial class SalvageMod : IPrototype, ISalvageMod
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTemperatureMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTemperatureMod.cs
@@ -1,11 +1,10 @@
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
 [Prototype("salvageTemperatureMod")]
-public sealed class SalvageTemperatureMod : IPrototype, IBiomeSpecificMod
+public sealed partial class SalvageTemperatureMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageWeatherMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageWeatherMod.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
 [Prototype("salvageWeatherMod")]
-public sealed class SalvageWeatherMod : IPrototype, IBiomeSpecificMod
+public sealed partial class SalvageWeatherMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Salvage/Expeditions/SalvageFactionPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/SalvageFactionPrototype.cs
@@ -1,11 +1,9 @@
-using Content.Shared.Salvage.Expeditions.Modifiers;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 
 namespace Content.Shared.Salvage.Expeditions;
 
 [Prototype("salvageFaction")]
-public sealed class SalvageFactionPrototype : IPrototype
+public sealed partial class SalvageFactionPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Speech/SpeechSoundsPrototype.cs
+++ b/Content.Shared/Speech/SpeechSoundsPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Speech
 {
     [Prototype("speechSounds")]
-    public sealed class SpeechSoundsPrototype : IPrototype
+    public sealed partial class SpeechSoundsPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Speech/SpeechVerbPrototype.cs
+++ b/Content.Shared/Speech/SpeechVerbPrototype.cs
@@ -1,5 +1,4 @@
 ﻿using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Speech;
 
@@ -8,7 +7,7 @@ namespace Content.Shared.Speech;
 ///     on punctuation or by directly overriding the prototype.
 /// </summary>
 [Prototype("speechVerb")]
-public sealed class SpeechVerbPrototype : IPrototype
+public sealed partial class SpeechVerbPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/SprayPainter/Prototypes/AirlockGroupPrototype.cs
+++ b/Content.Shared/SprayPainter/Prototypes/AirlockGroupPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.SprayPainter.Prototypes;
 
 [Prototype("AirlockGroup")]
-public sealed class AirlockGroupPrototype : IPrototype
+public sealed partial class AirlockGroupPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Spreader/EdgeSpreaderPrototype.cs
+++ b/Content.Shared/Spreader/EdgeSpreaderPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Spreader;
 /// Adds this node group to <see cref="Content.Server.Spreader.SpreaderSystem"/> for tick updates.
 /// </summary>
 [Prototype("edgeSpreader")]
-public sealed class EdgeSpreaderPrototype : IPrototype
+public sealed partial class EdgeSpreaderPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = string.Empty;
     [DataField(required:true)] public int UpdatesPerSecond;

--- a/Content.Shared/Stacks/StackPrototype.cs
+++ b/Content.Shared/Stacks/StackPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Stacks;
 
 [Prototype("stack")]
-public sealed class StackPrototype : IPrototype
+public sealed partial class StackPrototype : IPrototype
 {
     [ViewVariables]
     [IdDataField]

--- a/Content.Shared/StatusEffect/StatusEffectPrototype.cs
+++ b/Content.Shared/StatusEffect/StatusEffectPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.StatusEffect
 {
     [Prototype("statusEffect")]
-    public sealed class StatusEffectPrototype : IPrototype
+    public sealed partial class StatusEffectPrototype : IPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = default!;

--- a/Content.Shared/Tag/TagPrototype.cs
+++ b/Content.Shared/Tag/TagPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Tag
     ///     gets saved in TagComponent.
     /// </summary>
     [Prototype("Tag")]
-    public sealed class TagPrototype : IPrototype
+    public sealed partial class TagPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Tools/ToolQualityPrototype.cs
+++ b/Content.Shared/Tools/ToolQualityPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Tools
 {
     [Prototype("tool")]
-    public sealed class ToolQualityPrototype : IPrototype
+    public sealed partial class ToolQualityPrototype : IPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = default!;

--- a/Content.Shared/Traits/TraitPrototype.cs
+++ b/Content.Shared/Traits/TraitPrototype.cs
@@ -1,7 +1,8 @@
 using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
-using static Robust.Shared.Prototypes.EntityPrototype; // don't worry about it
+
+// don't worry about it
 
 namespace Content.Shared.Traits
 {
@@ -9,7 +10,7 @@ namespace Content.Shared.Traits
     ///     Describes a trait.
     /// </summary>
     [Prototype("trait")]
-    public sealed class TraitPrototype : IPrototype
+    public sealed partial class TraitPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/VendingMachines/VendingMachineInventoryPrototype.cs
+++ b/Content.Shared/VendingMachines/VendingMachineInventoryPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.VendingMachines
 {
     [Serializable, NetSerializable, Prototype("vendingMachineInventory")]
-    public sealed class VendingMachineInventoryPrototype : IPrototype
+    public sealed partial class VendingMachineInventoryPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Weapons/Ranged/HitscanPrototype.cs
+++ b/Content.Shared/Weapons/Ranged/HitscanPrototype.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Weapons.Ranged;
 
 [Prototype("hitscan")]
-public sealed class HitscanPrototype : IPrototype, IShootable
+public sealed partial class HitscanPrototype : IPrototype, IShootable
 {
     [ViewVariables]
     [IdDataField]

--- a/Content.Shared/Weather/WeatherPrototype.cs
+++ b/Content.Shared/Weather/WeatherPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Weather;
 
 [Prototype("weather")]
-public sealed class WeatherPrototype : IPrototype
+public sealed partial class WeatherPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = default!;
 


### PR DESCRIPTION
## About the PR
Same as the other data definitions like components.
This will be needed to make prototypes use the source generator for copying (and later reading/writing/validating).
This also lets downstreams extend a prototype type by adding more to it, which avoids conflicts in some cases.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

