### PR TITLE
Standardizes / nerfs material sheets to 10u, no more lead in steel sheets

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -81,7 +81,7 @@
       glass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 22
+          Quantity: 10
 
 - type: entity
   parent: SheetGlass
@@ -187,11 +187,11 @@
       rglass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 22
+          Quantity: 10
         - ReagentId: Iron
-          Quantity: 11
+          Quantity: 4.5
         - ReagentId: Carbon
-          Quantity: 1
+          Quantity: 0.5
 
 - type: entity
   parent: SheetGlassBase
@@ -263,7 +263,7 @@
       pglass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 22
+          Quantity: 10
         - ReagentId: Plasma
           Quantity: 10
 
@@ -301,13 +301,13 @@
       rpglass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 22
+          Quantity: 10
         - ReagentId: Plasma
           Quantity: 10
         - ReagentId: Iron
-          Quantity: 11
+          Quantity: 4.5
         - ReagentId: Carbon
-          Quantity: 1
+          Quantity: 0.5
 
 - type: entity
   parent: SheetRPGlass
@@ -379,7 +379,7 @@
       uglass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 22
+          Quantity: 10
         - ReagentId: Uranium
           Quantity: 10
 
@@ -428,13 +428,13 @@
       ruglass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 22
+          Quantity: 10
         - ReagentId: Uranium
           Quantity: 10
         - ReagentId: Iron
-          Quantity: 11
+          Quantity: 4.5
         - ReagentId: Carbon
-          Quantity: 1
+          Quantity: 0.5
 - type: entity
   parent: SheetRUGlass
   id: SheetRUGlass1

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -63,11 +63,9 @@
       steel:
         reagents:
         - ReagentId: Iron
-          Quantity: 22
+          Quantity: 9
         - ReagentId: Carbon
-          Quantity: 2.5
-        - ReagentId: Lead
-          Quantity: 0.5
+          Quantity: 1
 
 - type: entity
   parent: SheetSteel
@@ -136,11 +134,9 @@
         - ReagentId: Plasma
           Quantity: 10
         - ReagentId: Iron
-          Quantity: 22
+          Quantity: 9
         - ReagentId: Carbon
-          Quantity: 2.5
-        - ReagentId: Lead
-          Quantity: 0.5
+          Quantity: 1
 
 - type: entity
   parent: SheetPlasteel

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -154,7 +154,7 @@
     solutions:
       plastic:
         reagents:
-        - ReagentId: Carbon
+        - ReagentId: Oil
           Quantity: 10
 - type: entity
   parent: SheetPlastic

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -155,7 +155,9 @@
       plastic:
         reagents:
         - ReagentId: Oil
-          Quantity: 10
+          Quantity: 5
+        - ReagentID: Phosphorus
+          Quantity: 5
 - type: entity
   parent: SheetPlastic
   id: SheetPlastic10

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -154,9 +154,9 @@
     solutions:
       plastic:
         reagents:
-        - ReagentID: Oil
+        - ReagentId: Oil
           Quantity: 5
-        - ReagentID: Phosphorus
+        - ReagentId: Phosphorus
           Quantity: 5
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -154,10 +154,11 @@
     solutions:
       plastic:
         reagents:
-        - ReagentId: Oil
+        - ReagentID: Oil
           Quantity: 5
         - ReagentID: Phosphorus
           Quantity: 5
+
 - type: entity
   parent: SheetPlastic
   id: SheetPlastic10

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -155,7 +155,7 @@
       plastic:
         reagents:
         - ReagentId: Carbon
-          Quantity: 22
+          Quantity: 10
 - type: entity
   parent: SheetPlastic
   id: SheetPlastic10
@@ -213,7 +213,9 @@
       food:
         reagents:
         - ReagentId: Uranium
-          Quantity: 10
+          Quantity: 8
+        - ReagentId: Radium
+          Quantity: 2
 
 - type: entity
   parent: SheetUranium
@@ -260,7 +262,7 @@
         meatsheet:
           reagents:
           - ReagentId: Protein
-            Quantity: 22 #for consistency with other materials
+            Quantity: 7
           - ReagentId: Fat
             Quantity: 3
 

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -68,9 +68,9 @@
       rod:
         reagents:
         - ReagentId: Iron
-          Quantity: 11
-        - ReagentId: Carbon #Not 1.25 (half of 2.5) because that would probably be really weird
-          Quantity: 1
+          Quantity: 4.5
+        - ReagentId: Carbon
+          Quantity: 0.5
 
 - type: entity
   parent: PartRodMetal

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -107,7 +107,7 @@
       shardglass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 11 #Half of the value of regular glass. TECHNICALLY, welding a single shard of glass gives you the full thing back with just 1 sheet, but that is stupid so I am making it half.
+          Quantity: 5 #Half of the value of regular glass. TECHNICALLY, welding a single shard of glass gives you the full thing back with just 1 sheet, but that is stupid so I am making it half.
 
 - type: entity
   parent: ShardBase
@@ -136,7 +136,7 @@
       shardrglass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 11 #I don't care enough to divide all of the reinforced glass materials by 2 because reinforced glass shards are due for removal anyways.
+          Quantity: 5 #I don't care enough to divide all of the reinforced glass materials by 2 because reinforced glass shards are due for removal anyways.
 
 - type: entity
   parent: ShardBase
@@ -165,7 +165,7 @@
       shardpglass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 11
+          Quantity: 5
         - ReagentId: Plasma
           Quantity: 5
 
@@ -197,6 +197,6 @@
       sharduglass:
         reagents:
         - ReagentId: Silicon
-          Quantity: 11
+          Quantity: 5
         - ReagentId: Uranium
           Quantity: 5


### PR DESCRIPTION
## About the PR
Standardizes all material sheets that were 22u (+ byproducts) down to 10u, byproducts included.
Removes lead from steel sheets.
Grinding plastic now gives you oil instead of carbon.
Also, grinding uranium gives you radium now I guess.

This is untested BUT it should probably be fine since these are just numbers changes.

## Why / Balance
22u was WAY too fucking much for a single material sheet, that's half of an entire beaker for something that comes in 30 per stack. 10u is also easier to work with since it's... well, 10. It's just a good "baseline" for a raw material.

I didn't think I could really fit lead in trace amounts without doing some weird shit like making carbon 0.5u so I just opted to remove it for now. That one killchem is probably going to be unobtainable in the meantime, but it wouldn't be out of the question to add it to something else (like the lead-based maint items from /tg/.)

Plastic now gives you oil and phosphorous because carbon was dumb.
Radium is in Uranium because radium needed a source, simple-as.

**Changelog**
:cl:
- tweak: Standardized all material sheets to 10u of total reagents when grinded. Alloys are still worth the sum of their parts.
- tweak: You can now grind plastic into oil and phosphorous.
- tweak: Steel sheets no longer contain trace amounts of lead in them.