### PR TITLE
Update head rev to die on mind-shield

### DIFF
--- a/Content.Server/Mindshield/MindShieldDamageComponent.cs
+++ b/Content.Server/Mindshield/MindShieldDamageComponent.cs
@@ -1,0 +1,15 @@
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.MindShield;
+
+[RegisterComponent]
+public sealed partial class MindShieldDamageComponent : Component
+{
+
+    [DataField("mindShieldDamageGroup"), ViewVariables(VVAccess.ReadWrite)]
+    public ProtoId<DamageGroupPrototype> MindShieldDamageGroup = "Genetic";
+
+    [DataField("mindShieldDamageAmount"), ViewVariables(VVAccess.ReadWrite)]
+    public int MindShieldDamageAmount = 1000;
+}

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -7,7 +7,6 @@ using Content.Server.Roles;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Database;
-using Content.Shared.FixedPoint;
 using Content.Shared.Implants;
 using Content.Shared.Implants.Components;
 using Content.Shared.Mindshield.Components;

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -14,7 +14,7 @@ head-rev-briefing =
     Use flashes to convert people to your cause.
     Kill all heads to take over the station.
 
-head-rev-break-mindshield = The Mindshield was destroyed!
+head-rev-break-mindshield = The Mindshield was destroyed! Their brain hemorrhages, Gross!.
 
 ## Rev
 

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -14,7 +14,7 @@ head-rev-briefing =
     Use flashes to convert people to your cause.
     Kill all heads to take over the station.
 
-head-rev-break-mindshield = The Mindshield was destroyed! Their brain hemorrhages, Gross!.
+head-rev-break-mindshield = The Mindshield exploded violently!.
 
 ## Rev
 

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -239,3 +239,5 @@
   components:
     - type: Implanter
       implant: MindShieldImplant
+    - type: MindShieldDamage
+

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -313,3 +313,4 @@
    - type: Tag
      tags:
        - MindShield
+   - type: MindShieldDamage


### PR DESCRIPTION
## About the PR
Head revs die on mind-shielding, they bleed out and suffer unrevivable damage.

## Why / Balance
Admins are discussing to add a new rule to prevent head revs being held on to by other crew that prolong rounds and stall them out by the head revs not being executed. 
This would mechanically prevent those issues and prevent another rule from being added.

## Technical details
On mind shielding for a head rev, the entity takes 300 genetic damage and looses all their blood out to the floor in a simulated hemorrhage.

## Media

https://github.com/space-wizards/space-station-14/assets/47093363/3c64e8a2-8410-43f8-afdf-ccd28e2b1ba7


![image](https://github.com/space-wizards/space-station-14/assets/47093363/7c2ac31a-b892-4cdf-8464-84ca18e72e27)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: Repo
- tweak: Head revs now die on mind shielding.
