### PR TITLE
boxes inherit pilot access

### DIFF
--- a/Content.Server/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Server/CardboardBox/CardboardBoxSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Storage.Components;
 using Content.Server.Storage.EntitySystems;
+using Content.Shared.Access.Components;
 using Content.Shared.CardboardBox;
 using Content.Shared.CardboardBox.Components;
 using Content.Shared.Damage;
@@ -33,7 +34,8 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         SubscribeLocalEvent<CardboardBoxComponent, StorageAfterOpenEvent>(AfterStorageOpen);
         SubscribeLocalEvent<CardboardBoxComponent, StorageBeforeOpenEvent>(BeforeStorageOpen);
         SubscribeLocalEvent<CardboardBoxComponent, StorageAfterCloseEvent>(AfterStorageClosed);
-		SubscribeLocalEvent<CardboardBoxComponent, ActivateInWorldEvent>(OnInteracted);
+        SubscribeLocalEvent<CardboardBoxComponent, GetAdditionalAccessEvent>(OnGetAdditionalAccess);
+        SubscribeLocalEvent<CardboardBoxComponent, ActivateInWorldEvent>(OnInteracted);
         SubscribeLocalEvent<CardboardBoxComponent, InteractedNoHandEvent>(OnNoHandInteracted);
         SubscribeLocalEvent<CardboardBoxComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
         SubscribeLocalEvent<CardboardBoxComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
@@ -41,19 +43,19 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         SubscribeLocalEvent<CardboardBoxComponent, DamageChangedEvent>(OnDamage);
     }
 
-	private void OnInteracted(EntityUid uid, CardboardBoxComponent component, ActivateInWorldEvent args)
+    private void OnInteracted(EntityUid uid, CardboardBoxComponent component, ActivateInWorldEvent args)
     {
-		if (!TryComp<EntityStorageComponent>(uid, out var box))
+        if (!TryComp<EntityStorageComponent>(uid, out var box))
             return;
 
         args.Handled = true;
         _storage.ToggleOpen(args.User, uid, box);
 
-		if (box.Contents.Contains(args.User) && !box.Open)
-		{
-			_mover.SetRelay(args.User, uid);
-			component.Mover = args.User;
-		}
+        if (box.Contents.Contains(args.User) && !box.Open)
+        {
+            _mover.SetRelay(args.User, uid);
+            component.Mover = args.User;
+        }
     }
 
     private void OnNoHandInteracted(EntityUid uid, CardboardBoxComponent component, InteractedNoHandEvent args)
@@ -65,10 +67,17 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         _storage.OpenStorage(uid);
     }
 
+    private void OnGetAdditionalAccess(EntityUid uid, CardboardBoxComponent component, ref GetAdditionalAccessEvent args)
+    {
+        if (component.Mover == null)
+            return;
+        args.Entities.Add(component.Mover.Value);
+    }
+
     private void BeforeStorageOpen(EntityUid uid, CardboardBoxComponent component, ref StorageBeforeOpenEvent args)
     {
-		if (component.Quiet)
-			return;
+        if (component.Quiet)
+            return;
 
         //Play effect & sound
         if (component.Mover != null)
@@ -115,7 +124,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         if (component.Mover == null)
         {
             _mover.SetRelay(args.Entity, uid);
-			component.Mover = args.Entity;
+            component.Mover = args.Entity;
         }
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
makes big cardboard boxes inherit access of their current pilot

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
stealth boxes were basically impossible to use without this
specifically inherits only the pilot's access and not anyone else's so you can't just steal the captain and go into bridge

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
copied from elsewhere and adapted
also fixes cursed indent

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
none, but i have compiled and tested

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Large cardboard boxes and stealth boxes now inherit their mover's access.
