### PR TITLE
let cyberpen edit stamped papers

### DIFF
--- a/Content.Server/Paper/PaperSystem.cs
+++ b/Content.Server/Paper/PaperSystem.cs
@@ -100,7 +100,9 @@ namespace Content.Server.Paper
 
         private void OnInteractUsing(EntityUid uid, PaperComponent paperComp, InteractUsingEvent args)
         {
-            if (_tagSystem.HasTag(args.Used, "Write") && paperComp.StampedBy.Count == 0)
+            // only allow editing if there are no stamps or when using a cyberpen
+            var editable = paperComp.StampedBy.Count == 0 || _tagSystem.HasTag(args.Used, "WriteIgnoreStamps");
+            if (_tagSystem.HasTag(args.Used, "Write") && editable)
             {
                 var writeEvent = new PaperWriteEvent(uid, args.User);
                 RaiseLocalEvent(args.Used, ref writeEvent);

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -267,7 +267,7 @@ uplink-clothing-outer-hardsuit-juggernaut-desc = Hyper resilient armor made of m
 
 # Misc
 uplink-cyberpen-name = Cybersun Pen
-uplink-cyberpen-desc = Cybersun's legal department pen, invaluable for forging documents. Smells vaguely of hard-light and war profiteering.
+uplink-cyberpen-desc = Cybersun's legal department pen, invaluable for forging documents and escaping prisons. Smells vaguely of hard-light and war profiteering.
 
 uplink-decoy-disk-name = Decoy Nuclear Disk
 uplink-decoy-disk-desc = A piece of plastic with a lenticular printing, made to look like a nuclear auth disk.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -267,7 +267,7 @@ uplink-clothing-outer-hardsuit-juggernaut-desc = Hyper resilient armor made of m
 
 # Misc
 uplink-cyberpen-name = Cybersun Pen
-uplink-cyberpen-desc = Cybersun's legal department pen. Smells vaguely of hard-light and war profiteering.
+uplink-cyberpen-desc = Cybersun's legal department pen, invaluable for forging documents. Smells vaguely of hard-light and war profiteering.
 
 uplink-decoy-disk-name = Decoy Nuclear Disk
 uplink-decoy-disk-desc = A piece of plastic with a lenticular printing, made to look like a nuclear auth disk.

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -259,6 +259,7 @@
   - type: Tag
     tags:
     - Write
+    - WriteIgnoreStamps
     - Pickaxe
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1111,6 +1111,9 @@
   id: Write
 
 - type: Tag
+  id: WriteIgnoreStamps
+
+- type: Tag
   id: RifleStock
 
 - type: Tag


### PR DESCRIPTION
## About the PR
and by extension centcom pen

normal pens/crayons are unaffected

## Why / Balance
gives a little more utility, easily forge your favourite documents

## Technical details
tag youre it

## Media
btamped paper nothing sus
![17:03:04](https://github.com/space-wizards/space-station-14/assets/39013340/7d7e43d2-c471-4486-bef8-2534b69b61f7)

stamped so must be real...
![17:03:34](https://github.com/space-wizards/space-station-14/assets/39013340/e9f4e698-7757-4f57-b13f-7becc13fe1c1)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Cybersun and centcom pens can now edit stamped paper.