### PR TITLE
Service workers get botany access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -1,4 +1,4 @@
-﻿- type: job
+- type: job
   id: ServiceWorker
   name: job-name-serviceworker
   description: job-description-serviceworker
@@ -12,8 +12,9 @@
   - Maintenance
   - Bar
   - Kitchen
-  extendedAccess:
   - Hydroponics
+  extendedAccess:
+  - Janitor
 
 - type: startingGear
   id: ServiceWorkerGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

If service workers get access to both the kitchen AND the bar, which makes sense since they're closely linked; they should get botany access as well. Hell, they already break in all the time anyway since they're service workers.

**Changelog**

:cl: Ubaser
- tweak: Service workers now have botany access.
