### PR TITLE
Replace Crusher Glaive with Crusher in guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/Cargo/Salvage.xml
+++ b/Resources/ServerInfo/Guidebook/Cargo/Salvage.xml
@@ -32,7 +32,7 @@ Internals will be important, given all species need to breathe, and space doesnt
 <GuideEntityEmbed Entity="WeaponCrusherDagger"/>
 <GuideEntityEmbed Entity="WeaponProtoKineticAccelerator"/>
 </Box>
-The crusher devices are your first and last line of defense against space fauna and other things that want to bring cargo harm. While the dagger is just a standard knife, the glaive is has a special property that if you shoot something with it, then follow up with a melee attack, it deals 2x more damage. The protokinetic accelerator is like a recharging weapon that can provide thrust in the scenerio that your jetpack runs dry, or mine for you.
+The crusher devices are your first and last line of defense against space fauna and other things that want to bring cargo harm. While the dagger is just a standard knife, the crusher is has a special property that if you shoot something with it, then follow up with a melee attack, it deals 2x more damage. The protokinetic accelerator is like a recharging weapon that can provide thrust in the scenerio that your jetpack runs dry, or mine for you.
 
 <Box>
 <GuideEntityEmbed Entity="Pickaxe"/>

--- a/Resources/ServerInfo/Guidebook/Cargo/Salvage.xml
+++ b/Resources/ServerInfo/Guidebook/Cargo/Salvage.xml
@@ -28,7 +28,7 @@ Jetpacks will be needed to move thoughout space, since without floors and gravit
 Internals will be important, given all species need to breathe, and space doesnt have any gases. Your mask is used to connect the gas tank to your mouth to breath, while the gas tanks hold consumable gases and can be refilled at gas canisters. All species breathe oxygen (blue + yellow tanks) except slimes, which need nitrogen (red tanks)
 
 <Box>
-<GuideEntityEmbed Entity="WeaponCrusherGlaive"/>
+<GuideEntityEmbed Entity="WeaponCrusher"/>
 <GuideEntityEmbed Entity="WeaponCrusherDagger"/>
 <GuideEntityEmbed Entity="WeaponProtoKineticAccelerator"/>
 </Box>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Replaced Crusher Glaive with Crusher, removed glaive from text

## Why / Balance
Crusher Glaive is much less common and should not be used in the guidebook

## Technical details
n/a

## Media
- [ x] this PR does not require an ingame showcase

no changelog no fun
