### PR TITLE
Fix item cabinet's visual state desyncing when toggled by a different client in view

### DIFF
--- a/Content.Shared/Cabinet/ItemCabinetComponent.cs
+++ b/Content.Shared/Cabinet/ItemCabinetComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Cabinet;
 /// <summary>
 ///     Used for entities that can be opened, closed, and can hold one item. E.g., fire extinguisher cabinets.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class ItemCabinetComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Cabinet/SharedItemCabinetSystem.cs
+++ b/Content.Shared/Cabinet/SharedItemCabinetSystem.cs
@@ -22,6 +22,7 @@ public abstract class SharedItemCabinetSystem : EntitySystem
         SubscribeLocalEvent<ItemCabinetComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<ItemCabinetComponent, ComponentRemove>(OnComponentRemove);
         SubscribeLocalEvent<ItemCabinetComponent, ComponentStartup>(OnComponentStartup);
+        SubscribeLocalEvent<ItemCabinetComponent, AfterAutoHandleStateEvent>(OnComponentHandleState);
 
         SubscribeLocalEvent<ItemCabinetComponent, ActivateInWorldEvent>(OnActivateInWorld);
         SubscribeLocalEvent<ItemCabinetComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleOpenVerb);
@@ -46,6 +47,11 @@ public abstract class SharedItemCabinetSystem : EntitySystem
     {
         UpdateAppearance(uid, cabinet);
         _itemSlots.SetLock(uid, cabinet.CabinetSlot, !cabinet.Opened);
+    }
+
+    private void OnComponentHandleState(Entity<ItemCabinetComponent> ent, ref AfterAutoHandleStateEvent args)
+    {
+        UpdateAppearance(ent, ent);
     }
 
     protected virtual void UpdateAppearance(EntityUid uid, ItemCabinetComponent? cabinet = null)


### PR DESCRIPTION
## About the PR
The reason it doesn't desync when it is toggled outside of pvs range while already seen at least once is because when it comes back into pvs range it causes an entity inserted event, which updates the appearance. Probably not a great thing to rely on but this was the only edge-case I could find.
Also, if it is toggled before the client knows about it and then the client comes within pvs range of the cabinet, ComponentInit takes care of that case.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
