### PR TITLE
Pacifism rework

### DIFF
--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Speech;
 using Content.Shared.Throwing;
+using Content.Shared.Weapons.Melee;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
 
@@ -145,7 +146,7 @@ namespace Content.Shared.ActionBlocker
             return !ev.Cancelled;
         }
 
-        public bool CanAttack(EntityUid uid, EntityUid? target = null)
+        public bool CanAttack(EntityUid uid, EntityUid? target = null, Entity<MeleeWeaponComponent>? weapon = null, bool disarm = false)
         {
             _container.TryGetOuterContainer(uid, Transform(uid), out var outerContainer);
             if (target != null &&  target != outerContainer?.Owner && _container.IsEntityInContainer(uid))
@@ -155,7 +156,7 @@ namespace Content.Shared.ActionBlocker
                 return containerEv.CanAttack;
             }
 
-            var ev = new AttackAttemptEvent(uid, target);
+            var ev = new AttackAttemptEvent(uid, target, weapon, disarm);
             RaiseLocalEvent(uid, ev);
 
             if (ev.Cancelled)

--- a/Content.Shared/CombatMode/Pacification/PacifiedComponent.cs
+++ b/Content.Shared/CombatMode/Pacification/PacifiedComponent.cs
@@ -3,11 +3,42 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.CombatMode.Pacification;
 
 /// <summary>
-/// Status effect that disables combat mode and restricts aggressive actions.
+/// Status effect that disallows harming living things and restricts aggressive actions.
+///
+/// There is a caveat with pacifism. It's not intended to be wholly encompassing: there are ways of harming people
+/// while pacified--plenty of them, even! The goal is to restrict the obvious ones to make gameplay more interesting
+/// while not overly limiting.
+///
+/// If you want full-pacifism (no combat mode at all), you can simply set <see cref="DisallowAllCombat"/> before adding.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(PacificationSystem))]
 public sealed partial class PacifiedComponent : Component
 {
+    [DataField]
+    public bool DisallowDisarm = false;
+
+    /// <summary>
+    ///  If true, this will disable combat entirely instead of only disallowing attacking living creatures and harmful things.
+    /// </summary>
+    [DataField]
+    public bool DisallowAllCombat = false;
+
+
+    /// <summary>
+    ///     When attempting attack against the same entity multiple times,
+    ///     don't spam popups every frame and instead have a cooldown.
+    /// </summary>
+    [DataField]
+    public TimeSpan PopupCooldown = TimeSpan.FromSeconds(3.0);
+
+    [DataField]
+    public TimeSpan? NextPopupTime = null;
+
+    /// <summary>
+    ///     The last entity attacked, used for popup purposes (avoid spam)
+    /// </summary>
+    [DataField]
+    public EntityUid? LastAttackedEntity = null;
 
 }

--- a/Content.Shared/CombatMode/Pacification/PacifismDangerousAttackComponent.cs
+++ b/Content.Shared/CombatMode/Pacification/PacifismDangerousAttackComponent.cs
@@ -1,0 +1,13 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.CombatMode.Pacification;
+
+/// <summary>
+/// This is used for marking entities which could cause serious harm if attacked and should not be able to be harmed by
+/// pacifists.
+/// TODO ideally destructible is shared + converted to components so we can just check for a harmful damage trigger instead of this.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PacifismDangerousAttackComponent : Component
+{
+}

--- a/Content.Shared/Interaction/Events/AttackAttemptEvent.cs
+++ b/Content.Shared/Interaction/Events/AttackAttemptEvent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Weapons.Melee;
+
 namespace Content.Shared.Interaction.Events
 {
     /// <summary>
@@ -12,10 +14,19 @@ namespace Content.Shared.Interaction.Events
         public EntityUid Uid { get; }
         public EntityUid? Target { get; }
 
-        public AttackAttemptEvent(EntityUid uid, EntityUid? target = null)
+        public Entity<MeleeWeaponComponent>? Weapon { get; }
+
+        /// <summary>
+        ///     If this attempt is a disarm as opposed to an actual attack, for things that care about the difference.
+        /// </summary>
+        public bool Disarm { get; }
+
+        public AttackAttemptEvent(EntityUid uid, EntityUid? target = null, Entity<MeleeWeaponComponent>? weapon = null, bool disarm = false)
         {
             Uid = uid;
             Target = target;
+            Weapon = weapon;
+            Disarm = disarm;
         }
     }
 

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Bed.Sleep;
+using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.Emoting;
 using Content.Shared.Hands;
