### PR TITLE
Fix gas canister random item insertion prediction

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasCanisterComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasCanisterComponent.cs
@@ -19,7 +19,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         public string ContainerName { get; set; } = "tank_slot";
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("tank_slot")]
+        [DataField]
         public ItemSlot GasTankSlot = new();
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Atmos/Piping/Unary/Components/GasCanisterComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasCanisterComponent.cs
@@ -19,7 +19,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         public string ContainerName { get; set; } = "tank_slot";
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField]
+        [DataField("tank_slot")]
         public ItemSlot GasTankSlot = new();
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -94,7 +94,7 @@
       tank_slot:
         name: Gas Tank
         whitelist:
-          component:
+          components:
             - GasTank
     - type: StaticPrice
       price: 1000

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -91,7 +91,7 @@
     - type: ItemSlots
     - type: GasPortable
     - type: GasCanister
-      tank_slot:
+      gasTankSlot:
         name: Gas Tank
         whitelist:
           components:


### PR DESCRIPTION
Fix #22652

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixes the bug of client predicting insertion of any item into gas canister.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Only gas tanks are insertable to gas canisters.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Fixed typo in `gas_canisters.yml` prototype of components list and hooked properly the `GasTankSlot` attribute to the `gas_tank` name in the component c# file.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- fix: Gas tanks no longer predict insertion of random items.

