### PR TITLE
Last Words can no longer be prefixed with a radio channel identifier

### DIFF
--- a/Content.Server/Mobs/CritMobActionsSystem.cs
+++ b/Content.Server/Mobs/CritMobActionsSystem.cs
@@ -75,7 +75,7 @@ public sealed class CritMobActionsSystem : EntitySystem
                 }
                 lastWords += "...";
 
-                _chat.TrySendInGameICMessage(uid, lastWords, InGameICChatType.Whisper, ChatTransmitRange.Normal, ignoreActionBlocker: true);
+                _chat.TrySendInGameICMessage(uid, lastWords, InGameICChatType.Whisper, ChatTransmitRange.Normal, checkRadioPrefix: false, ignoreActionBlocker: true);
                 _host.ExecuteCommand(actor.PlayerSession, "ghost");
             });
 


### PR DESCRIPTION
## About the PR
Last Words messages now ignore radio prefixes (the prefix is actually whispered out with the rest of the words)

![Screenshot from 2023-12-13 19-25-41](https://github.com/space-wizards/space-station-14/assets/35878406/3e3ab9c1-9a6e-4aa2-9588-80313ad3b247)



## Why / Balance
I don't think it was ever intended for players to be able to do this. It allows one to broadcast the name of their killer to the entire station AFTER their attacker no longer considers them a threat, or the location of their body if they remember too late they forgot to turn their suit sensors up
I also asked about this on discord and at least one maintainer also thinks so https://discord.com/channels/310555209753690112/310555209753690112/1184549489839714324

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- fix: A dying person's Last Words can no longer be sent to radio channels.