### PR TITLE
Makes MORE raw materials grindable

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/reagents/meta/biological.ftl
@@ -17,4 +17,4 @@ reagent-name-fat = fat
 reagent-desc-fat = No matter how it was obtained, its application is important.
 
 reagent-name-vomit = vomit
-reagent-desc-vomit = You can see a few chunks of someones last meal in it.
+reagent-desc-vomit = You can see a few chunks of someone's last meal in it.

--- a/Resources/Locale/en-US/reagents/meta/chemicals.ftl
+++ b/Resources/Locale/en-US/reagents/meta/chemicals.ftl
@@ -12,3 +12,6 @@ reagent-desc-artifexium = A lavender mixture of microscopic artifact fragments a
 
 reagent-name-sodium-polyacrylate = Sodium Polyacrylate
 reagent-desc-sodium-polyacrylate = A super-absorbent polymer with assorted industrial uses.
+
+reagent-name-cellulose = cellulose fibers
+reagent-desc-cellulose = A crystaline polydextrose polymer, plants swear by this stuff.

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -49,17 +49,14 @@
   - type: Item
     heldPrefix: paper
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: paper
   - type: SolutionContainerManager
-#This should maybe be cellulose later on, refer to the comments in materials.yml on wood.
     solutions:
-      wood:
+      paper:
         reagents:
-        - ReagentId: Carbon
-          Quantity: 2
-        - ReagentId: Oxygen
-          Quantity: 0.5
-        - ReagentId: Hydrogen
-          Quantity: 0.5
+        - ReagentId: Cellulose
+          Quantity: 3
 
 
 - type: entity
@@ -151,7 +148,14 @@
   - type: Item
     heldPrefix: plastic
   - type: Appearance
-
+  - type: Extractable
+    grindableSolutionName: plastic
+  - type: SolutionContainerManager
+    solutions:
+      plastic:
+        reagents:
+        - ReagentId: Carbon
+          Quantity: 10
 - type: entity
   parent: SheetPlastic
   id: SheetPlastic10

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -253,16 +253,16 @@
     - type: Item
       sprite: Objects/Materials/Sheets/meaterial.rsi
       heldPrefix: meat
-  - type: Extractable
-    grindableSolutionName: meatsheet
-  - type: SolutionContainerManager
-    solutions:
-      meatsheet:
-        reagents:
-        - ReagentId: Protein
-          Quantity: 22 #for consistency with other materials
-        - ReagentId: Fat
-          Quantity: 3
+    - type: Extractable
+      grindableSolutionName: meatsheet
+    - type: SolutionContainerManager
+      solutions:
+        meatsheet:
+          reagents:
+          - ReagentId: Protein
+            Quantity: 22 #for consistency with other materials
+          - ReagentId: Fat
+            Quantity: 3
 
 - type: entity
   parent: MaterialSheetMeat

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -253,7 +253,6 @@
     - type: Item
       sprite: Objects/Materials/Sheets/meaterial.rsi
       heldPrefix: meat
-    - type: Appearance
   - type: Extractable
     grindableSolutionName: meatsheet
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -155,7 +155,7 @@
       plastic:
         reagents:
         - ReagentId: Carbon
-          Quantity: 10
+          Quantity: 22
 - type: entity
   parent: SheetPlastic
   id: SheetPlastic10
@@ -254,6 +254,16 @@
       sprite: Objects/Materials/Sheets/meaterial.rsi
       heldPrefix: meat
     - type: Appearance
+  - type: Extractable
+    grindableSolutionName: meatsheet
+  - type: SolutionContainerManager
+    solutions:
+      meatsheet:
+        reagents:
+        - ReagentId: Protein
+          Quantity: 22 #for consistency with other materials
+        - ReagentId: Fat
+          Quantity: 3
 
 - type: entity
   parent: MaterialSheetMeat

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -47,6 +47,14 @@
     - state: cardboard_3
       map: ["base"]
   - type: Appearance
+  - type: Extractable
+    grindableSolutionName: cardboard
+  - type: SolutionContainerManager
+    solutions:
+      cardboard:
+        reagents:
+        - ReagentId: Cellulose
+          Quantity: 6
 
 - type: entity
   parent: MaterialCardboard
@@ -238,17 +246,11 @@
   - type: Extractable
     grindableSolutionName: wood
   - type: SolutionContainerManager
-#Apparently these all components of cellulose, which is what you got in /tg/ when grinding wood + a bunch of other shit.
-#Considering the frequency of it, maybe there should be a cellulose reagent instead?
     solutions:
       wood:
         reagents:
-        - ReagentId: Carbon
+        - ReagentId: Cellulose
           Quantity: 10
-        - ReagentId: Oxygen
-          Quantity: 5
-        - ReagentId: Hydrogen
-          Quantity: 5
 
 - type: entity
   parent: MaterialWoodPlank

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -61,7 +61,7 @@
         - ReagentId: Iron
           Quantity: 3
         - ReagentId: Copper
-          Quantity: 3
+          Quantity: 2
         - ReagentId: Carbon #steel-reinforced
           Quantity: 1
 
@@ -128,7 +128,7 @@
         - ReagentId: Iron
           Quantity: 3
         - ReagentId: Copper
-          Quantity: 3
+          Quantity: 2
 
 - type: entity
   parent: CableMVStack
@@ -192,7 +192,7 @@
         - ReagentId: Iron
           Quantity: 3
         - ReagentId: Copper
-          Quantity: 3
+          Quantity: 2
 
 - type: entity
   parent: CableApcStack

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -98,3 +98,13 @@
         type: Local
         messages: [ "generic-reagent-effect-parched" ]
         probability: 0.1
+
+- type: reagent
+  id: Cellulose
+  name: reagent-name-cellulose
+  group: Biological
+  desc: reagent-desc-cellulose
+  flavor: bitter
+  color: "#E6E6DA"
+  physicalDesc: reagent-physical-desc-crystalline
+  slippery: false


### PR DESCRIPTION
## About the PR
More or less makes the remaining raw materials grindable (paper, cardboard, meat sheets, and plastic). Also changes wood to give cellulose fibers.

Also lowered the amount of copper you get per cable coil per request of Emo.

## Why / Balance
I wasn't really sure what to give cardboard or paper so I just bit the bullet and made them + wood give you cellulose, like in /tg/.
Also, more sources for chems is good.

## Media
![Content Client_S6ntRY5Dpi](https://github.com/space-wizards/space-station-14/assets/78941145/d054bd71-56d1-433a-a7f9-f58fc5ea8a3d)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- add: Added cellulose fibers, which can be obtained from grinding wood, cardboard, or paper. They are not currently used in any reactions yet.
- tweak: Made a few more raw material sheets grindable. Every single material sheet should be grindable now.
