### PR TITLE
Add job title to entity name when creating identity representation

### DIFF
--- a/Content.Shared/IdentityManagement/Components/IdentityComponent.cs
+++ b/Content.Shared/IdentityManagement/Components/IdentityComponent.cs
@@ -26,15 +26,17 @@ public sealed class IdentityRepresentation
 {
     public string TrueName;
     public Gender TrueGender;
+    public string? TrueJob;
 
     public string AgeString;
 
     public string? PresumedName;
     public string? PresumedJob;
 
-    public IdentityRepresentation(string trueName, Gender trueGender, string ageString, string? presumedName=null, string? presumedJob=null)
+    public IdentityRepresentation(string trueName, string? trueJob, Gender trueGender, string ageString, string? presumedName=null, string? presumedJob=null)
     {
         TrueName = trueName;
+        TrueJob = trueJob;
         TrueGender = trueGender;
 
         AgeString = ageString;
@@ -43,11 +45,22 @@ public sealed class IdentityRepresentation
         PresumedName = presumedName;
     }
 
-    public string ToStringKnown(bool trueName)
+    public string ToStringKnown(bool showTrueIdentity)
     {
-        return trueName
-            ? TrueName
-            : PresumedName ?? ToStringUnknown();
+        string? nameToShow;
+        string? jobToShow;
+        if (showTrueIdentity)
+        {
+            nameToShow = TrueName;
+            jobToShow = TrueJob;
+        }
+        else
+        {
+            nameToShow = PresumedName ?? ToStringUnknown();
+            jobToShow = PresumedJob;
+        }
+        jobToShow = jobToShow != null ? $" ({jobToShow})" : "";
+        return nameToShow + jobToShow;
     }
 
     /// <summary>
@@ -67,6 +80,6 @@ public sealed class IdentityRepresentation
         // i.e. 'young assistant man' or 'old cargo technician person' or 'middle-aged captain'
         return PresumedJob is null
             ? $"{AgeString} {genderString}"
-            : $"{AgeString} {PresumedJob} {genderString}";
+            : $"{AgeString} {PresumedJob.ToLowerInvariant()} {genderString}";
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I wanted to have the 'known' job title of a person show up when you examined them. Rather than doing a weird ID check dance, or consulting the Crew Manifest to figure out things.

That led me to actually just appending the "true job" of a crew member (determined from station records) to the entity name that the client sees.
Or alternatively the presumed job in the case that the observer doesn't actually know the true identity. The presumed job is actually derived from the ID card they have, which is a bit inconsistent with the idea of "you need to be in range to view the card" but that's a different problem to this PR.

The first change this leads to is the examine UI having a display for the job title, next to the name. But also has other consequences like the medical analysis UI showing the title, which I don't think are bad changes either.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I believe this is a pretty straight forward QoL change. It's entirely based on the knowledge that the player character should have. The alternative to this is consulting the crew manifest or using the awkward ID badge check verb.

The ID check badge is:
- Cumbersome to use, requiring an examine within a close range, and then another examine. On a moving character it's extremely hard.
- This is made worse when having high ping etc. Since your effective range for successfully examining an id badge is a lot lower, when a target is moving

An alternative to this might be some sort of "auto badge check", but my suspicion is that it would be a lot more complex.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Introduces a "true job" field when building an identity representation, from the station records. If the observer knows the true name of the observer it uses that true job, otherwise it uses the presumed job.

This job title is just appended to the entity name that the client receives.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

A basic examine on a un-obscured character, with a PDA looks like.
<img width="230" alt="final-basic" src="https://github.com/space-wizards/space-station-14/assets/7283010/cdab955e-a2b0-4529-aef6-ecd6d48e88e7">

Changing ID in the id card is reflected:
<img width="235" alt="final-changing-id" src="https://github.com/space-wizards/space-station-14/assets/7283010/879da18c-5284-40d3-aa5a-ae0f9ea8eb7e">

If you obscured a character, but they still have a pda/their pda it has the same result
<img width="238" alt="obscured-but-still-knows" src="https://github.com/space-wizards/space-station-14/assets/7283010/2a97997e-dd48-4c4c-8a30-f649e9ac9ccf">

An obscured character with no id, shows up same as previous:
<img width="216" alt="obscured-but-no-id" src="https://github.com/space-wizards/space-station-14/assets/7283010/f4c9a238-5db7-4ddd-b877-51094b4e9cfd">

An obscured character with a job title though:
![image](https://github.com/space-wizards/space-station-14/assets/7283010/e37a7fbd-ef49-4370-bbfc-25a95a89c37f)


Health scanner (and other things show the title now too, with the same rules):
<img width="219" alt="health-scanner-change" src="https://github.com/space-wizards/space-station-14/assets/7283010/f27c46d4-9d3e-47be-8896-c5298a746d81">

A character/unit without a job title in the records, also just works same as before:
![image](https://github.com/space-wizards/space-station-14/assets/7283010/172f54b6-6861-4e04-90fa-4614e1747c3b)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Job titles now show up when examining a character.
