### PR TITLE
Disables space wind and atmos tile ripping

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -927,7 +927,7 @@ namespace Content.Shared.CCVar
         ///     Whether gas differences will move entities.
         /// </summary>
         public static readonly CVarDef<bool> SpaceWind =
-            CVarDef.Create("atmos.space_wind", true, CVar.SERVERONLY);
+            CVarDef.Create("atmos.space_wind", false, CVar.SERVERONLY);
 
         /// <summary>
         ///     Divisor from maxForce (pressureDifference * 2.25f) to force applied on objects.
@@ -973,7 +973,7 @@ namespace Content.Shared.CCVar
         ///     Needs <see cref="MonstermosEqualization"/> and <see cref="MonstermosDepressurization"/> to be enabled to work.
         /// </summary>
         public static readonly CVarDef<bool> MonstermosRipTiles =
-            CVarDef.Create("atmos.monstermos_rip_tiles", true, CVar.SERVERONLY);
+            CVarDef.Create("atmos.monstermos_rip_tiles", false, CVar.SERVERONLY);
 
         /// <summary>
         ///     Whether explosive depressurization will cause the grid to gain an impulse.


### PR DESCRIPTION
## About the PR
Disables the space wind and tile ripping cvars by default.

## Why / Balance
Space wind as it is now feels terrible and needs some fixes before it can be enabled again. (see #20408)

Tile ripping, on the other hand, looks HIDEOUS and makes basically every late-game nukeops round into a visual clusterfuck where you can barely make out anything on the floor. It also doesn't help that slow spacing massively emphasizes its effect and causes way too many tiles to be ripped (if I'm remembering it correctly, at least.)
There is an argument to be made for this being good for the visual clarity of a spaced area, but there are plenty of other obvious tells for that (namely firelocks and air alarms) so it should be fine.

## Technical details
Just changes 2 lines in CCVars from "true" to "false."

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Probably not

**Changelog**
:cl:
- remove: Disabled space wind & atmos tile ripping.
