### PR TITLE
Add item sprite test

### DIFF
--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -426,25 +426,6 @@ we are just going to end this here to save a lot of time. This is the exception 
     }
 
     /// <summary>
-    ///     Helper method that retrieves all entity prototypes that have some component.
-    /// </summary>
-    public static List<EntityPrototype> GetPrototypesWithComponent<T>(RobustIntegrationTest.IntegrationInstance instance) where T : IComponent
-    {
-        var protoMan = instance.ResolveDependency<IPrototypeManager>();
-        var compFact = instance.ResolveDependency<IComponentFactory>();
-
-        var id = compFact.GetComponentName(typeof(T));
-        var list = new List<EntityPrototype>();
-        foreach (var ent in protoMan.EnumeratePrototypes<EntityPrototype>())
-        {
-            if (ent.Components.ContainsKey(id))
-                list.Add(ent);
-        }
-
-        return list;
-    }
-
-    /// <summary>
     /// Initialize the pool manager.
     /// </summary>
     /// <param name="assembly">Assembly to search for to discover extra test prototypes.</param>

--- a/Content.IntegrationTests/Tests/Sprite/ItemSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/Sprite/ItemSpriteTest.cs
@@ -9,7 +9,8 @@ namespace Content.IntegrationTests.Tests.Sprite;
 
 /// <summary>
 /// This test checks that all items have a visible sprite. The general rationale is that all items can be picked up
-/// by players, thus they need to be visible and have a sprite that can be rendered on screen and in their hand slot.
+/// by players, thus they need to be visible and have a sprite that can be rendered on screen and in their hands GUI.
+/// This has nothing to do with in-hand sprites.
 /// </summary>
 /// <remarks>
 /// If a prototype fails this test, its probably either because it:

