### PR TITLE
Rigged boxing gloves have variant TC costs.

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -916,7 +916,21 @@
     - Botanist
 
 - type: listing
-  id: uplinkRiggedBoxingGloves
+  id: uplinkRiggedBoxingGlovesPassenger
+  name: uplink-rigged-boxing-gloves-name
+  description: uplink-rigged-boxing-gloves-desc
+  productEntity: ClothingHandsGlovesBoxingRigged
+  cost:
+    Telecrystal: 8
+  categories:
+    - UplinkJob
+  conditions:
+    - !type:BuyerJobCondition
+      whitelist:
+        - Passenger
+
+- type: listing
+  id: uplinkRiggedBoxingGlovesBoxer
   name: uplink-rigged-boxing-gloves-name
   description: uplink-rigged-boxing-gloves-desc
   productEntity: ClothingHandsGlovesBoxingRigged
@@ -927,7 +941,6 @@
   conditions:
     - !type:BuyerJobCondition
       whitelist:
-        - Passenger
         - Boxer
 
 - type: listing


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changed the rigged boxing gloves to have an increased cost for passengers compared to the boxer. 8 TC for a passenger - on par with northstars - and 5 TC for boxers.

## Why / Balance
This was done as a way to encourage boxers to use their job specific item more than the passengers, and to push passenger syndies away from overreliance on the item. However, through much discussion on the discord forums, passengers with boxing gloves were deemed to be iconic enough to remain as part of their syndicate job item. A compromise was made that the passengers should have a penalty compared to the boxers, but that both should keep the item.

## Technical details
Simply changed the syndicate uplink YML to include two different versions of the purchase for the two different roles. 

## Media
![image](https://github.com/space-wizards/space-station-14/assets/88403244/c0777fdc-8d56-4a2e-ba8d-f62f6226d838)
![image](https://github.com/space-wizards/space-station-14/assets/88403244/54b7f623-68e9-4260-aa00-ed77f116be7f)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- tweak: Syndicate boxers now have an easier time acquiring rigged boxing gloves compared to passengers. 5 TC for boxers, 8 TC for passengers.
