### PR TITLE
Increase mothroach crate price

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -214,6 +214,6 @@
     sprite: Mobs/Animals/mothroach.rsi
     state: mothroach
   product: CrateNPCMothroach
-  cost: 2500
+  cost: 5000
   category: Livestock
   group: market


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR increases the mothroach crate price purchasable at cargo to 5000 spesos, for 4 mothroaches.
People spam mothroach crates and they either end up everywhere around the station or dead everywhere around the station which can be easily abusable, and while i love mothroaches I don't think this is great. After all, these are bought for pets; not for mindless murder (like monkey cubes for example). If I can at least help it a little, I will.

Though some people may not like this change, so its up for heavy discussion.

**Changelog**

:cl: Ubaser
- tweak: Mothroach crates are now twice as expensive
