### PR TITLE
Move Igniter from Vendomat to Engi-Vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -9,3 +9,4 @@
     ClothingHandsGlovesColorYellow: 6
     InflatableWallStack1: 24
     InflatableDoorStack1: 8
+    Igniter: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
@@ -2,7 +2,6 @@
   id: VendomatInventory
   startingInventory:
     RemoteSignaller: 1
-    Igniter: 2
     Wirecutter: 1
     CableApcStack: 2
     FlashlightLantern: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR moves the Igniter from the Vendomat to the Engi-Vend.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
An Igniter currently has two uses: Atmos and IEDs. It makes more sense for the Igniter to be in engineering. Also makes IEDs harder to make, since everything needed to make them can no longer be found in the toolstorage.
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Simyon
- tweak: Igniters can no longer be found in Vendomats, ask your local engineering department for them.
