### PR TITLE
Add maximum atmos temperature limit

### DIFF
--- a/Content.Server/Atmos/GasMixture.cs
+++ b/Content.Server/Atmos/GasMixture.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using Content.Server.Atmos.Reactions;
 using Content.Shared.Atmos;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Atmos
 {
@@ -58,8 +59,9 @@ namespace Content.Server.Atmos
             get => _temperature;
             set
             {
+                DebugTools.Assert(!float.IsNaN(_temperature));
                 if (Immutable) return;
-                _temperature = MathF.Max(value, Atmospherics.TCMB);
+                _temperature = MathF.Min(MathF.Max(value, Atmospherics.TCMB), Atmospherics.Tmax);
             }
         }
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -52,7 +52,7 @@ namespace Content.Shared.Atmos
         ///     calculations and so cap it here. The physical interpretation is that at this temperature, any
         ///     gas that you would have transforms into plasma.
         /// </summary>
-        public const float Tmax = T0C + 20000;
+        public const float Tmax = 200e3f;
 
         /// <summary>
         ///     Liters in a cell.

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -46,6 +46,15 @@ namespace Content.Shared.Atmos
         public const float T20C = 293.15f;
 
         /// <summary>
+        ///     Do not allow any gas mixture temperatures to exceed this number. It is occasionally possible
+        ///     to have very small heat capacity (e.g. room that was just unspaced) and for large amounts of
+        ///     energy to be transferred to it, even for a brief moment. However, this messes up subsequent
+        ///     calculations and so cap it here. The physical interpretation is that at this temperature, any
+        ///     gas that you would have transforms into plasma.
+        /// </summary>
+        public const float Tmax = T0C + 20000;
+
+        /// <summary>
         ///     Liters in a cell.
         /// </summary>
         public const float CellVolume = 2500f;


### PR DESCRIPTION
## About the PR
Adds `Atmospherics.Tmax`, a maximum absolute temperature temperature limit for gas mixtures.

## Why / Balance
Safe numeric code enforce numeric ranges to be within a certain well-defined range. For example in a temperature simulation, it is safe to constrain temperature in a "reasonable" range where we know that the physical laws stop applying. There is already such a limit for the minimum temperature; this adds one for the maximum temperature.

This should never happen:
![image](https://github.com/space-wizards/space-station-14/assets/3229565/7511bf7d-0efb-420f-87a6-1221ae60a1a9)

And of course while it is better to fix the problem at the root, bugs happen and code should still be robust.

### Balance
Anything that scales with temperature, e.g. damage and reaction rates, can still go through a very big range with this temperature cap.

### Physical Justification
These sorts of temperatures would never exist in real life for a variety of reasons:
- At some pressure the container would just explode, venting it
- At some temperature the container would just melt, also venting it
- At some temperature any gas would instantly converted to plasma, causing it to violently destroy the container

While it is true that temperatures exceeding this can exist on stars, that sort of defies the simple $PV=nRT$ physics we have. In numerics speak, we'd say that this is *out of the domain of our model*.