### PR TITLE
Bicaridine metabolism bandaid

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -12,8 +12,6 @@
       - !type:GenericStatusEffect
         key: Stutter
         component: ScrambledAccent
-    Alcohol:
-      effects:
       - !type:Drunk
         slurSpeech: false
         boozePower: 20
@@ -57,8 +55,6 @@
         - !type:ReagentThreshold
           min: 20
         probability: 0.02
-    Alcohol:
-      effects:
       - !type:Drunk
         conditions:
         - !type:ReagentThreshold
@@ -162,8 +158,6 @@
         conditions:
         - !type:ReagentThreshold
           min: 15
-    Alcohol:
-      effects:
       - !type:Drunk
 
 - type: reagent


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Bicaridine, Dylovene and Crytobiolin now metabolize at the same rate for all species.
Fixes #21397

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Previous behavior was causing more or less healing than expected, as well as unexpected ODs.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Since these three reagents have both Medicine and Alcohol metabolisms, there were some interactions there that messed up the math. I simply moved the Drunk effect to the Medicine metabolism.

I marked this is a bandaid, as there are design questions around how to handle different rates of metabolism on the same reagent (diona and slime stomach handles both Medicine and Alcohol), or if there are two organs metabolizing at once (human liver for Alcohol and human heart for Medicine).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Bicaridine, Dylovene and Crytobiolin now metabolize at the same rate for all species.