### PR TITLE
Fix construction graph ghost examine message

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Content.Client.Popups;
 using Content.Shared.Construction;
 using Content.Shared.Construction.Prototypes;
+using Content.Shared.Construction.Steps;
 using Content.Shared.Examine;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
@@ -97,7 +98,11 @@ namespace Content.Client.Construction
                 return;
             }
 
-            edge.Steps[0].DoExamine(args);
+            foreach (ConstructionGraphStep step in edge.Steps)
+            {
+                args.Message.PushNewline();
+                step.DoExamine(args);
+            }
         }
 
         public event EventHandler<CraftingAvailabilityChangedArgs>? CraftingAvailabilityChanged;

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/secretdoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/secretdoor.yml
@@ -12,7 +12,6 @@
       - material: Steel
         amount: 4
         doAfter: 4
-
       - material: MetalRod
         amount: 4
         doAfter: 4


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixes the construction graph for the solid secret door.
Also fixes the formatting for examine message of construction graph ghosts.

Fixes #22374 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes formatting and shows multi-material first edge without needing to check the construction guide entry.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

All construction graph ghosts needed a new line to fix formatting, and for the couple of instances where the ghost had multiple materials required on its first edge, it would not display the others.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![secretdoor](https://github.com/space-wizards/space-station-14/assets/89101928/5b3a8855-57d8-4cdb-b0e9-67de78690f4e)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fixed secret doors not requiring metal rods