### PR TITLE
Food/Bev updates and fixes

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/coffee.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/coffee.yml
@@ -5,5 +5,6 @@
     DrinkCafeLatte: 5
     DrinkTeacup: 5
     DrinkGreenTea: 5
+    DrinkHotCoco: 5
   emaggedInventory:
     DrinkNothing: 2

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_bottles.yml
@@ -31,6 +31,7 @@
       - DrinkWineBottleFull
       - DrinkBeerBottleFull
       - DrinkAleBottleFull
+      - DrinkChampagneBottleFull
     chance: 0.8
     offset: 0.0
     #rare

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_glass.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_glass.yml
@@ -91,6 +91,8 @@
       - DrinkWineGlass
       - DrinkShakeBlue
       - DrinkShakeWhite
+      - DrinkTheMartinez
+      - DrinkMoonshineGlass
     chance: 0.8
     offset: 0.0
     #rare

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_soda.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_soda.yml
@@ -1,0 +1,47 @@
+- type: entity
+  id: RandomDrinkSoda
+  name: random soda spawner
+  parent: MarkerBase
+  placement:
+    mode: AlignTileAny
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - sprite: Objects/Consumable/Drinks/dr_gibb.rsi
+        state: icon
+  - type: RandomSpawner
+    prototypes:
+      - DrinkColaBottleFull
+      - DrinkSpaceMountainWindBottleFull
+      - DrinkSpaceUpBottleFull
+      - DrinkWaterBottleFull
+      - DrinkColaCan
+      - DrinkIcedTeaCan
+      - DrinkLemonLimeCan
+      - DrinkGrapeCan
+      - DrinkRootBeerCan
+      - DrinkSodaWaterCan
+      - DrinkSpaceMountainWindCan
+      - DrinkSpaceUpCan
+      - DrinkStarkistCan
+      - DrinkTonicWaterCan
+      - DrinkFourteenLokoCan
+      - DrinkChangelingStingCan
+      - DrinkDrGibbCan
+      - DrinkEnergyDrinkCan
+      - DrinkShamblersJuiceCan
+      - DrinkPwrGameCan
+      - DrinkHotCoco
+      - DrinkHotCoffee
+      - DrinkCafeLatte
+      - DrinkTeacup
+      - DrinkGreenTea
+      - DrinkWaterCup
+    chance: 0.8
+    offset: 0.0
+    #rare
+    rarePrototypes:
+      - DrinkNukieCan
+      - DrinkLean
+    rareChance: 0.01

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_baked_single.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_baked_single.yml
@@ -25,6 +25,9 @@
       - FoodBreadJellySlice
       - FoodBreadFrenchToast
       - FoodBreadTwoSlice
+      - FoodBreadVolcanicSlice
+      - FoodBreadTofuSlice
+      - FoodBreadBaguetteSlice
       - FoodCakeBlueberrySlice
       - FoodCakePlainSlice
       - FoodCakeCarrotSlice
@@ -69,6 +72,8 @@
       - FoodTartGrape
       - FoodTartCoco
       - FoodBakedBrownie
+      - FoodPieBananaCreamSlice
+      - FoodTartMimeSlice
     chance: 0.8
     offset: 0.0
     #rare

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_meal.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_meal.yml
@@ -35,6 +35,9 @@
       - FoodNoodlesChowmein
       - FoodNoodlesSpesslaw
       - FoodNoodlesMeatball
+      - FoodNoodlesBoiled
+      - FoodNoodles
+      - FoodNoodlesButter
       - FoodMealHappyHonkClown
       - FoodSoupPea
       - FoodSaladHerb
@@ -45,6 +48,7 @@
       - FoodSaladCaesar
       - FoodSaladColeslaw
       - FoodSaladKimchi
+      - FoodSaladWatermelonFruitBowl
       - FoodRiceBoiled
       - FoodRiceEgg
       - FoodRicePork
@@ -60,10 +64,14 @@
       - FoodSoupMiso
       - FoodSoupMushroom
       - FoodSoupBeet
+      - FoodSoupBeetRed
       - FoodSoupPotato
       - FoodSoupOnion
       - FoodSoupBisque
       - FoodSoupBungo
