### PR TITLE
Rat king fixes + buffs

### DIFF
--- a/Content.Shared/RatKing/RatKingComponent.cs
+++ b/Content.Shared/RatKing/RatKingComponent.cs
@@ -49,7 +49,7 @@ public sealed partial class RatKingComponent : Component
     ///     How many moles of Miasma are released after one us of Domain
     /// </summary>
     [DataField("molesMiasmaPerDomain"), ViewVariables(VVAccess.ReadWrite)]
-    public float MolesMiasmaPerDomain = 100f;
+    public float MolesMiasmaPerDomain = 200f;
 
     /// <summary>
     /// The current order that the Rat King assigned.

--- a/Content.Shared/RatKing/SharedRatKingSystem.cs
+++ b/Content.Shared/RatKing/SharedRatKingSystem.cs
@@ -119,7 +119,8 @@ public abstract class SharedRatKingSystem : EntitySystem
                 {
                     BlockDuplicate = true,
                     BreakOnDamage = true,
-                    BreakOnUserMove = true
+                    BreakOnUserMove = true,
+                    DistanceThreshold = 2f
                 });
             }
         });

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -240,7 +240,7 @@
         scaleByQuantity: true
         ignoreResistances: true
         damage:
-          Groups:
+          groups:
             Brute: -5
             Burn: -5
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixed miasma not healing rat king
Fixed rummage range being infinite
Tweaked domain ability to release more miasma
Tweaked miasma healing

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

- fixes #21121
- The amount of miasma the rat king metabolizes isn't high enough to make a dent in healing damage, currently heals 0.3 spread between the three brute groups or so in a room filled with 15mols
- increased miasma release to help fill mildly bigger rooms as this ability is worthless in anything nearing the size of small science department front desks like on Dev map, and had to be used in a 3x3 area at most to get decent value

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: Whisper
- fix: Rat king and his servants properly heal from miasma.
- fix: Rat king no longer rummages from an infinite distance.
- tweak: Rat king generates more miasma to fill larger rooms.

