### PR TITLE
Add anti-rot to cold cart

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
@@ -49,6 +49,10 @@
     - type: Storage
       maxItemSize: Normal
       maxTotalWeight: 40
+      whitelist:
+        components:
+        - Food
+        - Produce
     - type: TileFrictionModifier
       modifier: 0.4 # makes it slide
 
@@ -161,3 +165,4 @@
     - type: ContainerContainer
       containers:
         storagebase: !type:Container
+    - type: AntiRottingContainer

--- a/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
@@ -49,10 +49,6 @@
     - type: Storage
       maxItemSize: Normal
       maxTotalWeight: 40
-      whitelist:
-        components:
-        - Food
-        - Produce
     - type: TileFrictionModifier
       modifier: 0.4 # makes it slide
 


### PR DESCRIPTION
## About the PR
- ~~Adds a whitelist for food and produce to the food carts~~
- Fixes cold cart not preserving food with AntiRottingContainer

## Why / Balance
Based on player feedback and cold storage should prevent food rot.

## Technical details
n/a

## Media
n/a

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a
