### PR TITLE
Marking Locale Fix

### DIFF
--- a/Resources/Locale/en-US/markings/moth.ftl
+++ b/Resources/Locale/en-US/markings/moth.ftl
@@ -1,134 +1,391 @@
-marking-MothAntennasDefault = Antennas (Default)
-marking-MothAntennasCharred = Antennas (Charred)
-marking-MothAntennasDbushy = Antennas (Bushy)
-marking-MothAntennasDcurvy = Antennas (Curvy)
-marking-MothAntennasDfan = Antennas (Fan)
-marking-MothAntennasDpointy = Antennas (Pointy)
-marking-MothAntennasFeathery = Antennas (Feathery)
-marking-MothAntennasFirewatch = Antennas (Firewatch)
-marking-MothAntennasGray = Antennas (Gray)
-marking-MothAntennasJungle = Antennas (Jungle)
-marking-MothAntennasMaple = Antennas (Maple)
-marking-MothAntennasMoffra = Antennas (Moffra)
-marking-MothAntennasOakworm = Antennas (Oak Worm)
-marking-MothAntennasPlasmafire = Antennas (Plasmafire)
-marking-MothAntennasRoyal = Antennas (Royal)
-marking-MothAntennasStriped = Antennas (Striped)
-marking-MothAntennasWhitefly = Antennas (White Fly)
-marking-MothAntennasWitchwing = Antennas (Witch Wing)
+marking-MothAntennasDefault-default = Antennae
+marking-MothAntennasDefault = Antennae (Default)
+
+marking-MothAntennasCharred-charred = Antennae
+marking-MothAntennasCharred = Antennae (Charred)
+
+marking-MothAntennasDbushy-dbushy = Antennae
+marking-MothAntennasDbushy = Antennae (Bushy)
+
+marking-MothAntennasDcurvy-dcurvy = Antennae
+marking-MothAntennasDcurvy = Antennae (Curvy)
+
+marking-MothAntennasDfan-dfan = Antennae
+marking-MothAntennasDfan = Antennae (Fan)
+
+marking-MothAntennasDpointy-dpointy = Antennae
+marking-MothAntennasDpointy = Antennae (Pointy)
+
+marking-MothAntennasFeathery-feathery = Antennae
+marking-MothAntennasFeathery = Antennae (Feathery)
+
+marking-MothAntennasFirewatch-firewatch = Antennae
+marking-MothAntennasFirewatch = Antennae (Firewatch)
+
+marking-MothAntennasGray-gray = Antennae
+marking-MothAntennasGray = Antennae (Gray)
+
+marking-MothAntennasJungle-jungle = Antennae
+marking-MothAntennasJungle = Antennae (Jungle)
+
+marking-MothAntennasMaple-maple = Antennae
+marking-MothAntennasMaple = Antennae (Maple)
+
+marking-MothAntennasMoffra-moffra = Antennae
+marking-MothAntennasMoffra = Antennae (Moffra)
+
+marking-MothAntennasOakworm-oakworm = Antennae
+marking-MothAntennasOakworm = Antennae (Oak Worm)
+
+marking-MothAntennasPlasmafire-plasmafire = Antennae
+marking-MothAntennasPlasmafire = Antennae (Plasmafire)
+
+marking-MothAntennasRoyal-royal = Antennae
+marking-MothAntennasRoyal = Antennae (Royal)
+
+marking-MothAntennasStriped-striped = Antennae
+marking-MothAntennasStriped = Antennae (Striped)
+
+marking-MothAntennasWhitefly-whitefly = Antennae
+marking-MothAntennasWhitefly = Antennae (White Fly)
+
+marking-MothAntennasWitchwing-witchwing = Antennae
+marking-MothAntennasWitchwing = Antennae (Witch Wing)
 
 
+
+
+
+marking-MothWingsDefault-default = Wing
 marking-MothWingsDefault = Wings (Default)
+
+marking-MothWingsCharred-charred = Wing
 marking-MothWingsCharred = Wings (Charred)
