### PR TITLE
Reduce ChunkingSystem allocations

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -287,11 +287,8 @@ public sealed partial class ExplosionSystem
         ref (List<(EntityUid, TransformComponent)> List, HashSet<EntityUid> Processed, EntityQuery<TransformComponent> XformQuery) state,
         in FixtureProxy proxy)
     {
-        var uid = proxy.Entity;
-        if (state.Processed.Add(uid) && state.XformQuery.TryGetComponent(uid, out var xform))
-            state.List.Add((uid, xform));
-
-        return true;
+        var owner = proxy.Entity;
+        return GridQueryCallback(ref state, in owner);
     }
 
     /// <summary>

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -273,7 +273,7 @@ public sealed partial class ExplosionSystem
         return !tileBlocked;
     }
 
-    private bool GridQueryCallback(
+    private static bool GridQueryCallback(
         ref (List<(EntityUid, TransformComponent)> List, HashSet<EntityUid> Processed, EntityQuery<TransformComponent> XformQuery) state,
         in EntityUid uid)
     {
@@ -283,12 +283,15 @@ public sealed partial class ExplosionSystem
         return true;
     }
 
-    private bool GridQueryCallback(
+    private static bool GridQueryCallback(
         ref (List<(EntityUid, TransformComponent)> List, HashSet<EntityUid> Processed, EntityQuery<TransformComponent> XformQuery) state,
         in FixtureProxy proxy)
     {
-        var owner = proxy.Entity;
-        return GridQueryCallback(ref state, in owner);
+        var uid = proxy.Entity;
+        if (state.Processed.Add(uid) && state.XformQuery.TryGetComponent(uid, out var xform))
+            state.List.Add((uid, xform));
+
+        return true;
     }
 
     /// <summary>
@@ -307,7 +310,7 @@ public sealed partial class ExplosionSystem
         var gridBox = Box2.FromDimensions(tile * DefaultTileSize, new Vector2(DefaultTileSize, DefaultTileSize));
         var worldBox = spaceMatrix.TransformBox(gridBox);
         var list = new List<(EntityUid, TransformComponent)>();
-        var state = (list, processed, invSpaceMatrix, lookup.Owner, _transformQuery, gridBox);
+        var state = (list, processed, invSpaceMatrix, lookup.Owner, _transformQuery, gridBox, _transformSystem);
 
         // get entities:
         lookup.DynamicTree.QueryAabb(ref state, SpaceQueryCallback, worldBox, true);
@@ -336,8 +339,8 @@ public sealed partial class ExplosionSystem
         }
     }
 
-    private bool SpaceQueryCallback(
-        ref (List<(EntityUid, TransformComponent)> List, HashSet<EntityUid> Processed, Matrix3 InvSpaceMatrix, EntityUid LookupOwner, EntityQuery<TransformComponent> XformQuery, Box2 GridBox) state,
+    private static bool SpaceQueryCallback(
+        ref (List<(EntityUid, TransformComponent)> List, HashSet<EntityUid> Processed, Matrix3 InvSpaceMatrix, EntityUid LookupOwner, EntityQuery<TransformComponent> XformQuery, Box2 GridBox, SharedTransformSystem System) state,
         in EntityUid uid)
     {
         if (state.Processed.Contains(uid))
@@ -355,14 +358,15 @@ public sealed partial class ExplosionSystem
         }
 
         // finally check if it intersects our tile
-        if (state.GridBox.Contains(state.InvSpaceMatrix.Transform(_transformSystem.GetWorldPosition(xform, state.XformQuery))))
+        var wpos = state.System.GetWorldPosition(xform);
+        if (state.GridBox.Contains(state.InvSpaceMatrix.Transform(wpos)))
             state.List.Add((uid, xform));
 
         return true;
     }
 
-    private bool SpaceQueryCallback(
-        ref (List<(EntityUid, TransformComponent)> List, HashSet<EntityUid> Processed, Matrix3 InvSpaceMatrix, EntityUid LookupOwner, EntityQuery<TransformComponent> XformQuery, Box2 GridBox) state,
+    private static bool SpaceQueryCallback(
+        ref (List<(EntityUid, TransformComponent)> List, HashSet<EntityUid> Processed, Matrix3 InvSpaceMatrix, EntityUid LookupOwner, EntityQuery<TransformComponent> XformQuery, Box2 GridBox, SharedTransformSystem System) state,
         in FixtureProxy proxy)
     {
         var uid = proxy.Entity;


### PR DESCRIPTION
Gets rid of an unnecessary `HashSet<EntityUid> viewers` and uses a grid query with a callback to get rid of a list.

The PR also makes the explosion queries static.