### PR TITLE
Remove plasma miners from maps

### DIFF
--- a/Resources/Maps/aspid.yml
+++ b/Resources/Maps/aspid.yml
@@ -60381,13 +60381,6 @@ entities:
     - pos: -0.5,-19.5
       parent: 1
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 3023
-    components:
-    - pos: -0.5,-27.5
-      parent: 1
-      type: Transform
 - proto: GasMixerFlipped
   entities:
   - uid: 4699

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -71580,14 +71580,6 @@ entities:
       type: Transform
     - maxExternalPressure: 4500
       type: GasMiner
-- proto: GasMinerPlasma
-  entities:
-  - uid: 15207
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -44.5,40.5
-      parent: 60
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 15206

--- a/Resources/Maps/barratry.yml
+++ b/Resources/Maps/barratry.yml
@@ -49248,13 +49248,6 @@ entities:
       type: Transform
     - maxExternalPressure: 4000
       type: GasMiner
-- proto: GasMinerPlasma
-  entities:
-  - uid: 10842
-    components:
-    - pos: -89.5,43.5
-      parent: 1
-      type: Transform
 - proto: GasOutletInjector
   entities:
   - uid: 13633

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -85806,14 +85806,6 @@ entities:
       type: Transform
     - maxExternalPressure: 4500
       type: GasMiner
-- proto: GasMinerPlasma
-  entities:
-  - uid: 15548
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 27.5,-47.5
-      parent: 8364
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 16806

--- a/Resources/Maps/cluster.yml
+++ b/Resources/Maps/cluster.yml
@@ -36196,13 +36196,6 @@ entities:
     - pos: 44.5,-7.5
       parent: 1
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 6806
-    components:
-    - pos: 44.5,-15.5
-      parent: 1
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 6805

--- a/Resources/Maps/core.yml
+++ b/Resources/Maps/core.yml
@@ -69581,14 +69581,6 @@ entities:
       pos: 16.5,-3.5
       parent: 2
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 1096
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 24.5,-3.5
-      parent: 2
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 1097

--- a/Resources/Maps/europa.yml
+++ b/Resources/Maps/europa.yml
@@ -49502,14 +49502,6 @@ entities:
       pos: -8.5,-19.5
       parent: 1
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 3173
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-19.5
-      parent: 1
-      type: Transform
 - proto: GasMixer
   entities:
   - uid: 4049

--- a/Resources/Maps/gemini.yml
+++ b/Resources/Maps/gemini.yml
@@ -83864,13 +83864,6 @@ entities:
       pos: -4.5,83.5
       parent: 2
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 12264
-    components:
-    - pos: 3.5,83.5
-      parent: 2
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 12265

--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -64657,13 +64657,6 @@ entities:
     - pos: 26.5,-24.5
       parent: 30
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 8774
-    components:
-    - pos: 26.5,-30.5
-      parent: 30
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 8692

--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -73770,13 +73770,6 @@ entities:
     - pos: 56.5,-29.5
       parent: 5350
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 11599
-    components:
-    - pos: 68.5,-15.5
-      parent: 5350
-      type: Transform
 - proto: GasMixer
   entities:
   - uid: 11074

--- a/Resources/Maps/omega.yml
+++ b/Resources/Maps/omega.yml
@@ -38029,13 +38029,6 @@ entities:
     - pos: -52.5,3.5
       parent: 4812
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 9456
-    components:
-    - pos: -52.5,9.5
-      parent: 4812
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 9454

--- a/Resources/Maps/origin.yml
+++ b/Resources/Maps/origin.yml
@@ -96710,13 +96710,6 @@ entities:
     - pos: -49.5,-52.5
       parent: 2
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 15367
-    components:
-    - pos: -49.5,-46.5
-      parent: 2
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 15368

--- a/Resources/Maps/packed.yml
+++ b/Resources/Maps/packed.yml
@@ -41718,13 +41718,6 @@ entities:
     - pos: 46.5,-25.5
       parent: 2
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 2130
-    components:
-    - pos: 46.5,-31.5
-      parent: 2
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 2138

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -33801,13 +33801,6 @@ entities:
     - pos: 36.5,22.5
       parent: 31
       type: Transform
-- proto: GasMinerPlasma
-  entities:
-  - uid: 11073
-    components:
-    - pos: 42.5,22.5
-      parent: 31
-      type: Transform
 - proto: GasMinerWaterVapor
   entities:
   - uid: 6836

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -6,6 +6,7 @@
   molarMass: 32
   color: 2887E8
   reagent: Oxygen
+  pricePerMole: 0
 
 - type: gas
   id: 1
@@ -15,6 +16,7 @@
   molarMass: 28
   color: DA1010
   reagent: Nitrogen
+  pricePerMole: 0
 
 - type: gas
   id: 2
@@ -24,6 +26,7 @@
   molarMass: 44
   color: 4e4e4e
   reagent: CarbonDioxide
+  pricePerMole: 0
 
 - type: gas
   id: 3
@@ -35,6 +38,7 @@
   gasOverlayState: plasma
   color: FF3300
   reagent: Plasma
+  pricePerMole: 0
 
 - type: gas
   id: 4
@@ -46,6 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
+  pricePerMole: 5
 
 - type: gas
   id: 5
@@ -57,6 +62,7 @@
   gasOverlayState: water_vapor
   color: bffffd
   reagent: Water
+  pricePerMole: 0
 
 - type: gas
   id: 6
@@ -70,6 +76,7 @@
   gasVisbilityFactor: 3.5
   color: 56941E
   reagent: Miasma
+  pricePerMole: 0.15
 
 - type: gas
   id: 7
@@ -79,6 +86,7 @@
   molarMass: 44
   color: 2887E8
   reagent: NitrousOxide
+  pricePerMole: 2.5
 
 - type: gas
   id: 8
@@ -91,3 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
+  pricePerMole: 7.5


### PR DESCRIPTION
## About the PR
This PR:

- Removes plasma miners from maps but keeps the round-start plasma fix to simulate NanoTrasen endowing the station with a healthy starting supply of plasma.
- Reverts 8b2579d56f770e08de55784b548a0c264439cf9e, which adds back some but not all gas prices.

## Why / Balance
Proposed by [many](https://discord.com/channels/310555209753690112/770682801607278632/1183284132709683200) in response to [limitless frezon hacking](https://discord.com/channels/310555209753690112/310555209753690112/1183662518309244958).

**Will this break TEG?**

No, people have been [pretty successful](https://discord.com/channels/310555209753690112/675078881425752124/1183013167115280446) at making TEG work without miners.

![canister-TEG](https://github.com/space-wizards/space-station-14/assets/3229565/8dff18a6-24f0-4566-9836-caf82c5b1b00)

It will encourage people to optimize setups not just for maximum power output, but also for better efficiency.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: notafet
- tweak: Stations no longer produce limitless plasma. Plasma refills can now be ordered at cargo.