### PR TITLE
Reduce absolute temperature tolerance

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -123,7 +123,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     Minimum temperature difference before the gas temperatures are just set to be equal.
         /// </summary>
-        public const float MinimumTemperatureDeltaToConsider = 0.1f;
+        public const float MinimumTemperatureDeltaToConsider = 0.01f;
 
         /// <summary>
         ///     Minimum temperature for starting superconduction.


### PR DESCRIPTION
## About the PR
MinimumTemperatureDeltaToConsider sets the minimum temperature difference for a heat capacity calculation to be run. The problem is that when heating up large quantities of gas (e.g. with a heater), a small dT becomes an even smaller dT when running DivideInto(). This means that small changes in temperature are completely ignored.

## Why / Balance
People [complained that heaters were "broken" because they couldn't heat up a canister of plasma](https://discord.com/channels/310555209753690112/1186977262508183592/1187088996099162182).

## Technical details

What was really going on:

1. Small heater, massive quantities of plasma, small temperature rise (let's say 0.18 K)
2. 0.18K gets DivideInto() the rest of the pipenet, the number gets even smaller (let's say 0.09K)
3. 0.09K is smaller than 0.1K, and so the temperature sharing calculation gets skipped
4. Temperature doesn't change

This is sort of a band-aid fix in that you can always find a smaller temperature change that will get annihilated. What you really want to do is rewrite atmos so that energy is stored as the state variable, not temperature, so that:

1. Heat calculations don't need to calculate specific heat capacity
2. Energy is conserved, bypassing this temperature delta issue

But that would take a possibly significant rewrite and is out of scope here.