### PR TITLE
Adds cosmetic sunglasses

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
@@ -14,5 +14,5 @@
     ClothingOuterArmorBasicSlim: 2
     ClothingOuterVest: 2
     ClothingBeltBandolier: 2
-    ClothingEyesGlassesSunglasses: 2
-    
+    ClothingEyesGlassesCosmeticSunglasses: 2
+

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -68,6 +68,7 @@
     ClothingHeadRastaHat: 2
     ClothingBeltStorageWaistbag: 3
     ClothingEyesGlasses: 6
+    ClothingEyesGlassesCosmeticSunglasses: 6
   contrabandInventory:
     ClothingUniformJumpsuitTacticool: 1
     ClothingUniformJumpskirtTacticool: 1

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -111,9 +111,9 @@
 
 - type: entity
   parent: ClothingEyesBase
-  id: ClothingEyesGlassesSunglasses
+  id: ClothingEyesGlassesCosmeticSunglasses
   name: sun glasses
-  description: Useful both for security and cargonia.
+  description: A pair of black sunglasses.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/sunglasses.rsi
@@ -126,6 +126,14 @@
     tags:
     - HamsterWearable
     - WhitelistChameleon
+
+- type: entity
+  parent: ClothingEyesGlassesCosmeticSunglasses
+  id: ClothingEyesGlassesSunglasses
+  components:
+  - type: FlashImmunity
+  - type: EyeProtection
+    protectionTime: 5
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -19,7 +19,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     back: ClothingBackpackMusicianFilled
-    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesCosmeticSunglasses
     shoes: ClothingShoesBootsLaceup
     id: MusicianPDA
     ears: ClothingHeadsetService


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added cosmetic sunglasses.
Barkeeper vendor only has cosmetic sunglasses.
Musician spawns with cosmetic sunglasses.
Added cosmetic sunglasses to clothesmate vendor.

Security and command still have access to flash resistant sunglasses, revs still spawn with flash resistant sunglasses if they choose to keep them, but having sunglasses on you won't be weird anymore.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Curbs metagaming of head revs if everyone has sunglasses

- #22072 


**Changelog**
:cl: Whisper
- add: Added cosmetic sunglasses to the clothesmate
- tweak: Musician and bartender now have cosmetic sunglasses


