### PR TITLE
"Realistic" blood powered "Hydraulic" "Limbs" for Arachnids

### DIFF
--- a/Content.Client/Body/Systems/SlowdownOnBloodlossSystem.cs
+++ b/Content.Client/Body/Systems/SlowdownOnBloodlossSystem.cs
@@ -1,0 +1,6 @@
+using Content.Shared.Body.Systems;
+
+namespace Content.Client.Body.Systems;
+public sealed partial class SlowdownOnBloodlossSystem : SharedSlowdownOnBloodlossSystem
+{
+}

--- a/Content.Server/Body/Systems/SlowdownOnBloodlossSystem.cs
+++ b/Content.Server/Body/Systems/SlowdownOnBloodlossSystem.cs
@@ -1,0 +1,37 @@
+using Content.Server.Body.Components;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Server.Body.Systems;
+
+public sealed partial class SlowdownOnBloodlossSystem : SharedSlowdownOnBloodlossSystem
+{
+    [Dependency] private readonly MovementSpeedModifierSystem _speedModifierSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SlowdownOnBloodlossComponent, SolutionChangedEvent>(SolutionChanged);
+    }
+
+    private void SolutionChanged(EntityUid uid, SlowdownOnBloodlossComponent comp, SolutionChangedEvent args)
+    {
+        if (!TryComp<BloodstreamComponent>(uid, out var bloodComp) || args.Solution != bloodComp.BloodSolution)
+            return;
+
+        foreach (var (threshold, multiplier) in comp.Thresholds)
+        {
+            if ((float) args.Solution.Volume < threshold)
+                continue;
+
+            comp.CurrentMultiplier = multiplier;
+            Dirty(uid, comp);
+            break;
+        }
+
+        _speedModifierSystem.RefreshMovementSpeedModifiers(uid);
+    }
+}

--- a/Content.Shared/Body/Components/SlowdownOnBloodlossComponent.cs
+++ b/Content.Shared/Body/Components/SlowdownOnBloodlossComponent.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Body.Components;
+
+/// <summary>
+/// Any entity with this component will experience slowdowns at certain levels of blood.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SlowdownOnBloodlossComponent : Component
+{
+
+    /// <summary>
+    /// The thresholds of blood required to change the entity's speed. First value is threshold and second value is speed multiplier.
+    /// </summary>
+    /// <returns></returns>
+    [DataField(required: true)]
+    public Dictionary<float, float> Thresholds = new();
+
+    [AutoNetworkedField]
+    public float CurrentMultiplier;
+}

--- a/Content.Shared/Body/Systems/SlowdownOnBloodlossSystem.cs
+++ b/Content.Shared/Body/Systems/SlowdownOnBloodlossSystem.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Body.Components;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared.Body.Systems;
+
+public abstract partial class SharedSlowdownOnBloodlossSystem : EntitySystem
+{
+    [Dependency] private readonly MovementSpeedModifierSystem _speedModifierSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SlowdownOnBloodlossComponent, RefreshMovementSpeedModifiersEvent>(MovementSpeedRefresh);
+    }
+
+    private void MovementSpeedRefresh(EntityUid uid, SlowdownOnBloodlossComponent comp, RefreshMovementSpeedModifiersEvent args)
+    {
+        args.ModifySpeed(comp.CurrentMultiplier, comp.CurrentMultiplier);
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -38,6 +38,13 @@
   # Damage (Self)
   - type: Bloodstream
     bloodReagent: CopperBlood
+  - type: SlowdownOnBloodloss
+    thresholds:
+      290: 1
+      280: 0.9
+      270: 0.8
+      250: 0.7
+      200: 0.5
   # Damage (Others)
   - type: MeleeWeapon
     animation: WeaponArcClaw


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR makes it so when arachnids lose blood, it impacts their overall speed.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Arachnids lack enough downsides, and are currently just an upgrade to humans. This should help resolve that.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a simple "SlowdownOnBloodlossSystem" and "SlowdownOnBloodlossComponent". Should be predicted, although I'm not sure. This shouldn't break too much overall I think.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/85175107/4dce28ef-bd83-4db0-8d0a-81fb2b148f14

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.

-->

:cl: PixelTK
- add: Arachnids will now slow down when they've lost enough blood.