### PR TITLE
Flammable system bug fixes.

### DIFF
--- a/Content.Server/Atmos/Components/FlammableComponent.cs
+++ b/Content.Server/Atmos/Components/FlammableComponent.cs
@@ -6,16 +6,15 @@ namespace Content.Server.Atmos.Components
     [RegisterComponent]
     public sealed partial class FlammableComponent : Component
     {
-        [ViewVariables]
-        public bool Resisting = false;
-
-        [ViewVariables]
-        public readonly List<EntityUid> Collided = new();
+        [DataField]
+        public bool Resisting;
 
         [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public bool OnFire { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public float FireStacks { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite)]


### PR DESCRIPTION
Fixes #21579, and reworks flammable collision logic a bit. Previously collisions would get processed twice, and the behaviour would differ depending on which entity received the collision event first.

:cl:
- fix: Fixed candle in-hand sprites not updating when the candle is extinguished.
- fix: Fixed flammable object collisions being processed twice. This may affect how fires spread. 