### PR TITLE
Prevent mice from spilling containers.

### DIFF
--- a/Content.Server/Fluids/Components/PreventSpillerComponent.cs
+++ b/Content.Server/Fluids/Components/PreventSpillerComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Fluids.Components;
+
+[RegisterComponent]
+public sealed partial class PreventSpillerComponent : Component
+{
+
+}

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -26,6 +26,7 @@ namespace Content.Server.Fluids.EntitySystems;
 public sealed partial class PuddleSystem
 {
     [Dependency] private readonly OpenableSystem _openable = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
 
     private void InitializeSpillable()
     {
@@ -183,6 +184,10 @@ public sealed partial class PuddleSystem
 
         if (solution.Volume == FixedPoint2.Zero)
             return;
+
+        if (_entityManager.HasComponent<PreventSpillerComponent>(args.User))
+            return;
+
 
         Verb verb = new()
         {

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1290,6 +1290,7 @@
     needsHands: true
   - type: BadFood
   - type: NonSpreaderZombie
+  - type: PreventSpiller
 
 - type: entity
   parent: MobMouse


### PR DESCRIPTION
## About the PR
Updated mouse (mice?) to not be able to see the spill verb.

## Why / Balance
Causing many admin issues with every chem and doc aHelping when a mouse comes and spills the last 10-20min of medicines made.

## Technical details
Updated when the spill verb is added to the menu to check if the user mob has a preventspiller component, if it does, it does not show the verb. Added this preventspiller component to the base mouse prototype.

## Media
Forgot to show, I was the mouse initially.

https://github.com/space-wizards/space-station-14/assets/47093363/81d62572-1ceb-42da-9b67-16d205d83c7f

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None I'm aware of.

**Changelog**
:cl: Repo
- tweak: Mice can no longer spill containers.

