### PR TITLE
Game server api

### DIFF
--- a/Content.Server/Administration/ServerAPI.cs
+++ b/Content.Server/Administration/ServerAPI.cs
@@ -74,7 +74,7 @@ public sealed class ServerApi : EntitySystem // should probably not be an entity
 
     private void UpdateToken(string token)
     {
-        this._token = token;
+        _token = token;
     }
 
     private void UpdateMotd(string motd)
@@ -589,7 +589,7 @@ public sealed class ServerApi : EntitySystem // should probably not be an entity
             }
         }
 
-        // The Serialize into JsonNode into Parse into JsonNode into Parse into string is a bit of a hack
+        // The Serialize into Parse is a bit of a hack
         // TODO: Find a better way to do this
 
         jObject["players"] = JsonNode.Parse(JsonSerializer.Serialize(players));

--- a/Content.Server/Administration/ServerAPI.cs
+++ b/Content.Server/Administration/ServerAPI.cs
@@ -736,7 +736,7 @@ public sealed class ServerApi : IPostInjectInit
             return true;
 
         // Invalid auth header, no access
-        _sawmill.Info(@"Unauthorized access attempt to admin API. ""{0}""", authToken);
+        _sawmill.Info(@"Unauthorized access attempt to admin API. ""{0}""", authToken.ToString());
         return false;
     }
 

--- a/Content.Server/Administration/ServerAPI.cs
+++ b/Content.Server/Administration/ServerAPI.cs
@@ -240,7 +240,7 @@ public sealed class ServerApi : IPostInjectInit
             return true;
         }
 
-        _sawmill.Info($"MOTD changed to {motd} by {actor!.Name}({actor!.Guid}).");
+        _sawmill.Info($"MOTD changed to \"{motd}\" by {actor!.Name}({actor!.Guid}).");
 
         _taskManager.RunOnMainThread(() => _config.SetCVar(CCVars.MOTD, motd.ToString()));
         // A hook in the MOTD system sends the changes to each client

--- a/Content.Server/Administration/ServerAPI.cs
+++ b/Content.Server/Administration/ServerAPI.cs
@@ -43,6 +43,8 @@ public sealed class ServerApi : IPostInjectInit
 
     public void PostInject()
     {
+        _sawmill = Logger.GetSawmill("serverApi");
+
         // Get
         _statusHost.AddHandler(InfoHandler);
         _statusHost.AddHandler(GetGameRules);
@@ -57,10 +59,19 @@ public sealed class ServerApi : IPostInjectInit
         _statusHost.AddHandler(ActionForceMotd);
         _statusHost.AddHandler(ActionPanicPunker);
 
-        _config.OnValueChanged(CCVars.AdminApiToken, UpdateToken, true);
-        _config.OnValueChanged(CCVars.MOTD, UpdateMotd, true);
+        // Bandaid fix for the test fails
+        // "System.Collections.Generic.KeyNotFoundException : The given key 'server.admin_api_token' was not present in the dictionary."
+        // TODO: Figure out why this happens
+        try
+        {
+            _config.OnValueChanged(CCVars.AdminApiToken, UpdateToken, true);
+            _config.OnValueChanged(CCVars.MOTD, UpdateMotd, true);
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error("Failed to subscribe to config vars: {0}", e);
+        }
 
-        _sawmill = Logger.GetSawmill("serverApi");
     }
 
     public void Shutdown()

