### PR TITLE
add tooltip with entity name on inventory hover

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
@@ -5,6 +5,7 @@ using Content.Shared.Storage;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.CustomControls;
 
 namespace Content.Client.UserInterface.Systems.Storage.Controls;
 
@@ -55,7 +56,20 @@ public sealed class ItemGridPiece : Control
         Visible = true;
         MouseFilter = MouseFilterMode.Pass;
 
+        TooltipSupplier = SupplyTooltip;
+
         OnThemeUpdated();
+    }
+
+    private Control? SupplyTooltip(Control sender)
+    {
+        if (_storageController.IsDragging)
+            return null;
+
+        return new Tooltip
+        {
+            Text = _entityManager.GetComponent<MetaDataComponent>(Entity).EntityName
+        };
     }
 
     protected override void OnThemeUpdated()


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
people wanted it

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/40266f2d-5406-49ff-a590-800ace036ec4)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Hovering over an item in storage now shows a tooltip with the name
