### PR TITLE
Super Bonk Smite

### DIFF
--- a/Content.Server/Administration/Components/SuperBonkComponent.cs
+++ b/Content.Server/Administration/Components/SuperBonkComponent.cs
@@ -15,10 +15,10 @@ public sealed partial class SuperBonkComponent: Component
     public Dictionary<EntityUid, BonkableComponent>.Enumerator Tables;
 
     [DataField("initialTime")]
-    public float InitialTime = 0.25f;
+    public float InitialTime = 0.10f;
 
     [DataField("timeRemaining")]
-    public float TimeRemaining = 0.25f;
+    public float TimeRemaining = 0.10f;
 
     [DataField("removeClumsy")]
     public bool RemoveClumsy;

--- a/Content.Server/Administration/Components/SuperBonkComponent.cs
+++ b/Content.Server/Administration/Components/SuperBonkComponent.cs
@@ -21,5 +21,8 @@ public sealed partial class SuperBonkComponent: Component
     public float TimeRemaining = 0.10f;
 
     [DataField("removeClumsy")]
-    public bool RemoveClumsy;
+    public bool RemoveClumsy = true;
+
+    [DataField("stopWhenDead")]
+    public bool StopWhenDead = true;
 }

--- a/Content.Server/Administration/Components/SuperBonkComponent.cs
+++ b/Content.Server/Administration/Components/SuperBonkComponent.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Climbing.Components;
+
+namespace Content.Server.Administration.Components;
+
+/// <summary>
+/// Component to track the timer for the SuperBonk smite.
+/// </summary>
+[RegisterComponent]
+public sealed partial class SuperBonkComponent: Component
+{
+    [DataField("target")]
+    public EntityUid Target;
+
+    [DataField("tables")]
+    public Dictionary<EntityUid, BonkableComponent>.Enumerator Tables;
+
+    [DataField("initialTime")]
+    public float InitialTime = 0.25f;
+
+    [DataField("timeRemaining")]
+    public float TimeRemaining = 0.25f;
+
+    [DataField("removeClumsy")]
+    public bool RemoveClumsy;
+}

--- a/Content.Server/Administration/Components/SuperBonkComponent.cs
+++ b/Content.Server/Administration/Components/SuperBonkComponent.cs
@@ -1,3 +1,4 @@
+using Content.Server.Administration.Systems;
 using Content.Shared.Climbing.Components;
 
 namespace Content.Server.Administration.Components;
@@ -5,24 +6,43 @@ namespace Content.Server.Administration.Components;
 /// <summary>
 /// Component to track the timer for the SuperBonk smite.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, Access(typeof(SuperBonkSystem))]
 public sealed partial class SuperBonkComponent: Component
 {
-    [DataField("target")]
+    /// <summary>
+    /// Entity being Super Bonked.
+    /// </summary>
+    [DataField]
     public EntityUid Target;
 
-    [DataField("tables")]
+    /// <summary>
+    /// All of the tables the target will be bonked on.
+    /// </summary>
+    [DataField]
     public Dictionary<EntityUid, BonkableComponent>.Enumerator Tables;
 
-    [DataField("initialTime")]
+    /// <summary>
+    /// Value used to reset the timer once it expires.
+    /// </summary>
+    [DataField]
     public float InitialTime = 0.10f;
 
-    [DataField("timeRemaining")]
+    /// <summary>
+    /// Timer till the next bonk.
+    /// </summary>
+    [DataField]
     public float TimeRemaining = 0.10f;
 
-    [DataField("removeClumsy")]
+    /// <summary>
+    /// Whether to remove the clumsy component from the target after SuperBonk is done.
+    /// </summary>
+    [DataField]
     public bool RemoveClumsy = true;
 
-    [DataField("stopWhenDead")]
+    /// <summary>
+    /// Whether to stop Super Bonk on the target once he dies. Otherwise it will continue until no other tables are left
+    /// or the target is gibbed.
+    /// </summary>
+    [DataField]
     public bool StopWhenDead = true;
 }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -794,9 +794,9 @@ public sealed partial class AdminVerbSystem
         };
         args.Verbs.Add(superSpeed);
         //Bonk
-        Verb slam = new()
+        Verb superBonk = new()
         {
-            Text = "Super Slam",
+            Text = "Super Bonk",
             Category = VerbCategory.Smite,
             Icon = new SpriteSpecifier.Rsi(new("Structures/Furniture/Tables/generic.rsi"), "full"),
             Act = () =>
@@ -823,6 +823,6 @@ public sealed partial class AdminVerbSystem
             Message = Loc.GetString("admin-smite-super-slam-description"),
             Impact = LogImpact.Extreme,
         };
