### PR TITLE
Vial Drinking

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
@@ -26,6 +26,7 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 6
     fillBaseName: vial-1-
+  - type: Drink
   - type: SolutionContainerManager
     solutions:
       drink:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR allows you to drink from vials; it also lets you see exactly the number of units in a vial.

## Why / Balance
You couldn't drink out of them, and you couldn't tell the exact measurement of the reagents inside despite the sprite having fill lines. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase



**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Vials can now be drank out of and tell you the exact unit measurement.


