### PR TITLE
Small item text tweak

### DIFF
--- a/Resources/Locale/en-US/items/components/item-component.ftl
+++ b/Resources/Locale/en-US/items/components/item-component.ftl
@@ -5,8 +5,8 @@ pick-up-verb-get-data-text = Pick Up
 # "pick up" doesn't make sense if the item is already in their inventory
 
 pick-up-verb-get-data-text-inventory = Put in hand
-i
-item-component-on-examine-size = This is {INDEFINITE($size)} {$size} item.
+
+item-component-on-examine-size = This is {INDEFINITE($size)} [bold]{$size}[/bold] item.
 
 item-component-size-Tiny = tiny
 item-component-size-Small = small

--- a/Resources/Locale/en-US/items/components/item-component.ftl
+++ b/Resources/Locale/en-US/items/components/item-component.ftl
@@ -5,8 +5,8 @@ pick-up-verb-get-data-text = Pick Up
 # "pick up" doesn't make sense if the item is already in their inventory
 
 pick-up-verb-get-data-text-inventory = Put in hand
-
-item-component-on-examine-size = Size: {$size}
+i
+item-component-on-examine-size = This is {INDEFINITE($size)} {$size} item.
 
 item-component-size-Tiny = tiny
 item-component-size-Small = small


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
from `size: small` to `This is a small item`

i feel like most examine text is full sentences plus the bold is nice.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/5d7bac0a-5ec9-4d2b-ac51-ca70ac3166dc)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun