### PR TITLE
Adds a new `AtmosphereSystem.GetTileMixture()` override

### DIFF
--- a/Content.Server/Anomaly/Effects/GasProducerAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/GasProducerAnomalySystem.cs
@@ -65,7 +65,7 @@ public sealed class GasProducerAnomalySystem : EntitySystem
         if (tilerefs.Length == 0)
             return;
 
-        var mixture = _atmosphere.GetTileMixture(xform.GridUid, xform.MapUid, _xform.GetGridOrMapTilePosition(uid, xform), true);
+        var mixture = _atmosphere.GetTileMixture((uid, xform), grid, true);
         if (mixture != null)
         {
             mixture.AdjustMoles(gas, mols);

--- a/Content.Server/Anomaly/Effects/TempAffectingAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/TempAffectingAnomalySystem.cs
@@ -22,7 +22,7 @@ public sealed class TempAffectingAnomalySystem : EntitySystem
         {
             var grid = xform.GridUid;
             var map = xform.MapUid;
-            var indices = _xform.GetGridOrMapTilePosition(ent, xform);
+            var indices = _xform.GetGridTilePositionOrDefault((ent, xform));
             var mixture = _atmosphere.GetTileMixture(grid, map, indices, true);
 
             if (mixture is { })

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -127,9 +127,18 @@ public partial class AtmosphereSystem
         return ev.Mixtures;
     }
 
-    public GasMixture? GetTileMixture(EntityUid? gridUid, EntityUid? mapUid, Vector2i tile, bool excite = false)
+    public GasMixture? GetTileMixture (Entity<TransformComponent?> entity, MapGridComponent? grid = null, bool excite = false)
     {
-        var ev = new GetTileMixtureMethodEvent(gridUid, mapUid, tile, excite);
+        if (!Resolve(entity.Owner, ref entity.Comp))
+            return null;
+
+        var indices = _transformSystem.GetGridTilePositionOrDefault(entity);
+        return GetTileMixture(entity.Comp.GridUid, entity.Comp.MapUid, indices, excite);
+    }
+
+    public GasMixture? GetTileMixture(EntityUid? gridUid, EntityUid? mapUid, Vector2i gridTile, bool excite = false)
+    {
+        var ev = new GetTileMixtureMethodEvent(gridUid, mapUid, gridTile, excite);
 
         // If we've been passed a grid, try to let it handle it.
         if(gridUid.HasValue)

--- a/Content.Server/Atmos/Miasma/RottingSystem.cs
+++ b/Content.Server/Atmos/Miasma/RottingSystem.cs
@@ -118,9 +118,7 @@ public sealed class RottingSystem : EntitySystem
             return;
 
         var molsToDump = perishable.MolsPerSecondPerUnitMass * physics.FixturesMass * (float) component.TotalRotTime.TotalSeconds;
-        var transform = Transform(uid);
-        var indices = _transform.GetGridOrMapTilePosition(uid, transform);
-        var tileMix = _atmosphere.GetTileMixture(transform.GridUid, transform.MapUid, indices, true);
+        var tileMix = _atmosphere.GetTileMixture(uid, excite: true);
         tileMix?.AdjustMoles(Gas.Miasma, molsToDump);
     }
 
@@ -214,8 +212,7 @@ public sealed class RottingSystem : EntitySystem
             // We need a way to get the mass of the mob alone without armor etc in the future
             // or just remove the mass mechanics altogether because they aren't good.
             var molRate = perishable.MolsPerSecondPerUnitMass * (float) rotting.RotUpdateRate.TotalSeconds;
-            var indices = _transform.GetGridOrMapTilePosition(uid);
-            var tileMix = _atmosphere.GetTileMixture(xform.GridUid, null, indices, true);
+            var tileMix = _atmosphere.GetTileMixture(uid, excite: true);
             tileMix?.AdjustMoles(Gas.Miasma, molRate * physics.FixturesMass);
         }
     }

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -110,9 +110,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             // Some of the gas from the mixture leaks when overclocked.
             if (pump.Overclocked)
             {
-                var transform = Transform(uid);
-                var indices = _transformSystem.GetGridOrMapTilePosition(uid, transform);
-                var tile = _atmosphereSystem.GetTileMixture(transform.GridUid, null, indices, true);
+                var tile = _atmosphereSystem.GetTileMixture(uid, excite: true);
 
                 if (tile != null)
                 {

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -67,8 +67,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (xform.GridUid == null)
                 return;
 
-            var position = _transformSystem.GetGridOrMapTilePosition(uid, xform);
-
+            var position = _transformSystem.GetGridTilePositionOrDefault((uid,xform));
             var environment = _atmosphereSystem.GetTileMixture(xform.GridUid, xform.MapUid, position, true);
 
             Scrub(timeDelta, scrubber, environment, outlet);

--- a/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
@@ -79,8 +79,7 @@ namespace Content.Server.Atmos.Portable
             if (xform.GridUid == null)
                 return;
 
-            var position = _transformSystem.GetGridOrMapTilePosition(uid, xform);
-
+            var position = _transformSystem.GetGridTilePositionOrDefault((uid,xform));
             var environment = _atmosphereSystem.GetTileMixture(xform.GridUid, xform.MapUid, position, true);
 
             var running = Scrub(timeDelta, component, environment);

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -337,8 +337,7 @@ namespace Content.Server.Cloning
             clonePod.CloningProgress = 0f;
             UpdateStatus(uid, CloningPodStatus.Idle, clonePod);
             var transform = Transform(uid);
-            var indices = _transformSystem.GetGridOrMapTilePosition(uid);
-
+            var indices = _transformSystem.GetGridTilePositionOrDefault((uid, transform));
             var tileMix = _atmosphereSystem.GetTileMixture(transform.GridUid, null, indices, true);
 
             if (HasComp<EmaggedComponent>(uid))

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -576,7 +576,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
     private void HandleAir(EntityUid uid, DisposalUnitComponent component, TransformComponent xform)
     {
         var air = component.Air;
-        var indices = _transformSystem.GetGridOrMapTilePosition(uid, xform);
+        var indices = _transformSystem.GetGridTilePositionOrDefault((uid, xform));
 
         if (_atmosSystem.GetTileMixture(xform.GridUid, xform.MapUid, indices, true) is { Temperature: > 0f } environment)
         {

--- a/Content.Server/RatKing/RatKingSystem.cs
+++ b/Content.Server/RatKing/RatKingSystem.cs
@@ -88,10 +88,7 @@ namespace Content.Server.RatKing
             _hunger.ModifyHunger(uid, -component.HungerPerDomainUse, hunger);
 
             _popup.PopupEntity(Loc.GetString("rat-king-domain-popup"), uid);
-
-            var transform = Transform(uid);
-            var indices = _xform.GetGridOrMapTilePosition(uid, transform);
-            var tileMix = _atmos.GetTileMixture(transform.GridUid, transform.MapUid, indices, true);
+            var tileMix = _atmos.GetTileMixture(uid, excite: true);
             tileMix?.AdjustMoles(Gas.Miasma, component.MolesMiasmaPerDomain);
         }
 

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -149,8 +149,7 @@ public sealed class TemperatureSystem : EntitySystem
         if (transform.MapUid == null)
             return;
 
-        var position = _transform.GetGridOrMapTilePosition(uid, transform);
-
+        var position = _transform.GetGridTilePositionOrDefault((uid, transform));
         var temperatureDelta = args.GasMixture.Temperature - temperature.CurrentTemperature;
         var tileHeatCapacity =
             _atmosphere.GetTileHeatCapacity(transform.GridUid, transform.MapUid.Value, position);

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactGasTriggerSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactGasTriggerSystem.cs
@@ -37,9 +37,7 @@ public sealed class ArtifactGasTriggerSystem : EntitySystem
             if (trigger.ActivationGas == null)
                 continue;
 
-            var environment = _atmosphereSystem.GetTileMixture(transform.GridUid, transform.MapUid,
-                _transformSystem.GetGridOrMapTilePosition(uid, transform));
-
+            var environment = _atmosphereSystem.GetTileMixture((uid, transform));
             if (environment == null)
                 continue;
 

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactHeatTriggerSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactHeatTriggerSystem.cs
@@ -28,8 +28,7 @@ public sealed class ArtifactHeatTriggerSystem : EntitySystem
         var query = EntityQueryEnumerator<ArtifactHeatTriggerComponent, TransformComponent, ArtifactComponent>();
         while (query.MoveNext(out var uid, out var trigger, out var transform, out var artifact))
         {
-            var environment = _atmosphereSystem.GetTileMixture(transform.GridUid, transform.MapUid,
-                _transformSystem.GetGridOrMapTilePosition(uid, transform));
+            var environment = _atmosphereSystem.GetTileMixture((uid, transform));
             if (environment == null)
                 continue;
 

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactPressureTriggerSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactPressureTriggerSystem.cs
@@ -21,9 +21,7 @@ public sealed class ArtifactPressureTriggerSystem : EntitySystem
         var query = EntityQueryEnumerator<ArtifactPressureTriggerComponent, ArtifactComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var trigger, out var artifact, out var transform))
         {
-            var environment = _atmosphereSystem.GetTileMixture(transform.GridUid, transform.MapUid,
-                _transformSystem.GetGridOrMapTilePosition(uid, transform));
-
+            var environment = _atmosphereSystem.GetTileMixture((uid, transform));
             if (environment == null)
                 continue;
 


### PR DESCRIPTION
Mainly for convenience, so that callers don't have to manually get an entity's current grid indices.