### PR TITLE
Atmos scaling cvar changes

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -43,10 +43,21 @@ namespace Content.Server.Atmos.EntitySystems
         /// <summary>
         ///     Calculates the heat capacity for a gas mixture.
         /// </summary>
-        public float GetHeatCapacity(GasMixture mixture)
+        /// <param name="mixture">The mixture whose heat capacity should be calculated</param>
+        /// <param name="applyScaling"> Whether the internal heat capacity scaling should be applied. This should not be
+        /// used outside of atmospheric related heat transfer.</param>
+        /// <returns></returns>
+        public float GetHeatCapacity(GasMixture mixture, bool applyScaling)
         {
-            return GetHeatCapacityCalculation(mixture.Moles, mixture.Immutable);
+            var scale = GetHeatCapacityCalculation(mixture.Moles, mixture.Immutable);
+
+            // By default GetHeatCapacityCalculation() has the heat-scale divisor pre-applied.
+            // So if we want the un-scaled heat capacity, we have to multiply by the scale.
+            return applyScaling ? scale : scale * HeatScale;
         }
+
+        private float GetHeatCapacity(GasMixture mixture)
+            =>  GetHeatCapacityCalculation(mixture.Moles, mixture.Immutable);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private float GetHeatCapacityCalculation(float[] moles, bool space)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -320,7 +320,9 @@ namespace Content.Server.Atmos.EntitySystems
 
                     var req = prototype.MinimumRequirements[i];
 
-                    if (!(mixture.GetMoles(i) < req)) continue;
+                    if (!(mixture.GetMoles(i) < req))
+                        continue;
+
                     doReaction = false;
                     break;
                 }
@@ -328,7 +330,7 @@ namespace Content.Server.Atmos.EntitySystems
                 if (!doReaction)
                     continue;
 
-                reaction = prototype.React(mixture, holder, this);
+                reaction = prototype.React(mixture, holder, this, HeatScale);
                 if(reaction.HasFlag(ReactionResult.StopReactions))
                     break;
             }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
@@ -3,6 +3,7 @@ using Content.Server.Atmos.Components;
 using Content.Server.Atmos.Reactions;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
+using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;
 
@@ -557,5 +558,13 @@ public sealed partial class AtmosphereSystem
             GridUpdateAdjacent(uid, gridAtmosphere, ref ev);
             InvalidateVisuals(uid, position, overlay);
         }
+    }
+
+    public TileRef GetTileRef(TileAtmosphere tile)
+    {
+        if (!TryComp(tile.GridIndex, out MapGridComponent? grid))
+            return default;
+        _map.TryGetTileRef(tile.GridIndex, grid, tile.GridIndices, out var tileRef);
+        return tileRef;
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -2,13 +2,11 @@ using Content.Server.Administration.Logs;
 using Content.Server.Atmos.Components;
 using Content.Server.Body.Systems;
 using Content.Server.Fluids.EntitySystems;
-using Content.Server.Maps;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Shared.Atmos.EntitySystems;
 using Content.Shared.Maps;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
@@ -33,7 +31,7 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
     [Dependency] private readonly GasTileOverlaySystem _gasTileOverlaySystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly TransformSystem _transformSystem = default!;
-    [Dependency] private readonly TileSystem _tile = default!;;
+    [Dependency] private readonly TileSystem _tile = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] public readonly PuddleSystem Puddle = default!;
 
@@ -83,7 +81,7 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
             return;
 
         var query = EntityQueryEnumerator<AtmosExposedComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var exposed, out var transform))
+        while (query.MoveNext(out var uid, out _, out var transform))
         {
             var air = GetContainingMixture(uid, transform:transform);
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.Components;
 using Content.Server.Body.Systems;
+using Content.Server.Fluids.EntitySystems;
 using Content.Server.Maps;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Shared.Atmos.EntitySystems;
@@ -32,7 +33,9 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
     [Dependency] private readonly GasTileOverlaySystem _gasTileOverlaySystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly TransformSystem _transformSystem = default!;
-    [Dependency] private readonly TileSystem _tile = default!;
+    [Dependency] private readonly TileSystem _tile = default!;;
+    [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] public readonly PuddleSystem Puddle = default!;
 
     private const float ExposedUpdateDelay = 1f;
     private float _exposedTimer = 0f;

--- a/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
@@ -83,7 +83,7 @@ public sealed class HeatExchangerSystem : EntitySystem
         else
             xfer = outlet.Air.Remove(-n);
 
-        float CXfer = _atmosphereSystem.GetHeatCapacity(xfer);
+        float CXfer = _atmosphereSystem.GetHeatCapacity(xfer, true);
         if (CXfer < Atmospherics.MinimumHeatCapacity)
             return;
 
@@ -94,7 +94,7 @@ public sealed class HeatExchangerSystem : EntitySystem
         float CEnv = 0f;
         if (environment != null)
         {
-            CEnv = _atmosphereSystem.GetHeatCapacity(environment);
+            CEnv = _atmosphereSystem.GetHeatCapacity(environment, true);
             hasEnv = CEnv >= Atmospherics.MinimumHeatCapacity && environment.TotalMoles > 0f;
             if (hasEnv)
                 radTemp = environment.Temperature;

--- a/Content.Server/Atmos/IGasReactionEffect.cs
+++ b/Content.Server/Atmos/IGasReactionEffect.cs
@@ -6,6 +6,14 @@ namespace Content.Server.Atmos
     [ImplicitDataDefinitionForInheritors]
     public partial interface IGasReactionEffect
     {
-        ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem);
+        /// <summary>
+        /// Process this reaction effect.
+        /// </summary>
+        /// <param name="mixture">The gas mixture to react</param>
+        /// <param name="holder">The container of this gas mixture</param>
+        /// <param name="atmosphereSystem">The atmosphere system</param>
+        /// <param name="heatScale">Scaling factor that should be applied to all heat input or outputs.</param>
+        ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem,
+            float heatScale);
     }
 }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCondenserSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCondenserSystem.cs
@@ -64,7 +64,7 @@ public sealed class GasCondenserSystem : EntitySystem
 
     public float NumberOfMolesToConvert(ApcPowerReceiverComponent comp, GasMixture mix, float dt)
     {
-        var hc = _atmosphereSystem.GetHeatCapacity(mix);
+        var hc = _atmosphereSystem.GetHeatCapacity(mix, true);
         var alpha = 0.8f; // tuned to give us 1-ish u/second of reagent conversion
         // ignores the energy needed to cool down the solution to the condensation point, but that probably adds too much difficulty and so let's not simulate that
         var energy = comp.Load * dt;

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -80,7 +80,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             float dQ = thermoMachine.HeatCapacity * thermoMachine.Cp * args.dt;
 
             // Clamps the heat transferred to not overshoot
-            float Cin = _atmosphereSystem.GetHeatCapacity(inlet.Air);
+            float Cin = _atmosphereSystem.GetHeatCapacity(inlet.Air, true);
             float dT = targetTemp - temp;
             float dQLim = dT * Cin;
             float scale = 1f;

--- a/Content.Server/Atmos/Reactions/FrezonCoolantReaction.cs
+++ b/Content.Server/Atmos/Reactions/FrezonCoolantReaction.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Atmos.Reactions;
 [UsedImplicitly]
 public sealed partial class FrezonCoolantReaction : IGasReactionEffect
 {
-    public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem)
+    public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
     {
         var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);
         var temperature = mixture.Temperature;
@@ -45,7 +45,7 @@ public sealed partial class FrezonCoolantReaction : IGasReactionEffect
             energyReleased = burnRate * Atmospherics.FrezonCoolEnergyReleased * energyModifier;
         }
 
-        energyReleased /= atmosphereSystem.HeatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
+        energyReleased /= heatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
         if (energyReleased >= 0f)
             return ReactionResult.NoReaction;
 

--- a/Content.Server/Atmos/Reactions/FrezonCoolantReaction.cs
+++ b/Content.Server/Atmos/Reactions/FrezonCoolantReaction.cs
@@ -12,7 +12,7 @@ public sealed partial class FrezonCoolantReaction : IGasReactionEffect
 {
     public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
     {
-        var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);
+        var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
         var temperature = mixture.Temperature;
 
         var energyModifier = 1f;
@@ -49,7 +49,7 @@ public sealed partial class FrezonCoolantReaction : IGasReactionEffect
         if (energyReleased >= 0f)
             return ReactionResult.NoReaction;
 
-        var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);
+        var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
         if (newHeatCapacity > Atmospherics.MinimumHeatCapacity)
             mixture.Temperature = (temperature * oldHeatCapacity + energyReleased) / newHeatCapacity;
 

--- a/Content.Server/Atmos/Reactions/FrezonProductionReaction.cs
+++ b/Content.Server/Atmos/Reactions/FrezonProductionReaction.cs
@@ -11,7 +11,7 @@ namespace Content.Server.Atmos.Reactions;
 [UsedImplicitly]
 public sealed partial class FrezonProductionReaction : IGasReactionEffect
 {
-    public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem)
+    public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
     {
         var initialN2 = mixture.GetMoles(Gas.Nitrogen);
         var initialOxy = mixture.GetMoles(Gas.Oxygen);
@@ -28,7 +28,6 @@ public sealed partial class FrezonProductionReaction : IGasReactionEffect
         // Amount of tritium & oxygen that are reacting
         var tritBurned = Math.Min(oxyLimit, initialTrit);
         var oxyBurned = tritBurned * Atmospherics.FrezonProductionTritRatio;
-        var burnRatio = tritBurned / initialTrit;
 
         var oxyConversion = oxyBurned / Atmospherics.FrezonProductionConversionRate;
         var tritConversion = tritBurned / Atmospherics.FrezonProductionConversionRate;

--- a/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
+++ b/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
@@ -60,13 +60,20 @@ namespace Content.Server.Atmos.Reactions
         /// </summary>
         [DataField("effects")] private List<IGasReactionEffect> _effects = new();
 
-        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem)
+        /// <summary>
+        /// Process all reaction effects.
+        /// </summary>
+        /// <param name="mixture">The gas mixture to react</param>
+        /// <param name="holder">The container of this gas mixture</param>
+        /// <param name="atmosphereSystem">The atmosphere system</param>
+        /// <param name="heatScale">Scaling factor that should be applied to all heat input or outputs.</param>
+        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
         {
             var result = ReactionResult.NoReaction;
 
             foreach (var effect in _effects)
             {
-                result |= effect.React(mixture, holder, atmosphereSystem);
+                result |= effect.React(mixture, holder, atmosphereSystem, heatScale);
             }
 
             return result;

--- a/Content.Server/Atmos/Reactions/MiasmicSubsumationReaction.cs
+++ b/Content.Server/Atmos/Reactions/MiasmicSubsumationReaction.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Atmos.Reactions;
 [UsedImplicitly]
 public sealed partial class MiasmicSubsumationReaction : IGasReactionEffect
 {
-    public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem)
+    public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
     {
         var initialMiasma = mixture.GetMoles(Gas.Miasma);
         var initialFrezon = mixture.GetMoles(Gas.Frezon);

--- a/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
@@ -11,7 +11,7 @@ namespace Content.Server.Atmos.Reactions
         public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
         {
             var energyReleased = 0f;
-            var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);
+            var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
             var temperature = mixture.Temperature;
             var location = holder as TileAtmosphere;
             mixture.ReactionResults[GasReaction.Fire] = 0;
@@ -65,7 +65,7 @@ namespace Content.Server.Atmos.Reactions
 
             if (energyReleased > 0)
             {
-                var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);
+                var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
                 if (newHeatCapacity > Atmospherics.MinimumHeatCapacity)
                     mixture.Temperature = (temperature * oldHeatCapacity + energyReleased) / newHeatCapacity;
             }

--- a/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
@@ -8,7 +8,7 @@ namespace Content.Server.Atmos.Reactions
     [DataDefinition]
     public sealed partial class PlasmaFireReaction : IGasReactionEffect
     {
-        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem)
+        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
         {
             var energyReleased = 0f;
             var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);
@@ -22,8 +22,10 @@ namespace Content.Server.Atmos.Reactions
             if (temperature > Atmospherics.PlasmaUpperTemperature)
                 temperatureScale = 1f;
             else
+            {
                 temperatureScale = (temperature - Atmospherics.PlasmaMinimumBurnTemperature) /
                                    (Atmospherics.PlasmaUpperTemperature - Atmospherics.PlasmaMinimumBurnTemperature);
+            }
 
             if (temperatureScale > 0)
             {
@@ -56,7 +58,7 @@ namespace Content.Server.Atmos.Reactions
                     mixture.AdjustMoles(Gas.CarbonDioxide, plasmaBurnRate * (1.0f - supersaturation));
 
                     energyReleased += Atmospherics.FirePlasmaEnergyReleased * plasmaBurnRate;
-                    energyReleased /= atmosphereSystem.HeatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
+                    energyReleased /= heatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
                     mixture.ReactionResults[GasReaction.Fire] += plasmaBurnRate * (1 + oxygenBurnRate);
                 }
             }

--- a/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
@@ -8,7 +8,7 @@ namespace Content.Server.Atmos.Reactions
     [DataDefinition]
     public sealed partial class TritiumFireReaction : IGasReactionEffect
     {
-        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem)
+        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
         {
             var energyReleased = 0f;
             var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);
