### PR TITLE
fix dragon threat

### DIFF
--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -8,7 +8,7 @@
 - type: ninjaHackingThreat
   id: Dragon
   announcement: terror-dragon
-  rule: Dragon
+  rule: DragonSpawn
 
 - type: ninjaHackingThreat
   id: Revenant


### PR DESCRIPTION
## About the PR
it was adding dragon rule not dragon spawn rule

## Why / Balance
fixes #22095

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed ninja calling in a dragon not actually spawning a dragon.
