### PR TITLE
Fix error when trying to get a state with deleted grid entity ids in ExplosionVisualsComponent

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared.Atmos;
+using Content.Shared.Explosion;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
@@ -37,6 +38,13 @@ public sealed partial class ExplosionSystem : EntitySystem
     {
         _airtightMap.Remove(ev.EntityUid);
         _gridEdges.Remove(ev.EntityUid);
+
+        // this should be a small enough set that iterating all of them is fine
+        var query = EntityQueryEnumerator<ExplosionVisualsComponent>();
+        while (query.MoveNext(out var visuals))
+        {
+            visuals.Tiles.Remove(ev.EntityUid);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
As seen on Grafana
```
Can't resolve "Robust.Shared.GameObjects.MetaDataComponent" on entity 88439!
   at Content.Server.Explosion.EntitySystems.ExplosionSystem.OnGetState(EntityUid uid, ExplosionVisualsComponent component, ComponentGetState& args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Explosion/EntitySystems/ExplosionSystem.Visuals.cs:line 21
   at Robust.Shared.GameObjects.EntityEventBus.Robust.Shared.GameObjects.IDirectedEventBus.RaiseComponentEvent[TEvent](IComponent component, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 163
   at Robust.Shared.GameObjects.EntityManager.GetComponentState(IEventBus eventBus, IComponent component, ICommonSession session, GameTick fromTick) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 1343
   at Robust.Server.GameStates.PvsSystem.GetEntityState(ICommonSession player, EntityUid entityUid, GameTick fromTick, MetaDataComponent meta) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.cs:line 1269
   at Robust.Server.GameStates.PvsSystem.CalculateEntityStates(ICommonSession session, GameTick fromTick, GameTick toTick, Nullable`1[] chunks, HashSet`1 visibleChunks, EntityUid[] viewers) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/PvsSystem.cs:line 836
   at Robust.Server.GameStates.ServerGameStateManager.SendStateUpdate(Int32 i, PvsThreadResources resources, InputSystem inputSystem, ICommonSession session, Nullable`1 pvsData, UInt32& oldestAckValue) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/ServerGameStateManager.cs:line 326
   at Robust.Server.GameStates.ServerGameStateManager.<>c__DisplayClass37_0.<SendStates>g__SendPlayer|0(Int32 i, ParallelLoopState state, PvsThreadResources resource) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameStates/ServerGameStateManager.cs:line 245
   at System.Threading.Tasks.Parallel.<>c__DisplayClass19_0`1.<ForWorker>b__1(RangeWorker& currentWorker, Int32 timeout, Boolean& replicationDelegateYieldedBeforeCompletion)
   at System.Threading.Tasks.TaskReplicator.Replica.Execute()
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