-        args.Verbs.Add(slam);
+        args.Verbs.Add(superBonk);
     }
 }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -22,7 +22,6 @@ using Content.Shared.Administration;
 using Content.Shared.Administration.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
-using Content.Shared.Climbing.Components;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Cluwne;
 using Content.Shared.Damage;
@@ -77,6 +76,7 @@ public sealed partial class AdminVerbSystem
     [Dependency] private readonly WeldableSystem _weldableSystem = default!;
     [Dependency] private readonly SharedContentEyeSystem _eyeSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly SuperBonkSystem _superBonkSystem = default!;
 
     // All smite verbs have names so invokeverb works.
     private void AddSmiteVerbs(GetVerbsEvent<Verb> args)
@@ -794,33 +794,29 @@ public sealed partial class AdminVerbSystem
         };
         args.Verbs.Add(superSpeed);
         //Bonk
-        Verb superBonk = new()
+        Verb superBonkLite = new()
+        {
+            Text = "Super Bonk Lite",
+            Category = VerbCategory.Smite,
+            Icon = new SpriteSpecifier.Rsi(new("Structures/Furniture/Tables/glass.rsi"), "full"),
+            Act = () =>
+            {
+                _superBonkSystem.StartSuperBonk(args.Target, stopWhenDead: true);
+            },
+            Message = Loc.GetString("admin-smite-super-bonk-lite-description"),
+            Impact = LogImpact.Extreme,
+        };
+        args.Verbs.Add(superBonkLite);
+        Verb superBonk= new()
         {
             Text = "Super Bonk",
             Category = VerbCategory.Smite,
             Icon = new SpriteSpecifier.Rsi(new("Structures/Furniture/Tables/generic.rsi"), "full"),
             Act = () =>
             {
-                var hadClumsy = EnsureComp<ClumsyComponent>(args.Target, out _);
-
-                var tables = EntityQueryEnumerator<BonkableComponent>();
-                var bonks = new Dictionary<EntityUid, BonkableComponent>();
-                // This is done so we don't crash if something like a new table is spawned.
-                while (tables.MoveNext(out var uid, out var comp))
-                {
-                    bonks.Add(uid, comp);
-                }
-
-                var sComp = new SuperBonkComponent
-                {
-                    Target = args.Target,
-                    Tables = bonks.GetEnumerator(),
-                    RemoveClumsy = !hadClumsy
-                };
-
-                AddComp(args.Target, sComp);
+                _superBonkSystem.StartSuperBonk(args.Target);
             },
-            Message = Loc.GetString("admin-smite-super-slam-description"),
+            Message = Loc.GetString("admin-smite-super-bonk-description"),
             Impact = LogImpact.Extreme,
         };
         args.Verbs.Add(superBonk);

--- a/Content.Server/Administration/Systems/SuperBonkSystem.cs
+++ b/Content.Server/Administration/Systems/SuperBonkSystem.cs
@@ -1,0 +1,72 @@
+using Content.Server.Administration.Components;
+using Content.Shared.Climbing.Components;
+using Content.Shared.Climbing.Events;
+using Content.Shared.Climbing.Systems;
+using Content.Shared.Interaction.Components;
+
+namespace Content.Server.Administration.Systems;
+
+public sealed class SuperBonkSystem: EntitySystem
+{
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly BonkSystem _bonkSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SuperBonkComponent, ComponentShutdown>(OnBonkShutdown);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var comps = EntityQueryEnumerator<SuperBonkComponent>();
+
+        while (comps.MoveNext(out var uid, out var comp))
+        {
+            comp.TimeRemaining -= frameTime;
+            if (!(comp.TimeRemaining <= 0))
+                continue;
+
+            Bonk(comp);
+
+            if (!(comp.Tables.MoveNext()))
+            {
+                RemComp<SuperBonkComponent>(comp.Target);
+                continue;
+            }
+
+            comp.TimeRemaining = comp.InitialTime;
+        }
+    }
+
+    public void Bonk(SuperBonkComponent comp)
+    {
+        var uid = comp.Tables.Current.Key;
+        var bonkComp = comp.Tables.Current.Value;
+
+        // It would be very weird for something without a transform component to have a bonk component
+        // but just in case because I don't want to crash the server.
+        if (!HasComp<TransformComponent>(uid))
+            return;
+
+        _transformSystem.SetCoordinates(comp.Target, Transform(uid).Coordinates);
+
+        //This is just so glass tables shatter which is funnier.
+        if (HasComp<GlassTableComponent>(uid))
+        {
+            var ev = new ClimbedOnEvent(comp.Target, comp.Target);
+            RaiseLocalEvent(uid, ref ev);
+            return;
+        }
+
+        _bonkSystem.TryBonk(comp.Target, uid, bonkComp);
+    }
+
+    private void OnBonkShutdown(EntityUid uid, SuperBonkComponent comp, ComponentShutdown ev)
+    {
+        if (comp.RemoveClumsy)
+            RemComp<ClumsyComponent>(comp.Target);
+    }
+}

