### PR TITLE
Allow mid-round borgs to emote

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -192,6 +192,7 @@
     tags:
     - ShoesRequiredStepTriggerImmune
     - DoorBumpOpener
+  - type: Emoting
 
 - type: entity
   id: BaseBorgChassisNT

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -192,7 +192,7 @@
     tags:
     - ShoesRequiredStepTriggerImmune
     - DoorBumpOpener
-  - type: Emoting
+  - type: Emoting 
 
 - type: entity
   id: BaseBorgChassisNT

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -192,7 +192,7 @@
     tags:
     - ShoesRequiredStepTriggerImmune
     - DoorBumpOpener
-  - type: Emoting 
+  - type: Emoting
 
 - type: entity
   id: BaseBorgChassisNT


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Allows cyborgs built by Science to emote.
Fixes #21539 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Makes it consistent with round-start cyborgs, which can emote.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The EmotableComponent is automatically added to all mobs that players can spawn in with from the lobby screen.
That behavior would need to be changed if we wanted all cyborgs to be unable to emote.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Science built cyborgs can now emote