### PR TITLE
Increase Nuclear Operative playtime requirements

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -6,7 +6,10 @@
   objective: roles-antag-nuclear-operative-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 72000 # 20h
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10h
 
 - type: antag
   id: NukeopsMedic
@@ -16,9 +19,12 @@
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 108000 # 30h
   - !type:DepartmentTimeRequirement
     department: Medical
+    time: 36000 # 10h
+  - !type:DepartmentTimeRequirement
+    department: Security
     time: 18000 # 5h
 
 - type: antag
@@ -29,8 +35,8 @@
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 144000 # 40
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 18000 # 5h
+    time: 108000 # 30
   # should be changed to nukie playtime when thats tracked (wyci)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
### Significantly increased the playtime requirements for nuclear operatives. 
Check out round 38253 if you want to see _a_ great example of why this should happen (**tldw**, my fellow nukies did not know how to turn on internals, one person microbombed themselves, and the commander somehow did not know how to use harm mode and took off their helmet in space when I explained what wielding an axe is in LOOC chat... oh and the reinforcement used an explosive grenade on me)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This will hopefully decrease the level of newkies blowing themselves up and taking 1 hour to arrive at station only to realise they don't know what a helmet is.

The following are the actual changes:

## Regular Nuclear Operative:
- Increased overall playtime from 5 hours to 20.
- Added a 5 hour Security requirement.

## Nuclear Operative Agent:
- Increased overall playtime from 5 hours to 30.
- Increased medical playtime from 5 hours to 10.
- Added a 5 hour Security requirement.

## Nuclear Operative Commander:
- Increased overall playtime from 5 hours to 40. This is on par with the Head Of Security's overall time requirement.
- Increased Security playtime from 5 hours to 30. This is also on par with HoS.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
None

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: The Syndicate has become more selective with Nuclear Operative recruitment.
