### PR TITLE
Make rev rounds end differently based on outcome

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
@@ -12,10 +12,10 @@ namespace Content.Server.GameTicking.Rules.Components;
 public sealed partial class RevolutionaryRuleComponent : Component
 {
     /// <summary>
-    /// When the round will if all the command are dead (Incase they are in space)
+    /// When the round will end if all the command or head revs are dead (or exiled)
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
-    public TimeSpan CommandCheck;
+    public TimeSpan RoundCheck;
 
     /// <summary>
     /// The amount of time between each check for command check.
@@ -73,5 +73,19 @@ public sealed partial class RevolutionaryRuleComponent : Component
     /// The time it takes after the last head is killed for the shuttle to arrive.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan ShuttleCallTime = TimeSpan.FromMinutes(5);
+    public TimeSpan ShuttleCallTime = TimeSpan.FromMinutes(3);
+
+    /// <summary>
+    /// The text that will be sent to the shuttle when it is called.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string ShuttleCallText = "rev-heads-were-killed-shuttle-call-text";
+
+    /// <summary>
+    /// Sender of the shuttle call text.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string ShuttleCallTextSender = "comms-console-announcement-title-centcom";
+
+
 }

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -50,6 +50,8 @@ rev-stalemate = All of the Head Revs and Command died. It's a draw.
 
 rev-reverse-stalemate = Both Command and Head Revs survived.
 
+rev-heads-were-killed-shuttle-call-text = The Head Revolutionaries were killed! The shuttle has been called. ETA: {$time} {$units}
+
 rev-headrev-count = {$initialCount ->
     [one] There was one Head Revolutionary:
     *[other] There were {$initialCount} Head Revolutionaries:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed the round ending conditions for Revolutionary rounds. When command wins and all rev heads have been killed or are off the station (exiled), the evac shuttle is called. But, if rev wins and all heads are killed, the round ends immediately. Closes #21619.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It was decided that the station would be too chaotic with no heads/security after a full rev takeover with no command.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Changed the `CommandCheck` to `RoundCheck` since it's the interval when we should check if the round will end.
- Added two more data fields for the shuttle call text and sender as well as lowering the evac shuttle time to 3 minutes.
- Finally, I included that if head revs are off-station they are counted as exiled.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
If I need to add any examples lmk.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Revolutionary rounds: When command wins and all rev heads have been killed or are off the station (exiled), the evac shuttle is called. But, if rev wins and all heads are killed, the round ends immediately.