@@ -47,7 +47,7 @@ namespace Content.Server.Atmos.Reactions
                 mixture.ReactionResults[GasReaction.Fire] += burnedFuel;
             }
 
-            energyReleased /= atmosphereSystem.HeatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
+            energyReleased /= heatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
             if (energyReleased > 0)
             {
                 var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);

--- a/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
@@ -11,7 +11,7 @@ namespace Content.Server.Atmos.Reactions
         public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
         {
             var energyReleased = 0f;
-            var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);
+            var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
             var temperature = mixture.Temperature;
             var location = holder as TileAtmosphere;
             mixture.ReactionResults[GasReaction.Fire] = 0f;
@@ -50,7 +50,7 @@ namespace Content.Server.Atmos.Reactions
             energyReleased /= heatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
             if (energyReleased > 0)
             {
-                var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture);
+                var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
                 if (newHeatCapacity > Atmospherics.MinimumHeatCapacity)
                     mixture.Temperature = ((temperature * oldHeatCapacity + energyReleased) / newHeatCapacity);
             }

--- a/Content.Server/Atmos/Reactions/WaterVaporReaction.cs
+++ b/Content.Server/Atmos/Reactions/WaterVaporReaction.cs
@@ -17,7 +17,7 @@ namespace Content.Server.Atmos.Reactions
 
         [DataField("molesPerUnit")] public float MolesPerUnit { get; private set; } = 1;
 
-        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem)
+        public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
         {
             // If any of the prototypes is invalid, we do nothing.
             if (string.IsNullOrEmpty(Reagent))
@@ -34,9 +34,8 @@ namespace Content.Server.Atmos.Reactions
             // Remove the moles from the mixture...
             mixture.AdjustMoles(GasId, -MolesPerUnit);
 
-            var tileRef = tile.GridIndices.GetTileRef(tile.GridIndex);
-            EntitySystem.Get<PuddleSystem>()
-                .TrySpillAt(tileRef, new Solution(Reagent, FixedPoint2.New(MolesPerUnit)), out _, sound: false);
+            var tileRef = atmosphereSystem.GetTileRef(tile);
+            atmosphereSystem.Puddle.TrySpillAt(tileRef, new Solution(Reagent, FixedPoint2.New(MolesPerUnit)), out _, sound: false);
 
             return ReactionResult.Reacting;
         }

--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -120,8 +120,8 @@ public sealed class TegSystem : EntitySystem
         var (airA, δpA) = GetCirculatorAirTransfer(inletA.Air, outletA.Air);
         var (airB, δpB) = GetCirculatorAirTransfer(inletB.Air, outletB.Air);
 
-        var cA = _atmosphere.GetHeatCapacity(airA);
-        var cB = _atmosphere.GetHeatCapacity(airB);
+        var cA = _atmosphere.GetHeatCapacity(airA, true);
+        var cB = _atmosphere.GetHeatCapacity(airB, true);
 
         // Shift ramp position based on demand and generation from previous tick.
         var curRamp = component.RampPosition;

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -149,13 +149,11 @@ public sealed class TemperatureSystem : EntitySystem
         if (transform.MapUid == null)
             return;
 
-        var position = _transform.GetGridTilePositionOrDefault((uid, transform));
         var temperatureDelta = args.GasMixture.Temperature - temperature.CurrentTemperature;
-        var tileHeatCapacity =
-            _atmosphere.GetTileHeatCapacity(transform.GridUid, transform.MapUid.Value, position);
+        var airHeatCapacity = _atmosphere.GetHeatCapacity(args.GasMixture, false);
         var heatCapacity = GetHeatCapacity(uid, temperature);
-        var heat = temperatureDelta * (tileHeatCapacity * heatCapacity /
-                                       (tileHeatCapacity + heatCapacity));
+        var heat = temperatureDelta * (airHeatCapacity * heatCapacity /
+                                       (airHeatCapacity + heatCapacity));
         ChangeHeat(uid, heat * temperature.AtmosTemperatureTransferEfficiency, temperature: temperature);
     }
 


### PR DESCRIPTION
This PR adds a heat-scale argument to `IGasReactionEffect.React()`, with the goal of ensuring that forks/downstreams don't accidentally fail to scale heat outputs, which is an easy mistake to make.

It also adds a non-optional bool to the public `GetHeatCapacity()` method to ensure that external systems intentionally choose to get either the scaled or un-scaled heat capacities. This also changes `TemperatureSystem` to use the un-scaled heat capacities, as it interacts with non-atmos heat capacities that don't get scaled by the atmos cvars.