### PR TITLE
give command staff brig access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -26,6 +26,7 @@
   - Quartermaster
   - Maintenance
   - Command
+  - Brig
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -28,6 +28,7 @@
   - External
   - ChiefEngineer
   - Atmospherics
+  - Brig
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -29,6 +29,7 @@
   - Maintenance
   - Chemistry
   - ChiefMedicalOfficer
+  - Brig
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -20,6 +20,7 @@
   - Command
   - Maintenance
   - ResearchDirector
+  - Brig
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
Gives command staff brig access. I want to test this out because ss13 uses it and it works quite well in most servers. Command staff can take dead antags/crit antags/employees to sec to be arrested. They can also get in easily during rev rounds. If it's bad we can just revert.

:cl:
- tweak: Command staff has brig access.