### PR TITLE
Biome niceties

### DIFF
--- a/Resources/Prototypes/Procedural/biome_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_templates.yml
@@ -74,12 +74,12 @@
         - 0
       tile: FloorLowDesert
     - !type:BiomeTileLayer
-      threshold: 0.6
-      tile: FloorLowDesert
+      threshold: 0.25
       noise:
-        seed: 0
-        noiseType: Cellular
-        frequency: 0.1
+        seed: 1
+        noiseType: OpenSimplex2
+        frequency: 2
+      tile: FloorLowDesert
 
 # Grass
 - type: biomeTemplate
@@ -444,15 +444,6 @@
         octaves: 5
         cellularDistanceFunction: Euclidean
         cellularReturnType: Distance2
-    - !type:BiomeDummyLayer
-      id: Loot
-    - !type:BiomeTileLayer
-      threshold: -0.7
-      tile: FloorSnow
-      noise:
-        seed: 0
-        frequency: 0.02
-        fractalType: None
     # Liquid plasma rivers. Ice moon baby
     - !type:BiomeEntityLayer
       allowedTiles:
@@ -468,6 +459,15 @@
         octaves: 1
       entities:
       - FloorLiquidPlasmaEntity
+    - !type:BiomeDummyLayer
+      id: Loot
+    - !type:BiomeTileLayer
+      threshold: -0.7
+      tile: FloorSnow
+      noise:
+        seed: 0
+        frequency: 0.02
+        fractalType: None
 
 # Shadow -> Derived from lava
 - type: biomeTemplate
@@ -547,15 +547,22 @@
       variants:
         - 0
       tile: FloorChromite
+    - !type:BiomeTileLayer
+      threshold: 0.25
+      noise:
+        seed: 1
+        noiseType: OpenSimplex2
+        frequency: 2
+      tile: FloorChromite
 
 # Caves
 - type: biomeTemplate
   id: Caves
   layers:
     - !type:BiomeEntityLayer
-      threshold: 0.8
+      threshold: 0.85
       noise:
-        seed: 0
+        seed: 2
         noiseType: OpenSimplex2
         fractalType: PingPong
       allowedTiles:
@@ -566,6 +573,21 @@
         - CrystalOrange
         - CrystalBlue
         - CrystalCyan
+    - !type:BiomeEntityLayer
+      threshold: 0.95
+      noise:
+        seed: 1
+        noiseType: OpenSimplex2
+        frequency: 1
+      allowedTiles:
+      - FloorAsteroidSand
+      entities:
+      - FloraStalagmite1
+      - FloraStalagmite2
+      - FloraStalagmite3
+      - FloraStalagmite4
+      - FloraStalagmite5
+      - FloraStalagmite6
     - !type:BiomeEntityLayer
       threshold: -0.5
       invert: true
@@ -584,4 +606,13 @@
       id: Loot
     - !type:BiomeTileLayer
       threshold: -1.0
+      tile: FloorAsteroidSand
+      variants:
+      - 0
+    - !type:BiomeTileLayer
+      threshold: 0.5
+      noise:
+        seed: 1
+        noiseType: OpenSimplex2
+        frequency: 2
       tile: FloorAsteroidSand


### PR DESCRIPTION
- Use floor variants for caves.
- Add stalagmites to caves.
- Use variants for existing biomes too ig.

![image](https://github.com/space-wizards/space-station-14/assets/31366439/a3532ed9-f38c-41fc-9e45-0a0d4a17a959)

:cl:
- tweak: Tweak biome generation on planets to make floors more varied and add stalagmites to caves.
