### PR TITLE
Add a 'Copy' button to the fax UI

### DIFF
--- a/Content.Client/Fax/UI/FaxBoundUi.cs
+++ b/Content.Client/Fax/UI/FaxBoundUi.cs
@@ -22,6 +22,7 @@ public sealed class FaxBoundUi : BoundUserInterface
         _window.OpenCentered();
 
         _window.OnClose += Close;
+        _window.CopyButtonPressed += OnCopyButtonPressed;
         _window.SendButtonPressed += OnSendButtonPressed;
         _window.RefreshButtonPressed += OnRefreshButtonPressed;
         _window.PeerSelected += OnPeerSelected;
@@ -30,6 +31,11 @@ public sealed class FaxBoundUi : BoundUserInterface
     private void OnSendButtonPressed()
     {
         SendMessage(new FaxSendMessage());
+    }
+
+    private void OnCopyButtonPressed()
+    {
+        SendMessage(new FaxCopyMessage());
     }
 
     private void OnRefreshButtonPressed()

--- a/Content.Client/Fax/UI/FaxWindow.xaml
+++ b/Content.Client/Fax/UI/FaxWindow.xaml
@@ -20,6 +20,10 @@
         </BoxContainer>
         <Control HorizontalExpand="True" MinHeight="20" />
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
+            <Button Name="CopyButton"
+                    Text="{Loc 'fax-machine-ui-copy-button'}"
+                    HorizontalExpand="False"
+                    Disabled="True" />
             <Button Name="SendButton"
                     Text="{Loc 'fax-machine-ui-send-button'}"
                     HorizontalExpand="True"

