### PR TITLE
Fix winter boot temperature protection

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -106,4 +106,4 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/winterboots.rsi
   - type: TemperatureProtection
-    coefficient: 0.05
+    coefficient: 0.2


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

Turns out the temperature protection was double that of a winter coat, when it was meant to be half. This PR fixes that.