### PR TITLE
give chemistry bag better storage

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/science.yml
@@ -5,6 +5,7 @@
   description: A box full of beakers.
   components:
   - type: Storage
+    maxTotalWeight: 12
     maxItemSize: Normal
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/science.yml
@@ -4,6 +4,8 @@
   id: BoxBeaker
   description: A box full of beakers.
   components:
+  - type: Storage
+    maxItemSize: Normal
   - type: StorageFill
     contents:
       - id: Beaker

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -12,6 +12,8 @@
         maxVol: 100
   - type: Sprite
     state: icon
+  - type: Item
+    size: Normal
   - type: DamageOnLand
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
@@ -13,13 +13,15 @@
     slots:
     - belt
   - type: Item
-    size: Normal
+    size: Ginormous
   - type: Storage
-    maxSlots: 40
+    maxItemSize: Normal # allow up to 5 large beakers / 10 beakers / 10 pill canisters
+    maxTotalWeight: 20
     quickInsert: true
     areaInsert: true
     whitelist:
       components:
+        - FitsInDispenser
         - Pill
       tags:
         - PillCanister

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -187,7 +187,7 @@
         map: ["enum.SolutionContainerLayers.Fill"]
         visible: false
   - type: Item
-    size: Small
+    size: Normal
     sprite: Objects/Specific/Chemistry/beaker_large.rsi
   - type: SolutionContainerManager
     solutions:


### PR DESCRIPTION
## About the PR
- chemistry bag changed from 40 slots, small items to 20 max weight, normal items
- large beaker and drink bottles changed to normal size since they hold double what beaker does
- made chemistry bag ginormous since it used to be normal!?

## Why / Balance
chemistry bag was useless for chemists outside of storing pills on a table or something:
- bottles are annoying
- couldnt store beakers which are better than bottles
- it was also slot based and had **40** slots which was fucking insane, 40 pill canisters!!!

since its just weight based you can decide to have 5 large beakers of main meds or a few small beakers as well for variety, mixed in with a few pills with combat juice or something

still cant store jugs since it would be a bit crazy

## Technical details
no

## Media
![00:46:09](https://github.com/space-wizards/space-station-14/assets/39013340/d63c304d-d9cc-4e81-ba63-b3378c35c276)

cant put chemistry bag in bag
![00:46:17](https://github.com/space-wizards/space-station-14/assets/39013340/1422f5ae-75c6-4c48-a38b-7685342214e2)

adjusted beaker box size to fit big boys
![15:18:22](https://github.com/space-wizards/space-station-14/assets/39013340/105e1963-01ca-42b2-8f4a-77a8c9e1d2de)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Chemistry bags had their storage rebalanced and can now hold beakers.
