### PR TITLE
Fix zipties/makeshift cuffs dropping multiple broken entities on removal

### DIFF
--- a/Content.Shared/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Shared/Cuffs/Components/HandcuffComponent.cs
@@ -45,6 +45,13 @@ public sealed partial class HandcuffComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public EntProtoId? BrokenPrototype;
 
+    /// <summary>
+    /// Whether or not these cuffs are in the process of being removed.
+    /// Used simply to prevent spawning multiple <see cref="BrokenPrototype"/>.
+    /// </summary>
+    [DataField]
+    public bool Removing;
+
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public DamageSpecifier DamageOnResist = new()
     {

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -621,7 +621,7 @@ namespace Content.Shared.Cuffs
             if (!Resolve(target, ref cuffable) || !Resolve(cuffsToRemove, ref cuff))
                 return;
 
-            if (TerminatingOrDeleted(cuffsToRemove) || TerminatingOrDeleted(target))
+            if (cuff.Removing || TerminatingOrDeleted(cuffsToRemove) || TerminatingOrDeleted(target))
                 return;
 
             if (user != null)
@@ -632,6 +632,7 @@ namespace Content.Shared.Cuffs
                     return;
             }
 
+            cuff.Removing = true;
             _audio.PlayPredicted(cuff.EndUncuffSound, target, user);
 
             cuffable.Container.Remove(cuffsToRemove);
@@ -688,6 +689,7 @@ namespace Content.Shared.Cuffs
                     }
                 }
             }
+            cuff.Removing = false;
         }
 
         #region ActionBlocker

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -52,6 +52,14 @@
   - type: Construction
     graph: makeshifthandcuffs
     node: cuffscable
+  - type: Item
+    inhandVisuals:
+      left:
+        - state: inhand-left
+          color: forestgreen
+      right:
+        - state: inhand-right
+          color: forestgreen
   - type: Sprite
     sprite: Objects/Misc/cablecuffs.rsi
     state: cuff
@@ -120,6 +128,14 @@
     sprite: Objects/Misc/cablecuffs.rsi
     state: cuff-broken
     color: forestgreen
+  - type: Item
+    inhandVisuals:
+      left:
+        - state: inhand-left
+          color: forestgreen
+      right:
+        - state: inhand-right
+          color: forestgreen
 
 - type: entity
   parent: Handcuffs


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
container events my beloathed.

oh yeah also random makeshift cuff inhand fix. CRAZY!

Fixes #23093
Fixes #21088 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/2940c2de-bb72-4ed5-a3cd-d69df982b413)
only one broken cuff.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun