### PR TITLE
add glaive to salv weapons

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: crusher
+  abstract: true
   parent: BaseItem
   id: BaseWeaponCrusher # Crusher? But I...
-  abstract: true
+  name: crusher
   description: An early design of the proto-kinetic accelerator.
   components:
   - type: Sharp
@@ -13,7 +13,6 @@
     radius: 4
 
 - type: entity
-  name: crusher
   parent: BaseWeaponCrusher
   id: WeaponCrusher
   components:
@@ -65,9 +64,9 @@
   - type: Prying
 
 - type: entity
-  name: crusher dagger
   parent: BaseWeaponCrusher
   id: WeaponCrusherDagger
+  name: crusher dagger
   description: A scaled down version of a proto-kinetic crusher, usually used in a last ditch scenario.
   components:
   - type: Sprite
@@ -79,37 +78,27 @@
     damage:
       types:
         Slash: 6.5
-  - type: Item
-    size: Small
   - type: Tag
     tags:
     - Knife
 
 # Like a crusher... but better
 - type: entity
-  name: crusher glaive
   parent: WeaponCrusher
   id: WeaponCrusherGlaive
+  name: crusher glaive
   description: An early design of the proto-kinetic accelerator, in glaive form.
   components:
-  - type: Tag
-    tags:
-      - Pickaxe
-  - type: UseDelayOnShoot
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/crusher_glaive.rsi
   - type: UseDelay
     delay: 1.9
-  - type: Gun
-    fireRate: 1
-  - type: RechargeBasicEntityAmmo
-    rechargeCooldown: 0.5
   - type: LeechOnMarker
     leech:
       groups:
         Brute: -15
-  - type: Sprite
-    sprite: Objects/Weapons/Melee/crusher_glaive.rsi
   - type: MeleeWeapon
-    wideAnimationRotation: -135
     attackRate: 1.25
-  - type: Item
-    size: Ginormous
+  - type: Tag
+    tags:
+      - Pickaxe

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -265,6 +265,7 @@
       - SyringeBluespace
       - WeaponCrusher
       - WeaponCrusherDagger
+      - WeaponCrusherGlaive
       - WeaponForceGun
       - WeaponProtoKineticAccelerator
       - WeaponTetherGun

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -150,6 +150,15 @@
     Plastic: 50
 
 - type: latheRecipe
+  id: WeaponCrusherGlaive
+  result: WeaponCrusherGlaive
+  completetime: 5
+  materials:
+    Steel: 1500
+    Glass: 250
+    Silver: 250
+
+- type: latheRecipe
   id: WeaponForceGun
   result: WeaponForceGun
   completetime: 5

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -14,6 +14,8 @@
   # These are roundstart but not replenishable for salvage
   - WeaponCrusher
   - WeaponCrusherDagger
+  # This is not roundstart since its a direct upgrade
+  - WeaponCrusherGlaive
 
 - type: technology
   id: DraconicMunitions


### PR DESCRIPTION
## About the PR
costs more steel + silver instead of plastic

## Why / Balance
better weapon for crusher enjoyers

## Technical details
no

## Media
so true
![23:52:13](https://github.com/space-wizards/space-station-14/assets/39013340/86ebb7b4-29a5-4ffd-9aa1-a6411219f9f7)

you are not admin
![23:52:25](https://github.com/space-wizards/space-station-14/assets/39013340/f84dd1af-609d-4dad-b4ea-e754a421a9a4)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Crusher Glaives can be made with the Salvage Weapons technology.
