### PR TITLE
Minor Borg Qol

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -79,10 +79,13 @@
   - type: IntrinsicRadioTransmitter
     channels:
     - Binary
+    - Common
+    - Science
   - type: ActiveRadio
     channels:
     - Binary
     - Common
+    - Science
   - type: ZombieImmune
   - type: Repairable
     doAfterDelay: 10
@@ -135,7 +138,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 75
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -144,7 +147,7 @@
             volume: 5
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 150
       behaviors:
       - !type:PlaySoundBehavior
         sound: /Audio/Effects/metalbreak.ogg
@@ -152,6 +155,7 @@
         containers:
         - borg_brain
         - borg_module
+        - cell_slot
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: HandheldLight

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -19,6 +19,7 @@
       path: /Audio/Effects/hit_kick.ogg
   - type: Clickable
   - type: CombatMode
+  - type: NoSlip
   - type: StaticPrice
     price: 1250
   - type: InteractionOutline
@@ -210,3 +211,7 @@
     enabled: false
     groups:
     - AllAccess
+  - type: Lock
+    locked: true
+  - type: AccessReader
+    access: [["Command"], ["Research"]]

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -49,7 +49,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead
+      150: Dead
     stateAlertDict:
       Alive: BorgHealth
     showOverlays: false

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -14,7 +14,7 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    maxModules: 5
+    maxModules: 6
     moduleWhitelist:
       tags:
       - BorgModuleGeneric

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -251,4 +251,4 @@
   - type: ContainerFill
     containers:
       borg_module:
-      - BorgModuleMusique
+      - BorgModuleService

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -63,6 +63,8 @@
     - Binary
     - Common
     - Science
+  - type: AccessReader
+    access: [["Cargo"], ["Salvage"], ["Command"], ["Research"]]
 
 - type: entity
   id: BorgChassisEngineer
@@ -102,6 +104,8 @@
     - Binary
     - Common
     - Science
+  - type: AccessReader
+    access: [["Engineering"], ["Command"], ["Research"]]
 
 - type: entity
   id: BorgChassisJanitor
@@ -141,6 +145,8 @@
     - Binary
     - Common
     - Science
+  - type: AccessReader
+    access: [["Service"], ["Command"], ["Research"]]
 
 - type: entity
   id: BorgChassisMedical
@@ -180,6 +186,8 @@
     - Binary
     - Common
     - Science
+  - type: AccessReader
+    access: [["Medical"], ["Command"], ["Research"]]
 
 - type: entity
   id: BorgChassisService
@@ -219,3 +227,6 @@
     - Binary
     - Common
     - Science
+  - type: AccessReader
+    access: [["Service"], ["Command"], ["Research"]]
+

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -42,7 +42,7 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    maxModules: 3
+    maxModules: 4
     moduleWhitelist:
       tags:
       - BorgModuleGeneric
@@ -51,6 +51,18 @@
     noMindState: miner_e_r
   - type: Construction
     node: mining
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Supply
+    - Binary
+    - Common
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Supply
+    - Binary
+    - Common
+    - Science
 
 - type: entity
   id: BorgChassisEngineer
@@ -69,7 +81,7 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    maxModules: 3
+    maxModules: 4
     moduleWhitelist:
       tags:
       - BorgModuleGeneric
@@ -78,6 +90,18 @@
     noMindState: engineer_e_r
   - type: Construction
     node: engineer
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Engineering
+    - Binary
+    - Common
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Engineering
+    - Binary
+    - Common
+    - Science
 
 - type: entity
   id: BorgChassisJanitor
@@ -96,7 +120,7 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    maxModules: 3
+    maxModules: 4
     moduleWhitelist:
       tags:
       - BorgModuleGeneric
@@ -105,6 +129,18 @@
     noMindState: janitor_e_r
   - type: Construction
     node: janitor
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Service
+    - Binary
+    - Common
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Service
+    - Binary
+    - Common
+    - Science
 
 - type: entity
   id: BorgChassisMedical
@@ -123,7 +159,7 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    maxModules: 3
+    maxModules: 4
     moduleWhitelist:
       tags:
       - BorgModuleGeneric
@@ -132,6 +168,18 @@
     noMindState: medical_e_r
   - type: Construction
     node: medical
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Medical
+    - Binary
+    - Common
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Medical
+    - Binary
+    - Common
+    - Science
 
 - type: entity
   id: BorgChassisService
@@ -150,7 +198,7 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    maxModules: 3
+    maxModules: 4
     moduleWhitelist:
       tags:
       - BorgModuleGeneric
