### PR TITLE
Remove white crayon from the art supplies box

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -130,7 +130,6 @@
   - type: StorageFill
     contents:
       - id: CrayonBox
-      - id: CrayonWhite
 
 - type: entity
   id: CrateFunBoardGames


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

It was an oversight on my part when i made the crayon box hold a white crayon on default. No longer do you get a duplicate white crayon in the crate.