### PR TITLE
Re-use atmos queues

### DIFF
--- a/Content.Server/Atmos/Components/GridAtmosphereComponent.cs
+++ b/Content.Server/Atmos/Components/GridAtmosphereComponent.cs
@@ -65,22 +65,22 @@ namespace Content.Server.Atmos.Components
         public readonly HashSet<Entity<AtmosDeviceComponent>> AtmosDevices = new();
 
         [ViewVariables]
-        public Queue<TileAtmosphere> CurrentRunTiles = new();
+        public readonly Queue<TileAtmosphere> CurrentRunTiles = new();
 
         [ViewVariables]
-        public Queue<ExcitedGroup> CurrentRunExcitedGroups = new();
+        public readonly Queue<ExcitedGroup> CurrentRunExcitedGroups = new();
 
         [ViewVariables]
-        public Queue<IPipeNet> CurrentRunPipeNet = new();
+        public readonly Queue<IPipeNet> CurrentRunPipeNet = new();
 
         [ViewVariables]
-        public Queue<Entity<AtmosDeviceComponent>> CurrentRunAtmosDevices = new();
+        public readonly Queue<Entity<AtmosDeviceComponent>> CurrentRunAtmosDevices = new();
 
         [ViewVariables]
         public readonly HashSet<Vector2i> InvalidatedCoords = new(1000);
 
         [ViewVariables]
-        public Queue<Vector2i> CurrentRunInvalidatedCoordinates = new();
+        public readonly Queue<Vector2i> CurrentRunInvalidatedCoordinates = new();
 
         [ViewVariables]
         public int InvalidatedCoordsCount => InvalidatedCoords.Count;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -41,7 +41,12 @@ namespace Content.Server.Atmos.EntitySystems
             var (owner, atmosphere) = ent;
             if (!atmosphere.ProcessingPaused)
             {
-                atmosphere.CurrentRunInvalidatedCoordinates = new Queue<Vector2i>(atmosphere.InvalidatedCoords);
+                atmosphere.CurrentRunInvalidatedCoordinates.Clear();
+                atmosphere.CurrentRunInvalidatedCoordinates.EnsureCapacity(atmosphere.InvalidatedCoords.Count);
+                foreach (var tile in atmosphere.InvalidatedCoords)
+                {
+                    atmosphere.CurrentRunInvalidatedCoordinates.Enqueue(tile);
+                }
                 atmosphere.InvalidatedCoords.Clear();
             }
 
@@ -151,11 +156,24 @@ namespace Content.Server.Atmos.EntitySystems
             return true;
         }
 
