### PR TITLE
fix: ExtensionCableSystem to be consistent

### DIFF
--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -145,9 +145,7 @@ namespace Content.Server.Power.EntitySystems
                 if (!receiver.Connectable || receiver.Provider != null)
                     continue;
 
-                var distance = Transform(entity).LocalPosition - xform.LocalPosition;
-                var manhattanDistance = Math.Abs(distance.X) + Math.Abs(distance.Y);
-                if (manhattanDistance <= Math.Min(range, receiver.ReceptionRange))
+                if ((Transform(entity).LocalPosition - xform.LocalPosition).Length() <= Math.Min(range, receiver.ReceptionRange))
                     yield return (entity, receiver);
             }
         }
@@ -278,13 +276,12 @@ namespace Content.Server.Power.EntitySystems
                 // Find the closest provider
                 if (!xformQuery.TryGetComponent(entity, out var entityXform))
                     continue;
-                var distance = entityXform.LocalPosition - xform.LocalPosition;
-                var manhattanDistance = Math.Abs(distance.X) + Math.Abs(distance.Y);
-                if (manhattanDistance >= closestDistanceFound)
+                var distance = (entityXform.LocalPosition - xform.LocalPosition).Length();
+                if (distance >= closestDistanceFound)
                     continue;
 
                 closestCandidate = provider;
-                closestDistanceFound = manhattanDistance;
+                closestDistanceFound = distance;
             }
 
             // Make sure the provider is in range before claiming success

--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -145,7 +145,9 @@ namespace Content.Server.Power.EntitySystems
                 if (!receiver.Connectable || receiver.Provider != null)
                     continue;
 
-                if ((Transform(entity).LocalPosition - xform.LocalPosition).Length() < Math.Min(range, receiver.ReceptionRange))
+                var distance = Transform(entity).LocalPosition - xform.LocalPosition;
+                var manhattanDistance = Math.Abs(distance.X) + Math.Abs(distance.Y);
+                if (manhattanDistance <= Math.Min(range, receiver.ReceptionRange))
                     yield return (entity, receiver);
             }
         }
@@ -276,12 +278,13 @@ namespace Content.Server.Power.EntitySystems
                 // Find the closest provider
                 if (!xformQuery.TryGetComponent(entity, out var entityXform))
                     continue;
-                var distance = (entityXform.LocalPosition - xform.LocalPosition).Length();
-                if (distance >= closestDistanceFound)
+                var distance = entityXform.LocalPosition - xform.LocalPosition;
+                var manhattanDistance = Math.Abs(distance.X) + Math.Abs(distance.Y);
+                if (manhattanDistance >= closestDistanceFound)
                     continue;
 
                 closestCandidate = provider;
-                closestDistanceFound = distance;
+                closestDistanceFound = manhattanDistance;
             }
 
             // Make sure the provider is in range before claiming success


### PR DESCRIPTION
## About the PR

Fix https://github.com/space-wizards/space-station-14/issues/22722

## Why
To make ExtensionCableSystem consistent regardless of the receiver/provider connection order end fix broken stations, Gemini, for example.

## Technical details
ExtensionCableSystem consists of two components, ExtensionCableProviderComponent and ExtensionCableReceiverComponent. The logic to connect Provider and Receiver together implemented differently depending on which component starts up first. When a Receiver starts up, it looks for the _closest_ Provider within its reception range. Contrary, when a Provider starts up, it connects to all the unconnected Receivers within its transfer range. Then an additional check is made to verify that both provider's reception range and receiver's transfer range can reach each other. Those checks are inconsistent.

https://github.com/space-wizards/space-station-14/blob/ef4afc56128a8ba8d7aafe760dba4d30ebb8ea6b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs#L288

https://github.com/space-wizards/space-station-14/blob/ef4afc56128a8ba8d7aafe760dba4d30ebb8ea6b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs#L148

## Media
Before the change (place power cable first, devices last):
<img width="530" alt="image" src="https://github.com/space-wizards/space-station-14/assets/1192090/cafff351-a51e-4845-9a31-427a088dff1a">

Before the change (place devices first, power cable last):
<img width="530" alt="image" src="https://github.com/space-wizards/space-station-14/assets/1192090/fbe3de73-b595-4343-b64f-0024cc638a39">

After the change (consistent regardless of the placement order):
<img width="531" alt="image" src="https://github.com/space-wizards/space-station-14/assets/1192090/b37fa0dc-01f7-4d41-9465-cc100ec01963">


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
I guess no, after I removed my sudden desire to change it to be Manhattan distance.



**Changelog**
I'm not sure if such a small change deserves to be mentioned on the Changelog.

<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
