### PR TITLE
Weapon Random Fixes (documented and removed hardcoded cluwnecomp)

### DIFF
--- a/Content.Server/Weapons/Melee/WeaponRandom/WeaponRandomComponent.cs
+++ b/Content.Server/Weapons/Melee/WeaponRandom/WeaponRandomComponent.cs
@@ -14,25 +14,13 @@ internal sealed partial class WeaponRandomComponent : Component
     public DamageSpecifier DamageBonus = new();
 
     /// <summary>
-    /// Chance for the damage bonus to occur.
+    /// Chance for the damage bonus to occur (1 = 100%).
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public float RandomDamageChance = 0.00001f;
 
     /// <summary>
-    /// If this is true then the random damage will occur.
-    /// </summary>
-    [DataField("randomDamage")]
-    public bool RandomDamage = true;
-
-    /// <summary>
-    /// If this is true then the weapon will have a unique interaction with cluwnes.
-    /// </summary>
-    [DataField("antiCluwne")]
-    public bool AntiCluwne = true;
-
-    /// <summary>
-    /// Noise to play when the damage bonus occurs.
+    /// Sound effect to play when the damage bonus occurs.
     /// </summary>
     [DataField("damageSound")]
     public SoundSpecifier DamageSound = new SoundPathSpecifier("/Audio/Items/bikehorn.ogg");

--- a/Content.Server/Weapons/Melee/WeaponRandom/WeaponRandomSystem.cs
+++ b/Content.Server/Weapons/Melee/WeaponRandom/WeaponRandomSystem.cs
@@ -1,11 +1,12 @@
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Random;
-using Content.Shared.Cluwne;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Server.Weapons.Melee.WeaponRandom;
 
+/// <summary>
+/// This adds a random damage bonus to melee attacks based on damage bonus amount and probability.
+/// </summary>
 public sealed class WeaponRandomSystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _random = default!;
@@ -17,22 +18,15 @@ public sealed class WeaponRandomSystem : EntitySystem
 
         SubscribeLocalEvent<WeaponRandomComponent, MeleeHitEvent>(OnMeleeHit);
     }
-
+    /// <summary>
+    /// On Melee hit there is a possible chance of additional bonus damage occuring.
+    /// </summary>
     private void OnMeleeHit(EntityUid uid, WeaponRandomComponent component, MeleeHitEvent args)
     {
-        foreach (var entity in args.HitEntities)
+        if (_random.Prob(component.RandomDamageChance))
         {
-            if (HasComp<CluwneComponent>(entity) && component.AntiCluwne)
-            {
-                _audio.PlayPvs(component.DamageSound, uid);
-                args.BonusDamage = component.DamageBonus;
-            }
-
-            else if (_random.Prob(component.RandomDamageChance) && component.RandomDamage)
-            {
-                _audio.PlayPvs(component.DamageSound, uid);
-                args.BonusDamage = component.DamageBonus;
-            }
+            _audio.PlayPvs(component.DamageSound, uid);
+            args.BonusDamage = component.DamageBonus;
         }
     }
 }


### PR DESCRIPTION
Fix - WeaponRandom is now documented.
Fix - CluwneCompnent is now removed from WeaponRandom.

### Breaking Changes
Removed RandomDamage and AntiCluwne fields from WeaponRandomComponent

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


