### PR TITLE
Align windoor bounds with thindow

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -17,7 +17,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.39,0.49,-0.36"
+          bounds: "-0.49,-0.49,0.49,-0.36"
         density: 1500
         mask:
         - TabletopMachineMask


### PR DESCRIPTION
I missed this one before.

:cl:
- fix: Align windoor collision bounds with thindow collision bounds.