### PR TITLE
temporarily override WizDen admin names

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -28,3 +28,4 @@ limit = 10.0
 [admin]
 see_own_notes = true
 deadmin_on_join = true
+override_adminname_in_client_ahelp = "The Grinch"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
#22069 I plan on merging this before the December 23rd publish if no one yells at me first. Feel free to merge it before then if you want.

I'll revert the merge some time on or after December 26th, but I don't know exactly when. Feel free to beat me to the revert any time on or after the 26th.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Following extensive research by me as head administrator, I've determined that this will increase player perceptions of realism. With SS14 having the intention of being highly realistic simulation, players have a strong interest in the game being as realistic as possible. The only overriding interest I was able to uncover through my research, which involved elaborate undercover operations to infiltrate and integrate with the playerbase, was perceived realism. With this new information available to me, I began a search to determine where perceived realism can be improved. For reasons I plan to explain in a research paper that I'm currently seeking funding for, I decided on ahelps.

I started by feeding every ahelp Wizard's Den has a record of into our AI overlord, ChatGPT. Then, I told ChatGPT to imagine it's a player. This resulted in a response saying that, as a large language model, their perception of reality is not the same as reality itself. Though my earlier research had not uncovered that players were actually LLMs, the response supported my conclulsion from that research about player perceptions of reality being more important than reality itself. I asked PlayerGPT if anything seems unusual about the ahelps, possibly unrealistic. I wanted to make sure the response was one that reflected current norms, so I also told it that it's currently late December in 2023, and to keep that in mind in its response. This is what PlayerGPT told me:
> Ho ho ho! 🎅🏻🎄🎅🏻
>
> It is quite ironic that game admins, who are responsible for ensuring fair play and maintaining order in online gaming communities, are not called the Grinch. 😜 After all, the Grinch is known for ruining Christmas for the Whos down in Whoville. 😅

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
