### PR TITLE
Add Smugglers Satchel

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -61,3 +61,36 @@
     solution: tank
   - type: ExaminableSolution
     solution: tank
+
+- type: entity
+  abstract: true
+  parent: ClothingBackpack
+  id: ClothingSatchelSmugglerAbstract
+  name: Smuggling Satchel
+  description: Smuggling Satchel Abstract
+  components:
+  - type: Tag
+    tags: [] # ignore "WhitelistChameleon" tag
+  - type: Storage
+    maxItemSize: Large
+    maxTotalWeight: 14
+  - type: Sprite
+    sprite: Clothing/Back/Satchels/satchel.rsi
+    drawdepth: ThinPipe
+    visible: false
+  - type: SubFloorHide
+  - type: Anchorable
+  - type: Appearance
+
+- type: entity
+  parent: ClothingSatchelSmugglerAbstract
+  id: ClothingSatchelSmuggler
+  name: Smuggling Satchel
+  description: A trendy looking satchel, modified to fit under floor tiles.
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+  - type: Construction
+    graph: smugglersbag
+    node: smugglersbag

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -85,7 +85,7 @@
   parent: ClothingSatchelSmugglerAbstract
   id: ClothingSatchelSmuggler
   name: Smuggling Satchel
-  description: A trendy looking satchel, modified to fit under floor tiles.
+  description: A makeshift satchel, slim enough to fit under floor tiles.
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -76,7 +76,6 @@
     maxTotalWeight: 14
   - type: Sprite
     sprite: Clothing/Back/Satchels/satchel.rsi
-    drawdepth: ThinPipe
     visible: false
   - type: SubFloorHide
   - type: Anchorable

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/smugglersbag.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/smugglersbag.yml
@@ -1,0 +1,14 @@
+- type: constructionGraph
+  id: SmugglersBag
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: smugglersbag
+      steps:
+      - material: Cloth
+        amount: 10
+      - material: Cable
+        amount: 5
+  - node: smugglersbag
+    entity: ClothingSatchelSmuggler

--- a/Resources/Prototypes/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/Recipes/Crafting/improvised.yml
@@ -188,3 +188,16 @@
     sprite: Objects/Materials/materials.rsi
     state: cloth_3
   objectType: Item
+
+- type: construction
+  name: smugglers bag
+  id: smugglersbag
+  graph: SmugglersBag
+  startNode: start
+  targetNode: smugglersbag
+  category: construction-category-clothing
+  description: "A modified satchel, holds less - but can be hidden under floor tiles"
+  icon:
+    sprite: Clothing/Back/Satchels/satchel.rsi
+    state: icon
+  objectType: Item


### PR DESCRIPTION
## About the PR
Add the smugglers satchel, a small bag that can be hidden under floor tiles

## Why / Balance
SS13 content
Additional ways to hide items

## Media
https://github.com/space-wizards/space-station-14/assets/11758391/3b7bf0c7-c900-41a5-b67d-f6b60e31f13f

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Smugglers Satchel