@@ -39,6 +40,7 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, StandAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, TryingToSleepEvent>(OnSleepAttempt);
         SubscribeLocalEvent<MobStateComponent, CombatModeShouldHandInteractEvent>(OnCombatModeShouldHandInteract);
+        SubscribeLocalEvent<MobStateComponent, AttemptPacifiedAttackEvent>(OnAttemptPacifiedAttack);
     }
 
     private void OnStateExitSubscribers(EntityUid target, MobStateComponent component, MobState state)
@@ -164,6 +166,11 @@ public partial class MobStateSystem
         // for non-dead mobs
         if (!IsDead(uid, component))
             args.Cancelled = true;
+    }
+
+    private void OnAttemptPacifiedAttack(Entity<MobStateComponent> ent, ref AttemptPacifiedAttackEvent args)
+    {
+        args.Cancelled = true;
     }
 
     #endregion

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -28,6 +28,7 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Robust.Shared.Toolshed.Syntax;
 
 namespace Content.Shared.Weapons.Melee;
 
@@ -350,7 +351,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             case LightAttackEvent light:
                 var lightTarget = GetEntity(light.Target);
 
-                if (!Blocker.CanAttack(user, lightTarget))
+                if (!Blocker.CanAttack(user, lightTarget, (weaponUid, weapon)))
                     return false;
 
                 // Can't self-attack if you're the weapon
@@ -361,11 +362,11 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             case DisarmAttackEvent disarm:
                 var disarmTarget = GetEntity(disarm.Target);
 
-                if (!Blocker.CanAttack(user, disarmTarget))
+                if (!Blocker.CanAttack(user, disarmTarget, (weaponUid, weapon), true))
                     return false;
                 break;
             default:
-                if (!Blocker.CanAttack(user))
+                if (!Blocker.CanAttack(user, weapon: (weaponUid, weapon)))
                     return false;
                 break;
         }
@@ -642,20 +643,27 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         foreach (var entity in targets)
         {
+            // We raise an attack attempt here as well,
+            // primarily because this was an untargeted wideswing: if a subscriber to that event cared about
+            // the potential target (such as for pacifism), they need to be made aware of the target here.
+            // In that case, just continue.
+            if (!Blocker.CanAttack(user, entity, (weapon, component)))
+                continue;
+
             var attackedEvent = new AttackedEvent(meleeUid, user, GetCoordinates(ev.Coordinates));
             RaiseLocalEvent(entity, attackedEvent);
             var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEvent.BonusDamage, hitEvent.ModifiersList);
 
             var damageResult = Damageable.TryChangeDamage(entity, modifiedDamage, origin:user);
 
