### PR TITLE
rev roundend shows converted count

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Mind;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.Systems;
+using Content.Server.Objectives;
 using Content.Server.Popups;
 using Content.Server.Revolutionary.Components;
 using Content.Server.Roles;
@@ -41,6 +42,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
+    [Dependency] private readonly ObjectivesSystem _objectives = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly RoleSystem _role = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
@@ -100,24 +102,19 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             var index = (commandLost ? 1 : 0) | (revsLost ? 2 : 0);
             ev.AddLine(Loc.GetString(Outcomes[index]));
 
-            ev.AddLine(Loc.GetString("head-rev-initial-count", ("initialCount", headrev.HeadRevs.Count)));
-            foreach (var player in headrev.HeadRevs)
+            ev.AddLine(Loc.GetString("rev-headrev-count", ("initialCount", headrev.HeadRevs.Count)));
+            foreach (var player in headrev.HeadRevs.Values)
             {
-                _mind.TryGetSession(player.Value, out var session);
-                var username = session?.Name;
-                if (username != null)
-                {
-                    ev.AddLine(Loc.GetString("head-rev-initial-name-user",
-                    ("name", player.Key),
-                    ("username", username)));
-                }
-                else
-                {
-                    ev.AddLine(Loc.GetString("head-rev-initial-name",
-                    ("name", player.Key)));
-                }
+                var title = _objectives.GetTitle(player);
+                if (title == null)
+                    continue;
+
+                // TODO: when role entities are a thing this has to change
+                var count = CompOrNull<RevolutionaryRoleComponent>(player)?.ConvertedCount ?? 0;
+                ev.AddLine(Loc.GetString("rev-headrev-player", ("title", title), ("count", count)));
+
+                // TODO: someone suggested listing all alive? revs maybe implement at some point
             }
-            break;
         }
     }
 
@@ -207,6 +204,9 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         if (ev.User != null)
         {
             _adminLogManager.Add(LogType.Mind, LogImpact.Medium, $"{ToPrettyString(ev.User.Value)} converted {ToPrettyString(ev.Target)} into a Revolutionary");
+
+            if (_mind.TryGetRole<RevolutionaryRoleComponent>(ev.User.Value, out var headrev))
+                headrev.ConvertedCount++;
         }
 
         if (mindId == default || !_role.MindHasRole<RevolutionaryRoleComponent>(mindId))

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -110,26 +110,9 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
             if (!TryComp(mindId, out MindComponent? mind))
                 continue;
 
-            var name = mind.CharacterName;
-            _mind.TryGetSession(mindId, out var session);
-            var username = session?.Name;
-
-            string title;
-            if (username != null)
-            {
-                if (name != null)
-                    title = Loc.GetString("objectives-player-user-named", ("user", username), ("name", name));
-                else
-                    title = Loc.GetString("objectives-player-user", ("user", username));
-            }
-            else
-            {
-                // nothing to identify the player by, just give up
-                if (name == null)
-                    continue;
-
-                title = Loc.GetString("objectives-player-named", ("name", name));
-            }
+            var title = GetTitle(mindId, mind);
+            if (title == null)
+                continue;
 
             result += "\n";
 
@@ -229,6 +212,33 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
 
         return originalEntityInCustody || (TryComp<CuffableComponent>(mind.OwnedEntity, out var cuffed) && cuffed.CuffedHandCount > 0
                && _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value));
+    }
+
+    /// <summary>
+    /// Get the title for a player's mind used in round end.
+    /// </summary>
+    public string? GetTitle(EntityUid mindId, MindComponent? mind = null)
+    {
+        if (!Resolve(mindId, ref mind))
+            return null;
+
+        var name = mind.CharacterName;
+        _mind.TryGetSession(mindId, out var session);
+        var username = session?.Name;
+
+        if (username != null)
+        {
+            if (name != null)
+                return Loc.GetString("objectives-player-user-named", ("user", username), ("name", name));
+
+            return Loc.GetString("objectives-player-user", ("user", username));
+        }
+
+        // nothing to identify the player by, just give up
+        if (name == null)
+            return null;
+
+        return Loc.GetString("objectives-player-named", ("name", name));
     }
 }
 

--- a/Content.Server/Roles/RevolutionaryRoleComponent.cs
+++ b/Content.Server/Roles/RevolutionaryRoleComponent.cs
@@ -8,5 +8,9 @@ namespace Content.Server.Roles;
 [RegisterComponent]
 public sealed partial class RevolutionaryRoleComponent : AntagonistRoleComponent
 {
-
+    /// <summary>
+    /// For headrevs, how many people you have converted.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public uint ConvertedCount = 0;
 }

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -14,14 +14,6 @@ head-rev-briefing =
     Use flashes to convert people to your cause.
     Kill all heads to take over the station.
 
-head-rev-initial-name = [color=#5e9cff]{$name}[/color] was one of the Head Revolutionaries.
-head-rev-initial-name-user = [color=#5e9cff]{$name}[/color] ([color=gray]{$username}[/color]) was one of the Head Revolutionaries.
-
-head-rev-initial-count = {$initialCount ->
-    [one] There was one Head Revolutionary:
-    *[other] There were {$initialCount} Head Revolutionaries:
-}
-
 head-rev-break-mindshield = The Mindshield was destroyed!
 
 ## Rev
@@ -58,4 +50,12 @@ rev-stalemate = All of the Head Revs and Command died. It's a draw.
 
 rev-reverse-stalemate = Both Command and Head Revs survived.
 
+rev-headrev-count = {$initialCount ->
+    [one] There was one Head Revolutionary:
+    *[other] There were {$initialCount} Head Revolutionaries:
+}
 
+rev-headrev-player = {$title} converted {$count} {$count ->
+    [one] person
+    *[other] people
+}.


### PR DESCRIPTION
## About the PR
title

## Why / Balance
good

## Technical details
made title logic in objectives system public as GetTitle

## Media
![08:22:02](https://github.com/space-wizards/space-station-14/assets/39013340/187444f2-8b82-4a92-9100-6c2804166fd1)

![08:23:22](https://github.com/space-wizards/space-station-14/assets/39013340/46709f84-7f0e-43a8-aa8f-b050e6d9b2b4)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: When Revolution rounds end each headrev has their number of converted people shown.
