### PR TITLE
give beer goggles solution scanning

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -43,6 +43,7 @@
   - type: Clothing
     sprite: Clothing/Eyes/Hud/beergoggles.rsi
   - type: ShowThirstIcons
+  - type: SolutionScanner
 
 - type: entity
   parent: ClothingEyesBase
@@ -158,4 +159,4 @@
     sprite: Clothing/Eyes/Hud/synd.rsi
   - type: ShowSyndicateIcons
   - type: ShowSecurityIcons
-  
+


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds solution scanning to the beer goggles, as stated in the description of the item (we didn't have the technology at the time)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I assume this was supposed to be implemented originally and it never happened.


**Changelog**
:cl: Whisper
- add: Beer goggles can now scan solutions. 