--- a/Content.Client/Fax/UI/FaxWindow.xaml.cs
+++ b/Content.Client/Fax/UI/FaxWindow.xaml.cs
@@ -9,6 +9,7 @@ namespace Content.Client.Fax.UI;
 [GenerateTypedNameReferences]
 public sealed partial class FaxWindow : DefaultWindow
 {
+    public event Action? CopyButtonPressed;
     public event Action? SendButtonPressed;
     public event Action? RefreshButtonPressed;
     public event Action<string>? PeerSelected;
@@ -17,6 +18,7 @@ public sealed partial class FaxWindow : DefaultWindow
     {
         RobustXamlLoader.Load(this);
 
+        CopyButton.OnPressed += _ => CopyButtonPressed?.Invoke();
         SendButton.OnPressed += _ => SendButtonPressed?.Invoke();
         RefreshButton.OnPressed += _ => RefreshButtonPressed?.Invoke();
         PeerSelector.OnItemSelected += args =>
@@ -25,6 +27,7 @@ public sealed partial class FaxWindow : DefaultWindow
 
     public void UpdateState(FaxUiState state)
     {
+        CopyButton.Disabled = !state.CanCopy;
         SendButton.Disabled = !state.CanSend;
         FromLabel.Text = state.DeviceName;
 

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Fax;
 
@@ -47,6 +48,7 @@ public sealed class FaxSystem : EntitySystem
     ///     The prototype ID to use for faxed or copied entities if we can't get one from
     ///     the paper entity for whatever reason.
     /// </summary>
+    [ValidatePrototypeId<EntityPrototype>]
     private const string DefaultPaperPrototypeId = "Paper";
 
     public override void Initialize()

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -43,6 +43,12 @@ public sealed class FaxSystem : EntitySystem
 
     private const string PaperSlotId = "Paper";
 
+    /// <summary>
+    ///     The prototype ID to use for faxed or copied entities if we can't get one from
+    ///     the paper entity for whatever reason.
+    /// </summary>
+    private const string DefaultPaperPrototypeId = "Paper";
+
     public override void Initialize()
     {
         base.Initialize();
@@ -63,6 +69,7 @@ public sealed class FaxSystem : EntitySystem
 
         // UI
         SubscribeLocalEvent<FaxMachineComponent, AfterActivatableUIOpenEvent>(OnToggleInterface);
+        SubscribeLocalEvent<FaxMachineComponent, FaxCopyMessage>(OnCopyButtonPressed);
         SubscribeLocalEvent<FaxMachineComponent, FaxSendMessage>(OnSendButtonPressed);
         SubscribeLocalEvent<FaxMachineComponent, FaxRefreshMessage>(OnRefreshButtonPressed);
         SubscribeLocalEvent<FaxMachineComponent, FaxDestinationMessage>(OnDestinationSelected);
@@ -291,6 +298,11 @@ public sealed class FaxSystem : EntitySystem
         UpdateUserInterface(uid, component);
     }
 
+    private void OnCopyButtonPressed(EntityUid uid, FaxMachineComponent component, FaxCopyMessage args)
+    {
+        Copy(uid, component);
+    }
+
     private void OnSendButtonPressed(EntityUid uid, FaxMachineComponent component, FaxSendMessage args)
     {
         Send(uid, component, args.Session.AttachedEntity);
@@ -329,7 +341,10 @@ public sealed class FaxSystem : EntitySystem
                       component.DestinationFaxAddress != null &&
                       component.SendTimeoutRemaining <= 0 &&
                       component.InsertingTimeRemaining <= 0;
-        var state = new FaxUiState(component.FaxName, component.KnownFaxes, canSend, isPaperInserted, component.DestinationFaxAddress);
+        var canCopy = isPaperInserted &&
+                      component.SendTimeoutRemaining <= 0 &&
+                      component.InsertingTimeRemaining <= 0;
+        var state = new FaxUiState(component.FaxName, component.KnownFaxes, canSend, canCopy, isPaperInserted, component.DestinationFaxAddress);
         _userInterface.TrySetUiState(uid, FaxUiKey.Key, state);
     }
 
@@ -370,8 +385,41 @@ public sealed class FaxSystem : EntitySystem
     }
 
     /// <summary>
+    ///     Copies the paper in the fax. A timeout is set after copying,
+    ///     which is shared by the send button.
+    /// </summary>
+    public void Copy(EntityUid uid, FaxMachineComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        var sendEntity = component.PaperSlot.Item;
+        if (sendEntity == null)
+            return;
+
+        if (!TryComp<MetaDataComponent>(sendEntity, out var metadata) ||
+            !TryComp<PaperComponent>(sendEntity, out var paper))
+            return;
+
+        // TODO: See comment in 'Send()' about not being able to copy whole entities
+        var printout = new FaxPrintout(paper.Content,
+                                       metadata.EntityName,
+                                       metadata.EntityPrototype?.ID ?? DefaultPaperPrototypeId,
+                                       paper.StampState,
+                                       paper.StampedBy);
+
+        component.PrintingQueue.Enqueue(printout);
+        component.SendTimeoutRemaining += component.SendTimeout;
+
+        // Don't play component.SendSound - it clashes with the printing sound, which
+        // will start immediately.
+
+        UpdateUserInterface(uid, component);
+    }
+
+    /// <summary>
     ///     Sends message to addressee if paper is set and a known fax is selected
-    ///     A timeout is set after sending
+    ///     A timeout is set after sending, which is shared by the copy button.
     /// </summary>
     public void Send(EntityUid uid, FaxMachineComponent? component = null, EntityUid? sender = null)
     {
@@ -404,7 +452,7 @@ public sealed class FaxSystem : EntitySystem
             // TODO: Ideally, we could just make a copy of the whole entity when it's
             // faxed, in order to preserve visuals, etc.. This functionality isn't
             // available yet, so we'll pass along the originating prototypeId and fall
-            // back to "Paper" in SpawnPaperFromQueue if we can't find one here.
+            // back to DefaultPaperPrototypeId in SpawnPaperFromQueue if we can't find one here.
             payload[FaxConstants.FaxPaperPrototypeData] = metadata.EntityPrototype.ID;
         }
 
@@ -454,7 +502,7 @@ public sealed class FaxSystem : EntitySystem
 
         var printout = component.PrintingQueue.Dequeue();
 
-        var entityToSpawn = printout.PrototypeId.Length == 0 ? "Paper" : printout.PrototypeId;
+        var entityToSpawn = printout.PrototypeId.Length == 0 ? DefaultPaperPrototypeId : printout.PrototypeId;
         var printed = EntityManager.SpawnEntity(entityToSpawn, Transform(uid).Coordinates);
 
         if (TryComp<PaperComponent>(printed, out var paper))

--- a/Content.Shared/Fax/SharedFax.cs
+++ b/Content.Shared/Fax/SharedFax.cs
@@ -16,10 +16,12 @@ public sealed class FaxUiState : BoundUserInterfaceState
     public string? DestinationAddress { get; }
     public bool IsPaperInserted { get; }
     public bool CanSend { get; }
+    public bool CanCopy { get; }
 
     public FaxUiState(string deviceName,
         Dictionary<string, string> peers,
         bool canSend,
+        bool canCopy,
         bool isPaperInserted,
         string? destAddress)
     {
@@ -27,8 +29,14 @@ public sealed class FaxUiState : BoundUserInterfaceState
         AvailablePeers = peers;
         IsPaperInserted = isPaperInserted;
         CanSend = canSend;
+        CanCopy = canCopy;
         DestinationAddress = destAddress;
     }
+}
+
+[Serializable, NetSerializable]
+public sealed class FaxCopyMessage : BoundUserInterfaceMessage
+{
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/fax/fax.ftl
+++ b/Resources/Locale/en-US/fax/fax.ftl
@@ -8,6 +8,7 @@ fax-machine-dialog-rename = Rename
 fax-machine-dialog-field-name = Name
 
 fax-machine-ui-window = Fax Machine
+fax-machine-ui-copy-button = Copy
 fax-machine-ui-send-button = Send
 fax-machine-ui-refresh-button = Refresh
 fax-machine-ui-no-peers = No Peers


### PR DESCRIPTION
## About the PR
Adds a 'Copy' button to the fax UI, which causes the inserted paper to be copied immediately.

## Why / Balance
Sometimes we make paperwork - cargo order forms, crew transfer forms, various other documentation that is worth keeping (and adds gameplay to HoP and QM!). Copying such papers is traditionally a tedious job of either copy-pasting onto blank sheets and hoping desperately that you have enough blank papers lying around, or, when you run out of paper, finding a fax machine, sending it somewhere else, and running halfway across the station to pick it up. With the 'Copy' button, you can do it all without even leaving your desk!

## Technical details
Content.Server.FaxSystem has a few new methods, most notably `Copy()`. I chose to add a new method that duplicates some functionality because copying does not require use of device networking, and also should not play the SendSound to avoid clashing with the printing sound (which starts immediately).

## Media
https://github.com/space-wizards/space-station-14/assets/30327355/baccdd6b-6f99-4511-a03a-6bad256740f9

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
:cl:
- add: Faxes now have a Copy button for copying the inserted paper.