### PR TITLE
Fix accidental plasma burn nerf

### DIFF
--- a/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
@@ -57,7 +57,7 @@ namespace Content.Server.Atmos.Reactions
                     mixture.AdjustMoles(Gas.Tritium, plasmaBurnRate * supersaturation);
                     mixture.AdjustMoles(Gas.CarbonDioxide, plasmaBurnRate * (1.0f - supersaturation));
 
-                    energyReleased += Atmospherics.FirePlasmaEnergyReleased * plasmaBurnRate * Atmospherics.PlasmaBurnRateDelta;
+                    energyReleased += Atmospherics.FirePlasmaEnergyReleased * plasmaBurnRate;
                     energyReleased /= heatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
                     mixture.ReactionResults[GasReaction.Fire] += plasmaBurnRate * (1 + oxygenBurnRate);
                 }

--- a/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
@@ -57,7 +57,7 @@ namespace Content.Server.Atmos.Reactions
                     mixture.AdjustMoles(Gas.Tritium, plasmaBurnRate * supersaturation);
                     mixture.AdjustMoles(Gas.CarbonDioxide, plasmaBurnRate * (1.0f - supersaturation));
 
-                    energyReleased += Atmospherics.FirePlasmaEnergyReleased * plasmaBurnRate;
+                    energyReleased += Atmospherics.FirePlasmaEnergyReleased * plasmaBurnRate * Atmospherics.PlasmaBurnRateDelta;
                     energyReleased /= heatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
                     mixture.ReactionResults[GasReaction.Fire] += plasmaBurnRate * (1 + oxygenBurnRate);
                 }

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -183,7 +183,7 @@ namespace Content.Shared.Atmos
         public const float FireMinimumTemperatureToExist = T0C + 100f;
         public const float FireMinimumTemperatureToSpread = T0C + 150f;
         public const float FireSpreadRadiosityScale = 0.85f;
-        public const float FirePlasmaEnergyReleased = 16e3f; // methane is 16 kJ/mol
+        public const float FirePlasmaEnergyReleased = 160e3f; // methane is 16 kJ/mol, plus plasma's spark of magic
         public const float FireGrowthRate = 40000f;
 
         public const float SuperSaturationThreshold = 96f;


### PR DESCRIPTION
![449646450853587](https://github.com/space-wizards/space-station-14/assets/21104932/4da6d81f-fc6a-49b5-bff3-e27c9908fc66)

## About the PR
This change buffs plasma burn energy output.

## Why / Balance
After time compression was added, it became very apparent that plasma oxygen burns became very weak. Previously, it was impossible to sustain a TEG at 8x atmos speedup where a 1x speedup would be stable.

## Technical details
Multiplies plasma energy output by 10x.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/21104932/d445b999-5eb2-4226-8a20-60412670b333)
<sup>Note: This *3.2 MW* TEG was built with a 32.3kL input pipenet.</sup>

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: router
- tweak: Plasma now outputs 10x as much energy per mole.
