### PR TITLE
Removes the "You require 0 minutes of playtime" message from the game

### DIFF
--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -132,7 +132,7 @@ namespace Content.Shared.Roles
 
                         reason = FormattedMessage.FromMarkup(Loc.GetString(
                             "role-timer-department-insufficient",
-                            ("time", Math.Max(1,deptDiff)),
+                            ("time", Math.Ceiling(deptDiff)),
                             ("department", Loc.GetString(deptRequirement.Department)),
                             ("departmentColor", department.Color.ToHex())));
                         return false;
@@ -163,7 +163,7 @@ namespace Content.Shared.Roles
 
                         reason = FormattedMessage.FromMarkup(Loc.GetString(
                               "role-timer-overall-insufficient", 
-                              ("time", Math.Max(1,overallDiff))));
+                              ("time", Math.Ceiling(overallDiff))));
                         return false;
                     }
                     else
@@ -199,7 +199,7 @@ namespace Content.Shared.Roles
 
                         reason = FormattedMessage.FromMarkup(Loc.GetString(
                             "role-timer-role-insufficient",
-                            ("time", Math.Max(1,roleDiff)),
+                            ("time", Math.Ceiling(roleDiff)),
                             ("job", Loc.GetString(proto)),
                             ("departmentColor", departmentColor.ToHex())));
                         return false;

--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -132,7 +132,7 @@ namespace Content.Shared.Roles
 
                         reason = FormattedMessage.FromMarkup(Loc.GetString(
                             "role-timer-department-insufficient",
-                            ("time", deptDiff),
+                            ("time", Math.Max(1,deptDiff)),
                             ("department", Loc.GetString(deptRequirement.Department)),
                             ("departmentColor", department.Color.ToHex())));
                         return false;
@@ -161,7 +161,9 @@ namespace Content.Shared.Roles
                         if (overallDiff <= 0 || overallTime >= overallRequirement.Time)
                             return true;
 
-                        reason = FormattedMessage.FromMarkup(Loc.GetString("role-timer-overall-insufficient", ("time", overallDiff)));
+                        reason = FormattedMessage.FromMarkup(Loc.GetString(
+                              "role-timer-overall-insufficient", 
+                              ("time", Math.Max(1,overallDiff))));
                         return false;
                     }
                     else
@@ -197,7 +199,7 @@ namespace Content.Shared.Roles
 
                         reason = FormattedMessage.FromMarkup(Loc.GetString(
                             "role-timer-role-insufficient",
-                            ("time", roleDiff),
+                            ("time", Math.Max(1,roleDiff)),
                             ("job", Loc.GetString(proto)),
                             ("departmentColor", departmentColor.ToHex())));
                         return false;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Players were becoming extremely confused when they were not allowed to play a while also being told they required zero more minutes to do so.

Closes: #21766 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Why? Because it is extremely confusing.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
If the playtime required to play is less than a minute the UI rounds up to one minute.
Basically ``Math.max(1, time_required)``

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->