### PR TITLE
Animal cruelty nerf - Microwaves no longer instantly gib living creatures + Microwaves now heat in real-time

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -35,7 +35,6 @@ public sealed class BodySystem : SharedBodySystem
 
         SubscribeLocalEvent<BodyComponent, MoveInputEvent>(OnRelayMoveInput);
         SubscribeLocalEvent<BodyComponent, ApplyMetabolicMultiplierEvent>(OnApplyMetabolicMultiplier);
-        SubscribeLocalEvent<BodyComponent, BeingMicrowavedEvent>(OnBeingMicrowaved);
     }
 
     private void OnRelayMoveInput(EntityUid uid, BodyComponent component, ref MoveInputEvent args)
@@ -54,19 +53,6 @@ public sealed class BodySystem : SharedBodySystem
         {
             RaiseLocalEvent(organ.Id, args);
         }
-    }
-
-    private void OnBeingMicrowaved(EntityUid uid, BodyComponent component, BeingMicrowavedEvent args)
-    {
-        if (args.Handled)
-            return;
-
-        // Don't microwave animals, kids
-        SharedTransform.AttachToGridOrMap(uid);
-        _appearance.SetData(args.Microwave, MicrowaveVisualState.Bloody, true);
-        GibBody(uid, false, component);
-
-        args.Handled = true;
     }
 
     protected override void AddPart(

--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -16,6 +16,10 @@ namespace Content.Server.Kitchen.Components
         public string MachinePartCookTimeMultiplier = "Capacitor";
         [DataField("cookTimeScalingConstant")]
         public float CookTimeScalingConstant = 0.5f;
+        [DataField("baseHeatMultiplier"), ViewVariables(VVAccess.ReadWrite)]
+        public float BaseHeatMultiplier = 100;
+        [DataField("objectHeatMultiplier"), ViewVariables(VVAccess.ReadWrite)]
+        public float ObjectHeatMultiplier = 100;
 
         [DataField("failureResult", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string BadRecipeEntityId = "FoodBadRecipe";

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -106,7 +106,7 @@ namespace Content.Server.Kitchen.EntitySystems
             foreach (var entity in component.Storage.ContainedEntities)
             {
                 if (TryComp<TemperatureComponent>(entity, out var tempComp))
-                    _temperature.ChangeHeat(entity, heatToAdd, false, tempComp);
+                    _temperature.ChangeHeat(entity, heatToAdd * 100, false, tempComp);
 
                 if (!TryComp<SolutionContainerManagerComponent>(entity, out var solutions))
                     continue;
@@ -465,10 +465,13 @@ namespace Content.Server.Kitchen.EntitySystems
                 //check if there's still cook time left
                 active.CookTimeRemaining -= frameTime;
                 if (active.CookTimeRemaining > 0)
+                {
+                    AddTemperature(microwave, frameTime);
                     continue;
+                }
 
                 //this means the microwave has finished cooking.
-                AddTemperature(microwave, active.TotalTime);
+                AddTemperature(microwave, Math.Max(frameTime + active.CookTimeRemaining, 0)); //Though there's still a little bit more heat to pump out
 
                 if (active.PortionedRecipe.Item1 != null)
                 {

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -102,11 +102,11 @@ namespace Content.Server.Kitchen.EntitySystems
         /// <param name="time">The time on the microwave, in seconds.</param>
         private void AddTemperature(MicrowaveComponent component, float time)
         {
-            var heatToAdd = time * 100;
+            var heatToAdd = time * component.BaseHeatMultiplier;
             foreach (var entity in component.Storage.ContainedEntities)
             {
                 if (TryComp<TemperatureComponent>(entity, out var tempComp))
-                    _temperature.ChangeHeat(entity, heatToAdd * 100, false, tempComp);
+                    _temperature.ChangeHeat(entity, heatToAdd * component.ObjectHeatMultiplier, false, tempComp);
 
                 if (!TryComp<SolutionContainerManagerComponent>(entity, out var solutions))
                     continue;


### PR DESCRIPTION
## About the PR
TL;DR: Hammy and other holdable critters can now be practically revived if microwaved, but still die as a result.

This PR is straight-forward, and does exactly what it says in the title. This also tweaks the level of heat that microwaves apply to objects within, as microwaves previously didn't affect object temperature much at all. The side effect of this is that this means microwaves are now a practical way to reheat Hammy if they're cold, just like the hamster reanimation story!

## Why / Balance
This primarily addresses a pretty grating issue: Players stuffing Hammy in the microwave over the tiniest of perceived slights. This is excruciatingly awful for players who wanna play Hammy, as being microwaved meant being gibbed, which is, effectively, an *instant* round removal. Needless to say, this is incredibly toxic.

So this PR makes a slight rework to how microwaves work, and how mobs react to being microwaved. More specifically, mobs no longer have an explicit reaction to being microwaved, and microwaves now heat their contents in real-time. This PR also adds a 100x multiplier to the heat that microwaves apply to objects (Chemical contents are unaffected), as before, they surprisingly didn't affect object temperature much at all, due to the way thermodynamic heat resistance is modeled.

This ultimately means that microwave cooking time is a factor in microwaving mobs; Rats take just a few seconds to kill in the microwave, whilst Hammy takes about 30 seconds to fall into crit from being microwaved! The amount of time a mob takes to properly microwave depends on a combination of their specific heat and physical mass.

Hammy in particular benefits the most from this change. It's a *lot* easier to revive a corpse than it is a pile of gibs, which means it's now very much practical to revive Hammy (whether that's through admin tools or various ingame methods) after a trip in the microwave.

## Technical details
This PR removes `OnBeingMicrowaved` from the server's `BodySystem.cs`, tweaks the amount of heat applied to objects within microwaves, and makes microwaves do `AddTemperature()` every update. Straight-forward and self-explanatory.

While we're at it, we also moved the heat multiplier to a vareditable variable within `MicrowaveComponent`. Yknow, just in case any badmin wishes to casually create a thermonuclear microwave.

## Media

https://github.com/space-wizards/space-station-14/assets/6356337/964adc10-043c-46e0-814d-9c5b110a5145



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- tweak: Mobs are no longer instantly gibbed when microwaved.
- tweak: Microwaves now heat their contents in real-time.
- tweak: Microwaves are now capable of properly heating their contents, such that microwaveable mobs will still reliably die as expected when microwaved. (They just won't be gibbed.)

