### PR TITLE
Gateway nerfs

### DIFF
--- a/Content.Server/Gateway/Components/GatewayGeneratorComponent.cs
+++ b/Content.Server/Gateway/Components/GatewayGeneratorComponent.cs
@@ -20,13 +20,13 @@ public sealed partial class GatewayGeneratorComponent : Component
     /// Next time another seed unlocks.
     /// </summary>
     [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
-    public TimeSpan NextUnlock;
+    public TimeSpan NextUnlock = TimeSpan.FromMinutes(5);
 
     /// <summary>
     /// How long it takes to unlock another destination once one is taken.
     /// </summary>
     [DataField]
-    public TimeSpan UnlockCooldown = TimeSpan.FromMinutes(45);
+    public TimeSpan UnlockCooldown = TimeSpan.FromMinutes(75);
 
     /// <summary>
     /// Maps we've generated.

--- a/Content.Server/Gateway/Components/GatewayGeneratorComponent.cs
+++ b/Content.Server/Gateway/Components/GatewayGeneratorComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class GatewayGeneratorComponent : Component
     /// Next time another seed unlocks.
     /// </summary>
     [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
-    public TimeSpan NextUnlock = TimeSpan.FromMinutes(5);
+    public TimeSpan NextUnlock;
 
     /// <summary>
     /// How long it takes to unlock another destination once one is taken.

--- a/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
+++ b/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
@@ -87,6 +87,8 @@ public sealed class GatewayGeneratorSystem : EntitySystem
 
     private void OnGeneratorMapInit(EntityUid uid, GatewayGeneratorComponent generator, MapInitEvent args)
     {
+        generator.NextUnlock = TimeSpan.FromMinutes(5);
+
         for (var i = 0; i < 3; i++)
         {
             GenerateDestination(uid, generator);

--- a/Content.Shared/Salvage/RestrictedRangeComponent.cs
+++ b/Content.Shared/Salvage/RestrictedRangeComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Salvage;
 public sealed partial class RestrictedRangeComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]
-    public float Range = 72f;
+    public float Range = 78f;
 
     [DataField, AutoNetworkedField]
     public Vector2 Origin;


### PR DESCRIPTION
The 5min initial timer I forgor to do but 75 minutes should be more time for it to be explored better I think based on the couple rounds I saw, it's not intended for this to be a steady stream of resources.

:cl:
- tweak: Added 5 minute initial timer to gateway + bump new portal generation from 45 minutes to 75 minutes.