### PR TITLE
Jetpack buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -47,7 +47,6 @@
       quickEquip: false
       slots:
         - Back
-        - SuitStorage
     - type: GasTank
       outputPressure: 21.3
       air:
@@ -88,7 +87,6 @@
     sprite: Objects/Tanks/Jetpacks/blue.rsi
     slots:
       - Back
-      - SuitStorage
 
 # Filled blue
 - type: entity
@@ -122,7 +120,6 @@
     sprite: Objects/Tanks/Jetpacks/black.rsi
     slots:
       - Back
-      - SuitStorage
 
 # Filled black
 - type: entity
@@ -233,7 +230,6 @@
     sprite: Objects/Tanks/Jetpacks/security.rsi
     slots:
       - Back
-      - suitStorage
 
 #Filled security
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -47,6 +47,7 @@
       quickEquip: false
       slots:
         - Back
+        - SuitStorage
     - type: GasTank
       outputPressure: 21.3
       air:
@@ -87,6 +88,7 @@
     sprite: Objects/Tanks/Jetpacks/blue.rsi
     slots:
       - Back
+      - SuitStorage
 
 # Filled blue
 - type: entity
@@ -120,6 +122,7 @@
     sprite: Objects/Tanks/Jetpacks/black.rsi
     slots:
       - Back
+      - SuitStorage
 
 # Filled black
 - type: entity
@@ -151,6 +154,7 @@
     sprite: Objects/Tanks/Jetpacks/captain.rsi
     slots:
       - Back
+      - SuitStorage
   - type: Item
     sprite: Objects/Tanks/Jetpacks/captain.rsi
     size: Normal
@@ -191,6 +195,7 @@
       slots:
         - Back
         - suitStorage
+        - Belt
     - type: GasTank
       outputPressure: 42.6
       air:
@@ -228,6 +233,7 @@
     sprite: Objects/Tanks/Jetpacks/security.rsi
     slots:
       - Back
+      - suitStorage
 
 #Filled security
 - type: entity
@@ -262,6 +268,7 @@
     slots:
       - Back
       - suitStorage
+      - Belt
 
 # Filled void
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

~~Standard jetpacks can now go in suit storage, while smaller jetpacks like the mini variant can now go in the belt slot.~~ If you need a way to visualise how that would work realistically, remember that mini jetpacks are not only small but you're going to be in space where there is no gravity. In the future, perhaps jetpacks can weigh more.

_Only cap and CE's along with the mini jetpack is buffed._

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Because there was no viable location to place the jetpack in normal circumstances, people would hold it in their hand. As a solution to that, I'm simply giving more options for players along with easier accessibility. Like, who would throw away their bag as a syndicate just to wear a jetpack?

**Changelog**

:cl: Ubaser
- tweak: Some jetpacks can be now worn in more slots.
