### PR TITLE
Add migration for MiasmaCanister

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -105,3 +105,6 @@ VendingMachineSmartFridge: SmartFridge
 ReagentContainerMilk: DrinkMilkCarton
 ReagentContainerMilkSoy: DrinkSoyMilkCarton
 ReagentContainerMilkOat: DrinkOatMilkCarton
+
+# 2023-12-20
+MiasmaCanister: AmmoniaCanister


### PR DESCRIPTION
## About the PR
https://github.com/space-wizards/space-station-14/pull/22791 changed miasma to ammonia, but did not provide a map migration.

## Why / Balance
Adds the map migration so that anyone who had mapped a miasma canister locally or on a fork doesn't have a map that fails to load.