### PR TITLE
Thief hotfix

### DIFF
--- a/Content.Client/Thief/ThiefBackpackBoundUserInterface.cs
+++ b/Content.Client/Thief/ThiefBackpackBoundUserInterface.cs
@@ -26,8 +26,10 @@ public sealed class ThiefBackpackBoundUserInterface : BoundUserInterface
         if (!disposing)
             return;
 
+        if (_window != null)
+            _window.OnClose -= Close;
+
         _window?.Dispose();
-        _window = null;
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -132,7 +132,7 @@ public sealed partial class AdminVerbSystem
                 if (!_minds.TryGetSession(targetMindComp.Mind, out var session))
                     return;
 
-                _thief.MakeThief(session, false); //Midround add pacific is bad
+                _thief.AdminMakeThief(session, false); //Midround add pacific is bad
             },
             Impact = LogImpact.High,
             Message = Loc.GetString("admin-verb-make-thief"),

--- a/Content.Server/GameTicking/Rules/Components/ThiefRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ThiefRuleComponent.cs
@@ -15,6 +15,7 @@ public sealed partial class ThiefRuleComponent : Component
     /// <summary>
     /// Add a Pacified comp to thieves
     /// </summary>
+    [DataField]
     public bool PacifistThieves = true;
 
     /// <summary>
@@ -41,9 +42,9 @@ public sealed partial class ThiefRuleComponent : Component
     public List<EntProtoId> StarterItems = new List<EntProtoId> { "ToolboxThief", "ClothingHandsChameleonThief" }; //TO DO - replace to chameleon thieving gloves whem merg
 
     /// <summary>
-    /// All Thiefes created by this rule
+    /// All Thieves created by this rule
     /// </summary>
-    public readonly List<EntityUid> ThiefMinds = new();
+    public readonly List<EntityUid> ThievesMinds = new();
 
     /// <summary>
     /// Max Thiefs created by rule on roundstart

--- a/Content.Server/GameTicking/Rules/Components/ThiefRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ThiefRuleComponent.cs
@@ -44,7 +44,8 @@ public sealed partial class ThiefRuleComponent : Component
     /// <summary>
     /// All Thieves created by this rule
     /// </summary>
-    public readonly List<EntityUid> ThievesMinds = new();
+    [DataField]
+    public List<EntityUid> ThievesMinds = new();
 
     /// <summary>
     /// Max Thiefs created by rule on roundstart

--- a/Content.Server/Thief/Components/ThiefUndeterminedBackpackComponent.cs
+++ b/Content.Server/Thief/Components/ThiefUndeterminedBackpackComponent.cs
@@ -1,3 +1,4 @@
+using Content.Server.Thief.Systems;
 using Content.Shared.Thief;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
@@ -8,7 +9,7 @@ namespace Content.Server.Thief.Components;
 /// This component stores the possible contents of the backpack,
 /// which can be selected via the interface.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, Access(typeof(ThiefUndeterminedBackpackSystem))]
 public sealed partial class ThiefUndeterminedBackpackComponent : Component
 {
     /// <summary>

--- a/Content.Server/Thief/Systems/ThiefUndeterminedBackpackSystem.cs
+++ b/Content.Server/Thief/Systems/ThiefUndeterminedBackpackSystem.cs
@@ -6,6 +6,11 @@ using Robust.Server.Audio;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.Thief.Systems;
+
+/// <summary>
+/// <see cref="ThiefUndeterminedBackpackComponent"/>
+/// this system links the interface to the logic, and will output to the player a set of items selected by him in the interface
+/// </summary>
 public sealed class ThiefUndeterminedBackpackSystem : EntitySystem
 {
     [Dependency] private readonly AudioSystem _audio = default!;
@@ -44,7 +49,7 @@ public sealed class ThiefUndeterminedBackpackSystem : EntitySystem
             }
         }
         _audio.PlayPvs(backpack.Comp.ApproveSound, backpack.Owner);