+        private void QueueRunTiles(
+            Queue<TileAtmosphere> queue,
+            HashSet<TileAtmosphere> tiles)
+        {
+
+            queue.Clear();
+            queue.EnsureCapacity(tiles.Count);
+            foreach (var tile in tiles)
+            {
+                queue.Enqueue(tile);
+            }
+        }
+
         private bool ProcessTileEqualize(Entity<GridAtmosphereComponent> ent, GasTileOverlayComponent? visuals)
         {
             var (uid, atmosphere) = ent;
             if (!atmosphere.ProcessingPaused)
-                atmosphere.CurrentRunTiles = new Queue<TileAtmosphere>(atmosphere.ActiveTiles);
+                QueueRunTiles(atmosphere.CurrentRunTiles, atmosphere.ActiveTiles);
 
             if (!TryComp(uid, out MapGridComponent? mapGridComp))
                 throw new Exception("Tried to process a grid atmosphere on an entity that isn't a grid!");
@@ -182,7 +200,7 @@ namespace Content.Server.Atmos.EntitySystems
         private bool ProcessActiveTiles(GridAtmosphereComponent atmosphere, GasTileOverlayComponent? visuals)
         {
             if(!atmosphere.ProcessingPaused)
-                atmosphere.CurrentRunTiles = new Queue<TileAtmosphere>(atmosphere.ActiveTiles);
+                QueueRunTiles(atmosphere.CurrentRunTiles, atmosphere.ActiveTiles);
 
             var number = 0;
             while (atmosphere.CurrentRunTiles.TryDequeue(out var tile))
@@ -205,8 +223,15 @@ namespace Content.Server.Atmos.EntitySystems
 
         private bool ProcessExcitedGroups(GridAtmosphereComponent gridAtmosphere)
         {
-            if(!gridAtmosphere.ProcessingPaused)
-                gridAtmosphere.CurrentRunExcitedGroups = new Queue<ExcitedGroup>(gridAtmosphere.ExcitedGroups);
+            if (!gridAtmosphere.ProcessingPaused)
+            {
+                gridAtmosphere.CurrentRunExcitedGroups.Clear();
+                gridAtmosphere.CurrentRunExcitedGroups.EnsureCapacity(gridAtmosphere.ExcitedGroups.Count);
+                foreach (var group in gridAtmosphere.ExcitedGroups)
+                {
+                    gridAtmosphere.CurrentRunExcitedGroups.Enqueue(group);
+                }
+            }
 
             var number = 0;
             while (gridAtmosphere.CurrentRunExcitedGroups.TryDequeue(out var excitedGroup))
@@ -238,7 +263,7 @@ namespace Content.Server.Atmos.EntitySystems
         {
             var atmosphere = ent.Comp;
             if (!atmosphere.ProcessingPaused)
-                atmosphere.CurrentRunTiles = new Queue<TileAtmosphere>(atmosphere.HighPressureDelta);
+                QueueRunTiles(atmosphere.CurrentRunTiles, atmosphere.HighPressureDelta);
 
             // Note: This is still processed even if space wind is turned off since this handles playing the sounds.
 
@@ -273,7 +298,7 @@ namespace Content.Server.Atmos.EntitySystems
         private bool ProcessHotspots(GridAtmosphereComponent atmosphere)
         {
             if(!atmosphere.ProcessingPaused)
-                atmosphere.CurrentRunTiles = new Queue<TileAtmosphere>(atmosphere.HotspotTiles);
+                QueueRunTiles(atmosphere.CurrentRunTiles, atmosphere.HotspotTiles);
 
             var number = 0;
             while (atmosphere.CurrentRunTiles.TryDequeue(out var hotspot))
@@ -297,7 +322,7 @@ namespace Content.Server.Atmos.EntitySystems
         private bool ProcessSuperconductivity(GridAtmosphereComponent atmosphere)
         {
             if(!atmosphere.ProcessingPaused)
-                atmosphere.CurrentRunTiles = new Queue<TileAtmosphere>(atmosphere.SuperconductivityTiles);
+                QueueRunTiles(atmosphere.CurrentRunTiles, atmosphere.SuperconductivityTiles);
 
             var number = 0;
             while (atmosphere.CurrentRunTiles.TryDequeue(out var superconductivity))
@@ -320,8 +345,15 @@ namespace Content.Server.Atmos.EntitySystems
 
         private bool ProcessPipeNets(GridAtmosphereComponent atmosphere)
         {
-            if(!atmosphere.ProcessingPaused)
-                atmosphere.CurrentRunPipeNet = new Queue<IPipeNet>(atmosphere.PipeNets);
+            if (!atmosphere.ProcessingPaused)
+            {
+                atmosphere.CurrentRunPipeNet.Clear();
+                atmosphere.CurrentRunPipeNet.EnsureCapacity(atmosphere.PipeNets.Count);
+                foreach (var net in atmosphere.PipeNets)
+                {
+                    atmosphere.CurrentRunPipeNet.Enqueue(net);
+                }
+            }
 
             var number = 0;
             while (atmosphere.CurrentRunPipeNet.TryDequeue(out var pipenet))
@@ -362,7 +394,14 @@ namespace Content.Server.Atmos.EntitySystems
         private bool ProcessAtmosDevices(GridAtmosphereComponent atmosphere)
         {
             if (!atmosphere.ProcessingPaused)
-                atmosphere.CurrentRunAtmosDevices = new Queue<Entity<AtmosDeviceComponent>>(atmosphere.AtmosDevices);
+            {
+                atmosphere.CurrentRunAtmosDevices.Clear();
+                atmosphere.CurrentRunAtmosDevices.EnsureCapacity(atmosphere.AtmosDevices.Count);
+                foreach (var device in atmosphere.AtmosDevices)
+                {
+                    atmosphere.CurrentRunAtmosDevices.Enqueue(device);
+                }
+            }
 
             var time = _gameTiming.CurTime;
             var number = 0;


### PR DESCRIPTION
This just makes atmos system processing re-use `Queue<T>` objects