### PR TITLE
Chefs start with pepper packets in their locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -42,6 +42,8 @@
       - id: ReagentContainerSugar
       - id: FoodCondimentPacketSalt
         amount: 3
+      - id: FoodCondimentPacketPepper
+        amount: 3
       - id: FoodCondimentBottleEnzyme
       # really, milk should go in the fridge. Unfortunately saltern only has freezers.
       # yes, I'm using this as an excuse to not have to do extra work.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Salt was a round-start resource which was godsent because many recipes use it. However, when i want to make a baguette and there's no condiment dispenser (only some stations have), i have to give up since there is no way to obtain it.

**Changelog**

:cl: Ubaser
- tweak: Chefs get black pepper packets in their lockers.