+      - FoodMealSoftTaco
+      - FoodMealCornInButter
+      - FoodSoupStew
     chance: 0.8
     offset: 0.0
     #rare
@@ -86,4 +94,5 @@
       - FoodSoupMonkey
       - FoodSoupEyeball
       - FoodSoupElectron
+      - FoodNoodlesCopy
     rareChance: 0.05

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_produce.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_produce.yml
@@ -1,0 +1,62 @@
+- type: entity
+  id: RandomProduce
+  name: random produce spawner
+  parent: MarkerBase
+  placement:
+    mode: AlignTileAny
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - sprite: Objects/Specific/Hydroponics/onion_red.rsi
+        state: produce
+  - type: RandomSpawner
+    prototypes:
+      - WheatBushel
+      - OatBushel
+      - Sugarcane
+      - Nettle
+      - FoodBanana
+      - FoodCarrot
+      - FoodCabbage
+      - FoodGarlic
+      - FoodLemon
+      - FoodLime
+      - FoodOrange
+      - FoodPineapple
+      - FoodPotato
+      - FoodTomato
+      - FoodEggplant
+      - FoodApple
+      - FoodCocoaPod
+      - FoodCorn
+      - FoodOnion
+      - FoodOnionRed
+      - FoodMushroom
+      - FoodChili
+      - FoodChilly
+      - FoodAloe
+      - FoodPoppy
+      - FoodLingzhi
+      - FoodAmbrosiaVulgaris
+      - RiceBushel
+      - FoodSoybeans
+      - FoodKoibean
+      - FoodWatermelon
+      - FoodGrape
+      - FoodBerries
+      - FoodBungo
+      - FoodPeaPod
+      - FoodPumpkin
+      - CottonBol
+    chance: 0.8
+    offset: 0.0
+    #rare
+    rarePrototypes:
+      - FoodBlueTomato
+      - FoodBloodTomato
+      - FoodAmbrosiaDeus
+      - FoodGalaxythistle
+      - FoodFlyAmanita
+      - DeathNettle
+    rareChance: 0.01

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_single.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_single.yml
@@ -46,6 +46,14 @@
       - FoodPizzaSassysageSlice
       - FoodPizzaPineappleSlice
       - FoodPizzaMoldySlice
+      - FoodBakedDumplings
+      - FoodBakedChevreChaud
+      - FoodBakedNugget
+      - FoodTacoBeef
+      - FoodTacoChicken
+      - FoodTacoFish
+      - FoodTacoBeefSupreme
+      - FoodTacoChickenSupreme
     chance: 0.8
     offset: 0.0
     #rare
@@ -67,4 +75,5 @@
       - FoodMeatRatKebab
       - FoodMeatRatdoubleKebab
       - FoodPizzaArnoldSlice
+      - FoodTacoRat
     rareChance: 0.05

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_snacks.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_snacks.yml
@@ -14,29 +14,6 @@
   - type: RandomSpawner
   #small item
     prototypes:
-      - DrinkColaBottleFull
-      - DrinkSpaceMountainWindBottleFull
-      - DrinkSpaceUpBottleFull
-      - DrinkWaterBottleFull
-      - DrinkColaCan
-      - DrinkIcedTeaCan
-      - DrinkLemonLimeCan
-      - DrinkGrapeCan
-      - DrinkRootBeerCan
-      - DrinkSodaWaterCan
-      - DrinkSpaceMountainWindCan
-      - DrinkSpaceUpCan
-      - DrinkStarkistCan
-      - DrinkTonicWaterCan
-      - DrinkFourteenLokoCan
-      - DrinkChangelingStingCan
-      - DrinkDrGibbCan
-      - DrinkEnergyDrinkCan
-      - DrinkHotCoco
-      - DrinkHotCoffee
-      - DrinkTeacup
-      - DrinkLean
-      - DrinkWaterCup
       - FoodSnackBoritos
       - FoodSnackCheesie
       - FoodSnackChips
@@ -52,5 +29,21 @@
       - FoodSnackCookieFortune
       - FoodSnackNutribrick
       - FoodSnackMREBrownie
