### PR TITLE
ciggie pack nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -45,6 +45,7 @@
   - type: Storage
     grid:
     - 0,0,4,1
+    maxItemSize: Tiny
   - type: Item
     size: Small
   - type: StorageFill


### PR DESCRIPTION
## About the PR
only holds tiny items now

## Why / Balance
fixes #22182

## Technical details
no

## Media
only hold tiny items like pens and mice
![23:48:04](https://github.com/space-wizards/space-station-14/assets/39013340/7ff012f7-a854-40a6-b633-3f3273744112)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun