### PR TITLE
Fix reptilians pulling after being zombiefied

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -263,10 +263,7 @@ namespace Content.Server.Zombies
                 RemComp(target, handsComp);
             }
 
-            if (TryComp<SharedPullerComponent>(target, out var pullerComp))
-            {
-                RemComp(target, pullerComp);
-            }
+            RemComp<SharedPullerComponent>(target);
 
             // No longer waiting to become a zombie:
             // Requires deferral because this is (probably) the event which called ZombifyEntity in the first place.

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -29,6 +29,7 @@ using Content.Shared.Nutrition.AnimalHusbandry;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
+using Content.Shared.Pulling.Components;
 using Content.Shared.Tools.Components;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Zombies;
@@ -260,6 +261,11 @@ namespace Content.Server.Zombies
             {
                 _hands.RemoveHands(target);
                 RemComp(target, handsComp);
+            }
+
+            if (TryComp<SharedPullerComponent>(target, out var pullerComp))
+            {
+                RemComp(target, pullerComp);
             }
 
             // No longer waiting to become a zombie:


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Now being zombefied removes ability to pull objects, regardless of if the entity could pull without using their hands.


## Why / Balance
Zombies should not have enough intelligence and motory skills to pull stuff.

## Technical details
Removes SharedPuller component on entity zombification.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
- Zombies no longer have `SharedPullerComponent`
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- fix: Zombiefied reptilians no longer can pull objects with their tail.
