### PR TITLE
Fix a replay spectating bug

### DIFF
--- a/Content.Client/Replay/ContentReplayPlaybackManager.cs
+++ b/Content.Client/Replay/ContentReplayPlaybackManager.cs
@@ -40,6 +40,7 @@ public sealed class ContentReplayPlaybackManager
     [Dependency] private readonly IClientConGroupController _conGrp = default!;
     [Dependency] private readonly IClientAdminManager _adminMan = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IBaseClient _client = default!;
 
     /// <summary>
     /// UI state to return to when stopping a replay or loading fails.
@@ -87,6 +88,9 @@ public sealed class ContentReplayPlaybackManager
             _stateMan.RequestStateChange<LauncherConnecting>().SetDisconnected();
         else
             _stateMan.RequestStateChange<MainScreen>();
+
+        if (_client.RunLevel == ClientRunLevel.SinglePlayerGame)
+            _client.StopSinglePlayer();
     }
 
     private void OnCheckpointReset()

--- a/Content.Client/Replay/Spectator/ReplaySpectatorSystem.Movement.cs
+++ b/Content.Client/Replay/Spectator/ReplaySpectatorSystem.Movement.cs
@@ -44,7 +44,7 @@ public sealed partial class ReplaySpectatorSystem
         if (_replayPlayback.Replay == null)
             return;
 
-        if (_player.LocalPlayer?.ControlledEntity is not { } player)
+        if (_player.LocalEntity is not { } player)
             return;
 
         if (Direction == DirectionFlag.None)
@@ -99,7 +99,7 @@ public sealed partial class ReplaySpectatorSystem
         var worldVec = parentRotation.RotateVec(localVec);
         var speed = CompOrNull<MovementSpeedModifierComponent>(player)?.BaseSprintSpeed ?? DefaultSpeed;
         var delta = worldVec * frameTime * speed;
-        _transform.SetWorldPositionRotation(xform, pos + delta, delta.ToWorldAngle());
+        _transform.SetWorldPositionRotation(player, pos + delta, delta.ToWorldAngle(), xform);
     }
 
     private sealed class MoverHandler : InputCmdHandler

--- a/Content.Client/Replay/Spectator/ReplaySpectatorSystem.Spectate.cs
+++ b/Content.Client/Replay/Spectator/ReplaySpectatorSystem.Spectate.cs
@@ -3,6 +3,7 @@ using Content.Client.Replay.UI;
 using Content.Shared.Verbs;
 using Robust.Shared.Console;
 using Robust.Shared.Map;
+using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
 namespace Content.Client.Replay.Spectator;
@@ -15,19 +16,13 @@ public sealed partial class ReplaySpectatorSystem
         if (_replayPlayback.Replay == null)
             return;
 
-        var verb = new AlternativeVerb
+        ev.Verbs.Add(new AlternativeVerb
         {
             Priority = 100,
-            Act = () =>
-            {
-                SpectateEntity(ev.Target);
-            },
-
+            Act = () => SpectateEntity(ev.Target),
             Text = Loc.GetString("replay-verb-spectate"),
             Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/vv.svg.192dpi.png"))
-        };
-
-        ev.Verbs.Add(verb);
+        });
     }
 
     public void SpectateEntity(EntityUid target)
@@ -35,7 +30,7 @@ public sealed partial class ReplaySpectatorSystem
         if (_player.LocalSession == null)
             return;
 
-        var old = _player.LocalSession.AttachedEntity;
+        var old = _player.LocalEntity;
 
         if (old == target)
         {
@@ -44,8 +39,11 @@ public sealed partial class ReplaySpectatorSystem
             return;
         }
 
-        _player.SetAttachedEntity(_player.LocalSession, target);
         EnsureComp<ReplaySpectatorComponent>(target);
+        if (TryComp(target, out ActorComponent? actor))
+            _player.SetLocalSession(actor.PlayerSession);
+        else
+            _player.SetAttachedEntity(_player.LocalSession, target);
 
         _stateMan.RequestStateChange<ReplaySpectateEntityState>();
         if (old == null)
