### PR TITLE
Consistent Absorbent System behavior

### DIFF
--- a/Content.IntegrationTests/Tests/Fluids/AbsorbentTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/AbsorbentTest.cs
@@ -1,0 +1,344 @@
+using Content.Server.Fluids.EntitySystems;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Fluids;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Content.IntegrationTests.Tests.Fluids;
+
+[TestFixture]
+[TestOf(typeof(AbsorbentComponent))]
+public sealed class AbsorbentTest
+{
+    private const string UserDummyId = "UserDummy";
+    private const string AbsorbentDummyId = "AbsorbentDummy";
+    private const string RefillableDummyId = "RefillableDummy";
+    private const string SmallRefillableDummyId = "SmallRefillableDummy";
+
+    private const string EvaporablePrototypeId = "Water";
+    private const string NonEvaporablePrototypeId = "Cola";
+
+    [TestPrototypes]
+    private const string Prototypes = $@"
+- type: entity
+  name: {UserDummyId}
+  id: {UserDummyId}
+
+- type: entity
+  name: {AbsorbentDummyId}
+  id: {AbsorbentDummyId}
+  components:
+  - type: Absorbent
+  - type: SolutionContainerManager
+    solutions:
+      absorbed:
+        maxVol: 100
+
+- type: entity
+  name: {RefillableDummyId}
+  id: {RefillableDummyId}
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      refillable:
+        maxVol: 200
+  - type: RefillableSolution
+    solution: refillable
+
+- type: entity
+  name: {SmallRefillableDummyId}
+  id: {SmallRefillableDummyId}
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      refillable:
+        maxVol: 20
+  - type: RefillableSolution
+    solution: refillable
+";
+    public sealed record TestSolutionReagents(FixedPoint2 VolumeOfEvaporable, FixedPoint2 VolumeOfNonEvaporable);
+
+    public record TestSolutionCase(
+        string Case, // Only for clarity purposes
+        TestSolutionReagents InitialAbsorbentSolution,
+        TestSolutionReagents InitialRefillableSolution,
+        TestSolutionReagents ExpectedAbsorbentSolution,
+        TestSolutionReagents ExpectedRefillableSolution);
+
+    [TestCaseSource(nameof(TestCasesToRun))]
+    public async Task AbsorbentOnRefillableTest(TestSolutionCase testCase)
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var testMap = await pair.CreateTestMap();
+        var coordinates = testMap.GridCoords;
+
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var absorbentSystem = entityManager.System<AbsorbentSystem>();
+        var solutionContainerSystem = entityManager.System<SolutionContainerSystem>();
+        var prototypeManager = server.ResolveDependency<IPrototypeManager>();
+
+        EntityUid user = default;
+        EntityUid absorbent = default;
+        EntityUid refillable = default;
+        AbsorbentComponent component = null;
+        await server.WaitAssertion(() =>
+        {
+            user = entityManager.SpawnEntity(UserDummyId, coordinates);
+            absorbent = entityManager.SpawnEntity(AbsorbentDummyId, coordinates);
+            refillable = entityManager.SpawnEntity(RefillableDummyId, coordinates);
+
+            entityManager.TryGetComponent(absorbent, out component);
+            solutionContainerSystem.TryGetSolution(absorbent, AbsorbentComponent.SolutionName, out var absorbentSolution);
+            solutionContainerSystem.TryGetRefillableSolution(refillable, out var refillableSolution);
+
+            // Arrange
+            if (testCase.InitialAbsorbentSolution.VolumeOfEvaporable > FixedPoint2.Zero)
+                solutionContainerSystem.AddSolution(absorbent, absorbentSolution, new Solution(EvaporablePrototypeId, testCase.InitialAbsorbentSolution.VolumeOfEvaporable));
+            if (testCase.InitialAbsorbentSolution.VolumeOfNonEvaporable > FixedPoint2.Zero)
+                solutionContainerSystem.AddSolution(absorbent, absorbentSolution, new Solution(NonEvaporablePrototypeId, testCase.InitialAbsorbentSolution.VolumeOfNonEvaporable));
+
+            if (testCase.InitialRefillableSolution.VolumeOfEvaporable > FixedPoint2.Zero)
+                solutionContainerSystem.AddSolution(refillable, refillableSolution, new Solution(EvaporablePrototypeId, testCase.InitialRefillableSolution.VolumeOfEvaporable));
+            if (testCase.InitialRefillableSolution.VolumeOfNonEvaporable > FixedPoint2.Zero)
+                solutionContainerSystem.AddSolution(refillable, refillableSolution, new Solution(NonEvaporablePrototypeId, testCase.InitialRefillableSolution.VolumeOfNonEvaporable));
+
+            // Act
+            absorbentSystem.Mop(user, refillable, absorbent, component);
+
+            // Assert
+            var absorbentComposition = absorbentSolution.GetReagentPrototypes(prototypeManager).ToDictionary(r => r.Key.ID, r => r.Value);
+            var refillableComposition = refillableSolution.GetReagentPrototypes(prototypeManager).ToDictionary(r => r.Key.ID, r => r.Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(VolumeOfPrototypeInComposition(absorbentComposition, EvaporablePrototypeId), Is.EqualTo(testCase.ExpectedAbsorbentSolution.VolumeOfEvaporable));
+                Assert.That(VolumeOfPrototypeInComposition(absorbentComposition, NonEvaporablePrototypeId), Is.EqualTo(testCase.ExpectedAbsorbentSolution.VolumeOfNonEvaporable));
+                Assert.That(VolumeOfPrototypeInComposition(refillableComposition, EvaporablePrototypeId), Is.EqualTo(testCase.ExpectedRefillableSolution.VolumeOfEvaporable));
+                Assert.That(VolumeOfPrototypeInComposition(refillableComposition, NonEvaporablePrototypeId), Is.EqualTo(testCase.ExpectedRefillableSolution.VolumeOfNonEvaporable));
+            });
+        });
+        await pair.RunTicksSync(5);
+
+        await pair.CleanReturnAsync();
+    }
+
+    [TestCaseSource(nameof(TestCasesToRunOnSmallRefillable))]
+    public async Task AbsorbentOnSmallRefillableTest(TestSolutionCase testCase)
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var testMap = await pair.CreateTestMap();
+        var coordinates = testMap.GridCoords;
+
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var absorbentSystem = entityManager.System<AbsorbentSystem>();
+        var solutionContainerSystem = entityManager.System<SolutionContainerSystem>();
+        var prototypeManager = server.ResolveDependency<IPrototypeManager>();
+
+        EntityUid user = default;
+        EntityUid absorbent = default;
+        EntityUid refillable = default;
+        AbsorbentComponent component = null;
+        await server.WaitAssertion(() =>
+        {
+            user = entityManager.SpawnEntity(UserDummyId, coordinates);
+            absorbent = entityManager.SpawnEntity(AbsorbentDummyId, coordinates);
+            refillable = entityManager.SpawnEntity(SmallRefillableDummyId, coordinates);
+
+            entityManager.TryGetComponent(absorbent, out component);
+            solutionContainerSystem.TryGetSolution(absorbent, AbsorbentComponent.SolutionName, out var absorbentSolution);
+            solutionContainerSystem.TryGetRefillableSolution(refillable, out var refillableSolution);
+
+            // Arrange
+            solutionContainerSystem.AddSolution(absorbent, absorbentSolution, new Solution(EvaporablePrototypeId, testCase.InitialAbsorbentSolution.VolumeOfEvaporable));
+            if (testCase.InitialAbsorbentSolution.VolumeOfNonEvaporable > FixedPoint2.Zero)
+                solutionContainerSystem.AddSolution(absorbent, absorbentSolution, new Solution(NonEvaporablePrototypeId, testCase.InitialAbsorbentSolution.VolumeOfNonEvaporable));
+
+            if (testCase.InitialRefillableSolution.VolumeOfEvaporable > FixedPoint2.Zero)
+                solutionContainerSystem.AddSolution(refillable, refillableSolution, new Solution(EvaporablePrototypeId, testCase.InitialRefillableSolution.VolumeOfEvaporable));
+            if (testCase.InitialRefillableSolution.VolumeOfNonEvaporable > FixedPoint2.Zero)
+                solutionContainerSystem.AddSolution(refillable, refillableSolution, new Solution(NonEvaporablePrototypeId, testCase.InitialRefillableSolution.VolumeOfNonEvaporable));
+
+            // Act
+            absorbentSystem.Mop(user, refillable, absorbent, component);
+
+            // Assert
+            var absorbentComposition = absorbentSolution.GetReagentPrototypes(prototypeManager).ToDictionary(r => r.Key.ID, r => r.Value);
+            var refillableComposition = refillableSolution.GetReagentPrototypes(prototypeManager).ToDictionary(r => r.Key.ID, r => r.Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(VolumeOfPrototypeInComposition(absorbentComposition, EvaporablePrototypeId), Is.EqualTo(testCase.ExpectedAbsorbentSolution.VolumeOfEvaporable));
+                Assert.That(VolumeOfPrototypeInComposition(absorbentComposition, NonEvaporablePrototypeId), Is.EqualTo(testCase.ExpectedAbsorbentSolution.VolumeOfNonEvaporable));
+                Assert.That(VolumeOfPrototypeInComposition(refillableComposition, EvaporablePrototypeId), Is.EqualTo(testCase.ExpectedRefillableSolution.VolumeOfEvaporable));
+                Assert.That(VolumeOfPrototypeInComposition(refillableComposition, NonEvaporablePrototypeId), Is.EqualTo(testCase.ExpectedRefillableSolution.VolumeOfNonEvaporable));
+            });
+        });
+        await pair.RunTicksSync(5);
+
+        await pair.CleanReturnAsync();
+    }
+
+    private static FixedPoint2 VolumeOfPrototypeInComposition(Dictionary<string, FixedPoint2> composition, string prototypeId)
+    {
+        return composition.TryGetValue(prototypeId, out var value) ? value : FixedPoint2.Zero;
+    }
+
+    public static readonly TestSolutionCase[] TestCasesToRun = new TestSolutionCase[]
+    {
+        // Both empty case
+        new(
+            "Both empty - no transfer",
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero)
+        ),
+        // Just water cases
+        new(
+            "Transfer water to empty refillable",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.Zero)
+        ),
+        new(
+            "Transfer water to empty absorbent",
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero)
+        ),
+        new(
+            "Both partially filled with water while everything fits in absorbent",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(40), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(90), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero)
+        ),
+        new(
+            "Both partially filled with water while not everything fits in absorbent",
+            new TestSolutionReagents(FixedPoint2.New(70), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(100), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(20), FixedPoint2.Zero)
+        ),
+        // Just contaminants cases
+        new(
+            "Transfer contaminants to empty refillable",
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(50))
+        ),
+        new(
+            "Do not transfer contaminants back to empty absorbent",
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(50))
+        ),
+        new(
+            "Add contaminants to preexisting while everything fits in refillable",
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(130)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(180))
+        ),
+        new(
+            "Add contaminants to preexisting while not everything fits in refillable",
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(90)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(130)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(20)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(200))
+        ),
+        // Mixed: water and contaminants cases
+        new(
+            "Transfer just contaminants into empty refillable",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(50))
+        ),
+        new(
+            "Transfer just contaminants into non-empty refillable while everything fits",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(60)),
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(110))
+        ),
+        new(
+            "Transfer just contaminants into non-empty refillable while not everything fits",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(170)),
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.New(20)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(200))
+        ),
+        new(
+            "Transfer just contaminants and absorb water from water refillable",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.New(70), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(100), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(20), FixedPoint2.New(50))
+        ),
+        new(
+            "Transfer just contaminants and absorb water from a full water refillable",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.New(200), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(100), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(150), FixedPoint2.New(50))
+        ),
+        new(
+            "Transfer just contaminants and absorb water from a full mixed refillable",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.New(100), FixedPoint2.New(100)),
+            new TestSolutionReagents(FixedPoint2.New(100), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.New(150))
+        ),
+        new(
+            "Transfer just contaminants and absorb water from a low-water mixed refillable",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.New(10), FixedPoint2.New(100)),
+            new TestSolutionReagents(FixedPoint2.New(60), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(150))
+        ),
+        new(
+            "Contaminants for water exchange",
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(100)),
+            new TestSolutionReagents(FixedPoint2.New(200), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(100), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(100), FixedPoint2.New(100))
+        )
+    };
+
+    public static readonly TestSolutionCase[] TestCasesToRunOnSmallRefillable = new TestSolutionCase[]
+    {
+        // Only testing cases where small refillable AvailableVolume makes a difference
+        new(
+            "Transfer water to empty refillable",
+            new TestSolutionReagents(FixedPoint2.New(50), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(30), FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.New(20), FixedPoint2.Zero)
+        ),
+        new(
+            "Transfer contaminants to empty refillable",
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(50)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.Zero),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(30)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(20))
+        ),
+        new(
+            "Mixed transfer in limited space",
+            new TestSolutionReagents(FixedPoint2.New(20), FixedPoint2.New(25)),
+            new TestSolutionReagents(FixedPoint2.New(10), FixedPoint2.New(5)),
+            new TestSolutionReagents(FixedPoint2.New(30), FixedPoint2.New(10)),
+            new TestSolutionReagents(FixedPoint2.Zero, FixedPoint2.New(20))
+        )
+    };
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Assumptions
This whole PR operates under the assumption that the below is the expected behavior of how Absorbent system should work:

Upon interacting with an Absorbent entity on an Refillable entity:
- as much as possible non-water is to be transferred from absorbent into refillable
- as much as possible water is to be transferred from refillable into absorbent

This behavior was inferred from how absorbents currently work on non-empty containers. Notably they currently do not work this way on **empty** containers.

**IMPORTANT: Whether this is how the Absorbent system should work or not is outside the scope of this PR. This PR does not aim to _change_, it only aims to _fix_. This means taking the existing behavior and making it consistent, as opposed to making the existing behavior into something else.**

## About the PR
<!-- What did you change in this PR? -->
Made Absorbent component behave consistently:
- expected behavior (in assumption) now applies to **empty containers as well**
- fixed one edge case where a popup stating "target is full" would show up even if the transfer completed successfully
- added the ability to transfer water from absorbent to container if the only absorbent solution is evaporating and Refillable is empty
- added test cases for Absorbent <-> Refillable interaction (feel free to run them on master to see what was changed in this PR)
- minor refactoring (updated obsolete calls, removed redundant system dependency, etc.)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It is possible to transfer dirt from a dirty mop to a dirty bucket, but attempting the same thing with an empty bucket fails unexpectedly. It follows that if a mop can be "wrung" over a bucket filled with a dirty solution, it can just as well be "wrung" over an empty bucket. Similarly, if "wringing" an arbitrary solution is allowed, then wringing clean solution out of the mop should also be possible.

Now it is.

I personally started the game as a janitor. Figuring out game controls for the first time was hard enough on its own, and this inconsistency made it even harder for me to learn how things work. So at the very least this benefits new player learning experience. Although making things consistent is generally good by itself.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
PREVIOUSLY:
Mop + Non-empty container -> transfer contaminants, absorb water
Mop w/ contaminants + Empty container -> "container has no water" popup, no effect
Mop w/o contaminants + Empty container -> "mop is full of water" or "container has no water", no effect

NOW:
Mop + Non-empty container -> transfer contaminants, absorb water
Mop w/ contaminants + Empty container -> transfer contaminants absorb water*
Mop w/o contaminants + Empty container -> transfer non-contaminants
\* - since container is empty, it absorbs 0 water, but this is still consistent

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
[mop.webm](https://github.com/space-wizards/space-station-14/assets/27449516/9757ad6a-afdb-4435-8960-c1472bbc8faf)

(All visible buckets initially empty - this would not have been possible on current master branch)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Extra
All comments - especially about the tests welcome. I had a hard time figuring out the expected tests format. Hopefully this is OK.