### PR TITLE
T shaped pickaxe and grid UI fix

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/Controls/StorageContainer.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/StorageContainer.cs
@@ -251,23 +251,23 @@ public sealed class StorageContainer : BaseWindow
         {
             for (var x = boundingGrid.Left; x <= boundingGrid.Right; x++)
             {
-                var currentPosition = new Vector2i(x, y);
-                var item = storageComp.StoredItems
-                    .Where(pair => pair.Value.Position == currentPosition)
-                    .FirstOrNull();
-
                 var control = new Control
                 {
                     MinSize = size
                 };
 
-                if (item != null)
+                var currentPosition = new Vector2i(x, y);
+
+                foreach (var item in storageComp.StoredItems)
                 {
-                    var itemEnt = _entity.GetEntity(item.Value.Key);
+                    if (item.Value.Position != currentPosition)
+                        continue;
+
+                    var itemEnt = _entity.GetEntity(item.Key);
 
                     if (_entity.TryGetComponent<ItemComponent>(itemEnt, out var itemEntComponent))
                     {
-                        var gridPiece = new ItemGridPiece((itemEnt, itemEntComponent), item.Value.Value, _entity)
+                        var gridPiece = new ItemGridPiece((itemEnt, itemEntComponent), item.Value, _entity)
                         {
                             MinSize = size,
                         };

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -27,6 +27,9 @@
         Structural: 10
   - type: Item
     size: Normal
+    shape:
+    - 0,0,2,0
+    - 1,1,1,2
     sprite: Objects/Weapons/Melee/pickaxe.rsi
   - type: UseDelay
     delay: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made the pickaxe T shaped when in storage and fixed a bug in storage UI rendering that popped up.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
![main-qimg-e588e1ebb94e7f30560d263c72c4811a-lq](https://github.com/space-wizards/space-station-14/assets/53582584/6ec5f6a3-887f-40c0-a68b-0115b81d49d6)
The UI fix was because the position of each item was stored as the top left cell of its AABB and the pickaxe could conflict with rendering other items in certain arrangements.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![PickaxeT](https://github.com/space-wizards/space-station-14/assets/53582584/25ace8fc-62cf-4f9f-a9dd-391c8dc25144)


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- tweak: Pickaxes have a more accurate shape in storage.
