### PR TITLE
Makes a whole bunch of raw materials grindable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -176,7 +176,6 @@
   - type: Stack
     stackType: ReinforcedGlass
     count: 1
-    node: SheetGlass
   - type: Extractable
     grindableSolutionName: rglass
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -72,6 +72,14 @@
   - type: Construction
     graph: Glass
     node: SheetGlass
+  - type: Extractable
+    grindableSolutionName: glass
+  - type: SolutionContainerManager
+    solutions:
+      glass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 22
 
 - type: entity
   parent: SheetGlass
@@ -168,6 +176,19 @@
   - type: Stack
     stackType: ReinforcedGlass
     count: 1
+    node: SheetGlass
+  - type: Extractable
+    grindableSolutionName: rglass
+  - type: SolutionContainerManager
+    solutions:
+      rglass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 22
+        - ReagentId: Iron
+          Quantity: 11
+        - ReagentId: Carbon
+          Quantity: 1
 
 - type: entity
   parent: SheetGlassBase
@@ -230,6 +251,16 @@
   - type: Stack
     stackType: PlasmaGlass
     count: 1
+  - type: Extractable
+    grindableSolutionName: pglass
+  - type: SolutionContainerManager
+    solutions:
+      pglass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 22
+        - ReagentId: Plasma
+          Quantity: 10
 
 - type: entity
   parent: SheetPGlass
@@ -258,6 +289,20 @@
   - type: Construction
     graph: Glass
     node: SheetRPGlass
+  - type: Extractable
+    grindableSolutionName: rpglass
+  - type: SolutionContainerManager
+    solutions:
+      rpglass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 22
+        - ReagentId: Plasma
+          Quantity: 10
+        - ReagentId: Iron
+          Quantity: 11
+        - ReagentId: Carbon
+          Quantity: 1
 
 - type: entity
   parent: SheetRPGlass
@@ -320,6 +365,16 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: Extractable
+    grindableSolutionName: uglass
+  - type: SolutionContainerManager
+    solutions:
+      uglass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 22
+        - ReagentId: Uranium
+          Quantity: 10
 
 - type: entity
   parent: SheetUGlass
@@ -359,7 +414,20 @@
   - type: Construction
     graph: Glass
     node: SheetRUGlass
-
+  - type: Extractable
+    grindableSolutionName: ruglass
+  - type: SolutionContainerManager
+    solutions:
+      ruglass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 22
+        - ReagentId: Uranium
+          Quantity: 10
+        - ReagentId: Iron
+          Quantity: 11
+        - ReagentId: Carbon
+          Quantity: 1
 - type: entity
   parent: SheetRUGlass
   id: SheetRUGlass1

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -127,6 +127,20 @@
   - type: Item
     heldPrefix: plasteel
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: plasteel
+  - type: SolutionContainerManager
+    solutions:
+      plasteel:
+        reagents:
+        - ReagentId: Plasma
+          Quantity: 10
+        - ReagentId: Iron
+          Quantity: 22
+        - ReagentId: Carbon
+          Quantity: 2.5
+        - ReagentId: Lead
+          Quantity: 0.5
 
 - type: entity
   parent: SheetPlasteel

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -49,6 +49,18 @@
   - type: Item
     heldPrefix: paper
   - type: Appearance
+  - type: SolutionContainerManager
+#This should maybe be cellulose later on, refer to the comments in materials.yml on wood.
+    solutions:
+      wood:
+        reagents:
+        - ReagentId: Carbon
+          Quantity: 2
+        - ReagentId: Oxygen
+          Quantity: 0.5
+        - ReagentId: Hydrogen
+          Quantity: 0.5
+
 
 - type: entity
   parent: SheetPaper

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -51,7 +51,15 @@
   - type: Item
     heldPrefix: gold
   - type: Appearance
-
+  - type: Extractable
+    grindableSolutionName: gold
+  - type: SolutionContainerManager
+    solutions:
+      gold:
+        reagents:
+        - ReagentId: Gold
+          Quantity: 10
+          
 - type: entity
   parent: IngotGold
   id: IngotGold1
@@ -88,6 +96,14 @@
   - type: Item
     heldPrefix: silver
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: gold
+  - type: SolutionContainerManager
+    solutions:
+      gold:
+        reagents:
+        - ReagentId: Silver
+          Quantity: 10
 
 - type: entity
   parent: IngotSilver

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -197,7 +197,14 @@
     state: durathread
   - type: Stack
     count: 1
-
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 5
+        reagents: #Hell if I know what durathread is made out of.
+        - ReagentId: Fiber
+          Quantity: 6
+          
 - type: entity
   parent: MaterialBase
   id: MaterialWoodPlank
@@ -228,6 +235,20 @@
     - Wooden
     - DroneUsable
     - RawMaterial
