### PR TITLE
Make ethylredoxrazine effective at curing drunkness

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -101,7 +101,7 @@
       effects:
       - !type:GenericStatusEffect
         key: Drunk
-        time: 2.0
+        time: 12.0
         type: Remove
       - !type:HealthChange
         damage:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -101,7 +101,7 @@
       effects:
       - !type:GenericStatusEffect
         key: Drunk
-        time: 12.0
+        time: 6.0
         type: Remove
       - !type:HealthChange
         damage:


### PR DESCRIPTION
## About the PR
Ethyl reduces drunkness far, far more effectively.

## Why / Balance
Ethyl was bad at removing drunkness, especially on lightweights.

## Technical details
Ethyl reduces 6 seconds of drunkness rather than 2.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Ethylredoxrazine is more effective at treating drunkness.
