### PR TITLE
add glaive to salv weapons research

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -79,37 +79,24 @@
     damage:
       types:
         Slash: 6.5
-  - type: Item
-    size: Small
   - type: Tag
     tags:
     - Knife
 
 # Like a crusher... but better
 - type: entity
-  name: crusher glaive
   parent: WeaponCrusher
   id: WeaponCrusherGlaive
+  name: crusher glaive
   description: An early design of the proto-kinetic accelerator, in glaive form.
   components:
-  - type: Tag
-    tags:
-      - Pickaxe
-  - type: UseDelayOnShoot
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/crusher_glaive.rsi
   - type: UseDelay
     delay: 1.9
-  - type: Gun
-    fireRate: 1
-  - type: RechargeBasicEntityAmmo
-    rechargeCooldown: 0.5
   - type: LeechOnMarker
     leech:
       groups:
         Brute: -15
-  - type: Sprite
-    sprite: Objects/Weapons/Melee/crusher_glaive.rsi
   - type: MeleeWeapon
-    wideAnimationRotation: -135
     attackRate: 1.25
-  - type: Item
-    size: Ginormous

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -150,6 +150,15 @@
     Plastic: 50
 
 - type: latheRecipe
+  id: WeaponCrusherGlaive
+  result: WeaponCrusherGlaive
+  completetime: 5
+  materials:
+    Steel: 1500
+    Glass: 500
+    Plastic: 100
+
+- type: latheRecipe
   id: WeaponForceGun
   result: WeaponForceGun
   completetime: 5

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -14,6 +14,8 @@
   # These are roundstart but not replenishable for salvage
   - WeaponCrusher
   - WeaponCrusherDagger
+  # This is not roundstart since its a direct upgrade
+  - WeaponCrusherGlaive
 
 - type: technology
   id: DraconicMunitions


### PR DESCRIPTION
## About the PR
title

also cleaned up crushers yml since it was massively duplicated

## Why / Balance
gives some reason to unlock it since you never actually need to make a crusher or pka outside of arming the masses, now you might since it has better stats than normal crusher

recipe is a bit more expensive than crusher to reflect better stats

## Technical details
no

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Crusher Glaives can now be made with Salvage Weapons technology.
