### PR TITLE
Try different spacing options on different servers

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/leviathan.toml
+++ b/Resources/ConfigPresets/WizardsDen/leviathan.toml
@@ -11,3 +11,9 @@ tags = "lang:en,region:am_n_e,rp:low"
 
 [worldgen]
 enabled = true
+
+# classic "monstermos" "fast" spacing
+[atmos]
+mmos_spacing_speed = 1.0
+monstermos_rip_tiles = true
+space_wind = true

--- a/Resources/ConfigPresets/WizardsDen/lizard.toml
+++ b/Resources/ConfigPresets/WizardsDen/lizard.toml
@@ -8,3 +8,8 @@ soft_max_players = 80
 
 [hub]
 tags = "lang:en,region:am_n_w,rp:low"
+
+# slow "linda-only" spacing
+[atmos]
+monstermos_equalization = false
+monstermos_depressurization = false


### PR DESCRIPTION
## About the PR
Otherwise known as the "great spacing race." This PR:

- Sets classic "fast" "monstermos" spacing on Leviathan
- Sets even slower "slow" "LINDA-only" spacing on Lizard
- No change to other servers

This is intended to be in place for a max of 1-ish week to get player feedback on how they want atmos to work going forwards.

## Why / Balance
- [sloth wants fast spacing back](https://discord.com/channels/310555209753690112/770682801607278632/1183282367473930240)

  - also [delta](https://github.com/space-wizards/space-station-14/pull/22362#issuecomment-1850929769)

- [flare wants to try LINDA-only](https://discord.com/channels/310555209753690112/770682801607278632/1183283314153508884)
- Some people like slow spacing, but think current slow spacing is too slow, but there has to be a middle ground somewhere.

**Changelog**
Somebody please figure out how to announce this test to players if we decide to go forward.