### PR TITLE
Adds coal

### DIFF
--- a/Resources/Locale/en-US/materials/materials.ftl
+++ b/Resources/Locale/en-US/materials/materials.ftl
@@ -24,6 +24,7 @@ materials-bananium = bananium
 materials-meat = meat
 materials-web = silk
 materials-bones = bone
+materials-coal = coal
 
 # Material Reclaimer
 material-reclaimer-upgrade-process-rate = process rate

--- a/Resources/Prototypes/Entities/Objects/Decoration/present.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/present.yml
@@ -330,6 +330,8 @@
         orGroup: GiftPool
       - id: Ash
         orGroup: GiftPool
+      - id: Coal1
+        orGroup: GiftPool
       - id: MiningDrill
         orGroup: GiftPool
       - id: CowToolboxFilled

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -218,5 +218,3 @@
   components:
   - type: Stack
     count: 1
-  - type: Item
-    size: 2

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -195,3 +195,28 @@
   components:
   - type: Stack
     count: 1
+
+- type: entity
+  parent: OreBase
+  id: Coal
+  name: coal
+  suffix: Full
+  components:
+  - type: Stack
+    stackType: Coal
+  - type: Sprite
+    state: coal
+  - type: Material
+  - type: PhysicalComposition
+    materialComposition:
+      Coal: 500
+
+- type: entity
+  parent: Coal
+  id: Coal1
+  suffix: Single
+  components:
+  - type: Stack
+    count: 1
+  - type: Item
+    size: 2

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -211,7 +211,7 @@
     grindableSolutionName: coal
   - type: SolutionContainerManager
     solutions:
-      plasma:
+      coal:
         reagents:
         - ReagentId: Carbon
           Quantity: 21

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -215,15 +215,13 @@
         reagents:
         - ReagentId: Carbon
           Quantity: 21
-        - ReagentId: Oxygen
-          Quantity: 1.5
+        - ReagentId: Ammonia
+          Quantity: 2
         - ReagentId: Hydrogen
           Quantity: 1.25
-        - ReagentId: Sulfer
+        - ReagentId: Sulfur
           Quantity: 0.5
-        - ReagentId: Nitrogen
-          Quantity: 0.5
-        - ReagentId: Nitrogen
+        - ReagentId: Mercury
           Quantity: 0.25
   - type: PhysicalComposition
     materialComposition:

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -207,6 +207,24 @@
   - type: Sprite
     state: coal
   - type: Material
+  - type: Extractable
+    grindableSolutionName: coal
+  - type: SolutionContainerManager
+    solutions:
+      plasma:
+        reagents:
+        - ReagentId: Carbon
+          Quantity: 21
+        - ReagentId: Oxygen
+          Quantity: 1.5
+        - ReagentId: Hydrogen
+          Quantity: 1.25
+        - ReagentId: Sulfer
+          Quantity: 0.5
+        - ReagentId: Nitrogen
+          Quantity: 0.5
+        - ReagentId: Nitrogen
+          Quantity: 0.25
   - type: PhysicalComposition
     materialComposition:
       Coal: 500

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -214,15 +214,15 @@
       coal:
         reagents:
         - ReagentId: Carbon
-          Quantity: 21
+          Quantity: 8.4
         - ReagentId: Ammonia
-          Quantity: 2
+          Quantity: 0.8
         - ReagentId: Hydrogen
-          Quantity: 1.25
-        - ReagentId: Sulfur
           Quantity: 0.5
+        - ReagentId: Sulfur
+          Quantity: 0.2
         - ReagentId: Mercury
-          Quantity: 0.25
+          Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
       Coal: 500

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -107,3 +107,11 @@
   icon: { sprite: Objects/Materials/materials.rsi, state: bones }
   color: "#896f5e"
   price: 0
+
+- type: material
+  id: Coal
+  name: materials-coal
+  unit: materials-unit-piece
+  icon: { sprite: Objects/Materials/materials.rsi, state: coal }
+  color: "#404040"
+  price: 0

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -112,6 +112,6 @@
   id: Coal
   name: materials-coal
   unit: materials-unit-piece
-  icon: { sprite: Objects/Materials/materials.rsi, state: coal }
+  icon: { sprite: Objects/Materials/ore.rsi, state: coal }
   color: "#404040"
   price: 0

--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -12,6 +12,7 @@
   completetime: 2
   materials:
     Steel: 3000
+    Coal: 1500
 
 - type: latheRecipe
   id: SheetGlass1
@@ -27,6 +28,7 @@
   completetime: 2
   materials:
     Glass: 3000
+    Coal: 1500
 
 - type: latheRecipe
   id: SheetRGlass
@@ -44,6 +46,7 @@
   materials:
     Glass: 3000
     Steel: 1500
+    Coal: 1500
 
 - type: latheRecipe
   id: SheetPGlass30
@@ -52,6 +55,7 @@
   materials:
     Glass: 3000
     Plasma: 3000
+    Coal: 1500
 
 - type: latheRecipe
   id: SheetRPGlass30
