### PR TITLE
Better and slower spreading plasma and tritium fires

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -179,11 +179,11 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     Amount of heat released per mole of burnt hydrogen or tritium (hydrogen isotope)
         /// </summary>
-        public const float FireHydrogenEnergyReleased = 560000f;
+        public const float FireHydrogenEnergyReleased = 284e3f; // hydrogen is 284 kJ/mol
         public const float FireMinimumTemperatureToExist = T0C + 100f;
         public const float FireMinimumTemperatureToSpread = T0C + 150f;
         public const float FireSpreadRadiosityScale = 0.85f;
-        public const float FirePlasmaEnergyReleased = 3000000f;
+        public const float FirePlasmaEnergyReleased = 16e3f; // methane is 16 kJ/mol
         public const float FireGrowthRate = 40000f;
 
         public const float SuperSaturationThreshold = 96f;
@@ -216,7 +216,7 @@ namespace Content.Shared.Atmos
         ///     Remove X mol of nitrogen for each mol of frezon.
         /// </summary>
         public const float FrezonNitrogenCoolRatio = 5;
-        public const float FrezonCoolEnergyReleased = -3000000f;
+        public const float FrezonCoolEnergyReleased = -600e3f;
         public const float FrezonCoolRateModifier = 20f;
 
         public const float FrezonProductionMaxEfficiencyTemperature = 73.15f;


### PR DESCRIPTION
## About the PR
Reduce the energy output of plasma and tritium fires.

## Why / Balance
Many have pointed out that tritium fires felt "broken" in SS14 because they burn too fast, spread too quickly, and result in a massive fire that has pressure and temperature that becomes instantly round-ending. To that effect, starting plasma fires isn't even allowed for antagonists.

To fix this, reduce the energy output of plasma and tritium fires. Adjust the frezon reaction by a similar amount.

**If you're an atmos developer, please help test this change locally!**

## FAQ

**Aasdflasdhfljasf THIS WILL BREAK TEG!?!?!?**
No, see screenshots below.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Plasma fires are still pretty deadly, but spread slower and don't result in instant death.**

https://github.com/space-wizards/space-station-14/assets/3229565/7ca170ea-bba3-469c-9cf9-79366c90d1c6

**Tritium fires are of course much more deadly.**

https://github.com/space-wizards/space-station-14/assets/3229565/c183dd75-cd39-4a72-88e3-c5d18ddaddc7

**TEG's still work**

![teg-not-broken](https://github.com/space-wizards/space-station-14/assets/3229565/9e30a8fe-bd13-4896-8259-814c3215de19)


**Changelog**
:cl: notafet
- tweak: Plasma and tritium fires spread more slowly and are now more survivable.