### PR TITLE
Add a bottle of water to the survival box

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -32,6 +32,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
       - state: internals

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -12,6 +12,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
       - state: internals
@@ -51,6 +52,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
       - state: internals
@@ -71,6 +73,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
       - state: internals
@@ -96,6 +99,7 @@
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
+      - id: DrinkWaterBottleFull
   - type: Tag
     tags:
       - BoxHug

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -23,6 +23,8 @@
   name: security gas mask
   description: A standard issue Security gas mask.
   components:
+  - type: Item
+    size: Tiny
   - type: Sprite
     sprite: Clothing/Mask/gassecurity.rsi
   - type: Clothing
@@ -120,6 +122,8 @@
   name: medical mask
   description: A close-fitting sterile mask that can be connected to an air supply.
   components:
+  - type: Item
+    size: Tiny
   - type: Sprite
     sprite: Clothing/Mask/medical.rsi
   - type: Clothing
@@ -137,6 +141,8 @@
   name: military-style medical mask
   description: A medical mask with a small layer of protection against damage and viruses, similar to the one used in the medical units of the first corporate war.
   components:
+  - type: Item
+    size: Tiny
   - type: Sprite
     sprite: Clothing/Mask/medicalsecurity.rsi
   - type: Clothing
@@ -155,6 +161,8 @@
   name: breath mask
   description: Might as well keep this on 24/7.
   components:
+  - type: Item
+    size: Tiny
   - type: Sprite
     sprite: Clothing/Mask/breath.rsi
   - type: Clothing
@@ -259,6 +267,8 @@
   name: muzzle
   description: To stop that awful noise.
   components:
+  - type: Item
+    size: Tiny
   - type: Sprite
     sprite: Clothing/Mask/muzzle.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -410,13 +410,15 @@
   name: water bottle
   description: Simple clean water of unknown origin. You think that maybe you dont want to know it.
   components:
+  - type: Item
+    size: Small
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 50
+        maxVol: 30
         reagents:
         - ReagentId: Water
-          Quantity: 50
+          Quantity: 30
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/waterbottle.rsi


### PR DESCRIPTION
## About the PR
A bottle of water has been added to every survival box along with the tin of meat.
The water bottle has been made small (1x2) from medium (2x2) and now only contains 30u water instead of 50u
The breath mask has also been made tiny (1x1) in order to fit the small (1x2) bottle of water.

## Why / Balance
Now you will be able to properly remain hydrated in survival scenarios where sustenance would be required but is not otherwise provided.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/140123969/fcadeb58-03d4-47ce-b28d-4927abad63e8)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Standard NT emergency survival boxes now contain bottles of clean water of unknown origin.
- tweak: Breath masks are now smaller than gas masks
