### PR TITLE
Sell plasma canister at cargo

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -90,17 +90,17 @@
 #  category: Atmospherics
 #  group: market
 
-#- type: cargoProduct
-#  name: "plasma canister"
-#  id: AtmosphericsPlasma
-#  description: "Plasma canister"
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: orange
-#  product: PlasmaCanister
-#  cost: 8500
-#  category: Atmospherics
-#  group: market
+- type: cargoProduct
+  name: "plasma canister"
+  id: AtmosphericsPlasma
+  description: "Plasma canister"
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: orange
+  product: PlasmaCanister
+  cost: 8500
+  category: Atmospherics
+  group: market
 
 #- type: cargoProduct
 #  name: "tritium canister"


### PR DESCRIPTION
## About the PR
This was removed a while ago to prevent griefing. Since then we've obtained gas canister locks and are also trying to limit the amount of frezon that can be produced, so bring it back.

## Why / Balance
Cargo techs can now get their hands on plasma canisters, but still need an atmos tech to unlock them.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
No need to tell anyone about this until plasma miners are yanked out from maps.