--- a/Content.Server/Administration/Systems/SuperBonkSystem.cs
+++ b/Content.Server/Administration/Systems/SuperBonkSystem.cs
@@ -89,14 +89,6 @@ public sealed class SuperBonkSystem: EntitySystem
 
         _transformSystem.SetCoordinates(comp.Target, Transform(uid).Coordinates);
 
-        //This is just so glass tables shatter which is funnier.
-        if (HasComp<GlassTableComponent>(uid))
-        {
-            var ev = new ClimbedOnEvent(comp.Target, comp.Target);
-            RaiseLocalEvent(uid, ref ev);
-            return;
-        }
-
         _bonkSystem.TryBonk(comp.Target, uid, bonkComp);
     }
 

--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -70,3 +70,7 @@ Entries:
   changes:
     - {message: 'The respawn verb now respawns the targeted player instead of the admin', type: Fix}
   time: '2023-11-22T16:39:00.0000000+00:00'
+- author: nikthechampiongr
+  changes:
+  - {message: 'The Super Bonk smite is now available. Targets will bonk their head on every single table.', type: Add}
+  time: '2023-12-12T11:54:00.0000000+00:00'

--- a/Resources/Locale/en-US/administration/smites.ftl
+++ b/Resources/Locale/en-US/administration/smites.ftl
@@ -55,8 +55,9 @@ admin-smite-lung-removal-description = Removes their lungs, drowning them.
 admin-smite-remove-hand-description = Removes only one of their hands instead of all of them.
 admin-smite-disarm-prone-description = Makes them get disarmed 100% of the time and cuffed instantly.
 admin-smite-garbage-can-description = Turn them into a garbage bin to emphasize what they remind you of.
-admin-smite-super-slam-description = Slams them on every single table on the Station and beyond.
-
+admin-smite-super-bonk-description = Slams them on every single table on the Station and beyond.
+admin-smite-super-bonk-lite-description= Slams them on every single table on the
+Station and beyond. Stops when the target is dead.
 
 ## Tricks descriptions
 

--- a/Resources/Locale/en-US/administration/smites.ftl
+++ b/Resources/Locale/en-US/administration/smites.ftl
@@ -56,8 +56,7 @@ admin-smite-remove-hand-description = Removes only one of their hands instead of
 admin-smite-disarm-prone-description = Makes them get disarmed 100% of the time and cuffed instantly.
 admin-smite-garbage-can-description = Turn them into a garbage bin to emphasize what they remind you of.
 admin-smite-super-bonk-description = Slams them on every single table on the Station and beyond.
-admin-smite-super-bonk-lite-description= Slams them on every single table on the
-Station and beyond. Stops when the target is dead.
+admin-smite-super-bonk-lite-description= Slams them on every single table on the Station and beyond. Stops when the target is dead.
 
 ## Tricks descriptions
 

--- a/Resources/Locale/en-US/administration/smites.ftl
+++ b/Resources/Locale/en-US/administration/smites.ftl
@@ -55,6 +55,7 @@ admin-smite-lung-removal-description = Removes their lungs, drowning them.
 admin-smite-remove-hand-description = Removes only one of their hands instead of all of them.
 admin-smite-disarm-prone-description = Makes them get disarmed 100% of the time and cuffed instantly.
 admin-smite-garbage-can-description = Turn them into a garbage bin to emphasize what they remind you of.
+admin-smite-super-slam-description = Slams them on every single table on the Station and beyond.
 
 
 ## Tricks descriptions


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR adds a smite that makes the target bonk their head on every single table on every single grid in no particular order.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I want raiders to think about what they've done wrong as their head violently impacts literally every table to ever exist. The light version also stops when the target dies as opposed to when they are gibbed or bonked on every single table.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The smite uses a component to keep track of all the tables, and the time between bonks. By default the time is 100msecs. Every time the timer expires, the target is teleported to the next table and gets bonked. If it's a glass table it will shatter as if they climbed it. During this the target is temporarily given the Clumsy Component so they can bonk their heads. I am not sure how necessary is this because on a normal station with arrivals and centcomm the target will almost certainly be gibbed. 

The reason the comp doesn't just keep the EntityQueryEnumerator and creates a new dictionary is because otherwise should a new table be added, or the round restarts then the server will crash.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.




Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/32041239/063e8234-9f65-41d1-ba6a-6048add1461a





- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no player cl