### PR TITLE
Add water cups to water coolers

### DIFF
--- a/Content.Shared/Storage/EntitySystems/BinSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/BinSystem.cs
@@ -96,23 +96,28 @@ public sealed class BinSystem : EntitySystem
         if (args.Using != null)
         {
             var canReach = args.CanAccess && args.CanInteract;
-            OnAfterInteractUsing(uid, component, new AfterInteractUsingEvent(args.User, (EntityUid) args.Using, args.Target, EntityCoordinates.Invalid, canReach));
+            InsertIntoBin(args.User, args.Target, (EntityUid) args.Using, component, false, canReach);
         }
     }
 
     private void OnAfterInteractUsing(EntityUid uid, BinComponent component, AfterInteractUsingEvent args)
     {
-        if (args.Handled || !args.CanReach)
+        InsertIntoBin(args.User, uid, args.Used, component, args.Handled, args.CanReach);
+        args.Handled = true;
+    }
+
+    private void InsertIntoBin(EntityUid user, EntityUid target, EntityUid itemInHand, BinComponent component, bool handled, bool canReach)
+    {
+        if (handled || !canReach)
             return;
 
         if (!_timing.IsFirstTimePredicted)
             return;
 
-        if (!TryInsertIntoBin(uid, args.Used, component))
+        if (!TryInsertIntoBin(target, itemInHand, component))
             return;
 
-        _admin.Add(LogType.Pickup, LogImpact.Low, $"{ToPrettyString(uid):player} inserted {ToPrettyString(args.User)} into bin {ToPrettyString(uid)}.");
-        args.Handled = true;
+        _admin.Add(LogType.Pickup, LogImpact.Low, $"{ToPrettyString(target):player} inserted {ToPrettyString(user)} into bin {ToPrettyString(target)}.");
     }
 
     /// <summary>

--- a/Content.Shared/Storage/EntitySystems/BinSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/BinSystem.cs
@@ -1,10 +1,13 @@
 ﻿using System.Linq;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
+using Content.Shared.Examine;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Storage.Components;
+using Content.Shared.Verbs;
 using Robust.Shared.Containers;
+using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
 
@@ -31,6 +34,13 @@ public sealed class BinSystem : EntitySystem
         SubscribeLocalEvent<BinComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
         SubscribeLocalEvent<BinComponent, InteractHandEvent>(OnInteractHand);
         SubscribeLocalEvent<BinComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
+        SubscribeLocalEvent<BinComponent, GetVerbsEvent<AlternativeVerb>>(OnAltInteractHand);
+        SubscribeLocalEvent<BinComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(EntityUid uid, BinComponent component, ExaminedEvent args)
+    {
+        args.PushText(Loc.GetString("bin-component-on-examine-text", ("count", component.Items.Count)));
     }
 
     private void OnStartup(EntityUid uid, BinComponent component, ComponentStartup args)
@@ -74,6 +84,20 @@ public sealed class BinSystem : EntitySystem
         _admin.Add(LogType.Pickup, LogImpact.Low,
             $"{ToPrettyString(uid):player} removed {ToPrettyString(toGrab.Value)} from bin {ToPrettyString(uid)}.");
         args.Handled = true;
+    }
+
+    /// <summary>
+    /// Alt interact acts the same as interacting with your hands normally, but allows fallback interaction if the item
+    /// has priority. E.g. a water cup on a water cooler fills itself on a normal click,
+    /// but you can use alternative interactions to restock the cup bin
+    /// </summary>
+    private void OnAltInteractHand(EntityUid uid, BinComponent component, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (args.Using != null)
+        {
+            var canReach = args.CanAccess && args.CanInteract;
+            OnAfterInteractUsing(uid, component, new AfterInteractUsingEvent(args.User, (EntityUid) args.Using, args.Target, EntityCoordinates.Invalid, canReach));
+        }
     }
 
     private void OnAfterInteractUsing(EntityUid uid, BinComponent component, AfterInteractUsingEvent args)

