### PR TITLE
Decal fix

### DIFF
--- a/Content.Client/Decals/DecalSystem.cs
+++ b/Content.Client/Decals/DecalSystem.cs
@@ -15,6 +15,9 @@ namespace Content.Client.Decals
 
         private DecalOverlay _overlay = default!;
 
+        private HashSet<uint> _removedUids = new();
+        private readonly List<Vector2i> _removedChunks = new();
+
         public override void Initialize()
         {
             base.Initialize();
@@ -65,13 +68,14 @@ namespace Content.Client.Decals
                 return;
 
             // is this a delta or full state?
-            var removedChunks = new List<Vector2i>();
+            _removedChunks.Clear();
+
             if (!state.FullState)
             {
                 foreach (var key in gridComp.ChunkCollection.ChunkCollection.Keys)
                 {
                     if (!state.AllChunks!.Contains(key))
-                        removedChunks.Add(key);
+                        _removedChunks.Add(key);
                 }
             }
             else
@@ -79,12 +83,12 @@ namespace Content.Client.Decals
                 foreach (var key in gridComp.ChunkCollection.ChunkCollection.Keys)
                 {
                     if (!state.Chunks.ContainsKey(key))
-                        removedChunks.Add(key);
+                        _removedChunks.Add(key);
                 }
             }
 
-            if (removedChunks.Count > 0)
-                RemoveChunks(gridUid, gridComp, removedChunks);
+            if (_removedChunks.Count > 0)
+                RemoveChunks(gridUid, gridComp, _removedChunks);
 
             if (state.Chunks.Count > 0)
                 UpdateChunks(gridUid, gridComp, state.Chunks);
@@ -137,9 +141,10 @@ namespace Content.Client.Decals
             {
                 if (chunkCollection.TryGetValue(indices, out var chunk))
                 {
-                    var removedUids = new HashSet<uint>(chunk.Decals.Keys);
-                    removedUids.ExceptWith(newChunkData.Decals.Keys);
-                    foreach (var removedUid in removedUids)
+                    _removedUids.Clear();
+                    _removedUids.UnionWith(chunk.Decals.Keys);
+                    _removedUids.ExceptWith(newChunkData.Decals.Keys);
+                    foreach (var removedUid in _removedUids)
                     {
                         OnDecalRemoved(gridId, removedUid, gridComp, indices, chunk);
                         gridComp.DecalIndex.Remove(removedUid);
@@ -166,7 +171,8 @@ namespace Content.Client.Decals
 
             foreach (var index in chunks)
             {
-                if (!chunkCollection.TryGetValue(index, out var chunk)) continue;
+                if (!chunkCollection.TryGetValue(index, out var chunk))
+                    continue;
 
                 foreach (var decalId  in chunk.Decals.Keys)
                 {

--- a/Content.Server/Decals/DecalSystem.cs
+++ b/Content.Server/Decals/DecalSystem.cs
@@ -454,9 +454,7 @@ namespace Content.Server.Decals
                     previouslySent.Remove(netGrid);
 
                     // Was the grid deleted?
-                    if (!TryGetEntity(netGrid, out var gridId) || !MapManager.IsGrid(gridId.Value))
-                        staleChunks[netGrid] = oldIndices;
-                    else
+                    if (TryGetEntity(netGrid, out var gridId) && !MapManager.IsGrid(gridId.Value))
                     {
                         // If grid was deleted then don't worry about telling the client to delete the chunk.
                         oldIndices.Clear();


### PR DESCRIPTION
- Don't send stale chunks for deleted grid as client just errors it anyway (this was causing the error log 100% of the time on grid deletion).
- Store some allocations in fields.

Pre sure I made an issue but can't find it.