### PR TITLE
change artifact recipe to use material

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/Graphs/artifact.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/artifact.yml
@@ -2,31 +2,12 @@
   id: Artifact
   start: start
   graph:
-    - node: start
-      edges:
-      - to: done
-        steps:
-        - tag: ArtifactFragment
-          name: artifact fragment
-          icon:
-            sprite: Objects/Specific/Xenoarchaeology/artifact_fragments.rsi
-            state: ancientball1
-        - tag: ArtifactFragment
-          name: artifact fragment
-          icon:
-            sprite: Objects/Specific/Xenoarchaeology/artifact_fragments.rsi
-            state: ancientball2
-        - tag: ArtifactFragment
-          name: artifact fragment
-          icon:
-            sprite: Objects/Specific/Xenoarchaeology/artifact_fragments.rsi
-            state: ancientball3
-        - tag: ArtifactFragment
-          name: artifact fragment
-          icon:
-            sprite: Objects/Specific/Xenoarchaeology/artifact_fragments.rsi
-            state: ancientball4
-          doAfter: 5
-
-    - node: done
-      entity: VariedXenoArtifactItem
+  - node: start
+    edges:
+    - to: done
+      steps:
+      - material: ArtifactFragment
+        amount: 4
+        doAfter: 5
+  - node: done
+    entity: VariedXenoArtifactItem


### PR DESCRIPTION
## About the PR
fixes #21727

## Why / Balance
oversight when fragments were made stackable

## Technical details
no

## Media
before craft
![19:40:04](https://github.com/space-wizards/space-station-14/assets/39013340/137de6e2-f657-43e3-aa25-520657a71c51)

after craft
![19:40:22](https://github.com/space-wizards/space-station-14/assets/39013340/a12d1b37-9b03-4e07-8be8-86c21c92edaf)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed artifact crafting requiring separate stacks and wasting fragments.