### PR TITLE
change the restart vote to have no effect with admins online

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -78,19 +78,20 @@ namespace Content.Server.Voting.Managers
                 var votesNo = vote.VotesPerOption["no"];
                 var total = votesYes + votesNo;
 
-                if (_cfg.GetCVar(CCVars.VoteRestartNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
-                {
-                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote attempted, but an admin was online. {votesYes}/{votesNo}");
-                    return;
-                }
-
                 var ratioRequired = _cfg.GetCVar(CCVars.VoteRestartRequiredRatio);
                 if (total > 0 && votesYes / (float) total >= ratioRequired)
                 {
-                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote succeeded: {votesYes}/{votesNo}");
-                    _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-restart-succeeded"));
-                    var roundEnd = _entityManager.EntitySysManager.GetEntitySystem<RoundEndSystem>();
-                    roundEnd.EndRound();
+                    if (_cfg.GetCVar(CCVars.VoteRestartNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
+                    {
+                        _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote attempted to pass, but an admin was online. {votesYes}/{votesNo}");
+                    }
+                    else
+                    {
+                        _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote succeeded: {votesYes}/{votesNo}");
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-restart-succeeded"));
+                        var roundEnd = _entityManager.EntitySysManager.GetEntitySystem<RoundEndSystem>();
+                        roundEnd.EndRound();
+                    }
                 }
                 else
                 {

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -81,11 +81,12 @@ namespace Content.Server.Voting.Managers
                 var ratioRequired = _cfg.GetCVar(CCVars.VoteRestartRequiredRatio);
                 if (total > 0 && votesYes / (float) total >= ratioRequired)
                 {
+                    // Check if an admin is online, and ignore the passed vote if the cvar is enabled
                     if (_cfg.GetCVar(CCVars.VoteRestartNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
                     {
                         _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote attempted to pass, but an admin was online. {votesYes}/{votesNo}");
-                    }
-                    else
+                    } 
+                    else // If the cvar is disabled or there's no admins on, proceed as normal
                     {
                         _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote succeeded: {votesYes}/{votesNo}");
                         _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-restart-succeeded"));

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -78,6 +78,12 @@ namespace Content.Server.Voting.Managers
                 var votesNo = vote.VotesPerOption["no"];
                 var total = votesYes + votesNo;
 
+                if (_cfg.GetCVar(CCVars.VoteRestartNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
+                {
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote attempted, but an admin was online. {votesYes}/{votesNo}");
+                    return;
+                }
+
                 var ratioRequired = _cfg.GetCVar(CCVars.VoteRestartRequiredRatio);
                 if (total > 0 && votesYes / (float) total >= ratioRequired)
                 {

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -338,10 +338,6 @@ namespace Content.Server.Voting.Managers
             if (voteType != null && _standardVoteTimeout.TryGetValue(voteType.Value, out timeSpan))
                 return false;
 
-            // No, seriously, stop spamming the restart vote!
-            if (voteType == StandardVoteType.Restart && _cfg.GetCVar(CCVars.VoteRestartNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
-                return false;
-
             // If only one Preset available thats not really a vote
             // Still allow vote if availbable one is different from current one
             if (voteType == StandardVoteType.Preset)

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1,4 +1,4 @@
-using Robust.Shared;
+ using Robust.Shared;
 using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar
@@ -1223,7 +1223,7 @@ namespace Content.Shared.CCVar
             CVarDef.Create("vote.restart_required_ratio", 0.85f, CVar.SERVERONLY);
 
         /// <summary>
-        /// Whether or not to restrict the restart vote when there's online admins.
+        /// Whether or not to prevent the restart vote from having any effect when there is an online admin
         /// </summary>
         public static readonly CVarDef<bool> VoteRestartNotAllowedWhenAdminOnline =
             CVarDef.Create("vote.restart_not_allowed_when_admin_online", true, CVar.SERVERONLY);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1,4 +1,4 @@
- using Robust.Shared;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Closes #16650. The restart vote, when the cvar is enabled, will now simply have no effect when the vote passes rather than being disabled entirely. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Currently it's incredibly easy to admin check by just opening the panel and seeing if the restart vote is enabled or not. I don't think there's a solution to outright remove admin checking with the restart vote other than allowing it to happen with admins on, but this implementation means that a restart vote now needs to be started *and pass* for an admin's prescence to be confirmed, which I think makes it effectively a non-issue for admin checking (at least compared to currently) 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Just moved the admin check to the passed vote instead of disabling it entirely. 