### PR TITLE
add black gloves to clothesmate

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -68,7 +68,7 @@
     ClothingHeadRastaHat: 2
     ClothingBeltStorageWaistbag: 3
     ClothingEyesGlasses: 6
-    ClothingHandsglovesColorBlack: 4
+    ClothingHandsGlovesColorBlack: 4
   contrabandInventory:
     ClothingUniformJumpsuitTacticool: 1
     ClothingUniformJumpskirtTacticool: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -68,6 +68,7 @@
     ClothingHeadRastaHat: 2
     ClothingBeltStorageWaistbag: 3
     ClothingEyesGlasses: 6
+    ClothingHandsglovesColorBlack: 4
   contrabandInventory:
     ClothingUniformJumpsuitTacticool: 1
     ClothingUniformJumpskirtTacticool: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds 4 black gloves to the clothes mate

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Curbs metagaming of thieving and combat gloves by making their visually identical base item more publicly accessible



**Changelog**

:cl: Whisper
- add: Added black gloves to the clothesmate
