### PR TITLE
make welding mask not eatable

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -14,6 +14,10 @@
       Glass: 100
   - type: StaticPrice
     price: 50
+  - type: Tag
+    tags:
+    - DroneUsable
+    - WhitelistChameleon
 
 - type: entity
   parent: WeldingMaskBase
@@ -27,6 +31,7 @@
     sprite: Clothing/Head/Welding/welding.rsi
   - type: Tag
     tags:
+    - DroneUsable
     - HamsterWearable
     - WhitelistChameleon
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Remove `ClothMade` tag from welding masks, return `DroneUsable` tag

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- fix: Moths can no longer eat welding masks.
