### PR TITLE
Prevents crafting tests from exploding when null-prototype entities are spawned.

### DIFF
--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.EntitySpecifier.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.EntitySpecifier.cs
@@ -112,17 +112,19 @@ public abstract partial class InteractionTest
     }
 
     /// <summary>
-    /// Convert an entity-uid to a matching entity specifier. Usefull when doing entity lookups & checking that the
-    /// right quantity of entities/materials werre produced.
+    /// Convert an entity-uid to a matching entity specifier. Useful when doing entity lookups & checking that the
+    /// right quantity of entities/materials werre produced. Returns null if passed an entity with a null prototype.
     /// </summary>
-    protected EntitySpecifier ToEntitySpecifier(EntityUid uid)
+    protected EntitySpecifier? ToEntitySpecifier(EntityUid uid)
     {
         if (SEntMan.TryGetComponent(uid, out StackComponent? stack))
             return new EntitySpecifier(stack.StackTypeId, stack.Count) { Converted = true };
 
         var meta = SEntMan.GetComponent<MetaDataComponent>(uid);
-        Assert.That(meta.EntityPrototype, Is.Not.Null);
 
-        return new(meta.EntityPrototype!.ID, 1) { Converted = true };
+        if (meta.EntityPrototype is null)
+            return null;
+
+        return new(meta.EntityPrototype.ID, 1) { Converted = true };
     }
 }

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.EntitySpecifierCollection.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.EntitySpecifierCollection.cs
@@ -156,7 +156,9 @@ public abstract partial class InteractionTest
 
     protected EntitySpecifierCollection ToEntityCollection(IEnumerable<EntityUid> entities)
     {
-        var collection = new EntitySpecifierCollection(entities.Select(uid => ToEntitySpecifier(uid)));
+        var collection = new EntitySpecifierCollection(entities
+            .Select(ToEntitySpecifier)
+            .OfType<EntitySpecifier>());
         Assert.That(collection.Converted);
         return collection;
     }

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
@@ -598,7 +598,7 @@ public abstract partial class InteractionTest
 
     /// <summary>
     /// Performs an entity lookup and asserts that only the listed entities exist and that they are all present.
-    /// Ignores the grid, map, player, target and contained entities.
+    /// Ignores the grid, map, player, target, contained entities, and entities with null prototypes.
     /// </summary>
     protected async Task AssertEntityLookup(
         EntitySpecifierCollection collection,
@@ -652,6 +652,9 @@ public abstract partial class InteractionTest
         foreach (var uid in entities)
         {
             var found = ToEntitySpecifier(uid);
+            if (found is null)
+                continue;
+
             if (spec.Prototype != found.Prototype)
                 continue;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made the the test framework ignore entities without prototypes when asserting the existence/nonexistence of entities.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
If you have an entity that spawns internal entities without prototypes (such as in #21916) this crashes the tests because they expect all entities to have been spawned from a prototype. This fixes tests without modifying the engine to require all entities be spawned from a prototype or rewriting half the interaction test helpers.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The proc `ToEntitySpecifier` now returns null if the passed entity was not constructed from a prototype.
Constructing `EntitySpecifierCollection`s from collections of entities will likewise ignore all entities with null prototypes.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
