### PR TITLE
Artistic toolbox fill

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -69,19 +69,18 @@
   components:
   - type: StorageFill
     contents:
-      - id: CrayonBox
-      - id: Paper
-      - id: Paper
-      - id: Paper
-      - id: Pen
-      - id: MysteryFigureBox
-        prob: 0.5
-      - id: MysteryFigureBox
-        prob: 0.5
-      - id: BookRandom
-      - id: BookRandom
-      - id: CrayonMime
-      - id: CrayonRainbow
+    - id: CrayonBox
+    - id: Paper
+      amount: 3
+    - id: Pen
+    - id: MysteryFigureBox
+      prob: 0.5
+    - id: MysteryFigureBox
+      prob: 0.5
+    - id: BookRandom
+      amount: 2 
+    - id: CrayonMime
+    - id: CrayonRainbow
 
 - type: entity
   id: ToolboxMechanicalFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -62,6 +62,28 @@
         orGroup: GlovesOrWires
 
 - type: entity
+  id: ToolboxArtisticFilled
+  name: artistic toolbox
+  suffix: Filled
+  parent: ToolboxArtistic
+  components:
+  - type: StorageFill
+    contents:
+      - id: CrayonBox
+      - id: Paper
+      - id: Paper
+      - id: Paper
+      - id: Pen
+      - id: MysteryFigureBox
+        prob: 0.5
+      - id: MysteryFigureBox
+        prob: 0.5
+      - id: BookRandom
+      - id: BookRandom
+      - id: CrayonMime
+      - id: CrayonRainbow
+
+- type: entity
   id: ToolboxMechanicalFilled
   name: mechanical toolbox
   suffix: Filled

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -142,6 +142,7 @@
         - YellowOxygenTankFilled
         - DoubleEmergencyOxygenTankFilled
         - ToolboxEmergencyFilled
+        - ToolboxArtisticFilled
         - NitrogenTankFilled
         - DoubleEmergencyNitrogenTankFilled
         - ToolboxElectricalFilled


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

It was the only toolbox that did not have a filled version and was often mapped empty. Now, it is filled with paper, pens and crayons. In the future, it can also hold other artistic tools like paint or spray cans.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/space-wizards/space-station-14/assets/134914314/7a77744e-392e-414d-acee-b55d427fd7cb)

![image](https://github.com/space-wizards/space-station-14/assets/134914314/17b06a7a-407c-40ef-b511-b9d4a60c90fa)

![image](https://github.com/space-wizards/space-station-14/assets/134914314/90b8418e-d3df-4851-bdbb-9f7ceef7c72d)

**Changelog**

:cl: Ubaser
- tweak: Artistic toolboxes now have a filled variant that can be found in maintenance occasionally.
