### PR TITLE
DumpableComponent on an empty container no longer stops other interactions

### DIFF
--- a/Content.Shared/Storage/EntitySystems/DumpableSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/DumpableSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Placeable;
 using Content.Shared.Storage.Components;
 using Content.Shared.Verbs;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
@@ -40,6 +39,12 @@ public sealed class DumpableSystem : EntitySystem
             return;
 
         if (!_disposalUnitSystem.HasDisposals(args.Target) && !HasComp<PlaceableSurfaceComponent>(args.Target))
+            return;
+
+        if (!TryComp<StorageComponent>(uid, out var storage))
+            return;
+
+        if (!storage.Container.ContainedEntities.Any())
             return;
 
         StartDoAfter(uid, args.Target.Value, args.User, component);
@@ -103,12 +108,12 @@ public sealed class DumpableSystem : EntitySystem
         }
     }
 
-    public void StartDoAfter(EntityUid storageUid, EntityUid? targetUid, EntityUid userUid, DumpableComponent dumpable)
+    private void StartDoAfter(EntityUid storageUid, EntityUid? targetUid, EntityUid userUid, DumpableComponent dumpable)
     {
         if (!TryComp<StorageComponent>(storageUid, out var storage))
             return;
 
-        float delay = storage.Container.ContainedEntities.Count * (float) dumpable.DelayPerItem.TotalSeconds * dumpable.Multiplier;
+        var delay = storage.Container.ContainedEntities.Count * (float) dumpable.DelayPerItem.TotalSeconds * dumpable.Multiplier;
 
         _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, userUid, delay, new DumpableDoAfterEvent(), storageUid, target: targetUid, used: storageUid)
         {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixed a bug where all entities with `DumpableComponent` would not process their expected actions if interacted using them with something else. Most common occurrence was trying to put an empty Dumpable container into a Disposal Unit (Chemistry Bag, Ore Bag, etc).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It was a bug. I did my due dilligence and researched git history to see if this functionality was removed on purpose (i.e. to stop people from accidentally dumping the container rather than just its contents), but that was not the case. So for all intents and purposes - this is a bugfix.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
`DumpableSystem` was greedily marking the `AfterInteractEvent` as handled, even if the later `DoAfter` did nothing (i.e. bag was empty). Since event was marked as handled, all other possible events ended up getting ignored.

One couldn't put a Chemistry Bag into a Disposal Unit, because `AfterInteractEvent` was marked as handled by `DumpableSystem` before it got to `DisposalSystem`.

The fix is simple - if the Dumpable is empty, then we can't dump its contents (dumping nothing is not an action). This check simply happens in `OnAfterInteract`. Now Dumpable `OnAfterInteract` of an empty container correctly does not mark `AfterInteractEvent` as handled. I obviously kept all the later validations in case state changed between Interaction and processing the DoAfter.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
[disposable_dumpables.webm](https://github.com/space-wizards/space-station-14/assets/27449516/29103284-1e23-49fa-bb48-395b615d1ffb)

(Observe how the first interaction of Chemistry Bag on Disposal Unit processes the Dumpable DoInteract because the container is not empty - this is the expected and current behavior; but the second interaction puts the **_now empty_** Chemistry Bag inside the Disposal Unit - this does not work on current master branch)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
**Any and all bugs that become apparent as a result of this change were previously broken, simply hidden by this bug.** `DumpableSystem` was effectively neutralizing a lot of possible actions by "unexpectedly cancelling" the whole interaction.
Keep in mind this PR only **reveals the existence of such bugs**, by removing the "neutralizing component". Any bugs made apparent in this fashion are already present on master, simply hidden from view.

All that being said - I do not expect any such issues to arise - but due to sheer volume of possible combinations I did not test every single set of interactions this could affect.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Carve
- fix: Fixed an issue where some containers could not be put into disposal unit via basic interaction.