### PR TITLE
Add proper suffix on turret tool box

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -43,7 +43,7 @@
 - type: entity
   id: ToolboxElectricalTurretFilled
   name: electrical toolbox
-  suffix: Filled
+  suffix: Syndicate, Turret, Filled
   parent: ToolboxElectricalTurret
   components:
   - type: StorageFill


### PR DESCRIPTION
## About the PR
- Fixes suffix for turret filled toolboxes.

## Why / Balance
To prevent funny mapping mistakes. 

## Technical details
n/a

## Media
Before:
![image](https://github.com/space-wizards/space-station-14/assets/107660393/5d004df5-75de-4033-b1c2-f5f6bd92b4b0)

After:
![image](https://github.com/space-wizards/space-station-14/assets/107660393/37b80aaf-d253-490b-989c-f08c0f93d1f6)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
n/a

**Changelog**
n/a