### PR TITLE
Turn off speedup and heat scaling to isolate bug

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1051,14 +1051,14 @@ namespace Content.Shared.CCVar
         ///     in-game.
         /// </summary>
         public static readonly CVarDef<float> AtmosSpeedup =
-            CVarDef.Create("atmos.speedup", 8f, CVar.SERVERONLY);
+            CVarDef.Create("atmos.speedup", 1f, CVar.SERVERONLY);
 
         /// <summary>
         ///     Like atmos.speedup, but only for gas and reaction heat values. 64x means
         ///     gases heat up and cool down 64x faster than real life.
         /// </summary>
         public static readonly CVarDef<float> AtmosHeatScale =
-            CVarDef.Create("atmos.heat_scale", 64f, CVar.SERVERONLY);
+            CVarDef.Create("atmos.heat_scale", 1f, CVar.SERVERONLY);
 
         /*
          * MIDI instruments


### PR DESCRIPTION
## About the PR
There appears to be some bug that showed up as a result of having atmos speedup. Turn off both heat scaling and pump speedup to verify that the problem goes away. If not, a full revert is in order.