### PR TITLE
Revert "Makes external & shuttle airlocks bump-openable"

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -2,9 +2,10 @@
   parent: Airlock
   id: AirlockExternal
   suffix: External
-  description: It opens, it closes, it might crush you, and there might be only space behind it.
+  description: It opens, it closes, it might crush you, and there might be only space behind it. Has to be manually activated.
   components:
   - type: Door
+    bumpOpen: false
     crushDamage:
       types:
         Blunt: 15

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -45,6 +45,7 @@
   - type: Wires
     layoutId: Docking
   - type: Door
+    bumpOpen: false
     closeTimeTwo: 0.4
     openTimeTwo: 0.4
     crushDamage:


### PR DESCRIPTION
Reverts space-wizards/space-station-14#22706

# Why

Those two types of airlocks mostly used between station and space, it might be VERY bad if you accidentally bump into one.

:cl:
- tweak: External and shuttle airlocks requires click to be open.