### PR TITLE
Mindbreaker hallucinogen

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -325,6 +325,7 @@
         type: Add
         time: 10
         refresh: false
+  # TODO: PROPER hallucinations
 
 - type: reagent
   id: Histamine

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -316,7 +316,15 @@
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 10
-  # TODO hallucinations
+  metabolisms:
+    Poison:
+      effects:
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 10
+        refresh: false
 
 - type: reagent
   id: Histamine


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Mindbreaker was supposed to be hallucinogenic as the "TODO" stated, and we have hallucinogens now so i added it to its effects.

**Changelog**

:cl: Ubaser
- tweak: Mindbreaker is now hallucinogenic.
