### PR TITLE
Revert "Reduce number of unsafe and insane presents"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -208,7 +208,7 @@
   - type: Sprite
     sprite: Objects/Decoration/Flora/flora_stalagmite.rsi
     state: stalagmite5
-
+    
 - type: entity
   parent: FloraStalagmite1
   id: FloraStalagmite6
@@ -423,10 +423,10 @@
       - id: PresentRandom
         orGroup: present
       - id: PresentRandomUnsafe
-        prob: 0.25
+        prob: 0.5
         orGroup: present
       - id: PresentRandomInsane
-        prob: 0.10
+        prob: 0.2
         orGroup: present
     receivedPopup: christmas-tree-got-gift
     deniedPopup: christmas-tree-no-gift
@@ -456,28 +456,28 @@
   components:
   - type: Sprite
     state: tree02
-
+    
 - type: entity
   parent: ShadowTree01
   id: ShadowTree03
   components:
   - type: Sprite
     state: tree03
-
+    
 - type: entity
   parent: ShadowTree01
   id: ShadowTree04
   components:
   - type: Sprite
     state: tree04
-
+    
 - type: entity
   parent: ShadowTree01
   id: ShadowTree05
   components:
   - type: Sprite
     state: tree05
-
+    
 - type: entity
   parent: ShadowTree01
   id: ShadowTree06

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -208,7 +208,7 @@
   - type: Sprite
     sprite: Objects/Decoration/Flora/flora_stalagmite.rsi
     state: stalagmite5
-    
+
 - type: entity
   parent: FloraStalagmite1
   id: FloraStalagmite6
@@ -456,28 +456,28 @@
   components:
   - type: Sprite
     state: tree02
-    
+
 - type: entity
   parent: ShadowTree01
   id: ShadowTree03
   components:
   - type: Sprite
     state: tree03
-    
+
 - type: entity
   parent: ShadowTree01
   id: ShadowTree04
   components:
   - type: Sprite
     state: tree04
-    
+
 - type: entity
   parent: ShadowTree01
   id: ShadowTree05
   components:
   - type: Sprite
     state: tree05
-    
+
 - type: entity
   parent: ShadowTree01
   id: ShadowTree06


### PR DESCRIPTION
Reverts space-wizards/space-station-14#22067

Reasons for:
- The whole point is that it was chaos.
- It was unjust to reduce the chaos.
- Project Managers liked the chaos.

Reasons against:
- Too much chaos is problematic.
- It's fine how it is right now.
- Head admins didn't like the issues that come with so much chaos.

This PR will be either closed or merged, based on maintainer's choice.