### PR TITLE
Add syndie encryption key to head rev loadout

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
@@ -66,7 +66,8 @@ public sealed partial class RevolutionaryRuleComponent : Component
     public List<EntProtoId> StartingGear = new()
     {
         "Flash",
-        "ClothingEyesGlassesSunglasses"
+        "ClothingEyesGlassesSunglasses",
+        "EncryptionKeySyndie"
     };
 
     /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds a syndicate encryption key to headrev loadout.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
People on discord bugs-feedback have been fawning over the idea, so why not try it.

Lets the head revs coordinate some maybe.
Gives something else for sec to find and know head revs are head revs.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
One line change, no really.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: The syndicate has sponsored head revolutionaries with access to their broadband radio frequency.