### PR TITLE
Makes sabre sheathe use ItemSlots

### DIFF
--- a/Resources/Locale/en-US/clothing/belts.ftl
+++ b/Resources/Locale/en-US/clothing/belts.ftl
@@ -1,0 +1,2 @@
+sheath-insert-verb = Sheathe
+sheath-eject-verb = Unsheathe

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -114,9 +114,10 @@
   parent: ClothingBeltSheath
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: CaptainSabre
+  - type: ContainerFill
+    containers:
+      item:
+      - CaptainSabre
 
 - type: entity
   id: ClothingBeltMilitaryWebbingGrenadeFilled

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -427,7 +427,7 @@
           tags:
           - CaptainSabre
   - type: Appearance
-
+ 
 # Belts without visualizers
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -399,7 +399,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltBase, ClothingSlotBase]
   id: ClothingBeltSheath
   name: sabre sheath
   description: An ornate sheath designed to hold an officer's blade.
@@ -409,12 +409,17 @@
     state: sheath
   - type: Clothing
     sprite: Clothing/Belt/sheath.rsi
-  - type: Storage
-    grid:
-    - 0,0,1,1
-    whitelist:
-      tags:
-        - CaptainSabre
+  - type: Item
+    size: Ginormous
+  - type: ItemSlots
+    slots:
+      item:
+        name: Sabre
+        insertVerbText: Sheathe
+        ejectVerbText: Unsheathe
+        whitelist:
+          tags:
+          - CaptainSabre
   - type: ItemMapper
     mapLayers:
       sheath-sabre:

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -415,8 +415,8 @@
     slots:
       item:
         name: Sabre
-        insertVerbText: Sheathe
-        ejectVerbText: Unsheathe
+        insertVerbText: sheath-insert-verb
+        ejectVerbText: sheath-eject-verb
         whitelist:
           tags:
           - CaptainSabre


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes the captain's sabre sheath use an item slot instead of opening a container.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Because the sheath already had a single slot for the sabre.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Would be cool if someone got sound effects for it. (not me though)
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/86210200/1477d352-e4d0-4e2a-b53d-958834183a3c

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: The captain's sabre sheath now uses a slot instead of a container UI.
