### PR TITLE
Prevent entities who do not have hands from setting off bombs.

### DIFF
--- a/Content.Server/Defusable/Systems/DefusableSystem.cs
+++ b/Content.Server/Defusable/Systems/DefusableSystem.cs
@@ -46,7 +46,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
     /// </summary>
     private void OnGetAltVerbs(EntityUid uid, DefusableComponent comp, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanInteract || !args.CanAccess)
+        if (!args.CanInteract || !args.CanAccess || args.Hands == null)
             return;
 
         args.Verbs.Add(new AlternativeVerb

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.OnUse.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.OnUse.cs
@@ -45,7 +45,7 @@ public sealed partial class TriggerSystem
     /// </summary>
     private void OnGetAltVerbs(EntityUid uid, OnUseTimerTriggerComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanInteract || !args.CanAccess)
+        if (!args.CanInteract || !args.CanAccess || args.Hands == null)
             return;
 
         if (component.UseVerbInstead)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Prevents entities without hands from changing a bomb’s timer or detonating a bomb. 

This is my first PR to this repository, please let me know about anything I can improve. I originally submitted this change [to the Delta-V fork](https://github.com/DeltaV-Station/Delta-v/pull/529) but was told by its maintainers to put it upstream. (Whoops.) I have tested that it works the same way here.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Applies to proper Syndicate Bombs, and practice bombs, which were previously operable to all sorts of miscreants (e.g. mice) — that was bad. Entities without hands could also change the timers on sticks of C4 and the Spider Clan Charges, but not detonate them.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds an extra check to the `OnGetAltVerbs` event handlers in `DefusableSystem` and `TriggerSystem`.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Bomb verbs are present when playing as a character with hands:
![image](https://github.com/space-wizards/space-station-14/assets/13428215/ba647f45-79a3-457d-9238-56c5839f7bd5)

Absent when playing as one without:
![image](https://github.com/space-wizards/space-station-14/assets/13428215/f9307132-a4b4-4a91-bdd8-27bd47c6e81f)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Entities without hands (like mice and mothroaches) are now forbidden from operating Syndicate Bombs, C4, and other timed explosives.