### PR TITLE
Add Thiefs to NukeOps

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -60,6 +60,8 @@
   components:
   - type: NukeopsRule
     faction: Syndicate
+  - type: ThiefRule #the thieves come as an extension of another gamemode
+    ruleChance: 0.5
 
 - type: entity
   id: Pirates


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
![image](https://github.com/space-wizards/space-station-14/assets/96445749/15adef48-7167-4d4a-9e46-32c0f2a2f07d)

**Changelog**

:cl:
- add: thieves can now appear in rounds with nuclear operatives
