### PR TITLE
fix explosion resistance

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -49,7 +49,7 @@ public partial class InventorySystem
 
     protected void RefRelayInventoryEvent<T>(EntityUid uid, InventoryComponent component, ref T args) where T : IInventoryRelayEvent
     {
-        RelayEvent((uid, component), args);
+        RelayEvent((uid, component), ref args);
     }
 
     protected void RelayInventoryEvent<T>(EntityUid uid, InventoryComponent component, T args) where T : IInventoryRelayEvent


### PR DESCRIPTION
## About the PR
stupid thing copied ref event into the non ref one

## Why / Balance
fixes #22212

## Technical details
FUCK C# FUCK C# FUCK C# FUCK C# FUCK C# FUCK C# FUCK C# FUCK C# RUST NUMERO UNOOOOOOOOOOOO

## Media
minibomb trolled
![18:40:22](https://github.com/space-wizards/space-station-14/assets/39013340/ba325ccd-f1a5-44b0-afd4-8c068db7b540)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed explosion resistance being ignored.
