### PR TITLE
restore chemical explosions to previous states

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -102,10 +102,10 @@
   effects:
     - !type:ExplosionReactionEffect
       explosionType: Default
-      maxIntensity: 5
+      maxIntensity: 100
       intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
-      intensitySlope: .5
-      maxTotalIntensity: 30
+      intensitySlope: 4
+      maxTotalIntensity: 100
 
 - type: reaction
   id: Smoke

--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -41,10 +41,10 @@
   # TODO solution temperature!!
   - !type:ExplosionReactionEffect
     explosionType: Default # 15 damage per intensity.
-    maxIntensity: 1 # at most 15 damage per tile.
-    intensityPerUnit: 3 # 12 total input reagent units reach max total intensity
-    intensitySlope: 0.5
-    maxTotalIntensity: 9
+    maxIntensity: 200
+    intensityPerUnit: 5
+    intensitySlope: 5
+    maxTotalIntensity: 200
   - !type:PopupMessage
     messages: [ "clf3-explosion" ]
     type: Pvs


### PR DESCRIPTION
this restores them to around the same effectiveness they were several years ago.
they were nerfed into the ground following the incident.
tested

🆑 
- tweak: Chemical explosions are powerful again.

