### PR TITLE
adds embedding + throw damage to cybersun pen

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -274,7 +274,7 @@
 
 - type: entity
   name: Cybersun pen
-  parent: BaseItem
+  parent: Pen
   id: CyberPen
   description: A high-tech pen straight from Cybersun's legal department, capable of refracting hard-light at impossible angles through its diamond tip in order to write.
   components:
@@ -289,6 +289,10 @@
   - type: ItemCooldown
   - type: MeleeWeapon
     wideAnimationRotation: -45
+    damage:
+      types:
+        Piercing: 15
+  - type: DamageOtherOnHit
     damage:
       types:
         Piercing: 15


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
title, makes it do equal throw damage to its melee damage
also makes it parent off pen and not baseitem, it didn't embed like normal pens without that

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
yes powercreep but makes sense for this to be a thing
also easily stolen if you do throw it
you will be able to put several cyberpens into a pneumatic cannon and use it as a real weapon, though you'd be much better off buying a real gun since cannon: 1) needs gas 2) fires slow 3) can only fit 16 pens, and, again, pens can be stolen

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/57039557/e91662b1-27b8-4264-a4bd-e847a2c41674)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: The cybersun pen now properly deals throw damage. 