### PR TITLE
Fix missing entities in round summary window

### DIFF
--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -125,19 +125,15 @@ namespace Content.Client.RoundEnd
                     VerticalExpand = true,
                 };
 
-                var playerUid = _entityManager.GetEntity(playerInfo.PlayerNetEntity);
-
-                if (_entityManager.HasComponent<SpriteComponent>(playerUid))
+                if (playerInfo.PlayerNetEntity != null)
                 {
-                    var spriteView = new SpriteView
-                    {
-                        OverrideDirection = Direction.South,
-                        VerticalAlignment = VAlignment.Center,
-                        SetSize = new Vector2(32, 32),
-                        VerticalExpand = true,
-                    };
-                    spriteView.SetEntity(playerUid);
-                    hBox.AddChild(spriteView);
+                    hBox.AddChild(new SpriteView(playerInfo.PlayerNetEntity.Value, _entityManager)
+                        {
+                            OverrideDirection = Direction.South,
+                            VerticalAlignment = VAlignment.Center,
+                            SetSize = new Vector2(32, 32),
+                            VerticalExpand = true,
+                        });
                 }
 
                 if (playerInfo.PlayerICName != null)


### PR DESCRIPTION
Changes the sprite-view to use `NetEntity` instead of `EntityUid`.
Requires https://github.com/space-wizards/RobustToolbox/pull/4771