### PR TITLE
Senior Physician Beret

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -24,7 +24,7 @@
 - type: startingGear
   id: SeniorPhysicianGear
   equipment:
-    head: ClothingHeadHatBeretMedicalBrigmedic
+    head: ClothingHeadHatBeretBrigmedic
     jumpsuit: ClothingUniformJumpsuitSeniorPhysician
     back: ClothingBackpackMedicalFilled
     shoes: ClothingShoesColorBlack

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -24,6 +24,7 @@
 - type: startingGear
   id: SeniorPhysicianGear
   equipment:
+    head: ClothingHeadHatBeretMedicalBrigmedic
     jumpsuit: ClothingUniformJumpsuitSeniorPhysician
     back: ClothingBackpackMedicalFilled
     shoes: ClothingShoesColorBlack


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

Senior physician is currently the only senior role without a beret. IIRC the reason was because the job looked better without it, but i noticed that over a large span of time that people mention the absurdity of this senior not spawning with one. Plus, people say it looks better and it actually does look better. Right now the medical beret ingame fits, but in the files it seems it was originally made for the brigmedic. Probably should have an ID change but im too lazy to in this PR right now.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/space-wizards/space-station-14/assets/134914314/e58e44e3-b197-4013-9785-4f9042fcdcfd)
![image](https://github.com/space-wizards/space-station-14/assets/134914314/048a1620-05c1-45bd-81c1-d6d8caca02d2)

**Changelog**

:cl: Ubaser
- tweak: The senior physician now spawns with a medical beret.