### PR TITLE
Fix closet skeletons spawning in nullspace

### DIFF
--- a/Content.Server/StationEvents/Components/RandomEntityStorageSpawnRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/RandomEntityStorageSpawnRuleComponent.cs
@@ -13,6 +13,6 @@ public sealed partial class RandomEntityStorageSpawnRuleComponent : Component
     /// <summary>
     /// The entity to be spawned.
     /// </summary>
-    [DataField("prototype", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string Prototype = string.Empty;
+    [DataField(required: true)]
+    public EntProtoId Prototype;
 }

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -258,7 +258,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
 
         if (component.Open)
         {
-            TransformSystem.SetWorldPosition(toInsert, TransformSystem.GetWorldPosition(container));
+            TransformSystem.DropNextTo(toInsert, container);
             return true;
         }
 


### PR DESCRIPTION
Was (very likely) caused by them spawning into open lockers, which just sets their world position without ever updating the map id.

fixes #20607
fixes #20646
fixes #21826

:cl:
- fix: Fixed the closet-skeleton ghost role sometimes not properly spawning.
