### PR TITLE
Welder Blindness Effect Increase

### DIFF
--- a/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
+++ b/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
@@ -54,7 +54,7 @@ namespace Content.Client.Eye.Blinding
             // Maybe gradually shrink the view-size?
             // Make the effect only apply to the edge of the viewport?
             // Actually make it blurry??
-            var opacity =  0.75f * _magnitude / BlurryVisionComponent.MaxMagnitude;
+            var opacity =  1f * _magnitude / BlurryVisionComponent.MaxMagnitude;
             var worldHandle = args.WorldHandle;
             var viewport = args.WorldBounds;
             worldHandle.SetTransform(Matrix3.Identity);

--- a/Content.Shared/Eye/Blinding/Components/BlindableComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/BlindableComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class BlindableComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("EyeDamage"), AutoNetworkedField]
     public int EyeDamage = 0;
 
-    public const int MaxDamage = 8;
+    public const int MaxDamage = 3;
 
     /// <description>
     /// Used to ensure that this doesn't break with sandbox or admin tools.

--- a/Content.Shared/Eye/Blinding/Components/BlurryVisionComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/BlurryVisionComponent.cs
@@ -17,5 +17,5 @@ public sealed partial class BlurryVisionComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("magnitude"), AutoNetworkedField]
     public float Magnitude;
 
-    public const float MaxMagnitude = 10;
+    public const float MaxMagnitude = 3;
 }


### PR DESCRIPTION
## About the PR
Changes the limit to perma blind from welding to 3 from 8.
Makes the screen overlay way more intense during stage 1 and 2.

## Why / Balance
People rarely interact with this mechanic and Oculine _at all_. People will constantly weld through secured walls with no eye protection without a care in the world because the system is so forgiving.

## Technical details
Nothing overly complex, it increases the magnitude of the overlay and decreases the max of the perma blind limit and overlay application.

## Media
https://github.com/space-wizards/space-station-14/assets/110078045/e6f6ad41-310d-4a17-bc76-a48f53840f79
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl:
- tweak: Adjusted welder blindness to be much less forgiving.