### PR TITLE
Sort reagent prototypes for solutions

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionContainerSystem.cs
@@ -174,10 +174,19 @@ public sealed partial class SolutionContainerSystem : EntitySystem
                 : "shared-solution-container-component-on-examine-worded-amount-multiple-reagents")),
             ("desc", primary.LocalizedPhysicalDescription)));
 
+
+        var reagentPrototypes = solution.GetReagentPrototypes(_prototypeManager);
+
+        // Sort the reagents by amount, descending then alphabetically
+        var sortedReagentPrototypes = reagentPrototypes
+            .OrderByDescending(pair => pair.Value.Value)
+            .ThenBy(pair => pair.Key.LocalizedName);
+
         // Add descriptions of immediately recognizable reagents, like water or beer
         var recognized = new List<ReagentPrototype>();
-        foreach (var proto in solution.GetReagentPrototypes(_prototypeManager).Keys)
+        foreach (var keyValuePair in sortedReagentPrototypes)
         {
+            var proto = keyValuePair.Key;
             if (!proto.Recognizable)
             {
                 continue;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The examinable list of contents for solutions now appears volume first, descending, then alphabetically.

This PR solves #21843.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It's more logical and allows players to be able to (roughly) tell what reagents there are more of in a solution.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Before the list of recognized reagents is compiled, the full list of reagents in a solution is sorted [here](https://github.com/enumerate0/space-station-14/blob/08b79035f7fb6509bb7ec0648cf907fdc50f8ebb/Content.Shared/Chemistry/EntitySystems/SolutionContainerSystem.cs#L181).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

| Before | After |
| ------ | ------ |
|![image](https://github.com/space-wizards/space-station-14/assets/148675436/cc78ca7f-663b-4831-8f28-a3527952656a)|![image](https://github.com/space-wizards/space-station-14/assets/148675436/467e8c9e-8816-4bb1-bdec-e4bc1db1b961)|
|![image](https://github.com/space-wizards/space-station-14/assets/148675436/bb4c3432-1a0a-47bd-8588-88834f4b305d)|![image](https://github.com/space-wizards/space-station-14/assets/148675436/76614894-8e3a-49e1-9180-3f44af7db4d1)|

Caption: In the first example you can see that even though the volume of water is higher, the blood appears first since it was added to the contents first. In the second example, you can see how even if the volumes are equal it sorts by alphabetical localized name.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Recognizable solutions now appear sorted by volume first, then by name