### PR TITLE
fix susbox slots

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -81,21 +81,20 @@
         prob: 0.5
 
 - type: entity
-  id: ToolboxSyndicateFilled
-  name: suspicious toolbox
-  suffix: Filled
   parent: ToolboxSyndicate
+  id: ToolboxSyndicateFilled
+  suffix: Filled
   components:
   - type: StorageFill
     contents:
-      - id: Crowbar
-      - id: Wrench
-      - id: Screwdriver
-      - id: Wirecutter
-      - id: Welder
-      - id: Multitool
-      - id: ClothingHandsGlovesCombat
-      - id: ClothingMaskGasSyndicate
+    - id: Crowbar
+    - id: Wrench
+    - id: Screwdriver
+    - id: Wirecutter
+    - id: Welder
+    - id: Multitool
+    - id: ClothingHandsGlovesCombat
+    - id: ClothingMaskGasSyndicate
 
 - type: entity
   id: ToolboxGoldFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -86,8 +86,6 @@
   suffix: Filled
   parent: ToolboxSyndicate
   components:
-  - type: Storage
-    maxSlots: 8
   - type: StorageFill
     contents:
       - id: Crowbar

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -117,7 +117,8 @@
     sprite: Objects/Tools/Toolboxes/toolbox_syn.rsi
   - type: Storage
     maxItemSize: Huge
-    maxTotalWeight: 28
+    maxSlots: 8
+    maxTotalWeight: 32
   - type: MeleeWeapon
     damage:
       types:


### PR DESCRIPTION
## About the PR
empty susbox has 8 slots like filled prototype, also cleaned up a little

allowed item size remains unchanged since idk

## Why / Balance
amogus

## Technical details
no

## Media
![19:45:18](https://github.com/space-wizards/space-station-14/assets/39013340/6b2dccf7-b453-4c72-b852-6a1bf3c08280)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun