### PR TITLE
jaws cant pry bolted doors

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -25,10 +25,7 @@
     speed: 1.5
     useSound: /Audio/Items/jaws_pry.ogg
   - type: Prying
-    pryPowered: !type:Bool
-      true
-    force: !type:Bool
-      true
+    pryPowered: true
     useSound: /Audio/Items/jaws_pry.ogg
   - type: ToolForcePowered
   - type: MultipleTool
@@ -66,6 +63,8 @@
     qualities:
       - Prying
     speed: 3.0
+  - type: Prying
+    force: true # syndie jaws bypass bolts
   - type: MultipleTool
     entries:
       - behavior: Prying

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -63,8 +63,6 @@
     qualities:
       - Prying
     speed: 3.0
-  - type: Prying
-    force: true # syndie jaws bypass bolts
   - type: MultipleTool
     entries:
       - behavior: Prying


### PR DESCRIPTION
## About the PR
fixes #22460

## Why / Balance
sci can mass produce them so they shouldnt be so crazy op

valid jaws cant either

## Technical details
!type:Bool destroyed real

## Media
normal jaw is stopped by bolts
![16:32:47](https://github.com/space-wizards/space-station-14/assets/39013340/feb20d10-04a0-4411-87bf-9783599cb0d0)

the unbolted door works

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun