### PR TITLE
Check for divide by near zero

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -123,7 +123,7 @@ namespace Content.Server.Atmos.EntitySystems
                 var receiverHeatCapacity = GetHeatCapacity(receiver);
                 var giverHeatCapacity = GetHeatCapacity(giver);
                 var combinedHeatCapacity = receiverHeatCapacity + giverHeatCapacity;
-                if (combinedHeatCapacity > 0f)
+                if (combinedHeatCapacity > Atmospherics.MinimumHeatCapacity)
                 {
                     receiver.Temperature = (GetThermalEnergy(giver, giverHeatCapacity) + GetThermalEnergy(receiver, receiverHeatCapacity)) / combinedHeatCapacity;
                 }
@@ -167,7 +167,7 @@ namespace Content.Server.Atmos.EntitySystems
                         sourceHeatCapacity ??= GetHeatCapacity(source);
                         var receiverHeatCapacity = GetHeatCapacity(receiver);
                         var combinedHeatCapacity = receiverHeatCapacity + sourceHeatCapacity.Value * fraction;
-                        if (combinedHeatCapacity > 0f)
+                        if (combinedHeatCapacity > Atmospherics.MinimumHeatCapacity)
                             receiver.Temperature = (GetThermalEnergy(source, sourceHeatCapacity.Value * fraction) + GetThermalEnergy(receiver, receiverHeatCapacity)) / combinedHeatCapacity;
                     }
                 }

--- a/Content.Server/Atmos/EntitySystems/GenericGasReactionSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GenericGasReactionSystem.cs
@@ -113,7 +113,10 @@ public sealed class GenericGasReactionSystem : EntitySystem
         }
 
         float newHeatCapacity = _atmosphere.GetHeatCapacity(mix, true);
-        mix.Temperature = (initialE + reactionE)/newHeatCapacity;
+        if (newHeatCapacity > Atmospherics.MinimumHeatCapacity)
+        {
+            mix.Temperature = (initialE + reactionE)/newHeatCapacity;
+        }
         if (reactionE > 0)
         {
             var location = holder as TileAtmosphere;


### PR DESCRIPTION
## About the PR
YAML gas reactions inadvertently re-introduced an issue which could allow a divide-by-near-zero. It is possible but not confirmed that this could cause a station heat-death event.

While here, audit any other uses of `.Temperature = * / *` and check for near-zero. Auditing found two causes that remained unchecked, so fix those as well.