### PR TITLE
Fix various errors/exceptions

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -77,7 +77,8 @@ public sealed class DefibrillatorSystem : EntitySystem
 
     private void OnPowerCellSlotEmpty(EntityUid uid, DefibrillatorComponent component, ref PowerCellSlotEmptyEvent args)
     {
-        TryDisable(uid, component);
+        if (!TerminatingOrDeleted(uid))
+            TryDisable(uid, component);
     }
 
     private void OnAfterInteract(EntityUid uid, DefibrillatorComponent component, AfterInteractEvent args)
@@ -139,6 +140,7 @@ public sealed class DefibrillatorSystem : EntitySystem
 
         component.Enabled = false;
         _appearance.SetData(uid, ToggleVisuals.Toggled, false);
+
         _audio.PlayPvs(component.PowerOffSound, uid);
         return true;
     }

--- a/Content.Server/Shuttles/Systems/DockingSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.cs
@@ -459,45 +459,24 @@ namespace Content.Server.Shuttles.Systems
             if (dock.DockedWith == null)
                 return;
 
-            if (TryComp<DoorBoltComponent>(dockUid, out var airlockA))
-            {
-                _bolts.SetBoltsWithAudio(dockUid, airlockA, false);
-            }
-
-            if (TryComp<DoorBoltComponent>(dock.DockedWith, out var airlockB))
-            {
-                _bolts.SetBoltsWithAudio(dock.DockedWith.Value, airlockB, false);
-            }
-
-            if (TryComp(dockUid, out DoorComponent? doorA))
-            {
-                if (_doorSystem.TryClose(dockUid, doorA))
-                {
-                    doorA.ChangeAirtight = true;
-                }
-            }
-
-            if (TryComp(dock.DockedWith, out DoorComponent? doorB))
-            {
-                if (_doorSystem.TryClose(dock.DockedWith.Value, doorB))
-                {
-                    doorB.ChangeAirtight = true;
-                }
-            }
-
-            if (LifeStage(dockUid) < EntityLifeStage.Terminating)
-            {
-                var recentlyDocked = EnsureComp<RecentlyDockedComponent>(dockUid);
-                recentlyDocked.LastDocked = dock.DockedWith.Value;
-            }
-
-            if (TryComp(dock.DockedWith.Value, out MetaDataComponent? meta) && meta.EntityLifeStage < EntityLifeStage.Terminating)
-            {
-                var recentlyDocked = EnsureComp<RecentlyDockedComponent>(dock.DockedWith.Value);
-                recentlyDocked.LastDocked = dock.DockedWith.Value;
-            }
-
+            OnUndock(dockUid, dock.DockedWith.Value);
+            OnUndock(dock.DockedWith.Value, dockUid);
             Cleanup(dockUid, dock);
+        }
+
+        private void OnUndock(EntityUid dockUid, EntityUid other)
+        {
+            if (TerminatingOrDeleted(dockUid))
+                return;
+
+            if (TryComp<DoorBoltComponent>(dockUid, out var airlock))
+                _bolts.SetBoltsWithAudio(dockUid, airlock, false);
+
+            if (TryComp(dockUid, out DoorComponent? door) && _doorSystem.TryClose(dockUid, door))
+                door.ChangeAirtight = true;
+
+            var recentlyDocked = EnsureComp<RecentlyDockedComponent>(dockUid);
+            recentlyDocked.LastDocked = other;
         }
     }
 }

--- a/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
+++ b/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
@@ -154,6 +154,8 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
                 .Where(x => !Deleted(x.Value))
                 .Select(static x => x.Key)
                 .ToList();
+
+            component.OwnedDebris.Clear();
         }
 
         points ??= GeneratePointsInChunk(args.Chunk, density, chunk.Coordinates, chunk.Map);

--- a/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
+++ b/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
@@ -8,6 +8,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Worldgen.Systems.Debris;
 
@@ -154,8 +155,6 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
                 .Where(x => !Deleted(x.Value))
                 .Select(static x => x.Key)
                 .ToList();
-
-            component.OwnedDebris.Clear();
         }
 
         points ??= GeneratePointsInChunk(args.Chunk, density, chunk.Coordinates, chunk.Map);
@@ -164,6 +163,12 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
         var failures = 0; // Avoid severe log spam.
         foreach (var point in points)
         {
+            if (component.OwnedDebris.TryGetValue(point, out var existing))
+            {
+                DebugTools.Assert(Exists(existing));
+                continue;
+            }
+
             var pointDensity = _noiseIndex.Evaluate(uid, densityChannel, WorldGen.WorldToChunkCoords(point));
             if (pointDensity == 0 && component.DensityClip || _random.Prob(component.RandomCancellationChance))
                 continue;

--- a/Content.Server/Xenoarchaeology/Equipment/Components/ActiveArtifactAnalyzerComponent.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Components/ActiveArtifactAnalyzerComponent.cs
@@ -1,5 +1,4 @@
-﻿using Robust.Shared.Audio;
-using Robust.Shared.Serialization.TypeSerializers.Implementations;
+﻿using Robust.Shared.Serialization.TypeSerializers.Implementations;
 
 namespace Content.Server.Xenoarchaeology.Equipment.Components;
 
@@ -19,6 +18,6 @@ public sealed partial class ActiveArtifactAnalyzerComponent : Component
     /// <summary>
     /// What is being scanned?
     /// </summary>
-    [ViewVariables]
+    [DataField]
     public EntityUid Artifact;
 }

--- a/Content.Server/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
@@ -52,7 +52,7 @@ public sealed partial class ArtifactAnalyzerComponent : Component
     public SoundSpecifier ScanFinishedSound = new SoundPathSpecifier("/Audio/Machines/scan_finish.ogg");
 
     #region Analysis Data
-    [ViewVariables]
+    [DataField]
     public EntityUid? LastAnalyzedArtifact;
 
     [ViewVariables]

--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactAnalyzerSystem.cs
@@ -195,7 +195,7 @@ public sealed class ArtifactAnalyzerSystem : EntitySystem
         var canScan = false;
         var canPrint = false;
         var points = 0;
-        if (component.AnalyzerEntity != null && TryComp<ArtifactAnalyzerComponent>(component.AnalyzerEntity, out var analyzer))
+        if (TryComp<ArtifactAnalyzerComponent>(component.AnalyzerEntity, out var analyzer))
         {
             artifact = analyzer.LastAnalyzedArtifact;
             msg = GetArtifactScanMessage(analyzer);
@@ -438,9 +438,14 @@ public sealed class ArtifactAnalyzerSystem : EntitySystem
 
     private void OnItemRemoved(EntityUid uid, ArtifactAnalyzerComponent component, ref ItemRemovedEvent args)
     {
+        // Scanners shouldn't give permanent remove vision to an artifact, and the scanned artifact doesn't have any
+        // component to track analyzers that have scanned it for removal if the artifact gets deleted.
+        // So we always clear this on removal.
+        component.LastAnalyzedArtifact = null;
+
         // cancel the scan if the artifact moves off the analyzer
         CancelScan(args.OtherEntity);
-        if (component.Console != null && Exists(component.Console))
+        if (Exists(component.Console))
             UpdateUserInterface(component.Console.Value);
     }
 

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -67,13 +67,13 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         bool permanent = false,
         HumanoidAppearanceComponent? humanoid = null)
     {
-        if (!Resolve(uid, ref humanoid))
+        if (!Resolve(uid, ref humanoid, false))
             return;
 
         var dirty = false;
         SetLayerVisibility(uid, humanoid, layer, visible, permanent, ref dirty);
         if (dirty)
-            Dirty(humanoid);
+            Dirty(uid, humanoid);
     }
 
     /// <summary>

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -787,7 +787,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
         if (!_sharedHandsSystem.CanDrop(player, toInsert.Value, hands))
         {
-            _popupSystem.PopupClient(Loc.GetString("comp-storage-cant-drop"), uid, player);
+            _popupSystem.PopupClient(Loc.GetString("comp-storage-cant-drop", ("entity", toInsert.Value)), uid, player);
             return false;
         }
 

--- a/Content.Shared/Weapons/Reflect/SharedReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/SharedReflectSystem.cs
@@ -121,7 +121,7 @@ public abstract class SharedReflectSystem : EntitySystem
 
         if (Resolve(projectile, ref projectileComp, false))
         {
-            _adminLogger.Add(LogType.BulletHit, LogImpact.Medium, $"{ToPrettyString(user)} reflected {ToPrettyString(projectile)} from {ToPrettyString(projectileComp.Weapon!.Value)} shot by {projectileComp.Shooter!.Value}");
+            _adminLogger.Add(LogType.BulletHit, LogImpact.Medium, $"{ToPrettyString(user)} reflected {ToPrettyString(projectile)} from {ToPrettyString(projectileComp.Weapon)} shot by {projectileComp.Shooter}");
 
             projectileComp.Shooter = user;
             projectileComp.Weapon = user;


### PR DESCRIPTION
- Fixes #22602
- Fixes an entity storage localization error.
- Fixes null reference exceptions in reflection system logs
- Removes invalid humanoid appearance resolve error logs
- Fixes a duplicate key exception in `DebrisFeaturePlacerSystem`
- Stops some entities from playing sounds on deletion

Most of these were just error logs or exceptions that don't affect players directly, and the entity storage localization one is too minor to bother giving a CL.
