### PR TITLE
Make moth accent regex smarter

### DIFF
--- a/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MothAccentSystem.cs
@@ -16,9 +16,9 @@ public sealed class MothAccentSystem : EntitySystem
         var message = args.Message;
 
         // buzzz
-        message = Regex.Replace(message, "z+", "zzz");
+        message = Regex.Replace(message, "(z{1,3})+", "zzz");
         // buZZZ
-        message = Regex.Replace(message, "Z+", "ZZZ");
+        message = Regex.Replace(message, "(Z{1,3})+", "ZZZ");
         
         args.Message = message;
     }


### PR DESCRIPTION
## About the PR
Moths can buzz longer if they wish.

## Why / Balance
*squeaks!

## Technical details
Treats multiples of up to 3 `z`s as replaceables.
PS: No backreferences. Regex is hell.

## Media
N/A

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
no cl no fun