### PR TITLE
Fixes speech bubbles now lacking names for the living

### DIFF
--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -187,7 +187,7 @@ namespace Content.Client.Chat.UI
             var rawmsg = message.WrappedMessage;
             var tagStart = rawmsg.IndexOf($"[{tag}]");
             var tagEnd = rawmsg.IndexOf($"[/{tag}]");
-            if (tagStart <= 0 || tagEnd <= 0) //the above return -1 if the tag's not found, which in turn will cause the below to throw an exception. a blank speech bubble is far more noticeably broken than the bubble not appearing at all -bhijn
+            if (tagStart < 0 || tagEnd < 0) //the above return -1 if the tag's not found, which in turn will cause the below to throw an exception. a blank speech bubble is far more noticeably broken than the bubble not appearing at all -bhijn
                 return "";
             tagStart += tag.Length + 2;
             return rawmsg.Substring(tagStart, tagEnd - tagStart);


### PR DESCRIPTION
## About the PR
[distressed kobold noises]

## Why / Balance
We broke our own code :<

## Technical details
When making the previous speech bubble fix PR, we had the check for whether `tagStart` or `tagEnd` are -1 below the line that pads the `tagStart` length to accommodate for the tag's wrapping. At the last minute, we moved this above that line, and only double-checked that ghost speech was working. However, because we overlooked it being a `<=` instead of a `<`, and because `tagStart` is 100% capable of beginning at 0, this means that speech bubbles for the living now have a distinct lack of name. Oops

## Media
![image](https://github.com/space-wizards/space-station-14/assets/6356337/030374b2-2e39-4284-8979-3ce805f29f89)
![image](https://github.com/space-wizards/space-station-14/assets/6356337/7a343dbc-96a3-4652-9fd5-5815404e973a)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- fix: Speech bubbles for the living now again have names when fancy speech bubbles are enabled