### PR TITLE
Clamp after AdjustMoles()

### DIFF
--- a/Content.Server/Atmos/GasMixture.cs
+++ b/Content.Server/Atmos/GasMixture.cs
@@ -120,12 +120,9 @@ namespace Content.Server.Atmos
                 if (!float.IsFinite(quantity))
                     throw new ArgumentException($"Invalid quantity \"{quantity}\" specified!", nameof(quantity));
 
-                Moles[gasId] += quantity;
-
-                var moles = Moles[gasId];
-
-                if (!float.IsFinite(moles) || float.IsNegative(moles))
-                    throw new Exception($"Invalid mole quantity \"{moles}\" in gas Id {gasId} after adjusting moles with \"{quantity}\"!");
+                // Clamping is needed because x - x can be negative with floating point numbers. If we don't
+                // clamp here, the caller always has to call GetMoles(), clamp, then SetMoles().
+                Moles[gasId] = MathF.Max(Moles[gasId] + quantity, 0);
             }
         }
 


### PR DESCRIPTION
## About the PR
Clamping is needed because x - x can be negative with floating point numbers. If we don't clamp here, the caller always has to call GetMoles(), clamp, then SetMoles(), which makes this function not very useful.

## Why / Balance
Fixes:

```
[ERRO] runtime: Caught exception in "entsys"
System.Exception: Invalid mole quantity "-1.314096E-06" in gas Id 1 after adjusting moles with "2.2767226E-14"!
   at Content.Server.Atmos.EntitySystems.GenericGasReactionSystem.ReactAll(IEnumerable`1 reactions, GasMixture mix, IGasMixtureHolder holder) in /home/runner/work/space-station-14/space-station-14/Content.Server/Atmos/EntitySystems/GenericGasReactionSystem.cs:line 103
   at Content.Server.Atmos.EntitySystems.AtmosphereSystem.ProcessCell(GridAtmosphereComponent gridAtmosphere, TileAtmosphere tile, Int32 fireCount, GasTileOverlayComponent visuals) in /home/runner/work/space-station-14/space-station-14/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs:line 102
```

Conceptually [approved by pjb](https://discord.com/channels/310555209753690112/934134975492653056/1188302310011568239).