### PR TITLE
Ion law visuals

### DIFF
--- a/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml
+++ b/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml
@@ -6,7 +6,7 @@
                       HorizontalExpand="True"
                       VerticalExpand="True"
                       Margin="5 5 5 5">
-            <Label Name="LawNumberLabel" StyleClasses="StatusFieldTitle"/>
+            <RichTextLabel Name="LawNumberLabel" StyleClasses="LabelKeyText"/>
             <customControls:HSeparator Margin="0 5 0 5"/>
             <RichTextLabel Name="LawLabel"/>
             <BoxContainer Name="LawAnnouncementButtons" Orientation="Horizontal" HorizontalExpand="True" Margin="0 5 0 0">

--- a/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml.cs
+++ b/Content.Client/Silicons/Laws/Ui/LawDisplay.xaml.cs
@@ -1,4 +1,5 @@
 using Content.Client.Chat.Managers;
+using Content.Client.Message;
 using Content.Shared.Chat;
 using Content.Shared.Radio;
 using Content.Shared.Silicons.Laws;
@@ -29,7 +30,7 @@ public sealed partial class LawDisplay : Control
         var lawIdentifier = Loc.GetString("laws-ui-law-header", ("id", identifier));
         var lawDescription = Loc.GetString(law.LawString);
 
-        LawNumberLabel.Text = lawIdentifier;
+        LawNumberLabel.SetMarkup(lawIdentifier);
         LawLabel.SetMessage(lawDescription);
 
         // If you can't talk, you can't state your laws...

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -910,6 +910,12 @@ namespace Content.Client.Stylesheets
                     new StyleProperty("font", notoSansItalic12),
                 }),
 
+                new StyleRule(new SelectorElement(typeof(RichTextLabel), new[] {StyleClassLabelKeyText}, null, null), new[]
+                {
+                    new StyleProperty(Label.StylePropertyFont, notoSansBold12),
+                    new StyleProperty( Control.StylePropertyModulateSelf, NanoGold)
+                }),
+
                 // alert tooltip
                 new StyleRule(new SelectorElement(typeof(RichTextLabel), new[] {StyleClassTooltipAlertTitle}, null, null), new[]
                 {

--- a/Content.Client/UserInterface/RichText/ScrambleTag.cs
+++ b/Content.Client/UserInterface/RichText/ScrambleTag.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using JetBrains.Annotations;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Client.UserInterface.RichText;
+
+/// <summary>
+/// Adds a specified length of random characters that scramble at a set rate.
+/// </summary>
+[UsedImplicitly]
+public sealed class ScrambleTag : IMarkupTag
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public string Name => "scramble";
+
+    public string TextBefore(MarkupNode node)
+    {
+        if (!node.Attributes.TryGetValue("rate", out var rateParam) ||
+            !rateParam.TryGetLong(out var rate) ||
+            !node.Attributes.TryGetValue("length", out var lengthParam) ||
+            !lengthParam.TryGetLong(out var length) ||
+            !node.Attributes.TryGetValue("chars", out var charsParam) ||
+            !charsParam.TryGetString(out var chars))
+            return string.Empty;
+
+        var seed = (int) (_timing.CurTime.TotalMilliseconds / rate);
+        var rand = new Random(seed + node.GetHashCode());
+        var charOptions = chars.ToCharArray();
+        var sb = new StringBuilder();
+        for (var i = 0; i < length; i++)
+        {
+            var index = rand.Next() % charOptions.Length;
+            sb.Append(charOptions[index]);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -137,11 +137,11 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
             }
             else
             {
-                laws.Laws.Insert(0, new SiliconLaw()
+                laws.Laws.Insert(0, new SiliconLaw
                 {
                     LawString = newLaw,
                     Order = -1,
-                    LawIdentifierOverride = "#"
+                    LawIdentifierOverride = Loc.GetString("ion-storm-law-scrambled-number", ("length", RobustRandom.Next(5, 10)))
                 });
             }
 

--- a/Resources/Locale/en-US/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/en-US/station-events/events/ion-storm.ftl
@@ -1,5 +1,7 @@
 station-event-ion-storm-start-announcement = Ion storm detected near the station. Please check all AI-controlled equipment for errors.
 
+ion-storm-law-scrambled-number = [font="Monospace"][scramble rate=250 length={$length} chars="@@###$$&%!01"/][/font]
+
 ion-storm-you = YOU
 ion-storm-the-station = THE STATION
 ion-storm-the-crew = THE CREW

--- a/Resources/Prototypes/fonts.yml
+++ b/Resources/Prototypes/fonts.yml
@@ -37,3 +37,7 @@
 - type: font
   id: AnimalSilence
   path: /Fonts/Animal Silence.otf
+
+- type: font
+  id: Monospace
+  path: /EngineFonts/NotoSans/NotoSansMono-Regular.ttf


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes ion laws have cool scramble visuals instead of boring ass `#`.
The visuals are just a set of 5-9 non-letter characters that it scrambles every .25 seconds.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds in a new `scramble` markup tag:
- rate: how fast the scrambling occurs.
- length: how many characters are in the tag
- chars: a list of the characters that will be picked for the scrambling.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Content Client_RKWiZBDQ2o](https://github.com/space-wizards/space-station-14/assets/98561806/85f3cee9-5f66-4701-89d4-fa9de0e0cefc)

the rate at which the symbols scramble is constant my screen recorder is just laggy as shit.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Ion laws now have unique chaotic visuals in the laws menu.
