### PR TITLE
Increase gas leak event weight

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -128,7 +128,7 @@
     endAnnouncement: station-event-gas-leak-end-announcement
     earliestStart: 10
     minimumPlayers: 5
-    weight: 5
+    weight: 10
     startDelay: 20
   - type: GasLeakRule
 


### PR DESCRIPTION
## About the PR
After the recent changes to plasma, trit, and frezon, these gas leaks are no longer as threatening and they used to be. Scrubbers are also now faster, so it stands that we can make this random event happen more often.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Based on a discussion starting from [this message on Discord](https://discord.com/channels/310555209753690112/310555209753690112/1184981893641408543).