### PR TITLE
Add New Reaction : Oil into Ash Reaction

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -51,3 +51,12 @@
     visualType: LargeCaution
   products:
     ChlorineTrifluoride: 4
+
+- type: reaction
+  id: Ash
+  minTemp: 520
+  reactants:
+    Oil:
+      amount: 1
+  products:
+    Ash: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adding New Reaction Oil to Ash reaction

## Why / Balance
to make plastic creation easier within chemist capability as the only source of ash currently by burning paper, would be a great addition by adding ash reaction possible so it's easier for chemist to make charcoal and plastic.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Ash reaction only require Oil as the reactants but the minimumTemp for the reaction is set to 520. you can review this in Resources/Prototypes/Recipes/Reactions/pyrotechnics.yml 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X ] this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
no changes, only new addition in
Resources/Prototypes/Recipes/Reactions/pyrotechnics.ym

**Changelog**
:cl:
- add: Ash can now be created by burning oil.
