### PR TITLE
fixes drug shader in compatibility mode FOR REAL THIS TIME

### DIFF
--- a/Resources/Textures/Shaders/rainbow.swsl
+++ b/Resources/Textures/Shaders/rainbow.swsl
@@ -5,12 +5,12 @@ const highp float TimeScale = 0.15;
 const highp float DistortionScale = 0.02; // how strongly to warp the screen
 const highp float NoiseScale = 4.0; // scale of the random noise
 const highp float MaxColorMix = 0.05; // rainbow effect strength. at 1.0, you wont be able to see the screen anymore
-const highp float BaseColorMult = 8; // multiplier of the underlying screen texture for the rainbow effect
+const highp float BaseColorMult = 8.0; // multiplier of the underlying screen texture for the rainbow effect
 const highp float BaseColorPow = 0.8; // exponent for the rainbow effect's 
-const highp float CenterRadius = 200; // radius of the gradient used to tone down the distortion effect
+const highp float CenterRadius = 200.0; // radius of the gradient used to tone down the distortion effect
 const highp float CenterMinDist = 0.4; // minimum distance from the center of the screen for the distortion to appear at all
-const highp float CenterPow = 3; // the exponent used for the distortion center
-const highp float CenterColorRadius = 250; // radius of the gradient used to tone down the color effect
+const highp float CenterPow = 3.0; // the exponent used for the distortion center
+const highp float CenterColorRadius = 250.0; // radius of the gradient used to tone down the color effect
 const highp float CenterColorMinDist = 0.2; // minimum distance from the center of the screen for the color to appear at all
 const highp float CenterColorPow = 1.25; // the exponent used for the color's center
 


### PR DESCRIPTION
## About the PR
W h  y   is `display.compat` not archived aaUGUGH
In our previous hotfix PR, we thought we had `display.compat` set to true and were launching in compatibility when we started via command line, but apparently not?? So we thought we fixed it when it wasn't

## Why / Balance
being able to launch the game is good we think

fixes #22900

## Technical details
So apparently compatibility just does not care what a shader's variable is actually typecast as; `1` will always compile as an int even if it's explicitly defined as a float. So this just slaps a `.0` on all of the variables that were being incorrectly compiled as ints

## Media

https://github.com/space-wizards/space-station-14/assets/6356337/105b8bde-d234-4930-8dab-524d3b02064f



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl: Bhijn and Myr
- fix: Compatibility mode now *actually* launches. For real this time.
