### PR TITLE
fix ninja draining in no grav

### DIFF
--- a/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
+++ b/Content.Server/Ninja/Systems/BatteryDrainerSystem.cs
@@ -51,6 +51,7 @@ public sealed class BatteryDrainerSystem : SharedBatteryDrainerSystem
         var doAfterArgs = new DoAfterArgs(EntityManager, uid, comp.DrainTime, new DrainDoAfterEvent(), target: target, eventTarget: uid)
         {
             BreakOnUserMove = true,
+            BreakOnWeightlessMove = true, // prevent a ninja on a pod remotely draining it
             MovementThreshold = 0.5f,
             CancelDuplicate = false,
             AttemptFrequency = AttemptFrequency.StartAndEnd


### PR DESCRIPTION
## About the PR
fixes #22562
you can still drain with no grav but if you actually move > 0.5 it will cancel, before you could get on a pod drain the apc then fuck off into space

## Why / Balance
.

## Technical details
1 line change

## Media
hard to screenshot the doafter cancelling but it happen, too lazy to record

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun