### PR TITLE
keybinds for opening bag/belt & context logic for opening storage window

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -65,6 +65,8 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.OpenInventoryMenu);
             human.AddFunction(ContentKeyFunctions.SmartEquipBackpack);
             human.AddFunction(ContentKeyFunctions.SmartEquipBelt);
+            human.AddFunction(ContentKeyFunctions.OpenBackpack);
+            human.AddFunction(ContentKeyFunctions.OpenBelt);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);
             human.AddFunction(ContentKeyFunctions.ArcadeUp);
             human.AddFunction(ContentKeyFunctions.ArcadeDown);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -188,6 +188,8 @@ namespace Content.Client.Options.UI.Tabs
             AddHeader("ui-options-header-interaction-adv");
             AddButton(ContentKeyFunctions.SmartEquipBackpack);
             AddButton(ContentKeyFunctions.SmartEquipBelt);
+            AddButton(ContentKeyFunctions.OpenBackpack);
+            AddButton(ContentKeyFunctions.OpenBelt);
             AddButton(ContentKeyFunctions.ThrowItemInHand);
             AddButton(ContentKeyFunctions.TryPullObject);
             AddButton(ContentKeyFunctions.MovePulledObject);

--- a/Content.Client/Storage/StorageBoundUserInterface.cs
+++ b/Content.Client/Storage/StorageBoundUserInterface.cs
@@ -17,21 +17,24 @@ public sealed class StorageBoundUserInterface : BoundUserInterface
         _storage = _entManager.System<StorageSystem>();
     }
 
-    protected override void Open()
-    {
-        base.Open();
-
-        if (_entManager.TryGetComponent<StorageComponent>(Owner, out var comp))
-            _storage.OpenStorageUI(Owner, comp);
-    }
-
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
         if (!disposing)
             return;
 
-        _storage.CloseStorageUI(Owner);
+        _storage.CloseStorageWindow(Owner);
+    }
+
+    protected override void ReceiveMessage(BoundUserInterfaceMessage message)
+    {
+        base.ReceiveMessage(message);
+
+        if (message is StorageModifyWindowMessage)
+        {
+            if (_entManager.TryGetComponent<StorageComponent>(Owner, out var comp))
+                _storage.OpenStorageWindow((Owner, comp));
+        }
     }
 }
 

--- a/Content.Client/Storage/Systems/StorageSystem.cs
+++ b/Content.Client/Storage/Systems/StorageSystem.cs
@@ -35,18 +35,38 @@ public sealed class StorageSystem : SharedStorageSystem
             StorageUpdated?.Invoke((entity, entity.Comp));
     }
 
-    public void OpenStorageUI(EntityUid uid, StorageComponent component)
+    public void OpenStorageWindow(Entity<StorageComponent> entity)
     {
-        if (_openStorages.Contains((uid, component)))
-            return;
+        if (_openStorages.Contains(entity))
+        {
+            if (_openStorages.LastOrDefault() == entity)
+            {
+                CloseStorageWindow((entity, entity.Comp));
+            }
+            else
+            {
+                var storages = new ValueList<Entity<StorageComponent>>(_openStorages);
+                var reverseStorages = storages.Reverse();
 
-        ClearNonParentStorages(uid);
-        _openStorages.Add((uid, component));
+                foreach (var storageEnt in reverseStorages)
+                {
+                    if (storageEnt == entity)
+                        break;
+
+                    CloseStorageBoundUserInterface(storageEnt.Owner);
+                    _openStorages.Remove(entity);
+                }
+            }
+            return;
+        }
+
+        ClearNonParentStorages(entity);
+        _openStorages.Add(entity);
         Entity<StorageComponent>? last = _openStorages.LastOrDefault();
         StorageOrderChanged?.Invoke(last);
     }
 
-    public void CloseStorageUI(Entity<StorageComponent?> entity)
+    public void CloseStorageWindow(Entity<StorageComponent?> entity)
     {
         if (!Resolve(entity, ref entity.Comp))
             return;
@@ -99,7 +119,7 @@ public sealed class StorageSystem : SharedStorageSystem
 
     private void OnShutdown(Entity<StorageComponent> ent, ref ComponentShutdown args)
     {
-        CloseStorageUI((ent, ent.Comp));
+        CloseStorageWindow((ent, ent.Comp));
     }
 
     /// <inheritdoc />

--- a/Content.Client/UserInterface/Systems/Storage/Controls/StorageContainer.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/StorageContainer.cs
@@ -12,7 +12,6 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
 
 namespace Content.Client.UserInterface.Systems.Storage.Controls;
 
@@ -155,6 +154,15 @@ public sealed class StorageContainer : BaseWindow
         exitButton.OnPressed += _ =>
         {
             Close();
+        };
+        exitButton.OnKeyBindDown += args =>
+        {
+            // it just makes sense...
+            if (!args.Handled && args.Function == ContentKeyFunctions.ActivateItemInWorld)
+            {
+                Close();
+                args.Handle();
+            }
         };
         var exitContainer = new BoxContainer
         {
@@ -448,6 +456,6 @@ public sealed class StorageContainer : BaseWindow
         if (StorageEntity == null)
             return;
 
-        _entity.System<StorageSystem>().CloseStorageUI(StorageEntity.Value);
+        _entity.System<StorageSystem>().CloseStorageWindow(StorageEntity.Value);
     }
 }

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -3,6 +3,8 @@ using Content.Shared.Administration;
 using Content.Shared.Explosion;
 using Content.Shared.Ghost;
 using Content.Shared.Hands;
+using Content.Shared.Input;
+using Content.Shared.Inventory;
 using Content.Shared.Lock;
 using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
@@ -10,6 +12,7 @@ using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Timing;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
+using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -21,6 +24,7 @@ public sealed partial class StorageSystem : SharedStorageSystem
 {
     [Dependency] private readonly IAdminManager _admin = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
 
     public override void Initialize()
@@ -31,6 +35,11 @@ public sealed partial class StorageSystem : SharedStorageSystem
         SubscribeLocalEvent<StorageComponent, BeforeExplodeEvent>(OnExploded);
 
         SubscribeLocalEvent<StorageFillComponent, MapInitEvent>(OnStorageFillMapInit);
+
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.OpenBackpack, InputCmdHandler.FromDelegate(HandleOpenBackpack))
+            .Bind(ContentKeyFunctions.OpenBelt, InputCmdHandler.FromDelegate(HandleOpenBelt))
+            .Register<StorageSystem>();
     }
 
     private void AddUiVerb(EntityUid uid, StorageComponent component, GetVerbsEvent<ActivationVerb> args)
@@ -125,8 +134,10 @@ public sealed partial class StorageSystem : SharedStorageSystem
         Log.Debug($"Storage (UID {uid}) \"used\" by player session (UID {player.PlayerSession.AttachedEntity}).");
 
         var bui = _uiSystem.GetUiOrNull(uid, StorageComponent.StorageUiKey.Key);
-        if (bui != null)
-            _uiSystem.OpenUi(bui, player.PlayerSession);
+        if (bui == null)
+            return;
+        _uiSystem.OpenUi(bui, player.PlayerSession);
+        _uiSystem.SendUiMessage(bui, new StorageModifyWindowMessage());
     }
 
     /// <inheritdoc />
@@ -161,5 +172,32 @@ public sealed partial class StorageSystem : SharedStorageSystem
                 _uiSystem.TryClose(entity, bui.UiKey, session, ui);
             }
         }
+    }
+
+    private void HandleOpenBackpack(ICommonSession? session)
+    {
+        HandleOpenSlotUI(session, "back");
+    }
+
+    private void HandleOpenBelt(ICommonSession? session)
+    {
+        HandleOpenSlotUI(session, "belt");
+    }
+
+    private void HandleOpenSlotUI(ICommonSession? session, string slot)
+    {
+        if (session is not { } playerSession)
+            return;
+
+        if (playerSession.AttachedEntity is not {Valid: true} playerEnt || !Exists(playerEnt))
+            return;
+
+        if (!_inventory.TryGetSlotEntity(playerEnt, slot, out var storageEnt))
+            return;
+
+        if (!ActionBlocker.CanInteract(playerEnt, storageEnt))
+            return;
+
+        OpenStorageUI(storageEnt.Value, playerEnt);
     }
 }

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -119,7 +119,7 @@ public sealed partial class StorageSystem : SharedStorageSystem
     /// <param name="entity">The entity to open the UI for</param>
     public override void OpenStorageUI(EntityUid uid, EntityUid entity, StorageComponent? storageComp = null, bool silent = false)
     {
-        if (!Resolve(uid, ref storageComp) || !TryComp(entity, out ActorComponent? player))
+        if (!Resolve(uid, ref storageComp, false) || !TryComp(entity, out ActorComponent? player))
             return;
 
         // prevent spamming bag open / honkerton honk sound

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -30,6 +30,8 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction OpenInventoryMenu = "OpenInventoryMenu";
         public static readonly BoundKeyFunction SmartEquipBackpack = "SmartEquipBackpack";
         public static readonly BoundKeyFunction SmartEquipBelt = "SmartEquipBelt";
+        public static readonly BoundKeyFunction OpenBackpack = "OpenBackpack";
+        public static readonly BoundKeyFunction OpenBelt = "OpenBelt";
         public static readonly BoundKeyFunction OpenAHelp = "OpenAHelp";
         public static readonly BoundKeyFunction SwapHands = "SwapHands";
         public static readonly BoundKeyFunction MoveStoredItem = "MoveStoredItem";

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -37,7 +37,7 @@ public abstract class SharedStorageSystem : EntitySystem
     [Dependency] protected readonly SharedItemSystem ItemSystem = default!;
     [Dependency] private   readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private   readonly SharedHandsSystem _sharedHandsSystem = default!;
-    [Dependency] private   readonly ActionBlockerSystem _actionBlockerSystem = default!;
+    [Dependency] protected readonly ActionBlockerSystem ActionBlocker = default!;
     [Dependency] private   readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
     [Dependency] private   readonly SharedCombatModeSystem _combatMode = default!;
@@ -334,7 +334,7 @@ public abstract class SharedStorageSystem : EntitySystem
             return;
         }
 
-        if (!_actionBlockerSystem.CanInteract(player, entity) || !storageComp.Container.Contains(entity))
+        if (!ActionBlocker.CanInteract(player, entity) || !storageComp.Container.Contains(entity))
             return;
 
         // Does the player have hands?
@@ -377,7 +377,7 @@ public abstract class SharedStorageSystem : EntitySystem
             return;
         }
 
-        if (!_actionBlockerSystem.CanInteract(player, itemEnt))
+        if (!ActionBlocker.CanInteract(player, itemEnt))
             return;
 
         TrySetItemStorageLocation((itemEnt, null), (storageEnt, storageComp), msg.Location);
@@ -404,7 +404,7 @@ public abstract class SharedStorageSystem : EntitySystem
             return;
         }
 
-        if (!_actionBlockerSystem.CanInteract(player, itemEnt) || !_sharedHandsSystem.IsHolding(player, itemEnt, out _))
+        if (!ActionBlocker.CanInteract(player, itemEnt) || !_sharedHandsSystem.IsHolding(player, itemEnt, out _))
             return;
 
         InsertAt((storageEnt, storageComp), (itemEnt, null), msg.Location, out _, player, stackAutomatically: false);

--- a/Content.Shared/Storage/StorageComponent.cs
+++ b/Content.Shared/Storage/StorageComponent.cs
@@ -170,6 +170,15 @@ namespace Content.Shared.Storage
         }
     }
 
+    /// <summary>
+    /// An extra BUI message that either opens, closes, or focuses the storage window based on context.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed class StorageModifyWindowMessage : BoundUserInterfaceMessage
+    {
+
+    }
+
     [NetSerializable]
     [Serializable]
     public enum StorageVisuals : byte

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -118,6 +118,8 @@ ui-options-static-storage-ui = Static storage UI
 
 ui-options-function-smart-equip-backpack = Smart-equip to backpack
 ui-options-function-smart-equip-belt = Smart-equip to belt
+ui-options-function-open-backpack = Open backpack
+ui-options-function-open-belt = Open belt
 ui-options-function-throw-item-in-hand = Throw item
 ui-options-function-try-pull-object = Pull object
 ui-options-function-move-pulled-object = Move pulled object

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -244,6 +244,13 @@ binds:
   type: State
   key: E
   mod1: Shift
+- function: OpenBackpack
+  type: State
+  key: V
+- function: OpenBelt
+  type: State
+  key: V
+  mod1: Shift
 - function: ShowDebugConsole
   type: State
   key: Tilde


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Double trouble with this change:

### Keybinds for opening bags/belts
Opening bags and opening belts are now bound to V and shift-V by default. Pressing these just toggles the window for whatever storage item is in your belt/bag slot. How nice!

### Context logic for storage window
Previously, clicking on a storage item would simply open the window. If you want to close it, use the verb or the `X` in the UI. Simple, but kinda rusty. There is now context sensitive logic to it! 

If the window is closed, then simply open it. If the window is open, but another container is being displayed, switch the displayed container to this one. If this is the container being displayed, then close the window.

This is all compatible with the aforementioned keybinds.

### Other stuff
you can use E to press the exit button. neat!

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: V and shift-V can now be used to open the bag and belt, respectively.
- fix: Interacting with a storage item now has context-sensitive logic based on whether or not the window is open or focused.
