### PR TITLE
Fix multi-ghosts

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -15,6 +15,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using System.Numerics;
+using Content.Shared.Movement.Systems;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Server.Body.Systems;
@@ -41,6 +42,13 @@ public sealed class BodySystem : SharedBodySystem
 
     private void OnRelayMoveInput(EntityUid uid, BodyComponent component, ref MoveInputEvent args)
     {
+        // If they haven't actually moved then ignore it.
+        if ((args.Component.HeldMoveButtons &
+             (MoveButtons.Down | MoveButtons.Left | MoveButtons.Up | MoveButtons.Right)) == 0x0)
+        {
+            return;
+        }
+
         if (_mobState.IsDead(uid) && _mindSystem.TryGetMind(uid, out var mindId, out var mind))
         {
             mind.TimeOfDeath ??= _gameTiming.RealTime;

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Mind.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
+using Content.Shared.Movement.Systems;
 using Content.Shared.Storage.Components;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -116,6 +117,13 @@ namespace Content.Server.Ghost
 
         private void OnRelayMoveInput(EntityUid uid, GhostOnMoveComponent component, ref MoveInputEvent args)
         {
+            // If they haven't actually moved then ignore it.
+            if ((args.Component.HeldMoveButtons &
+                 (MoveButtons.Down | MoveButtons.Left | MoveButtons.Up | MoveButtons.Right)) == 0x0)
+            {
+                return;
+            }
+
             // Let's not ghost if our mind is visiting...
             if (HasComp<VisitingMindComponent>(uid))
                 return;

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -171,14 +171,17 @@ public sealed class MindSystem : SharedMindSystem
             return;
         }
 
-        if (GetSession(mind) is { } session)
-            _players.SetAttachedEntity(session, entity);
-
         mind.VisitingEntity = entity;
 
         // EnsureComp instead of AddComp to deal with deferred deletions.
         var comp = EnsureComp<VisitingMindComponent>(entity);
         comp.MindId = mindId;
+
+        // Do this AFTER the entity changes above as this will fire off a player-detached event
+        // which will run ghosting twice.
+        if (GetSession(mind) is { } session)
+            _players.SetAttachedEntity(session, entity);
+
         Log.Info($"Session {mind.Session?.Name} visiting entity {entity}.");
     }
 


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/22961

This has 2 fixes:
1. The attached entity is set after the mind changes so any recursive ticker calls won't inadvertantly spawn multiple ghosts.
2. I added a guard for no move input so it doesn't hit that code path (when they're detached it fires off a nomoveinput event).

:cl:
- fix: Fix ghosts persisting.