### PR TITLE
Fixes ghosts completely lacking speech bubbles (+ replaces the exception with more noticeably broken behavior)

### DIFF
--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -187,6 +187,8 @@ namespace Content.Client.Chat.UI
             var rawmsg = message.WrappedMessage;
             var tagStart = rawmsg.IndexOf($"[{tag}]");
             var tagEnd = rawmsg.IndexOf($"[/{tag}]");
+            if (tagStart <= 0 || tagEnd <= 0) //the above return -1 if the tag's not found, which in turn will cause the below to throw an exception. a blank speech bubble is far more noticeably broken than the bubble not appearing at all -bhijn
+                return "";
             tagStart += tag.Length + 2;
             return rawmsg.Substring(tagStart, tagEnd - tagStart);
         }

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -37,8 +37,8 @@ chat-manager-entity-looc-wrap-message = LOOC: [bold]{$entityName}:[/bold] {$mess
 chat-manager-send-ooc-wrap-message = OOC: [bold]{$playerName}:[/bold] {$message}
 chat-manager-send-ooc-patron-wrap-message = OOC: [bold][color={$patronColor}]{$playerName}[/color]:[/bold] {$message}
 
-chat-manager-send-dead-chat-wrap-message = {$deadChannelName}: [bold]{$playerName}:[/bold] {$message}
-chat-manager-send-admin-dead-chat-wrap-message = {$adminChannelName}: [bold]({$userName}):[/bold] {$message}
+chat-manager-send-dead-chat-wrap-message = {$deadChannelName}: [bold][BubbleHeader]{$playerName}[/BubbleHeader]:[/bold] [BubbleContent]{$message}[/BubbleContent]
+chat-manager-send-admin-dead-chat-wrap-message = {$adminChannelName}: [bold]([BubbleHeader]{$userName}[/BubbleHeader]):[/bold] [BubbleContent]{$message}[/BubbleContent]
 chat-manager-send-admin-chat-wrap-message = {$adminChannelName}: [bold]{$playerName}:[/bold] {$message}
 chat-manager-send-admin-announcement-wrap-message = [bold]{$adminChannelName}: {$message}[/bold]
 


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Deadchat is great. You should 100% be allowed to see deadchat fly across your screen like NicoNicoDouga comments.

## Technical details
This tweaks the behavior of `ExtractSpeechSubstring()` such that, instead of throwing an exception when the tag's missing from the message, it'll return a blank string. This, among other things, will cause a missing tag to be *far* more noticeably broken in the future, as the current behavior of just throwing an exception means that players are likely to assume that a missing speech bubble is intentional rather than a bug, which *really* isn't desirable for a feature as crucial as chat bubbles.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/6356337/cf50411d-7d37-4c38-b912-7758d3dd20e4)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- fix: Ghosts now have speech bubbles again
