### PR TITLE
Fix handcuffed entity deletion and a mind shutdown error.

### DIFF
--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -40,7 +40,7 @@ public sealed class MindSystem : SharedMindSystem
         if (mind.UserId is {} user)
         {
             UserMinds.Remove(user);
-            if (_players.GetPlayerData(user).ContentData() is { } oldData)
+            if (_players.TryGetPlayerData(user, out var data) && data.ContentData() is { } oldData)
                 oldData.Mind = null;
             mind.UserId = null;
         }

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -619,6 +619,9 @@ namespace Content.Shared.Cuffs
             if (!Resolve(target, ref cuffable) || !Resolve(cuffsToRemove, ref cuff))
                 return;
 
+            if (TerminatingOrDeleted(cuffsToRemove) || TerminatingOrDeleted(target))
+                return;
+
             if (user != null)
             {
                 var attempt = new UncuffAttemptEvent(user.Value, target);


### PR DESCRIPTION
- Stops handcuff system from spawning entities while deleting a handcuffed entity.
- Fixes a mind exception that gets thrown while shutting down a server 