+      - FoodFrozenSandwich
+      - FoodFrozenSandwichStrawberry
+      - FoodFrozenFreezy
+      - FoodFrozenSundae
+      - FoodFrozenCornuto
+      - FoodFrozenPopsicleOrange
+      - FoodFrozenPopsicleBerry
+      - FoodFrozenPopsicleJumbo
+      - FoodFrozenSnowcone
+      - FoodFrozenSnowconeBerry
+      - FoodFrozenSnowconeFruit
+      - FoodFrozenSnowconeClown
+      - FoodFrozenSnowconeMime
+      - FoodFrozenSnowconeRainbow
+      - FoodSnackPistachios
+      - FoodSnackSemki
     chance: 0.8
     offset: 0.0

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/trash.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/trash.yml
@@ -32,6 +32,7 @@
         - FoodPacketSemkiTrash
         - FoodPacketSusTrash
         - FoodPacketSyndiTrash
+        - BrokenBottle
       chance: 0.5
       offset: 0.2
   placement:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -1,0 +1,186 @@
+- type: entity
+  parent: DrinkBase
+  id: DrinkCartonBaseFull
+  abstract: true
+  components:
+  - type: Openable
+    sound:
+      collection: bottleOpenSounds #Could use a new sound someday ¯\_(ツ)_/¯
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 50
+  - type: Sprite
+    state: icon
+  - type: Item
+    size: Normal
+  - type: MeleeWeapon
+    soundNoDamage:
+      path: "/Audio/Effects/Fluids/splat.ogg"
+    damage:
+      types:
+        Blunt: 0
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 5
+      behaviors:
+      - !type:SpillBehavior { }
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: TrashOnSolutionEmpty
+    solution: drink
+
+- type: entity
+  parent: DrinkCartonBaseFull
+  id: DrinkJuiceLimeCarton
+  name: lime juice
+  description: Sweet-sour goodness.
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        reagents:
+        - ReagentId: JuiceLime
+          Quantity: 50
+  - type: Drink
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/limejuice.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          DrinkCartonLime:
+            min: 1
+            max: 1
+
+- type: entity
+  parent: DrinkCartonBaseFull
+  id: DrinkJuiceOrangeCarton
+  name: orange juice
+  description: Full of vitamins and deliciousness!
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        reagents:
+        - ReagentId: JuiceOrange
+          Quantity: 50
+  - type: Drink
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/orangejuice.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          DrinkCartonOrange:
+            min: 1
+            max: 1
+
+- type: entity
+  parent: DrinkCartonBaseFull
+  id: DrinkJuiceTomatoCarton
+  name: tomato juice
+  description: Well, at least it LOOKS like tomato juice. You can't tell with all that redness.
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        reagents:
+        - ReagentId: JuiceTomato
+          Quantity: 50
+  - type: Drink
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/tomatojuice.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          DrinkCartonTomato:
+            min: 1
+            max: 1
+
+- type: entity
+  parent: DrinkCartonBaseFull
+  id: DrinkCreamCarton
+  name: Milk Cream
+  description: It's cream. Made from milk. What else did you think you'd find in there?
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        reagents:
+        - ReagentId: Cream
+          Quantity: 50
+  - type: Drink
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/cream.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          DrinkCartonCream:
+            min: 1
+            max: 1
+
+- type: entity
+  parent: DrinkCartonBaseFull
+  id: DrinkMilkCarton
+  name: milk
+  description: An opaque white liquid produced by the mammary glands of mammals.
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 100
+        reagents:
+        - ReagentId: Milk
+          Quantity: 100
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/milk.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          DrinkCartonMilk:
+            min: 1
+            max: 1
+
+- type: entity
+  parent: DrinkCartonBaseFull
+  id: DrinkSoyMilkCarton
+  name: soy milk
+  description: White and nutritious soy goodness!
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 100
+        reagents:
+        - ReagentId: MilkSoy
+          Quantity: 100
+  - type: Drink
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/soymilk.rsi
+  - type: Destructible
+    thresholds:
+    - trigger:
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          DrinkCartonSoyMilk:
+            min: 1
+            max: 1

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -26,11 +26,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 5
+        damage: 20
       behaviors:
       - !type:SpillBehavior { }
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+        #In future maybe add generic plastic scrap trash/debris
   - type: TrashOnSolutionEmpty
     solution: drink
 