--- a/Content.Server/Administration/ServerAPI.cs
+++ b/Content.Server/Administration/ServerAPI.cs
@@ -1,0 +1,606 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Content.Server.Administration.Systems;
+using Content.Server.GameTicking;
+using Content.Server.GameTicking.Presets;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Maps;
+using Content.Server.RoundEnd;
+using Content.Shared.Administration.Managers;
+using Content.Shared.CCVar;
+using Content.Shared.Prototypes;
+using Robust.Server.ServerStatus;
+using Robust.Shared.Configuration;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Administration;
+
+public sealed class ServerApi : EntitySystem // should probably not be an entity system
+{
+    [Dependency] private readonly IStatusHost _statusHost = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!; // Players
+    [Dependency] private readonly ISharedAdminManager _adminManager = default!; // Admins
+    [Dependency] private readonly GameTicker _gameTicker = default!; // Round ID and stuff
+    [Dependency] private readonly IGameMapManager _gameMapManager = default!; // Map name
+    [Dependency] private readonly AdminSystem _adminSystem = default!; // Panic bunker
+    [Dependency] private readonly RoundEndSystem _roundEndSystem = default!; // Round API
+    [Dependency] private readonly IServerNetManager _netManager = default!; // Kick
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!; // Game rules
+
+    [Dependency] private readonly IComponentFactory _componentFactory = default!; // Needed to circumvent the "IoC has no context on this thread" error until I figure out how to do it properly
+
+    private string token = default!;
+    private ISawmill _sawmill = default!;
+    private string _motd = default!;
+
+    protected override void PostInject()
+    {
+        base.PostInject();
+        // Get
+        _statusHost.AddHandler(InfoHandler);
+        _statusHost.AddHandler(GetGameRules);
+        _statusHost.AddHandler(GetForcePresets);
+
+        // Post
+        _statusHost.AddHandler(ActionRoundStatus);
+        _statusHost.AddHandler(ActionKick);
+        _statusHost.AddHandler(ActionAddGameRule);
+        _statusHost.AddHandler(ActionEndGameRule);
+        _statusHost.AddHandler(ActionForcePreset);
+        _statusHost.AddHandler(ActionForceMotd);
+        _statusHost.AddHandler(ActionPanicPunker);
+
+        _config.OnValueChanged(CCVars.AdminApiToken, UpdateToken, true);
+        _config.OnValueChanged(CCVars.MOTD, UpdateMotd, true);
+
+        _sawmill = Logger.GetSawmill("serverApi");
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _config.UnsubValueChanged(CCVars.AdminApiToken, UpdateToken);
+        _config.UnsubValueChanged(CCVars.MOTD, UpdateMotd);
+    }
+
+    private void UpdateToken(string token)
+    {
+        this.token = token;
+    }
+
+    private void UpdateMotd(string motd)
+    {
+        _motd = motd;
+    }
+
+
+#region Actions
+
+    /// <summary>
+    ///     Changes the panic bunker settings.
+    /// </summary>
+    private async Task<bool> ActionPanicPunker(IStatusHandlerContext context)
+    {
+        if (context.RequestMethod != HttpMethod.Post || context.Url!.AbsolutePath != "/admin/actions/panic_bunker")
+        {
+            return false;
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        var actionSupplied = context.RequestHeaders.TryGetValue("Action", out var action);
+        if (!actionSupplied)
+        {
+            await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+            return true;
+        }
+
+        var valueSupplied = context.RequestHeaders.TryGetValue("Value", out var value);
+        if (!valueSupplied)
+        {
+            await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+            return true;
+        }
+
+        switch (action) // TODO: This looks bad, there has to be a better way to do this.
+        {
+            case "enabled":
+                if (!bool.TryParse(value.ToString(), out var enabled))
+                {
+                    await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+                    return true;
+                }
+
+                _config.SetCVar(CCVars.PanicBunkerEnabled, enabled);
+                break;
+            case "disable_with_admins":
+                if (!bool.TryParse(value.ToString(), out var disableWithAdmins))
+                {
+                    await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+                    return true;
+                }
+
+                _config.SetCVar(CCVars.PanicBunkerDisableWithAdmins, disableWithAdmins);
+                break;
+
+            case "enable_without_admins":
+                if (!bool.TryParse(value.ToString(), out var enableWithoutAdmins))
+                {
+                    await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+                    return true;
+                }
+
+                _config.SetCVar(CCVars.PanicBunkerEnableWithoutAdmins, enableWithoutAdmins);
+                break;
+            case "count_deadminned_admins":
+                if (!bool.TryParse(value.ToString(), out var countDeadminnedAdmins))
+                {
+                    await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+                    return true;
+                }
+
+                _config.SetCVar(CCVars.PanicBunkerCountDeadminnedAdmins, countDeadminnedAdmins);
+                break;
+            case "show_reason":
+                if (!bool.TryParse(value.ToString(), out var showReason))
+                {
+                    await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+                    return true;
+                }
+
+                _config.SetCVar(CCVars.PanicBunkerShowReason, showReason);
+                break;
+
+            case "min_account_age_hours":
+                if (!int.TryParse(value.ToString(), out var minAccountAgeHours))
+                {
+                    await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+                    return true;
+                }
+
+                _config.SetCVar(CCVars.PanicBunkerMinAccountAge, minAccountAgeHours * 60);
+                break;
+            case "min_overall_hours":
+                if (!int.TryParse(value.ToString(), out var minOverallHours))
+                {
+                    await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+                    return true;
+                }
+
+                _config.SetCVar(CCVars.PanicBunkerMinOverallHours, minOverallHours * 60);
+                break;
+        }
+
+        await context.RespondAsync("Success", HttpStatusCode.OK);
+        return true;
+    }
+
+    /// <summary>
+    ///     Sets the current MOTD.
+    /// </summary>
+    private async Task<bool> ActionForceMotd(IStatusHandlerContext context)
+    {
+        if (context.RequestMethod != HttpMethod.Post || context.Url!.AbsolutePath != "/admin/actions/set_motd")
+        {
+            return false;
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        var motdSupplied = context.RequestHeaders.TryGetValue("MOTD", out var motd);
+        if (!motdSupplied)
+        {
+            await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+            return true;
+        }
+
+        _config.SetCVar(CCVars.MOTD, motd.ToString()); // A hook in the MOTD system sends the changes to each client
+        await context.RespondAsync("Success", HttpStatusCode.OK);
+        return true;
+    }
+
+    /// <summary>
+    ///     Forces the next preset-
+    /// </summary>
+    private async Task<bool> ActionForcePreset(IStatusHandlerContext context)
+    {
+        if (context.RequestMethod != HttpMethod.Post || context.Url!.AbsolutePath != "/admin/actions/force_preset")
+        {
+            return false;
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        if (_gameTicker.RunLevel != GameRunLevel.PreRoundLobby)
+        {
+            await context.RespondAsync("This can only be executed while the game is in the pre-round lobby.", HttpStatusCode.BadRequest);
+            return true;
+        }
+
+        var presetSupplied = context.RequestHeaders.TryGetValue("PresetId", out var preset);
+        if (!presetSupplied)
+        {
+            await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+            return true;
+        }
+
+        if (!_gameTicker.TryFindGamePreset(preset.ToString(), out var type))
+        {
+            await context.RespondAsync($"No preset exists with name {preset}.", HttpStatusCode.NotFound);
+            return true;
+        }
+
+        _gameTicker.SetGamePreset(type);
+        _sawmill.Info($"Forced the game to start with preset {preset}.");
+        await context.RespondAsync("Success", HttpStatusCode.OK);
+        return true;
+    }
+
+    /// <summary>
+    ///     Ends an active game rule.
+    /// </summary>
+    private async Task<bool> ActionEndGameRule(IStatusHandlerContext context)
+    {
+        if (context.RequestMethod != HttpMethod.Post || context.Url!.AbsolutePath != "/admin/actions/end_game_rule")
+        {
+            return false;
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        var gameRuleSupplied = context.RequestHeaders.TryGetValue("GameRuleId", out var gameRule);
+        if (!gameRuleSupplied)
+        {
+            await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+            return true;
+        }
+
+        var gameRuleEntity = _gameTicker
+            .GetActiveGameRules()
+            .FirstOrNull(rule => MetaData(rule).EntityPrototype?.ID == gameRule.ToString());
+
+        if (gameRuleEntity == null) // Game rule not found
+        {
+            await context.RespondAsync("Gamerule not found or not active",HttpStatusCode.NotFound);
+            return true;
+        }
+
+        _gameTicker.EndGameRule((EntityUid) gameRuleEntity);
+        await context.RespondAsync($"Ended game rule {gameRuleEntity}", HttpStatusCode.OK);
+        return true;
+    }
+
+    /// <summary>
+    ///     Adds a game rule to the current round.
+    /// </summary>
+    private async Task<bool> ActionAddGameRule(IStatusHandlerContext context)
+    {
+        if (context.RequestMethod != HttpMethod.Post || context.Url!.AbsolutePath != "/admin/actions/add_game_rule")
+        {
+            return false;
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        var gameRuleSupplied = context.RequestHeaders.TryGetValue("GameRuleId", out var gameRule);
+        if (!gameRuleSupplied)
+        {
+            await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+            return true;
+        }
+
+        var ruleEntity = _gameTicker.AddGameRule(gameRule.ToString());
+        if (_gameTicker.RunLevel == GameRunLevel.InRound)
+        {
+            _gameTicker.StartGameRule(ruleEntity);
+        }
+
+        await context.RespondAsync($"Added game rule {ruleEntity}", HttpStatusCode.OK);
+        return true;
+    }
+
+    /// <summary>
+    ///     Kicks a player.
+    /// </summary>
+    private async Task<bool> ActionKick(IStatusHandlerContext context)
+    {
+        if (context.RequestMethod != HttpMethod.Post || context.Url!.AbsolutePath != "/admin/actions/kick")
+        {
+            return false;
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        var playerSupplied = context.RequestHeaders.TryGetValue("Username", out var username);
+        if (!playerSupplied)
+        {
+            await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+            return true;
+        }
+
+        var found = _playerManager.TryGetSessionByUsername(username.ToString(), out var session);
+        if (!found)
+        {
+            await context.RespondAsync("Player not found", HttpStatusCode.NotFound);
+            return true;
+        }
+
+        var reasonSupplied = context.RequestHeaders.TryGetValue("Reason", out var reason);
+        if (!reasonSupplied)
+        {
+            reason = "No reason supplied";
+        }
+
+        reason += " (kicked by admin)";
+
+        if (session == null)
+        {
+            await context.RespondAsync("Player not found", HttpStatusCode.NotFound);
+            return true;
+        }
+        _netManager.DisconnectChannel(session.Channel, reason.ToString());
+        await context.RespondAsync("Success", HttpStatusCode.OK);
+        _sawmill.Info("Kicked player {0} ({1})", username, reason);
+        return true;
+    }
+
+    /// <summary>
+    ///     Round restart/end
+    /// </summary>
+    private async Task<bool> ActionRoundStatus(IStatusHandlerContext context)
+    {
+        // TODO: Any of those actions break the game ticker, fix that.
+        if (context.RequestMethod != HttpMethod.Post || context.Url!.AbsolutePath != "/admin/actions/round")
+        {
+            return false;
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        // Not using body, because that's a stream and I don't want to deal with that
+        var actionSupplied = context.RequestHeaders.TryGetValue("Action", out var action);
+        if (!actionSupplied)
+        {
+            await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+            return true;
+        }
+        switch (action)
+        {
+            case "start":
+                if (_gameTicker.RunLevel != GameRunLevel.PreRoundLobby)
+                {
+                    await context.RespondAsync("Round already started", HttpStatusCode.BadRequest);
+                    _sawmill.Info("Forced round start failed: round already started");
+                    return true;
+                }
+                _gameTicker.StartRound();
+                _sawmill.Info("Forced round start");
+                break;
+            case "end":
+                if (_gameTicker.RunLevel != GameRunLevel.InRound)
+                {
+                    await context.RespondAsync("Round already ended", HttpStatusCode.BadRequest);
+                    _sawmill.Info("Forced round end failed: round is not in progress");
+                    return true;
+                }
+                _gameTicker.EndRound();
+                _sawmill.Info("Forced round end");
+                break;
+            case "restart":
+                if (_gameTicker.RunLevel != GameRunLevel.InRound)
+                {
+                    await context.RespondAsync("Round already ended", HttpStatusCode.BadRequest);
+                    _sawmill.Info("Forced round restart failed: round is not in progress");
+                    return true;
+                }
+                _roundEndSystem.EndRound();
+                _sawmill.Info("Forced round restart");
+                break;
+            case "restartnow": // You should restart yourself NOW!!!
+                _gameTicker.RestartRound();
+                _sawmill.Info("Forced instant round restart");
+                break;
+            default:
+                await context.RespondErrorAsync(HttpStatusCode.BadRequest);
+                return true;
+        }
+
+        await context.RespondAsync("Success", HttpStatusCode.OK);
+        return true;
+    }
+#endregion
+
+#region Fetching
+
+    /// <summary>
+    ///     Returns an array containing all presets.
+    /// </summary>
+    private async Task<bool> GetForcePresets(IStatusHandlerContext context)
+    {
+        if (context.RequestMethod != HttpMethod.Get || context.Url!.AbsolutePath != "/admin/force_presets")
+        {
+            return false;
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        var jObject = new JsonObject();
+        var presets = new List<string>();
+        foreach (var preset in _prototypeManager.EnumeratePrototypes<GamePresetPrototype>())
+        {
+            presets.Add(preset.ID);
+        }
+
+        jObject["presets"] = JsonNode.Parse(JsonSerializer.Serialize(presets));
+        await context.RespondAsync(jObject.ToString(), HttpStatusCode.OK);
+        return true;
+    }
+
+    /// <summary>
+    ///    Returns an array containing all game rules.
+    /// </summary>
+    private async Task<bool> GetGameRules(IStatusHandlerContext context)
+    {
+        if (context.RequestMethod != HttpMethod.Get || context.Url!.AbsolutePath != "/admin/game_rules")
+        {
+            return false;
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        var jObject = new JsonObject();
+        var gameRules = new List<string>();
+        foreach (var gameRule in _prototypeManager.EnumeratePrototypes<EntityPrototype>())
+        {
+            if (gameRule.Abstract)
+                continue;
+
+            if (gameRule.HasComponent<GameRuleComponent>(_componentFactory))
+                gameRules.Add(gameRule.ID);
+        }
+
+        jObject["game_rules"] = JsonNode.Parse(JsonSerializer.Serialize(gameRules));
+        await context.RespondAsync(jObject.ToString(), HttpStatusCode.OK);
+        return true;
+    }
+
+
+    /// <summary>
+    ///     Handles fetching information.
+    /// </summary>
+    private async Task<bool> InfoHandler(IStatusHandlerContext context)
+    {
+        if (context.RequestMethod != HttpMethod.Get || context.Url!.AbsolutePath != "/admin/info" || token == string.Empty)
+        {
+            return false;
+            // 404
+        }
+
+        if (!CheckAccess(context))
+        {
+            await context.RespondErrorAsync(HttpStatusCode.Unauthorized);
+            return true;
+        }
+
+        /*  Information to display
+            Round number
+            Connected players
+            Active admins
+            Active game rules
+            Active game preset
+            Active map
+            MOTD
+            Panic bunker status
+         */
+
+        var jObject = new JsonObject();
+
+        jObject["round_id"] = _gameTicker.RoundId;
+
+        var players = new List<string>();
+        var onlineAdmins = new List<string>();
+        var onlineAdminsDeadmined = new List<string>();
+
+        foreach (var player in _playerManager.Sessions)
+        {
+            players.Add(player.UserId.UserId.ToString());
+            if (_adminManager.IsAdmin(player))
+            {
+                onlineAdmins.Add(player.UserId.UserId.ToString());
+            }
+            else if (_adminManager.IsAdmin(player, true))
+            {
+                onlineAdminsDeadmined.Add(player.UserId.UserId.ToString());
+            }
+        }
+
+        jObject["players"] = JsonNode.Parse(JsonSerializer.Serialize(players));
+        jObject["admins"] = JsonNode.Parse(JsonSerializer.Serialize(onlineAdmins));
+        jObject["deadmined"] = JsonNode.Parse(JsonSerializer.Serialize(onlineAdminsDeadmined));
+
+        var gameRules = new List<string>();
+        foreach (var addedGameRule in _gameTicker.GetActiveGameRules())
+        {
+            var meta = MetaData(addedGameRule);
+            gameRules.Add(meta.EntityPrototype?.ID ?? meta.EntityPrototype?.Name ?? "Unknown");
+        }
+
+        jObject["game_rules"] = JsonNode.Parse(JsonSerializer.Serialize(gameRules));
+        jObject["game_preset"] = _gameTicker.CurrentPreset?.ID;
+        jObject["map"] = _gameMapManager.GetSelectedMap()?.MapName;
+        jObject["motd"] = _motd;
+        jObject["panic_bunker"] = new JsonObject();
+        jObject["panic_bunker"]!["enabled"] = _adminSystem.PanicBunker.Enabled;
+        jObject["panic_bunker"]!["disable_with_admins"] = _adminSystem.PanicBunker.DisableWithAdmins;
+        jObject["panic_bunker"]!["enable_without_admins"] = _adminSystem.PanicBunker.EnableWithoutAdmins;
+        jObject["panic_bunker"]!["count_deadminned_admins"] = _adminSystem.PanicBunker.CountDeadminnedAdmins;
+        jObject["panic_bunker"]!["show_reason"] = _adminSystem.PanicBunker.ShowReason;
+        jObject["panic_bunker"]!["min_account_age_hours"] = _adminSystem.PanicBunker.MinAccountAgeHours;
+        jObject["panic_bunker"]!["min_overall_hours"] = _adminSystem.PanicBunker.MinOverallHours;
+
+        await context.RespondAsync(jObject.ToString(), HttpStatusCode.OK);
+        return true;
+    }
+
+#endregion
+
+    private bool CheckAccess(IStatusHandlerContext context)
+    {
+        var auth = context.RequestHeaders.TryGetValue("Authorization", out var authToken);
+        if (!auth)
+        {
+            _sawmill.Info(@"Unauthorized access attempt to admin API. No auth header");
+            return false;
+        } // No auth header, no access
+
+        if (authToken == token)
+            return true;
+
+        // Invalid auth header, no access
+        _sawmill.Info(@"Unauthorized access attempt to admin API. ""{0}"" vs ""{1}""", authToken, token);
+        return false;
+    }
+}

--- a/Content.Server/Administration/ServerAPI.cs
+++ b/Content.Server/Administration/ServerAPI.cs
@@ -124,7 +124,10 @@ public sealed class ServerApi : EntitySystem // should probably not be an entity
                     return true;
                 }
 
-                _config.SetCVar(CCVars.PanicBunkerEnabled, enabled);
+                _taskManager.RunOnMainThread(() =>
+                {
+                    _config.SetCVar(CCVars.PanicBunkerEnabled, enabled);
+                });
                 break;
             case "disable_with_admins":
                 if (!bool.TryParse(value.ToString(), out var disableWithAdmins))
@@ -133,9 +136,11 @@ public sealed class ServerApi : EntitySystem // should probably not be an entity
                     return true;
                 }
 
-                _config.SetCVar(CCVars.PanicBunkerDisableWithAdmins, disableWithAdmins);
+                _taskManager.RunOnMainThread(() =>
+                {
+                    _config.SetCVar(CCVars.PanicBunkerDisableWithAdmins, disableWithAdmins);
+                });
                 break;
-
             case "enable_without_admins":
                 if (!bool.TryParse(value.ToString(), out var enableWithoutAdmins))
                 {
@@ -143,7 +148,10 @@ public sealed class ServerApi : EntitySystem // should probably not be an entity
                     return true;
                 }
 
-                _config.SetCVar(CCVars.PanicBunkerEnableWithoutAdmins, enableWithoutAdmins);
+                _taskManager.RunOnMainThread(() =>
+                {
+                    _config.SetCVar(CCVars.PanicBunkerEnableWithoutAdmins, enableWithoutAdmins);
+                });
                 break;
             case "count_deadminned_admins":
                 if (!bool.TryParse(value.ToString(), out var countDeadminnedAdmins))
@@ -152,7 +160,10 @@ public sealed class ServerApi : EntitySystem // should probably not be an entity
                     return true;
                 }
 
-                _config.SetCVar(CCVars.PanicBunkerCountDeadminnedAdmins, countDeadminnedAdmins);
+                _taskManager.RunOnMainThread(() =>
+                {
+                    _config.SetCVar(CCVars.PanicBunkerCountDeadminnedAdmins, countDeadminnedAdmins);
+                });
                 break;
             case "show_reason":
                 if (!bool.TryParse(value.ToString(), out var showReason))
@@ -161,9 +172,11 @@ public sealed class ServerApi : EntitySystem // should probably not be an entity
                     return true;
                 }
 
-                _config.SetCVar(CCVars.PanicBunkerShowReason, showReason);
+                _taskManager.RunOnMainThread(() =>
+                {
+                    _config.SetCVar(CCVars.PanicBunkerShowReason, showReason);
+                });
                 break;
-
             case "min_account_age_hours":
                 if (!int.TryParse(value.ToString(), out var minAccountAgeHours))
                 {
@@ -171,7 +184,10 @@ public sealed class ServerApi : EntitySystem // should probably not be an entity
                     return true;
                 }
 
-                _config.SetCVar(CCVars.PanicBunkerMinAccountAge, minAccountAgeHours * 60);
+                _taskManager.RunOnMainThread(() =>
+                {
+                    _config.SetCVar(CCVars.PanicBunkerMinAccountAge, minAccountAgeHours * 60);
+                });
                 break;
             case "min_overall_hours":
                 if (!int.TryParse(value.ToString(), out var minOverallHours))
@@ -180,7 +196,10 @@ public sealed class ServerApi : EntitySystem // should probably not be an entity
                     return true;
                 }
 
-                _config.SetCVar(CCVars.PanicBunkerMinOverallHours, minOverallHours * 60);
+                _taskManager.RunOnMainThread(() =>
+                {
+                    _config.SetCVar(CCVars.PanicBunkerMinOverallHours, minOverallHours * 60);
+                });
                 break;
         }
 

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -61,7 +61,7 @@ namespace Content.Server.Administration.Systems
         public IReadOnlySet<NetUserId> RoundActivePlayers => _roundActivePlayers;
 
         private readonly HashSet<NetUserId> _roundActivePlayers = new();
-        private readonly PanicBunkerStatus _panicBunker = new();
+        public readonly PanicBunkerStatus PanicBunker = new();
 
         public override void Initialize()
         {
@@ -248,7 +248,7 @@ namespace Content.Server.Administration.Systems
 
         private void OnPanicBunkerChanged(bool enabled)
         {
-            _panicBunker.Enabled = enabled;
+            PanicBunker.Enabled = enabled;
             _chat.SendAdminAlert(Loc.GetString(enabled
                 ? "admin-ui-panic-bunker-enabled-admin-alert"
                 : "admin-ui-panic-bunker-disabled-admin-alert"
@@ -259,52 +259,52 @@ namespace Content.Server.Administration.Systems
 
         private void OnPanicBunkerDisableWithAdminsChanged(bool enabled)
         {
-            _panicBunker.DisableWithAdmins = enabled;
+            PanicBunker.DisableWithAdmins = enabled;
             UpdatePanicBunker();
         }
 
         private void OnPanicBunkerEnableWithoutAdminsChanged(bool enabled)
         {
-            _panicBunker.EnableWithoutAdmins = enabled;
+            PanicBunker.EnableWithoutAdmins = enabled;
             UpdatePanicBunker();
         }
 
         private void OnPanicBunkerCountDeadminnedAdminsChanged(bool enabled)
         {
-            _panicBunker.CountDeadminnedAdmins = enabled;
+            PanicBunker.CountDeadminnedAdmins = enabled;
             UpdatePanicBunker();
         }
 
         private void OnShowReasonChanged(bool enabled)
         {
-            _panicBunker.ShowReason = enabled;
+            PanicBunker.ShowReason = enabled;
             SendPanicBunkerStatusAll();
         }
 
         private void OnPanicBunkerMinAccountAgeChanged(int minutes)
         {
-            _panicBunker.MinAccountAgeHours = minutes / 60;
+            PanicBunker.MinAccountAgeHours = minutes / 60;
             SendPanicBunkerStatusAll();
         }
 
         private void OnPanicBunkerMinOverallHoursChanged(int hours)
         {
-            _panicBunker.MinOverallHours = hours;
+            PanicBunker.MinOverallHours = hours;
             SendPanicBunkerStatusAll();
         }
 
         private void UpdatePanicBunker()
         {
-            var admins = _panicBunker.CountDeadminnedAdmins
+            var admins = PanicBunker.CountDeadminnedAdmins
                 ? _adminManager.AllAdmins
                 : _adminManager.ActiveAdmins;
             var hasAdmins = admins.Any();
 
-            if (hasAdmins && _panicBunker.DisableWithAdmins)
+            if (hasAdmins && PanicBunker.DisableWithAdmins)
             {
                 _config.SetCVar(CCVars.PanicBunkerEnabled, false);
             }
-            else if (!hasAdmins && _panicBunker.EnableWithoutAdmins)
+            else if (!hasAdmins && PanicBunker.EnableWithoutAdmins)
             {
                 _config.SetCVar(CCVars.PanicBunkerEnabled, true);
             }
@@ -314,7 +314,7 @@ namespace Content.Server.Administration.Systems
 
         private void SendPanicBunkerStatusAll()
         {
-            var ev = new PanicBunkerChangedEvent(_panicBunker);
+            var ev = new PanicBunkerChangedEvent(PanicBunker);
             foreach (var admin in _adminManager.AllAdmins)
             {
                 RaiseNetworkEvent(ev, admin);

--- a/Content.Server/IoC/ServerContentIoC.cs
+++ b/Content.Server/IoC/ServerContentIoC.cs
@@ -58,6 +58,7 @@ namespace Content.Server.IoC
             IoCManager.Register<PoissonDiskSampler>();
             IoCManager.Register<DiscordWebhook>();
             IoCManager.Register<ServerDbEntryManager>();
+            IoCManager.Register<ServerApi>();
         }
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -29,6 +29,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> RulesHeader =
             CVarDef.Create("server.rules_header", "ui-rules-header", CVar.REPLICATED | CVar.SERVER);
 
+        /// <summary>
+        ///     The token used to authenticate with the admin API. Leave empty to disable the admin API. This is a secret! Do not share!
+        /// </summary>
+        public static readonly CVarDef<string> AdminApiToken =
+            CVarDef.Create("server.admin_api_token", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
         /*
          * Ambience
          */


### PR DESCRIPTION
## About the PR
Adds an admin API which allows for better moderation.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
resolves #19853 

## Todo
- [x] Some of the code is very messy. I need to un-messify it
- [x] Video showcasing the API

## Technical details
I define the `ServerApi` class and register it in the IoCManager in `ServerContentIoC`. This class is used to handle HTTP requests to the /admin endpoint.
The class has 2 helper methods. `RunOnMainThread` and `CheckAccess`.
`RunOnMainThread` is a helper function for executing a task on the main thread asynchronously.
`CheckAccess`  checks the authorization header to determine if the requester has the correct token for accessing the admin API.
Methods prefixed with `Action` are, well, actions that can be performed through the admin API. These include actions for changing Panic Bunker settings, setting the MOTD, forcing presets, ending and adding game rules, and kicking players.
There are three Methods which handle fetching Information. These don't have a fancy prefix.
`GetForcePresets` returns all instances of `GamePresetPrototype`.
`GetGameRules` returns all `EntityPrototype` with the `GameRuleComponent`.
`InfoHandler` returns general information about the current server status. Look at the Media section for more information.

Everything touching in-game logic, should be ran on the main thread. I have probably missed something, so please mentioned those I have missed, so that I can make them not explode the server.
## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
https://cdn.discordapp.com/attachments/903694002577113118/1190028451533553825/Desktop_2023.12.28_-_21.06.37.04.mp4?ex=65a04f5c&is=658dda5c&hm=e9a0cbe6831c41fee58ae9e9914ed2ff9a8d06542a07a39a805b37fb972ede2d&

(I don't know how to embed video)
## Breaking changes
None