### PR TITLE
Makes external & shuttle airlocks bump-openable

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -2,10 +2,9 @@
   parent: Airlock
   id: AirlockExternal
   suffix: External
-  description: It opens, it closes, it might crush you, and there might be only space behind it. Has to be manually activated.
+  description: It opens, it closes, it might crush you, and there might be only space behind it.
   components:
   - type: Door
-    bumpOpen: false
     crushDamage:
       types:
         Blunt: 15

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -45,7 +45,6 @@
   - type: Wires
     layoutId: Docking
   - type: Door
-    bumpOpen: false
     closeTimeTwo: 0.4
     openTimeTwo: 0.4
     crushDamage:


### PR DESCRIPTION
## About the PR
Makes external airlocks and shuttle airlocks able to be opened by bumping, like all other airlocks.

This is untested but the component is pretty obviously named so I'm at least a little confident it will work, assuming tests don't fail.

## Why / Balance
Unnessecarry and really damn obnoxious; we have cycling airlocks now, and most shuttles have tiny fans on their external airlocks anyways. Instaspacing has also been gone for ages, so any airlock incidents will end up being pretty ignorable most of the time, especially considering tiles are no longer instantly ripped up when exposed to the vaccuum.

Also happens to be an accessibility issue for at least one person in the discord, which happened to be the main prompter for this PR. This does not really hold that much weight on its own, but considering this feature is already incredibly obnoxious as-is, I figured I might as well do it.

**Changelog**
:cl:
- tweak: You can now walk into external and shuttle airlocks to open them, like all other airlocks.
