### PR TITLE
Fix device networking, again

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
@@ -92,7 +92,8 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
         //Don't filter anything if the device list is empty
         if (component.Devices.Count == 0)
         {
-            if (component.IsAllowList) args.Cancel();
+            if (component.IsAllowList)
+                args.Cancel();
             return;
         }
 
@@ -100,7 +101,8 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
 
         foreach (var recipient in args.Recipients)
         {
-            if (component.Devices.Contains(recipient.Owner) == component.IsAllowList) filteredRecipients.Add(recipient);
+            if (component.Devices.Contains(recipient.Owner) == component.IsAllowList)
+                filteredRecipients.Add(recipient);
         }
 
         args.ModifiedRecipients = filteredRecipients;
@@ -162,7 +164,7 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
             var old = device.Devices.ToList();
             device.Devices.ExceptWith(toRemove);
             RaiseLocalEvent(uid, new DeviceListUpdateEvent(old, device.Devices.ToList()));
-            Dirty(device);
+            Dirty(uid, device);
             toRemove.Clear();
         }
     }

--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -532,11 +532,12 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     /// </summary>
     private void OnUiClosed(EntityUid uid, NetworkConfiguratorComponent component, BoundUIClosedEvent args)
     {
-        component.ActiveDeviceList = null;
         if (TryComp(component.ActiveDeviceList, out DeviceListComponent? list))
         {
             list.Configurators.Remove(uid);
         }
+
+        component.ActiveDeviceList = null;
 
         if (args.UiKey is NetworkConfiguratorUiKey.Link)
         {


### PR DESCRIPTION
Follow-up to #22845 that fixes a bug that meant that a deleted entities stuck around in a hashset.
I'm fairly sure there's still some other bug somewhere, but I can't seem to find it.
