### PR TITLE
Fix Client RoleSystem not inheriting SharedRoleSystem, network job component

### DIFF
--- a/Content.Client/Roles/RoleSystem.cs
+++ b/Content.Client/Roles/RoleSystem.cs
@@ -1,5 +1,7 @@
-﻿namespace Content.Client.Roles;
+﻿using Content.Shared.Roles;
 
-public sealed class RoleSystem : EntitySystem
+namespace Content.Client.Roles;
+
+public sealed class RoleSystem : SharedRoleSystem
 {
 }

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -200,7 +200,7 @@ namespace Content.Server.GameTicking
             _mind.SetUserId(newMind, data.UserId);
 
             var jobPrototype = _prototypeManager.Index<JobPrototype>(jobId);
-            var job = new JobComponent { PrototypeId = jobId };
+            var job = new JobComponent { Prototype = jobId };
             _roles.MindAddRole(newMind, job, silent: silent);
             var jobName = _jobs.MindTryGetJobName(newMind);
 

--- a/Content.Server/Objectives/Systems/NotJobRequirementSystem.cs
+++ b/Content.Server/Objectives/Systems/NotJobRequirementSystem.cs
@@ -1,4 +1,3 @@
-using Content.Server.Objectives.Components;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Roles.Jobs;
 
@@ -25,7 +24,7 @@ public sealed class NotJobRequirementSystem : EntitySystem
         if (!TryComp<JobComponent>(args.MindId, out var job))
             return;
 
-        if (job.PrototypeId == comp.Job)
+        if (job.Prototype == comp.Job)
             args.Cancelled = true;
     }
 }

--- a/Content.Server/Roles/Jobs/JobSystem.cs
+++ b/Content.Server/Roles/Jobs/JobSystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Mind;
 using Content.Shared.Mind;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Roles.Jobs;
 
@@ -48,6 +47,6 @@ public sealed class JobSystem : SharedJobSystem
         if (MindHasJobWithId(mindId, jobPrototypeId))
             return;
 
-        _roles.MindAddRole(mindId, new JobComponent { PrototypeId = jobPrototypeId });
+        _roles.MindAddRole(mindId, new JobComponent { Prototype = jobPrototypeId });
     }
 }

