### PR TITLE
Fix MapPainter

### DIFF
--- a/Content.IntegrationTests/PoolManager.Cvars.cs
+++ b/Content.IntegrationTests/PoolManager.Cvars.cs
@@ -35,7 +35,7 @@ public static partial class PoolManager
         (CVars.NetBufferSize.Name, "0")
     };
 
-    public static async Task  SetupCVars(RobustIntegrationTest.IntegrationInstance instance, PoolSettings settings)
+    public static async Task SetupCVars(RobustIntegrationTest.IntegrationInstance instance, PoolSettings settings)
     {
         var cfg = instance.ResolveDependency<IConfigurationManager>();
         await instance.WaitPost(() =>

--- a/Content.MapRenderer/Painters/MapPainter.cs
+++ b/Content.MapRenderer/Painters/MapPainter.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Content.IntegrationTests;
+using Content.Server.GameTicking;
+using Content.Server.Maps;
 using Robust.Client.GameObjects;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -10,6 +12,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -29,7 +32,8 @@ namespace Content.MapRenderer.Painters
                 DummyTicker = false,
                 Connected = true,
                 Fresh = true,
-                Map = map
+                // Seriously whoever made MapPainter use GameMapPrototype I wish you step on a lego one time.
+                Map = map,
             });
 
             var server = pair.Server;
@@ -73,7 +77,7 @@ namespace Content.MapRenderer.Painters
                     sEntityManager.DeleteEntity(playerEntity.Value);
                 }
 
-                var mapId = sMapManager.GetAllMapIds().Last();
+                var mapId = sEntityManager.System<GameTicker>().DefaultMap;
                 grids = sMapManager.GetAllGrids(mapId).ToArray();
 
                 foreach (var (uid, _) in grids)


### PR DESCRIPTION
Okay so this is the prime example of why copy-pasting code is awful and if you're doing it large-scale you should reconsider your fellow coders.

Every single instance of someone re-using GetAllMapIds().Last() from tests has now broken with a 100% failure rate because everyone copies everyone else. Thankfully this is the last one left but I have had to fix all the other ones.