### PR TITLE
make sheath use item slot

### DIFF
--- a/Resources/Locale/en-US/clothing/belts.ftl
+++ b/Resources/Locale/en-US/clothing/belts.ftl
@@ -1,0 +1,1 @@
+clothing-sheath-blade = Blade

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -114,9 +114,10 @@
   parent: ClothingBeltSheath
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: CaptainSabre
+  - type: ContainerFill
+    containers:
+      item:
+      - CaptainSabre
 
 - type: entity
   id: ClothingBeltMilitaryWebbingGrenadeFilled

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -385,7 +385,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltBase, ClothingSlotBase]
   id: ClothingBeltSheath
   name: sabre sheath
   description: An ornate sheath designed to hold an officer's blade.
@@ -395,12 +395,13 @@
     state: sheath
   - type: Clothing
     sprite: Clothing/Belt/sheath.rsi
-  - type: Storage
-    grid:
-    - 0,0,1,1
-    whitelist:
-      tags:
-        - CaptainSabre
+  - type: ItemSlots
+    slots:
+      item:
+        name: clothing-sheath-blade
+        whitelist:
+          tags:
+          - CaptainSabre
   - type: ItemMapper
     mapLayers:
       sheath-sabre:


### PR DESCRIPTION
## About the PR
depends on ctrl + e supporting itemslots

## Why / Balance
good

## Technical details
no

## Media
![18:16:11](https://github.com/space-wizards/space-station-14/assets/39013340/c7fca50b-9c3b-4495-aab2-a1b40995310b)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Captain's sabre sheath now uses an item slot instead of a storage window.