+  - type: Extractable
+    grindableSolutionName: wood
+  - type: SolutionContainerManager
+#Apparently these all components of cellulose, which is what you got in /tg/ when grinding wood + a bunch of other shit.
+#Considering the frequency of it, maybe there should be a cellulose reagent instead?
+    solutions:
+      wood:
+        reagents:
+        - ReagentId: Carbon
+          Quantity: 10
+        - ReagentId: Oxygen
+          Quantity: 5
+        - ReagentId: Hydrogen
+          Quantity: 5
 
 - type: entity
   parent: MaterialWoodPlank
@@ -335,6 +356,14 @@
     state: diamond
   - type: Item
     heldPrefix: diamond
+  - type: Extractable
+    grindableSolutionName: diamond
+  - type: SolutionContainerManager
+    solutions:
+      diamond:
+        reagents:
+        - ReagentId: Carbon
+          Quantity: 20
 
 - type: entity
   parent: MaterialDiamond
@@ -372,6 +401,11 @@
         reagents:
         - ReagentId: Fiber
           Quantity: 5
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Fiber
+        Quantity: 3
   - type: Tag
     tags:
       - ClothMade
@@ -472,6 +506,11 @@
       - cobwebs
     ignoreReagents:
       - Fiber
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Fiber
+        Quantity: 3
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -29,6 +29,9 @@
   name: metal rods
   suffix: Full
   components:
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 50 #Half of a regular steel sheet to reflect the crafting recipe
   - type: Stack
     stackType: MetalRod
     baseLayer: base
@@ -58,6 +61,16 @@
     price: 0
   - type: StackPrice
     price: 5
+  - type: Extractable
+    grindableSolutionName: rod
+  - type: SolutionContainerManager
+    solutions:
+      rod:
+        reagents:
+        - ReagentId: Iron
+          Quantity: 11
+        - ReagentId: Carbon #Not 1.25 (half of 2.5) because that would probably be really weird
+          Quantity: 1
 
 - type: entity
   parent: PartRodMetal

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -100,6 +100,14 @@
     tags:
       - GlassShard
       - Trash
+  - type: Extractable
+    grindableSolutionName: shardglass
+  - type: SolutionContainerManager
+    solutions:
+      shardglass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 11 #Half of the value of regular glass. TECHNICALLY, welding a single shard of glass gives you the full thing back with just 1 sheet, but that is stupid so I am making it half.
 
 - type: entity
   parent: ShardBase
@@ -121,6 +129,14 @@
     tags:
       - ReinforcedGlassShard
       - Trash
+  - type: Extractable
+    grindableSolutionName: shardrglass
+  - type: SolutionContainerManager
+    solutions:
+      shardrglass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 11 #I don't care enough to divide all of the reinforced glass materials by 2 because reinforced glass shards are due for removal anyways.
 
 - type: entity
   parent: ShardBase
@@ -142,6 +158,16 @@
     tags:
       - PlasmaGlassShard
       - Trash
+  - type: Extractable
+    grindableSolutionName: shardpglass
+  - type: SolutionContainerManager
+    solutions:
+      shardpglass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 11
+        - ReagentId: Plasma
+          Quantity: 5
 
 - type: entity
   parent: ShardBase
@@ -164,4 +190,13 @@
     tags:
       - UraniumGlassShard
       - Trash
-
+  - type: Extractable
+    grindableSolutionName: sharduglass
+  - type: SolutionContainerManager
+    solutions:
+      sharduglass:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 11
+        - ReagentId: Uranium
+          Quantity: 5

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -52,6 +52,18 @@
     cablePrototypeID: CableHV
     blockingWireType: HighVoltage
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: hvcable
+  - type: SolutionContainerManager
+    solutions:
+      hvcable:
+        reagents:
+        - ReagentId: Iron
+          Quantity: 3
+        - ReagentId: Copper
+          Quantity: 3
+        - ReagentId: Carbon #steel-reinforced
+          Quantity: 1
 
 - type: entity
   parent: CableHVStack
@@ -107,6 +119,16 @@
     cablePrototypeID: CableMV
     blockingWireType: MediumVoltage
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: mvcable
+  - type: SolutionContainerManager
+    solutions:
+      mvcable:
+        reagents:
+        - ReagentId: Iron
+          Quantity: 3
+        - ReagentId: Copper
+          Quantity: 3
 
 - type: entity
   parent: CableMVStack
@@ -161,6 +183,16 @@
     cablePrototypeID: CableApcExtension
     blockingWireType: Apc
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: lvcable
+  - type: SolutionContainerManager
+    solutions:
+      lvcable:
+        reagents:
+        - ReagentId: Iron
+          Quantity: 3
+        - ReagentId: Copper
+          Quantity: 3
 
 - type: entity
   parent: CableApcStack


### PR DESCRIPTION
## About the PR
Makes most of the raw materials in the game (eg. glass, plasmaglass, silver, wood, etc.) grindable in the all-in-one grinder for reagents.

## Why / Balance
A large part of the chem rework was to make chemistry accessible for theoretically anyone on the station. This should help with that significantly.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- add: Most raw materials (eg. glass, gold, wood) are now grindable in the all-in-one grinder.