### PR TITLE
Increase cigarette count in cig packs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -52,7 +52,7 @@
   - type: StorageFill
     contents:
     - id: Cigarette
-      amount: 5
+      amount: 10
   - type: ItemCounter
     count:
       tags: [Cigarette]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

It was weird how only half of the packet was filled. I had the choice to either fill the current slots, or remove the extra slots. I decided that 5 was too little and doubled the amount of cigs.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**BEFORE:**
![image](https://github.com/space-wizards/space-station-14/assets/134914314/285a5e6c-36f1-4b2e-bf91-cc70329993da)

**AFTER:**
![image](https://github.com/space-wizards/space-station-14/assets/134914314/ad8d258a-a08d-4900-b3d3-cdc059970d80)

**Changelog**

:cl: Ubaser
- tweak: Cigarette packets now contain twice the amount of cigarettes
