### PR TITLE
Fix wallmount board dropping at random side of the wall

### DIFF
--- a/Content.Server/Construction/Completions/EmptyAllContainers.cs
+++ b/Content.Server/Construction/Completions/EmptyAllContainers.cs
@@ -3,6 +3,7 @@ using Content.Shared.Construction;
 using Content.Shared.Hands.Components;
 using JetBrains.Annotations;
 using Robust.Server.Containers;
+using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
@@ -32,18 +33,18 @@ namespace Content.Server.Construction.Completions
 
             var containerSys = entityManager.EntitySysManager.GetEntitySystem<ContainerSystem>();
             var handSys = entityManager.EntitySysManager.GetEntitySystem<HandsSystem>();
+            var transformSys = entityManager.EntitySysManager.GetEntitySystem<TransformSystem>();
 
             HandsComponent? hands = null;
             var pickup = Pickup && entityManager.TryGetComponent(userUid, out hands);
 
-            EntityCoordinates? dropCoordinates = null;
-            if (EmptyAtUser && entityManager.TryGetComponent(userUid, out TransformComponent? userXform))
-                dropCoordinates = userXform.Coordinates;
-
             foreach (var container in containerManager.GetAllContainers())
             {
-                foreach (var ent in containerSys.EmptyContainer(container, true, dropCoordinates, reparent: !pickup))
+                foreach (var ent in containerSys.EmptyContainer(container, true, reparent: !pickup))
                 {
+                    if (EmptyAtUser && userUid is not null)
+                        transformSys.DropNextTo(ent, (EntityUid) userUid);
+
                     if (pickup)
                         handSys.PickupOrDrop(userUid, ent, handsComp: hands);
                 }

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -54,6 +54,12 @@
     key: walls
     mode: NoSprite
   - type: Occluder
+  - type: ContainerFill
+    containers:
+      battery-container: [ PowerCellMedium ]
+  - type: ContainerContainer
+    containers:
+      battery-container: !type:Container
 
 - type: entity
   id: BaseSecretDoorAssembly

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -81,7 +81,9 @@
       conditions:
       - !type:EntityAnchored {}
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Prying
         doAfter: 5
@@ -102,7 +104,9 @@
       conditions:
       - !type:EntityAnchored {}
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       - !type:SpawnPrototype
         prototype: SheetRGlass1
         amount: 1
@@ -134,7 +138,7 @@
       steps:
       - tool: Prying
         doAfter: 2
-        
+
     - to: medSecurityUnfinished
       conditions:
       - !type:WirePanel {}
@@ -142,7 +146,7 @@
       - material: Steel
         amount: 2
         doAfter: 2
-    
+
     - to: highSecurityUnfinished
       conditions:
       - !type:WirePanel {}
@@ -150,7 +154,7 @@
       - material: Plasteel
         amount: 2
         doAfter: 2
-        
+
 ## Standard airlock
   - node: airlock
     entity: Airlock
@@ -169,11 +173,13 @@
       - !type:WirePanel {}
       - !type:AllWiresCut
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Prying
         doAfter: 5
-        
+
     - to: medSecurityUnfinished
       conditions:
       - !type:WirePanel {}
@@ -181,7 +187,7 @@
       - material: Steel
         amount: 2
         doAfter: 2
-    
+
     - to: highSecurityUnfinished
       conditions:
       - !type:WirePanel {}
@@ -196,7 +202,7 @@
     - !type:SetWiresPanelSecurity
       wiresAccessible: true
       weldingAllowed: true
-    edges:   
+    edges:
     - to: medSecurityUnfinished
       conditions:
       - !type:WirePanel {}
@@ -204,7 +210,7 @@
       - material: Steel
         amount: 2
         doAfter: 2
-    
+
     - to: highSecurityUnfinished
       conditions:
       - !type:WirePanel {}
@@ -221,7 +227,7 @@
       wiresAccessible: false
       weldingAllowed: false
     edges:
-    - to: glassAirlock 
+    - to: glassAirlock
       completed:
       - !type:GivePrototype
         prototype: SheetSteel1
@@ -233,8 +239,8 @@
       steps:
       - tool: Prying
         doAfter: 4
-        
-    - to: airlock 
+
+    - to: airlock
       completed:
       - !type:GivePrototype
         prototype: SheetSteel1
@@ -246,8 +252,8 @@
       steps:
       - tool: Prying
         doAfter: 4
-        
-    - to: highSecDoor 
+
+    - to: highSecDoor
       completed:
       - !type:GivePrototype
         prototype: SheetSteel1
@@ -259,14 +265,14 @@
       steps:
       - tool: Prying
         doAfter: 4
-    
-    - to: medSecurity 
-      conditions:  
+
+    - to: medSecurity
+      conditions:
       - !type:WirePanel {}
       steps:
       - tool: Welding
         doAfter: 3
-      
+
   - node: medSecurity
     actions:
     - !type:SetWiresPanelSecurity
@@ -274,7 +280,7 @@
       wiresAccessible: false
       weldingAllowed: false
     edges:
-    - to: medSecurityUnfinished 
+    - to: medSecurityUnfinished
       conditions:
       - !type:WirePanel {}
       steps:
@@ -289,7 +295,7 @@
       wiresAccessible: false
       weldingAllowed: false
     edges:
-    - to: glassAirlock 
+    - to: glassAirlock
       completed:
       - !type:GivePrototype
         prototype: SheetPlasteel1
@@ -301,8 +307,8 @@
       steps:
       - tool: Prying
         doAfter: 4
-        
-    - to: airlock 
+
+    - to: airlock
       completed:
       - !type:GivePrototype
         prototype: SheetPlasteel1
@@ -314,8 +320,8 @@
       steps:
       - tool: Prying
         doAfter: 4
-        
-    - to: highSecDoor 
+
+    - to: highSecDoor
       completed:
       - !type:GivePrototype
         prototype: SheetPlasteel1
@@ -327,14 +333,14 @@
       steps:
       - tool: Prying
         doAfter: 4
-    
-    - to: highSecurity 
-      conditions:  
+
+    - to: highSecurity
+      conditions:
       - !type:WirePanel {}
       steps:
       - tool: Welding
         doAfter: 5
-      
+
   - node: highSecurity
     actions:
     - !type:SetWiresPanelSecurity
@@ -348,16 +354,16 @@
       steps:
       - tool: Welding
         doAfter: 15
-    
+
     - to: maxSecurity
       conditions:
       - !type:WirePanel {}
-      steps:     
+      steps:
       - material: MetalRod
         amount: 2
         doAfter: 1
 
-## Max security level door: an electric grill is added        
+## Max security level door: an electric grill is added
   - node: maxSecurity
     actions:
     - !type:SetWiresPanelSecurity
@@ -365,27 +371,27 @@
       wiresAccessible: false
       weldingAllowed: true
     edges:
-    - to: highSecurity 
+    - to: highSecurity
       completed:
       - !type:AttemptElectrocute
       - !type:GivePrototype
         prototype: PartRodMetal1
         amount: 2
-      conditions:  
+      conditions:
       - !type:WirePanel {}
       steps:
       - tool: Cutting
-        doAfter: 0.5 
+        doAfter: 0.5
 
     - to: superMaxSecurityUnfinished
       conditions:
       - !type:WirePanel {}
-      steps:     
+      steps:
       - material: Plasteel
         amount: 2
         doAfter: 2
 
-## Super max security level door: an additional layer of plasteel is added     
+## Super max security level door: an additional layer of plasteel is added
   - node: superMaxSecurityUnfinished
     actions:
     - !type:SetWiresPanelSecurity
@@ -393,7 +399,7 @@
       wiresAccessible: false
       weldingAllowed: false
     edges:
-    - to: maxSecurity 
+    - to: maxSecurity
       completed:
       - !type:GivePrototype
         prototype: SheetPlasteel1
@@ -403,25 +409,25 @@
       steps:
       - tool: Prying
         doAfter: 4
-    
-    - to: superMaxSecurity 
-      conditions:  
-      - !type:WirePanel {}
-      steps:
-      - tool: Welding
-        doAfter: 5
-      
-  - node: superMaxSecurity
-    actions:
-    - !type:SetWiresPanelSecurity
-      examine: wires-panel-component-on-examine-security-level7
-      wiresAccessible: false  
-      weldingAllowed: false
-    edges:
-    - to: superMaxSecurityUnfinished 
+
+    - to: superMaxSecurity
       conditions:
       - !type:WirePanel {}
       steps:
       - tool: Welding
-        doAfter: 15        
- 
+        doAfter: 5
+
+  - node: superMaxSecurity
+    actions:
+    - !type:SetWiresPanelSecurity
+      examine: wires-panel-component-on-examine-security-level7
+      wiresAccessible: false
+      weldingAllowed: false
+    edges:
+    - to: superMaxSecurityUnfinished
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - tool: Welding
+        doAfter: 15
+

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/firelock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/firelock.yml
@@ -80,7 +80,9 @@
               doAfter: 0.25
         - to: frame2
           completed:
-            - !type:EmptyAllContainers {}
+            - !type:EmptyAllContainers
+              pickup: true
+              emptyAtUser: true
           conditions:
             - !type:EntityAnchored
               anchored: true

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/secretdoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/secretdoor.yml
@@ -80,7 +80,9 @@
       - !type:EntityAnchored {}
       - !type:DoorWelded {}
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Prying
         doAfter: 5

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/shuttle.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/shuttle.yml
@@ -54,7 +54,9 @@
         doAfter: 2.5
     - to: assembly
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Prying
         doAfter: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
@@ -113,7 +113,9 @@
       - !type:WirePanel {}
       - !type:AllWiresCut
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Anchoring
         doAfter: 1
@@ -213,7 +215,9 @@
         container: board
       - !type:AllWiresCut
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Anchoring
         doAfter: 4

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/air_alarms.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/air_alarms.yml
@@ -70,7 +70,9 @@
       - !type:ContainerNotEmpty
         container: board
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Prying
         doAfter: 1
@@ -147,7 +149,9 @@
       - !type:ContainerNotEmpty
         container: board
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Prying
         doAfter: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/intercom.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/intercom.yml
@@ -66,7 +66,9 @@
       - !type:ContainerNotEmpty
         container: board
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Prying
         doAfter: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/station_maps.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/station_maps.yml
@@ -70,7 +70,9 @@
       - !type:ContainerNotEmpty
         container: board
       completed:
-      - !type:EmptyAllContainers {}
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
       steps:
       - tool: Prying
         doAfter: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/timer.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/timer.yml
@@ -84,7 +84,9 @@
         - !type:ContainerNotEmpty
           container: board
         completed:
-        - !type:EmptyAllContainers {}
+        - !type:EmptyAllContainers
+          pickup: true
+          emptyAtUser: true
 
     - node: screenElectronics
       edges:
@@ -101,7 +103,9 @@
         - !type:ContainerNotEmpty
           container: board
         completed:
-        - !type:EmptyAllContainers {}
+        - !type:EmptyAllContainers
+          pickup: true
+          emptyAtUser: true
 
     - node: brigElectronics
       edges:
@@ -118,7 +122,9 @@
         - !type:ContainerNotEmpty
           container: board
         completed:
-        - !type:EmptyAllContainers {}
+        - !type:EmptyAllContainers
+          pickup: true
+          emptyAtUser: true
 
     - node: screenGlass
       entity: TimerFrame

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
@@ -84,7 +84,9 @@
         - !type:ContainerNotEmpty
           container: board
         completed:
-        - !type:EmptyAllContainers {}
+        - !type:EmptyAllContainers
+          pickup: true
+          emptyAtUser: true
         steps:
         - tool: Prying
           doAfter: 1
@@ -98,7 +100,9 @@
         - !type:ContainerNotEmpty
           container: board
         completed:
-        - !type:EmptyAllContainers {}
+        - !type:EmptyAllContainers
+          pickup: true
+          emptyAtUser: true
         steps:
         - tool: Prying
           doAfter: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
@@ -68,7 +68,9 @@
         - !type:ContainerNotEmpty
           container: board
         completed:
-        - !type:EmptyAllContainers {}
+        - !type:EmptyAllContainers
+          pickup: true
+          emptyAtUser: true
         steps:
         - tool: Prying
           doAfter: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
During deconstruction, many devices drop the board at their own coordinates. This is mostly fine, but when the device is wall-mounted, the board will warp to a random side of the wall, sometimes opposite of the player deconstructing it, and sometimes inside the wall. I change this so the board is picked up when the player has free hands, otherwise, it drops under the player's feet.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Add `EmptyAtUser` data field to `EmptyAllContainers`. When true, get user coords and empty the container there. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
The boards drop at my feet, instead of under the wall, inside it, or on the other side.
![boards working](https://github.com/space-wizards/space-station-14/assets/69696513/1e65ae71-fc9d-47f5-b094-cc1b83df1c6e)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->