--- a/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnPointSystem.cs
@@ -39,7 +39,7 @@ public sealed class SpawnPointSystem : EntitySystem
 
             if (_gameTicker.RunLevel != GameRunLevel.InRound &&
                 spawnPoint.SpawnType == SpawnPointType.Job &&
-                (args.Job == null || spawnPoint.Job?.ID == args.Job.PrototypeId))
+                (args.Job == null || spawnPoint.Job?.ID == args.Job.Prototype))
             {
                 possiblePositions.Add(xform.Coordinates);
             }

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -97,7 +97,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
         EntityUid? station,
         EntityUid? entity = null)
     {
-        _prototypeManager.TryIndex(job?.PrototypeId ?? string.Empty, out JobPrototype? prototype);
+        _prototypeManager.TryIndex(job?.Prototype ?? string.Empty, out JobPrototype? prototype);
 
         // If we're not spawning a humanoid, we're gonna exit early without doing all the humanoid stuff.
         if (prototype?.JobEntity != null)
@@ -161,7 +161,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
 
     private void DoJobSpecials(JobComponent? job, EntityUid entity)
     {
-        if (!_prototypeManager.TryIndex(job?.PrototypeId ?? string.Empty, out JobPrototype? prototype))
+        if (!_prototypeManager.TryIndex(job?.Prototype ?? string.Empty, out JobPrototype? prototype))
             return;
 
         foreach (var jobSpecial in prototype.Special)

--- a/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
+++ b/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
@@ -39,11 +39,11 @@ public sealed partial class BuyerDepartmentCondition : ListingCondition
         var jobs = ent.System<SharedJobSystem>();
         jobs.MindTryGetJob(mindId, out var job, out _);
 
-        if (Blacklist != null && job?.PrototypeId != null)
+        if (Blacklist != null && job?.Prototype != null)
         {
             foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
             {
-                if (department.Roles.Contains(job.PrototypeId) && Blacklist.Contains(department.ID))
+                if (department.Roles.Contains(job.Prototype) && Blacklist.Contains(department.ID))
                     return false;
             }
         }
@@ -52,11 +52,11 @@ public sealed partial class BuyerDepartmentCondition : ListingCondition
         {
             var found = false;
 
-            if (job?.PrototypeId != null)
+            if (job?.Prototype != null)
             {
                 foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
                 {
-                    if (department.Roles.Contains(job.PrototypeId) && Whitelist.Contains(department.ID))
+                    if (department.Roles.Contains(job.Prototype) && Whitelist.Contains(department.ID))
                     {
                         found = true;
                         break;

--- a/Content.Server/Store/Conditions/BuyerJobCondition.cs
+++ b/Content.Server/Store/Conditions/BuyerJobCondition.cs
@@ -38,13 +38,13 @@ public sealed partial class BuyerJobCondition : ListingCondition
 
         if (Blacklist != null)
         {
-            if (job?.PrototypeId != null && Blacklist.Contains(job.PrototypeId))
+            if (job?.Prototype != null && Blacklist.Contains(job.Prototype))
                 return false;
         }
 
         if (Whitelist != null)
         {
-            if (job?.PrototypeId == null || !Whitelist.Contains(job.PrototypeId))
+            if (job?.Prototype == null || !Whitelist.Contains(job.Prototype))
                 return false;
         }
 

--- a/Content.Shared/Roles/Jobs/JobComponent.cs
+++ b/Content.Shared/Roles/Jobs/JobComponent.cs
@@ -1,13 +1,14 @@
-﻿using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Roles.Jobs;
 
 /// <summary>
 ///     Added to mind entities to hold the data for the player's current job.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class JobComponent : Component
 {
-    [DataField("prototype", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<JobPrototype>))]
-    public string? PrototypeId;
+    [DataField(required: true), AutoNetworkedField]
+    public ProtoId<JobPrototype>? Prototype;
 }

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -83,7 +83,7 @@ public abstract class SharedJobSystem : EntitySystem
 
     public bool MindHasJobWithId(EntityUid? mindId, string prototypeId)
     {
-        return CompOrNull<JobComponent>(mindId)?.PrototypeId == prototypeId;
+        return CompOrNull<JobComponent>(mindId)?.Prototype == prototypeId;
     }
 
     public bool MindTryGetJob(
@@ -95,8 +95,8 @@ public abstract class SharedJobSystem : EntitySystem
         prototype = null;
 
         return TryComp(mindId, out comp) &&
-               comp.PrototypeId != null &&
-               _prototypes.TryIndex(comp.PrototypeId, out prototype);
+               comp.Prototype != null &&
+               _prototypes.TryIndex(comp.Prototype, out prototype);
     }
 
     /// <summary>

--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -25,7 +25,7 @@ public abstract class SharedRoleSystem : EntitySystem
     {
         var name = "game-ticker-unknown-role";
         string? playTimeTracker = null;
-        if (component.PrototypeId != null && _prototypes.TryIndex(component.PrototypeId, out JobPrototype? job))
+        if (component.Prototype != null && _prototypes.TryIndex(component.Prototype, out JobPrototype? job))
         {
             name = job.Name;
             playTimeTracker = job.PlayTimeTracker;


### PR DESCRIPTION
## About the PR
Small blunder

## Media
It won't get networked for other players' minds since mind entities are in nullspace and only added to the player's override if its their own:
![Content Client_mj1BgTLtxR](https://github.com/space-wizards/space-station-14/assets/10968691/c4f2d632-0093-4367-9b46-218b9cc754cd)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

