### PR TITLE
Fix fulton size inconsistency

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
@@ -83,8 +83,6 @@
   name: fulton
   suffix: One
   components:
-  - type: Item
-    size: Small
   - type: Stack
     count: 1
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

Remove redundant inventory size from the Fulton stack prototype to make it consistently `Normal` size.

## Why / Balance
It works inconsistently, check my demo recording in https://github.com/space-wizards/space-station-14/issues/22936

## Technical details
I checked the steel stack prototype implementation for a reference and noticed that it doesn't override its parent item size. Applied the same solution here.

## Media
<img width="255" alt="image" src="https://github.com/space-wizards/space-station-14/assets/1192090/b56227d1-c05b-476b-b601-2faba2a5b30c">


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

<!--
## Breaking changes
~~Because of the consistency fix, fultons that players can buy from the salvage vending machine are larger than it used to be. Custom container prototypes, containing fultons, that are filled to capacity may go over their limit.~~ Probably no.

**Changelog**

Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
