### PR TITLE
Anomaly Synchronizer fixes

### DIFF
--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -27,6 +27,11 @@ anomaly-scanner-pulse-timer = Time until next pulse: [color=gray]{$time}[/color]
 
 anomaly-sync-connected = Anomaly successfully attached
 anomaly-sync-disconnected = The connection to the anomaly has been lost!
+anomaly-sync-no-anomaly = No anomaly in range.
+anomaly-sync-examine-connected = It is [color=darkgreen]attached[/color] to an anomaly.
+anomaly-sync-examine-not-connected = It is [color=darkred]not attached[/color] to an anomaly.
+anomaly-sync-connect-verb-text = Attach anomaly
+anomaly-sync-connect-verb-message = Attach a nearby anomaly to {THE($machine)}.
 
 anomaly-generator-ui-title = Anomaly Generator
 anomaly-generator-fuel-display = Fuel:


### PR DESCRIPTION
## About the PR
The problem: Players using the synchronizer for the first time often don't realize they have to "attach" the anomaly to the machine by clicking on it with an empty hand, and would be confused why the signals don't work.

The solution: Make the interaction more discoverable, both by adding examine text hinting that the anomaly has to be attached for the machine to work, and by adding a verb in the right click menu.

Full list of changes:
- Show if an anomaly is attached when examining
- Add verb for attaching anomaly
- Add popup messages for when you try to attach when machine isn't powered, or when no anomaly is in range.
- Use anomaly threshold values from anomaly comp, instead of hardcoded **and incorrect** values
- Use `Entity<T>`
- Formatting fixes and other misc code cleanup

## Media
![image](https://github.com/space-wizards/space-station-14/assets/48867431/d982de30-e9ce-4242-81ca-75dc6cff7dca)

![image](https://github.com/space-wizards/space-station-14/assets/48867431/5d1e8c81-53ba-468a-aa0b-783ea13639b5)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
No changes significant enough to warrant cl entry.