### PR TITLE
Update ToolshedTest for engine PR

### DIFF
--- a/Content.IntegrationTests/Tests/Toolshed/ToolshedTest.cs
+++ b/Content.IntegrationTests/Tests/Toolshed/ToolshedTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Content.IntegrationTests.Pair;
 using Content.Server.Administration.Managers;
+using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Errors;
@@ -95,6 +96,7 @@ public abstract class ToolshedTest : IInvocationContext
     }
 
     protected ICommonSession? InvocationSession { get; set; }
+    public NetUserId? User => Session?.UserId
 
     public ICommonSession? Session
     {

--- a/Content.IntegrationTests/Tests/Toolshed/ToolshedTest.cs
+++ b/Content.IntegrationTests/Tests/Toolshed/ToolshedTest.cs
@@ -96,7 +96,7 @@ public abstract class ToolshedTest : IInvocationContext
     }
 
     protected ICommonSession? InvocationSession { get; set; }
-    public NetUserId? User => Session?.UserId
+    public NetUserId? User => Session?.UserId;
 
     public ICommonSession? Session
     {

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Commands.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Commands.cs
@@ -23,7 +23,10 @@ public partial class ArtifactSystem
     private void ForceArtifactNode(IConsoleShell shell, string argstr, string[] args)
     {
         if (args.Length != 2)
+        {
             shell.WriteError("Argument length must be 2");
+            return;
+        }
 
         if (!NetEntity.TryParse(args[0], out var uidNet) || !TryGetEntity(uidNet, out var uid) || !int.TryParse(args[1], out var id))
             return;


### PR DESCRIPTION
These changes are required for an engine PR, though this PR should be fine to merge on its own.

Checking tests still pass with the engine PR:
Requires space-wizards/RobustToolbox/pull/4766