### PR TITLE
Dummy proof China Lake

### DIFF
--- a/Content.Server/Explosion/Components/TriggerWhenReachingCoordinatesComponent.cs
+++ b/Content.Server/Explosion/Components/TriggerWhenReachingCoordinatesComponent.cs
@@ -1,0 +1,26 @@
+using System.Numerics;
+using Robust.Shared.Map;
+
+namespace Content.Server.Explosion.Components;
+
+/// <summary>
+/// Triggers a projectile when they reach the coordinates the shooter was aiming at.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TriggerWhenReachingCoordinatesComponent: Component
+{
+    /// <summary>
+    ///     Coordinates the projectile will trigger at.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("destination")]
+    public Vector2 Destination;
+
+
+    /// <summary>
+    ///    Coordinates the projectile was launched from.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("origin")]
+    public MapCoordinates? Origin;
+}

--- a/Content.Server/Explosion/EntitySystems/CoordinateTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/CoordinateTriggerSystem.cs
@@ -1,0 +1,72 @@
+using Content.Server.Explosion.Components;
+using Robust.Shared.Physics.Events;
+
+namespace Content.Server.Explosion.EntitySystems;
+
+public sealed class CoordinateTriggerSystem : EntitySystem
+{
+    [Dependency] private readonly TriggerSystem _triggerSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+
+    // Tile distance from cursor where projectile will still explode if colliding.
+    private const float AimCompensation = 1f;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<TriggerWhenReachingCoordinatesComponent, StartCollideEvent>(OnStartCollide);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var query = EntityQueryEnumerator<TriggerWhenReachingCoordinatesComponent>();
+
+        while (query.MoveNext(out var uid, out var aimCoordinates))
+        {
+
+            if (aimCoordinates.Origin != null)
+            {
+                var xform = Transform(uid);
+                var bulletLocation = xform.Coordinates.ToMapPos(EntityManager, _transformSystem);
+                var bulletOrigin = aimCoordinates.Origin.Value.Position;
+                var bulletDestination = aimCoordinates.Destination;
+
+                // Checks if shot projectile has reached the destination point
+                if (bulletLocation.X < bulletDestination.X &&
+                    bulletOrigin.X > bulletDestination.X)
+                {
+                    _triggerSystem.Trigger(uid);
+                }
+                else if (bulletLocation.X > bulletDestination.X &&
+                         bulletOrigin.X < bulletDestination.X)
+                {
+                    _triggerSystem.Trigger(uid);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Triggers the projectile if it starts colliding with an entity close to the aimed location.
+    /// This compensates for hitboxes larger than the sprite and allows people to aim on top of stationary targets.
+    /// </summary>
+    /// <param name="uid">EntityUid of the projectile </param>
+    /// <param name="comp">TriggerWhenReachingCoordinatesComponent</param>
+    /// <param name="args">arguments related to StartcollideEvent</param>
+    private void OnStartCollide(EntityUid uid, TriggerWhenReachingCoordinatesComponent comp,
+        ref StartCollideEvent args)
+    {
+        var xform = Transform(uid);
+        var projectileLocation = xform.Coordinates.ToMapPos(EntityManager, _transformSystem);
+        var projectileDestination = comp.Destination;
+
+        if (projectileLocation.X - projectileDestination.X > -AimCompensation &&
+            projectileLocation.X - projectileDestination.X < AimCompensation &&
+            projectileLocation.Y - projectileDestination.Y > -AimCompensation &&
+            projectileLocation.Y - projectileDestination.Y < AimCompensation)
+        {
+            _triggerSystem.Trigger(uid);
+        }
+    }
+}

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Numerics;
 using Content.Server.Administration.Logs;
 using Content.Server.Cargo.Systems;
+using Content.Server.Explosion.Components;
 using Content.Server.Interaction;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Stunnable;
@@ -149,6 +150,13 @@ public sealed partial class GunSystem : SharedGunSystem
                             var uid = Spawn(cartridge.Prototype, fromEnt);
                             ShootOrThrow(uid, mapDirection, gunVelocity, gun, gunUid, user);
                             shotProjectiles.Add(uid);
+
+                            // Stores spawn and aim coordinates for projectiles needing to trigger at aim location
+                            if (TryComp<TriggerWhenReachingCoordinatesComponent>(uid, out var comp))
+                            {
+                                comp.Destination = toMap;
+                                comp.Origin = fromMap;
+                            }
                         }
 
                         RaiseLocalEvent(ent!.Value, new AmmoShotEvent()

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -93,7 +93,7 @@
   noSpawn: true
   components:
   - type: Transform
-  - type: TriggerWhenReachingLocation
+  - type: TriggerWhenReachingCoordinates
   - type: Projectile
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -71,8 +71,6 @@
   parent: BaseBullet
   noSpawn: true
   components:
-  - type: TriggerOnCollide
-    fixtureID: projectile
   - type: Projectile
     damage:
       types:
@@ -88,6 +86,18 @@
         - Impassable
         - BulletImpassable
       fly-by: *flybyfixture
+
+- type: entity
+  id: BaseBulletGrenade
+  parent: BaseBulletTrigger
+  noSpawn: true
+  components:
+  - type: Transform
+  - type: TriggerWhenReachingLocation
+  - type: Projectile
+    damage:
+      types:
+        Blunt: 20
 
 - type: entity
   id: BaseBulletPractice
@@ -615,7 +625,7 @@
 - type: entity
   id: BulletGrenadeBlast
   name: blast grenade
-  parent: BaseBulletTrigger
+  parent: BaseBulletGrenade
   noSpawn: true
   components:
   - type: Sprite
@@ -646,7 +656,7 @@
 - type: entity
   id: BulletGrenadeFrag
   name: frag grenade
-  parent: BaseBulletTrigger
+  parent: BaseBulletGrenade
   noSpawn: true
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
China lake ammo now explodes on the location you aim at and does not explode if it collides with an entity before coming within +/- 0.75 tile of the place you aimed at.
This change aims to fix the unwieldiness of the china lake and make it a more reliable and consistent weapon.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
China lakes are quite accident prone because of the amount of unexpected things that are able to get in the path of your projectile, for example: 
- A crit person/animal right in front of your feet or or in a dark spot.
- Your nukie teammate making an unexpected move the moment you decide to fire
- The hitbox of the object you're peeking from extending a little bit further than the sprite

After this PR abovementioned situations will just end up in you wasting one of your bullets instead of it blowing up in your face.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Added the aptly named TriggerWhenReachingCoordinatesComponent, adding this component to an entity will trigger it whenever it passes the location the shooter was aiming at.
Currently the destination gets added whenever a projectile is shot so it doesn't work on thrown objects.
Above mentioned component has been added to the china lake ammo and TriggerOnCollide has been removed from said ammo.
With TriggerOnCollide removed the shot projectile won't explode and just get deleted if it collides with any entity that's not within +/- 0.75 tile of the place the user clicked when they shot.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.
If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->


https://github.com/space-wizards/space-station-14/assets/137322659/b74a713a-6f5e-4e00-b8c2-1edbf07df50d


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->

:cl: Dygon
- tweak: Projectiles now explode on the aimed location and don't explode if they collide with any entity before reaching said location.