### PR TITLE
Wintercoats container max size fixed

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -11,7 +11,7 @@
   - type: TemperatureProtection
     coefficient: 0.1
   - type: Item
-    size: Small
+    size: Normal
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
Wintercoats' containers could only fit tiny items. To make them work like lab coats they can now fit small items.

Why:
As a CMO you can carry your stamp, hypo and door remote on your coat, HoP is given a wintercoat in their locker, but if it's maxsize is tiny they can't carry their door remote or access configurator in it, only the stamp.

As a result all wintercoats are now Normal sized like the lab coats. I think not being able to fit a whole coat in your pocket makes sense.

![image](https://github.com/space-wizards/space-station-14/assets/86210200/a80e5482-319b-48a2-9dd5-49e5eb7dcd29)
