### PR TITLE
Tiny mobs can no longer pass on the zombie disease

### DIFF
--- a/Content.Server/Zombies/NonSpreaderZombieComponent.cs
+++ b/Content.Server/Zombies/NonSpreaderZombieComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.Zombies;
+
+/// <summary>
+/// This is used for Zombies that cannot infect by biting
+/// </summary>
+[RegisterComponent]
+public sealed partial class NonSpreaderZombieComponent: Component
+{
+
+}

--- a/Content.Server/Zombies/NonSpreaderZombieComponent.cs
+++ b/Content.Server/Zombies/NonSpreaderZombieComponent.cs
@@ -1,7 +1,7 @@
 namespace Content.Server.Zombies;
 
 /// <summary>
-/// This is used for Zombies that cannot infect by biting
+/// Zombified entities with this component cannot infect other entities by attacking.
 /// </summary>
 [RegisterComponent]
 public sealed partial class NonSpreaderZombieComponent: Component

--- a/Content.Server/Zombies/ZombieImmuneComponent.cs
+++ b/Content.Server/Zombies/ZombieImmuneComponent.cs
@@ -1,5 +1,8 @@
 namespace Content.Server.Zombies;
 
+/// <summary>
+/// Entities with this component cannot be zombified.
+/// </summary>
 [RegisterComponent]
 public sealed partial class ZombieImmuneComponent : Component
 {

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -219,7 +219,7 @@ namespace Content.Server.Zombies
                 }
                 else
                 {
-                    if (!HasComp<ZombieImmuneComponent>(entity) && _random.Prob(GetZombieInfectionChance(entity, component)))
+                    if (!HasComp<ZombieImmuneComponent>(entity) && !HasComp<NonSpreaderZombieComponent>(args.User) && _random.Prob(GetZombieInfectionChance(entity, component)))
                     {
                         EnsureComp<PendingZombieComponent>(entity);
                         EnsureComp<ZombifyOnDeathComponent>(entity);

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1262,6 +1262,7 @@
   - type: Puller
     needsHands: true
   - type: BadFood
+  - type: ZombieImmune
 
 - type: entity
   parent: MobMouse

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -63,6 +63,7 @@
   - type: Tag
     tags:
     - VimPilot
+  - type: NonSpreaderZombie
 
 - type: entity
   name: bee
@@ -313,6 +314,7 @@
         damage: 10
       behaviors:
       - !type:GibBehavior { }
+  - type: NonSpreaderZombie
 
 - type: entity
   name: glockroach
@@ -1262,7 +1264,7 @@
   - type: Puller
     needsHands: true
   - type: BadFood
-  - type: ZombieImmune
+  - type: NonSpreaderZombie
 
 - type: entity
   parent: MobMouse
@@ -2681,6 +2683,7 @@
     BaseResistTime: 3
   - type: MobPrice
     price: 60
+  - type: NonSpreaderZombie
 
 - type: entity
   name: pig

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -63,7 +63,6 @@
   - type: Tag
     tags:
     - VimPilot
-  - type: NonSpreaderZombie
 
 - type: entity
   name: bee

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -84,6 +84,7 @@
     accent: genericAggressive
   - type: Speech
     speechVerb: SmallMob
+  - type: NonSpreaderZombie
 
 - type: entity
   id: MobTickSalvage


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Mice and other small creatures can now no longer infect others by biting.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
See discussion in this PR's comments section, and https://discord.com/channels/310555209753690112/1174662886791061534/1174662886791061534. Additionally see #21507 for a similar change.

Mice and other very small creatures like ticks or hamlet are granted a large amount of mobility by being able to go under doors, and are extremely hard to hit or in some cases impossible to hit if under a door or a table (This is due to wide swing just existing, it will automatically target the table/door instead of the actual mouse and since it is done through right clicking you can't go in the context menu and click on the mouse directly). Additionally something specific to mice: Mice spawn constantly in the station, this means there is an infinite supply of them. Players also often choose mice ghost roles specifically to get infected and join the hoard. Lastly we have already done something more extreme with bees on #21507 where due to their even smaller hitbox they are completely immune to the zombie disease(that pr is also why I didn't touch bees with this one). All these issues makes fighting these mobs extremely frustrating.

This change will at the very least alleviate these problems by making it so fighting a zombie mouse, or similar small mobs isn't a death sentence if you cannot get ambuzol in time and is a compromise by the opinion here that no change is necessary and the discussion on discord which seems to be in support of such a change if not a more extreme change where mice and other small mobs just die from the disease instead of becoming zombified.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I added the NonSpreaderZombieComponent which the zombie system checks for in the hit mob during its check to see whether it will be infected. If it exists then the check automatically fails, other special things that happen in that function remain unaffected.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/32041239/390d06cc-9592-49c7-9588-875428c35663


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Zombified mice and other small animals no longer spread zombification.