### PR TITLE
Remove remote signal from ieds

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/ied.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/ied.yml
@@ -21,10 +21,6 @@
     initialBeepDelay: 0
     beepSound: /Audio/Effects/lightburn.ogg
   # TODO: random timer when crafted
-  - type: TriggerOnSignal
-  - type: DeviceLinkSink
-    ports:
-    - Trigger
   - type: Explosive # Weak explosion in a very small radius. Doesn't break underplating.
     explosionType: Default
     totalIntensity: 50


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This removes the ability to link ieds to a remote signal.

## Why / Balance
Being able to instakill someone with a bag of ieds is too powerful for how cheap they are. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- remove: Removed the ability to link IEDs to a remote signal. 
