### PR TITLE
Mothroach crates nerf

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -214,6 +214,6 @@
     sprite: Mobs/Animals/mothroach.rsi
     state: mothroach
   product: CrateNPCMothroach
-  cost: 2500
+  cost: 2000
   category: Livestock
   group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/npc.yml
@@ -211,4 +211,4 @@
   - type: StorageFill
     contents:
       - id: MobMothroach
-        amount: 4
+        amount: 1

--- a/Resources/Prototypes/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/npc.yml
@@ -211,4 +211,4 @@
   - type: StorageFill
     contents:
       - id: MobMothroach
-        amount: 1
+        amount: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changed 2 lines of code. Mothroach crates now only contain 2 mothroaches, but the price has been nerfed down to 2000.
<!-- What did you change in this PR? -->

## Why / Balance
More balanced. Emag Moth can no longer order 20 mothroach crates to crash the server.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
It's just a few YML, nothing really that much
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->



:cl: Avalon
- tweak: Due to budget cuts, CentCom is now supplying less mothroaches per mothroach crate.