@@ -61,6 +65,7 @@
     Glass: 3000
     Plasma: 3000
     Steel: 1500
+    Coal: 1500
 
 - type: latheRecipe
   id: SheetPlasma30
@@ -68,6 +73,7 @@
   completetime: 2
   materials:
     Plasma: 3000
+    Coal: 1500
 
 - type: latheRecipe
   id: SheetUranium30
@@ -75,20 +81,23 @@
   completetime: 2
   materials:
     Uranium: 3000
-  
+    Coal: 1500
+
 - type: latheRecipe
   id: IngotGold30
   result: IngotGold
   completetime: 2
   materials:
     Gold: 3000
-  
+    Coal: 1500
+
 - type: latheRecipe
   id: IngotSilver30
   result: IngotSilver
   completetime: 2
   materials:
     Silver: 3000
+    Coal: 1500
 
 - type: latheRecipe
   id: MaterialBananium10
@@ -96,7 +105,8 @@
   completetime: 2
   materials:
     Bananium: 3000
-    
+    Coal: 1500
+
 - type: latheRecipe
   id: SheetUranium1
   result: SheetUranium1

--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -12,7 +12,7 @@
   completetime: 2
   materials:
     Steel: 3000
-    Coal: 1500
+    Coal: 1000
 
 - type: latheRecipe
   id: SheetGlass1
@@ -28,7 +28,6 @@
   completetime: 2
   materials:
     Glass: 3000
-    Coal: 1500
 
 - type: latheRecipe
   id: SheetRGlass
@@ -46,7 +45,6 @@
   materials:
     Glass: 3000
     Steel: 1500
-    Coal: 1500
 
 - type: latheRecipe
   id: SheetPGlass30
@@ -55,7 +53,6 @@
   materials:
     Glass: 3000
     Plasma: 3000
-    Coal: 1500
 
 - type: latheRecipe
   id: SheetRPGlass30
@@ -65,7 +62,6 @@
     Glass: 3000
     Plasma: 3000
     Steel: 1500
-    Coal: 1500
 
 - type: latheRecipe
   id: SheetPlasma30
@@ -73,7 +69,6 @@
   completetime: 2
   materials:
     Plasma: 3000
-    Coal: 1500
 
 - type: latheRecipe
   id: SheetUranium30
@@ -81,7 +76,6 @@
   completetime: 2
   materials:
     Uranium: 3000
-    Coal: 1500
 
 - type: latheRecipe
   id: IngotGold30
@@ -89,7 +83,6 @@
   completetime: 2
   materials:
     Gold: 3000
-    Coal: 1500
 
 - type: latheRecipe
   id: IngotSilver30
@@ -97,7 +90,6 @@
   completetime: 2
   materials:
     Silver: 3000
-    Coal: 1500
 
 - type: latheRecipe
   id: MaterialBananium10
@@ -105,7 +97,6 @@
   completetime: 2
   materials:
     Bananium: 3000
-    Coal: 1500
 
 - type: latheRecipe
   id: SheetUranium1

--- a/Resources/Prototypes/Stacks/Materials/ore.yml
+++ b/Resources/Prototypes/Stacks/Materials/ore.yml
@@ -54,3 +54,11 @@
   spawn: BananiumOre1
   maxCount: 30
   itemSize: 2
+
+- type: stack
+  id: Coal
+  name: coal
+  icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: coal }
+  spawn: GoldOre1
+  maxCount: 30
+  itemSize: 2

--- a/Resources/Prototypes/Stacks/Materials/ore.yml
+++ b/Resources/Prototypes/Stacks/Materials/ore.yml
@@ -59,6 +59,6 @@
   id: Coal
   name: coal
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: coal }
-  spawn: GoldOre1
+  spawn: Coal1
   maxCount: 30
   itemSize: 2

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -14,6 +14,10 @@
   id: OreSpaceQuartz
   oreEntity: SpaceQuartz1
 
+- type: ore
+  id: OreCoal
+  oreEntity: Coal1
+
 # Medium yields
 - type: ore
   id: OreGold
@@ -58,6 +62,7 @@
   id: RandomOreDistributionStandard
   weights:
     OreSteel: 10
+    OreCoal: 10
     OreSpaceQuartz: 8
     OreGold: 2
     OrePlasma: 4


### PR DESCRIPTION
## About the PR
- Adds coal material that can be mined from asteroids
- Adjusts bulk steel recipe in the Ore Processor to require coal
- Adds reagent extraction through grinding to produce Carbon, Ammonia, and Hydrogen, along with trace elements of Sulfer and Mercury
- Adds coal to the Xmas present pool

## Why / Balance
- ~~Adds a little bit of depth to mining/ore processing as it makes the processors require a type of fuel.~~
- Adds new resource and method for obtaining useful reagents. 
- Makes a classic funny gift.  

## Technical details
n/a

## Media
Doesn't add any sprites. Coal sprite already existed. 

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**

:cl: Velcroboy
- add: Added coal. Coal has been added to the steel recipe in the Ore Processor. Coal can be ground up for Carbon and other elements. Coal can be mined or received as a gift if you've been naughty.  
