### PR TITLE
Allow chemistry to create jugs earlier in the game

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -684,6 +684,7 @@
       - MedkitAdvanced
       - MedkitRadiation
       - MedkitCombat
+      - Jug
     dynamicRecipes:
       - HandheldCrewMonitor
       - ClothingHandsGlovesNitrile

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -699,7 +699,6 @@
       - Hemostat
       - BluespaceBeaker
       - SyringeBluespace
-      - Jug
   - type: Machine
     board: MedicalTechFabCircuitboard
 

--- a/Resources/Prototypes/Research/biochemical.yml
+++ b/Resources/Prototypes/Research/biochemical.yml
@@ -15,7 +15,6 @@
   - HotplateMachineCircuitboard
   - ChemicalPayload
   - ClothingEyesGlassesChemical
-  - Jug
 
 - type: technology
   id: SurgicalTools


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR allows chemists or any other medical personnel to produce **jugs** using the medical techfab without having to rely on science to research it first.

Closes #21789 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This change was made because chemistry are only given access to four empty jugs.
On some maps there can be up the three chemists. ( sometimes more because doctors like making chemicals )

Because there are so few empty jugs chemists would resort to dumping their already filled jugs from the vending machine down the drain until it clogs.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes jugs from chemistry research.
Adds jugs to base medical technofab.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
