### PR TITLE
medibot toctou gaming

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/MedibotInjectOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/MedibotInjectOperator.cs
@@ -16,8 +16,9 @@ namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Specific;
 public sealed partial class MedibotInjectOperator : HTNOperator
 {
     [Dependency] private readonly IEntityManager _entMan = default!;
-    private SharedAudioSystem _audio = default!;
     private ChatSystem _chat = default!;
+    private MedibotSystem _medibot = default!;
+    private SharedAudioSystem _audio = default!;
     private SharedInteractionSystem _interaction = default!;
     private SharedPopupSystem _popup = default!;
     private SolutionContainerSystem _solution = default!;
@@ -31,8 +32,9 @@ public sealed partial class MedibotInjectOperator : HTNOperator
     public override void Initialize(IEntitySystemManager sysManager)
     {
         base.Initialize(sysManager);
-        _audio = sysManager.GetEntitySystem<SharedAudioSystem>();
         _chat = sysManager.GetEntitySystem<ChatSystem>();
+        _medibot = sysManager.GetEntitySystem<MedibotSystem>();
+        _audio = sysManager.GetEntitySystem<SharedAudioSystem>();
         _interaction = sysManager.GetEntitySystem<SharedInteractionSystem>();
         _popup = sysManager.GetEntitySystem<SharedPopupSystem>();
         _solution = sysManager.GetEntitySystem<SolutionContainerSystem>();
@@ -75,8 +77,7 @@ public sealed partial class MedibotInjectOperator : HTNOperator
             return HTNOperatorStatus.Failed;
 
         var state = mobState.CurrentState;
-        var treatment = botComp.Treatments[mobState.CurrentState];
-        if (!treatment.IsValid(total))
+        if (!_medibot.TryGetTreatment(botComp, mobState.CurrentState, out var treatment) || !treatment.IsValid(total))
             return HTNOperatorStatus.Failed;
 
         _entMan.EnsureComponent<NPCRecentlyInjectedComponent>(target);


### PR DESCRIPTION
## About the PR
fix a toctou thing with medibot

## Why / Balance
fixes #22604

## Technical details
on first tick it sees that patient is not dead, so it queues up injection of inaprov
patient then dies and whenever it injects it is dead
just makes it use TryGetTreatment

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun