### PR TITLE
Make cameras cycle sprite states

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -33,6 +33,7 @@
     layers:
       - map: [ "enum.SurveillanceCameraVisualsKey.Layer" ]
         state: camera
+        cycle: true
   - type: Appearance
   - type: SurveillanceCameraVisuals
     sprites:


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/4763

https://github.com/space-wizards/space-station-14/assets/31366439/865dc559-0a36-4ae8-a5c7-d779e65da664

:cl:
- add: Surveillance cameras now cycle their animation forwards and backwards.