### PR TITLE
Makes brown rocks have a planetmap suffix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -1,5 +1,7 @@
-#Asteroid rocks
-#These can probably be merged with the rock types below these now, but I'm not going to mess with it since I don't want to risk altering any behavior.
+#TODO: Someone should probably move the ore vein prototypes into their own file, or otherwise split this up in some way. This should not be 1.5k lines long.
+
+
+#Asteroid rock
 - type: entity
   id: AsteroidRock
   parent: BaseStructure
@@ -152,6 +154,7 @@
   id: WallRock
   parent: BaseStructure
   name: rock
+  suffix: planetmap
   components:
     - type: PlacementReplacement
       key: walls

--- a/Resources/Prototypes/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/Entities/World/Debris/asteroids.yml
@@ -14,35 +14,11 @@
     - type: SimpleFloorPlanPopulator
       entries:
         FloorAsteroidSand:
-          - id: WallRock
+          - id: AsteroidRock
             prob: 0.5
             orGroup: rock
-          - id: WallRockCoal
-            prob: 0.15
-            orGroup: rock
-          - id: WallRockTin
-            prob: 0.15
-            orGroup: rock
-          - id: WallRockQuartz
-            prob: 0.15
-            orGroup: rock
-          - id: WallRockGold
-            prob: 0.05
-            orGroup: rock
-          - id: WallRockSilver
-            prob: 0.05
-            orGroup: rock
-          - id: WallRockPlasma
-            prob: 0.05
-            orGroup: rock
-          - id: WallRockUranium
-            prob: 0.02
-            orGroup: rock
-          - id: WallRockBananium
-            prob: 0.02
-            orGroup: rock
-          - id: WallRockArtifactFragment
-            prob: 0.01
+          - id: AsteroidRockMining
+            prob: 0.5
             orGroup: rock
     - type: IFF
       flags: HideLabel

--- a/Resources/Prototypes/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/Entities/World/Debris/asteroids.yml
@@ -14,11 +14,35 @@
     - type: SimpleFloorPlanPopulator
       entries:
         FloorAsteroidSand:
-          - id: AsteroidRock
+          - id: WallRock
             prob: 0.5
             orGroup: rock
-          - id: AsteroidRockMining
-            prob: 0.5
+          - id: WallRockCoal
+            prob: 0.15
+            orGroup: rock
+          - id: WallRockTin
+            prob: 0.15
+            orGroup: rock
+          - id: WallRockQuartz
+            prob: 0.15
+            orGroup: rock
+          - id: WallRockGold
+            prob: 0.05
+            orGroup: rock
+          - id: WallRockSilver
+            prob: 0.05
+            orGroup: rock
+          - id: WallRockPlasma
+            prob: 0.05
+            orGroup: rock
+          - id: WallRockUranium
+            prob: 0.02
+            orGroup: rock
+          - id: WallRockBananium
+            prob: 0.02
+            orGroup: rock
+          - id: WallRockArtifactFragment
+            prob: 0.01
             orGroup: rock
     - type: IFF
       flags: HideLabel


### PR DESCRIPTION
## About the PR
Adds a "planetmap" suffix to brown rock so that people don't use it on-station.

## Why / Balance
Brown rock just doesn't really fit in well on station maps, especially when visually compared with ironrock and asteroid rock.

This used to change procgen asteroids to use asteroid rock, but sloth is bulldozing those *very* soon.

**Changelog**
no cl no fun
