### PR TITLE
Include URL in Discord bot changelog to link to the Github PR page

### DIFF
--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -114,8 +114,9 @@ def send_to_discord(entries: Iterable[ChangelogEntry]) -> None:
         for entry in group:
             for change in entry["changes"]:
                 emoji = TYPES_TO_EMOJI.get(change['type'], "❓")
+                url = entry["url"]
                 message = change['message']
-                content.write(f"{emoji} {message}\n")
+                content.write(f"[{emoji}]({url}) {message}\n")
 
     body = {
         "content": content.getvalue(),

--- a/Tools/update_changelog.py
+++ b/Tools/update_changelog.py
@@ -61,6 +61,7 @@ def main():
             "time", datetime.datetime.now(datetime.timezone.utc).isoformat()
         )
         changes = partyaml["changes"]
+        url = partyaml["url"]
 
         if not isinstance(changes, list):
             changes = [changes]
@@ -71,7 +72,7 @@ def main():
             new_id = max_id
 
             entries_list.append(
-                {"author": author, "time": time, "changes": changes, "id": new_id}
+                {"author": author, "time": time, "changes": changes, "id": new_id, "url": url}
             )
 
         os.remove(partpath)


### PR DESCRIPTION
## About the PR
Includes URLs to Github PRs in the Changelog, and adds a hyperlink to each change submitted via the Changelog Discord bot. 

## Why / Balance
Improves discoverability of PRs, letting users quickly access them with one click as opposed to looking through the Closed Pull requests tab.

## Technical details
This change relies on [PR #5](https://github.com/space-wizards/SS14.Changelog/pull/5) in the SS14.Changelog app and should be included only once that PR is approved and merged.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Discord bot Changelog now includes hyperlinks to the PRs.