### PR TITLE
Revert "Enable skeletons temporarily for Halloween (#21356)"

### DIFF
--- a/Resources/Prototypes/Species/skeleton.yml
+++ b/Resources/Prototypes/Species/skeleton.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Skeleton
   name: Skeleton
-  roundStart: true
+  roundStart: false
   prototype: MobSkeletonPerson
   sprites: MobSkeletonSprites
   defaultSkinTone: "#fff9e2"


### PR DESCRIPTION
## About the PR
Halloween is over, it was a fun but now its time for the skeletons to go back to sleep.

## Why / Balance
Was a temp change for Halloween

## Technical details
NA

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

<!--
:cl:
- remove: No more skeletal crewmates.

