### PR TITLE
Fixes GLES2 crashing when compiling the drug shader

### DIFF
--- a/Resources/Textures/Shaders/rainbow.swsl
+++ b/Resources/Textures/Shaders/rainbow.swsl
@@ -54,6 +54,10 @@ highp float mixNoise(highp vec2 point, highp float phase) {
     return mix(a,b,0.5);
 }
 
+highp float genGradient(highp vec2 center, highp vec2 coord, highp float radius, highp float dist, highp float power) {
+    return pow(min(max((length(center - coord) / radius) - dist, 0.0), 1.0), power);
+}
+
 void fragment() {
     highp vec2 coord = FRAGCOORD.xy * SCREEN_PIXEL_SIZE.xy;
     highp vec2 aspect = vec2(1.0/SCREEN_PIXEL_SIZE.x, 1.0/SCREEN_PIXEL_SIZE.y);
@@ -61,13 +65,13 @@ void fragment() {
     
     // warp the screen.
     highp vec2 offset = vec2(mixNoise(coord, 0.), mixNoise(coord, 5.));
-    highp float centergradient = pow(clamp((length(center - FRAGCOORD.xy) / CenterRadius) - CenterMinDist, 0.0, 1.0), CenterPow);
+    highp float centergradient = genGradient(center, FRAGCOORD.xy, CenterRadius, CenterMinDist, CenterPow);
     COLOR = zTextureSpec(SCREEN_TEXTURE, coord + effectScale * (DistortionScale * centergradient) * offset);
     
     // apply rainbow effect.
     highp float hue = 1. + mixNoise(coord, 10.);
     highp vec3 color = hsv2rgb_smooth(vec3(hue,1.0,1.0));
-    highp float centercolor = pow(clamp((length(center - FRAGCOORD.xy) / CenterColorRadius) - CenterColorMinDist, 0.0, 1.0), CenterColorPow);
+    highp float centercolor = genGradient(center, FRAGCOORD.xy, CenterColorRadius, CenterColorMinDist, CenterColorPow);
     highp float coloration = pow((COLOR.x + COLOR.y + COLOR.z) * BaseColorMult, BaseColorPow) * centercolor;
     COLOR.xyz = mix(COLOR.xyz, color, MaxColorMix * effectScale * effectScale * coloration);
 }


### PR DESCRIPTION
## About the PR
Title. Also applies a bit of DRY while we're at it

## Why / Balance
The GLES2 users can't experience the less motionsickness-inducing drug shader. This is, quite literally, unplayable for them

## Technical details
GLES2 completely lacks `clamp()`. So any attempt to use `clamp()` results in an immediate crash. This is easy to fix by just replacing it with `min(max())`, which is ugly af, but does the same thing as `clamp()`.

This also moves the gradient generation to it's own function. Doesn't affect performance, looks a little cleaner, etc etc.

## Media
There's no good way to show it but yeah the shader's unaffected and GLES2 boots with this change

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
The previous PR was technically a breaking change, but not in this section's definition of a breaking change. Oops.

**Changelog**
:cl: Bhijn and Myr
- fix: The client now boots in GLES2/compatibility mode again. Apologies!
