### PR TITLE
Fix heat capacity scaling

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Atmos.EntitySystems
             _cfg.OnValueChanged(CCVars.AtmosMaxProcessTime, value => AtmosMaxProcessTime = value, true);
             _cfg.OnValueChanged(CCVars.AtmosTickRate, value => AtmosTickRate = value, true);
             _cfg.OnValueChanged(CCVars.AtmosSpeedup, value => Speedup = value, true);
-            _cfg.OnValueChanged(CCVars.AtmosHeatScale, value => HeatScale = value, true);
+            _cfg.OnValueChanged(CCVars.AtmosHeatScale, value => { HeatScale = value; InitializeGases(); }, true);
             _cfg.OnValueChanged(CCVars.ExcitedGroups, value => ExcitedGroups = value, true);
             _cfg.OnValueChanged(CCVars.ExcitedGroupsSpaceIsAllConsuming, value => ExcitedGroupsSpaceIsAllConsuming = value, true);
         }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Atmos.EntitySystems
 
             for (var i = 0; i < GasPrototypes.Length; i++)
             {
-                _gasSpecificHeats[i] = GasPrototypes[i].SpecificHeat;
+                _gasSpecificHeats[i] = GasPrototypes[i].SpecificHeat / HeatScale;
                 GasReagents[i] = GasPrototypes[i].Reagent;
             }
         }
@@ -61,7 +61,7 @@ namespace Content.Server.Atmos.EntitySystems
             NumericsHelpers.Multiply(moles, GasSpecificHeats, tmp);
             // Adjust heat capacity by speedup, because this is primarily what
             // determines how quickly gases heat up/cool.
-            return MathF.Max(NumericsHelpers.HorizontalAdd(tmp), Atmospherics.MinimumHeatCapacity) / HeatScale;
+            return MathF.Max(NumericsHelpers.HorizontalAdd(tmp), Atmospherics.MinimumHeatCapacity);
         }
 
         /// <summary>

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -222,7 +222,7 @@ namespace Content.Server.Atmos.EntitySystems
                 if (!(MathF.Abs(delta) >= Atmospherics.GasMinMoles)) continue;
                 if (absTemperatureDelta > Atmospherics.MinimumTemperatureDeltaToConsider)
                 {
-                    var gasHeatCapacity = delta * GasSpecificHeats[i];
+                    var gasHeatCapacity = delta * GasSpecificHeats[i] / HeatScale;
                     if (delta > 0)
                     {
                         heatCapacityToSharer += gasHeatCapacity;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -222,7 +222,7 @@ namespace Content.Server.Atmos.EntitySystems
                 if (!(MathF.Abs(delta) >= Atmospherics.GasMinMoles)) continue;
                 if (absTemperatureDelta > Atmospherics.MinimumTemperatureDeltaToConsider)
                 {
-                    var gasHeatCapacity = delta * GasSpecificHeats[i] / HeatScale;
+                    var gasHeatCapacity = delta * GasSpecificHeats[i];
                     if (delta > 0)
                     {
                         heatCapacityToSharer += gasHeatCapacity;

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1053,14 +1053,14 @@ namespace Content.Shared.CCVar
         ///     in-game.
         /// </summary>
         public static readonly CVarDef<float> AtmosSpeedup =
-            CVarDef.Create("atmos.speedup", 1f, CVar.SERVERONLY);
+            CVarDef.Create("atmos.speedup", 8f, CVar.SERVERONLY);
 
         /// <summary>
         ///     Like atmos.speedup, but only for gas and reaction heat values. 64x means
         ///     gases heat up and cool down 64x faster than real life.
         /// </summary>
         public static readonly CVarDef<float> AtmosHeatScale =
-            CVarDef.Create("atmos.heat_scale", 1f, CVar.SERVERONLY);
+            CVarDef.Create("atmos.heat_scale", 8f, CVar.SERVERONLY);
 
         /*
          * MIDI instruments


### PR DESCRIPTION
## About the PR
Fix heat capacity scaling and turn on a conservative speedup and heat scale.

## Technical details
- @Ilya246 pointed out that LINDA was using the unscaled heat capacity.
- @Ilya246 also suggested scaling the cached value instead of just the heat capacity calculation.

As shown below this looks like it fixes the issue, but out of an abundance of caution set `heat_scale` to only 8 (instead of the target 64) because even with the buggy code 8 was still safe. Once this fix is tested a bit more it can be raised again.

## Verification

### Steps To Reproduce Bug
To verify the fix, I've provided reproduction instructions for the old bug.

0. Set up a map as shown in the screenshot below and `fixgridatmos` (and possibly save it)
1. set atmos.heat_scale=64
2. load map and mapinit
3. let plasma fire burn to completion
4. check temperature inside plasma fire room
5. open door
6. check final temperature, it's very big

![image](https://github.com/space-wizards/space-station-14/assets/3229565/61fea2ab-7ae6-43d1-a5bf-068851ced99b)

### Before Fix
Step 4:
![image](https://github.com/space-wizards/space-station-14/assets/3229565/a02c891b-0fe0-4fb3-9e41-3634157f2cdf)

Step 6:
![image](https://github.com/space-wizards/space-station-14/assets/3229565/1df676b9-c6f3-45a7-87be-4484d286a7eb)

### After Fix
Step 4:
![image](https://github.com/space-wizards/space-station-14/assets/3229565/fe72f9ce-2f81-4de3-a6fc-5e2fd13748b8)

Step 6:
![image](https://github.com/space-wizards/space-station-14/assets/3229565/8f937888-1da3-4f85-b573-4a57552b19a5)