### PR TITLE
Changing "egg" reagent to "cooked egg"

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/consumable/food/ingredients.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/food/ingredients.ftl
@@ -10,7 +10,7 @@ reagent-desc-oats = Used for a variety of tasty purposes.
 reagent-name-enzyme = universal enzyme
 reagent-desc-enzyme = Used in cooking various dishes.
 
-reagent-name-egg = egg
+reagent-name-egg = cooked egg
 reagent-desc-egg = Cooked chicken embryo, delicious.
 
 reagent-name-raw-egg = raw egg


### PR DESCRIPTION

## About the PR
Changes the name of the egg reagent to "cooked egg". This is because it was causing some issues and confusion when it came to recipes like pancakes not working because the eggs had cooked after a few batches and the users could not tell that the change had happened.

**Changelog**
:cl:
- tweak: The reagent "egg" is now known as "cooked egg"
