### PR TITLE
Fix chameleon changing ID card metadata

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Clothing.Components;
+using Content.Shared.Access.Components;
+using Content.Shared.Clothing.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
@@ -45,10 +46,13 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
         // world sprite icon
         UpdateSprite(uid, proto);
 
-        // copy name and description
-        var meta = MetaData(uid);
-        _metaData.SetEntityName(uid, proto.Name, meta);
-        _metaData.SetEntityDescription(uid, proto.Description, meta);
+        // copy name and description, unless its an ID card
+        if (!HasComp<IdCardComponent>(uid))
+        {
+            var meta = MetaData(uid);
+            _metaData.SetEntityName(uid, proto.Name, meta);
+            _metaData.SetEntityDescription(uid, proto.Description, meta);
+        }
 
         // item sprite logic
         if (TryComp(uid, out ItemComponent? item) &&


### PR DESCRIPTION
## About the PR
Fixed #21995 

## Why / Balance
Agent ID card should preserve your current Name and Job Title when changing appearance

## Technical details
Skip updating metadata if the chameleon item has an IDCardComponent

## Media
![image](https://github.com/space-wizards/space-station-14/assets/11758391/0962b132-a936-432a-aff0-c3fedc466c78)
![image](https://github.com/space-wizards/space-station-14/assets/11758391/462c4140-fa52-4f4b-a097-37d340c674fd)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Agent ID not longer resets name when changing its appearance