-        QueueDel(backpack); //hehe
+        QueueDel(backpack);
     }
     private void OnChangeSet(Entity<ThiefUndeterminedBackpackComponent> backpack, ref ThiefBackpackChangeSetMessage args)
     {

--- a/Resources/Locale/en-US/thief/backpack.ftl
+++ b/Resources/Locale/en-US/thief/backpack.ftl
@@ -32,7 +32,8 @@ thief-backpack-category-chemistry-description =
     A set for those who love to improve their body.
     It includes a storage implanter,
     a DNA scrambler implanter,
-    and a set of chemicals for a rainy day.
+    a set of chemicals for a rainy day,
+    and omega soap.
 
 thief-backpack-category-syndie-name = syndie kit
 thief-backpack-category-syndie-description =

--- a/Resources/Locale/en-US/thief/backpack.ftl
+++ b/Resources/Locale/en-US/thief/backpack.ftl
@@ -3,7 +3,7 @@ thief-backpack-window-title = thief toolbox
 thief-backpack-window-description =
     This toolbox is filled with unspecified contents.
     Now you need to remember what you put in it.
-    Choose up to two different sets from the list.
+    Choose 2 different sets from the list.
 
 thief-backpack-window-selected = Kits selected: ({$selectedCount}/{$maxCount})
 
@@ -37,7 +37,7 @@ thief-backpack-category-chemistry-description =
 thief-backpack-category-syndie-name = syndie kit
 thief-backpack-category-syndie-description =
     A set of items from a syndicate agent you've robbed
-    in the past. Includes an Agent ID card, a syndicate pAI,
+    in the past. Includes an Agent ID card, Emag, a syndicate pAI,
     and some strange red crystals.
 
 thief-backpack-category-sleeper-name = sleepwalker's kit
@@ -50,13 +50,13 @@ thief-backpack-category-sleeper-description =
 thief-backpack-category-communicator-name = communicator's kit
 thief-backpack-category-communicator-description =
     A communication enthusiast's kit. Includes a master key
-    for all station channels, a radio jammer, a portable
+    for all station channels, a cybersun pen, a portable
     crew monitor, a voice chameleon mask and lots of money for business deals.
 
 thief-backpack-category-smuggler-name = smuggler's kit
 thief-backpack-category-smuggler-description =
     A kit for those who like to have big pockets.
-    Includes a fulton beacon, ten fultons
+    Includes a fulton beacon, ten fultons, 3 smoke grenades
     and an invisible crate. You can't move in them,
     but you can quickly hide or carry valuable loot.
     This kit also has a cool void cloak to go along with it.

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -43,7 +43,7 @@
   - StorageImplanter
   - DnaScramblerImplanter
   - EphedrineChemistryBottle
-  - OmnizineChemistryBottle
+  - SoapOmega
   - Syringe
   - DrinkVodkaBottleFull
 
@@ -56,6 +56,7 @@
     state: telecrystal
   content:
   - AgentIDCard
+  - Emag
   - SyndicatePersonalAI
   - ClothingHeadHatSyndieMAA
   - CigPackSyndicate
@@ -87,7 +88,7 @@
     state: icon
   content:
   - EncryptionKeyStationMaster
-  - RadioJammer
+  - CyberPen
   - SpyCrewMonitor
   - BriefcaseSyndieLobbyingBundleFilled
   - ClothingMaskGasVoiceChameleon
@@ -105,3 +106,6 @@
   - ClothingNeckCloakVoid
   - FultonBeacon
   - Fulton
+  - SmokeGrenade
+  - SmokeGrenade
+  - SmokeGrenade

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -51,7 +51,7 @@
 - type: weightedRandom
   id: ThiefBigObjectiveGroups
   weights:
-    ThiefObjectiveGroupStructure: 1
+    ThiefObjectiveGroupStructure: 0 #Temporarily disabled until obvious ways to steal structures are added
     ThiefObjectiveGroupAnimal: 2
 
 - type: weightedRandom

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -123,8 +123,8 @@
     job: Scientist
   - type: StealCondition
     stealGroup: TechnologyDisk
-    minCollectionSize: 10
-    maxCollectionSize: 20
+    minCollectionSize: 5
+    maxCollectionSize: 15
     verifyMapExistance: false
   - type: Objective
     difficulty: 0.8
@@ -136,8 +136,8 @@
   components:
   - type: StealCondition
     stealGroup: IDCard
-    minCollectionSize: 10
-    maxCollectionSize: 20
+    minCollectionSize: 5
+    maxCollectionSize: 15
     verifyMapExistance: false
   - type: Objective
     difficulty: 0.7
@@ -150,7 +150,7 @@
   - type: StealCondition
     stealGroup: EncryptionKey
     minCollectionSize: 5
-    maxCollectionSize: 25
+    maxCollectionSize: 15
   - type: Objective
     difficulty: 0.7
 
@@ -180,7 +180,7 @@
   - type: StealCondition
     stealGroup: LAMP
     minCollectionSize: 1
-    maxCollectionSize: 30
+    maxCollectionSize: 10
     verifyMapExistance: true
   - type: Objective
     difficulty: 0.5 # just for fun, collectings LAMP on Moth


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
fix some sloth review tasks
Small rebalancing of the contents of the kits
Disabling structure theft. So far, this type of task is not feasible. We need some new items for this in the form of separate PR
reduced the number of items in tasks with collections. The player has problems with free space

**Changelog**

:cl:
- tweak: The thief will temporarily not steal structures for the time being, as this task seems too difficult.
- add: Added Emag into thief's syndie kit
- add: Added 3 smoke grenades into thief's smuggler kit
- tweak: Replaced radio jammer to cyber pen into thief's communicator kit
- tweak: Replaced omnizine bottle to omega soap into thief's chemistry kit

