### PR TITLE
Fix ghosts following a moving entity causing them to be offset

### DIFF
--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -162,8 +162,6 @@ public sealed class FollowerSystem : EntitySystem
         if (TryComp<JointComponent>(follower, out var joints))
             _jointSystem.ClearJoints(follower, joints);
 
-        _physicsSystem.SetLinearVelocity(follower, Vector2.Zero);
-
         var xform = Transform(follower);
         _containerSystem.AttachParentToContainerOrGrid((follower, xform));
 
@@ -172,6 +170,8 @@ public sealed class FollowerSystem : EntitySystem
         {
             _transform.SetCoordinates(follower, xform, new EntityCoordinates(entity, Vector2.Zero), rotation: Angle.Zero);
         }
+
+        _physicsSystem.SetLinearVelocity(follower, Vector2.Zero);
 
         EnsureComp<OrbitVisualsComponent>(follower);
 


### PR DESCRIPTION
## About the PR
Fixes #14220

## Technical details
Because the entity they start following is moving, the physics system gives the follower opposing velocity to counteract, at the time the parent change happens. This happens *after* the follower system tries to clear the follower's velocity, so the follower gets some velocity that will still move them a bit off-center.

Fix is easy enough, just reset velocity *after* reparenting, not before.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- fix: Fix starting to follow a moving player as a ghost causing your camera to keep jumping around anymore.