@@ -159,4 +207,15 @@
     noMindState: service_e_r
   - type: Construction
     node: service
-
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Service
+    - Binary
+    - Common
+    - Science
+  - type: ActiveRadio
+    channels:
+    - Service
+    - Binary
+    - Common
+    - Science

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -65,6 +65,11 @@
     - Science
   - type: AccessReader
     access: [["Cargo"], ["Salvage"], ["Command"], ["Research"]]
+  - type: ContainerFill
+    containers:
+      borg_module:
+      - BorgModuleMining
+      - BorgModuleFireExtinguisher
 
 - type: entity
   id: BorgChassisEngineer
@@ -106,6 +111,11 @@
     - Science
   - type: AccessReader
     access: [["Engineering"], ["Command"], ["Research"]]
+  - type: ContainerFill
+    containers:
+      borg_module:
+      - BorgModuleTool
+      - BorgModuleCable
 
 - type: entity
   id: BorgChassisJanitor
@@ -147,6 +157,11 @@
     - Science
   - type: AccessReader
     access: [["Service"], ["Command"], ["Research"]]
+  - type: ContainerFill
+    containers:
+      borg_module:
+      - BorgModuleCleaning
+      - BorgModuleTrashCollection
 
 - type: entity
   id: BorgChassisMedical
@@ -188,6 +203,10 @@
     - Science
   - type: AccessReader
     access: [["Medical"], ["Command"], ["Research"]]
+  - type: ContainerFill
+    containers:
+      borg_module:
+      - BorgModuleTreatment
 
 - type: entity
   id: BorgChassisService
@@ -229,4 +248,7 @@
     - Science
   - type: AccessReader
     access: [["Service"], ["Command"], ["Research"]]
-
+  - type: ContainerFill
+    containers:
+      borg_module:
+      - BorgModuleMusique

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -411,7 +411,7 @@
     - BooksBag
     - HandLabeler
     - Lighter
-    - Shaker
+    - DrinkShaker
 
 - type: entity
   id: BorgModuleMusique

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -153,7 +153,7 @@
     - Screwdriver
     - Wirecutter
     - Multitool
-    - WelderMini
+    - Welder
 
 # cargo modules
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -397,9 +397,9 @@
 
 # service modules
 - type: entity
-  id: BorgModuleLiteracy
+  id: BorgModuleService
   parent: [ BaseBorgModuleService, BaseProviderBorgModule ]
-  name: literacy cyborg module
+  name: service cyborg module
   components:
   - type: Sprite
     layers:
@@ -472,5 +472,4 @@
     items:
     - BikeHorn
     - ClownRecorder
-    - CrayonRainbow
     - BikeHornInstrument

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -152,6 +152,8 @@
     - Wrench
     - Screwdriver
     - Wirecutter
+    - Multitool
+    - WelderMini
 
 # cargo modules
 - type: entity
@@ -179,7 +181,9 @@
   - type: ItemBorgModule
     items:
     - MiningDrill
+    - Shovel
     - OreBag
+    - Crowbar
 
 - type: entity
   id: BorgModuleGrapplingGun
@@ -193,6 +197,7 @@
   - type: ItemBorgModule
     items:
     - WeaponGrapplingGun
+    - WeaponCrusherDagger
 
 # engineering modules
 - type: entity
@@ -222,6 +227,9 @@
   - type: ItemBorgModule
     items:
     - GasAnalyzer
+    - trayScanner
+    - Crowbar
+    - Wrench
 
 - type: entity
   id: BorgModuleConstruction
@@ -264,6 +272,8 @@
   - type: ItemBorgModule
     items:
     - LightReplacer
+    - Crowbar
+    - Screwdriver
 
 - type: entity
   id: BorgModuleCleaning
@@ -279,6 +289,7 @@
     - MopItem
     - Bucket
     - Holoprojector
+    - SprayBottleSpaceCleaner
 
 - type: entity
   id: BorgModuleTrashCollection
@@ -291,7 +302,7 @@
     - state: icon-trash-bag
   - type: ItemBorgModule
     items:
-    - TrashBag
+    - TrashBagBlue
 
 # medical modules
 - type: entity
@@ -324,6 +335,7 @@
     - Gauze10Lingering
     - Bloodpack10Lingering
     - Syringe
+    - Dropper
 
 - type: entity
   id: BorgModuleDefibrillator
@@ -397,6 +409,9 @@
     items:
     - Pen
     - BooksBag
+    - HandLabeler
+    - Lighter
+    - Shaker
 
 - type: entity
   id: BorgModuleMusique
