### PR TITLE
Fix conveyors to allow doors to close over top

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -460,6 +460,10 @@ public abstract class SharedDoorSystem : EntitySystem
             //If the colliding entity is a slippable item ignore it by the airlock
             if (otherPhysics.CollisionLayer == (int)CollisionGroup.SlipLayer && otherPhysics.CollisionMask == (int)CollisionGroup.ItemMask)
                 continue;
+            
+            //For when doors need to close over conveyor belts
+            if (otherPhysics.CollisionLayer == (int) CollisionGroup.ConveyorMask)
+                continue;
 
             if ((physics.CollisionMask & otherPhysics.CollisionLayer) == 0 && (otherPhysics.CollisionMask & physics.CollisionLayer) == 0)
                 continue;

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -22,6 +22,7 @@ public enum CollisionGroup
     GhostImpassable    = 1 << 5, // 32 Things impassible by ghosts/observers, ie blessed tiles or forcefields
     BulletImpassable   = 1 << 6, // 64 Can be hit by bullets
     InteractImpassable = 1 << 7, // 128 Blocks interaction/InRangeUnobstructed
+    DoorPassable       = 1 << 8, // 256 Allows door to close over top, Like blast doors over conveyors for disposals rooms/cargo.
 
     MapGrid = MapGridHelpers.CollisionGroup, // Map grids, like shuttles. This is the actual grid itself, not the walls or other entities connected to the grid.
 
@@ -45,6 +46,7 @@ public enum CollisionGroup
     // Machines, computers
     MachineMask = Impassable | MidImpassable | LowImpassable,
     MachineLayer = Opaque | MidImpassable | LowImpassable | BulletImpassable,
+    ConveyorMask = Impassable | MidImpassable | LowImpassable | DoorPassable,
 
     // Tables that SmallMobs can go under
     TableMask = Impassable | MidImpassable,

--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -32,6 +32,7 @@
         - Impassable
         - MidImpassable
         - LowImpassable
+        - DoorPassable
         hard: False
   - type: Conveyor
   - type: DeviceLinkSink


### PR DESCRIPTION
## About the PR
Doors could not close over top of conveyor belts this allows them to close over top of them. Fixes #21725 and fixes #19316

## Why / Balance
Some maps put doors and firedoors over conveyors in cargo and disposals so they can not be closed if they are opened.

## Technical details
Added a new collision group that is put on the conveyor belt that wont interfere with the collision detection of objects being moved over the conveyor or other regular door functions.

## Media
Some of the tests that it works, Open/closing. Tested with firedoors too:

https://github.com/space-wizards/space-station-14/assets/47093363/739d507f-ec9b-448c-813b-f52ceb10632e



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Should not contain any breaking changes.

**Changelog**
We can remove the CI if its too minor.

:cl: Repo
- fix: Doors can close over conveyor belts.

