### PR TITLE
Fix double clicking actions, vote overlap, make adding actions more visible

### DIFF
--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
@@ -16,10 +16,12 @@
     <controls:RecordedSplitContainer Name="ScreenContainer" HorizontalExpand="True" VerticalExpand="True" SplitWidth="0" StretchDirection="TopLeft">
         <LayoutContainer Name="ViewportContainer" HorizontalExpand="True" VerticalExpand="True">
             <controls:MainViewport Name="MainViewport"/>
-            <BoxContainer Name="VoteMenu" Access="Public" Orientation="Vertical"/>
             <widgets:GhostGui Name="Ghost" Access="Protected" />
             <hotbar:HotbarGui Name="Hotbar" Access="Protected" />
-            <actions:ActionsBar Name="Actions" Access="Protected" />
+            <BoxContainer Name="TopLeftContainer" Orientation="Vertical">
+                <actions:ActionsBar Name="Actions" Access="Protected" />
+                <BoxContainer Name="VoteMenu" Access="Public" Orientation="Vertical"/>
+            </BoxContainer>
             <alerts:AlertsUI Name="Alerts" Access="Protected" />
         </LayoutContainer>
         <PanelContainer HorizontalExpand="True" MinWidth="300">

--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
@@ -18,8 +18,7 @@ public sealed partial class SeparatedChatGameScreen : InGameScreen
         SetAnchorPreset(ScreenContainer, LayoutPreset.Wide);
         SetAnchorPreset(ViewportContainer, LayoutPreset.Wide);
         SetAnchorPreset(MainViewport, LayoutPreset.Wide);
-        SetAnchorAndMarginPreset(VoteMenu, LayoutPreset.TopLeft, margin: 10);
-        SetAnchorAndMarginPreset(Actions, LayoutPreset.TopLeft, margin: 10);
+        SetAnchorAndMarginPreset(TopLeftContainer, LayoutPreset.TopLeft, margin: 10);
         SetAnchorAndMarginPreset(Ghost, LayoutPreset.BottomWide, margin: 80);
         SetAnchorAndMarginPreset(Hotbar, LayoutPreset.BottomWide, margin: 5);
         SetAnchorAndMarginPreset(Alerts, LayoutPreset.CenterRight, margin: 10);

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -752,6 +752,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
     public void RegisterActionContainer(ActionButtonContainer container)
     {
+        if (_container != null)
+        {
+            _container.ActionPressed -= OnActionPressed;
+            _container.ActionUnpressed -= OnActionUnpressed;
+        }
+
         _container = container;
         _container.ActionPressed += OnActionPressed;
         _container.ActionUnpressed += OnActionUnpressed;

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -283,13 +283,15 @@ public sealed class ActionButton : Control, IEntityControl
 
     public void UpdateBackground()
     {
-        if (_action == null)
+        _controller ??= UserInterfaceManager.GetUIController<ActionUIController>();
+        if (_action != null ||
+            _controller.IsDragging && GetPositionInParent() == Parent?.ChildCount - 1)
         {
-            Button.Texture = null;
+            Button.Texture = _buttonBackgroundTexture;
         }
         else
         {
-            Button.Texture = _buttonBackgroundTexture;
+            Button.Texture = null;
         }
     }
 
@@ -325,6 +327,8 @@ public sealed class ActionButton : Control, IEntityControl
     protected override void FrameUpdate(FrameEventArgs args)
     {
         base.FrameUpdate(args);
+
+        UpdateBackground();
 
         Cooldown.Visible = _action != null && _action.Cooldown != null;
         if (_action == null)
@@ -397,7 +401,7 @@ public sealed class ActionButton : Control, IEntityControl
 
         // it's only depress-able if it's usable, so if we're depressed
         // show the depressed style
-        if (_depressed)
+        if (_depressed && !_beingHovered)
         {
             HighlightRect.Visible = false;
             SetOnlyStylePseudoClass(ContainerButton.StylePseudoClassPressed);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Closes #21654
Closes #21649

Thank you @MACMAN2003 for the report that helped me track down the bug.

Fixes:
- Actions no longer get duplicated click subscriptions (clicking on actions works properly again)
- Vote box no longer overlaps action bar in separated HUD
- When dragging actions, the last slot now shows an empty texture to make it more obvious that you can place an action there.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/e8d25190-8db1-4b91-b4de-f6dbce3de290)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Clicking actions in the HUD no longer triggers them multiple times.
- fix: Fixed action bar overlapping vote box in separated HUD.
- tweak: Dragging actions to the action bar now shows an empty slot where they can be added.
