### PR TITLE
Adds a vscode launch option for starting the client in the compatibility renderer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,15 @@
             "stopAtEntry": false
         },
         {
+            "name": "Client (Compatibility renderer)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
+            "args": "--cvar display.compat=true",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
             "name": "Server",
             "type": "coreclr",
             "request": "launch",


### PR DESCRIPTION
## About the PR
Does exactly as the title says; adds a new `Client (Compatibility renderer)` option to the list of vscode launch options, for the sake of making it easy to start the client in compatibility mode

## Why / Balance
Helping prevent repeats of #22903 is probably a good idea!

## Technical details
It's pretty much just a copy of the existing `Client` start option but with `--cvar display.compat=true` attached

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

No CL no fun

~~yes this is a salt pr~~