@@ -49,15 +50,6 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/limejuice.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          DrinkCartonLime:
-            min: 1
-            max: 1
 
 - type: entity
   parent: DrinkCartonBaseFull
@@ -74,15 +66,6 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/orangejuice.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          DrinkCartonOrange:
-            min: 1
-            max: 1
 
 - type: entity
   parent: DrinkCartonBaseFull
@@ -99,15 +82,6 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/tomatojuice.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          DrinkCartonTomato:
-            min: 1
-            max: 1
 
 - type: entity
   parent: DrinkCartonBaseFull
@@ -124,15 +98,6 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/cream.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          DrinkCartonCream:
-            min: 1
-            max: 1
 
 - type: entity
   parent: DrinkCartonBaseFull
@@ -149,15 +114,6 @@
           Quantity: 100
   - type: Sprite
     sprite: Objects/Consumable/Drinks/milk.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          DrinkCartonMilk:
-            min: 1
-            max: 1
 
 - type: entity
   parent: DrinkCartonBaseFull
@@ -175,12 +131,3 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/soymilk.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          DrinkCartonSoyMilk:
-            min: 1
-            max: 1

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -47,7 +47,6 @@
         reagents:
         - ReagentId: JuiceLime
           Quantity: 50
-  - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/limejuice.rsi
 
@@ -63,7 +62,6 @@
         reagents:
         - ReagentId: JuiceOrange
           Quantity: 50
-  - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/orangejuice.rsi
 
@@ -79,7 +77,6 @@
         reagents:
         - ReagentId: JuiceTomato
           Quantity: 50
-  - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/tomatojuice.rsi
 
@@ -95,7 +92,6 @@
         reagents:
         - ReagentId: Cream
           Quantity: 50
-  - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/cream.rsi
 
@@ -128,6 +124,5 @@
         reagents:
         - ReagentId: MilkSoy
           Quantity: 100
-  - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/soymilk.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -1,5 +1,7 @@
 # TODO: Find remaining cans and move to drinks_cans
 # TODO: Find empty containers (e.g. mug, pitcher) and move to their own yml
+# Organize Albhabetically
+# When adding new drinks also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\drinks_glass.yml
 - type: entity
   parent: BaseItem
   id: DrinkBase
@@ -1848,6 +1850,22 @@
 
 - type: entity
   parent: DrinkGlassBase
+  id: DrinkTheMartinez
+  name: The Martinez glass
+  description: The edgerunner legend.  Remembered by a drink, Forgotten by a drunk.
+  components:
+    - type: SolutionContainerManager
+      solutions:
+        drink:
+          maxVol: 30
+          reagents:
+            - ReagentId: TheMartinez
+              Quantity: 30
+    - type: Sprite
+      sprite: Objects/Consumable/Drinks/the_martinez.rsi
+
+- type: entity
+  parent: DrinkGlassBase
   id: DrinkThreeMileIslandGlass
   name: three mile island glass
   description: A glass of this is sure to prevent a meltdown.
@@ -2168,19 +2186,3 @@
           Quantity: 30
         - ReagentId: CapsaicinOil
           Quantity: 5
-
-- type: entity
-  parent: DrinkGlassBase
-  id: DrinkTheMartinez
-  name: The Martinez glass
-  description: The edgerunner legend.  Remembered by a drink, Forgotten by a drunk.
-  components:
-    - type: SolutionContainerManager
-      solutions:
-        drink:
-          maxVol: 30
-          reagents:
-            - ReagentId: TheMartinez
-              Quantity: 30
-    - type: Sprite
-      sprite: Objects/Consumable/Drinks/the_martinez.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -1,6 +1,5 @@
 # TODO: Find remaining cans and move to drinks_cans
 # TODO: Find empty containers (e.g. mug, pitcher) and move to their own yml
-# Organize Albhabetically
 # When adding new drinks also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\drinks_glass.yml
 - type: entity
   parent: BaseItem
