### PR TITLE
Mirror speed penalty for worn duffels and hardsuits when in-hand

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Hands.Components;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared.Hands.EntitySystems;
+
+public abstract partial class SharedHandsSystem
+{
+    private void InitializeRelay()
+    {
+        SubscribeLocalEvent<HandsComponent, RefreshMovementSpeedModifiersEvent>(RelayEvent);
+    }
+
+    private void RelayEvent<T>(Entity<HandsComponent> entity, ref T args) where T : EntityEventArgs
+    {
+        var ev = new HeldRelayedEvent<T>(args);
+        foreach (var held in EnumerateHeld(entity, entity.Comp))
+        {
+            RaiseLocalEvent(held, ref ev);
+        }
+    }
+}

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -31,6 +31,7 @@ public abstract partial class SharedHandsSystem
         InitializeDrop();
         InitializePickup();
         InitializeVirtual();
+        InitializeRelay();
     }
 
     public override void Shutdown()

--- a/Content.Shared/Hands/HandEvents.cs
+++ b/Content.Shared/Hands/HandEvents.cs
@@ -319,4 +319,15 @@ namespace Content.Shared.Hands
 
         public EntityUid Sender { get; }
     }
+
+    [ByRefEvent]
+    public sealed class HeldRelayedEvent<TEvent> : EntityEventArgs
+    {
+        public TEvent Args;
+
+        public HeldRelayedEvent(TEvent args)
+        {
+            Args = args;
+        }
+    }
 }

--- a/Content.Shared/Item/HeldSpeedModifierComponent.cs
+++ b/Content.Shared/Item/HeldSpeedModifierComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Clothing;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Item;
@@ -12,12 +13,18 @@ public sealed partial class HeldSpeedModifierComponent : Component
     /// <summary>
     /// A multiplier applied to the walk speed.
     /// </summary>
