### PR TITLE
Fixes A Anomaly Core Description Typo

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
@@ -3,7 +3,7 @@
   id: BaseAnomalyCore
   abstract: true
   name: anomaly core
-  description: The core of a detroyed incomprehensible object.
+  description: The core of a destroyed incomprehensible object.
   components:
   - type: Sprite
     sprite: Structures/Specific/Anomalies/Cores/gravity_core.rsi


### PR DESCRIPTION
### About the PR
Fixes/closes [this](https://discord.com/channels/310555209753690112/1170085210470228019/1170085210470228019) forum thread.

Changes detroyed to destroyed.

### Why / Balance
It seems like a pretty blatent typo, it was a single line fix that nobody else in the thread wanted to do.

This PR I don't believe requires media, its a typo fix and isn't adding new content in any significant manner.