### PR TITLE
buff ore bag a bit

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -16,7 +16,7 @@
   - type: Item
     size: Ginormous
   - type: Storage
-    maxSlots: 10
+    maxSlots: 14
     maxItemSize: Normal
     quickInsert: true
     areaInsert: true


### PR DESCRIPTION
## About the PR
10 -> 14 slots

## Why / Balance
since arti fragments dont stack you can very easily fill a bag with just 10 fragments which is annoying
now you have a little more room to fill it with ore first

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Ore bags have 4 more slots now.
