### PR TITLE
Remove RCD from tech and make it a crate

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/engineering-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/engineering-crates.ftl
@@ -33,3 +33,9 @@ ent-CrateAirlockKit = Airlock kit
 
 ent-CrateEvaKit = EVA kit
     .desc = A set consisting of two prestigious EVA suits and helmets.
+
+ent-CrateRCDAmmo = RCD ammo crate
+    .desc = 3 RCD ammo, each restoring 5 charges.
+
+ent-CrateRCD = RCD crate
+    .desc = A crate containing a single Rapid Construction Device.

--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -12,7 +12,6 @@ research-technology-compact-power = Compact Power
 research-technology-industrial-engineering = Industrial Engineering
 research-technology-power-generation = Power Generation
 research-technology-atmospheric-tech = Atmospherics
-research-technology-rapid-construction = Rapid Construction
 research-technology-shuttlecraft = Shuttlecraft
 research-technology-ripley-aplu = Ripley APLU
 research-technology-advanced-atmospherics = Advanced Atmospherics

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -87,3 +87,23 @@
   cost: 5000
   category: Engineering
   group: market
+
+- type: cargoProduct
+  id: EngineeringRCDAmmo
+  icon:
+    sprite: Objects/Tools/rcd.rsi
+    state: icon
+  product: CrateRCDAmmo
+  cost: 2500
+  category: Engineering
+  group: market
+
+- type: cargoProduct
+  id: EngineeringRCD
+  icon:
+    sprite: Objects/Tools/rcd.rsi
+    state: ammo
+  product: CrateRCD
+  cost: 800
+  category: Engineering
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
@@ -127,3 +127,20 @@
         amount: 2
       - id: ClothingOuterHardsuitEVA
         amount: 2
+
+- type: entity
+  id: CrateRCDAmmo
+  parent: CrateEngineering
+  components:
+  - type: StorageFill
+    contents:
+    - id: RCDAmmo
+      amount: 3
+
+- type: entity
+  id: CrateRCD
+  parent: CrateEngineeringSecure
+  components:
+  - type: StorageFill
+    contents:
+    - id: RCD

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -210,8 +210,6 @@
       - AnomalyScanner
       - AnomalyLocator
       - AnomalyLocatorWide
-      - RCD
-      - RCDAmmo
       - HandheldCrewMonitor
       - Scalpel
       - Retractor

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -123,20 +123,6 @@
   - BorgModuleGrapplingGun
 
 - type: technology
-  id: RapidConstruction
-  name: research-technology-rapid-construction
-  icon:
-    sprite: Objects/Tools/rcd.rsi
-    state: icon
-  discipline: Industrial
-  tier: 2
-  cost: 10000
-  recipeUnlocks:
-  - RCD
-  - RCDAmmo
-  - BorgModuleRCD
-
-- type: technology
   id: Shuttlecraft
   name: research-technology-shuttlecraft
   icon:
@@ -193,6 +179,7 @@
     - PowerDrill
     - JawsOfLife
     - BorgModuleAdvancedTool
+    - BorgModuleRCD
 
 # Tier 3
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
RCD is roundstart which means making it t2 tech feels like a gut punch.
This moves it and the ammo to a crate so cargo actually has something nifty that engies will want.

Removes the lathe recipes because they're obsolete in the face of this.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Roundstart tools should have roundstart resupplying.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added the RCD and RCD ammo crates to cargo.