### PR TITLE
make cleanbot anchorable

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -300,6 +300,7 @@
     baseWalkSpeed: 2
     baseSprintSpeed: 3
   - type: NoSlip
+  - type: Anchorable
   - type: HTN
     rootTask:
       task: CleanbotCompound


### PR DESCRIPTION
## About the PR
title

## Why / Balance
so science can more effectively force cleanbots to do their bidding

## Technical details
no

## Media

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Cleanbots can now be anchored in places you expect to get messy.
