### PR TITLE
fix ghost command damage when in crit

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -260,15 +260,13 @@ namespace Content.Server.GameTicking
                     //todo: what if they dont breathe lol
                     //cry deeply
 
-                    FixedPoint2 dealtDamage;
-                    if (TryComp<DamageableComponent>(playerEntity, out var damageableComp))
+                    FixedPoint2 dealtDamage = 200;
+                    if (TryComp<DamageableComponent>(playerEntity, out var damageable))
                     {
-                        TryComp<MobThresholdsComponent>(playerEntity, out var thresholdsComponent);
-                        var playerDeadThreshold = _mobThresholdSystem.GetThresholdForState((EntityUid) playerEntity, MobState.Dead, thresholdsComponent);
-                        dealtDamage = playerDeadThreshold - damageableComp.TotalDamage;
+                        TryComp<MobThresholdsComponent>(playerEntity, out var thresholds);
+                        var playerDeadThreshold = _mobThresholdSystem.GetThresholdForState((EntityUid) playerEntity, MobState.Dead, thresholds);
+                        dealtDamage = playerDeadThreshold > 0 ? playerDeadThreshold - damageable.TotalDamage : 200;
                     }
-                    else
-                        dealtDamage = 200;
 
                     DamageSpecifier damage = new(_prototypeManager.Index<DamageTypePrototype>("Asphyxiation"), dealtDamage);
 

--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -261,9 +261,10 @@ namespace Content.Server.GameTicking
                     //cry deeply
 
                     FixedPoint2 dealtDamage = 200;
-                    if (TryComp<DamageableComponent>(playerEntity, out var damageable) && TryComp<MobThresholdsComponent>(playerEntity, out var thresholds))
+                    if (TryComp<DamageableComponent>(playerEntity, out var damageable)
+                        && TryComp<MobThresholdsComponent>(playerEntity, out var thresholds))
                     {
-                        var playerDeadThreshold = _mobThresholdSystem.GetThresholdForState((EntityUid) playerEntity, MobState.Dead, thresholds);
+                        var playerDeadThreshold = _mobThresholdSystem.GetThresholdForState(playerEntity.Value, MobState.Dead, thresholds);
                         dealtDamage = playerDeadThreshold - damageable.TotalDamage;
                     }
 

--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -261,11 +261,10 @@ namespace Content.Server.GameTicking
                     //cry deeply
 
                     FixedPoint2 dealtDamage = 200;
-                    if (TryComp<DamageableComponent>(playerEntity, out var damageable))
+                    if (TryComp<DamageableComponent>(playerEntity, out var damageable) && TryComp<MobThresholdsComponent>(playerEntity, out var thresholds))
                     {
-                        TryComp<MobThresholdsComponent>(playerEntity, out var thresholds);
                         var playerDeadThreshold = _mobThresholdSystem.GetThresholdForState((EntityUid) playerEntity, MobState.Dead, thresholds);
-                        dealtDamage = playerDeadThreshold > 0 ? playerDeadThreshold - damageable.TotalDamage : 200;
+                        dealtDamage = playerDeadThreshold - damageable.TotalDamage;
                     }
 
                     DamageSpecifier damage = new(_prototypeManager.Index<DamageTypePrototype>("Asphyxiation"), dealtDamage);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When crit, damage on ghost command is now just enough to kill, instead of flat 200.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Up to 200 free asphyxiation bug.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Gets the threshold for death from Thresholds component and deals enough to reach the specific mob's death, not just to get 200. Good!

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Works with any mob.

https://github.com/space-wizards/space-station-14/assets/69696513/c745d440-5720-4641-b695-ece5dad4b2f2


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
n

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
The issue was quite popular on discord so cl might be useful here.

:cl:

- fix: When ghosting from a critical state, the ghost command now kills with damage relative to current health instead of flat 200.

