### PR TITLE
Make Woodblocks, reverse cymbals, and kalimbas into percussion instruments

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
@@ -96,6 +96,7 @@
   - type: Tag
     tags:
     - KeyedInstrument
+    - PercussionInstrument
 
 - type: entity
   parent: BaseHandheldInstrument
@@ -108,6 +109,9 @@
   - type: Sprite
     sprite: Objects/Fun/Instruments/woodblock.rsi
     state: icon
+  - type: Tag
+    tags:
+    - PercussionInstrument
 
 - type: entity
   parent: BaseHandheldInstrument
@@ -120,6 +124,9 @@
   - type: Sprite
     sprite: Objects/Fun/Instruments/reversecymbal.rsi
     state: icon
+  - type: Tag
+    tags:
+    - PercussionInstrument
 
 - type: entity
   parent: BaseHandheldInstrument


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
fixes #21985
Adds the `PercussionInstrument` tag to woodblocks, reverse cymbals, and kalimbas

## Why / Balance
This will affect bounties, but as I never play cargo I'm unsure of how much
All these instruments were found in the `instruments_percussion.yml`

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Woodblocks, reverse cymbals, and kalimbas are now properly recognized as percussion instruments.
