### PR TITLE
UnPullOperator for HTN

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Interactions/UnPullOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Interactions/UnPullOperator.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Content.Shared.Pulling;
+using Content.Shared.Pulling.Components;
+
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Interactions;
+
+public sealed partial class UnPullOperator : HTNOperator
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    private SharedPullingSystem _pulling = default!;
+
+    public override void Initialize(IEntitySystemManager sysManager)
+    {
+        base.Initialize(sysManager);
+
+        _pulling = sysManager.GetEntitySystem<SharedPullingSystem>();
+    }
+
+    public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(NPCBlackboard blackboard,
+        CancellationToken token)
+    {
+        var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
+
+        if (!_pulling.IsPulled(owner) ||
+            !_entManager.TryGetComponent<SharedPullableComponent>(owner, out var pullable))
+            return (false, null);
+
+        return (_pulling.TryStopPull(pullable), null);
+    }
+
+}

--- a/Resources/Prototypes/NPCs/Combat/melee.yml
+++ b/Resources/Prototypes/NPCs/Combat/melee.yml
@@ -3,6 +3,14 @@
 - type: htnCompound
   id: MeleeCombatCompound
   branches:
+    # Tore pull if we have one
+    - preconditions:
+        - !type:PulledPrecondition
+          isPulled: true
+      tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:UnPullOperator
+
     # Pickup weapon if we don't have one.
     - preconditions:
        - !type:ActiveHandComponentPrecondition


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added new HTN operator to tore pulls, i just can't imagine why space carps, and space bears keeps in your hands when you pull them, wtf

## Why / Balance
No one could pull hostile animals anymore, you need to kill it before pulling. I don't think it will influence gameplay much, but still..

## Technical details
Just added a new primitive task for MeleeCombatCompound, if PulledPrecondition is true, then use UnPullOperator

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

https://github.com/space-wizards/space-station-14/assets/48524572/6b51e84e-b763-4a4a-aa6e-9ec5897b091b


Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
https://github.com/space-wizards/space-station-14/assets/48524572/6b51e84e-b763-4a4a-aa6e-9ec5897b091b

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: JerryImMouse
- add: Added an UnPullOperator to prevent pulling hostile mobs

