### PR TITLE
hide medibot messages from chat and logs

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/SpeakOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/SpeakOperator.cs
@@ -9,6 +9,12 @@ public sealed partial class SpeakOperator : HTNOperator
     [DataField("speech", required: true)]
     public string Speech = string.Empty;
 
+    /// <summary>
+    /// Whether to hide message from chat window and logs.
+    /// </summary>
+    [DataField]
+    public bool Hidden;
+
     public override void Initialize(IEntitySystemManager sysManager)
     {
         base.Initialize(sysManager);
@@ -19,7 +25,7 @@ public sealed partial class SpeakOperator : HTNOperator
     {
         var speaker = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
 
-        _chat.TrySendInGameICMessage(speaker, Loc.GetString(Speech), InGameICChatType.Speak, false);
+        _chat.TrySendInGameICMessage(speaker, Loc.GetString(Speech), InGameICChatType.Speak, hideChat: Hidden, hideLog: Hidden);
         return base.Update(blackboard, frameTime);
     }
 }

--- a/Resources/Prototypes/NPCs/medibot.yml
+++ b/Resources/Prototypes/NPCs/medibot.yml
@@ -21,6 +21,7 @@
         - !type:HTNPrimitiveTask
           operator: !type:SpeakOperator
             speech: medibot-start-inject
+            hidden: true
 
         - !type:HTNPrimitiveTask
           operator: !type:MoveToOperator


### PR DESCRIPTION
## About the PR
fixes underlying issue of #21454

## Why / Balance
bad

## Technical details
added `Hidden` bool to SpeechOperator (default: false) which hides messages in chat and logs
medibot Hold still, please. spam was being logged real???

## Media
![20:44:38](https://github.com/space-wizards/space-station-14/assets/39013340/94143806-74d9-4c62-bf5b-2a4b134e8559)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun