### PR TITLE
Prevent shoving incapacitated mobs

### DIFF
--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Effects;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Speech.Components;
 using Content.Shared.StatusEffect;
@@ -40,6 +41,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly DamageExamineSystem _damageExamine = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly LagCompensationSystem _lag = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly SolutionContainerSystem _solutions = default!;
     [Dependency] private readonly TagSystem _tag = default!;
@@ -100,6 +102,11 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         }
 
         var target = GetEntity(ev.Target!.Value);
+
+        if (_mobState.IsIncapacitated(target))
+        {
+            return false;
+        }
 
         if (!TryComp<HandsComponent>(target, out var targetHandsComponent))
         {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Shoves will now always fail on incapacitated mobs
Fixes #21400

## Why / Balance
Players are shoving the incapacitated people they are dragging, to induce a temporary friction reduction every time the already limp body is "knocked down", resulting in brief bursts of acceleration which rougly amount to a 15% speed boost over time compared to just dragging the body. It also makes no sense and looks absurd.

I can't think of a reason anyone would want/need to stamcrit an incapacitated mob for any other reason than this exploit. If someone needs to take an item that somehow ended up in the hands of an unconscious/dead body, strip can be used instead, which would probably be the first thing a player actually tries in such a situation anyway

It technically still works on a conscious mob you are dragging, but this seems to barely have any effect on speed. And I suspect players would be much less likely to use this exploit on someone who can complain right back at them

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- fix: Incapacitated mobs can no longer be shoved for a speed boost