### PR TITLE
structural damage rework / melee damage curve flattening

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -74,6 +74,12 @@
     Telecrystal: 10
   categories:
   - UplinkWeapons
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
+      - TraitorUplink
 
 - type: listing
   id: UplinkGlovesNorthStar
@@ -100,6 +106,7 @@
       blacklist:
         tags:
           - NukeOpsUplink
+          - TraitorUplink
 
 - type: listing
   id: UplinkDisposableTurret
@@ -551,7 +558,7 @@
     Telecrystal: 3
   categories:
   - UplinkUtility
-  
+
 # Implants
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -66,22 +66,6 @@
   - UplinkWeapons
 
 - type: listing
-  id: UplinkFireAxeFlaming
-  name: uplink-fire-axe-flaming-name
-  description: uplink-fire-axe-flaming-desc
-  productEntity: FireAxeFlaming
-  cost:
-    Telecrystal: 10
-  categories:
-  - UplinkWeapons
-  conditions:
-  - !type:StoreWhitelistCondition
-    blacklist:
-      tags:
-      - NukeOpsUplink
-      - TraitorUplink
-
-- type: listing
   id: UplinkGlovesNorthStar
   name: uplink-gloves-north-star-name
   description: uplink-gloves-north-star-desc
@@ -90,23 +74,6 @@
     Telecrystal: 8
   categories:
   - UplinkWeapons
-
-- type: listing
-  id: UplinkEswordDouble
-  name: uplink-esword-double-name
-  description: uplink-esword-double-desc
-  icon: { sprite: /Textures/Objects/Weapons/Melee/e_sword_double.rsi, state: icon }
-  productEntity: EnergySwordDouble
-  cost:
-    Telecrystal: 20 #(Originally 16)
-  categories:
-  - UplinkWeapons
-  conditions:
-    - !type:StoreWhitelistCondition
-      blacklist:
-        tags:
-          - NukeOpsUplink
-          - TraitorUplink
 
 - type: listing
   id: UplinkDisposableTurret

--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -14,7 +14,15 @@
   supportedTypes:
     - Heat
     - Shock
-    - Structural # this probably should be in separate container
+
+- type: damageContainer
+  id: StructuralInorganic
+  supportedGroups:
+  - Brute
+  supportedTypes:
+  - Heat
+  - Shock
+  - Structural
 
 - type: damageContainer
   id: Silicon

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -89,10 +89,10 @@
     Heat: 0.5
     Shock: 0
   flatReductions:
-    Blunt: 10
-    Slash: 10
-    Piercing: 10
-    Heat: 10
+    Blunt: 5
+    Slash: 7
+    Piercing: 5
+    Heat: 5
     Structural: 12.5
 
 - type: damageModifierSet

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -10,6 +10,17 @@
     Heat: 5
 
 - type: damageModifierSet
+  id: StructuralMetallic
+  coefficients:
+    Shock: 1.2
+  flatReductions:
+    Blunt: 25
+    Slash: 25
+    Piercing: 25
+    Heat: 25
+    Structural: 40
+
+- type: damageModifierSet
   id: PerforatedMetallic
   coefficients:
     Blunt: 2
@@ -64,22 +75,25 @@
     Heat: 0.8
     Shock: 0 #glass is an insulator!
   flatReductions:
-    Blunt: 5
     Slash: 5
+    Piercing: 5
+    Heat: 5
+    Structural: 10
 
 - type: damageModifierSet
   id: RGlass
   coefficients:
-    Blunt: 1.0
+    Blunt: 0.5
     Slash: 0.3
     Piercing: 0.6
     Heat: 0.5
     Shock: 0
   flatReductions:
-    Blunt: 5
-    Slash: 7
-    Piercing: 5
-    Heat: 5
+    Blunt: 10
+    Slash: 10
+    Piercing: 10
+    Heat: 10
+    Structural: 12.5
 
 - type: damageModifierSet
   id: Wood

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -163,9 +163,6 @@
     interfaces:
     - key: enum.StoreUiKey.Key
       type: StoreBoundUserInterface
-  - type: Tag
-    tags:
-    - TraitorUplink
 
 - type: entity
   parent: BaseSubdermalImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -163,6 +163,9 @@
     interfaces:
     - key: enum.StoreUiKey.Key
       type: StoreBoundUserInterface
+  - type: Tag
+    tags:
+    - TraitorUplink
 
 - type: entity
   parent: BaseSubdermalImplant

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -81,6 +81,9 @@
     preset: StorePresetUplink
     balance:
       Telecrystal: 20
+  - type: Tag
+    tags:
+    - TraitorUplink
 
 - type: entity
   parent: BaseUplinkRadio
@@ -91,6 +94,9 @@
     preset: StorePresetUplink
     balance:
       Telecrystal: 25
+  - type: Tag
+    tags:
+    - TraitorUplink
 
 #this uplink MUST be used for nukeops, as it has the tag for filtering the listing.
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -81,9 +81,6 @@
     preset: StorePresetUplink
     balance:
       Telecrystal: 20
-  - type: Tag
-    tags:
-    - TraitorUplink
 
 - type: entity
   parent: BaseUplinkRadio
@@ -94,9 +91,6 @@
     preset: StorePresetUplink
     balance:
       Telecrystal: 25
-  - type: Tag
-    tags:
-    - TraitorUplink
 
 #this uplink MUST be used for nukeops, as it has the tag for filtering the listing.
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -155,7 +155,7 @@
     damage:
       types:
         Blunt: 8
-        Structural: 3
+        Structural: 15
   - type: Tool
     qualities:
       - Prying
@@ -337,7 +337,7 @@
     attackRate: 1.5
     damage:
       types:
-        Piercing: 8
+        Piercing: 10
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
 

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -155,7 +155,6 @@
     damage:
       types:
         Blunt: 8
-        Structural: 15
   - type: Tool
     qualities:
       - Prying

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -12,11 +12,13 @@
     damage:
       types:
         Blunt: 10
+        Structural: 5
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 8
+        Blunt: 5
+        Structural: 10
   - type: Item
     size: Normal
   - type: Tool

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
@@ -27,9 +27,8 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Slash: 5
-        Blunt: 5
-        Structural: 20
+        Slash: 10
+        Structural: 10
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/chainsaw.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
@@ -37,7 +37,7 @@
     attackRate: 0.75
     damage:
       types:
-        Slash: 33
+        Slash: 16
   - type: Item
     size: Normal
   - type: Clothing
@@ -65,15 +65,15 @@
     damage:
       types:
         Blunt: 10
-        Slash: 20
-        Structural: 3
+        Slash: 10
+        Structural: 5
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 4
-        Slash: 12
-        Structural: 30
+        Blunt: 5
+        Slash: 5
+        Structural: 10
   - type: Item
     size: Ginormous
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -7,9 +7,9 @@
   - type: EnergySword
     litDamageBonus:
         types:
-            Slash: 15
-            Heat: 15
-            Structural: 4
+            Slash: 10
+            Heat: 10
+            Structural: 20
             Blunt: -4.5
     litDisarmMalus: 0.6
   - type: Sprite
@@ -66,8 +66,8 @@
     secret: true
     litDamageBonus:
         types:
-            Slash: 9
-            Heat: 9
+            Slash: 7
+            Heat: 8
             Blunt: -1
     litDisarmMalus: 0.4
     activateSound: !type:SoundPathSpecifier
@@ -149,8 +149,8 @@
     secret: true
     litDamageBonus:
         types:
-            Slash: 7.5
-            Heat: 7.5
+            Slash: 10
+            Heat: 12
             Blunt: -1
     litDisarmMalus: 0.6
   - type: Sprite
