### PR TITLE
Add component query benchmarks

### DIFF
--- a/Content.Benchmarks/EntityQueryBenchmark.cs
+++ b/Content.Benchmarks/EntityQueryBenchmark.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Content.IntegrationTests;
+using Content.IntegrationTests.Pair;
+using Content.Shared.Clothing.Components;
+using Content.Shared.Item;
+using Robust.Server.GameObjects;
+using Robust.Shared;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Benchmarks;
+
+[Virtual]
+public class EntityQueryBenchmark
+{
+    public const string Map = "Maps/atlas.yml";
+
+    private TestPair _pair = default!;
+    private IEntityManager _entMan = default!;
+    private MapId _mapId = new MapId(10);
+    private EntityQuery<ClothingComponent> _clothingQuery;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        ProgramShared.PathOffset = "../../../../";
+        PoolManager.Startup(null);
+
+        _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
+        _entMan = _pair.Server.ResolveDependency<IEntityManager>();
+
+        _pair.Server.ResolveDependency<IRobustRandom>().SetSeed(42);
+        _pair.Server.WaitPost(() =>
+        {
+            var success = _entMan.System<MapLoaderSystem>().TryLoad(_mapId, Map, out _);
+            if (!success)
+                throw new Exception("Map load failed");
+            _pair.Server.MapMan.DoMapInitialize(_mapId);
+        }).GetAwaiter().GetResult();
+
+        _clothingQuery = _entMan.GetEntityQuery<ClothingComponent>();
+
+        var entCount = _entMan.EntityCount;
+        var itemCount = _entMan.Count<ItemComponent>();
+        var clothingCount = _entMan.Count<ClothingComponent>();
+        var itemRatio = (float) itemCount / entCount;
+        var clothingRatio = (float) clothingCount / entCount;
+        Console.WriteLine($"Entities: {entCount}. Items: {itemRatio:P2}. Clothing: {clothingRatio:P2}.");
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _pair.DisposeAsync();
+        PoolManager.Shutdown();
+    }
+
+    /// <summary>
+    /// Enumerate all items and check if they have a clothing component.
+    /// </summary>
+    [Benchmark]
+    public int HasComponent()
+    {
+        var hashCode = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent>();
+        while (enumerator.MoveNext(out var uid, out var _))
+        {
+            if (_clothingQuery.HasComponent(uid))
+                hashCode = HashCode.Combine(hashCode, uid.Id);
+        }
+
+        return hashCode;
+    }
+
+    /// <summary>
+    /// Enumerate all items and get their clothing component.
+    /// </summary>
+    [Benchmark]
+    public int TryGetComponent()
+    {
+        var hashCode = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent>();
+        while (enumerator.MoveNext(out var uid, out var _))
+        {
+            if (_clothingQuery.TryGetComponent(uid, out var clothing))
+                hashCode = HashCode.Combine(hashCode, clothing.GetHashCode());
+        }
+
+        return hashCode;
+    }
+
+    /// <summary>
+    /// Enumerate all entities with both an item and clothing component.
+    /// </summary>
+    [Benchmark]
+    public int Enumerator()
+    {
+        var hashCode = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent, ClothingComponent>();
+        while (enumerator.MoveNext(out var _, out var clothing))
+        {
+            hashCode = HashCode.Combine(hashCode, clothing.GetHashCode());
+        }
+
+        return hashCode;
+    }
+}


### PR DESCRIPTION
Requires space-wizards/RobustToolbox/pull/4606

This adds a benchmark that loads a map (atlas), iterates over entities, and tries to fetch some components. This is meant to be a variant of the engine benchmarks that uses a more realistic distribution of entities / archetypes. The results below are from my laptop, which was probably thermally throttling and somewhat inconsistent:

``` ini
BenchmarkDotNet=v0.13.1, OS=arch 
Intel Core i7-7500U CPU 2.70GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
.NET SDK=7.0.113
  [Host]     : .NET 7.0.13 (7.0.1323.52501), X64 RyuJIT
  DefaultJob : .NET 7.0.13 (7.0.1323.52501), X64 RyuJIT
```
|               Method |      Mean |    Error |   StdDev |
|--------------------- |----------:|---------:|---------:|
|         HasComponent | 214.00 μs | 3.789 μs | 3.164 μs |
|    HasComponentQuery | 115.93 μs | 1.768 μs | 1.815 μs |
|      TryGetComponent | 231.47 μs | 4.380 μs | 4.302 μs |
| TryGetComponentQuery | 116.47 μs | 0.552 μs | 0.489 μs |
|           Enumerator |  97.90 μs | 0.736 μs | 0.652 μs |


And here are the results before arch was reverted (v182.0.0 / 0c4e2650dd0b5b75e419e2f987f3450359c3dad5)

|               Method |      Mean |    Error |   StdDev |
|--------------------- |----------:|---------:|---------:|
|         HasComponent | 464.13 μs | 2.736 μs | 2.425 μs |
|    HasComponentQuery | 460.08 μs | 1.863 μs | 1.742 μs |
|      TryGetComponent | 478.29 μs | 5.330 μs | 4.451 μs |
| TryGetComponentQuery | 478.05 μs | 1.488 μs | 1.392 μs |
|           Enumerator |  48.59 μs | 0.173 μs | 0.145 μs |



At least on my laptop the arch try-get and has-comp calls seem to be 4 times slower than the old dictionary lookups with entity queries, so we should probably figure out why and try to improve those so they are roughly on par with the old methods before un-reverting, because so much of content & engine code uses them. I haven't looked into why they were slow, even just writing and running this on my laptop has been hard enough.
