### PR TITLE
remove unsafe presents from present tree.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -422,14 +422,11 @@
     spawnEntries:
       - id: PresentRandom
         orGroup: present
-      - id: PresentRandomUnsafe
-        prob: 0.35
-        orGroup: present
-      - id: PresentRandomInsane
-        prob: 0.20
-        orGroup: present
       - id: PresentRandomCash
         prob: 0.20
+        orGroup: present
+      - id: PresentRandomAsh
+        prob: 0.05
         orGroup: present
     receivedPopup: christmas-tree-got-gift
     deniedPopup: christmas-tree-no-gift

--- a/Resources/Prototypes/Entities/Objects/Decoration/present.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/present.yml
@@ -20,7 +20,7 @@
 - type: entity
   id: PresentRandomUnsafe
   parent: [PresentBase, BaseItem]
-  suffix: Filled Unsafe
+  suffix: Filled, any item
   components:
   - type: RandomGift
     wrapper: PresentTrash
@@ -35,7 +35,7 @@
 - type: entity
   id: PresentRandomInsane
   parent: PresentRandomUnsafe
-  suffix: Filled Insane
+  suffix: Filled, any entity
   components:
     - type: RandomGift
       insaneMode: true
@@ -351,9 +351,6 @@
       - id: ToyRubberDuck
         orGroup: GiftPool
       - id: BalloonSyn
-        orGroup: GiftPool
-      - id: WeaponPulseCarbine
-        prob: .001
         orGroup: GiftPool
       - id: RGBStaff
         orGroup: GiftPool


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removed unsafe presents from the present tree.
Added the random coal present to the tree.
Changed the unsafe present prefix to be more clear.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

- Insane presents can be any entity in the game
  - This is what results in signs, walls, singularities, etc, appearing in presents
- unsafe presents can be any entity in the game with item component
  - This is what results in debug items and round ending items from being given to random players
- (Possibly bad actor) Players take this as a opportunity to self antag with round ending items. (It's just a winter event who cares! Once a year thing! etc etc)
  - when not used for this, are used to powergame against antagonists
- Admins endlessly on the conflict of having to ban people for using debug items then recieving numerous complaints about being banned for using debug weapons
- Admins endlessly on the conflict of being told they shouldn't be banning people for using debug weapons and reciving complaints from players about the round being ended by said items

Going forward, presents should be further filtered (we have component filtering technology! See the randompresent system.) to exclude problem items like weapons and explosives.

If that is not reasonable, items will otherwise need to be handpicked and added to the whitelist, like the safe present.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

