### PR TITLE
revenant emag whitelist

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -321,6 +321,9 @@ public sealed partial class RevenantSystem
 
         foreach (var ent in _lookup.GetEntitiesInRange(uid, component.MalfunctionRadius))
         {
+            if (component.MalfunctionWhitelist?.IsValid(ent, EntityManager) == false)
+                continue;
+
             _emag.DoEmagEffect(uid, ent); //it does not emag itself. adorable.
         }
     }

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -324,6 +324,9 @@ public sealed partial class RevenantSystem
             if (component.MalfunctionWhitelist?.IsValid(ent, EntityManager) == false)
                 continue;
 
+            if (component.MalfunctionBlacklist?.IsValid(ent, EntityManager) == true)
+                continue;
+
             _emag.DoEmagEffect(uid, ent); //it does not emag itself. adorable.
         }
     }

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared.FixedPoint;
 using Content.Shared.Store;
+using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -182,6 +183,13 @@ public sealed partial class RevenantComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("malfunctionRadius")]
     public float MalfunctionRadius = 3.5f;
+
+    /// <summary>
+    /// Whitelist for entities that can be emagged by malfunction.
+    /// Used to prevent ultra gamer things like ghost emagging chem or instantly launching the shuttle.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? MalfunctionWhitelist;
     #endregion
 
     #region Visualizer

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -190,6 +190,12 @@ public sealed partial class RevenantComponent : Component
     /// </summary>
     [DataField]
     public EntityWhitelist? MalfunctionWhitelist;
+
+    /// <summary>
+    /// Whitelist for entities that can never be emagged by malfunction.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? MalfunctionBlacklist;
     #endregion
 
     #region Visualizer

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -58,6 +58,15 @@
     rules: ghost-role-information-revenant-rules
   - type: GhostTakeoverAvailable
   - type: Revenant
+    malfunctionWhitelist:
+      components:
+      # emag lockers open
+      - EntityStorage
+      # emag doors open
+      - Airlock
+      # troll medical to help get kills
+      - StasisBed
+      - EmaggableMedibot
   - type: PointLight
     color: MediumPurple
     radius: 2

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -67,6 +67,8 @@
       # troll medical to help get kills
       - StasisBed
       - EmaggableMedibot
+      # borg become killer
+      - EmagSiliconLaw
   - type: PointLight
     color: MediumPurple
     radius: 2


### PR DESCRIPTION
## About the PR
whitelisted emagging to lockers doors stasis beds and medibots

## Why / Balance
fixes #21499 and resolves #21719

## Technical details
added optional whitelist to rev component which is checked when emagging

## Media
evac isnt launched, doors are emagged
![04:47:23](https://github.com/space-wizards/space-station-14/assets/39013340/173b05c8-018b-4d8b-8404-c84288d71a5b)

borg isnt malf since that was op too
![04:47:47](https://github.com/space-wizards/space-station-14/assets/39013340/0b495f9d-9785-4f37-9407-6fd0d4062a67)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Revenants can no longer emag evac to instantly launch the shuttle.
