### PR TITLE
Miscellaneous inventory tweaks

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
@@ -6,7 +6,6 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.CustomControls;
-using YamlDotNet.Core;
 
 namespace Content.Client.UserInterface.Systems.Storage.Controls;
 
@@ -177,7 +176,7 @@ public sealed class ItemGridPiece : Control
             handle.SetTransform(pos, iconRotation);
             var box = new UIBox2(root, root + sprite.Size * scale);
             handle.DrawTextureRect(sprite, box);
-            handle.SetTransform(Matrix3.Identity);
+            handle.SetTransform(GlobalPixelPosition, Angle.Zero);
         }
         else
         {

--- a/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
@@ -102,7 +102,7 @@ public sealed class ItemGridPiece : Control
             return;
         }
 
-        if (_storageController.IsDragging && _storageController.CurrentlyDragging == this)
+        if (_storageController.IsDragging && _storageController.DraggingGhost?.Entity == Entity && _storageController.DraggingGhost != this)
             return;
 
         var adjustedShape = _entityManager.System<ItemSystem>().GetAdjustedItemShape((Entity, itemComponent), Location.Rotation, Vector2i.Zero);

--- a/Content.Client/UserInterface/Systems/Storage/Controls/StorageContainer.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/StorageContainer.cs
@@ -445,6 +445,7 @@ public sealed class StorageContainer : BaseWindow
                         _entity.GetNetEntity(handEntity),
                         _entity.GetNetEntity(StorageEntity.Value),
                         insertLocation));
+                    _storageController.DraggingRotation = Angle.Zero;
                     args.Handle();
                 }
             }

--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -279,6 +279,7 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
             }
             else //if we just clicked, then take it out of the bag.
             {
+                DraggingRotation = control.Location.Rotation;
                 _entity.RaisePredictiveEvent(new StorageInteractWithItemEvent(
                     _entity.GetNetEntity(control.Entity),
                     _entity.GetNetEntity(storageEnt)));

--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -263,30 +263,55 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
 
     private void OnPieceUnpressed(GUIBoundKeyEventArgs args, ItemGridPiece control)
     {
-        if (_container?.StorageEntity is not { } storageEnt)
+        if (args.Function != ContentKeyFunctions.MoveStoredItem)
             return;
 
-        if (args.Function == ContentKeyFunctions.MoveStoredItem)
+        if (_container?.StorageEntity is not { } storageEnt|| !_entity.TryGetComponent<StorageComponent>(storageEnt, out var storageComp))
+            return;
+
+        if (DraggingGhost is { } draggingGhost)
         {
-            if (DraggingGhost is { } draggingGhost)
+            var dragEnt = draggingGhost.Entity;
+            var dragLoc = draggingGhost.Location;
+            var itemSys = _entity.System<SharedItemSystem>();
+
+            var position = _container.GetMouseGridPieceLocation(dragEnt, dragLoc);
+            var itemBounding = itemSys.GetAdjustedItemShape(dragEnt, dragLoc).GetBoundingBox();
+            var gridBounding = storageComp.Grid.GetBoundingBox();
+
+            // The extended bounding box for if this is out of the window is the grid bounding box dimensions combined
+            // with the item shape bounding box dimensions. Plus 1 on the left for the sidebar. This makes it so that.
+            // dropping an item on the floor requires dragging it all the way out of the window.
+            var left = gridBounding.Left - itemBounding.Width - 1;
+            var bottom = gridBounding.Bottom - itemBounding.Height;
+            var top = gridBounding.Top;
+            var right = gridBounding.Right;
+            var lenientBounding = new Box2i(left, bottom, right, top);
+
+            if (lenientBounding.Contains(position))
             {
-                var position = _container.GetMouseGridPieceLocation(draggingGhost.Entity, draggingGhost.Location);
                 _entity.RaisePredictiveEvent(new StorageSetItemLocationEvent(
                     _entity.GetNetEntity(draggingGhost.Entity),
                     _entity.GetNetEntity(storageEnt),
                     new ItemStorageLocation(DraggingRotation, position)));
-                _container?.BuildItemPieces();
             }
-            else //if we just clicked, then take it out of the bag.
+            else
             {
-                DraggingRotation = control.Location.Rotation;
-                _entity.RaisePredictiveEvent(new StorageInteractWithItemEvent(
-                    _entity.GetNetEntity(control.Entity),
+                _entity.RaisePredictiveEvent(new StorageRemoveItemEvent(
+                    _entity.GetNetEntity(draggingGhost.Entity),
                     _entity.GetNetEntity(storageEnt)));
             }
-            _menuDragHelper.EndDrag();
-            args.Handle();
+
+            _container?.BuildItemPieces();
         }
+        else //if we just clicked, then take it out of the bag.
+        {
+            _entity.RaisePredictiveEvent(new StorageInteractWithItemEvent(
+                _entity.GetNetEntity(control.Entity),
+                _entity.GetNetEntity(storageEnt)));
+        }
+        _menuDragHelper.EndDrag();
+        args.Handle();
     }
 
     private bool OnMenuBeginDrag()

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -81,6 +81,7 @@ public abstract class SharedStorageSystem : EntitySystem
         SubscribeAllEvent<StorageInteractWithItemEvent>(OnInteractWithItem);
         SubscribeAllEvent<StorageSetItemLocationEvent>(OnSetItemLocation);
         SubscribeAllEvent<StorageInsertItemIntoLocationEvent>(OnInsertItemIntoLocation);
+        SubscribeAllEvent<StorageRemoveItemEvent>(OnRemoveItem);
     }
 
     private void OnComponentInit(EntityUid uid, StorageComponent storageComp, ComponentInit args)
@@ -381,6 +382,34 @@ public abstract class SharedStorageSystem : EntitySystem
             return;
 
         TrySetItemStorageLocation((itemEnt, null), (storageEnt, storageComp), msg.Location);
+    }
+
+    private void OnRemoveItem(StorageRemoveItemEvent msg, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } player)
+            return;
+
+        var storageEnt = GetEntity(msg.StorageEnt);
+        var itemEnt = GetEntity(msg.ItemEnt);
+
+        if (!TryComp<StorageComponent>(storageEnt, out var storageComp))
+            return;
+
+        if (!_ui.TryGetUi(storageEnt, StorageComponent.StorageUiKey.Key, out var bui) ||
+            !bui.SubscribedSessions.Contains(args.SenderSession))
+            return;
+
+        if (!Exists(itemEnt))
+        {
+            Log.Error($"Player {args.SenderSession} set location of non-existent item {msg.ItemEnt} stored in {ToPrettyString(storageEnt)}");
+            return;
+        }
+
+        if (!ActionBlocker.CanInteract(player, itemEnt))
+            return;
+
+        TransformSystem.DropNextTo(itemEnt, player);
+        Audio.PlayPredicted(storageComp.StorageRemoveSound, storageEnt, player);
     }
 
     private void OnInsertItemIntoLocation(StorageInsertItemIntoLocationEvent msg, EntitySessionEventArgs args)

--- a/Content.Shared/Storage/StorageComponent.cs
+++ b/Content.Shared/Storage/StorageComponent.cs
@@ -108,6 +108,8 @@ namespace Content.Shared.Storage
 
         public readonly NetEntity StorageUid;
 
+        public bool Remove;
+
         public StorageInteractWithItemEvent(NetEntity interactedItemUid, NetEntity storageUid)
         {
             InteractedItemUid = interactedItemUid;

--- a/Content.Shared/Storage/StorageComponent.cs
+++ b/Content.Shared/Storage/StorageComponent.cs
@@ -108,8 +108,6 @@ namespace Content.Shared.Storage
 
         public readonly NetEntity StorageUid;
 
-        public bool Remove;
-
         public StorageInteractWithItemEvent(NetEntity interactedItemUid, NetEntity storageUid)
         {
             InteractedItemUid = interactedItemUid;
@@ -131,6 +129,20 @@ namespace Content.Shared.Storage
             ItemEnt = itemEnt;
             StorageEnt = storageEnt;
             Location = location;
+        }
+    }
+
+    [Serializable, NetSerializable]
+    public sealed class StorageRemoveItemEvent : EntityEventArgs
+    {
+        public readonly NetEntity ItemEnt;
+
+        public readonly NetEntity StorageEnt;
+
+        public StorageRemoveItemEvent(NetEntity itemEnt, NetEntity storageEnt)
+        {
+            ItemEnt = itemEnt;
+            StorageEnt = storageEnt;
         }
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- fixes the quick remove star not appearing on entities with unique storage sprites
- fixes an issue where dragging a piece would sometimes leave the old piece on the board visible
- dragging an item out of the bounds of the window now drops it on the ground
- fixes an issue where placing an item wouldn't reset rotation, leading to inconsistency with other instances of rotation resetting.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed the quick-remove star in the inventory sometimes not appearing.
- add: You can drag items out of the inventory window to drop them on the ground.
