### PR TITLE
egg rework

### DIFF
--- a/Content.Server/Construction/Completions/DamageEntity.cs
+++ b/Content.Server/Construction/Completions/DamageEntity.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Construction;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+
+namespace Content.Server.Construction.Completions;
+
+/// <summary>
+/// Damage the entity on step completion.
+/// </summary>
+[DataDefinition]
+public sealed partial class DamageEntity : IGraphAction
+{
+    /// <summary>
+    /// Damage to deal to the entity.
+    /// </summary>
+    [DataField]
+    public DamageSpecifier Damage;
+
+    public void PerformAction(EntityUid uid, EntityUid? userUid, IEntityManager entityManager)
+    {
+        entityManager.System<DamageableSystem>().TryChangeDamage(uid, Damage, origin: userUid);
+    }
+}

--- a/Resources/Locale/en-US/flavors/flavor-profiles.ftl
+++ b/Resources/Locale/en-US/flavors/flavor-profiles.ftl
@@ -71,6 +71,7 @@ flavor-complex-bread = like bread
 flavor-complex-batter = like batter
 flavor-complex-butter = like butter
 flavor-complex-egg = like egg
+flavor-complex-raw-egg = like raw egg
 flavor-complex-bacon = like bacon
 flavor-complex-chicken = like chicken
 flavor-complex-duck = like duck

--- a/Resources/Locale/en-US/reagents/meta/consumable/food/ingredients.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/food/ingredients.ftl
@@ -11,7 +11,10 @@ reagent-name-enzyme = universal enzyme
 reagent-desc-enzyme = Used in cooking various dishes.
 
 reagent-name-egg = egg
-reagent-desc-egg = Used for baking.
+reagent-desc-egg = Cooked chicken embryo, delicious.
+
+reagent-name-raw-egg = raw egg
+reagent-desc-raw-egg = Used for baking.
 
 reagent-name-sugar = sugar
 reagent-desc-sugar = Tasty spacey sugar!

--- a/Resources/Locale/en-US/reagents/meta/physical-desc.ftl
+++ b/Resources/Locale/en-US/reagents/meta/physical-desc.ftl
@@ -89,3 +89,4 @@ reagent-physical-desc-exotic-smelling = exotic smelling
 reagent-physical-desc-energizing = energizing
 reagent-physical-desc-exhilarating = exhilarating
 reagent-physical-desc-vibrant = vibrant
+reagent-physical-desc-fluffy = fluffy

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -56,6 +56,16 @@
           # Wow double-yolk you're so lucky!
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  # all below are for egg cooking/exploding
+  - type: AtmosExposed
+  - type: Temperature
+    currentTemperature: 290
+  - type: InternalTemperature
+    # ~1mm shell and ~1cm of albumen
+    thickness: 0.011
+    area: 0.04
+    # conductivity of egg shell based on a paper from Romanoff and Romanoff (1949)
+    conductivity: 0.456
 
 # Splat
 - type: entity
@@ -91,7 +101,6 @@
   name: egg
   components:
   - type: Sprite
-    sprite: Objects/Consumable/Food/egg.rsi
     layers:
       - state: icon
         map: [ "enum.DamageStateVisualLayers.Base" ]
@@ -101,3 +110,30 @@
           icon: ""
       - enum.DamageStateVisualLayers.Base:
           white: ""
+  - type: Construction
+    graph: Egg
+    node: start
+
+- type: entity
+  parent: FoodEggBase
+  id: FoodEggBoiled
+  name: boiled egg
+  description: A delicious hardboiled egg.
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      map: [ "enum.DamageStateVisualLayers.Base" ]
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 6
+        reagents:
+        - ReagentId: EggCooked
+          Quantity: 6
+  - type: Temperature
+    # preserve temperature from the boiling step
+    currentTemperature: 344
+  - type: Construction
+    graph: Egg
+    node: boiled

--- a/Resources/Prototypes/Flavors/flavors.yml
+++ b/Resources/Prototypes/Flavors/flavors.yml
@@ -230,6 +230,11 @@
   description: flavor-complex-egg
 
 - type: flavor
+  id: raw-egg
+  flavorType: Complex
+  description: flavor-complex-raw-egg
+
+- type: flavor
   id: bacon
   flavorType: Complex
   description: flavor-complex-bacon

--- a/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
@@ -65,10 +65,26 @@
 
 - type: reagent
   id: Egg
+  name: reagent-name-raw-egg
+  group: Foods
+  desc: reagent-desc-raw-egg
+  physicalDesc: reagent-physical-desc-mucus-like
+  flavor: raw-egg
+  color: white
+  recognizable: true
+  metabolisms:
+    Food:
+      effects:
+      - !type:AdjustReagent
+        reagent: UncookedAnimalProteins
+        amount: 0.5
+
+- type: reagent
+  id: EggCooked
   name: reagent-name-egg
   group: Foods
   desc: reagent-desc-egg
-  physicalDesc: reagent-physical-desc-mucus-like
+  physicalDesc: reagent-physical-desc-fluffy
   flavor: egg
   color: white
   recognizable: true
@@ -77,7 +93,7 @@
       effects:
       - !type:AdjustReagent
         reagent: Protein
-        amount: 0.5
+        amount: 1
 
 - type: reagent
   id: Blackpepper

--- a/Resources/Prototypes/Recipes/Construction/Graphs/food/egg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/food/egg.yml
@@ -1,0 +1,22 @@
+# egg explodes when heated!!!
+- type: constructionGraph
+  id: Egg
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: boiled
+      steps:
+      - minTemperature: 344
+  - node: boiled
+    entity: FoodEggBoiled
+    edges:
+    - to: explode
+      completed:
+      - !type:DamageEntity
+        damage:
+          Blunt: 10
+      steps:
+      # egg explodes some time after the water in it boils and increases pressure, guessing ~110C
+      - minTemperature: 383
+  - node: explode

--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -9,6 +9,16 @@
     Protein: 0.5
 
 - type: reaction
+  id: EggCooking
+  impact: Low
+  minTemp: 344
+  reactants:
+    Egg:
+      amount: 0.5
+  products:
+    EggCooked: 0.5
+
+- type: reaction
   id: BloodToWine
   impact: Low
   requiredMixerCategories:


### PR DESCRIPTION
## About the PR
- made raw egg turn into uncooked protein when eaten
- raw egg can be heated to become cooked egg which becomes cooked protein when eaten
- eggs can be heated in a plasma fire / on a grill / in a microwave to boil then and eventually explode if the internal pressure is too high (conductivity of eggshell has a cited paper)

frying pan and egg frying when :trollface:

## Why / Balance
eating raw egg can make you puke :trollface:
cooking egg now makes it twice as yummy as before
eggs eggs eggs eggs eggs

## Technical details
added `DamageEntity` construction completion thing for egg to explode

## Media
raw egg
![10:20:59](https://github.com/space-wizards/space-station-14/assets/39013340/a7b17acb-15c3-480c-9bab-d82d9dd7ab56)

egg cooked in a hotplate
![10:20:44](https://github.com/space-wizards/space-station-14/assets/39013340/d125fa76-dd61-47ac-b2e9-5325bb67fc5c)

egg boiling and exploding also work trust

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Raw eggs are no longer safe to eat, you have to make a dish or boil them first.