### PR TITLE
fix mod pull issue

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -317,6 +317,8 @@
       behaviors:
       - !type:GibBehavior { }
   - type: NonSpreaderZombie
+  - type: Puller
+    needsHands: true
 
 - type: entity
   name: glockroach
@@ -443,6 +445,8 @@
     prototype: Mothroach
   - type: TypingIndicator
     proto: moth
+    - type: Puller
+    needsHands: true
 
 - type: entity
   name: mallard duck #Quack

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -105,5 +105,5 @@
     price: 150
   - type: FloatingVisuals
   - type: Puller
-    needsHands: True
+    needsHands: false
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -104,6 +104,4 @@
   - type: MobPrice
     price: 150
   - type: FloatingVisuals
-  - type: Puller
-    needsHands: false
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The PR that did not allow mothroach to pull was made through changing simplemob, I remade it through changing only them and returned the ability to pull things to simplemob.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Solves this issue.
https://github.com/space-wizards/space-station-14/issues/22465
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- fix: Fixed the inability of mobs to pull items.
