### PR TITLE
Implements greyscale (white) chairs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -70,7 +70,7 @@
   name: chair
   id: ChairGreyscale
   parent: Chair
-  suffix: Greyscale
+  suffix: White
   components:
   - type: Sprite
     state: chair-greyscale

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -67,6 +67,15 @@
     node: chair
 
 - type: entity
+  name: chair
+  id: ChairGreyscale
+  parent: Chair
+  suffix: Greyscale
+  components:
+  - type: Sprite
+    state: chair-greyscale
+
+- type: entity
   name: stool
   id: Stool
   parent: SeatBase


### PR DESCRIPTION
## About the PR
Adds white chairs into the game.
The sprite for these has been rotting in the codebase for god knows how long.

## Why / Balance
The sprite for this has probably existed since the RSI was imported.
Probably good for mappers? If it looks any good is up for debate, but considering this was literally only an 8 line change I figured I might as well go ahead and do it.

## Me
![Content Client_KdTZF0CjY4](https://github.com/space-wizards/space-station-14/assets/78941145/173667c9-6056-437e-be8a-5c42cca37913)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
no cl no fun
