### PR TITLE
Makes syndicate stealth effective even against players wearing sechud or any hud

### DIFF
--- a/Content.Client/Overlays/ShowHungerIconsSystem.cs
+++ b/Content.Client/Overlays/ShowHungerIconsSystem.cs
@@ -19,7 +19,7 @@ public sealed class ShowHungerIconsSystem : EquipmentHudSystem<ShowHungerIconsCo
 
     private void OnGetStatusIconsEvent(EntityUid uid, HungerComponent hungerComponent, ref GetStatusIconsEvent args)
     {
-        if (!IsActive || args.InContainer)
+        if (!IsActive || args.InContainer || args.HasStealthComponent)
             return;
 
         var healthIcons = DecideHungerIcon(uid, hungerComponent);

--- a/Content.Client/Overlays/ShowSecurityIconsSystem.cs
+++ b/Content.Client/Overlays/ShowSecurityIconsSystem.cs
@@ -24,7 +24,7 @@ public sealed class ShowSecurityIconsSystem : EquipmentHudSystem<ShowSecurityIco
 
     private void OnGetStatusIconsEvent(EntityUid uid, StatusIconComponent _, ref GetStatusIconsEvent @event)
     {
-        if (!IsActive || @event.InContainer)
+        if (!IsActive || @event.InContainer || @event.HasStealthComponent)
         {
             return;
         }

--- a/Content.Client/Overlays/ShowThirstIconsSystem.cs
+++ b/Content.Client/Overlays/ShowThirstIconsSystem.cs
@@ -19,7 +19,7 @@ public sealed class ShowThirstIconsSystem : EquipmentHudSystem<ShowThirstIconsCo
 
     private void OnGetStatusIconsEvent(EntityUid uid, ThirstComponent thirstComponent, ref GetStatusIconsEvent args)
     {
-        if (!IsActive || args.InContainer)
+        if (!IsActive || args.InContainer || args.HasStealthComponent)
             return;
 
         var healthIcons = DecideThirstIcon(uid, thirstComponent);

--- a/Content.Client/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Client/SSDIndicator/SSDIndicatorSystem.cs
@@ -26,7 +26,8 @@ public sealed class SSDIndicatorSystem : EntitySystem
     {
         if (!component.IsSSD ||
             !_cfg.GetCVar(CCVars.ICShowSSDIndicator) ||
-            args.InContainer)
+            args.InContainer ||
+            args.HasStealthComponent)
             return;
 
         args.StatusIcons.Add(_prototype.Index<StatusIconPrototype>(component.Icon));

--- a/Content.Client/StatusIcon/StatusIconSystem.cs
+++ b/Content.Client/StatusIcon/StatusIconSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.CCVar;
 using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
+using Content.Shared.Stealth.Components;
 using Robust.Client.Graphics;
 using Robust.Shared.Configuration;
 
@@ -13,6 +14,7 @@ public sealed class StatusIconSystem : SharedStatusIconSystem
 {
     [Dependency] private readonly IConfigurationManager _configuration = default!;
     [Dependency] private readonly IOverlayManager _overlay = default!;
+    [Dependency] private readonly IEntityManager _entManager = default!;
 
     private bool _globalEnabled;
     private bool _localEnabled;
@@ -63,7 +65,8 @@ public sealed class StatusIconSystem : SharedStatusIconSystem
             return list;
 
         var inContainer = (meta.Flags & MetaDataFlags.InContainer) != 0;
-        var ev = new GetStatusIconsEvent(list, inContainer);
+        var hasStealthComponent = _entManager.HasComponent<StealthComponent>(uid);
+        var ev = new GetStatusIconsEvent(list, inContainer, hasStealthComponent);
         RaiseLocalEvent(uid, ref ev);
         return ev.StatusIcons;
     }

--- a/Content.Shared/StatusIcon/Components/StatusIconComponent.cs
+++ b/Content.Shared/StatusIcon/Components/StatusIconComponent.cs
@@ -24,4 +24,4 @@ public sealed partial class StatusIconComponent : Component
 /// </summary>
 /// <param name="StatusIcons"></param>
 [ByRefEvent]
-public record struct GetStatusIconsEvent(List<StatusIconData> StatusIcons, bool InContainer);
+public record struct GetStatusIconsEvent(List<StatusIconData> StatusIcons, bool InContainer, bool HasStealthComponent);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This makes stealth effective against all huds.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It was annoying ninjas could easily be seen by people wearing sec huds or beer goggles.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
It creates a new bool member HasStealthComponent in GetStatusIconsEvent which is used to
pass that state, exactly how InContainer was being done, instead of spreading HasComponent tests all over the place.

It also hides AFK marker when on stealth, making it harder for players to find it before an admin gets to make a ghost role for it or something in case the ninja player suddenly disconnects

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Image with a cloaked space ninja not showing a gray hud icon
![image](https://github.com/space-wizards/space-station-14/assets/472878/708df0e8-1386-47a0-92a1-ea64168318cb)

Images showing behavior prior to this change
![image](https://github.com/space-wizards/space-station-14/assets/472878/2a3ed471-19cc-4f9e-be22-fa076c16e013)
![image](https://github.com/space-wizards/space-station-14/assets/472878/1096d5d9-9aea-47d6-b69f-b6055c113f35)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: rber
- tweak: Syndicate stealth tech now has electronic countermeasures and is effective against NT augmented reality devices.

