### PR TITLE
Fix voice mask popup location

### DIFF
--- a/Content.Server/VoiceMask/VoiceMaskSystem.cs
+++ b/Content.Server/VoiceMask/VoiceMaskSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Chat.Systems;
 using Content.Server.Popups;
 using Content.Shared.Database;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Popups;
 using Content.Shared.Preferences;
 using Content.Shared.VoiceMask;
 using Robust.Server.GameObjects;
@@ -35,7 +36,7 @@ public sealed partial class VoiceMaskSystem : EntitySystem
     {
         if (message.Name.Length > HumanoidCharacterProfile.MaxNameLength || message.Name.Length <= 0)
         {
-            _popupSystem.PopupCursor(Loc.GetString("voice-mask-popup-failure"), message.Session);
+            _popupSystem.PopupEntity(Loc.GetString("voice-mask-popup-failure"), uid, message.Session, PopupType.SmallCaution);
             return;
         }
 
@@ -45,7 +46,7 @@ public sealed partial class VoiceMaskSystem : EntitySystem
         else
             _adminLogger.Add(LogType.Action, LogImpact.Medium, $"Voice of {ToPrettyString(uid):mask} set: {component.VoiceName}");
 
-        _popupSystem.PopupCursor(Loc.GetString("voice-mask-popup-success"), message.Session);
+        _popupSystem.PopupEntity(Loc.GetString("voice-mask-popup-success"), uid, message.Session);
 
         TrySetLastKnownName(uid, message.Name);
 


### PR DESCRIPTION
## About the PR
The voice mask confirmation and error popups were placed at the cursor, which made the popup render hidden under the voice mask UI. This moves the message to the player entity, and colors the error feedback red to make it more distinct.

## Why / Balance
N/A

## Technical details
N/A

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/space-wizards/space-station-14/assets/8277780/f8e40bf9-cd5d-487c-b215-b22567dd3633)


## Breaking changes
N/A

**Changelog**
no cl no fun
