### PR TITLE
Make open valves on tanks only produce noise once they pass a threshold

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -39,6 +39,7 @@ namespace Content.Server.Atmos.EntitySystems
 
         private const float TimerDelay = 0.5f;
         private float _timer = 0f;
+        private const float MinimumSoundValvePressure = 10.0f;
 
         public override void Initialize()
         {
@@ -178,7 +179,8 @@ namespace Content.Server.Atmos.EntitySystems
             var strength = removed.TotalMoles * MathF.Sqrt(removed.Temperature);
             var dir = _random.NextAngle().ToWorldVec();
             _throwing.TryThrow(gasTank, dir * strength, strength);
-            _audioSys.PlayPvs(gasTank.Comp.RuptureSound, gasTank);
+            if (gasTank.Comp.OutputPressure >= MinimumSoundValvePressure)
+                _audioSys.PlayPvs(gasTank.Comp.RuptureSound, gasTank);
         }
 
         private void ToggleInternals(Entity<GasTankComponent> ent)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Introduced a 10.0 valve pressure minimum to produce noise

Addresses  #22251 and #22208 to some extent

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I guess let's you silently open tanks, but more importantly makes annoying tanks less problematic. At the minimum 10.0 pressure the tank capacity will empty pretty quickly, instead of setting it at 0.1 and annoying everyone for ages.

Alternative suggestions could be applied afterwards, e.g. scaling volume, minimum release. But I think a minimum noise threshold is good for our health always.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.


If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
https://github.com/space-wizards/space-station-14/assets/7283010/8472b308-40d4-49b6-8de6-099e2178eca8


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Open tanks will no longer make noise at very low release pressure.