### PR TITLE
Fix shuttle loading error

### DIFF
--- a/Content.Server/GameTicking/Rules/PiratesRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/PiratesRuleSystem.cs
@@ -196,6 +196,7 @@ public sealed class PiratesRuleSystem : GameRuleSystem<PiratesRuleComponent>
             var gridId = _map.LoadGrid(GameTicker.DefaultMap, map, new MapLoadOptions
             {
                 Offset = aabb.Center + new Vector2(a, a),
+                LoadMap = false,
             });
 
             if (!gridId.HasValue)

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -409,7 +409,10 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         }
 
         var mapId = _mapManager.CreateMap();
-        var grid = _map.LoadGrid(mapId, component.Map.ToString());
+        var grid = _map.LoadGrid(mapId, component.Map.ToString(),  new MapLoadOptions()
+        {
+            LoadMap = false,
+        });
         var map = _mapManager.GetMapEntityId(mapId);
 
         if (!Exists(map))
@@ -469,7 +472,9 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         var shuttle = _map.LoadGrid(map.MapId, shuttlePath.ToString(), new MapLoadOptions()
         {
             // Should be far enough... right? I'm too lazy to bounds check CentCom rn.
-            Offset = new Vector2(500f + centcomm.ShuttleIndex, 0f)
+            Offset = new Vector2(500f + centcomm.ShuttleIndex, 0f),
+            // fun fact: if you just fucking yeet centcomm into nullspace anytime you try to spawn the shuttle, then any distance is far enough. so lets not do that
+            LoadMap = false,
         });
 
         if (shuttle == null)

--- a/Resources/Maps/Shuttles/emergency_transit.yml
+++ b/Resources/Maps/Shuttles/emergency_transit.yml
@@ -23,7 +23,7 @@ entities:
     - name: NT Evac Transit
       type: MetaData
     - pos: -4.3957214,6.3308363
-      parent: 161
+      parent: invalid
       type: Transform
     - chunks:
         0,-2:
@@ -430,18 +430,6 @@ entities:
       type: GridAtmosphere
     - type: GasTileOverlay
     - type: GridPathfinding
-  - uid: 161
-    components:
-    - name: map 20
-      type: MetaData
-    - type: Transform
-    - type: Map
-    - type: PhysicsMap
-    - type: GridTree
-    - type: MovedGrids
-    - type: Broadphase
-    - type: OccluderTree
-    - type: LoadedMap
 - proto: AirAlarm
   entities:
   - uid: 3


### PR DESCRIPTION
An emergency shuttle wasn't saved as a grid, causing centomm to be sent to nullspace and atmos to break. I love maploader,