### PR TITLE
Add missing constructor in RandomSpawnLootEntry struct

### DIFF
--- a/Content.Shared/Procedural/Loot/RandomSpawnsLoot.cs
+++ b/Content.Shared/Procedural/Loot/RandomSpawnsLoot.cs
@@ -14,7 +14,7 @@ public sealed partial class RandomSpawnsLoot : IDungeonLoot
 }
 
 [DataDefinition]
-public partial record struct RandomSpawnLootEntry : IBudgetEntry
+public partial record struct RandomSpawnLootEntry() : IBudgetEntry
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("proto", required: true, customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string Proto { get; set; } = string.Empty;


### PR DESCRIPTION
## About the PR
This is automatically generated by the serialization source generator either way, but when applying code changes on Rider without restarting it sometimes gets confused and raises this as an error blocking it from doing so.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase