### PR TITLE
Hardsuit and EVA helmets allow using internals without a mask

### DIFF
--- a/Content.Server/Atmos/Components/BreathToolComponent.cs
+++ b/Content.Server/Atmos/Components/BreathToolComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Atmos.Components
         /// Tool is functional only in allowed slots
         /// </summary>
         [DataField("allowedSlots")]
-        public SlotFlags AllowedSlots = SlotFlags.MASK;
+        public SlotFlags AllowedSlots = SlotFlags.MASK | SlotFlags.HEAD;
         public bool IsFunctional;
         public EntityUid? ConnectedInternalsEntity;
     }

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -34,7 +34,7 @@ public sealed class LungSystem : EntitySystem
     private void OnGotEquipped(EntityUid uid, BreathToolComponent component, GotEquippedEvent args)
     {
 
-        if ((args.SlotFlags & component.AllowedSlots) != component.AllowedSlots) return;
+        if ((args.SlotFlags & component.AllowedSlots) == 0) return;
         component.IsFunctional = true;
 
         if (TryComp(args.Equipee, out InternalsComponent? internals))

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -5,6 +5,7 @@
   name: EVA helmet
   description: An old-but-gold helmet designed for extravehicular activites. Infamous for making security officers paranoid.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Helmets/eva.rsi
   - type: Clothing
@@ -21,6 +22,7 @@
   name: EVA helmet
   description: An old-but-gold helmet designed for extravehicular activites.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Helmets/eva_large.rsi
   - type: Clothing
@@ -33,6 +35,7 @@
   name: syndicate EVA helmet
   description: A simple, stylish EVA helmet. Designed for maximum humble space-badassery.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Helmets/eva_syndicate.rsi
   - type: Clothing
@@ -45,6 +48,7 @@
   name: cosmonaut helmet
   description: Ancient design, but advanced manufacturing. #Description here originally started with " A deceptively well armored space helmet." Potentially had armor values in SS13 that weren't brought over?
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Helmets/cosmonaut.rsi
   - type: Clothing
@@ -57,6 +61,7 @@
   name: Paramedic Void Helmet
   description: A void helmet made for paramedics.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Helmets/paramedhelm.rsi
   - type: Clothing
@@ -77,6 +82,7 @@
   name: NTSRA void helmet
   description: An ancient space helmet, designed by the NTSRA branch of CentCom.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Helmets/ancientvoidsuit.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -12,6 +12,7 @@
   name: basic hardsuit helmet
   description: A basic-looking hardsuit helmet that provides minor protection against most sources of damage.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/basic.rsi
   - type: Clothing
@@ -24,6 +25,7 @@
   name: atmos hardsuit helmet
   description: A special hardsuit helmet designed for working in low-pressure, high thermal environments.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/atmospherics.rsi
     layers:
@@ -63,6 +65,7 @@
   name: engineering hardsuit helmet
   description: An engineering hardsuit helmet designed for working in low-pressure, high radioactive environments.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/engineering.rsi
   - type: Clothing
@@ -80,6 +83,7 @@
   name: spationaut hardsuit helmet
   description: A sturdy helmet designed for complex industrial operations in space.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/spatiohelm.rsi
     layers:
@@ -114,6 +118,7 @@
   name: salvage hardsuit helmet
   description: A special helmet designed for work in a hazardous, low pressure environment. Has reinforced plating for wildlife encounters and dual floodlights.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/salvage.rsi
   - type: Clothing
@@ -132,6 +137,7 @@
   name: security hardsuit helmet
   description: Armored hardsuit helmet for security needs.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/security.rsi
   - type: Clothing
@@ -156,6 +162,7 @@
   name: brigmedic hardsuit helmet
   description: The lightweight helmet of the brigmedic hardsuit. Protects against viruses, and clowns.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/brigmedic.rsi
   - type: Clothing
@@ -182,6 +189,7 @@
   name: warden's hardsuit helmet
   description: A modified riot helmet. Oddly comfortable.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/security-warden.rsi
   - type: Clothing
@@ -206,6 +214,7 @@
   name: captain's hardsuit helmet
   description: Special hardsuit helmet, made for the captain of the station.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/capspace.rsi
   - type: Clothing
@@ -221,6 +230,7 @@
   name: chief engineer's hardsuit helmet
   description: Special hardsuit helmet, made for the chief engineer of the station.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/engineering-white.rsi
   - type: Clothing
@@ -238,6 +248,7 @@
   name: chief medical officer's hardsuit helmet
   description: Lightweight medical hardsuit helmet that doesn't restrict your head movements.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/medical.rsi
   - type: Clothing
@@ -255,6 +266,7 @@
   name: experimental research hardsuit helmet
   description: Lightweight hardsuit helmet that doesn't restrict your head movements.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/rd.rsi
   - type: Clothing
@@ -272,6 +284,7 @@
   name: head of security's hardsuit helmet
   description: Security hardsuit helmet with the latest top secret NT-HUD software. Belongs to the HoS.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/security-red.rsi
   - type: Clothing
@@ -296,6 +309,7 @@
   name: luxury mining hardsuit helmet
   description: A refurbished mining hardsuit helmet, fitted with satin cushioning and an extra (non-functioning) antenna, because you're that extra.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/luxury.rsi
   - type: Clothing
@@ -315,6 +329,7 @@
   name: blood-red hardsuit helmet
   description: A heavily armored helmet designed for work in special operations. Property of Gorlex Marauders.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
   - type: Clothing
@@ -339,6 +354,7 @@
   name: blood-red medic hardsuit helmet
   description: An advanced red hardsuit helmet specifically designed for field medic operations.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
   - type: Clothing
@@ -363,6 +379,7 @@
   name: syndicate elite helmet
   description: An elite version of the blood-red hardsuit's helmet, with improved armor and fireproofing. Property of Gorlex Marauders.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
   - type: Clothing
@@ -389,6 +406,7 @@
   name: syndicate commander helmet
   description: A bulked up version of the blood-red hardsuit's helmet, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
   - type: Clothing
@@ -413,6 +431,7 @@
   name: cybersun juggernaut helmet
   description: Made of compressed red matter, this helmet was designed in the Tau chromosphere facility.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/cybersun.rsi
   - type: Clothing
@@ -435,6 +454,7 @@
   name: wizard hardsuit helmet
   description: A bizarre gem-encrusted helmet that radiates magical energies.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/wizard.rsi
   - type: Clothing
@@ -459,6 +479,7 @@
   name: organic space helmet
   description: A spaceworthy biomass of pressure and temperature resistant tissue.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/lingspacehelmet.rsi
   - type: Clothing
@@ -475,6 +496,7 @@
   suffix: Pirate
   description: A deep space EVA helmet, very heavy but provides good protection.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/pirateeva.rsi
   - type: Clothing
@@ -491,6 +513,7 @@
   suffix: Pirate
   description: A special hardsuit helmet, made for the captain of a pirate ship.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/piratecaptainhelm.rsi
   - type: Clothing
@@ -507,6 +530,7 @@
   name: ERT leader hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertleader.rsi
   - type: Clothing
@@ -528,6 +552,7 @@
   name: ERT engineer hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertengineer.rsi
   - type: Clothing
@@ -549,6 +574,7 @@
   name: ERT medic hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertmedical.rsi
   - type: Clothing
@@ -563,6 +589,7 @@
   name: ERT security hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertsecurity.rsi
   - type: Clothing
@@ -584,6 +611,7 @@
   name: ERT janitor hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertjanitor.rsi
   - type: Clothing
@@ -598,6 +626,7 @@
   name: CBURN exosuit helmet
   description: A pressure resistant and fireproof hood worn by special cleanup units.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/cburn.rsi
     layers:
@@ -636,6 +665,7 @@
   name: deathsquad hardsuit helmet
   description: A robust helmet for special operations.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/deathsquad.rsi
   - type: Clothing
@@ -661,6 +691,7 @@
   name: clown hardsuit helmet
   description: A clown hardsuit helmet.
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/clown.rsi
   - type: Clothing


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Hardsuit and EVA helmets now allow you to use internals without a mask, because they're airtight. Has been tested.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
If a helmet is airtight enough to hold air in a vaccuum, it's definitely airtight enough to use internals with. It's kinda weird that you still need a mask even in a full space suit.

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: EVA and hardsuit helmets now allow breathing from gas tanks without a mask.