### PR TITLE
give plasma half of co2 air alarm threshold

### DIFF
--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -40,6 +40,13 @@
     threshold: 0.5
 
 - type: alarmThreshold
+  id: stationPlasma
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 0.00125
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.5
+
+- type: alarmThreshold
   id: stationWaterVapor
   upperBound: !type:AlarmThresholdSetting
     threshold: 1.5

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -47,7 +47,7 @@
         Oxygen: stationOxygen
         Nitrogen: ignore
         CarbonDioxide: stationCO2
-        Plasma: danger # everything below is usually bad
+        Plasma: stationPlasma # everything below is usually bad
         Tritium: danger
         WaterVapor: stationWaterVapor
         Ammonia: stationAmmonia
@@ -138,7 +138,7 @@
         Oxygen: stationOxygen
         Nitrogen: ignore
         CarbonDioxide: stationCO2
-        Plasma: danger # everything below is usually bad
+        Plasma: stationPlasma # everything below is usually bad
         Tritium: danger
         WaterVapor: stationWaterVapor
         Ammonia: stationAmmonia

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -52,7 +52,7 @@
         Oxygen: stationOxygen
         Nitrogen: ignore
         CarbonDioxide: stationCO2
-        Plasma: danger # everything below is usually bad
+        Plasma: stationPlasma # everything below is usually bad
         Tritium: danger
         WaterVapor: stationWaterVapor
         Ammonia: stationAmmonia


### PR DESCRIPTION
## About the PR
change to 0.1% minimum instead of 0.001%

## Why / Balance
save atmosians and fed up tiders having to set *every fucking sensor* to 0.5 or something to stop harmless trace plasma from trolling firelocks, which happens basically every round

## Technical details
no

## Media
![04:23:45](https://github.com/space-wizards/space-station-14/assets/39013340/1bcb4128-351a-4b94-a2be-004fbbd56d83)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun