### PR TITLE
adds a warning for the monstermos tile ripping cvar

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -960,6 +960,7 @@ namespace Content.Shared.CCVar
         ///     Needs <see cref="MonstermosEqualization"/> and <see cref="MonstermosDepressurization"/> to be enabled to work.
 		///		WARNING: This has MAJOR contrast issues, and usually tends to make any spaced scene look very cluttered.
 		///		This not only usually looks strange, but can also reduce playability for people with impaired vision. Think twice before enabling this on your server!
+		///     Also looks weird on slow spacing for unrelated reasons. If you want to enable this, you should probably turn off instaspacing.
         /// </summary>
         public static readonly CVarDef<bool> MonstermosRipTiles =
             CVarDef.Create("atmos.monstermos_rip_tiles", false, CVar.SERVERONLY);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -958,8 +958,8 @@ namespace Content.Shared.CCVar
         /// <summary>
         ///     Whether monstermos explosive depressurization will rip tiles..
         ///     Needs <see cref="MonstermosEqualization"/> and <see cref="MonstermosDepressurization"/> to be enabled to work.
-		///		WARNING: This cvar causes MAJOR contrast issues, and usually tends to make any spaced scene look very cluttered.
-		///		This not only usually looks strange, but can also reduce playability for people with impaired vision. Please think twice before enabling this on your server.
+		///     WARNING: This cvar causes MAJOR contrast issues, and usually tends to make any spaced scene look very cluttered.
+		///     This not only usually looks strange, but can also reduce playability for people with impaired vision. Please think twice before enabling this on your server.
 		///     Also looks weird on slow spacing for unrelated reasons. If you do want to enable this, you should probably turn on instaspacing.
         /// </summary>
         public static readonly CVarDef<bool> MonstermosRipTiles =

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -958,9 +958,9 @@ namespace Content.Shared.CCVar
         /// <summary>
         ///     Whether monstermos explosive depressurization will rip tiles..
         ///     Needs <see cref="MonstermosEqualization"/> and <see cref="MonstermosDepressurization"/> to be enabled to work.
-		///		WARNING: This has MAJOR contrast issues, and usually tends to make any spaced scene look very cluttered.
-		///		This not only usually looks strange, but can also reduce playability for people with impaired vision. Think twice before enabling this on your server!
-		///     Also looks weird on slow spacing for unrelated reasons. If you want to enable this, you should probably turn off instaspacing.
+		///		WARNING: This cvar causes MAJOR contrast issues, and usually tends to make any spaced scene look very cluttered.
+		///		This not only usually looks strange, but can also reduce playability for people with impaired vision. Please think twice before enabling this on your server.
+		///     Also looks weird on slow spacing for unrelated reasons. If you do want to enable this, you should probably turn on instaspacing.
         /// </summary>
         public static readonly CVarDef<bool> MonstermosRipTiles =
             CVarDef.Create("atmos.monstermos_rip_tiles", false, CVar.SERVERONLY);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -958,6 +958,8 @@ namespace Content.Shared.CCVar
         /// <summary>
         ///     Whether monstermos explosive depressurization will rip tiles..
         ///     Needs <see cref="MonstermosEqualization"/> and <see cref="MonstermosDepressurization"/> to be enabled to work.
+		///		WARNING: This has MAJOR contrast issues, and usually tends to make any spaced scene look very cluttered.
+		///		This not only usually looks strange, but can also reduce playability for people with impaired vision. Think twice before enabling this on your server!
         /// </summary>
         public static readonly CVarDef<bool> MonstermosRipTiles =
             CVarDef.Create("atmos.monstermos_rip_tiles", false, CVar.SERVERONLY);


### PR DESCRIPTION
## About the PR
Adds a comment warning people against enabling the monstermos tile ripping cvar.

## Why / Balance
This was disabled for a good reason, forks deserve to know why. They REALLY should probably not be using this unless they have instaspacing. 

## Breaking changes
no cl no fun