@@ -59,10 +57,9 @@ public sealed partial class ReplaySpectatorSystem
 
     public TransformComponent SpawnSpectatorGhost(EntityCoordinates coords, bool gridAttach)
     {
-        if (_player.LocalSession == null)
-            throw new InvalidOperationException();
-
-        var old = _player.LocalSession.AttachedEntity;
+        var old = _player.LocalEntity;
+        var session = _player.GetSessionById(DefaultUser);
+        _player.SetLocalSession(session);
 
         var ent = Spawn("ReplayObserver", coords);
         _eye.SetMaxZoom(ent, Vector2.One * 5);
@@ -73,7 +70,7 @@ public sealed partial class ReplaySpectatorSystem
         if (gridAttach)
             _transform.AttachToGridOrMap(ent);
 
-        _player.SetAttachedEntity(_player.LocalSession, ent);
+        _player.SetAttachedEntity(session, ent);
 
         if (old != null)
         {

--- a/Content.Client/Replay/Spectator/ReplaySpectatorSystem.cs
+++ b/Content.Client/Replay/Spectator/ReplaySpectatorSystem.cs
@@ -1,11 +1,11 @@
 using Content.Shared.Movement.Systems;
 using Content.Shared.Verbs;
-using Robust.Client;
 using Robust.Client.GameObjects;
 using Robust.Client.Player;
 using Robust.Client.Replays.Playback;
 using Robust.Client.State;
 using Robust.Shared.Console;
+using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization.Markdown.Mapping;
 
@@ -27,12 +27,16 @@ public sealed partial class ReplaySpectatorSystem : EntitySystem
     [Dependency] private readonly IStateManager _stateMan = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly SharedMoverController _mover = default!;
-    [Dependency] private readonly IBaseClient _client = default!;
     [Dependency] private readonly SharedContentEyeSystem _eye = default!;
     [Dependency] private readonly IReplayPlaybackManager _replayPlayback = default!;
 
     private SpectatorData? _spectatorData;
     public const string SpectateCmd = "replay_spectate";
+
+    /// <summary>
+    /// User Id that corresponds to the local user in a single-player game.
+    /// </summary>
+    public static readonly NetUserId DefaultUser = default;
 
     public override void Initialize()
     {
@@ -49,6 +53,7 @@ public sealed partial class ReplaySpectatorSystem : EntitySystem
         _replayPlayback.AfterSetTick += OnAfterSetTick;
         _replayPlayback.ReplayPlaybackStarted += OnPlaybackStarted;
         _replayPlayback.ReplayPlaybackStopped += OnPlaybackStopped;
+        _replayPlayback.BeforeApplyState += OnBeforeApplyState;
     }
 
     public override void Shutdown()
@@ -58,6 +63,7 @@ public sealed partial class ReplaySpectatorSystem : EntitySystem
         _replayPlayback.AfterSetTick -= OnAfterSetTick;
         _replayPlayback.ReplayPlaybackStarted -= OnPlaybackStarted;
         _replayPlayback.ReplayPlaybackStopped -= OnPlaybackStopped;
+        _replayPlayback.BeforeApplyState -= OnBeforeApplyState;
     }
 
     private void OnPlaybackStarted(MappingDataNode yamlMappingNode, List<object> objects)

--- a/Content.Replay/Menu/ReplayMainMenu.cs
+++ b/Content.Replay/Menu/ReplayMainMenu.cs
@@ -47,7 +47,7 @@ public sealed class ReplayMainScreen : State
         _mainMenuControl.QuitButton.OnPressed += QuitButtonPressed;
         _mainMenuControl.OptionsButton.OnPressed += OptionsButtonPressed;
         _mainMenuControl.FolderButton.OnPressed += OnFolderPressed;
-        _mainMenuControl.LoadButton.OnPressed += OnLoadpressed;
+        _mainMenuControl.LoadButton.OnPressed += OnLoadPressed;
 
         _directory = new ResPath(_cfg.GetCVar(CVars.ReplayDirectory)).ToRootedPath();
         RefreshReplays();
@@ -205,7 +205,7 @@ public sealed class ReplayMainScreen : State
         _resMan.UserData.OpenOsWindow(_directory);
     }
 
-    private void OnLoadpressed(BaseButton.ButtonEventArgs obj)
+    private void OnLoadPressed(BaseButton.ButtonEventArgs obj)
     {
         if (_selected.HasValue)
         {

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -647,7 +647,9 @@ public abstract class SharedActionsSystem : EntitySystem
 
         if (action.AttachedEntity != performer)
         {
-            DebugTools.Assert(!Resolve(performer, ref comp, false) || !comp.Actions.Contains(actionId.Value));
+            DebugTools.Assert(!Resolve(performer, ref comp, false)
+                              || comp.LifeStage >= ComponentLifeStage.Stopping
+                              || !comp.Actions.Contains(actionId.Value));
 
             if (!GameTiming.ApplyingState)
                 Log.Error($"Attempted to remove an action {ToPrettyString(actionId)} from an entity that it was never attached to: {ToPrettyString(performer)}");


### PR DESCRIPTION
This fixes the bug where spectating as a player in a replay wouldn't follow the player if the player's attached entity changes. It also fixes some other small bugs & bad debug asserts. 

https://github.com/space-wizards/space-station-14/assets/60421075/15fdb324-8097-4275-9e93-d4d8d70c460d

:cl:
- fix: Fixed spectating a player in a replay not following the spectated player when they become a ghost.
