### PR TITLE
Reduce space music grid range

### DIFF
--- a/Resources/Prototypes/audio.yml
+++ b/Resources/Prototypes/audio.yml
@@ -203,14 +203,13 @@
   rules:
     - !type:AlwaysTrueRule
 
-# TODO: Need to make sure no grids nearby
 - type: rules
   id: InSpace
   rules:
     - !type:InSpaceRule
     - !type:GridInRangeRule
       inverted: true
-      range: 10
+      range: 1
 
 # TODO
 - type: rules


### PR DESCRIPTION
Don't want it to play if they're on a single spaced tile but 10 is probably overkill.

:cl:
- tweak: Make space ambient music more likely to play by reducing the required space range.