@@ -176,9 +176,9 @@
   - type: EnergySword
     litDamageBonus:
         types:
-            Slash: 17
-            Heat: 17
-            Structural: 20
+            Slash: 12
+            Heat: 12
+            Structural: 15
             Blunt: -4.5
     litDisarmMalus: 0.7
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -7,8 +7,8 @@
   - type: EnergySword
     litDamageBonus:
         types:
-            Slash: 10
-            Heat: 10
+            Slash: 15
+            Heat: 15
             Structural: 20
             Blunt: -4.5
     litDisarmMalus: 0.6
@@ -66,8 +66,8 @@
     secret: true
     litDamageBonus:
         types:
-            Slash: 7
-            Heat: 8
+            Slash: 10
+            Heat: 10
             Blunt: -1
     litDisarmMalus: 0.4
     activateSound: !type:SoundPathSpecifier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -19,15 +19,14 @@
       types:
         # axes are kinda like sharp hammers, you know?
         Blunt: 5
-        Slash: 13
-        Structural: 7
+        Slash: 10
+        Structural: 10
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 2.5
-        Slash: 10.5
-        Structural: 60
+        Slash: 10
+        Structural: 40
   - type: Item
     size: Ginormous
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/gohei.yml
@@ -11,7 +11,7 @@
     wideAnimationRotation: -150
     damage:
       types:
-        Blunt: 3 #You'd be better off punching people
+        Blunt: 0
   - type: Item
     size: Small
     sprite: Objects/Weapons/Melee/gohei.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -15,7 +15,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Slash: 12
+        Slash: 10
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Sprite
@@ -62,7 +62,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 10
+        Slash: 13
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/cleaver.rsi
@@ -88,7 +88,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 10
+        Slash: 12
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
   - type: DamageOtherOnHit

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -77,7 +77,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 6.5
+        Slash: 12
   - type: Tag
     tags:
     - Knife

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -16,8 +16,6 @@
     damage:
       groups:
         Brute: 5
-      types:
-        Structural: 10
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
@@ -10,13 +10,13 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 14
-        Structural: 15
+        Blunt: 10
+        Structural: 10
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
         Blunt: 10
-        Structural: 60
+        Structural: 10
   - type: Item
     size: Large

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -45,7 +45,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Slash: 25
+        Slash: 15
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item
@@ -101,7 +101,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Slash: 20
+        Slash: 15
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item
@@ -124,7 +124,7 @@
     attackRate: 0.75
     damage:
       types:
-        Slash: 33
+        Slash: 20
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -107,8 +107,8 @@
     resistance: 3
   - type: Occluder
   - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -82,8 +82,8 @@
     fixVacuum: true
   - type: Occluder
   - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
+    damageContainer: StructuralInorganic
+    damageModifierSet: StrongMetallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -25,7 +25,7 @@
   - type: RadiationBlocker
     resistance: 8
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: StrongMetallic
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -62,8 +62,8 @@
   - type: RadiationBlocker
     resistance: 2
   - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
+    damageContainer: StructuralInorganic
+    damageModifierSet: StrongMetallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -56,8 +56,8 @@
     placeCentered: true
     isPlaceable: false
   - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -101,8 +101,8 @@
       map: ["enum.StorageVisualLayers.Lock"]
       shader: unshaded
   - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: StrongMetallic
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -28,8 +28,8 @@
   - type: PlacementReplacement
     key: walls
   - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -506,13 +506,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 1200 #excess damage (nuke?). avoid computational cost of spawning entities.
+        damage: 600
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
-        damage: 600
+        damage: 400
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -677,7 +677,7 @@
     state: state0
   - type: Damageable
     damageContainer: Inorganic
-    damageModifierSet: StrongMetallic
+    damageModifierSet: StructuralMetallic
   - type: Physics
     bodyType: Static
   - type: Reflect
@@ -795,13 +795,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 600
+        damage: 400
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 200
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Structures/Windows/mining.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/mining.yml
@@ -12,19 +12,19 @@
     fuelCost: 15
     doAfterDelay: 3
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 1000
+        damage: 200
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 500
+        damage: 100
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -9,13 +9,19 @@
   - type: Icon
     sprite: Structures/Windows/plasma_window.rsi
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 120
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 60
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -12,19 +12,19 @@
     fuelCost: 10
     doAfterDelay: 2
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300 #excess damage (nuke?). Avoid computational cost of spawning entities.
+        damage: 150
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 75
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -9,7 +9,7 @@
   - type: Icon
     sprite: Structures/Windows/reinforced_plasma_window.rsi
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: RGlass
   - type: RadiationBlocker
     resistance: 4
@@ -17,13 +17,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 1000
+        damage: 200
       behaviors: #excess damage, don't spawn entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 600
+        damage: 100
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -9,19 +9,19 @@
   - type: Icon
     sprite: Structures/Windows/reinforced_uranium_window.rsi
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 1500
-      behaviors: #excess damage, don't spawn entities.
+        damage: 200
+      behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 850
+        damage: 100
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -12,7 +12,7 @@
     fuelCost: 15
     doAfterDelay: 3
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: RGlass
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
@@ -10,13 +10,19 @@
     sprite: Structures/Windows/uranium_window.rsi
     state: full
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 400
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -38,7 +38,7 @@
         layer:
         - GlassLayer
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: Glass
   - type: ExaminableDamage
     messages: WindowMessages
@@ -47,7 +47,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 150 #excess damage (nuke?). avoid computational cost of spawning entities.
+        damage: 100
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Structures/barricades.yml
+++ b/Resources/Prototypes/Entities/Structures/barricades.yml
@@ -28,7 +28,7 @@
         - WallLayer
   - type: Damageable
     damageModifierSet: Wood
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
   - type: Destructible
     thresholds:
     - trigger:
@@ -43,7 +43,7 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: AtmosExposed
-  
+
 #Regular Barricade
 - type: entity
   id: Barricade

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -27,7 +27,7 @@
         layer:
         - MidImpassable
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: Metallic
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -93,7 +93,7 @@
       Heat: 12
       Blunt: 12
       Piercing: 12
-      Structural: 40
+      Structural: 30
   tileBreakChance: [ 0, 0.5, 1 ]
   tileBreakIntensity: [ 1, 5, 10 ]
   tileBreakRerollReduction: 3
@@ -109,7 +109,7 @@
       Heat: 15
       Blunt: 15
       Piercing: 6
-      Structural: 15
+      Structural: 40
   tileBreakChance: [ 0.75, 0.95, 1 ]
   tileBreakIntensity: [ 1, 10, 15 ]
   tileBreakRerollReduction: 30

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1072,9 +1072,6 @@
   id: TrashBag
 
 - type: Tag
-  id: TraitorUplink
-
-- type: Tag
   id: Unstackable # To prevent things like atmos devices (filters etc) being stacked on one tile. See NoUnstackableInTile
 
 - type: Tag

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1072,6 +1072,9 @@
   id: TrashBag
 
 - type: Tag
+  id: TraitorUplink
+
+- type: Tag
   id: Unstackable # To prevent things like atmos devices (filters etc) being stacked on one tile. See NoUnstackableInTile
 
 - type: Tag


### PR DESCRIPTION
makes walls almost impervious to weapons
windows are generally weaker
structures now use a new damage container and walls now use a new modifier set to make them strong against weapons
secure crates/lockers are now stronger and will no longer be busted open by crowbars
powercrept melee weapons have been brought down
dblade and syndi fireaxe are now unavailable

🆑 
- tweak: Walls are stronger and windows are weaker.
- tweak: Secure crates and lockers are a lot stronger.
- tweak: Melee weapons are now more balanced within a closer range of damage.
- tweak: Double energy sword and fireaxe are now unavailable in uplink.
