### PR TITLE
Fix: the character preview

### DIFF
--- a/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
+++ b/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
@@ -119,7 +119,7 @@ namespace Content.Client.Lobby.UI
                         OverrideDirection = Direction.South,
                         Scale = new Vector2(4f, 4f),
                         MaxSize = new Vector2(112, 112),
-                        Stretch = SpriteView.StretchMode.None,
+                        Stretch = SpriteView.StretchMode.Fill,
                     };
                     spriteView.SetEntity(_previewDummy.Value);
                     _viewBox.AddChild(spriteView);


### PR DESCRIPTION
## About the PR
Fixes the  Character preview in lobby

## Why / Balance
It was cutting off a portion of the preview previously, fixes #21943

## Technical details
Fill the preview to the container it is in instead of using default size.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/47093363/be21c127-adaa-4a5e-b14f-12046b170364)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
Pretty small, log probably not required.