### PR TITLE
Drug overlay shader rework - a little more motion-sickness friendly, a little less shonky

### DIFF
--- a/Resources/Textures/Shaders/rainbow.swsl
+++ b/Resources/Textures/Shaders/rainbow.swsl
@@ -5,6 +5,11 @@ const highp float TimeScale = 0.15;
 const highp float DistortionScale = 0.02; // how strongly to warp the screen
 const highp float NoiseScale = 4.0; // scale of the random noise
 const highp float MaxColorMix = 0.05; // rainbow effect strength. at 1.0, you wont be able to see the screen anymore
+const highp float BaseColorMult = 8; // multiplier of the underlying screen texture for the rainbow effect
+const highp float BaseColorPow = 0.8; // exponent for the rainbow effect's 
+const highp float CenterRadius = 200; // radius of the gradient used to tone down the distortion effect
+const highp float CenterMinDist = 0.4; // minimum distance from the center of the screen for the distortion to appear at all
+const highp float CenterPow = 3; // the exponent used for the distortion center
 
 // hash(),  noise(), and hsv2rgb_smooth() were converted from shadertoy examples, which were released under the MIT License:
 // The MIT License
@@ -48,15 +53,19 @@ highp float mixNoise(highp vec2 point, highp float phase) {
 
 void fragment() {
     highp vec2 coord = FRAGCOORD.xy * SCREEN_PIXEL_SIZE.xy;
+    highp vec2 aspect = vec2(1.0/SCREEN_PIXEL_SIZE.x, 1.0/SCREEN_PIXEL_SIZE.y);
+    highp vec2 center = aspect * 0.5;
     
     // warp the screen.
     highp vec2 offset = vec2(mixNoise(coord, 0.), mixNoise(coord, 5.));
-    COLOR = zTextureSpec(SCREEN_TEXTURE, coord + effectScale * DistortionScale * offset);
+    highp float centergradient = pow(clamp((length(center - FRAGCOORD.xy) / CenterRadius) - CenterMinDist, 0.0, 1.0), CenterPow);
+    COLOR = zTextureSpec(SCREEN_TEXTURE, coord + effectScale * (DistortionScale * centergradient) * offset);
     
     // apply rainbow effect.
-    highp float hue = 1. + mixNoise(coord, 10.);
+    highp float hue = 1. + mixNoise(Pos, 10.);
     highp vec3 color = hsv2rgb_smooth(vec3(hue,1.0,1.0));
-    COLOR.xyz = mix(COLOR.xyz, color, MaxColorMix * effectScale * effectScale);
+    highp float coloration = pow((COLOR.x + COLOR.y + COLOR.z) * BaseColorMult, BaseColorPow);
+    COLOR.xyz = mix(COLOR.xyz, color, MaxColorMix * effectScale * effectScale * coloration);
 }
 
 

--- a/Resources/Textures/Shaders/rainbow.swsl
+++ b/Resources/Textures/Shaders/rainbow.swsl
@@ -62,7 +62,7 @@ void fragment() {
     COLOR = zTextureSpec(SCREEN_TEXTURE, coord + effectScale * (DistortionScale * centergradient) * offset);
     
     // apply rainbow effect.
-    highp float hue = 1. + mixNoise(Pos, 10.);
+    highp float hue = 1. + mixNoise(coord, 10.);
     highp vec3 color = hsv2rgb_smooth(vec3(hue,1.0,1.0));
     highp float coloration = pow((COLOR.x + COLOR.y + COLOR.z) * BaseColorMult, BaseColorPow);
     COLOR.xyz = mix(COLOR.xyz, color, MaxColorMix * effectScale * effectScale * coloration);

--- a/Resources/Textures/Shaders/rainbow.swsl
+++ b/Resources/Textures/Shaders/rainbow.swsl
@@ -10,6 +10,9 @@ const highp float BaseColorPow = 0.8; // exponent for the rainbow effect's
 const highp float CenterRadius = 200; // radius of the gradient used to tone down the distortion effect
 const highp float CenterMinDist = 0.4; // minimum distance from the center of the screen for the distortion to appear at all
 const highp float CenterPow = 3; // the exponent used for the distortion center
+const highp float CenterColorRadius = 250; // radius of the gradient used to tone down the color effect
+const highp float CenterColorMinDist = 0.2; // minimum distance from the center of the screen for the color to appear at all
+const highp float CenterColorPow = 1.25; // the exponent used for the color's center
 
 // hash(),  noise(), and hsv2rgb_smooth() were converted from shadertoy examples, which were released under the MIT License:
 // The MIT License
@@ -64,7 +67,8 @@ void fragment() {
     // apply rainbow effect.
     highp float hue = 1. + mixNoise(coord, 10.);
     highp vec3 color = hsv2rgb_smooth(vec3(hue,1.0,1.0));
-    highp float coloration = pow((COLOR.x + COLOR.y + COLOR.z) * BaseColorMult, BaseColorPow);
+    highp float centercolor = pow(clamp((length(center - FRAGCOORD.xy) / CenterColorRadius) - CenterColorMinDist, 0.0, 1.0), CenterColorPow);
+    highp float coloration = pow((COLOR.x + COLOR.y + COLOR.z) * BaseColorMult, BaseColorPow) * centercolor;
     COLOR.xyz = mix(COLOR.xyz, color, MaxColorMix * effectScale * effectScale * coloration);
 }
 


### PR DESCRIPTION
## About the PR
This PR does some funky things to a funky shader. Drugs :D

## Why / Balance
The screenspace effect that drugs currently have is one that can genuinely induce motion sickness due to there being a lack of proper grounding point while it makes your screen wobble and warp. So this PR adds one by making it so that the distortion fades out around the center of your screen. We ended up at the value we did by starting off with a small radius, seeing how the effect looks at a low framerate (which is when the effect normally gives us motion sickness), and gradually increasing the radius until we're able to stare at it without feeling motion sickness. This might not end up working for *everyone*, but hopefully it'll make it less severe!

Additionally, the rainbow effect honestly looked outright atrocious due to it being just kinda plastered on top of your screen like a transparent film. This is similar to how the drug overlay in SS13 works, but SS13 has the excuse of being stuck in Byond where it's hard to actually do anything particularly psychedelic. So this PR takes a slightly different approach: the blending between the rainbow effect and the underlying image is now directly influenced by the overall brightness of the underlying image! In laymen's terms, the effect now blends much better with the game world, with space in particular looking extremely pretty as a result. Additionally, the rainbow effect's strength is controlled by a gradient, with the effect being at it's weakest near the center of the screen.

## Technical details
This just applies a bit of simple math to the distortion effect and rainbow effect. The distortion effect has its strength scaled down depending on how far the fragment is from UV coordinate `0.5, 0.5`, and the rainbow effect has its strength scaled depending on the brightness of  the texture prior to the rainbow effect being applied, along with a gradient similar to what the distortion effect is subject to.

## Media

What the effect looks like as of commit `3ad81285f9`

https://github.com/space-wizards/space-station-14/assets/6356337/76ad101e-5f6e-40a8-82e3-7153f60b2341



<details>
<summary>[<b>Spoiler</b> - Outdated video within]</summary>

https://github.com/space-wizards/space-station-14/assets/6356337/007fa29d-9acd-442a-b8a8-8f7d9ae2f01f

</details>

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- tweak: The drug effect has been reworked. It should now hopefully cause less motion sickness, while also looking a little nicer in general.
