### PR TITLE
Fix implant action icon bug

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -767,11 +767,15 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     private bool OnMenuBeginDrag()
     {
+        // TODO ACTIONS
+        // The dragging icon shuld be based on the entity's icon style. I.e. if the action has a large icon texture,
+        // and a small item/provider sprite, then the dragged icon should be the big texture, not the provider.
         if (_actionsSystem != null && _actionsSystem.TryGetActionData(_menuDragHelper.Dragged?.ActionId, out var action))
         {
-            if (EntityManager.TryGetComponent(action.EntityIcon, out SpriteComponent? sprite))
+            if (EntityManager.TryGetComponent(action.EntityIcon, out SpriteComponent? sprite)
+                && sprite.Icon?.GetFrame(RsiDirection.South, 0) is {} frame)
             {
-                _dragShadow.Texture = sprite.Icon?.GetFrame(RsiDirection.South, 0);
+                _dragShadow.Texture = frame;
             }
             else if (action.Icon != null)
             {

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,15 +1,14 @@
 - type: entity
-  parent: BaseItem
   id: BaseSubdermalImplant
   name: implant
   description: A microscopic chip that's injected under the skin.
   abstract: true
   components:
-    - type: SubdermalImplant
-    - type: Tag
-      tags:
-        - SubdermalImplant
-        - HideContextMenu
+  - type: SubdermalImplant
+  - type: Tag
+    tags:
+    - SubdermalImplant
+    - HideContextMenu
 
 #Fun implants
 


### PR DESCRIPTION
Fixes #21569. The action drag icon was being pulled from the implant's sprite, which had no layers.
This just removes BaseItem as the parent of all implant entities. As far as I know, none of them rely on any of those components.


https://github.com/space-wizards/space-station-14/assets/60421075/7014a328-b6f1-4136-8318-f46dfd62ecb8



:cl:
- fix: Fixed being unable to re-add the storage implant action to the actions bar once it has been removed.
