### PR TITLE
Split up atmos speedup from heat scaling

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
@@ -25,6 +25,7 @@ namespace Content.Server.Atmos.EntitySystems
         public float AtmosMaxProcessTime { get; private set; }
         public float AtmosTickRate { get; private set; }
         public float Speedup { get; private set; }
+        public float HeatScale { get; private set; }
 
         /// <summary>
         /// Time between each atmos sub-update.  If you are writing an atmos device, use AtmosDeviceUpdateEvent.dt
@@ -51,6 +52,7 @@ namespace Content.Server.Atmos.EntitySystems
             _cfg.OnValueChanged(CCVars.AtmosMaxProcessTime, value => AtmosMaxProcessTime = value, true);
             _cfg.OnValueChanged(CCVars.AtmosTickRate, value => AtmosTickRate = value, true);
             _cfg.OnValueChanged(CCVars.AtmosSpeedup, value => Speedup = value, true);
+            _cfg.OnValueChanged(CCVars.AtmosHeatScale, value => HeatScale = value, true);
             _cfg.OnValueChanged(CCVars.ExcitedGroups, value => ExcitedGroups = value, true);
             _cfg.OnValueChanged(CCVars.ExcitedGroupsSpaceIsAllConsuming, value => ExcitedGroupsSpaceIsAllConsuming = value, true);
         }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -61,7 +61,7 @@ namespace Content.Server.Atmos.EntitySystems
             NumericsHelpers.Multiply(moles, GasSpecificHeats, tmp);
             // Adjust heat capacity by speedup, because this is primarily what
             // determines how quickly gases heat up/cool.
-            return MathF.Max(NumericsHelpers.HorizontalAdd(tmp), Atmospherics.MinimumHeatCapacity) / Speedup;
+            return MathF.Max(NumericsHelpers.HorizontalAdd(tmp), Atmospherics.MinimumHeatCapacity) / HeatScale;
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float PumpSpeedup()
         {
-            return MathF.Sqrt(Speedup);
+            return Speedup;
         }
 
         /// <summary>

--- a/Content.Server/Atmos/Reactions/FrezonCoolantReaction.cs
+++ b/Content.Server/Atmos/Reactions/FrezonCoolantReaction.cs
@@ -45,7 +45,7 @@ public sealed partial class FrezonCoolantReaction : IGasReactionEffect
             energyReleased = burnRate * Atmospherics.FrezonCoolEnergyReleased * energyModifier;
         }
 
-        energyReleased /= atmosphereSystem.Speedup; // adjust energy to make sure speedup doesn't cause mega temperature rise
+        energyReleased /= atmosphereSystem.HeatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
         if (energyReleased >= 0f)
             return ReactionResult.NoReaction;
 

--- a/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
@@ -56,7 +56,7 @@ namespace Content.Server.Atmos.Reactions
                     mixture.AdjustMoles(Gas.CarbonDioxide, plasmaBurnRate * (1.0f - supersaturation));
 
                     energyReleased += Atmospherics.FirePlasmaEnergyReleased * plasmaBurnRate;
-                    energyReleased /= atmosphereSystem.Speedup; // adjust energy to make sure speedup doesn't cause mega temperature rise
+                    energyReleased /= atmosphereSystem.HeatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
                     mixture.ReactionResults[GasReaction.Fire] += plasmaBurnRate * (1 + oxygenBurnRate);
                 }
             }

--- a/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
@@ -47,7 +47,7 @@ namespace Content.Server.Atmos.Reactions
                 mixture.ReactionResults[GasReaction.Fire] += burnedFuel;
             }
 
-            energyReleased /= atmosphereSystem.Speedup; // adjust energy to make sure speedup doesn't cause mega temperature rise
+            energyReleased /= atmosphereSystem.HeatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
             if (energyReleased > 0)
             {
                 var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1046,12 +1046,19 @@ namespace Content.Shared.CCVar
 
         /// <summary>
         ///     Scale factor for how fast things happen in our atmosphere
-        ///     simulation compared to real life. 1x means that a room takes as
-        ///     long to heat up in game as real life. Players typically expect
-        ///     things to happen faster in-game.
+        ///     simulation compared to real life. 1x means pumps run at 1x
+        ///     speed. Players typically expect things to happen faster
+        ///     in-game.
         /// </summary>
         public static readonly CVarDef<float> AtmosSpeedup =
-            CVarDef.Create("atmos.speedup", 64f, CVar.SERVERONLY);
+            CVarDef.Create("atmos.speedup", 8f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Like atmos.speedup, but only for gas and reaction heat values. 64x means
+        ///     gases heat up and cool down 64x faster than real life.
+        /// </summary>
+        public static readonly CVarDef<float> AtmosHeatScale =
+            CVarDef.Create("atmos.heat_scale", 64f, CVar.SERVERONLY);
 
         /*
          * MIDI instruments


### PR DESCRIPTION
## About the PR
Split up `atmos.speedup` from a new CVar `atmos.heatscale`. The former speeds up pumping-like devices, and the latter scales gas prototype specific heat and reaction energy.

## Why / Balance
To address reviewer comments.
