### PR TITLE
Bump expedition timer to 11mins

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1526,7 +1526,7 @@ namespace Content.Shared.CCVar
         /// Duration for missions
         /// </summary>
         public static readonly CVarDef<float>
-            SalvageExpeditionDuration = CVarDef.Create("salvage.expedition_duration", 420f, CVar.REPLICATED);
+            SalvageExpeditionDuration = CVarDef.Create("salvage.expedition_duration", 660f, CVar.REPLICATED);
 
         /// <summary>
         /// Cooldown for missions.


### PR DESCRIPTION
We've had it at like, 18, 12, and 7, I think 7 is too low and 18 is definitely too high.

Ideally:
- 2 minutes to get inside
- 7 or so minutes inside.
- 2 minutes as a buffer to either fulton themselves out or run out if necessary.

:cl:
- tweak: Expedition timer bumped from 7 minutes to 11 minutes.