@@ -410,6 +425,8 @@
   - type: ItemBorgModule
     items:
     - SynthesizerInstrument
+    - ElectricGuitarInstrument
+    - SaxophoneInstrument
 
 - type: entity
   id: BorgModuleGardening
@@ -455,3 +472,5 @@
     items:
     - BikeHorn
     - ClownRecorder
+    - CrayonRainbow
+    - BikeHornInstrument

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -463,7 +463,7 @@
     - BorgModuleGardening
     - BorgModuleHarvesting
     - BorgModuleMusique
-    - BorgModuleLiteracy
+    - BorgModuleService
     - BorgModuleClowning
     - BorgModuleDiagnosis
     - BorgModuleTreatment

--- a/Resources/Prototypes/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/robotics.yml
@@ -323,8 +323,8 @@
   result: BorgModuleCable
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -333,8 +333,8 @@
   result: BorgModuleFireExtinguisher
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -343,8 +343,8 @@
   result: BorgModuleGPS
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -353,8 +353,8 @@
   result: BorgModuleRadiationDetection
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -363,8 +363,8 @@
   result: BorgModuleTool
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -373,8 +373,8 @@
   result: BorgModuleAppraisal
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -383,8 +383,8 @@
   result: BorgModuleMining
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -394,7 +394,7 @@
   completetime: 3
   materials:
     Steel: 500
-    Glass: 750
+    Glass: 500
     Plastic: 250
     Gold: 50
 
@@ -404,7 +404,7 @@
   completetime: 3
   materials:
     Steel: 500
-    Glass: 750
+    Glass: 500
     Plastic: 250
     Gold: 50
 
@@ -414,7 +414,7 @@
   completetime: 3
   materials:
     Steel: 500
-    Glass: 750
+    Glass: 500
     Plastic: 250
     Gold: 50
 
@@ -423,8 +423,8 @@
   result: BorgModuleGasAnalyzer
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -434,7 +434,7 @@
   completetime: 3
   materials:
     Steel: 500
-    Glass: 750
+    Glass: 500
     Plastic: 250
     Gold: 50
 
@@ -443,8 +443,8 @@
   result: BorgModuleLightReplacer
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -453,8 +453,8 @@
   result: BorgModuleCleaning
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -463,8 +463,8 @@
   result: BorgModuleTrashCollection
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -473,8 +473,8 @@
   result: BorgModuleDiagnosis
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -483,8 +483,8 @@
   result: BorgModuleTreatment
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -494,7 +494,7 @@
   completetime: 3
   materials:
     Steel: 500
-    Glass: 750
+    Glass: 500
     Plastic: 250
     Gold: 50
 
@@ -504,7 +504,7 @@
   completetime: 3
   materials:
     Steel: 500
-    Glass: 750
+    Glass: 500
     Plastic: 250
     Gold: 50
 
@@ -513,8 +513,8 @@
   result: BorgModuleArtifact
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -523,18 +523,18 @@
   result: BorgModuleAnomaly
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
 - type: latheRecipe
-  id: BorgModuleLiteracy
-  result: BorgModuleLiteracy
+  id: BorgModuleService
+  result: BorgModuleService
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -543,8 +543,8 @@
   result: BorgModuleMusique
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -553,8 +553,8 @@
   result: BorgModuleGardening
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -563,8 +563,8 @@
   result: BorgModuleHarvesting
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50
 
@@ -573,7 +573,7 @@
   result: BorgModuleClowning
   completetime: 3
   materials:
-    Steel: 500
-    Glass: 750
+    Steel: 250
+    Glass: 250
     Plastic: 250
     Gold: 50

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -110,7 +110,7 @@
     - ComputerTelevisionCircuitboard
     - SynthesizerInstrument
     - BorgModuleMusique
-    - BorgModuleLiteracy
+    - BorgModuleService
     - BorgModuleClowning
     - DawInstrumentMachineCircuitboard
     - MassMediaCircuitboard


### PR DESCRIPTION
planning on doing more stuff later but wanted to do some easy qol stuff for them since they are bloopy
basically:
-they cant slip anymore
-they all have intrinsic radio for common,sci,binary and can also hear/speak on cooresponding dept radio (restricting their radio access just makes it a bit boring)
-they can be locked by people with access so tiders cant pull their brains out 
-they are 50% tankier since they are very squishy atm
-department specific borgs start with basic kits for their departments so they arent left hanging with nothing
-buffed many of the lackluster modules with applicable/qol tools

🆑 
- tweak: Borgs have had a QOL pass, they are access locked now and the department specific ones start with applicable tools.