--- a/Content.IntegrationTests/Tests/Sprite/ItemSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/Sprite/ItemSpriteTest.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System.Collections.Generic;
+using Content.Shared.Item;
+using Robust.Client.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Sprite;
+
+/// <summary>
+/// This test checks that all items have a visible sprite. The general rationale is that all items can be picked up
+/// by players, thus they need to be visible and have a sprite that can be rendered on screen and in their hand slot.
+/// </summary>
+/// <remarks>
+/// If a prototype fails this test, its probably either because it:
+/// - Should be marked abstract
+/// - inherits from BaseItem despite not being an item
+/// - Shouldn't have an item component
+/// - Is missing the required sprite information.
+/// If none of the abveo are true, it might need to be added to the list of ignored components, see
+/// <see cref="_ignored"/>
+/// </remarks>
+[TestFixture]
+public sealed class PrototypeSaveTest
+{
+    private static HashSet<string> _ignored = new()
+    {
+        // The only prototypes that should get ignored are those that REQUIRE setup to get a sprite. At that point it is
+        // the responsibility of the spawner to ensure that a valid sprite is set.
+        "HandVirtualItem"
+    };
+
+    [Test]
+    public async Task AllItemsHaveSpritesTest()
+    {
+        var settings = new PoolSettings() {Connected = true}; // client needs to be in-game
+        await using var pair = await PoolManager.GetServerClient(settings);
+        List<EntityPrototype> badPrototypes = new();
+
+        await pair.Client.WaitPost(() =>
+        {
+            foreach (var proto in pair.GetPrototypesWithComponent<ItemComponent>(_ignored))
+            {
+                var dummy = pair.Client.EntMan.Spawn(proto.ID);
+                pair.Client.EntMan.RunMapInit(dummy, pair.Client.MetaData(dummy));
+                var spriteComponent = pair.Client.EntMan.GetComponentOrNull<SpriteComponent>(dummy);
+                if (spriteComponent?.Icon == null)
+                    badPrototypes.Add(proto);
+                pair.Client.EntMan.DeleteEntity(dummy);
+            }
+        });
+
+        Assert.Multiple(() =>
+        {
+            foreach (var proto in badPrototypes)
+            {
+                Assert.Fail($"Item prototype has no sprite: {proto.ID}. It should probably either be marked as abstract, not be an item, or have a valid sprite");
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/StorageTest.cs
+++ b/Content.IntegrationTests/Tests/StorageTest.cs
@@ -94,7 +94,7 @@ namespace Content.IntegrationTests.Tests
 
             Assert.Multiple(() =>
             {
-                foreach (var proto in PoolManager.GetPrototypesWithComponent<StorageFillComponent>(server))
+                foreach (var proto in pair.GetPrototypesWithComponent<StorageFillComponent>())
                 {
                     if (proto.HasComponent<EntityStorageComponent>(compFact))
                         continue;
@@ -174,7 +174,7 @@ namespace Content.IntegrationTests.Tests
 
             Assert.Multiple(() =>
             {
-                foreach (var proto in PoolManager.GetPrototypesWithComponent<StorageFillComponent>(server))
+                foreach (var proto in pair.GetPrototypesWithComponent<StorageFillComponent>())
                 {
                     if (proto.HasComponent<StorageComponent>(compFact))
                         continue;

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -23,6 +23,7 @@
   id: BaseTorso
   name: "torso"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Torso
@@ -31,6 +32,7 @@
   id: BaseHead
   name: "head"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Head
@@ -45,6 +47,7 @@
   id: BaseLeftArm
   name: "left arm"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Arm
@@ -54,6 +57,7 @@
   id: BaseRightArm
   name: "right arm"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Arm
@@ -63,6 +67,7 @@
   id: BaseLeftHand
   name: "left hand"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Hand
@@ -72,6 +77,7 @@
   id: BaseRightHand
   name: "right hand"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Hand
@@ -81,6 +87,7 @@
   id: BaseLeftLeg
   name: "left leg"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Leg
@@ -91,6 +98,7 @@
   id: BaseRightLeg
   name: "right leg"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Leg
@@ -101,6 +109,7 @@
   id: BaseLeftFoot
   name: "left foot"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Foot
@@ -110,6 +119,7 @@
   id: BaseRightFoot
   name: "right foot"
   parent: BasePart
+  abstract: true
   components:
   - type: BodyPart
     partType: Foot

--- a/Resources/Prototypes/Body/Parts/rat.yml
+++ b/Resources/Prototypes/Body/Parts/rat.yml
@@ -13,3 +13,8 @@
   - type: Tag
     tags:
       - Trash
+  # TODO get a proper rat king & servant torso sprite.
+  # currently their torso is just a small dead rat....
+  - type: Sprite
+    sprite: Mobs/Animals/mouse.rsi
+    state: splat-0

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -443,6 +443,7 @@
   parent: BaseItem
   id: FoodPacketTrash
   description: This is rubbish.
+  abstract: true
   components:
   - type: Sprite
     sprite: Objects/Consumable/Food/snacks.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -3,7 +3,7 @@
   id: IDCardStandard
   name: identification card
   description: A card necessary to access various areas aboard the station.
-  noSpawn: true
+  abstract: true
   components:
   - type: Sprite
     sprite: Objects/Misc/id_cards.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,5 +1,4 @@
 - type: entity
-  parent: BaseItem
   id: BaseSubdermalImplant
   name: implant
   description: A microscopic chip that's injected under the skin.
@@ -118,8 +117,6 @@
       whitelist:
         components:
         - Hands # no use giving a mouse a storage implant, but a monkey is another story...
-    - type: Item
-      size: Ginormous
     - type: Storage
       maxSlots: 4
       maxItemSize: Small

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -4,7 +4,7 @@
 
 - type: entity
   id: CableStack
-  noSpawn: true
+  abstract: true
   parent: BaseItem
   name: cable stack
   suffix: Full


### PR DESCRIPTION
This adds a test that checks that all entity prototypes with an item component have a valid sprite. I.e., all entities that can be picked up should be visible and have some icon that appears in the hands GUI. This has nothing to do with in-hand sprites.

Fixes #21598

