### PR TITLE
Re-enable round-end PVS overrides

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -363,8 +363,7 @@ namespace Content.Server.GameTicking
 
                 if (TryGetEntity(mind.OriginalOwnedEntity, out var entity))
                 {
-                    // Temporarily disabled to test if this causes issues on live servers
-                    // _pvsOverride.AddGlobalOverride(GetNetEntity(entity.Value), recursive: true);
+                    _pvsOverride.AddGlobalOverride(GetNetEntity(entity.Value), recursive: true);
                 }
 
                 var roles = _roles.MindGetAllRoles(mindId);


### PR DESCRIPTION
This shouldn't be merged untill after space-wizards/RobustToolbox/pull/4706 and the engine version is updated.