### PR TITLE
add limits to steal objectives

### DIFF
--- a/Content.Server/Objectives/Components/ObjectiveLimitComponent.cs
+++ b/Content.Server/Objectives/Components/ObjectiveLimitComponent.cs
@@ -1,0 +1,20 @@
+using Content.Server.Objectives.Systems;
+
+namespace Content.Server.Objectives.Components;
+
+/// <summary>
+/// Limits the number of traitors that can have the same objective.
+/// Checked by the prototype id, so only considers the exact same objectives.
+/// </summary>
+/// <remarks>
+/// Only works for traitors so don't use for anything else.
+/// </remarks>
+[RegisterComponent, Access(typeof(ObjectiveLimitSystem))]
+public sealed partial class ObjectiveLimitComponent : Component
+{
+    /// <summary>
+    /// Max number of players
+    /// </summary>
+    [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
+    public uint Limit;
+}

--- a/Content.Server/Objectives/Systems/ObjectiveLimitSystem.cs
+++ b/Content.Server/Objectives/Systems/ObjectiveLimitSystem.cs
@@ -1,0 +1,64 @@
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Objectives.Components;
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Components;
+
+public sealed class ObjectiveLimitSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ObjectiveLimitComponent, RequirementCheckEvent>(OnCheck);
+    }
+
+    private void OnCheck(Entity<ObjectiveLimitComponent> ent, ref RequirementCheckEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (Prototype(ent)?.ID is not {} proto)
+        {
+            Log.Error($"ObjectiveLimit used for non-prototyped objective {ent}");
+            return;
+        }
+
+        var remaining = ent.Comp.Limit;
+        // all traitor rules are considered
+        // maybe this would interfere with multistation stuff in the future but eh
+        foreach (var rule in EntityQuery<TraitorRuleComponent>())
+        {
+            foreach (var mindId in rule.TraitorMinds)
+            {
+                if (mindId == args.MindId || !HasObjective(mindId, proto))
+                    continue;
+
+                remaining--;
+
+                // limit has been reached, prevent adding the objective
+                if (remaining == 0)
+                {
+                    args.Cancelled = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the mind has an objective of a certain prototype.
+    /// </summary>
+    public bool HasObjective(EntityUid mindId, string proto, MindComponent? mind = null)
+    {
+        if (!Resolve(mindId, ref mind))
+            return false;
+
+        foreach (var objective in mind.AllObjectives)
+        {
+            if (Prototype(objective)?.ID == proto)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -29,7 +29,7 @@
   - type: Objective
     difficulty: 2.75
   - type: ObjectiveLimit
-    limit: 1 # there is usually only 1 of each steal objective
+    limit: 2 # there is usually only 1 of each steal objective, have 2 max for drama
 
 # state
 
@@ -235,7 +235,7 @@
   - type: NotJobRequirement
     job: HeadOfPersonnel
   - type: ObjectiveLimit
-    limit: 2 # ian only has 2 slices
+    limit: 3 # ian only has 2 slices, 3 obj for drama
   - type: StealCondition
     prototype: FoodMeatCorgi
     owner: objective-condition-steal-Ian

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -232,6 +232,8 @@
   components:
   - type: NotJobRequirement
     job: HeadOfPersonnel
+  - type: ObjectiveLimit
+    limit: 2 # ian only has 2 slices
   - type: StealCondition
     prototype: FoodMeatCorgi
     owner: objective-condition-steal-Ian
@@ -285,6 +287,8 @@
     # it's close to being a stealth loneop
     difficulty: 4
   - type: NotCommandRequirement
+  - type: ObjectiveLimit
+    limit: 1
   - type: StealCondition
     prototype: NukeDisk
     owner: objective-condition-steal-station

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -28,6 +28,8 @@
   components:
   - type: Objective
     difficulty: 2.75
+  - type: ObjectiveLimit
+    limit: 1 # there is usually only 1 of each steal objective
 
 # state
 
@@ -287,8 +289,6 @@
     # it's close to being a stealth loneop
     difficulty: 4
   - type: NotCommandRequirement
-  - type: ObjectiveLimit
-    limit: 1
   - type: StealCondition
     prototype: NukeDisk
     owner: objective-condition-steal-station


### PR DESCRIPTION
## About the PR
ian limited to 3 all others are 2

## Why / Balance
prevent 5 people having disk objective, 2 max for a little bit of conflict but not excessive

## Technical details
it checks all traitors of all rules so wont work with multi station

## Media
monkey 1 can get disk
![14:17:19](https://github.com/space-wizards/space-station-14/assets/39013340/0c231c99-68ea-4a68-94bc-96808825aa50)

monkey 2 cant
![14:18:41](https://github.com/space-wizards/space-station-14/assets/39013340/f654eef9-473c-4c38-b058-ab91e6299901)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Traitor steal objectives are limited to 1 player per available item. Corgi meat has 2 slices, so that gets 2 players maximum.
