### PR TITLE
Use different chatbox placeholder when dependent keys unbound

### DIFF
--- a/Content.Client/UserInterface/BoundKeyHelpers.cs
+++ b/Content.Client/UserInterface/BoundKeyHelpers.cs
@@ -13,6 +13,11 @@ public static class BoundKeyHelper
         return TryGetShortKeyName(keyFunction, out var name) ? Loc.GetString(name) : " ";
     }
 
+    public static bool IsBound(BoundKeyFunction keyFunction)
+    {
+        return TryGetShortKeyName(keyFunction, out _);
+    }
+
     private static string? DefaultShortKeyName(BoundKeyFunction keyFunction)
     {
         var name = FormattedMessage.EscapeText(IoCManager.Resolve<IInputManager>().GetKeyFunctionButtonString(keyFunction));

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChatInputBox.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChatInputBox.cs
@@ -33,7 +33,7 @@ public class ChatInputBox : PanelContainer
         Input = new HistoryLineEdit
         {
             Name = "Input",
-            PlaceHolder = Loc.GetString("hud-chatbox-info", ("talk-key", BoundKeyHelper.ShortKeyName(ContentKeyFunctions.FocusChat)), ("cycle-key", BoundKeyHelper.ShortKeyName(ContentKeyFunctions.CycleChatChannelForward))),
+            PlaceHolder = GetChatboxInfoPlaceholder(),
             HorizontalExpand = true,
             StyleClasses = {"chatLineEdit"}
         };
@@ -50,5 +50,16 @@ public class ChatInputBox : PanelContainer
     private void UpdateActiveChannel(ChatSelectChannel selectedChannel)
     {
         ActiveChannel = (ChatChannel) selectedChannel;
+    }
+
+    private static string GetChatboxInfoPlaceholder()
+    {
+        return (BoundKeyHelper.IsBound(ContentKeyFunctions.FocusChat), BoundKeyHelper.IsBound(ContentKeyFunctions.CycleChatChannelForward)) switch
+        {
+            (true, true) => Loc.GetString("hud-chatbox-info", ("talk-key", BoundKeyHelper.ShortKeyName(ContentKeyFunctions.FocusChat)), ("cycle-key", BoundKeyHelper.ShortKeyName(ContentKeyFunctions.CycleChatChannelForward))),
+            (true, false) => Loc.GetString("hud-chatbox-info-talk", ("talk-key", BoundKeyHelper.ShortKeyName(ContentKeyFunctions.FocusChat))),
+            (false, true) => Loc.GetString("hud-chatbox-info-cycle", ("cycle-key", BoundKeyHelper.ShortKeyName(ContentKeyFunctions.CycleChatChannelForward))),
+            (false, false) => Loc.GetString("hud-chatbox-info-unbound")
+        };
     }
 }

--- a/Resources/Locale/en-US/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/chat/ui/chat-box.ftl
@@ -1,4 +1,7 @@
 hud-chatbox-info = {$talk-key} to talk, {$cycle-key} to cycle channels.
+hud-chatbox-info-talk = {$talk-key} to talk.
+hud-chatbox-info-cycle = Click here to talk, {$cycle-key} to cycle channels.
+hud-chatbox-info-unbound = Click here to talk.
 
 hud-chatbox-select-name-prefixed = {$prefix} {$name}
 hud-chatbox-select-channel-Admin = Admin


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Chatbox placeholder does not care if some of the keys it depends on are unbound. It will print a space in place of the key binding. Looks bad and is confusing:
![when_unbound_current](https://github.com/space-wizards/space-station-14/assets/27449516/b2bcc140-de0a-4256-a97d-cd64691a1726)


This PR fixes it.

I know this is "C# UI" which is planned to be removed in the future, but per guideline docs: fixes are still allowed. This is a fix.
I also noticed there is a bug where this placeholder will not immediately update upon changing keybindings (restart required), but that is beyond the scope of this PR.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Self-explanatory.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Initially I explored splitting the localized string into two segments - one about Talk keybinding, and the other about Channel cycling - and building the placeholder out of that. However, I very quickly realized the limitations of this approach:
- requires separator to be configured separately (the "comma + space" that would join the segments)
- enforces the order - first talk key, then cycle key - which may not be natural for all languages
- is not nearly as flexible (i.e. you cannot replace an unbound key binding with "Click here")

So instead I opted to have localized strings for every case which addresses all the shortcomings. More localization strings, but everything is neat, precise and tidy - maximum flexibility.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Before (with unbound hotkeys):
![when_unbound_current](https://github.com/space-wizards/space-station-14/assets/27449516/b2bcc140-de0a-4256-a97d-cd64691a1726)

After (varies which hotkeys are bound, case where both hotkeys are bound unchanged and not pictured):
![when_unbound_new](https://github.com/space-wizards/space-station-14/assets/27449516/d836fba1-182a-49bc-868b-664cb12367ee)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Help me define the exact wording!
When only "talk" key is bound, I went with "X to talk." but it can be "Press X to talk." "Use X to talk." or any variant thereof. "X to talk." feels too short, but maybe it just needs getting used to.

When "cycle" key is bound, then text is appended with ", Y to cycle channels." - this seems fine to me, but all comments welcome.

When "talk" key is not bound, I went with "Click here to talk", but it might as well be "Press here to talk", "Type here to talk" or similar.

Which do you find best?
Note that getting the exact wording right **is not a big deal** - it can be changed **very quickly**, so if you think the current wording is fine it's most likely fine.