+
+marking-MothWingsDbushy-dbushy_primary = Primary
+marking-MothWingsDbushy-dbushy_secondary = Secondary
 marking-MothWingsDbushy = Wings (Dark & Bushy)
+
+marking-MothWingsDeathhead-deathhead_primary = Primary
+marking-MothWingsDeathhead-deathhead_secondary = Secondary
 marking-MothWingsDeathhead = Wings (Death's-Head)
+
+marking-MothWingsFan-fan = Wing
 marking-MothWingsFan = Wings (Fan)
+
+marking-MothWingsDfan-dfan = Wing
 marking-MothWingsDfan = Wings (Dark & Fan)
+
+marking-MothWingsFeathery-feathery = Wing
 marking-MothWingsFeathery = Wings (Feathery)
+
+marking-MothWingsFirewatch-firewatch_primary = Primary
+marking-MothWingsFirewatch-firewatch_secondary = Secondary
 marking-MothWingsFirewatch = Wings (Firewatch)
+
+marking-MothWingsGothic-gothic = Wing
 marking-MothWingsGothic = Wings (Gothic)
+
+marking-MothWingsJungle-jungle = Wing
 marking-MothWingsJungle = Wings (Jungle)
+
+marking-MothWingsLadybug-ladybug = Wing
 marking-MothWingsLadybug = Wings (Ladybug)
+
+marking-MothWingsMaple-maple = Wing
 marking-MothWingsMaple = Wings (Maple)
+
+marking-MothWingsMoffra-moffra_primary = Primary
+marking-MothWingsMoffra-moffra_secondary = Secondary
 marking-MothWingsMoffra = Wings (Moffra)
+
+marking-MothWingsOakworm-oakworm = Wing
 marking-MothWingsOakworm = Wings (Oak Worm)
+
+marking-MothWingsPlasmafire-plasmafire_primary = Primary
+marking-MothWingsPlasmafire-plasmafire_secondary = Secondary
 marking-MothWingsPlasmafire = Wings (Plasmafire)
+
+marking-MothWingsPointy-pointy = Wing
 marking-MothWingsPointy = Wings (Pointy)
+
+marking-MothWingsRoyal-royal_primary = Primary
+marking-MothWingsRoyal-royal_secondary = Secondary
 marking-MothWingsRoyal = Wings (Royal)
+
+marking-MothWingsStellar-stellar = Wing
 marking-MothWingsStellar = Wings (Stellar)
+
+marking-MothWingsStriped-striped = Wing
 marking-MothWingsStriped = Wings (Striped)
+
+marking-MothWingsSwirly-swirly = Wing
 marking-MothWingsSwirly = Wings (Swirly)
+
+marking-MothWingsWhitefly-whitefly = Wing
 marking-MothWingsWhitefly = Wings (White Fly)
+
+marking-MothWingsWitchwing-witchwing = Wing
 marking-MothWingsWitchwing = Wings (Witch Wing)
 
 
+
+
+
+marking-MothChestCharred-charred_chest = Chest
 marking-MothChestCharred = Moth Chest (Charred)
+
+marking-MothHeadCharred-charred_head = Head
 marking-MothHeadCharred = Moth Head (Charred)
+
+marking-MothLLegCharred-charred_l_leg =  Left Leg
 marking-MothLLegCharred = Moth Left Leg (Charred)
+
+marking-MothRLegCharred-charred_r_leg = Right Leg
 marking-MothRLegCharred = Moth Right Leg (Charred)
+
+marking-MothLArmCharred-charred_l_arm = Left Arm
 marking-MothLArmCharred = Moth Left Arm (Charred)
+
+marking-MothRArmCharred-charred_r_arm = Right Arm
 marking-MothRArmCharred = Moth Right Arm (Charred)
 
+
+
+marking-MothChestDeathhead-deathhead_chest = Chest
 marking-MothChestDeathhead = Moth Chest (Death's-Head)
+
+marking-MothHeadDeathhead-deathhead_head = Head
 marking-MothHeadDeathhead = Moth Head (Death's-Head)
+
+marking-MothLLegDeathhead-deathhead_l_leg = Left Leg
 marking-MothLLegDeathhead = Moth Left Leg (Death's-Head)
+
+marking-MothRLegDeathhead-deathhead_r_leg = Right Leg
 marking-MothRLegDeathhead = Moth Right Leg (Death's-Head)
+
+marking-MothLArmDeathhead-deathhead_l_arm = Left Arm
 marking-MothLArmDeathhead = Moth Left Arm (Death's-Head)
+
+marking-MothRArmDeathhead-deathhead_r_arm = Right Arm
 marking-MothRArmDeathhead = Moth Right Arm (Death's-Head)
 
+
+
+marking-MothChestFan-fan_chest = Chest
 marking-MothChestFan = Moth Chest (Fan)
+
+marking-MothHeadFan-fan_head = Head
 marking-MothHeadFan = Moth Head (Fan)
+
+marking-MothLLegFan-fan_l_leg = Left Leg
 marking-MothLLegFan = Moth Left Leg (Fan)
+
+marking-MothRLegFan-fan_r_leg = Right Leg
 marking-MothRLegFan = Moth Right Leg (Fan)
+
+marking-MothLArmFan-fan_l_arm = Left Arm
 marking-MothLArmFan = Moth Left Arm (Fan)
+
+marking-MothRArmFan-fan_r_arm = Right Arm
 marking-MothRArmFan = Moth Right Arm (Fan)
 
+
+
+marking-MothChestFirewatch-firewatch_chest = Chest
 marking-MothChestFirewatch = Moth Chest (Firewatch)
+
+marking-MothHeadFirewatch-firewatch_head = Head
 marking-MothHeadFirewatch = Moth Head (Firewatch)
+
+marking-MothLLegFirewatch-firewatch_l_leg = Left Leg
 marking-MothLLegFirewatch = Moth Left Leg (Firewatch)
+
+marking-MothRLegFirewatch-firewatch_r_leg = Right Leg
 marking-MothRLegFirewatch = Moth Right Leg (Firewatch)
+
+marking-MothLArmFirewatch-firewatch_l_arm = Left Arm
 marking-MothLArmFirewatch = Moth Left Arm (Firewatch)
+
+marking-MothRArmFirewatch-firewatch_r_arm = Right Arm
 marking-MothRArmFirewatch = Moth Right Arm (Firewatch)
 
+
+
+marking-MothChestGothic-gothic_chest = Chest
 marking-MothChestGothic = Moth Chest (Gothic)
+
+marking-MothHeadGothic-gothic_head = Head 
 marking-MothHeadGothic = Moth Head (Gothic)
+
+marking-MothLLegGothic-gothic_l_leg = Left Leg
 marking-MothLLegGothic = Moth Left Leg (Gothic)
+
+marking-MothRLegGothic-gothic_r_leg = Right Leg
 marking-MothRLegGothic = Moth Right Leg (Gothic)
+
+marking-MothLArmGothic-gothic_l_arm = Left Arm
 marking-MothLArmGothic = Moth Left Arm (Gothic)
+
+marking-MothRArmGothic-gothic_r_arm = Right Arm
 marking-MothRArmGothic = Moth Right Arm (Gothic)
 
+
+
+marking-MothChestJungle-jungle_chest = Chest
 marking-MothChestJungle = Moth Chest (Jungle)
+
+marking-MothHeadJungle-jungle_head = Head
 marking-MothHeadJungle = Moth Head (Jungle)
+
+marking-MothLLegJungle-jungle_l_leg = Left Leg
 marking-MothLLegJungle = Moth Left Leg (Jungle)
+
+marking-MothRLegJungle-jungle_r_leg = Right Leg
 marking-MothRLegJungle = Moth Right Leg (Jungle)
+
+marking-MothLArmJungle-jungle_l_arm = Left Arm
 marking-MothLArmJungle = Moth Left Arm (Jungle)
+
+marking-MothRArmJungle-jungle_r_arm = Right Arm
 marking-MothRArmJungle = Moth Right Arm (Jungle)
 
+
+
+marking-MothChestMoonfly-moonfly_chest = Chest
 marking-MothChestMoonfly = Moth Chest (Moonfly)
+
+marking-MothHeadMoonfly-moonfly_head = Head
 marking-MothHeadMoonfly = Moth Head (Moonfly)
+
+marking-MothLLegMoonfly-moonfly_l_leg = Left Leg
 marking-MothLLegMoonfly = Moth Left Leg (Moonfly)
+
+marking-MothRLegMoonfly-moonfly_r_leg = Right Leg
 marking-MothRLegMoonfly = Moth Right Leg (Moonfly)
+
+marking-MothLArmMoonfly-moonfly_l_arm = Left Arm
 marking-MothLArmMoonfly = Moth Left Arm (Moonfly)
+
+marking-MothRArmMoonfly-moonfly_r_arm = Right Arm
 marking-MothRArmMoonfly = Moth Right Arm (Moonfly)
 
+
+
+marking-MothChestOakworm-oakworm_chest = Chest
 marking-MothChestOakworm = Moth Chest (Oak Worm)
+
+marking-MothHeadOakworm-oakworm_head = Head
 marking-MothHeadOakworm = Moth Head (Oak Worm)
+
+marking-MothLLegOakworm-oakworm_l_leg = Left Leg
 marking-MothLLegOakworm = Moth Left Leg (Oak Worm)
+
+marking-MothRLegOakworm-oakworm_r_leg = Right Leg
 marking-MothRLegOakworm = Moth Right Leg (Oak Worm)
+
+marking-MothLArmOakworm-oakworm_l_arm = Left Arm
 marking-MothLArmOakworm = Moth Left Arm (Oak Worm)
+
+marking-MothRArmOakworm-oakworm_r_arm = Right Arm
 marking-MothRArmOakworm = Moth Right Arm (Oak Worm)
 
+
+
+marking-MothChestPointy-pointy_chest = Chest
 marking-MothChestPointy = Moth Chest (Pointy)
+
+marking-MothHeadPointy-pointy_head = Head
 marking-MothHeadPointy = Moth Head (Pointy)
+
+marking-MothLLegPointy-pointy_l_leg = Left Leg
 marking-MothLLegPointy = Moth Left Leg (Pointy)
+
+marking-MothRLegPointy-pointy_r_leg = Right Leg
 marking-MothRLegPointy = Moth Right Leg (Pointy)
+
+marking-MothLArmPointy-pointy_l_arm = Left Arm
 marking-MothLArmPointy = Moth Left Arm (Pointy)
+
+marking-MothRArmPointy-pointy_r_arm = Right Arm
 marking-MothRArmPointy = Moth Right Arm (Pointy)
 
+
+
+marking-MothChestRagged-ragged_chest = Chest
 marking-MothChestRagged = Moth Chest (Ragged)
+
+marking-MothHeadRagged-ragged_head = Head
 marking-MothHeadRagged = Moth Head (Ragged)
+
+marking-MothLLegRagged-ragged_l_leg = Left Leg
 marking-MothLLegRagged = Moth Left Leg (Ragged)
+
+marking-MothRLegRagged-ragged_r_leg = Right Leg
 marking-MothRLegRagged = Moth Right Leg (Ragged)
+
+marking-MothLArmRagged-ragged_l_arm = Left Arm
 marking-MothLArmRagged = Moth Left Arm (Ragged)
+
+marking-MothRArmRagged-ragged_r_arm = Right Arm
 marking-MothRArmRagged = Moth Right Arm (Ragged)
 
+
+
+marking-MothChestRoyal-royal_chest = Chest
 marking-MothChestRoyal = Moth Chest (Royal)
+
+marking-MothHeadRoyal-royal_head = Head
 marking-MothHeadRoyal = Moth Head (Royal)
+
+marking-MothLLegRoyal-royal_l_leg = Left Leg
 marking-MothLLegRoyal = Moth Left Leg (Royal)
+
+marking-MothRLegRoyal-royal_r_leg = Right Leg
 marking-MothRLegRoyal = Moth Right Leg (Royal)
+
+marking-MothLArmRoyal-royal_l_arm = Left Arm
 marking-MothLArmRoyal = Moth Left Arm (Royal)
+
+marking-MothRArmRoyal-royal_r_arm = Right Arm
 marking-MothRArmRoyal = Moth Right Arm (Royal)
 
+
+
+marking-MothChestWhitefly-whitefly_chest = Chest
 marking-MothChestWhitefly = Moth Chest (White Fly)
+
+marking-MothHeadWhitefly-whitefly_head = Head
 marking-MothHeadWhitefly = Moth Head (White Fly)
+
+marking-MothLLegWhitefly-whitefly_l_leg = Left Leg
 marking-MothLLegWhitefly = Moth Left Leg (White Fly)
+
+marking-MothRLegWhitefly-whitefly_r_leg = Right Leg
 marking-MothRLegWhitefly = Moth Right Leg (White Fly)
+
+marking-MothLArmWhitefly-whitefly_l_arm = Left Arm
 marking-MothLArmWhitefly = Moth Left Arm (White Fly)
+
+marking-MothRArmWhitefly-whitefly_r_arm = Right Arm
 marking-MothRArmWhitefly = Moth Right Arm (White Fly)
 
+
+
+marking-MothChestWitchwing-witchwing_chest = Chest
 marking-MothChestWitchwing = Moth Chest (Witch Wing)
+
+marking-MothHeadWitchwing-witchwing_head = Head
 marking-MothHeadWitchwing = Moth Head (Witch Wing)
+
+marking-MothLLegWitchwing-witchwing_l_leg = Left Leg
 marking-MothLLegWitchwing = Moth Left Leg (Witch Wing)
+
+marking-MothRLegWitchwing-witchwing_r_leg = Right Leg
 marking-MothRLegWitchwing = Moth Right Leg (Witch Wing)
+
+marking-MothLArmWitchwing-witchwing_l_arm = Left Arm
 marking-MothLArmWitchwing = Moth Left Arm (Witch Wing)
+
+marking-MothRArmWitchwing-witchwing_r_arm = Right Arm
 marking-MothRArmWitchwing = Moth Right Arm (Witch Wing)

--- a/Resources/Locale/en-US/markings/reptilian.ftl
+++ b/Resources/Locale/en-US/markings/reptilian.ftl
@@ -40,7 +40,7 @@ marking-LizardSnoutRound = Lizard Snout (Round)
 marking-LizardSnoutSharp-snout_sharp = Lizard Snout (Sharp)
 marking-LizardSnoutSharp = Lizard Snout (Sharp)
 
-marking-LizardChestTiger-chest_tiger = Lizard Chest (Tiger)
+marking-LizardChestTiger-body_tiger = Lizard Chest (Tiger)
 marking-LizardChestTiger = Lizard Chest (Tiger)
 
 marking-LizardHeadTiger-head_tiger = Lizard Head (Tiger)
@@ -70,7 +70,8 @@ marking-LizardHornsDouble = Lizard Horns (Double)
 marking-LizardFrillsAxolotl-frills_axolotl = Lizard Frills (Axolotl)
 marking-LizardFrillsAxolotl = Lizard Frills (Axolotl)
 
-marking-LizardFrillsHood-frills_hood = Lizard Frills (Hood)
+marking-LizardFrillsHood-frills_hood_primary = Outer Hood
+marking-LizardFrillsHood-frills_hood_secondary = Inner Hood
 marking-LizardFrillsHood = Lizard Frills (Hood)
 
 marking-LizardHornsArgali-horns_argali = Lizard Horns (Argali)

--- a/Resources/Locale/en-US/markings/scars.ftl
+++ b/Resources/Locale/en-US/markings/scars.ftl
@@ -1,8 +1,8 @@
 marking-ScarEyeRight-scar_eye_right = Right Eye Scar
 marking-ScarEyeRight = Eye Scar (Right)
 
-marking-ScarEyeLeft-scar_eye_left = Eye scar (Left)
-marking-ScarEyeLeft = Left Eye Scar
+marking-ScarEyeLeft-scar_eye_left = Left Eye Scar
+marking-ScarEyeLeft = Eye Scar(Left)
 
 marking-ScarTopSurgeryShort-scar_top_surgery_short = Top Surgery Scar
 marking-ScarTopSurgeryShort = Top Surgery Scar (Short)

--- a/Resources/Locale/en-US/markings/scars.ftl
+++ b/Resources/Locale/en-US/markings/scars.ftl
@@ -2,7 +2,7 @@ marking-ScarEyeRight-scar_eye_right = Right Eye Scar
 marking-ScarEyeRight = Eye Scar (Right)
 
 marking-ScarEyeLeft-scar_eye_left = Left Eye Scar
-marking-ScarEyeLeft = Eye Scar(Left)
+marking-ScarEyeLeft = Eye Scar (Left)
 
 marking-ScarTopSurgeryShort-scar_top_surgery_short = Top Surgery Scar
 marking-ScarTopSurgeryShort = Top Surgery Scar (Short)

--- a/Resources/Locale/en-US/markings/scars.ftl
+++ b/Resources/Locale/en-US/markings/scars.ftl
@@ -1,8 +1,11 @@
-marking-ScarEyeRight-eyescarright = Eye scar (Right)
+marking-ScarEyeRight-scar_eye_right = Right Eye Scar
 marking-ScarEyeRight = Eye Scar (Right)
 
-marking-ScarEyeLeft-eyescarleft = Eye scar (Left)
-marking-ScarEyeLeft = Eye Scar (Left)
+marking-ScarEyeLeft-scar_eye_left = Eye scar (Left)
+marking-ScarEyeLeft = Left Eye Scar
 
+marking-ScarTopSurgeryShort-scar_top_surgery_short = Top Surgery Scar
 marking-ScarTopSurgeryShort = Top Surgery Scar (Short)
+
+marking-ScarTopSurgeryLong-scar_top_surgery_long = Top Surgery Scar
 marking-ScarTopSurgeryLong = Top Surgery Scar (Long)

--- a/Resources/Locale/en-US/markings/slimeperson.ftl
+++ b/Resources/Locale/en-US/markings/slimeperson.ftl
@@ -1,17 +1,17 @@
-marking-SlimeGradientLeftArm-gradient_left_arm = Slime Left Arm (Gradient)
+marking-SlimeGradientLeftArm-gradient_l_arm = Slime Left Arm (Gradient)
 marking-SlimeGradientLeftArm = Slime Left Arm (Gradient)
 
-marking-SlimeGradientRightArm-gradient_right_arm = Slime Right Arm (Gradient)
+marking-SlimeGradientRightArm-gradient_r_arm = Slime Right Arm (Gradient)
 marking-SlimeGradientRightArm = Slime Right Arm (Gradient)
 
-marking-SlimeGradientLeftLeg-gradient_left_leg = Slime Left Leg (Gradient)
+marking-SlimeGradientLeftLeg-gradient_l_leg = Slime Left Leg (Gradient)
 marking-SlimeGradientLeftLeg = Slime Left Leg (Gradient)
 
-marking-SlimeGradientRightLeg-gradient_right_leg = Slime Right Leg (Gradient)
+marking-SlimeGradientRightLeg-gradient_r_leg = Slime Right Leg (Gradient)
 marking-SlimeGradientRightLeg = Slime Right Leg (Gradient)
 
-marking-SlimeGradientLeftHand-gradient_left_hand = Slime Left Hand (Gradient)
+marking-SlimeGradientLeftHand-gradient_l_hand = Slime Left Hand (Gradient)
 marking-SlimeGradientLeftHand = Slime Left Hand (Gradient)
 
-marking-SlimeGradientRightHand-gradient_Right_hand = Slime Right Hand (Gradient)
+marking-SlimeGradientRightHand-gradient_r_hand = Slime Right Hand (Gradient)
 marking-SlimeGradientRightHand = Slime Right Hand (Gradient)

--- a/Resources/Locale/en-US/markings/tattoos.ftl
+++ b/Resources/Locale/en-US/markings/tattoos.ftl
@@ -27,5 +27,3 @@ marking-TattooEyeRight = Right Eye
 
 marking-TattooEyeLeft-tattoo_eye_l = Left Eye
 marking-TattooEyeLeft = Left Eye
-
-

--- a/Resources/Locale/en-US/markings/tattoos.ftl
+++ b/Resources/Locale/en-US/markings/tattoos.ftl
@@ -1,31 +1,31 @@
-marking-TattooHiveChest-hivechest = Back Tattoo (Hive)
+marking-TattooHiveChest-tattoo_hive_chest = Back Tattoo (Hive)
 marking-TattooHiveChest = Back Tattoo (Hive)
 
-marking-TattooNightlingChest-nightlingchest = Chest Tattoo (nightling)
+marking-TattooNightlingChest-tattoo_nightling = Chest Tattoo (nightling)
 marking-TattooNightlingChest = Chest Tattoo (Nightling)
 
-marking-TattooSilverburghLeftLeg-silverburghleftleg = Left Leg Tattoo (Silverburg)
+marking-TattooSilverburghLeftLeg-tattoo_silverburgh_l_leg = Left Leg Tattoo (Silverburg)
 marking-TattooSilverburghLeftLeg = Left Leg Tattoo (Silverburg)
 
-marking-TattooSilverburghRightLeg-silverburghRightleg = Right Leg Tattoo (Silverburg)
+marking-TattooSilverburghRightLeg-tattoo_silverburgh_r_leg = Right Leg Tattoo (Silverburg)
 marking-TattooSilverburghRightLeg = Right Leg Tattoo (Silverburg)
 
-marking-TattooCampbellLeftArm-campbelleleftArm = Left Arm Tattoo (Campbelle)
+marking-TattooCampbellLeftArm-tattoo_campbell_l_arm = Left Arm Tattoo (Campbelle)
 marking-TattooCampbellLeftArm = Left Arm Tattoo (Campbelle)
 
-marking-TattooCampbellRightArm-campbellrightarm = Right Arm Tattoo (Campbelle)
+marking-TattooCampbellRightArm-tattoo_campbell_r_arm = Right Arm Tattoo (Campbelle)
 marking-TattooCampbellRightArm = Right Arm Tattoo (Campbelle)
 
-marking-TattooCampbellLeftLeg-campbellleftleg = Left Leg Tattoo (Campbelle)
+marking-TattooCampbellLeftLeg-tattoo_campbell_l_leg = Left Leg Tattoo (Campbelle)
 marking-TattooCampbellLeftLeg = Left Leg Tattoo (Campbelle)
 
-marking-TattooCampbellRightLeg-campbellrightleg = Right Leg Tattoo (Campbelle)
+marking-TattooCampbellRightLeg-tattoo_campbell_r_leg = Right Leg Tattoo (Campbelle)
 marking-TattooCampbellRightLeg = Right Leg Tattoo (Campbelle)
 
-marking-TattooEyeRight-eyeright = Right Eye
+marking-TattooEyeRight-tattoo_eye_r = Right Eye
 marking-TattooEyeRight = Right Eye
 
-marking-TattooEyeLeft-eyeleft = Left Eye
+marking-TattooEyeLeft-tattoo_eye_l = Left Eye
 marking-TattooEyeLeft = Left Eye
 
 


### PR DESCRIPTION
## About the PR
Fixes all locale errors for markings. At least I don't think I missed or fucked up one.
Also since I was already in the file changes "Antennas" to "Antennae" because it _seems_ to be more grammatically correct. 

## Why / Balance
Because it's such a small thing that only pisses me off. There was probably a more sane way to do this, but I'm neither sane nor smart.

## Media
**Before:**
![image](https://github.com/space-wizards/space-station-14/assets/110078045/b304e069-5966-42ae-a27a-8de64ab9069c)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
Not required.