### PR TITLE
Audio fixes

### DIFF
--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -14,6 +14,9 @@ namespace Content.Client.Audio;
 [UsedImplicitly]
 public sealed class BackgroundAudioSystem : EntitySystem
 {
+    /*
+     * TODO: Nuke this system and merge into contentaudiosystem
+     */
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly IBaseClient _client = default!;
     [Dependency] private readonly IConfigurationManager _configManager = default!;
@@ -22,7 +25,7 @@ public sealed class BackgroundAudioSystem : EntitySystem
 
     private readonly AudioParams _lobbyParams = new(-5f, 1, "Master", 0, 0, 0, true, 0f);
 
-    private EntityUid? _lobbyStream;
+    public EntityUid? LobbyStream;
 
     public override void Initialize()
     {
@@ -109,7 +112,7 @@ public sealed class BackgroundAudioSystem : EntitySystem
 
     public void StartLobbyMusic()
     {
-        if (_lobbyStream != null || !_configManager.GetCVar(CCVars.LobbyMusicEnabled))
+        if (LobbyStream != null || !_configManager.GetCVar(CCVars.LobbyMusicEnabled))
             return;
 
         var file = _gameTicker.LobbySong;
@@ -118,12 +121,12 @@ public sealed class BackgroundAudioSystem : EntitySystem
             return;
         }
 
-        _lobbyStream = _audio.PlayGlobal(file, Filter.Local(), false,
+        LobbyStream = _audio.PlayGlobal(file, Filter.Local(), false,
             _lobbyParams.WithVolume(_lobbyParams.Volume + SharedAudioSystem.GainToVolume(_configManager.GetCVar(CCVars.LobbyMusicVolume))))?.Entity;
     }
 
     private void EndLobbyMusic()
     {
-        _lobbyStream = _audio.Stop(_lobbyStream);
+        LobbyStream = _audio.Stop(LobbyStream);
     }
 }

--- a/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
+++ b/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
@@ -159,7 +159,7 @@ public sealed partial class ContentAudioSystem
         // Update still runs in lobby so just ignore it.
         if (_state.CurrentState is not GameplayState)
         {
-            FadeOut(_ambientMusicStream);
+            Audio.Stop(_ambientMusicStream);
             _ambientMusicStream = null;
             _musicProto = null;
             return;

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -1,7 +1,9 @@
 using Content.Server.GameTicking.Events;
 using Content.Shared.Audio;
+using Content.Shared.GameTicking;
 using Robust.Server.Audio;
 using Robust.Shared.Audio;
+using Robust.Shared.Audio.Components;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.Audio;
@@ -14,8 +16,14 @@ public sealed class ContentAudioSystem : SharedContentAudioSystem
     public override void Initialize()
     {
         base.Initialize();
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);
         SubscribeLocalEvent<RoundStartingEvent>(OnRoundStart);
         _protoManager.PrototypesReloaded += OnProtoReload;
+    }
+
+    private void OnRoundCleanup(RoundRestartCleanupEvent ev)
+    {
+        SilenceAudio();
     }
 
     private void OnProtoReload(PrototypesReloadedEventArgs obj)

--- a/Content.Shared/Audio/SharedContentAudioSystem.cs
+++ b/Content.Shared/Audio/SharedContentAudioSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Physics;
 using Robust.Shared.Audio;
+using Robust.Shared.Audio.Components;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Shared.Audio;
@@ -17,5 +18,15 @@ public abstract class SharedContentAudioSystem : EntitySystem
     {
         base.Initialize();
         Audio.OcclusionCollisionMask = (int) CollisionGroup.Impassable;
+    }
+
+    protected void SilenceAudio()
+    {
+        var query = AllEntityQuery<AudioComponent>();
+
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            Audio.SetGain(uid, 0f, comp);
+        }
     }
 }


### PR DESCRIPTION
- Turn off all audio on round cleanup
- Cut ambience when changing state instead of fading out.

:cl:
- fix: Fix game audio persisting to lobby.