### PR TITLE
Mark all tests that restart rounds as dirty

### DIFF
--- a/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
@@ -1,8 +1,6 @@
 ﻿using System.Linq;
 using Content.Shared.Ghost;
 using Content.Shared.Mind;
-using NUnit.Framework.Interfaces;
-using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
@@ -124,7 +122,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestVisitingReconnect()
     {
-        await using var pair = await SetupPair();
+        await using var pair = await SetupPair(true);
         var entMan = pair.Server.ResolveDependency<IEntityManager>();
         var mindSys = entMan.System<SharedMindSystem>();
         var mind = GetMind(pair);

--- a/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
+++ b/Content.IntegrationTests/Tests/Replays/ReplayTests.cs
@@ -14,7 +14,11 @@ public sealed class ReplayTests
     [Test]
     public async Task AutoRecordReplayTest()
     {
-        var settings = new PoolSettings {DummyTicker = false};
+        var settings = new PoolSettings
+        {
+            DummyTicker = false,
+            Dirty = true
+        };
         await using var pair = await PoolManager.GetServerClient(settings);
         var server = pair.Server;
 

--- a/Content.IntegrationTests/Tests/ResettingEntitySystemTests.cs
+++ b/Content.IntegrationTests/Tests/ResettingEntitySystemTests.cs
@@ -33,7 +33,8 @@ namespace Content.IntegrationTests.Tests
             await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 DummyTicker = false,
-                Connected = true
+                Connected = true,
+                Dirty = true
             });
             var server = pair.Server;
 

--- a/Content.IntegrationTests/Tests/RestartRoundTest.cs
+++ b/Content.IntegrationTests/Tests/RestartRoundTest.cs
@@ -1,6 +1,5 @@
 using Content.Server.GameTicking;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 
 namespace Content.IntegrationTests.Tests
 {
@@ -13,7 +12,8 @@ namespace Content.IntegrationTests.Tests
             await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 DummyTicker = false,
-                Connected = true
+                Connected = true,
+                Dirty = true
             });
             var server = pair.Server;
             var sysManager = server.ResolveDependency<IEntitySystemManager>();

--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -16,7 +16,8 @@ namespace Content.IntegrationTests.Tests
             await using var pair = await PoolManager.GetServerClient(new PoolSettings
             {
                 DummyTicker = false,
-                Connected = true
+                Connected = true,
+                Dirty = true
             });
 
             var server = pair.Server;


### PR DESCRIPTION
## About the PR
Some of these cause errors if executed in a specific order, where the next test expects a status of "InGame" but gets "ReadyToPlay" instead when validating settings.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase