### PR TITLE
Fix robusted dionas not being recoverable

### DIFF
--- a/Content.Server/Polymorph/Components/PolymorphableComponent.cs
+++ b/Content.Server/Polymorph/Components/PolymorphableComponent.cs
@@ -13,6 +13,13 @@ namespace Content.Server.Polymorph.Components
         public Dictionary<string, EntityUid>? PolymorphActions = null;
 
         /// <summary>
+        /// Timestamp for when the most recent polymorph ended.
+        /// </summary>
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public TimeSpan? LastPolymorphEnd = null;
+
+        /// <summary>
         /// The polymorphs that the entity starts out being able to do.
         /// </summary>
         [DataField("innatePolymorphs", customTypeSerializer : typeof(PrototypeIdListSerializer<PolymorphPrototype>))]

--- a/Content.Server/Polymorph/Components/PolymorphableComponent.cs
+++ b/Content.Server/Polymorph/Components/PolymorphableComponent.cs
@@ -15,7 +15,6 @@ namespace Content.Server.Polymorph.Components
         /// <summary>
         /// Timestamp for when the most recent polymorph ended.
         /// </summary>
-
         [ViewVariables(VVAccess.ReadOnly)]
         public TimeSpan? LastPolymorphEnd = null;
 

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -189,7 +189,7 @@ namespace Content.Server.Polymorph.Systems
             // last polymorph ended.
             if (TryComp<PolymorphableComponent>(uid, out var polymorphableComponent) &&
                 polymorphableComponent.LastPolymorphEnd != null &&
-                _gameTiming.CurTime <= polymorphableComponent.LastPolymorphEnd + proto.Cooldown)
+                _gameTiming.CurTime < polymorphableComponent.LastPolymorphEnd + proto.Cooldown)
                 return null;
 
             // mostly just for vehicles

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -1,5 +1,4 @@
 using Content.Server.Actions;
-using Content.Server.Destructible;
 using Content.Server.Humanoid;
 using Content.Server.Inventory;
 using Content.Server.Mind.Commands;
@@ -8,6 +7,7 @@ using Content.Server.Polymorph.Components;
 using Content.Shared.Actions;
 using Content.Shared.Buckle;
 using Content.Shared.Damage;
+using Content.Shared.Destructible;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mind;
@@ -61,7 +61,7 @@ namespace Content.Server.Polymorph.Systems
             SubscribeLocalEvent<PolymorphedEntityComponent, BeforeFullyEatenEvent>(OnBeforeFullyEaten);
             SubscribeLocalEvent<PolymorphedEntityComponent, BeforeFullySlicedEvent>(OnBeforeFullySliced);
             SubscribeLocalEvent<PolymorphedEntityComponent, RevertPolymorphActionEvent>(OnRevertPolymorphActionEvent);
-            SubscribeLocalEvent<PolymorphedEntityComponent, DamageThresholdReached>(OnDamageThresholdReached);
+            SubscribeLocalEvent<PolymorphedEntityComponent, DestructionEventArgs>(OnDestruction);
 
             InitializeCollide();
             InitializeMap();
@@ -129,7 +129,7 @@ namespace Content.Server.Polymorph.Systems
         /// It is possible to be polymorphed into an entity that can't "die", but is instead
         /// destroyed. This handler ensures that destruction is treated like death.
         /// </summary>
-        private void OnDamageThresholdReached(EntityUid uid, PolymorphedEntityComponent comp, DamageThresholdReached args)
+        private void OnDestruction(EntityUid uid, PolymorphedEntityComponent comp, DestructionEventArgs args)
         {
             if (!_proto.TryIndex<PolymorphPrototype>(comp.Prototype, out var proto))
             {

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -97,6 +97,15 @@ namespace Content.Shared.Polymorph
 
         [DataField("allowRepeatedMorphs", serverOnly: true)]
         public bool AllowRepeatedMorphs = false;
+
+        /// <summary>
+        /// The amount of time that should pass after this polymorph has ended, before a new one
+        /// can occur.
+        /// </summary>
+
+        [DataField("cooldown", serverOnly: true)]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public TimeSpan Cooldown = TimeSpan.Zero;
     }
 
     public enum PolymorphInventoryChange : byte

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -102,7 +102,6 @@ namespace Content.Shared.Polymorph
         /// The amount of time that should pass after this polymorph has ended, before a new one
         /// can occur.
         /// </summary>
-
         [DataField("cooldown", serverOnly: true)]
         [ViewVariables(VVAccess.ReadWrite)]
         public TimeSpan Cooldown = TimeSpan.Zero;

--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -102,6 +102,7 @@
   transferName: true
   revertOnDeath: true
   inventory: Drop
+  cooldown: 160
 
 # this is the monkey polymorph for artifact.
 - type: polymorph

--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -101,7 +101,7 @@
   forced: true
   transferName: true
   revertOnDeath: true
-
+  inventory: Drop
 
 # this is the monkey polymorph for artifact.
 - type: polymorph


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Diona that have robusted themselves into a tree now drop their items before polymorphing, and can be recovered by chopping down the tree.

## Why / Balance
The polymorph definition for this set `revertOnDeath: true`, but trees do not have a `mobState` that can die so that never worked. Further, this sends all items carried by the diona (including the nuke disk if they are holding it) into the ether leaving them unrecoverable.

## Technical details
- `PolymorphSystem` subscribes to `DamageThresholdReached` to detect imminent destruction and revert the polymorph on destruction if `revertOnDeath` is true. I figured this makes sense since destruction and death are about analogous here. There is a comment on `DamageThresholdReached` that says it's not being used anywhere else, but this is as good a first use as any I suppose.
- To avoid diona immediately turning into a tree again, allowing them to be chopped repeatedly for infinite wood, this adds a configurable cooldown to polymorphs that defaults to zero. For TreeMorph this is set to 160 seconds, enough for 80u of robust harvest to be processed out of their bodies.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/space-wizards/space-station-14/assets/8277780/aeef384b-8620-4329-93db-8b7b3656df8b)


## Breaking changes
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Diona now drop their items when robusted into a tree.
- fix: Diona can be cut free from their robust tree-form.
