### PR TITLE
remove ion storm announcement

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -427,8 +427,5 @@
     weight: 5
     earliestStart: 20
     reoccurrenceDelay: 60
-    startAnnouncement: station-event-ion-storm-start-announcement
-    startAudio:
-      path: /Audio/Announcements/ion_storm.ogg
     duration: 1
   - type: IonStormRule


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
remove ion storm announcement

## Why / Balance
it affects nothing if people know it happened and can just ask borgs the new laws, they should have to infer something changed based on borg behavior

🆑 
- tweak: Ion Storm is silent now
