### PR TITLE
Action Cooldowns Reset on Rejuvenate

### DIFF
--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -39,7 +39,7 @@ public abstract class SharedActionsSystem : EntitySystem
         SubscribeLocalEvent<ActionsComponent, DidEquipHandEvent>(OnHandEquipped);
         SubscribeLocalEvent<ActionsComponent, DidUnequipEvent>(OnDidUnequip);
         SubscribeLocalEvent<ActionsComponent, DidUnequipHandEvent>(OnHandUnequipped);
-        SubscribeLocalEvent<ActionsComponent, RejuvenateEvent>();
+        SubscribeLocalEvent<ActionsComponent, RejuvenateEvent>(OnRejuventate);
 
         SubscribeLocalEvent<ActionsComponent, ComponentShutdown>(OnShutdown);
 
@@ -165,7 +165,7 @@ public abstract class SharedActionsSystem : EntitySystem
         Dirty(actionId.Value, action);
     }
 
-    public void OnRejuventate(EntityUid uid, ActionsComponent component)
+    public void OnRejuventate(EntityUid uid, ActionsComponent component, RejuvenateEvent args)
     {
         foreach (var act in component.Actions)
         {

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -165,7 +165,7 @@ public abstract class SharedActionsSystem : EntitySystem
         Dirty(actionId.Value, action);
     }
 
-    public void OnRejuventate(EntityUid uid, ActionsComponent component, RejuvenateEvent args)
+    private void OnRejuventate(EntityUid uid, ActionsComponent component, RejuvenateEvent args)
     {
         foreach (var act in component.Actions)
         {

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -15,6 +15,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared.Rejuvenate;
 
 namespace Content.Shared.Actions;
 
@@ -38,6 +39,7 @@ public abstract class SharedActionsSystem : EntitySystem
         SubscribeLocalEvent<ActionsComponent, DidEquipHandEvent>(OnHandEquipped);
         SubscribeLocalEvent<ActionsComponent, DidUnequipEvent>(OnDidUnequip);
         SubscribeLocalEvent<ActionsComponent, DidUnequipHandEvent>(OnHandUnequipped);
+        SubscribeLocalEvent<ActionsComponent, RejuvenateEvent>();
 
         SubscribeLocalEvent<ActionsComponent, ComponentShutdown>(OnShutdown);
 
@@ -161,6 +163,14 @@ public abstract class SharedActionsSystem : EntitySystem
 
         action.Cooldown = (GameTiming.CurTime, GameTiming.CurTime + action.UseDelay.Value);
         Dirty(actionId.Value, action);
+    }
+
+    public void OnRejuventate(EntityUid uid, ActionsComponent component)
+    {
+        foreach (var act in component.Actions)
+        {
+            ClearCooldown(act);
+        }
     }
 
     #region ComponentStateManagement


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR resolves #20261.

## Why / Balance
Per #20261, this change is intended to make testing actions easier.

## Technical details
`ActionsComponent` subscribes to `RejuvenateEvent`. On raise, all actions are iterated through and have their cooldowns reset.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
This PR is a minor change and probably doesn't need a video.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
This PR has no breaking changes.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: The rejuvenate command/verb resets all action cooldowns.
