### PR TITLE
let ghosts hear freelance radio

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -51,6 +51,7 @@
     - Service
     - Supply
     - Syndicate
+    - Freelance
     globalReceive: true
   - type: Physics
     bodyType: KinematicController


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Freelance radio was recently added, ghosts (and aghosts by extension) aren't able to hear it. This fixes that.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
aghosts should be able to hear the radio they use for their own events. ghosts can already hear every other radio. I'm fairly certain this was just forgotten. 
