### PR TITLE
Borgs No Longer Take Structural Damage

### DIFF
--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -17,6 +17,14 @@
     - Structural # this probably should be in separate container
 
 - type: damageContainer
+  id: Silicon
+  supportedGroups:
+    - Brute
+  supportedTypes:
+    - Heat
+    - Shock
+
+- type: damageContainer
   id: Shield
   supportedGroups:
     - Brute

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -131,7 +131,7 @@
     - cell_slot
   - type: Flashable
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: Silicon
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
## About the PR
Changed Borg damage container type so they no longer take structural damage.

## Why / Balance
Fixes https://github.com/space-wizards/space-station-14/issues/21390

## Technical details
- Added Silicon damage type to container prototype
- Updated Borg damage container type to Silicon

## Media
![BorgDamage](https://github.com/space-wizards/space-station-14/assets/30051988/49f56bbd-5cd2-40ed-b6f7-3402db0b85e9)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Borgs no longer take structural damage.
