### PR TITLE
Changed NukeOps Shuttle Call Time from 10 Minutes to 3 Minutes

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -35,7 +35,7 @@ public sealed partial class NukeopsRuleComponent : Component
     /// What will happen if all of the nuclear operatives will die. Used by LoneOpsSpawn event.
     /// </summary>
     [DataField]
-    public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.ShuttleCall;
+    public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.InstantEnd;
 
     /// <summary>
     /// Text for shuttle call if RoundEndBehavior is ShuttleCall.

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -35,7 +35,7 @@ public sealed partial class NukeopsRuleComponent : Component
     /// What will happen if all of the nuclear operatives will die. Used by LoneOpsSpawn event.
     /// </summary>
     [DataField]
-    public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.InstantEnd;
+    public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.ShuttleCall;
 
     /// <summary>
     /// Text for shuttle call if RoundEndBehavior is ShuttleCall.
@@ -59,7 +59,7 @@ public sealed partial class NukeopsRuleComponent : Component
     /// Time to emergency shuttle to arrive if RoundEndBehavior is ShuttleCall.
     /// </summary>
     [DataField]
-    public TimeSpan EvacShuttleTime = TimeSpan.FromMinutes(10);
+    public TimeSpan EvacShuttleTime = TimeSpan.FromMinutes(3);
 
     /// <summary>
     /// Whether or not to spawn the nuclear operative outpost. Used by LoneOpsSpawn event.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Emergency Shuttle time should be 3 minutes from 10 minutes when all Nuke Ops are dead.

## Why / Balance
#21617 
Issue requested for nuke ops round to end immediately instead of shuttle call. 
**Update**: Changed from instant end to Shuttle Call with 3 minute call time

## Technical details
`NukeopsRuleComponent`:

- `EvacShuttleTime` changed from `TimeSpan.FromMinutes(10)` to `TimeSpan.FromMinutes(3)`

## Media
https://github.com/space-wizards/space-station-14/assets/2664520/b2e8563a-b32c-479e-9fc8-bb244a8962fe

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
:cl:
- tweak: Shuttle Call Time reduced to 3 minutes from 10 minutes for NukeOps gamerule

