### PR TITLE
Use object-spaced bounding boxes for putting stuff in crates

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -370,7 +370,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
 
         if (TryComp<PhysicsComponent>(toAdd, out var phys))
         {
-            var aabb = _physics.GetWorldAABB(toAdd, body: phys);
+            var aabb = _physics.GetObjectAABB(toAdd, body: phys);
 
             if (component.MaxSize < aabb.Size.X || component.MaxSize < aabb.Size.Y)
                 return false;

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using Content.Shared.Body.Components;
@@ -368,9 +368,11 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (toAdd == container)
             return false;
 
-        if (TryComp<PhysicsComponent>(toAdd, out var phys))
+        if (TryComp<TransformComponent>(toAdd, out var xform))
         {
-            var aabb = _physics.GetObjectAABB(toAdd, body: phys);
+            var xformQuery = GetEntityQuery<TransformComponent>();
+            xform ??= xformQuery.GetComponent(toAdd);
+            var aabb = _lookup.GetAABB(toAdd, Vector2.Zero, 0, xform, xformQuery);
 
             if (component.MaxSize < aabb.Size.X || component.MaxSize < aabb.Size.Y)
                 return false;

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -368,14 +368,9 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (toAdd == container)
             return false;
 
-        if (TryComp<TransformComponent>(toAdd, out var xform))
-        {
-            var xformQuery = GetEntityQuery<TransformComponent>();
-            var aabb = _lookup.GetAABB(toAdd, Vector2.Zero, 0, xform, xformQuery);
-
-            if (component.MaxSize < aabb.Size.X || component.MaxSize < aabb.Size.Y)
-                return false;
-        }
+        var aabb = _lookup.GetAABBNoContainer(toAdd, Vector2.Zero, 0);
+        if (component.MaxSize < aabb.Size.X || component.MaxSize < aabb.Size.Y)
+            return false;
 
         return Insert(toAdd, container, component);
     }

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using Content.Shared.Body.Components;
@@ -371,7 +371,6 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (TryComp<TransformComponent>(toAdd, out var xform))
         {
             var xformQuery = GetEntityQuery<TransformComponent>();
-            xform ??= xformQuery.GetComponent(toAdd);
             var aabb = _lookup.GetAABB(toAdd, Vector2.Zero, 0, xform, xformQuery);
 
             if (component.MaxSize < aabb.Size.X || component.MaxSize < aabb.Size.Y)


### PR DESCRIPTION
## About the PR
UPDATE: No longer involves an engine change.
Swaps the logic used in crates from using world-space AABB calculation to a 0-transform AABB calculation, so rotation of objects doesn't mess with the overall size of their bounding boxes and thus ability to fit into crates.

## Why / Balance
#19301 
#19012 
#19205 
Spears and soaps will routinely not fit into crates due to, of all things, the rotation of the station in world space. They're meant to fit in, but can't. Also, while I've seen no reports about it, this same bug could also in theory allow objects that aren't intended to fit into crates to fit in at certain angles, since the ability to grow certain bounding boxes by rotation also entails the ability to shrink others.

## Technical details
Just a swap from one AABB function to another AABB function, to use one that can do the bounding box in object-space instead of world-space

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None, no changes to any APIs, just correcting a bad behavior.

**Changelog**
:cl:
- fix: Fixed certain objects not fitting into crates and lockers due to the angle of space itself.
