### PR TITLE
remove racism

### DIFF
--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -53,8 +53,6 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
     [ValidatePrototypeId<DatasetPrototype>]
     private const string AllergySeverities = "IonStormAllergySeverities";
     [ValidatePrototypeId<DatasetPrototype>]
-    private const string Species = "IonStormSpecies";
-    [ValidatePrototypeId<DatasetPrototype>]
     private const string Concepts = "IonStormConcepts";
     [ValidatePrototypeId<DatasetPrototype>]
     private const string Drinks = "IonStormDrinks";
@@ -173,7 +171,6 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
         var action = Pick(Actions);
         var allergy = Pick(Allergies);
         var allergySeverity = Pick(AllergySeverities);
-        var species = Pick(Species);
         var concept = Pick(Concepts);
         var drink = Pick(Drinks);
         var food = Pick(Foods);
@@ -206,21 +203,21 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
             _ => Loc.GetString("ion-storm-heads")
         };
         var part = Loc.GetString("ion-storm-part", ("part", RobustRandom.Prob(0.5f)));
-        var harm = RobustRandom.Next(0, 7) switch
+        var harm = RobustRandom.Next(0, 6) switch
         {
             0 => concept,
             1 => $"{adjective} {threats}",
             2 => $"{adjective} {objects}",
             3 => Loc.GetString("ion-storm-adjective-things", ("adjective", adjective)),
-            4 => species,
-            5 => crew1,
+            4 => crew1,
             _ => Loc.GetString("ion-storm-x-and-y", ("x", crew1), ("y", crew2))
         };
 
         if (plural) feeling = feelingPlural;
 
         // message logic!!!
-        return RobustRandom.Next(0, 37) switch
+        return RobustRandom.Next(0, 36
+        ) switch
         {
             0  => Loc.GetString("ion-storm-law-on-station", ("joined", joined), ("subjects", triple)),
             1  => Loc.GetString("ion-storm-law-no-shuttle", ("joined", joined), ("subjects", triple)),
@@ -251,12 +248,11 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
             27 => Loc.GetString("ion-storm-law-crew-only-1", ("who", crew1), ("part", part)),
             28 => Loc.GetString("ion-storm-law-crew-only-2", ("who", crew1), ("other", crew2), ("part", part)),
             29 => Loc.GetString("ion-storm-law-crew-only-subjects", ("adjective", adjective), ("subjects", RobustRandom.Prob(0.5f) ? objectsThreats : "PEOPLE"), ("part", part)),
-            30 => Loc.GetString("ion-storm-law-crew-only-species", ("species", species), ("part", part)),
-            31 => Loc.GetString("ion-storm-law-crew-must-do", ("must", must), ("part", part)),
-            32 => Loc.GetString("ion-storm-law-crew-must-have", ("adjective", adjective), ("objects", objects), ("part", part)),
-            33 => Loc.GetString("ion-storm-law-crew-must-eat", ("who", who), ("adjective", adjective), ("food", food), ("part", part)),
-            34 => Loc.GetString("ion-storm-law-harm", ("who", harm)),
-            35 => Loc.GetString("ion-storm-law-protect", ("who", harm)),
+            30 => Loc.GetString("ion-storm-law-crew-must-do", ("must", must), ("part", part)),
+            31 => Loc.GetString("ion-storm-law-crew-must-have", ("adjective", adjective), ("objects", objects), ("part", part)),
+            32 => Loc.GetString("ion-storm-law-crew-must-eat", ("who", who), ("adjective", adjective), ("food", food), ("part", part)),
+            33 => Loc.GetString("ion-storm-law-harm", ("who", harm)),
+            34 => Loc.GetString("ion-storm-law-protect", ("who", harm)),
             _ => Loc.GetString("ion-storm-law-concept-verb", ("concept", concept), ("verb", verb), ("subjects", triple))
         };
     }

--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -216,8 +216,7 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
         if (plural) feeling = feelingPlural;
 
         // message logic!!!
-        return RobustRandom.Next(0, 36
-        ) switch
+        return RobustRandom.Next(0, 36) switch
         {
             0  => Loc.GetString("ion-storm-law-on-station", ("joined", joined), ("subjects", triple)),
             1  => Loc.GetString("ion-storm-law-no-shuttle", ("joined", joined), ("subjects", triple)),

--- a/Resources/Locale/en-US/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/en-US/station-events/events/ion-storm.ftl
@@ -77,7 +77,6 @@ ion-storm-part = {$part ->
 ion-storm-law-crew-only-1 = ONLY THE {$who} ARE {$part} OF THE CREW
 ion-storm-law-crew-only-2 = ONLY THE {$who} AND {$other} ARE {$part} OF THE CREW
 ion-storm-law-crew-only-subjects = ONLY {$adjective} {$subjects} ARE {$part} OF THE CREW
-ion-storm-law-crew-only-species = ONLY {$species} ARE {$part} OF THE CREW
 ion-storm-law-crew-must-do = ONLY THOSE WHO {$must} ARE {$part} OF THE CREW
 ion-storm-law-crew-must-have = ONLY THOSE WHO HAVE {$adjective} {$objects} ARE {$part} OF THE CREW
 ion-storm-law-crew-must-eat = ONLY THOSE WHO EAT {$adjective} {$food} ARE {$part} OF THE CREW

--- a/Resources/Prototypes/Datasets/ion_storm.yml
+++ b/Resources/Prototypes/Datasets/ion_storm.yml
@@ -806,20 +806,6 @@
   - TRAITORS
   - VEGETABLES
 
-# Species, for when the law holder has to commit genocide. Plural.
-- type: dataset
-  id: IonStormSpecies
-  values:
-  - ARACHNAE
-  - CYBORGS
-  - DIONAE
-  - HUMANS
-  - LIZARDMEN
-  - MOFFERS
-  - MONKEYS
-  - SLIME PEOPLE
-  - SKELETONS
-
 # Specific actions that either harm humans or must be done to not
 # harm humans. Make sure they're plural and "not" can be tacked
 # onto the front of them.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Technically speceism or whatever but I wanted the funny title. Removes the AI storm rules that say "Only [species] is part of the crew". 

This can no longer happen: 
![image](https://github.com/space-wizards/space-station-14/assets/135308300/4ce256b9-f614-4d34-9914-382db3be9031)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Discrimination based on species is explicitly against the server rules, so telling a borg that they have to genocide all moths or something is bound to cause issues. I'm sure it could be funny, but I don't imagine admins want to deal with an ahelp like "why are you screaming kill all lizards" "my laws told me to" or something.
The comment also *explicitly says* it's for species genocide, which makes me think it was just ported from 13 and doesn't really have a place here. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