@@ -509,6 +508,13 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/chocolateglass.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: HotCocoa
+          Quantity: 30
 
 - type: entity
   parent: DrinkGlassBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -1,3 +1,4 @@
+# When adding new drinks also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\drinks_bottles.yml
 - type: entity
   parent: DrinkBase
   id: DrinkBottleBaseFull

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -96,6 +96,21 @@
 
 - type: entity
   parent: DrinkBottleBaseFull
+  id: DrinkChampagneBottleFull
+  name: champagne bottle
+  description: Only people devoid of imagination can't find an excuse for champagne.
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        reagents:
+        - ReagentId: Champagne
+          Quantity: 100
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/champagnebottle.rsi
+
+- type: entity
+  parent: DrinkBottleBaseFull
   id: DrinkCognacBottleFull
   name: cognac bottle
   description: A sweet and strongly alchoholic drink, made after numerous distillations and years of maturing. You might as well not scream 'SHITCURITY' this time.
@@ -391,21 +406,6 @@
 
 - type: entity
   parent: DrinkBottleBaseFull
-  id: DrinkChampagneBottleFull
-  name: champagne bottle
-  description: Only people devoid of imagination can't find an excuse for champagne.
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: Champagne
-          Quantity: 100
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/champagnebottle.rsi
-
-- type: entity
-  parent: DrinkBottleBaseFull
   id: DrinkWaterBottleFull
   name: water bottle
   description: Simple clean water of unknown origin. You think that maybe you dont want to know it.
@@ -420,106 +420,3 @@
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/waterbottle.rsi
-
-# Cartons, TODO: this needs to be moved elsewhere eventually, since cartons shouldnt smash into glass shards
-
-- type: entity
-  parent: DrinkBottleBaseFull
-  id: DrinkJuiceLimeCarton
-  name: lime juice
-  description: Sweet-sour goodness.
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 50
-        reagents:
-        - ReagentId: JuiceLime
-          Quantity: 50
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/limejuice.rsi
-
-- type: entity
-  parent: DrinkBottleBaseFull
-  id: DrinkJuiceOrangeCarton
-  name: orange juice
-  description: Full of vitamins and deliciousness!
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 50
-        reagents:
-        - ReagentId: JuiceOrange
-          Quantity: 50
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/orangejuice.rsi
-
-- type: entity
-  parent: DrinkBottleBaseFull
-  id: DrinkJuiceTomatoCarton
-  name: tomato juice
-  description: Well, at least it LOOKS like tomato juice. You can't tell with all that redness.
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 50
-        reagents:
-        - ReagentId: JuiceTomato
-          Quantity: 50
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/tomatojuice.rsi
-
-- type: entity
-  parent: DrinkBottleBaseFull
-  id: DrinkCreamCarton
-  name: Milk Cream
-  description: It's cream. Made from milk. What else did you think you'd find in there?
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 50
-        reagents:
-        - ReagentId: Cream
-          Quantity: 50
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/cream.rsi
-
-- type: entity
-  parent: DrinkBottleBaseFull
-  id: DrinkMilkCarton
-  name: milk
-  description: An opaque white liquid produced by the mammary glands of mammals.
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 100
-        reagents:
-        - ReagentId: Milk
-          Quantity: 100
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/milk.rsi
-
-- type: entity
-  parent: DrinkBottleBaseFull
-  id: DrinkSoyMilkCarton
-  name: soy milk
-  description: White and nutritious soy goodness!
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 100
-        reagents:
-        - ReagentId: MilkSoy
-          Quantity: 100
-  - type: Drink
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/soymilk.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -1,3 +1,4 @@
+# When adding new drinks also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\drinks_soda.yml
 - type: entity
   parent: BaseItem
   id: DrinkCanBaseFull

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -1,4 +1,5 @@
 # Empty drink containers; different from bottles in that these are intended to be spawned empty
+# When adding new drinks also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\drinks_soda.yml
 - type: entity
   parent: BaseItem
   id: DrinkBaseCup
@@ -178,6 +179,12 @@
   name: Hot chocolate
   description: A heated drink consisting melted chocolate and heated milk.
   components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        reagents:
+        - ReagentId: HotCocoa
+          Quantity: 20
   - type: Sprite
     sprite: Objects/Consumable/Drinks/hot_coco.rsi
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -11,7 +11,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 50
+        maxVol: 100
   - type: SolutionTransfer
     canChangeTransferAmount: true
     maxTransferAmount: 5
@@ -72,6 +72,57 @@
       Glass: 100
   - type: SpaceGarbage
 
+- type: entity
+  name: base empty carton
+  id: DrinkCartonBaseEmpty
+  parent: BaseItem
+  abstract: true
+  description: An empty carton.
+  components:
+  - type: Sprite
+    state: icon
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 50
+  - type: SolutionTransfer
+    canChangeTransferAmount: true
+    maxTransferAmount: 5
+  - type: Drink
+  - type: Spillable
+    solution: drink
+  - type: FitsInDispenser
+    solution: drink
+  - type: DrawableSolution
+    solution: drink
+  - type: RefillableSolution
+    solution: drink
+  - type: DrainableSolution
+    solution: drink
+  - type: UserInterface
+    interfaces:
+    - key: enum.TransferAmountUiKey.Key
+      type: TransferAmountBoundUserInterface
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 5
+      behaviors:
+      - !type:SpillBehavior { }
+        transferForensics: true
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Tag
+    tags:
+    - Trash
+  - type: PhysicalComposition
+    materialComposition:
+      Cardboard: 20
+  - type: SpaceGarbage
+
 # Containers
 - type: entity
   name: jailbreaker verte bottle
@@ -98,6 +149,10 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/TrashDrinks/alebottle_empty.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 50
 
 
 - type: entity
@@ -107,6 +162,10 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/TrashDrinks/beer_empty.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 50
 
 
 - type: entity
@@ -225,3 +284,64 @@
   - type: Sprite
     sprite: Objects/Consumable/TrashDrinks/winebottle_empty.rsi
 
+
+- type: entity
+  name: lime juice carton
+  parent: DrinkCartonBaseEmpty
+  id: DrinkCartonLime
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/limejuice.rsi
+
+
+- type: entity
+  name: orange juice carton
+  parent: DrinkCartonBaseEmpty
+  id: DrinkCartonOrange
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/orangejuice.rsi
+
+
+- type: entity
+  name: tomato juice carton
+  parent: DrinkCartonBaseEmpty
+  id: DrinkCartonTomato
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/tomatojuice.rsi
+
+
+- type: entity
+  name: Milk Cream carton
+  parent: DrinkCartonBaseEmpty
+  id: DrinkCartonCream
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/cream.rsi
+
+
+- type: entity
+  name: milk carton
+  parent: DrinkCartonBaseEmpty
+  id: DrinkCartonMilk
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/milk.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 100
+
+
+- type: entity
+  name: soy milk carton
+  parent: DrinkCartonBaseEmpty
+  id: DrinkCartonSoyMilk
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/soymilk.rsi
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 100

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -112,7 +112,6 @@
         damage: 20
       behaviors:
       - !type:SpillBehavior { }
-        transferForensics: true
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -308,7 +308,7 @@
   id: DrinkCartonTomato
   components:
   - type: Sprite
-    sprite: Objects/Consumable/tomatojuice.rsi
+    sprite: Objects/Consumable/Drinks/tomatojuice.rsi
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -109,7 +109,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 5
+        damage: 20
       behaviors:
       - !type:SpillBehavior { }
         transferForensics: true

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_baked_whole.yml & food_baked_single.yml
 # Base
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_baked_whole.yml & food_baked_single.yml
 # Base
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to the appropriate random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\
 # Base
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_baked_whole.yml & food_baked_single.yml
 # Base
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_meal.yml & food_single.yml
 # Base
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_single.yml
 # Bun
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_snack.yml
 # Base
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_meal.yml
 # A bunch of different meals. This stuff doesn't come off their plates because
 # it's assembled on them. Or they just don't have plates.
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_meal.yml
 # Base
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_produce.yml
 # For produce that can't be immediately eaten
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_single.yml
 # Base
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -1,3 +1,4 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_snack.yml
 # Base
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -1,3 +1,5 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_meal.yml
+
 - type: entity
   parent: FoodBase
   id: FoodBowlBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/taco.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/taco.yml
@@ -1,3 +1,5 @@
+# When adding new food also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\food_single.yml
+
 - type: entity
   name: taco shell
   parent: FoodMealBase

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1393,9 +1393,9 @@
       effects:
         - !type:SatiateThirst
           factor: 1
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.15
+        - !type:AdjustReagent
+          reagent: Ethanol
+          amount: 0.15
 
 - type: reagent
   id: WhiteRussian

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1254,6 +1254,18 @@
         amount: 0.15
 
 - type: reagent
+  id: TheMartinez
+  name: reagent-name-the-martinez
+  parent: BaseAlcohol
+  desc: reagent-desc-the-martinez
+  physicalDesc: reagent-physical-desc-vibrant
+  flavor: themartinez
+  color: "#75b1f0"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/the_martinez.rsi
+    state: icon
+
+- type: reagent
   id: ThreeMileIsland
   name: reagent-name-three-mile-island
   parent: BaseAlcohol
@@ -1367,6 +1379,23 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.07
+
+- type: reagent
+  id: WhiteGilgamesh
+  name: reagent-name-white-gilgamesh
+  parent: BaseDrink
+  desc: reagent-desc-white-gilgamesh
+  physicalDesc: reagent-physical-desc-creamy
+  flavor: white-gilgamesh
+  color: "#e5d27e"
+  metabolisms:
+    Drink:
+      effects:
+        - !type:SatiateThirst
+          factor: 1
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.15
 
 - type: reagent
   id: WhiteRussian

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -17,6 +17,24 @@
         amount: 0.05
 
 - type: reagent
+  id: HotCocoa
+  name: reagent-name-cocoa
+  parent: BaseDrink
+  desc: reagent-desc-cocoa
+  physicalDesc: reagent-physical-desc-aromatic
+  flavor: chocolate
+  color: "#664300"
+  recognizable: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+
+- type: reagent
   id: Cream
   name: reagent-name-cream
   group: Drinks
@@ -406,29 +424,3 @@
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/rewriter.rsi
     state: icon
-
-- type: reagent
-  id: TheMartinez
-  name: reagent-name-the-martinez
-  parent: BaseDrink
-  desc: reagent-desc-the-martinez
-  physicalDesc: reagent-physical-desc-vibrant
-  flavor: themartinez
-  color: "#75b1f0"
-  metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/the_martinez.rsi
-    state: icon
-
-- type: reagent
-  id: WhiteGilgamesh
-  name: reagent-name-white-gilgamesh
-  parent: BaseDrink
-  desc: reagent-desc-white-gilgamesh
-  physicalDesc: reagent-physical-desc-creamy
-  flavor: white-gilgamesh
-  color: "#e5d27e"
-  metabolisms:
-    Drink:
-      effects:
-        - !type:SatiateThirst
-          factor: 1

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -355,6 +355,17 @@
     Hooch: 3
 
 - type: reaction
+  id: HotCocoa
+  minTemp: 350
+  reactants:
+    Water:
+      amount: 1
+    CocoaPowder:
+      amount: 1
+  products:
+    HotCocoa: 2
+
+- type: reaction
   id: IceCream
   reactants:
     Cream:


### PR DESCRIPTION
## About the PR
- Updates rndm spawners with missing items and adds note in files to help with future additions
- Moves soda from snack spawner into its own spawner
- Adds a produce spawner for Hydro/kitchens
- Fixes The Martinez and the White Gilgamesh not having alcohol even thought they have alcohol as an ingredient, and moves them to appropriate file
- Fills Hot Cocoa cups with Hot Cocoa(they were previously empty) 
- Fixes [#19787](https://github.com/space-wizards/space-station-14/issues/19787)
- Adds Recipe for Hot Cocoa and adds to Coffee vending machine
- Fixes carton based beverages turning into broken bottles when smashed
- Fixes some empty bottles not being able to be filled to max capacity after being emptied

## Why / Balance
Fixes some errors and makes spawners maximum robust.

## Technical details
n/a

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a Primarily mapping changes/small tweaks
