### PR TITLE
Tiny 1x1 Zipties

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -63,6 +63,9 @@
   id: Zipties
   parent: Handcuffs
   components:
+  - type: Item
+    size: Tiny
+    storedRotation: 0
   - type: Handcuff
     breakoutTime: 20  # halfway between improvised cablecuffs and metal ones
     cuffedRSI: Objects/Misc/cablecuffs.rsi  # cablecuffs will look fine


### PR DESCRIPTION
## About the PR
Zipties are now 1x1 (tiny) and no longer rotated 90 degrees. This does not affect makeshift handcuffs as due to them being makeshift, they aren't as compact and space efficient.

## Why / Balance
Zipties have absolutely no real upsides currently compared to standard cuffs. They take up the same space as cuffs, take the same time to cuff (against popular belief), are easier to escape from (20s vs 30s), and cannot be reused. You not being able to reuse them is a semi-upside however since neither can the person you cuff if they escape.

## Media

![image](https://github.com/space-wizards/space-station-14/assets/140123969/b2b05e4e-0553-4600-89a8-5bde02fd7f45)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Alzore
- tweak: Security zipties are now tiny and easier to store.
