### PR TITLE
No more stacked RoboDrobe

### DIFF
--- a/Resources/Maps/aspid.yml
+++ b/Resources/Maps/aspid.yml
@@ -106921,13 +106921,6 @@ entities:
     - pos: -18.5,30.5
       parent: 1
       type: Transform
-  - uid: 2645
-    components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: -18.5,30.5
-      parent: 1
-      type: Transform
 - proto: VendingMachineRobotics
   entities:
   - uid: 2652


### PR DESCRIPTION
## About the PR
Removes the physics defying phenomena involving a RoboDrobe creating a perfect atomic copy of itself.

## Why / Balance
Because having a double stacked RoboDrobe is silly and it makes no sense

## Technical details
I removed like 2 lines from a YAML file

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
