### PR TITLE
Add chameleon functionality to Agent ID

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -20,6 +20,7 @@
   - type: Tag
     tags:
     - DoorBumpOpener
+    - WhitelistChameleon
 
 #IDs with layers
 
@@ -582,10 +583,18 @@
   - type: ActivatableUI
     key: enum.AgentIDCardUiKey.Key
     inHandsOnly: true
+  - type: Tag
+    tags:
+    - DoorBumpOpener
+  - type: ChameleonClothing
+    slot: [idcard]
+    default: PassengerIDCard
   - type: UserInterface
     interfaces:
       - key: enum.AgentIDCardUiKey.Key
         type: AgentIDCardBoundUserInterface
+      - key: enum.ChameleonUiKey.Key
+        type: ChameleonBoundUserInterface
 
 - type: entity
   name: passenger ID card


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added Chameleon functionality to the Agent ID card (and Nukie ID card by extension)

## Why / Balance
Lack of chameleon functionality allows for easy identification of an Agent ID card

## Media
![image](https://github.com/space-wizards/space-station-14/assets/11758391/dc82f05d-bff0-4ea2-b029-e39ce7229fc3)

![image](https://github.com/space-wizards/space-station-14/assets/11758391/a0fa3f95-b8fb-40fa-bd85-fd624e9fa484)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Chameleon functionality to Agent and Nukie ID cards