-    [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [DataField] [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public float WalkModifier = 1.0f;
 
     /// <summary>
     /// A multiplier applied to the sprint speed.
     /// </summary>
-    [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [DataField] [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public float SprintModifier = 1.0f;
+
+    /// <summary>
+    /// If true, values from <see cref="ClothingSpeedModifierComponent"/> will attempted to be used before the ones in this component.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public bool MirrorClothingModifier = true;
 }

--- a/Content.Shared/Item/HeldSpeedModifierComponent.cs
+++ b/Content.Shared/Item/HeldSpeedModifierComponent.cs
@@ -6,6 +6,10 @@ namespace Content.Shared.Item;
 /// <summary>
 /// This is used for items that change your speed when they are held.
 /// </summary>
+/// <remarks>
+/// This is separate from <see cref="ClothingSpeedModifierComponent"/> because things like boots increase/decrease speed when worn, but
+/// shouldn't do that when just held in hand.
+/// </remarks>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(HeldSpeedModifierSystem))]
 public sealed partial class HeldSpeedModifierComponent : Component

--- a/Content.Shared/Item/HeldSpeedModifierComponent.cs
+++ b/Content.Shared/Item/HeldSpeedModifierComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Item;
+
+/// <summary>
+/// This is used for items that change your speed when they are held.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(HeldSpeedModifierSystem))]
+public sealed partial class HeldSpeedModifierComponent : Component
+{
+    /// <summary>
+    /// A multiplier applied to the walk speed.
+    /// </summary>
+    [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public float WalkModifier = 1.0f;
+
+    /// <summary>
+    /// A multiplier applied to the sprint speed.
+    /// </summary>
+    [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public float SprintModifier = 1.0f;
+}

--- a/Content.Shared/Item/HeldSpeedModifierSystem.cs
+++ b/Content.Shared/Item/HeldSpeedModifierSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Clothing;
 using Content.Shared.Hands;
 using Content.Shared.Movement.Systems;
 
@@ -30,6 +31,14 @@ public sealed class HeldSpeedModifierSystem : EntitySystem
 
     private void OnRefreshMovementSpeedModifiers(EntityUid uid, HeldSpeedModifierComponent component, HeldRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
     {
-        args.Args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+        var walkMod = component.WalkModifier;
+        var sprintMod = component.SprintModifier;
+        if (component.MirrorClothingModifier && TryComp<ClothingSpeedModifierComponent>(uid, out var clothingSpeedModifier))
+        {
+            walkMod = clothingSpeedModifier.WalkModifier;
+            sprintMod = clothingSpeedModifier.SprintModifier;
+        }
+
+        args.Args.ModifySpeed(walkMod, sprintMod);
     }
 }

--- a/Content.Shared/Item/HeldSpeedModifierSystem.cs
+++ b/Content.Shared/Item/HeldSpeedModifierSystem.cs
@@ -1,0 +1,35 @@
+using Content.Shared.Hands;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared.Item;
+
+/// <summary>
+/// This handles <see cref="HeldSpeedModifierComponent"/>
+/// </summary>
+public sealed class HeldSpeedModifierSystem : EntitySystem
+{
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<HeldSpeedModifierComponent, GotEquippedHandEvent>(OnGotEquippedHand);
+        SubscribeLocalEvent<HeldSpeedModifierComponent, GotUnequippedHandEvent>(OnGotUnequippedHand);
+        SubscribeLocalEvent<HeldSpeedModifierComponent, HeldRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnRefreshMovementSpeedModifiers);
+    }
+
+    private void OnGotEquippedHand(Entity<HeldSpeedModifierComponent> ent, ref GotEquippedHandEvent args)
+    {
+        _movementSpeedModifier.RefreshMovementSpeedModifiers(args.User);
+    }
+
+    private void OnGotUnequippedHand(Entity<HeldSpeedModifierComponent> ent, ref GotUnequippedHandEvent args)
+    {
+        _movementSpeedModifier.RefreshMovementSpeedModifiers(args.User);
+    }
+
+    private void OnRefreshMovementSpeedModifiers(EntityUid uid, HeldSpeedModifierComponent component, HeldRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
+    {
+        args.Args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -13,6 +13,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 0.9
+  - type: HeldSpeedModifier
+    walkModifier: 1
+    sprintModifier: 0.9
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -236,6 +239,8 @@
     - 0,0,19,9
   - type: ClothingSpeedModifier
     sprintModifier: 1 # makes its stats identical to other variants of bag of holding
+  - type: HeldSpeedModifier
+    sprintModifier: 1
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -246,5 +251,8 @@
   - type: Storage
     maxItemSize: Huge
   - type: ClothingSpeedModifier
+    walkModifier: 1
+    sprintModifier: 1
+  - type: HeldSpeedModifier
     walkModifier: 1
     sprintModifier: 1

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -14,8 +14,6 @@
     walkModifier: 1
     sprintModifier: 0.9
   - type: HeldSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.9
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -240,7 +238,6 @@
   - type: ClothingSpeedModifier
     sprintModifier: 1 # makes its stats identical to other variants of bag of holding
   - type: HeldSpeedModifier
-    sprintModifier: 1
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -254,5 +251,3 @@
     walkModifier: 1
     sprintModifier: 1
   - type: HeldSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -230,6 +230,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
+  - type: HeldSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ExplosionResistance
     damageCoefficient: 0.65
   - type: GroupExamine
@@ -255,6 +258,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.65
+  - type: HeldSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: GroupExamine
@@ -276,6 +282,8 @@
         Slash: 0.8
         Piercing: 0.4
   - type: ClothingSpeedModifier
+    walkModifier: 0.8
+  - type: HeldSpeedModifier
     walkModifier: 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.4

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -231,8 +231,6 @@
     walkModifier: 1.0
     sprintModifier: 1.0
   - type: HeldSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
   - type: ExplosionResistance
     damageCoefficient: 0.65
   - type: GroupExamine
@@ -259,8 +257,6 @@
     walkModifier: 0.7
     sprintModifier: 0.65
   - type: HeldSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: GroupExamine
@@ -284,7 +280,6 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
   - type: HeldSpeedModifier
-    walkModifier: 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.4
   - type: GroupExamine

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -23,8 +23,6 @@
     walkModifier: 0.9
     sprintModifier: 0.9
   - type: HeldSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
 
 - type: entity
   abstract: true
@@ -74,8 +72,6 @@
     walkModifier: 0.4
     sprintModifier: 0.6
   - type: HeldSpeedModifier
-    walkModifier: 0.4
-    sprintModifier: 0.6
   - type: Item
     size: Ginormous
   - type: Armor
@@ -112,8 +108,6 @@
     walkModifier: 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
   - type: Item
     size: Huge
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -22,6 +22,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+  - type: HeldSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
 
 - type: entity
   abstract: true
@@ -70,6 +73,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.4
     sprintModifier: 0.6
+  - type: HeldSpeedModifier
+    walkModifier: 0.4
+    sprintModifier: 0.6
   - type: Item
     size: Ginormous
   - type: Armor
@@ -103,6 +109,9 @@
   - type: TemperatureProtection
     coefficient: 0.01 # Not complete protection from fire
   - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
+  - type: HeldSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
   - type: Item

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -24,6 +24,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.80
+  - type: HeldSpeedModifier
+    walkModifier: 0.80
+    sprintModifier: 0.80
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBasic
 
@@ -55,6 +58,9 @@
         Radiation: 0.5
         Caustic: 0.5
   - type: ClothingSpeedModifier
+    walkModifier: 0.7
+    sprintModifier: 0.7
+  - type: HeldSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
   - type: ToggleableClothing
@@ -90,6 +96,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
+  - type: HeldSpeedModifier
+    walkModifier: 0.7
+    sprintModifier: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
 
@@ -116,6 +125,9 @@
         Radiation: 0.3 #salv is supposed to have radiation hazards in the future
         Caustic: 0.8
   - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.8
+  - type: HeldSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.8
   - type: ToggleableClothing
@@ -148,6 +160,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
+  - type: HeldSpeedModifier
+    walkModifier: 0.75
+    sprintModifier: 0.75
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
 
@@ -177,6 +192,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
+  - type: HeldSpeedModifier
+    walkModifier: 0.75
+    sprintModifier: 0.75
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
 
@@ -201,6 +219,9 @@
         Slash: 0.8
         Piercing: 0.7
   - type: ClothingSpeedModifier
+    walkModifier: 0.65
+    sprintModifier: 0.65
+  - type: HeldSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
   - type: ToggleableClothing
@@ -230,6 +251,9 @@
         Piercing: 0.6
         Caustic: 0.7
   - type: ClothingSpeedModifier
+    walkModifier: 0.7
+    sprintModifier: 0.7
+  - type: HeldSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
   - type: ToggleableClothing
@@ -263,6 +287,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: HeldSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap
 
@@ -294,6 +321,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.8
+  - type: HeldSpeedModifier
+    walkModifier: 0.75
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhite
 
@@ -316,6 +346,9 @@
       coefficients:
         Caustic: 0.1
   - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.95
+  - type: HeldSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.95
   - type: ToggleableClothing
@@ -347,6 +380,9 @@
   - type: ExplosionResistance
     damageCoefficient: 0.1
   - type: ClothingSpeedModifier
+    walkModifier: 0.75
+    sprintModifier: 0.75
+  - type: HeldSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: Item
@@ -387,6 +423,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: HeldSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
 
@@ -415,6 +454,9 @@
         Radiation: 0.5
         Caustic: 0.8
   - type: ClothingSpeedModifier
+    walkModifier: 0.85
+    sprintModifier: 0.9
+  - type: HeldSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.9
   - type: ToggleableClothing
@@ -449,6 +491,9 @@
         Radiation: 0.5
         Caustic: 0.5
   - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
+  - type: HeldSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
   - type: ToggleableClothing
@@ -498,6 +543,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
+  - type: HeldSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
 
@@ -527,6 +575,9 @@
         Radiation: 0.25
         Caustic: 0.4
   - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
+  - type: HeldSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
   - type: ToggleableClothing
@@ -560,6 +611,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.65
+  - type: HeldSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.65
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
 
@@ -591,6 +645,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: HeldSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
 
@@ -620,6 +677,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: HeldSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLing
 
@@ -647,6 +707,9 @@
         Heat: 0.4
         Caustic: 0.75
   - type: ClothingSpeedModifier
+    walkModifier: 0.6
+    sprintModifier: 0.6
+  - type: HeldSpeedModifier
     walkModifier: 0.6
     sprintModifier: 0.6
   - type: ToggleableClothing
@@ -679,6 +742,9 @@
         Heat: 0.4
         Caustic: 0.75
   - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
+  - type: HeldSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
   - type: ToggleableClothing
@@ -787,6 +853,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
+  - type: HeldSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
 
@@ -822,6 +891,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
+  - type: HeldSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURN
 
@@ -850,6 +922,9 @@
         Piercing: 0.9
         Caustic: 0.8
   - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
+  - type: HeldSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
   - type: Construction

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -25,8 +25,6 @@
     walkModifier: 0.80
     sprintModifier: 0.80
   - type: HeldSpeedModifier
-    walkModifier: 0.80
-    sprintModifier: 0.80
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBasic
 
@@ -61,8 +59,6 @@
     walkModifier: 0.7
     sprintModifier: 0.7
   - type: HeldSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
 
@@ -97,8 +93,6 @@
     walkModifier: 0.7
     sprintModifier: 0.7
   - type: HeldSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
 
@@ -128,8 +122,6 @@
     walkModifier: 0.9
     sprintModifier: 0.8
   - type: HeldSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSpatio
 
@@ -161,8 +153,6 @@
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: HeldSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
 
@@ -193,8 +183,6 @@
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: HeldSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
 
@@ -222,8 +210,6 @@
     walkModifier: 0.65
     sprintModifier: 0.65
   - type: HeldSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
 
@@ -254,8 +240,6 @@
     walkModifier: 0.7
     sprintModifier: 0.7
   - type: HeldSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
 
@@ -288,8 +272,6 @@
     walkModifier: 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap
 
@@ -322,8 +304,6 @@
     walkModifier: 0.75
     sprintModifier: 0.8
   - type: HeldSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhite
 
@@ -349,8 +329,6 @@
     walkModifier: 0.9
     sprintModifier: 0.95
   - type: HeldSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.95
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMedical
 
@@ -383,8 +361,6 @@
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: HeldSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
   - type: Item
     size: Normal
   - type: Tag
@@ -424,8 +400,6 @@
     walkModifier: 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
 
@@ -457,8 +431,6 @@
     walkModifier: 0.85
     sprintModifier: 0.9
   - type: HeldSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.9
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLuxury
 
@@ -494,8 +466,6 @@
     walkModifier: 0.9
     sprintModifier: 0.9
   - type: HeldSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndie
 
@@ -544,8 +514,6 @@
     walkModifier: 1.0
     sprintModifier: 1.0
   - type: HeldSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
 
@@ -578,8 +546,6 @@
     walkModifier: 1.0
     sprintModifier: 1.0
   - type: HeldSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
 
@@ -612,8 +578,6 @@
     walkModifier: 0.9
     sprintModifier: 0.65
   - type: HeldSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.65
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
 
@@ -646,8 +610,6 @@
     walkModifier: 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
 
@@ -678,8 +640,6 @@
     walkModifier: 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLing
 
@@ -710,8 +670,6 @@
     walkModifier: 0.6
     sprintModifier: 0.6
   - type: HeldSpeedModifier
-    walkModifier: 0.6
-    sprintModifier: 0.6
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateEVA
   - type: StaticPrice
@@ -745,8 +703,6 @@
     walkModifier: 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateCap
   - type: StaticPrice
@@ -854,8 +810,6 @@
     walkModifier: 1.0
     sprintModifier: 1.0
   - type: HeldSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
 
@@ -892,8 +846,6 @@
     walkModifier: 1.0
     sprintModifier: 1.0
   - type: HeldSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURN
 
@@ -925,8 +877,6 @@
     walkModifier: 0.9
     sprintModifier: 0.9
   - type: HeldSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
   - type: Construction
     graph: ClownHardsuit
     node: clownHardsuit

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -45,8 +45,6 @@
     walkModifier: 0.5
     sprintModifier: 0.5
   - type: HeldSpeedModifier
-    walkModifier: 0.5
-    sprintModifier: 0.5
   - type: TemperatureProtection
     coefficient: 0.5
   - type: ToggleableClothing
@@ -87,8 +85,6 @@
     walkModifier: 0.85
     sprintModifier: 0.85
   - type: HeldSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
 
 #Paramedic Voidsuit
 #Despite having resistances and looking like one, this is two-piece and parents off the EVA suit so it goes here.
@@ -109,8 +105,6 @@
     walkModifier: 0.9
     sprintModifier: 0.9
   - type: HeldSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
   - type: TemperatureProtection
     coefficient: 0.1
   - type: Armor

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -44,6 +44,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.5
     sprintModifier: 0.5
+  - type: HeldSpeedModifier
+    walkModifier: 0.5
+    sprintModifier: 0.5
   - type: TemperatureProtection
     coefficient: 0.5
   - type: ToggleableClothing
@@ -83,6 +86,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.85
+  - type: HeldSpeedModifier
+    walkModifier: 0.85
+    sprintModifier: 0.85
 
 #Paramedic Voidsuit
 #Despite having resistances and looking like one, this is two-piece and parents off the EVA suit so it goes here.
@@ -100,6 +106,9 @@
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
+  - type: HeldSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
   - type: TemperatureProtection

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -46,6 +46,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.7
+  - type: HeldSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.7
   - type: GroupExamine
 
 - type: entity
@@ -70,6 +73,9 @@
           Heat: 0.3
           Cold: 0.2
     - type: ClothingSpeedModifier
+      walkModifier: 0.8
+      sprintModifier: 0.8
+    - type: HeldSpeedModifier
       walkModifier: 0.8
       sprintModifier: 0.8
     - type: GroupExamine

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -47,8 +47,6 @@
     walkModifier: 0.8
     sprintModifier: 0.7
   - type: HeldSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.7
   - type: GroupExamine
 
 - type: entity
@@ -76,8 +74,6 @@
       walkModifier: 0.8
       sprintModifier: 0.8
     - type: HeldSpeedModifier
-      walkModifier: 0.8
-      sprintModifier: 0.8
     - type: GroupExamine
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds ye olde feature Emisse asked for ages ago.
Mirrors the speed penalty from ClothingSpeedModifier with a new HeldSpeedModifier.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The speed penalties for both duffels and hardsuits are trivial to bypass. By simply holding it in your hand, you can ignore an up to 50% speed penalty with the only risk being slipping, something that's also trivial to bypass by just instantly equipping the item.

By adding the penalty when held, not just when worn, you actually have to think about the tradeoffs of the penalty instead of just holding it in your hand and sprinting at full speed and little consideration for much else.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Speed penalties for duffels and hardsuits now apply when held, not just when worn.