-            if (damageResult != null && damageResult.Total > FixedPoint2.Zero)
+            if (damageResult != null && damageResult.GetTotal() > FixedPoint2.Zero)
             {
                 appliedDamage += damageResult;
 
                 if (meleeUid == user)
                 {
                     AdminLogger.Add(LogType.MeleeHit, LogImpact.Medium,
-                        $"{ToPrettyString(user):actor} melee attacked (heavy) {ToPrettyString(entity):subject} using their hands and dealt {damageResult.Total:damage} damage");
+                        $"{ToPrettyString(user):actor} melee attacked (heavy) {ToPrettyString(entity):subject} using their hands and dealt {damageResult.GetTotal():damage} damage");
                 }
                 else
                 {
@@ -667,7 +675,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         if (entities.Count != 0)
         {
-            if (appliedDamage.Total > FixedPoint2.Zero)
+            if (appliedDamage.GetTotal() > FixedPoint2.Zero)
             {
                 var target = entities.First();
                 PlayHitSound(target, user, GetHighestDamageSound(appliedDamage, _protoManager), hitEvent.HitSoundOverride, component.HitSound);
@@ -685,7 +693,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             }
         }
 
-        if (appliedDamage.Total > FixedPoint2.Zero)
+        if (appliedDamage.GetTotal() > FixedPoint2.Zero)
         {
             DoDamageEffect(targets, user, Transform(targets[0]));
         }

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -94,7 +94,7 @@ alerts-bleed-name = [color=red]Bleed[/color]
 alerts-bleed-desc = You're [color=red]bleeding[/color].
 
 alerts-pacified-name = [color=green]Pacified[/color]
-alerts-pacified-desc = You're pacified; you won't be able to attack anyone directly.
+alerts-pacified-desc = You're pacified; you won't be able to harm living creatures.
 
 alerts-suit-power-name = Suit Power
 alerts-suit-power-desc = How much power your space ninja suit has.

--- a/Resources/Locale/en-US/pacified/pacified.ftl
+++ b/Resources/Locale/en-US/pacified/pacified.ftl
@@ -2,7 +2,7 @@
 ## Messages shown to Pacified players when they try to do violence:
 
 # With projectiles:
-pacified-cannot-throw = I can't bring yourself to throw { THE($projectile) }, that could hurt someone!
+pacified-cannot-throw = I can't bring myself to throw { THE($projectile) }, that could hurt someone!
 # With embedding projectiles:
 pacified-cannot-throw-embed = No way I could throw { THE($projectile) }, that could get lodged inside someone!
 # With liquid-spilling projectiles:

--- a/Resources/Locale/en-US/pacified/pacified.ftl
+++ b/Resources/Locale/en-US/pacified/pacified.ftl
@@ -2,10 +2,14 @@
 ## Messages shown to Pacified players when they try to do violence:
 
 # With projectiles:
-pacified-cannot-throw = You can't bring yourself to throw { THE($projectile) }, that could hurt someone!
+pacified-cannot-throw = I can't bring yourself to throw { THE($projectile) }, that could hurt someone!
 # With embedding projectiles:
-pacified-cannot-throw-embed = No way you can throw { THE($projectile) }, that could get lodged inside someone!
+pacified-cannot-throw-embed = No way I could throw { THE($projectile) }, that could get lodged inside someone!
 # With liquid-spilling projectiles:
-pacified-cannot-throw-spill = You can't possibly throw { THE($projectile) }, that could spill nasty stuff on someone!
+pacified-cannot-throw-spill = I can't possibly throw { THE($projectile) }, that could spill nasty stuff on someone!
 # With bolas and snares:
-pacified-cannot-throw-snare = You can't throw { THE($projectile) }, what if someone trips?!
+pacified-cannot-throw-snare = I can't throw { THE($projectile) }, what if someone trips?!
+
+pacified-cannot-harm-directly = I can't bring myself to hurt { THE($entity) }!
+pacified-cannot-harm-indirect = I can't damage { THE($entity) }, it could hurt someone!
+pacified-cannot-fire-gun = I can't fire { THE($entity) }, it could hurt someone!

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -54,6 +54,7 @@
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic
+  - type: PacifismDangerousAttack
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -59,6 +59,7 @@
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: StrongMetallic
+  - type: PacifismDangerousAttack
   - type: Destructible
     thresholds:
     - trigger:
@@ -191,6 +192,7 @@
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic
+  - type: PacifismDangerousAttack
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -28,6 +28,7 @@
     weldingDamage:
       types:
         Heat: 10
+  - type: PacifismDangerousAttack
   - type: Explosive
     explosionType: Default
     totalIntensity: 120 # ~ 5 tile radius


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

primarily to alleviate valid concerns from #22932, but i think this is less limiting while still retaining the fun core of pacifism in general!

this change applies to all pacifism--i.e. trait, thief, and pax, since they all use the same system.

the changes are as follows:
- pacifists now have melee access, but simply cant attack living things or dangerous things. they can attack basic structures and such
- pacifists can now disarm people. the main tool of a pacifist in my opinion
- pacifists now explicitly are not allowed to use guns
- pacifists can now use melee weapons that deal no damage freely (including **flashes**!!!!)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

pacifism before wasnt thought through super well and was unintuitive in a lot of ways--players expected to be able to flash people, disarm etc but the previous system was too limiting. now it's less limiting while still retaining the fun core of not being able to attack people!

for coders/downstreams that want the original functionality, you can still completely disable their ability to use melee combat by tweaking the component.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

couple annoying things had to be done:
- introduction of PacifismDangerousAttackComponent. as the comment says, ideally destructible is shared and handles this by simply not allowing it if there are dangerous damage triggers, but this will have to do for now.
- heavy attacks now check canattack before attacking each of their hit entities. this is so subscribers which care about the specific target being attacked can properly stop damage from occurring
- attackattempt now passes whether it was a disarm. because its raised so early in the melee flow and disarm is pretty linked to melee in general i felt this was the easiest option that preserved compatbility since ofc most attackattemptevent subscribers also want to cancel disarming--only some dont care
- because melee/shooting uses input events and are raised continuously a basic cooldown for the pacifism popup was introduced to avoid spamming

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/19853115/41953a5f-1321-4a57-9457-f468058051d8

i didnt show flashes in this because forgog but trust me it works!

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

n/a

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Pacifists can now attack in general, but are still forbidden from hurting living creatures or dangerous things.
- tweak: Pacifists can now disarm people. They are pacifist, after all.
- tweak: Pacifists can now use flashes (and zero-damaging melee weapons, in general)