### PR TITLE
Gave HighSecDoor AccessReaderComponent

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -58,6 +58,7 @@
     time: 10
   - type: Airlock
   - type: DoorBolt
+  - type: AccessReader
   - type: Appearance
   - type: WiresVisuals
   - type: ApcPowerReceiver


### PR DESCRIPTION
For some reason it didn't have it before, while command, armory and captain access prototypes variants had.
Doesn't change anything but now the access configurador works on it.