### PR TITLE
reduce nuke required floor radius variable

### DIFF
--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -181,6 +181,6 @@ namespace Content.Server.Nuke
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("requiredFloorRadius")]
-        public float RequiredFloorRadius = 7;
+        public float RequiredFloorRadius = 5;
     }
 }


### PR DESCRIPTION
this makes it unusable on several stations and required to be moved, making it more lenient so its less obtrusive for nukies
