### PR TITLE
buff bag of holding

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -264,7 +264,7 @@
     size: Ginormous
   - type: Storage
     maxItemSize: Huge
-    maxTotalWeight: 56 #14 normal-sized items.
+    maxTotalWeight: 200 #5 duffels worth of gear
 
 - type: entity
   parent: ClothingBackpackClown

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -231,7 +231,7 @@
     size: Ginormous
   - type: Storage
     maxItemSize: Huge
-    maxTotalWeight: 56 #14 normal-sized items.
+    maxTotalWeight: 200 #5 duffels worth of gear
   - type: ClothingSpeedModifier
     sprintModifier: 1 # makes its stats identical to other variants of bag of holding
 

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -171,4 +171,4 @@
     size: Ginormous
   - type: Storage
     maxItemSize: Huge
-    maxTotalWeight: 56 #14 normal-sized items.
+    maxTotalWeight: 200 #5 duffels worth of gear


### PR DESCRIPTION
## About the PR
increased from 2 backpacks to 5 duffels of storage

## Why / Balance
you could invalidate a **tier 3** tech which is expensive to produce by just holding a bag in your hand
now there is an actual reason to use it, though its still not as good as pre nerf of 100 bags

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Increased the capacity of Bags of holding.
