### PR TITLE
clerical error station event

### DIFF
--- a/Content.Server/StationEvents/Components/ClericalErrorRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/ClericalErrorRuleComponent.cs
@@ -1,0 +1,23 @@
+using Content.Server.StationEvents.Events;
+
+namespace Content.Server.StationEvents.Components;
+
+/// <summary>
+/// This is a station event that randomly removes some records from the station record database.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(ClericalErrorRule))]
+public sealed partial class ClericalErrorRuleComponent : Component
+{
+    /// <summary>
+    /// The minimum percentage number of records to remove from the station.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float MinToRemove = 0.0025f;
+
+    /// <summary>
+    /// The maximum percentage number of records to remove from the station.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float MaxToRemove = 0.1f;
+}

--- a/Content.Server/StationEvents/Events/ClericalErrorRule.cs
+++ b/Content.Server/StationEvents/Events/ClericalErrorRule.cs
@@ -1,0 +1,43 @@
+﻿using Content.Server.GameTicking.Rules.Components;
+using Content.Server.StationEvents.Components;
+using Content.Server.StationRecords;
+using Content.Server.StationRecords.Systems;
+using Content.Shared.StationRecords;
+using Robust.Shared.Random;
+
+namespace Content.Server.StationEvents.Events;
+
+public sealed class ClericalErrorRule : StationEventSystem<ClericalErrorRuleComponent>
+{
+    [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
+
+    protected override void Started(EntityUid uid, ClericalErrorRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        if (!TryGetRandomStation(out var chosenStation))
+            return;
+
+        if (!TryComp<StationRecordsComponent>(chosenStation, out var stationRecords))
+            return;
+
+        var recordCount = stationRecords.Records.Keys.Count;
+
+        if (recordCount == 0)
+            return;
+
+        var min = (int) Math.Max(1, Math.Round(component.MinToRemove * recordCount));
+        var max = (int) Math.Max(min, Math.Round(component.MaxToRemove * recordCount));
+        var toRemove = RobustRandom.Next(min, max);
+        var keys = new List<StationRecordKey>();
+        for (var i = 0; i < toRemove; i++)
+        {
+            keys.Add(RobustRandom.Pick(stationRecords.Records.Keys));
+        }
+
+        foreach (var key in keys)
+        {
+            _stationRecords.RemoveRecord(chosenStation.Value, key, stationRecords);
+        }
+    }
+}

--- a/Resources/Locale/en-US/station-events/events/bureaucratic-error.ftl
+++ b/Resources/Locale/en-US/station-events/events/bureaucratic-error.ftl
@@ -1,1 +1,2 @@
 ﻿station-event-bureaucratic-error-announcement = A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.
+station-event-clerical-error-announcement = A minor clerical error in the Organic Resources Department has resulted in the permanent destruction of some of the station records.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -56,6 +56,18 @@
   - type: BureaucraticErrorRule
 
 - type: entity
+  id: ClericalError
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-clerical-error-announcement
+    minimumPlayers: 15
+    weight: 5
+    duration: 1
+  - type: ClericalErrorRule
+
+- type: entity
   parent: BaseGameRule
   id: ClosetSkeleton
   noSpawn: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds the "clerical error" station event, an average rarity (weight 5) event that causes a small portion of the station records to ~~be destroy in order to dodge a space IRS audit~~ get misplaced.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The intent is mostly just to introduce a small degree of fallibility into the station records. It's not super common or absolute, but just a small seed of "oh yeah this info could possibly be incomplete." Specifically in relation to midround stealth antags like Exterminators or using fake names with agent IDs, not seeing a name on a crew manifest should be less of an instant valid indicator and moreso just a slight "huh. that's kinda suspicious."

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/4d5948ee-e150-4be5-a3f1-48424d89b72d)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added the clerical error station event, which causes a small amount of station records to be destroyed.
