### PR TITLE
Fixes jani items not being storable on jani trolley

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -295,31 +295,31 @@
             tags:
               - Mop
           insertOnInteract: false # or it conflicts with bucket logic
-          priority: 9 # Higher than bucket slot
+          priority: 12 # Higher than bucket slot
         plunger_slot:
           name: Plunger
           whitelist:
             tags:
               - Plunger
-          priority: 8
+          priority: 11
         wetfloorsign_slot4:
           name: WetFloorSign
           whitelist:
             tags:
               - WetFloorSign
-          priority: 7
+          priority: 10
         wetfloorsign_slot3:
           name: WetFloorSign
           whitelist:
             tags:
               - WetFloorSign
-          priority: 7
+          priority: 9
         wetfloorsign_slot2:
           name: WetFloorSign
           whitelist:
             tags:
               - WetFloorSign
-          priority: 7
+          priority: 8
         wetfloorsign_slot1:
           name: WetFloorSign
           whitelist:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -295,31 +295,31 @@
             tags:
               - Mop
           insertOnInteract: false # or it conflicts with bucket logic
-          priority: 12 # Higher than bucket slot
+          priority: 9 # Higher than bucket slot
         plunger_slot:
           name: Plunger
           whitelist:
             tags:
               - Plunger
-          priority: 11
+          priority: 8
         wetfloorsign_slot4:
           name: WetFloorSign
           whitelist:
             tags:
               - WetFloorSign
-          priority: 10
+          priority: 7
         wetfloorsign_slot3:
           name: WetFloorSign
           whitelist:
             tags:
               - WetFloorSign
-          priority: 9
+          priority: 7
         wetfloorsign_slot2:
           name: WetFloorSign
           whitelist:
             tags:
               - WetFloorSign
-          priority: 8
+          priority: 7
         wetfloorsign_slot1:
           name: WetFloorSign
           whitelist:
@@ -471,6 +471,13 @@
         mop_slot: !type:ContainerSlot {}
         trashbag_slot: !type:ContainerSlot {}
         bucket_slot: !type:ContainerSlot {}
+        plunger_slot: !type:ContainerSlot {}
+        wetfloorsign_slot4: !type:ContainerSlot {}
+        wetfloorsign_slot3: !type:ContainerSlot {}
+        wetfloorsign_slot2: !type:ContainerSlot {}
+        wetfloorsign_slot1: !type:ContainerSlot {}
+        lightreplacer_slot: !type:ContainerSlot {}
+        spraybottle_slot:  !type:ContainerSlot {}
     - type: GuideHelp
       guides:
       - Janitorial

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -295,6 +295,49 @@
             tags:
               - Mop
           insertOnInteract: false # or it conflicts with bucket logic
+          priority: 9 # Higher than bucket slot
+        plunger_slot:
+          name: Plunger
+          whitelist:
+            tags:
+              - Plunger
+          priority: 8
+        wetfloorsign_slot4:
+          name: WetFloorSign
+          whitelist:
+            tags:
+              - WetFloorSign
+          priority: 7
+        wetfloorsign_slot3:
+          name: WetFloorSign
+          whitelist:
+            tags:
+              - WetFloorSign
+          priority: 7
+        wetfloorsign_slot2:
+          name: WetFloorSign
+          whitelist:
+            tags:
+              - WetFloorSign
+          priority: 7
+        wetfloorsign_slot1:
+          name: WetFloorSign
+          whitelist:
+            tags:
+              - WetFloorSign
+          priority: 7
+        lightreplacer_slot:
+          name: LightReplacer
+          whitelist:
+            tags:
+              - LightReplacer
+          priority: 6
+        spraybottle_slot:
+          name: Spray
+          whitelist:
+            tags:
+              - Spray
+          insertOnInteract: false # or it conflicts with bucket logic
           priority: 5 # Higher than bucket slot
         bucket_slot:
           name: Bucket

--- a/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
@@ -17,6 +17,7 @@
       amount: 5
   - type: Tag
     tags:
+      - LightReplacer
       - DroneUsable
   - type: StaticPrice
     price: 100

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -648,6 +648,9 @@
   id: Lemon
 
 - type: Tag
+  id: LightReplacer
+
+- type: Tag
   id: Lime
 
 - type: Tag


### PR DESCRIPTION
## About the PR
- Adds slots to janitor's trolley for storing wet floor signs, spray bottles, light replacers, and plungers  

## Why / Balance
The textures were there and it was half-implemented in the yaml. This completes it so it works as intended.

## Technical details
n/a

## Media
![image](https://github.com/space-wizards/space-station-14/assets/107660393/9429a923-0ac4-4448-9b38-813ba0ce222a)
![image](https://github.com/space-wizards/space-station-14/assets/107660393/a9bfe170-12f1-4e97-871c-91f04fa80f40)
![image](https://github.com/space-wizards/space-station-14/assets/107660393/cc903cd5-f2e5-4d00-b0ee-24d1a4cc0838)

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**

:cl: Velcroboy
- fix: Fixed janitorial items (wet floor signs, spray bottles, light replacers, and plungers) not fitting in the janitor's trolley.