### PR TITLE
make suit slot (gas tank slot) only depend on jumpsuit

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
@@ -129,5 +129,5 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
+      dependsOn: jumpsuit
       displayName: Suit Storage

--- a/Resources/Prototypes/InventoryTemplates/corpse_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/corpse_inventory_template.yml
@@ -80,7 +80,7 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
+      dependsOn: jumpsuit
       displayName: Suit Storage
     - name: belt
       slotTexture: belt

--- a/Resources/Prototypes/InventoryTemplates/diona_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/diona_inventory_template.yml
@@ -81,7 +81,7 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
+      dependsOn: jumpsuit
       displayName: Suit Storage
     - name: id
       slotTexture: id

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -87,7 +87,7 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
+      dependsOn: jumpsuit
       displayName: Suit Storage
     - name: id
       slotTexture: id

--- a/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
@@ -49,7 +49,7 @@
     stripTime: 3
     uiWindowPos: 2,0
     strippingWindowPos: 2,5
-    dependsOn: outerClothing
+    dependsOn: jumpsuit
     displayName: Suit Storage
   - name: outerClothing
     slotTexture: suit


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Now gas tanks can be equipped without outer clothing (e.g. coat).

## Why / Balance
It doesn't make sense that someone can't strap a gas tank over jumpsuit.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/74560659/f92408fd-1525-4a74-8db3-c19b7a337c68)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: gas tanks (and etc.) can now be put in suit slot without outer clothing!

