### PR TITLE
Fix item size misinterpretation

### DIFF
--- a/Resources/Locale/en-US/items/components/item-component.ftl
+++ b/Resources/Locale/en-US/items/components/item-component.ftl
@@ -6,7 +6,7 @@ pick-up-verb-get-data-text = Pick Up
 
 pick-up-verb-get-data-text-inventory = Put in hand
 
-item-component-on-examine-size = This is {INDEFINITE($size)} [bold]{$size}[/bold] item.
+item-component-on-examine-size = This is {INDEFINITE($size)} [bold]{$size}-sized[/bold] item.
 
 item-component-size-Tiny = tiny
 item-component-size-Small = small

--- a/Resources/Locale/en-US/items/components/item-component.ftl
+++ b/Resources/Locale/en-US/items/components/item-component.ftl
@@ -6,11 +6,11 @@ pick-up-verb-get-data-text = Pick Up
 
 pick-up-verb-get-data-text-inventory = Put in hand
 
-item-component-on-examine-size = This is {INDEFINITE($size)} [bold]{$size}-sized[/bold] item.
+item-component-on-examine-size = This is {INDEFINITE($size)} [bold]{$size}[/bold] item.
 
 item-component-size-Tiny = tiny
 item-component-size-Small = small
-item-component-size-Normal = normal
+item-component-size-Normal = medium
 item-component-size-Large = large
 item-component-size-Huge = huge
 item-component-size-Ginormous = ginormous


### PR DESCRIPTION
## About the PR
An item description as "This is a normal item." could be misinterpreted as the items rarity instead of its size.
This PR changes so it now reads "This is a normal-sized item.". Also suffixes all other sizes with "-sized".

Edit:
PR now only changes "normal" over to "medium".

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- fix: Item size cannot be misinterpreted now.
