### PR TITLE
fix humanoid fire visuals missing

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -296,6 +296,8 @@
     damageRecovery:
       types:
         Asphyxiation: -1.0
+  - type: FireVisuals
+    alternateState: Standing
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -98,6 +98,8 @@
           visualType: Large
           messages: [ "skeleton-sprayed-by-oat-milk-popup" ]
           probability: 0.5
+  - type: FireVisuals
+    alternateState: Standing
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
## About the PR
<!-- What did you change in this PR? -->
humanoids used to use the more intense fire sprite after reaching fire level 4. It went gone after some rework it seems. I add it back.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
fix

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The parent to all humanoid species now gets the texture for alternate state. For definition of the FireVisuals component in question, see `MobFlammable`.

## Media
✅ Humanoids use the sprite
✅ Other mobs do not use the sprite
![23-12-04_282_Content Client](https://github.com/space-wizards/space-station-14/assets/69696513/6253fa33-17eb-4294-bbb9-c79864d1aee4)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
n
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
