### PR TITLE
Fix adding collision wake component while applying state

### DIFF
--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -82,7 +82,9 @@ public partial class MobStateSystem
                 _appearance.SetData(target, MobStateVisuals.State, MobState.Critical);
                 break;
             case MobState.Dead:
-                EnsureComp<CollisionWakeComponent>(target);
+                if (!_gameTiming.ApplyingState)
+                    EnsureComp<CollisionWakeComponent>(target);
+
                 _standing.Down(target);
 
                 if (_standing.IsDown(target) && TryComp<PhysicsComponent>(target, out var physics))

--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Standing;
 using Robust.Shared.GameStates;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Mobs.Systems;
 
@@ -15,6 +16,7 @@ public partial class MobStateSystem : EntitySystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly ILogManager _logManager = default!;
     private ISawmill _sawmill = default!;
 


### PR DESCRIPTION
## About the PR
Tests sometimes catch this.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase