### PR TITLE
Fixes a few common incorrect gridinv sprite rotations

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -6,6 +6,7 @@
   components:
   - type: Item
     size: Small
+    storedRotation: 90
   - type: Handcuff
     cuffedRSI: Objects/Misc/handcuffs.rsi
     bodyIconState: body-overlay

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -14,6 +14,7 @@
   - type: Item
     size: Small
     heldPrefix: default
+    storedRotation: -90
   - type: Access
   - type: IdCard
   - type: StationRecordKeyStorage

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -19,6 +19,7 @@
   - type: Appearance
   - type: Item
     sprite: Objects/Specific/Janitorial/soap.rsi
+    storedRotation: -90
   - type: Slippery
     paralyzeTime: 2
     launchForwardsMultiplier: 1.5
@@ -67,7 +68,6 @@
   - type: Food
     solution: soap
   - type: BadFood
-
 
 - type: entity
   name: soap

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -19,6 +19,8 @@
   - type: GuideHelp
     guides:
     - ScannersAndVessels
+  - type: Item
+    storedRotation: -90
 
 - type: entity
   id: AnomalyLocatorUnpowered


### PR DESCRIPTION

## About the PR
Adds ``storedRotation`` to soap, ID cards, handcuffs, and the anomaly scanner, making their sprites face correctly in the inventory.

## Media
![Content Client_ALHhEFmMBs](https://github.com/space-wizards/space-station-14/assets/78941145/1c2276ef-0246-42a9-8480-ef7d69eecaa3)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun