### PR TITLE
Hide verb expansion indicators on debug

### DIFF
--- a/Content.Client/Verbs/UI/VerbMenuElement.cs
+++ b/Content.Client/Verbs/UI/VerbMenuElement.cs
@@ -33,11 +33,14 @@ namespace Content.Client.Verbs.UI
 
             Label.SetOnlyStyleClass(verb.TextStyleClass);
 
+            // There are no confirmations in debug fam.
+#if !DEBUG
             if (verb.ConfirmationPopup)
             {
                 ExpansionIndicator.SetOnlyStyleClass(StyleClassVerbMenuConfirmationTexture);
                 ExpansionIndicator.Visible = true;
             }
+#endif
 
             var entManager = IoCManager.Resolve<IEntityManager>();
 


### PR DESCRIPTION
I forget if it's actually going to popup or not.