### PR TITLE
fix the mothroach crate saying it contains six mothroaches instead of four

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/livestock-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/livestock-crates.ftl
@@ -47,7 +47,7 @@ ent-CrateNPCPenguin = Penguin crate
     .desc = A crate containing two penguins.
 
 ent-CrateNPCMothroach = Crate of mothroaches
-    .desc = A crate containing six mothroaches.
+    .desc = A crate containing four mothroaches.
 
 ent-CrateNPCPig = Pig crate
     .desc = A crate containing a single pig.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Made the mothroach crate no longer lie about how many moths it contains

## Why / Balance
I changed it because the minor error pissed me off, you're welcome

## Technical details
1 line change to locale.. 
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
This pull request does not require media.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
1 line change to a locale file, your code will be fine

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Avalon

- fix: Fixed the description of Mothroach Crates lying about their contents


![moff](https://github.com/space-wizards/space-station-14/assets/148660190/062138b8-db6a-493e-82f6-99eef03249e0)
