### PR TITLE
Fix history about gas prices

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -2845,11 +2845,6 @@ Entries:
       to time, type: Add}
   id: 5322
   time: '2023-12-11T11:36:19.0000000+00:00'
-- author: metalgearsloth
-  changes:
-  - {message: Removed gas selling until properly fixed., type: Fix}
-  id: 5323
-  time: '2023-12-11T12:28:33.0000000+00:00'
 - author: ninruB
   changes:
   - {message: Familiar Garbs may now appear as maintenance loot., type: Add}


### PR DESCRIPTION
## About the PR
Gas selling was added back the same day it was removed after a rebalancing change.

## Why / Balance
Many folks who found out about the initial change were not aware that gas selling was back.

:cl: notafet
- tweak: Tritium and frezon can once again be sold for profit.