### PR TITLE
make explosions affect containers

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -406,6 +406,19 @@ public sealed partial class ExplosionSystem
             _damageableSystem.TryChangeDamage(uid, damage, ignoreResistances: true, damageable: damageable);
         }
 
+        // if it's a container, try to damage all its contents
+        if (_containersQuery.TryGetComponent(uid, out var containers))
+        {
+            foreach (var container in containers.Containers.Values)
+            {
+                foreach (var ent in container.ContainedEntities)
+                {
+                    // setting throw force to 0 to prevent offset items inside containers
+                    ProcessEntity(ent, epicenter, damage, 0f, id, _transformQuery.GetComponent(uid));
+                }
+            }
+        }
+
         // throw
         if (xform != null // null implies anchored
             && !xform.Anchored

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -21,6 +21,7 @@ using Robust.Server.GameStates;
 using Robust.Server.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Configuration;
+using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
@@ -51,6 +52,7 @@ public sealed partial class ExplosionSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
     private EntityQuery<TransformComponent> _transformQuery;
+    private EntityQuery<ContainerManagerComponent> _containersQuery;
     private EntityQuery<DamageableComponent> _damageQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<ProjectileComponent> _projectileQuery;
@@ -104,6 +106,7 @@ public sealed partial class ExplosionSystem : EntitySystem
         InitVisuals();
 
         _transformQuery = GetEntityQuery<TransformComponent>();
+        _containersQuery = GetEntityQuery<ContainerManagerComponent>();
         _damageQuery = GetEntityQuery<DamageableComponent>();
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
         _projectileQuery = GetEntityQuery<ProjectileComponent>();


### PR DESCRIPTION
## About the PR
things you are holding / wearing / storing can be damaged by explosions

indirectly fixes #14070, the unit will survive but you get killed by the nuke

## Why / Balance
- china laking a c-4 bundle is big boom now :trollface:
- allow for pro thieving gloves + ciggie carton + linked c4 + minibomb strat :trollface:
- bombing someone kills their headmouse
- for some forks this also reduces felenids' invincibility, now they are Only immune to weapons

## Technical details
recursively checks containers and has throw force set to 0 to prevent making items unusable after exploding or whatever

im pretty sure its doesnt do anything to actions since they arent damageable

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/eda74a6f-eabf-4d5e-827e-fba39cd69b5c


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Explosions now damage items in containers like backpacks or equipped items.
