### PR TITLE
Fix decal draw-order

### DIFF
--- a/Content.Client/Decals/Overlays/DecalOverlay.cs
+++ b/Content.Client/Decals/Overlays/DecalOverlay.cs
@@ -38,13 +38,13 @@ namespace Content.Client.Decals.Overlays
                 return;
             }
 
+            if (xform.MapID != args.MapId)
+                return;
+
             // Shouldn't need to clear cached textures unless the prototypes get reloaded.
             var handle = args.WorldHandle;
             var xformSystem = _entManager.System<TransformSystem>();
             var eyeAngle = args.Viewport.Eye?.Rotation ?? Angle.Zero;
-
-            if (xform.MapID != args.MapId)
-                return;
 
             var zIndexDictionary = decalGrid.DecalRenderIndex;
 

--- a/Content.Client/Decals/Overlays/DecalOverlay.cs
+++ b/Content.Client/Decals/Overlays/DecalOverlay.cs
@@ -2,17 +2,16 @@ using Content.Shared.Decals;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.Decals.Overlays
 {
-    public sealed class DecalOverlay : Overlay
+    public sealed class DecalOverlay : GridOverlay
     {
         private readonly SpriteSystem _sprites;
         private readonly IEntityManager _entManager;
         private readonly IPrototypeManager _prototypeManager;
-
-        public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowEntities;
 
         private readonly Dictionary<string, (Texture Texture, bool SnapCardinals)> _cachedTextures = new(64);
 
@@ -28,52 +27,58 @@ namespace Content.Client.Decals.Overlays
 
         protected override void Draw(in OverlayDrawArgs args)
         {
+            if (args.MapId == MapId.Nullspace)
+                return;
+
+            var grid = Grid;
+
+            if (!_entManager.TryGetComponent(grid, out DecalGridComponent? decalGrid) ||
+                !_entManager.TryGetComponent(grid, out TransformComponent? xform))
+            {
+                return;
+            }
+
             // Shouldn't need to clear cached textures unless the prototypes get reloaded.
             var handle = args.WorldHandle;
             var xformSystem = _entManager.System<TransformSystem>();
             var eyeAngle = args.Viewport.Eye?.Rotation ?? Angle.Zero;
 
-            var gridQuery = _entManager.AllEntityQueryEnumerator<DecalGridComponent, TransformComponent>();
+            if (xform.MapID != args.MapId)
+                return;
 
-            while (gridQuery.MoveNext(out var decalGrid, out var xform))
+            var zIndexDictionary = decalGrid.DecalRenderIndex;
+
+            if (zIndexDictionary.Count == 0)
+                return;
+
+            var (_, worldRot, worldMatrix) = xformSystem.GetWorldPositionRotationMatrix(xform);
+
+            handle.SetTransform(worldMatrix);
+
+            foreach (var decals in zIndexDictionary.Values)
             {
-                if (xform.MapID != args.MapId)
-                    continue;
-
-                var zIndexDictionary = decalGrid.DecalRenderIndex;
-
-                if (zIndexDictionary.Count == 0)
-                    continue;
-
-                var (_, worldRot, worldMatrix) = xformSystem.GetWorldPositionRotationMatrix(xform);
-
-                handle.SetTransform(worldMatrix);
-
-                foreach (var decals in zIndexDictionary.Values)
+                foreach (var decal in decals.Values)
                 {
-                    foreach (var decal in decals.Values)
+                    if (!_cachedTextures.TryGetValue(decal.Id, out var cache) && _prototypeManager.TryIndex<DecalPrototype>(decal.Id, out var decalProto))
                     {
-                        if (!_cachedTextures.TryGetValue(decal.Id, out var cache) && _prototypeManager.TryIndex<DecalPrototype>(decal.Id, out var decalProto))
-                        {
-                            cache = (_sprites.Frame0(decalProto.Sprite), decalProto.SnapCardinals);
-                            _cachedTextures[decal.Id] = cache;
-                        }
-
-                        var cardinal = Angle.Zero;
-
-                        if (cache.SnapCardinals)
-                        {
-                            var worldAngle = eyeAngle + worldRot;
-                            cardinal = worldAngle.GetCardinalDir().ToAngle();
-                        }
-
-                        var angle = decal.Angle - cardinal;
-
-                        if (angle.Equals(Angle.Zero))
-                            handle.DrawTexture(cache.Texture, decal.Coordinates, decal.Color);
-                        else
-                            handle.DrawTexture(cache.Texture, decal.Coordinates, angle, decal.Color);
+                        cache = (_sprites.Frame0(decalProto.Sprite), decalProto.SnapCardinals);
+                        _cachedTextures[decal.Id] = cache;
                     }
+
+                    var cardinal = Angle.Zero;
+
+                    if (cache.SnapCardinals)
+                    {
+                        var worldAngle = eyeAngle + worldRot;
+                        cardinal = worldAngle.GetCardinalDir().ToAngle();
+                    }
+
+                    var angle = decal.Angle - cardinal;
+
+                    if (angle.Equals(Angle.Zero))
+                        handle.DrawTexture(cache.Texture, decal.Coordinates, decal.Color);
+                    else
+                        handle.DrawTexture(cache.Texture, decal.Coordinates, angle, decal.Color);
                 }
             }
 


### PR DESCRIPTION
Using the new overlayspace ensures they don't draw above grids for stuff like planet maps.

:cl:
- fix: Fix decals such as grass drawing over shuttles on planet maps.