--- a/Resources/Locale/en-US/entity-systems/bin/bin-system.ftl
+++ b/Resources/Locale/en-US/entity-systems/bin/bin-system.ftl
@@ -1,0 +1,1 @@
+﻿bin-component-on-examine-text = Looks like there's {$count} items left.

--- a/Resources/Locale/en-US/prototypes/entities/structures/storage/tanks/tanks.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/storage/tanks/tanks.ftl
@@ -14,7 +14,7 @@ ent-WaterTankFull = { ent-WaterTank }
     .desc = { ent-WaterTank.desc }
 
 ent-WaterCooler = water cooler
-    .desc = Seems like a good place to stand and waste time.
+    .desc = Seems like a good place to stand and waste time. It has a stock of paper cups on the side
 
 ent-WaterTankHighCapacity = high-capacity water tank
     .desc = A highly pressurized water tank made to hold gargantuan amounts of water.

--- a/Resources/Locale/en-US/prototypes/entities/structures/storage/tanks/tanks.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/storage/tanks/tanks.ftl
@@ -14,7 +14,7 @@ ent-WaterTankFull = { ent-WaterTank }
     .desc = { ent-WaterTank.desc }
 
 ent-WaterCooler = water cooler
-    .desc = Seems like a good place to stand and waste time. It has a stock of paper cups on the side
+    .desc = Seems like a good place to stand and waste time. It has a stock of paper cups on the side.
 
 ent-WaterTankHighCapacity = high-capacity water tank
     .desc = A highly pressurized water tank made to hold gargantuan amounts of water.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -318,5 +318,8 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 1
     fillBaseName: icon-
+  - type: Tag
+    tags:
+    - Trash
   - type: TrashOnSolutionEmpty
     solution: drink

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -307,12 +307,6 @@
   name: water cup
   description: A paper water cup.
   components:
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        reagents:
-        - ReagentId: Water
-          Quantity: 20
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/water_cup.rsi

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -127,6 +127,9 @@
         reagents:
         - ReagentId: Water
           Quantity: 500
+  - type: ContainerContainer
+    containers:
+      bin-container: !type:Container
   - type: Bin
     initialContents:
     - DrinkWaterCup

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -127,6 +127,24 @@
         reagents:
         - ReagentId: Water
           Quantity: 500
+  - type: Bin
+    initialContents:
+    - DrinkWaterCup
+    - DrinkWaterCup
+    - DrinkWaterCup
+    - DrinkWaterCup
+    - DrinkWaterCup
+    - DrinkWaterCup
+    - DrinkWaterCup
+    - DrinkWaterCup
+    - DrinkWaterCup
+    - DrinkWaterCup
+    whitelist:
+      requireAll: true
+      components:
+      - FitsInDispenser
+      tags:
+      - Trash
 
 - type: entity
   parent: StorageTank


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added water cup dispensing to water coolers

As well as added examine on Bins (e.g. a paper bin) to say how many items are left.
And added an alt interact on bin interaction as a fallback to restocking items in bins.
Also to simplify things I make Water cups now default to empty, which is more sensible to me, why would a station have random water cups sitting around for hours? Minor nerf I guess to some maps?

Another note is you can technically put other cups in the bin, if you want. Which is a bit odd, but better than adding a random tag for just a paper cup I think.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Water coolers without cups are kinda useless in a lot of maps, other than as a random water tank.
The sprite has a paper cups on the side so I guess this was intended at some point.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Reuses the same bin component as Paper Bin
- Use alt verbs to construct a fallback on bin interaction for restocking

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Water cooler examine
<img width="329" alt="watercooler" src="https://github.com/space-wizards/space-station-14/assets/7283010/6f433664-8ab6-441b-94b4-535568c08e5b">

And demo of the usage.
https://github.com/space-wizards/space-station-14/assets/7283010/4232839d-daf8-4b0b-a3f2-b9e55ec20882

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Paper cups are now available at water coolers.
