### PR TITLE
make boots with storage use itemslot

### DIFF
--- a/Resources/Locale/en-US/clothing/boots.ftl
+++ b/Resources/Locale/en-US/clothing/boots.ftl
@@ -1,0 +1,1 @@
+clothing-military-boots-sidearm = Sidearm

--- a/Resources/Prototypes/Catalog/Fills/Items/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/misc.yml
@@ -3,16 +3,25 @@
   parent: ClothingShoesBootsCombat
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: CombatKnife
+  # TODO: this is trash write SlotFill then
+  # - type: SlotFill
+  #   slots:
+  #     item: CombatKnife
+  # way better than this non-gaming
+  - type: ItemSlots
+    slots:
+      item:
+        name: clothing-military-boots-sidearm
+        startingItem: CombatKnife
 
 - type: entity
   id: ClothingShoesBootsMercFilled
   parent: ClothingShoesBootsMerc
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: KukriKnife
+  - type: ItemSlots
+    slots:
+      item:
+        name: clothing-military-boots-sidearm
+        startingItem: KukriKnife
 

--- a/Resources/Prototypes/Catalog/Fills/Items/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/misc.yml
@@ -3,25 +3,18 @@
   parent: ClothingShoesBootsCombat
   suffix: Filled
   components:
-  # TODO: this is trash write SlotFill then
-  # - type: SlotFill
-  #   slots:
-  #     item: CombatKnife
-  # way better than this non-gaming
-  - type: ItemSlots
-    slots:
+  - type: ContainerFill
+    containers:
       item:
-        name: clothing-military-boots-sidearm
-        startingItem: CombatKnife
+      - CombatKnife
 
 - type: entity
   id: ClothingShoesBootsMercFilled
   parent: ClothingShoesBootsMerc
   suffix: Filled
   components:
-  - type: ItemSlots
-    slots:
+  - type: ContainerFill
+    containers:
       item:
-        name: clothing-military-boots-sidearm
-        startingItem: KukriKnife
+      - KukriKnife
 

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -35,20 +35,18 @@
     - id: MaterialCloth1
       amount: 1
 
+# stuff common to all military boots
 - type: entity
   abstract: true
-  parent: ClothingShoesBase
-  id: ClothingShoesStorageBase
+  parent: [ClothingShoesBase, ClothingSlotBase]
+  id: ClothingShoesMilitaryBase
   components:
-  - type: Storage
-    grid:
-    - 0,0,0,1
-    maxItemSize: Normal
-  - type: ContainerContainer
-    containers:
-      storagebase: !type:Container
-        ents: []
-  - type: UserInterface
-    interfaces:
-    - key: enum.StorageUiKey.Key
-      type: StorageBoundUserInterface
+  - type: Matchbox
+  - type: ItemSlots
+    slots:
+      item:
+        name: clothing-military-boots-sidearm
+        whitelist:
+          tags:
+          - Knife
+          - Sidearm

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -11,7 +11,7 @@
   - type: Matchbox
 
 - type: entity
-  parent: ClothingShoesStorageBase
+  parent: ClothingShoesMilitaryBase
   id: ClothingShoesBootsJack
   name: jackboots
   description: Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time.
@@ -20,12 +20,6 @@
     sprite: Clothing/Shoes/Boots/jackboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/jackboots.rsi
-  - type: Matchbox
-  - type: Storage
-    whitelist:
-      tags:
-        - Knife
-        - Sidearm
 
 - type: entity
   parent: ClothingShoesBaseButcherable
@@ -51,7 +45,7 @@
     sprite: Clothing/Shoes/Boots/performer.rsi
 
 - type: entity
-  parent: ClothingShoesStorageBase
+  parent: ClothingShoesMilitaryBase
   id: ClothingShoesBootsCombat
   name: combat boots
   description: Robust combat boots for combat scenarios or combat situations. All combat, all the time.
@@ -60,15 +54,9 @@
     sprite: Clothing/Shoes/Boots/combatboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/combatboots.rsi
-  - type: Matchbox
-  - type: Storage
-    whitelist:
-      tags:
-        - Knife
-        - Sidearm
 
 - type: entity
-  parent: ClothingShoesStorageBase
+  parent: ClothingShoesMilitaryBase
   id: ClothingShoesBootsMerc
   name: mercenary boots
   description: Boots that have gone through many conflicts and that have proven their combat reliability.
@@ -77,12 +65,6 @@
     sprite: Clothing/Shoes/Boots/mercboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/mercboots.rsi
-  - type: Matchbox
-  - type: Storage
-    whitelist:
-      tags:
-        - Knife
-        - Sidearm
 
 - type: entity
   parent: ClothingShoesBaseButcherable

--- a/Resources/Prototypes/Entities/Clothing/base_clothing.yml
+++ b/Resources/Prototypes/Entities/Clothing/base_clothing.yml
@@ -18,3 +18,14 @@
   components:
     - type: Geiger
       attachedToSuit: true
+
+# for clothing that has a single item slot to insert and alt click out.
+# inheritors add a whitelisted slot named item
+- type: entity
+  abstract: true
+  id: ClothingSlotBase
+  components:
+  - type: ItemSlots
+  - type: ContainerContainer
+    containers:
+      item: !type:ContainerSlot


### PR DESCRIPTION
## About the PR
title

in the future, sabre sheath can use ClothingSlotBase once ctrl e supports item slots

## Why / Balance
fixes #22172

also removes need for having 1000 storages open, just 999 now since you can alt click boot to get item out :trollface:

## Technical details
:trollface:

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/0321451b-9975-4fab-8aa8-fe0a8ad79e52

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
all boots with storage no longer use `Storage`, they have `ItemSlots` with a slot named `item`

**Changelog**
:cl:
- tweak: Combat boots and friends use a slot for sidearms instead of a storage window.
