### PR TITLE
Replace Crusher Glaive icon with Normal Crusher on Salvage guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/Cargo/Salvage.xml
+++ b/Resources/ServerInfo/Guidebook/Cargo/Salvage.xml
@@ -28,7 +28,7 @@ Jetpacks will be needed to move thoughout space, since without floors and gravit
 Internals will be important, given all species need to breathe, and space doesnt have any gases. Your mask is used to connect the gas tank to your mouth to breath, while the gas tanks hold consumable gases and can be refilled at gas canisters. All species breathe oxygen (blue + yellow tanks) except slimes, which need nitrogen (red tanks)
 
 <Box>
-<GuideEntityEmbed Entity="WeaponCrusherGlaive"/>
+<GuideEntityEmbed Entity="WeaponCrusher"/>
 <GuideEntityEmbed Entity="WeaponCrusherDagger"/>
 <GuideEntityEmbed Entity="WeaponProtoKineticAccelerator"/>
 </Box>


### PR DESCRIPTION
## About the PR
See title
(webedit moment)

## Why / Balance
Crusher Glaive is uncommon and not even in the salvage vendor. replacing with normal Crusher for clarity for "new" players

- [x ] this PR does not require an ingame showcase

