### PR TITLE
Remove need to toggle vending machine button

### DIFF
--- a/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml
+++ b/Content.Client/VendingMachines/UI/VendingMachineMenu.xaml
@@ -1,9 +1,10 @@
-﻿<DefaultWindow xmlns="https://spacestation14.io">
+<DefaultWindow xmlns="https://spacestation14.io">
     <BoxContainer Orientation="Vertical">
         <LineEdit Name="SearchBar" PlaceHolder="{Loc 'vending-machine-component-search-filter'}" HorizontalExpand="True"  Margin ="0 4" Access="Public"/>
         <ItemList Name="VendingContents"
                   SizeFlagsStretchRatio="8"
-                  VerticalExpand="True">
+                  VerticalExpand="True"
+                  SelectMode="Button">
         </ItemList>
     </BoxContainer>
 </DefaultWindow>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Removes the need to toggle off a vending machine button in order to dispense again.

Closes #15718 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

QOL - fewer clicks to dispense multiple items

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
### **Before**
![before](https://github.com/space-wizards/space-station-14/assets/89101928/d9df518c-5592-46c9-be9f-d37177bec42a)
### **After**
![after](https://github.com/space-wizards/space-station-14/assets/89101928/b4044e0f-0416-4504-a068-0d981d17d82a)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Reduced clicks needed to dispense vending machine items
