### PR TITLE
Microreactor power cell research

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -19,6 +19,7 @@ research-technology-advanced-atmospherics = Advanced Atmospherics
 research-technology-advanced-tools = Advanced Tools
 research-technology-super-powercells = Super Powercells
 research-technology-bluespace-storage = Bluespace Storage
+research-technology-portable-fission = Portable Fission
 
 research-technology-chemistry = Chemistry
 research-technology-surgical-tools = Surgical Tools

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -208,25 +208,41 @@
     startingCharge: 0
 
 - type: entity
-  name: small microreactor cell
-  description: A rechargeable standardized microreactor cell. Intended for low-power devices, it slowly recharges by itself.
-  id: PowerCellMicroreactor
-  suffix: Full
   parent: BasePowerCell
+  id: PowerCellMicroreactor
+  name: microreactor power cell
+  description: A rechargeable standardized microreactor cell. Has lower capacity but slowly recharges by itself.
+  suffix: Full
   components:
-    - type: Sprite
-      layers:
-      - map: [ "enum.PowerCellVisualLayers.Base" ]
-        state: microreactor
-      - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
-        state: o2
-        shader: unshaded
-    - type: Battery
-      maxCharge: 50
-      startingCharge: 50
-    - type: BatterySelfRecharger
-      autoRecharge: true
-      autoRechargeRate: 0.16667 #takes about 5 minutes to charge itself back to full
+  - type: Sprite
+    layers:
+    - map: [ "enum.PowerCellVisualLayers.Base" ]
+      state: microreactor
+    - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+      state: o2
+      shader: unshaded
+  - type: Battery
+    maxCharge: 720
+    startingCharge: 720
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 12 # takes 1 minute to charge itself back to full
+
+- type: entity
+  parent: PowerCellMicroreactor
+  id: PowerCellMicroreactorPrinted
+  suffix: Empty
+  components:
+  - type: Sprite
+    layers:
+    - map: [ "enum.PowerCellVisualLayers.Base" ]
+      state: microreactor
+    - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+      state: o2
+      shader: unshaded
+      visible: false
+  - type: Battery
+    startingCharge: 0
 
 - type: entity
   name: antique power cell prototype

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -249,6 +249,7 @@
       - VoiceTrigger
       - Igniter
       - PowerCellMedium
+      - PowerCellMicroreactor
       - PowerCellHigh
       - WeaponPistolCHIMP
       - SynthesizerInstrument

--- a/Resources/Prototypes/Recipes/Lathes/powercells.yml
+++ b/Resources/Prototypes/Recipes/Lathes/powercells.yml
@@ -25,3 +25,13 @@
     Glass: 400
     Plastic: 200
     Gold: 50
+
+- type: latheRecipe
+  id: PowerCellMicroreactor
+  result: PowerCellMicroreactorPrinted
+  completetime: 10
+  materials:
+    Steel: 500
+    Glass: 400
+    Uranium: 200
+    Gold: 100

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -208,3 +208,17 @@
   - ClothingBackpackHolding
   - ClothingBackpackSatchelHolding
   - ClothingBackpackDuffelHolding
+
+- type: technology
+  id: PortableFission
+  name: research-technology-portable-fission
+  icon:
+    sprite: Objects/Power/power_cells.rsi
+    state: microreactor
+  discipline: Industrial
+  tier: 3
+  cost: 10000
+  recipeUnlocks:
+  - PowerCellMicroreactor
+  technologyPrerequisites:
+  - SuperPowercells


### PR DESCRIPTION
## About the PR
- made microreactor good (medium powercell that recharges itself in 1 minute)
- added t3 research to make it

## Why / Balance
- microreactor was previously unused
- science equivalent of salv finding an antique powercell, its worse overall but can be mass produced which is good especially for med since if salv gets one they are just gonna put it in a floodlight but sci can put microreactors in every defib and scanner :trollface:

## Technical details
no

## Media
the tech
![22:27:15](https://github.com/space-wizards/space-station-14/assets/39013340/9cd3bc28-4d5d-477a-96aa-2a67b09f4212)

the recipe
![22:24:05](https://github.com/space-wizards/space-station-14/assets/39013340/0f1caff6-5d5a-4678-8b09-7596c288ebdd)

the battery
![22:25:29](https://github.com/space-wizards/space-station-14/assets/39013340/13e358b0-43f2-427d-b58e-bcab1b65fbda)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Microreactor powercells can be researched under the Tier 3 Portable Fission technology, they slowly recharge on their own.
