### PR TITLE
nerf roller skates, buff speed boots

### DIFF
--- a/Content.Shared/Clothing/Components/SkatesComponent.cs
+++ b/Content.Shared/Clothing/Components/SkatesComponent.cs
@@ -12,31 +12,31 @@ public sealed partial class SkatesComponent : Component
     /// the levels of friction the wearer is subected to, higher the number the more friction.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float Friction = 5;
+    public float Friction = 2.5f;
 
     /// <summary>
     /// Determines the turning ability of the wearer, Higher the number the less control of their turning ability.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float? FrictionNoInput = 5f;
+    public float? FrictionNoInput = 2.5f;
 
     /// <summary>
     /// Sets the speed in which the wearer accelerates to full speed, higher the number the quicker the acceleration.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float Acceleration = 10f;
+    public float Acceleration = 5f;
 
     /// <summary>
     /// The minimum speed the wearer needs to be traveling to take damage from collision.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MinimumSpeed = 4f;
+    public float MinimumSpeed = 3f;
 
     /// <summary>
     /// The length of time the wearer is stunned for on collision.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float StunSeconds = 1f;
+    public float StunSeconds = 3f;
 
     /// <summary>
     /// The time duration before another collision can take place.
@@ -48,7 +48,7 @@ public sealed partial class SkatesComponent : Component
     /// The damage per increment of speed on collision.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float SpeedDamage = 0.5f;
+    public float SpeedDamage = 1f;
 
     /// <summary>
     /// Defaults for MinimumSpeed, StunSeconds, DamageCooldown and SpeedDamage.

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -86,8 +86,8 @@
   - type: ToggleClothingSpeed
     toggleAction: ActionToggleSpeedBoots
   - type: ClothingSpeedModifier
-    walkModifier: 1.25
-    sprintModifier: 1.25
+    walkModifier: 1.5
+    sprintModifier: 1.5
     enabled: false
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -204,8 +204,8 @@
   - type: Item
     sprite: Clothing/Shoes/Specific/skates.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.2
-    sprintModifier: 1.2
+    walkModifier: 1.1
+    sprintModifier: 1.1
   - type: Skates
   - type: FootstepModifier
     footstepSoundCollection:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
`>`common maint item is extremely powerful
`>`T3 tech is barely powerful

rollerskates have a lower max speed, slower acceleration, and less friction.
speed boots got a higher speed boost.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
roller skates were being used as a mobility item rather than a meme. this basically invalidated actual movement items like speedboots, so i remedied it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Roller skates are slower and have less friction and acceleration.
- tweak: Speed boots give a much more pronounced speed boost. Research them today!

