### PR TITLE
Reduce frezon price

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 7.5
+  pricePerMole: 0.3


### PR DESCRIPTION
## About the PR
Reduces the price of frezon gas.

50 mols of frezon can be made from one mol of tritium, and so without adjusting the price pretty ridiculous sums of money can be made in cargo.

I considered reducing the amount of frezon producible, but all of the atmos players that I surveyed prefered a price decrease instead of a yield decrease, so give them what they want.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
**We don't want this to happen:**
![image](https://github.com/space-wizards/space-station-14/assets/3229565/85034eb3-1e3a-47f6-8966-430aefc27954)

2/2 atmos techs I surveyed preferred reducing price over reducing yield, so give them what they want.