### PR TITLE
saltern beacons

### DIFF
--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -3931,21 +3931,24 @@ entities:
   entities:
   - uid: 4082
     components:
-    - name: Dorms 1
+    - flags: PvsPriority
+      name: Dorms 1
       type: MetaData
     - pos: -26.5,0.5
       parent: 31
       type: Transform
   - uid: 4083
     components:
-    - name: Dorms 2
+    - flags: PvsPriority
+      name: Dorms 2
       type: MetaData
     - pos: -26.5,-2.5
       parent: 31
       type: Transform
   - uid: 4084
     components:
-    - name: Dorms 3
+    - flags: PvsPriority
+      name: Dorms 3
       type: MetaData
     - pos: -26.5,-5.5
       parent: 31
@@ -3968,6 +3971,8 @@ entities:
   entities:
   - uid: 2272
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-6.5
       parent: 31
       type: Transform
@@ -4012,21 +4017,18 @@ entities:
   entities:
   - uid: 149
     components:
-    - name: Captain's Bathroom
+    - flags: PvsPriority
+      name: Captain's Bathroom
       type: MetaData
     - pos: 12.5,25.5
       parent: 31
       type: Transform
   - uid: 731
     components:
-    - name: Captain's Bedroom
+    - flags: PvsPriority
+      name: Captain's Bedroom
       type: MetaData
     - pos: 9.5,25.5
-      parent: 31
-      type: Transform
-  - uid: 1258
-    components:
-    - pos: 27.5,2.5
       parent: 31
       type: Transform
 - proto: AirlockCargoGlassLocked
@@ -4066,6 +4068,8 @@ entities:
   entities:
   - uid: 10439
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,16.5
       parent: 31
       type: Transform
@@ -4073,6 +4077,8 @@ entities:
   entities:
   - uid: 2128
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-3.5
       parent: 31
       type: Transform
@@ -4120,8 +4126,17 @@ entities:
       type: Transform
 - proto: AirlockCommandLocked
   entities:
+  - uid: 15
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 27.5,2.5
+      parent: 31
+      type: Transform
   - uid: 92
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,6.5
       parent: 31
       type: Transform
@@ -4130,6 +4145,8 @@ entities:
       type: DeviceLinkSink
   - uid: 116
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,6.5
       parent: 31
       type: Transform
@@ -4186,73 +4203,96 @@ entities:
   entities:
   - uid: 649
     components:
-    - name: Gravity Generator
+    - flags: PvsPriority
+      name: Gravity Generator
       type: MetaData
     - pos: 49.5,-1.5
       parent: 31
       type: Transform
   - uid: 1178
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,20.5
       parent: 31
       type: Transform
   - uid: 2010
     components:
-    - name: Southern Solars
+    - flags: PvsPriority
+      name: Southern Solars
       type: MetaData
     - pos: 15.5,-26.5
       parent: 31
       type: Transform
   - uid: 2050
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -32.5,8.5
       parent: 31
       type: Transform
   - uid: 3423
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-34.5
       parent: 31
       type: Transform
   - uid: 3852
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,16.5
       parent: 31
       type: Transform
   - uid: 4172
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-9.5
       parent: 31
       type: Transform
   - uid: 4405
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,-6.5
       parent: 31
       type: Transform
   - uid: 4424
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-4.5
       parent: 31
       type: Transform
   - uid: 4982
     components:
-    - name: Northern Solars
+    - flags: PvsPriority
+      name: Northern Solars
       type: MetaData
     - pos: -22.5,21.5
       parent: 31
       type: Transform
   - uid: 6451
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,9.5
       parent: 31
       type: Transform
   - uid: 9592
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-13.5
       parent: 31
       type: Transform
   - uid: 9986
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -27.5,-11.5
       parent: 31
@@ -4261,11 +4301,15 @@ entities:
   entities:
   - uid: 8456
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-26.5
       parent: 31
       type: Transform
   - uid: 8525
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-26.5
       parent: 31
       type: Transform
@@ -4593,11 +4637,15 @@ entities:
   entities:
   - uid: 599
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-4.5
       parent: 31
       type: Transform
   - uid: 820
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-2.5
       parent: 31
       type: Transform
@@ -4791,7 +4839,8 @@ entities:
   entities:
   - uid: 1852
     components:
-    - name: 'Head Of Personnel '
+    - flags: PvsPriority
+      name: 'Head Of Personnel '
       type: MetaData
     - pos: 6.5,17.5
       parent: 31
@@ -4819,6 +4868,8 @@ entities:
   entities:
   - uid: 2709
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-12.5
       parent: 31
       type: Transform
@@ -4833,26 +4884,36 @@ entities:
   entities:
   - uid: 1675
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-24.5
       parent: 31
       type: Transform
   - uid: 4858
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-9.5
       parent: 31
       type: Transform
   - uid: 4948
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-23.5
       parent: 31
       type: Transform
   - uid: 4974
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-19.5
       parent: 31
       type: Transform
   - uid: 5216
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,16.5
       parent: 31
       type: Transform
@@ -4860,6 +4921,8 @@ entities:
   entities:
   - uid: 6575
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,12.5
       parent: 31
       type: Transform
@@ -4867,6 +4930,8 @@ entities:
   entities:
   - uid: 615
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-8.5
       parent: 31
       type: Transform
@@ -4874,6 +4939,8 @@ entities:
   entities:
   - uid: 564
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,12.5
       parent: 31
       type: Transform
@@ -4881,11 +4948,15 @@ entities:
   entities:
   - uid: 154
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,12.5
       parent: 31
       type: Transform
   - uid: 635
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,22.5
       parent: 31
       type: Transform
@@ -4893,88 +4964,120 @@ entities:
   entities:
   - uid: 186
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-18.5
       parent: 31
       type: Transform
   - uid: 600
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,2.5
       parent: 31
       type: Transform
   - uid: 614
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-6.5
       parent: 31
       type: Transform
   - uid: 627
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,20.5
       parent: 31
       type: Transform
   - uid: 636
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,2.5
       parent: 31
       type: Transform
   - uid: 897
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-16.5
       parent: 31
       type: Transform
   - uid: 2354
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -32.5,-12.5
       parent: 31
       type: Transform
   - uid: 5757
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-18.5
       parent: 31
       type: Transform
   - uid: 9220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -9.5,-13.5
       parent: 31
       type: Transform
   - uid: 9402
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 8.5,-31.5
       parent: 31
       type: Transform
   - uid: 9445
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -19.5,-33.5
       parent: 31
       type: Transform
   - uid: 9450
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -15.5,-36.5
       parent: 31
       type: Transform
   - uid: 9453
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -10.5,-38.5
       parent: 31
       type: Transform
   - uid: 9671
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-41.5
       parent: 31
       type: Transform
   - uid: 9733
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-39.5
       parent: 31
       type: Transform
   - uid: 9933
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,26.5
       parent: 31
       type: Transform
@@ -4982,11 +5085,15 @@ entities:
   entities:
   - uid: 2230
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-5.5
       parent: 31
       type: Transform
   - uid: 2237
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,0.5
       parent: 31
       type: Transform
@@ -5001,6 +5108,8 @@ entities:
   entities:
   - uid: 4143
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,19.5
       parent: 31
       type: Transform
@@ -5008,6 +5117,8 @@ entities:
   entities:
   - uid: 524
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-3.5
       parent: 31
       type: Transform
@@ -5015,6 +5126,8 @@ entities:
   entities:
   - uid: 3137
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-12.5
       parent: 31
       type: Transform
@@ -5022,62 +5135,86 @@ entities:
   entities:
   - uid: 543
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-19.5
       parent: 31
       type: Transform
   - uid: 604
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,13.5
       parent: 31
       type: Transform
   - uid: 1334
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,12.5
       parent: 31
       type: Transform
   - uid: 2026
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-24.5
       parent: 31
       type: Transform
   - uid: 2053
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,14.5
       parent: 31
       type: Transform
   - uid: 2454
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-8.5
       parent: 31
       type: Transform
   - uid: 4170
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-10.5
       parent: 31
       type: Transform
   - uid: 4508
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-9.5
       parent: 31
       type: Transform
   - uid: 6166
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,19.5
       parent: 31
       type: Transform
   - uid: 6452
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,15.5
       parent: 31
       type: Transform
   - uid: 7378
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -33.5,9.5
       parent: 31
       type: Transform
   - uid: 10224
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,-5.5
       parent: 31
       type: Transform
@@ -5085,6 +5222,8 @@ entities:
   entities:
   - uid: 9516
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 9.5,-18.5
       parent: 31
@@ -5093,11 +5232,15 @@ entities:
   entities:
   - uid: 184
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-33.5
       parent: 31
       type: Transform
   - uid: 8448
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-27.5
       parent: 31
       type: Transform
@@ -5105,6 +5248,8 @@ entities:
   entities:
   - uid: 58
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,14.5
       parent: 31
       type: Transform
@@ -5112,6 +5257,8 @@ entities:
   entities:
   - uid: 9132
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,14.5
       parent: 31
       type: Transform
@@ -5119,6 +5266,8 @@ entities:
   entities:
   - uid: 525
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-7.5
       parent: 31
       type: Transform
@@ -5165,7 +5314,8 @@ entities:
   entities:
   - uid: 4146
     components:
-    - name: Morgue
+    - flags: PvsPriority
+      name: Morgue
       type: MetaData
     - pos: 16.5,-15.5
       parent: 31
@@ -5191,6 +5341,8 @@ entities:
   entities:
   - uid: 9590
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-22.5
       parent: 31
       type: Transform
@@ -5277,6 +5429,8 @@ entities:
   entities:
   - uid: 4719
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-30.5
       parent: 31
       type: Transform
@@ -5284,6 +5438,8 @@ entities:
   entities:
   - uid: 7337
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-8.5
       parent: 31
       type: Transform
@@ -5510,7 +5666,7 @@ entities:
       type: Transform
   - uid: 2154
     components:
-    - name: Captain's Office APC
+    - name: Captain's Quarters APC
       type: MetaData
     - pos: 8.5,27.5
       parent: 31
@@ -5810,26 +5966,36 @@ entities:
   entities:
   - uid: 6326
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-35.5
       parent: 31
       type: Transform
   - uid: 10807
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-35.5
       parent: 31
       type: Transform
   - uid: 10810
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-34.5
       parent: 31
       type: Transform
   - uid: 10811
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-32.5
       parent: 31
       type: Transform
   - uid: 10812
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-32.5
       parent: 31
       type: Transform
@@ -6425,6 +6591,8 @@ entities:
   entities:
   - uid: 66
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,28.5
       parent: 31
       type: Transform
@@ -6433,6 +6601,8 @@ entities:
       type: DeviceLinkSink
   - uid: 1561
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-16.5
       parent: 31
       type: Transform
@@ -6441,6 +6611,8 @@ entities:
       type: DeviceLinkSink
   - uid: 1756
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,12.5
       parent: 31
       type: Transform
@@ -6449,6 +6621,8 @@ entities:
       type: DeviceLinkSink
   - uid: 3905
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,28.5
       parent: 31
       type: Transform
@@ -6457,6 +6631,8 @@ entities:
       type: DeviceLinkSink
   - uid: 6557
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,14.5
       parent: 31
       type: Transform
@@ -6465,6 +6641,8 @@ entities:
       type: DeviceLinkSink
   - uid: 7588
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,-31.5
       parent: 31
       type: Transform
@@ -6473,6 +6651,8 @@ entities:
       type: DeviceLinkSink
   - uid: 10095
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,25.5
       parent: 31
       type: Transform
@@ -6481,6 +6661,8 @@ entities:
       type: DeviceLinkSink
   - uid: 10096
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,25.5
       parent: 31
       type: Transform
@@ -6489,6 +6671,8 @@ entities:
       type: DeviceLinkSink
   - uid: 10201
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-16.5
       parent: 31
       type: Transform
@@ -6547,6 +6731,8 @@ entities:
   entities:
   - uid: 9372
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-21.5
       parent: 31
       type: Transform
@@ -6561,56 +6747,78 @@ entities:
   entities:
   - uid: 135
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-23.5
       parent: 31
       type: Transform
   - uid: 333
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-23.5
       parent: 31
       type: Transform
   - uid: 625
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-22.5
       parent: 31
       type: Transform
   - uid: 662
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-25.5
       parent: 31
       type: Transform
   - uid: 666
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-24.5
       parent: 31
       type: Transform
   - uid: 668
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-24.5
       parent: 31
       type: Transform
   - uid: 669
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-28.5
       parent: 31
       type: Transform
   - uid: 741
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-26.5
       parent: 31
       type: Transform
   - uid: 957
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-26.5
       parent: 31
       type: Transform
   - uid: 1037
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-26.5
       parent: 31
       type: Transform
   - uid: 1519
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-30.5
       parent: 31
       type: Transform
@@ -15302,19 +15510,14 @@ entities:
     - pos: 48.373375,5.713002
       parent: 31
       type: Transform
+  - uid: 134
+    components:
+    - pos: 29.54536,1.2261796
+      parent: 31
+      type: Transform
   - uid: 1021
     components:
     - pos: 48.373375,5.713002
-      parent: 31
-      type: Transform
-  - uid: 1316
-    components:
-    - pos: 27.24574,0.6870463
-      parent: 31
-      type: Transform
-  - uid: 1374
-    components:
-    - pos: 27.24574,0.6870463
       parent: 31
       type: Transform
   - uid: 4539
@@ -19007,14 +19210,9 @@ entities:
       type: Transform
 - proto: CableHVStack
   entities:
-  - uid: 3509
+  - uid: 538
     components:
-    - pos: 27.261366,0.3432963
-      parent: 31
-      type: Transform
-  - uid: 3513
-    components:
-    - pos: 27.261366,0.3432963
+    - pos: 29.54536,1.7105546
       parent: 31
       type: Transform
   - uid: 6023
@@ -21690,17 +21888,12 @@ entities:
       type: Transform
   - uid: 152
     components:
-    - pos: 27.261366,0.5307963
+    - pos: 29.54536,1.4761796
       parent: 31
       type: Transform
   - uid: 712
     components:
     - pos: 48.35775,5.619252
-      parent: 31
-      type: Transform
-  - uid: 934
-    components:
-    - pos: 27.261366,0.5307963
       parent: 31
       type: Transform
 - proto: CableTerminal
@@ -26728,23 +26921,6 @@ entities:
       pos: -31.5,-3.5
       parent: 31
       type: Transform
-- proto: ClothingBackpackDuffel
-  entities:
-  - uid: 134
-    components:
-    - pos: 29.55824,1.3120463
-      parent: 31
-      type: Transform
-  - uid: 774
-    components:
-    - pos: 29.55824,1.5776713
-      parent: 31
-      type: Transform
-  - uid: 794
-    components:
-    - pos: 29.542616,1.7495463
-      parent: 31
-      type: Transform
 - proto: ClothingBeltChampion
   entities:
   - uid: 4197
@@ -27506,6 +27682,11 @@ entities:
   - uid: 9957
     components:
     - pos: -24.138485,-21.92873
+      parent: 31
+      type: Transform
+  - uid: 11362
+    components:
+    - pos: -5.414235,-29.644104
       parent: 31
       type: Transform
 - proto: ClothingUnderSocksCoder
@@ -28668,6 +28849,361 @@ entities:
   - uid: 7293
     components:
     - pos: 11.27607,-24.265812
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeacon
+  entities:
+  - uid: 774
+    components:
+    - pos: -39.5,5.5
+      parent: 31
+      type: Transform
+    - text: evac
+      type: NavMapBeacon
+  - uid: 1374
+    components:
+    - pos: 44.5,-24.5
+      parent: 31
+      type: Transform
+    - text: observatory
+      type: NavMapBeacon
+- proto: DefaultStationBeaconAME
+  entities:
+  - uid: 7280
+    components:
+    - pos: 47.5,8.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconAnomalyGenerator
+  entities:
+  - uid: 11361
+    components:
+    - pos: -5.5,-30.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconArmory
+  entities:
+  - uid: 10088
+    components:
+    - pos: -12.5,19.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconArrivals
+  entities:
+  - uid: 812
+    components:
+    - pos: -44.5,-10.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconArtifactLab
+  entities:
+  - uid: 11363
+    components:
+    - pos: -12.5,-29.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconAtmospherics
+  entities:
+  - uid: 11312
+    components:
+    - pos: 31.5,12.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconBar
+  entities:
+  - uid: 11319
+    components:
+    - pos: -5.5,-5.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconBotany
+  entities:
+  - uid: 11320
+    components:
+    - pos: -18.5,-0.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconBridge
+  entities:
+  - uid: 11269
+    components:
+    - pos: 3.5,30.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconBrig
+  entities:
+  - uid: 8881
+    components:
+    - pos: -10.5,8.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconCaptainsQuarters
+  entities:
+  - uid: 11268
+    components:
+    - pos: 8.5,25.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconCargoBay
+  entities:
+  - uid: 3509
+    components:
+    - pos: 21.5,16.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconCargoReception
+  entities:
+  - uid: 2494
+    components:
+    - pos: 14.5,10.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconCERoom
+  entities:
+  - uid: 3513
+    components:
+    - pos: 39.5,-0.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconChapel
+  entities:
+  - uid: 11324
+    components:
+    - pos: -36.5,14.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconChemistry
+  entities:
+  - uid: 7256
+    components:
+    - pos: 16.5,-0.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconCMORoom
+  entities:
+  - uid: 7276
+    components:
+    - pos: 23.5,-10.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconCryonics
+  entities:
+  - uid: 8316
+    components:
+    - pos: 8.5,-15.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconDisposals
+  entities:
+  - uid: 7954
+    components:
+    - pos: -30.5,-16.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconEngineering
+  entities:
+  - uid: 7281
+    components:
+    - pos: 33.5,4.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconEVAStorage
+  entities:
+  - uid: 7640
+    components:
+    - pos: 8.5,9.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconHOPOffice
+  entities:
+  - uid: 2464
+    components:
+    - pos: 8.5,19.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconHOSRoom
+  entities:
+  - uid: 778
+    components:
+    - pos: -8.5,20.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconJanitorsCloset
+  entities:
+  - uid: 11323
+    components:
+    - pos: -18.5,-11.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconKitchen
+  entities:
+  - uid: 11318
+    components:
+    - pos: -12.5,-0.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconLibrary
+  entities:
+  - uid: 11325
+    components:
+    - pos: 9.5,-26.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconMedbay
+  entities:
+  - uid: 5767
+    components:
+    - pos: 9.5,-9.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconMedical
+  entities:
+  - uid: 1215
+    components:
+    - pos: 9.5,-2.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconMorgue
+  entities:
+  - uid: 7275
+    components:
+    - pos: 13.5,-15.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconPermaBrig
+  entities:
+  - uid: 11316
+    components:
+    - pos: -17.5,9.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconPowerBank
+  entities:
+  - uid: 11352
+    components:
+    - pos: 41.5,5.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconQMRoom
+  entities:
+  - uid: 11353
+    components:
+    - pos: 27.5,9.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconRDRoom
+  entities:
+  - uid: 11354
+    components:
+    - pos: -4.5,-21.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconRND
+  entities:
+  - uid: 11355
+    components:
+    - pos: -15.5,-23.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconRobotics
+  entities:
+  - uid: 11360
+    components:
+    - pos: -1.5,-27.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconSalvage
+  entities:
+  - uid: 11321
+    components:
+    - pos: 27.5,18.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconScience
+  entities:
+  - uid: 1208
+    components:
+    - pos: -9.5,-20.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconSecurity
+  entities:
+  - uid: 1136
+    components:
+    - pos: -7.5,11.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconServerRoom
+  entities:
+  - uid: 11356
+    components:
+    - pos: -1.5,-21.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconSingularity
+  entities:
+  - uid: 11358
+    components:
+    - pos: 60.5,2.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconSolars
+  entities:
+  - uid: 11364
+    components:
+    - pos: 15.5,-29.5
+      parent: 31
+      type: Transform
+  - uid: 11365
+    components:
+    - pos: -31.5,-32.5
+      parent: 31
+      type: Transform
+  - uid: 11366
+    components:
+    - pos: -22.5,24.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconTechVault
+  entities:
+  - uid: 1316
+    components:
+    - pos: 27.5,1.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconTEG
+  entities:
+  - uid: 11314
+    components:
+    - pos: 38.5,14.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconTelecoms
+  entities:
+  - uid: 11357
+    components:
+    - pos: 50.5,-5.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconToolRoom
+  entities:
+  - uid: 11317
+    components:
+    - pos: -27.5,9.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconVault
+  entities:
+  - uid: 11315
+    components:
+    - pos: -1.5,17.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconWardensOffice
+  entities:
+  - uid: 762
+    components:
+    - pos: -1.5,8.5
       parent: 31
       type: Transform
 - proto: DefibrillatorCabinetFilled
@@ -32533,7 +33069,7 @@ entities:
     - pos: 38.5,-5.5
       parent: 31
       type: Transform
-    - secondsUntilStateChange: -3421.156
+    - secondsUntilStateChange: -4580.918
       state: Closing
       type: Door
   - uid: 4019
@@ -43125,6 +43661,8 @@ entities:
       pos: 23.5,15.5
       parent: 31
       type: Transform
+    - joinedGrid: 31
+      type: AtmosDevice
     - color: '#0055CCFF'
       type: AtmosPipeColor
   - uid: 4267
@@ -47846,13 +48384,16 @@ entities:
   entities:
   - uid: 1052
     components:
-    - name: Vault
+    - flags: PvsPriority
+      name: Vault
       type: MetaData
     - pos: 0.5,17.5
       parent: 31
       type: Transform
   - uid: 9195
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,-9.5
       parent: 31
       type: Transform
@@ -47860,18 +48401,24 @@ entities:
   entities:
   - uid: 9695
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 12.5,-42.5
       parent: 31
       type: Transform
   - uid: 9696
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 12.5,-41.5
       parent: 31
       type: Transform
   - uid: 9697
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 12.5,-40.5
       parent: 31
@@ -49343,11 +49890,6 @@ entities:
     - pos: -19.682484,-11.924354
       parent: 31
       type: Transform
-  - uid: 8881
-    components:
-    - pos: 26.48231,1.5389521
-      parent: 31
-      type: Transform
   - uid: 10216
     components:
     - pos: -31.665886,-19.55848
@@ -49355,21 +49897,6 @@ entities:
       type: Transform
 - proto: MopItem
   entities:
-  - uid: 15
-    components:
-    - pos: 25.68625,0.6714213
-      parent: 31
-      type: Transform
-  - uid: 778
-    components:
-    - pos: 25.905,0.6557963
-      parent: 31
-      type: Transform
-  - uid: 786
-    components:
-    - pos: 26.06125,0.6245463
-      parent: 31
-      type: Transform
   - uid: 2708
     components:
     - pos: -18.42709,-10.56736
@@ -50851,6 +51378,8 @@ entities:
   entities:
   - uid: 41
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -25.5,6.5
       parent: 31
@@ -50859,6 +51388,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 143
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 12.5,-3.5
       parent: 31
@@ -50867,12 +51398,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -10.5,-31.5
       parent: 31
       type: Transform
   - uid: 303
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,21.5
       parent: 31
       type: Transform
@@ -50880,12 +51415,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 401
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -25.5,-13.5
       parent: 31
       type: Transform
   - uid: 493
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 24.5,11.5
       parent: 31
@@ -50894,6 +51433,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 516
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,6.5
       parent: 31
       type: Transform
@@ -50901,6 +51442,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 557
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,10.5
       parent: 31
       type: Transform
@@ -50908,12 +51451,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 776
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -15.5,13.5
       parent: 31
       type: Transform
   - uid: 857
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,0.5
       parent: 31
@@ -50922,6 +51469,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 891
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,-4.5
       parent: 31
@@ -50930,6 +51479,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 892
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,5.5
       parent: 31
       type: Transform
@@ -50937,6 +51488,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 917
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,3.5
       parent: 31
@@ -50945,12 +51498,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 994
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 22.5,-11.5
       parent: 31
       type: Transform
   - uid: 1033
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -29.5,9.5
       parent: 31
@@ -50959,6 +51516,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1034
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -26.5,8.5
       parent: 31
@@ -50967,6 +51526,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1058
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,2.5
       parent: 31
@@ -50975,6 +51536,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1059
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -20.5,3.5
       parent: 31
@@ -50983,6 +51546,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1060
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,-0.5
       parent: 31
@@ -50991,6 +51556,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1061
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,5.5
       parent: 31
       type: Transform
@@ -50998,6 +51565,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1064
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -20.5,0.5
       parent: 31
@@ -51006,6 +51575,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1066
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -25.5,-4.5
       parent: 31
@@ -51014,6 +51585,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1069
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -20.5,-2.5
       parent: 31
@@ -51022,6 +51595,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1122
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -2.5,30.5
       parent: 31
@@ -51030,6 +51605,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1123
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 9.5,30.5
       parent: 31
@@ -51038,6 +51615,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1135
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,27.5
       parent: 31
       type: Transform
@@ -51045,6 +51624,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1171
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 1.5,30.5
       parent: 31
@@ -51053,6 +51634,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1186
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 5.5,30.5
       parent: 31
@@ -51061,6 +51644,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1188
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 2.5,23.5
       parent: 31
@@ -51069,6 +51654,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1200
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 4.5,23.5
       parent: 31
@@ -51077,6 +51664,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1210
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 5.5,16.5
       parent: 31
@@ -51085,6 +51674,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1211
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 1.5,16.5
       parent: 31
@@ -51093,6 +51684,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1212
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,18.5
       parent: 31
       type: Transform
@@ -51100,6 +51693,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1213
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 6.5,9.5
       parent: 31
@@ -51108,6 +51703,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 10.5,9.5
       parent: 31
@@ -51116,6 +51713,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1228
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 12.5,10.5
       parent: 31
@@ -51124,6 +51723,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1234
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 4.5,12.5
       parent: 31
@@ -51132,6 +51733,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1252
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 31
@@ -51140,6 +51743,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1253
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,12.5
       parent: 31
       type: Transform
@@ -51147,6 +51752,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1259
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 18.5,13.5
       parent: 31
@@ -51155,6 +51762,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1261
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 18.5,8.5
       parent: 31
@@ -51163,6 +51772,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1262
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 16.5,7.5
       parent: 31
@@ -51171,6 +51782,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1265
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 18.5,3.5
       parent: 31
@@ -51179,6 +51792,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1266
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 13.5,3.5
       parent: 31
@@ -51187,6 +51802,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1271
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,1.5
       parent: 31
       type: Transform
@@ -51194,6 +51811,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1272
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,1.5
       parent: 31
       type: Transform
@@ -51201,6 +51820,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1274
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,1.5
       parent: 31
       type: Transform
@@ -51208,6 +51829,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1281
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 23.5,3.5
       parent: 31
@@ -51216,6 +51839,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1283
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 27.5,0.5
       parent: 31
@@ -51224,6 +51849,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1284
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 29.5,-2.5
       parent: 31
@@ -51232,6 +51859,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1285
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 31.5,-0.5
       parent: 31
@@ -51240,6 +51869,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1286
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 31.5,2.5
       parent: 31
@@ -51248,6 +51879,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1287
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 37.5,2.5
       parent: 31
@@ -51256,6 +51889,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1288
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,6.5
       parent: 31
       type: Transform
@@ -51263,6 +51898,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1301
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 35.5,-2.5
       parent: 31
@@ -51271,6 +51908,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1303
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-4.5
       parent: 31
       type: Transform
@@ -51278,6 +51917,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1306
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 19.5,-8.5
       parent: 31
@@ -51286,6 +51927,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1313
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 5.5,-21.5
       parent: 31
@@ -51294,6 +51937,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1322
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 5.5,-17.5
       parent: 31
@@ -51302,6 +51947,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1323
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 7.5,-14.5
       parent: 31
@@ -51311,6 +51958,8 @@ entities:
     - type: Timer
   - uid: 1324
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 6.5,-11.5
       parent: 31
@@ -51319,6 +51968,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1325
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 1.5,-17.5
       parent: 31
@@ -51327,6 +51978,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1331
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -1.5,-17.5
       parent: 31
@@ -51335,6 +51988,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1344
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 18.5,17.5
       parent: 31
@@ -51343,6 +51998,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1354
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 4.5,-28.5
       parent: 31
@@ -51351,6 +52008,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1356
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 9.5,-29.5
       parent: 31
@@ -51359,6 +52018,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1358
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 12.5,-25.5
       parent: 31
@@ -51367,6 +52028,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1359
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592697301183 rad
       pos: 31.5,2.5
       parent: 31
@@ -51375,6 +52038,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1360
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-22.5
       parent: 31
       type: Transform
@@ -51382,6 +52047,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1361
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 2.5,-9.5
       parent: 31
@@ -51390,6 +52057,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1366
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 31
@@ -51398,6 +52067,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1367
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 31
@@ -51406,6 +52077,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1371
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 31
@@ -51414,6 +52087,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1372
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 31
@@ -51422,6 +52097,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 1538
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 45.5,15.5
       parent: 31
@@ -51430,12 +52107,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 1605
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 58.5,-5.5
       parent: 31
       type: Transform
   - uid: 1915
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,1.5
       parent: 31
       type: Transform
@@ -51443,11 +52124,15 @@ entities:
       type: ApcPowerReceiver
   - uid: 1962
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-24.5
       parent: 31
       type: Transform
   - uid: 1965
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -11.5,16.5
       parent: 31
@@ -51456,24 +52141,32 @@ entities:
       type: ApcPowerReceiver
   - uid: 1979
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-23.5
       parent: 31
       type: Transform
   - uid: 2179
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 6.5,-3.5
       parent: 31
       type: Transform
   - uid: 2220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -18.5,-8.5
       parent: 31
       type: Transform
   - uid: 2247
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 31
@@ -51482,12 +52175,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 2621
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -37.5,17.5
       parent: 31
       type: Transform
   - uid: 3380
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -4.5,-29.5
       parent: 31
@@ -51496,30 +52193,40 @@ entities:
       type: ApcPowerReceiver
   - uid: 3551
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 31.5,9.5
       parent: 31
       type: Transform
   - uid: 3728
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -14.5,-22.5
       parent: 31
       type: Transform
   - uid: 3732
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -17.5,-27.5
       parent: 31
       type: Transform
   - uid: 3734
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -16.5,-29.5
       parent: 31
       type: Transform
   - uid: 3963
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -10.5,7.5
       parent: 31
@@ -51528,6 +52235,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 3983
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,17.5
       parent: 31
       type: Transform
@@ -51535,6 +52244,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 3998
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -9.5,17.5
       parent: 31
@@ -51543,6 +52254,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4097
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,11.5
       parent: 31
       type: Transform
@@ -51550,6 +52263,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4119
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,5.5
       parent: 31
       type: Transform
@@ -51557,6 +52272,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4120
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,5.5
       parent: 31
       type: Transform
@@ -51564,6 +52281,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4121
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,5.5
       parent: 31
       type: Transform
@@ -51571,6 +52290,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4122
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -16.5,-1.5
       parent: 31
@@ -51579,6 +52300,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4124
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,1.5
       parent: 31
       type: Transform
@@ -51586,6 +52309,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4152
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -13.5,-1.5
       parent: 31
@@ -51594,6 +52319,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4177
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 31
@@ -51602,6 +52329,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4232
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -3.5,-6.5
       parent: 31
@@ -51610,12 +52339,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 4251
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -21.5,9.5
       parent: 31
       type: Transform
   - uid: 4602
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 59.5,4.5
       parent: 31
       type: Transform
@@ -51623,6 +52356,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4606
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 55.5,0.5
       parent: 31
@@ -51631,6 +52366,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4607
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,3.5
       parent: 31
       type: Transform
@@ -51638,6 +52375,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4608
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 52.5,1.5
       parent: 31
@@ -51646,6 +52385,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 4912
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 24.5,15.5
       parent: 31
@@ -51654,6 +52395,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 5103
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 19.5,-0.5
       parent: 31
@@ -51662,12 +52405,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 6182
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,18.5
       parent: 31
       type: Transform
   - uid: 6327
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 41.5,11.5
       parent: 31
@@ -51676,6 +52423,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6330
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 30.5,13.5
       parent: 31
@@ -51684,6 +52433,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6332
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,9.5
       parent: 31
@@ -51692,6 +52443,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6384
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,23.5
       parent: 31
       type: Transform
@@ -51699,6 +52452,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6385
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 42.5,23.5
       parent: 31
       type: Transform
@@ -51706,6 +52461,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6387
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,23.5
       parent: 31
       type: Transform
@@ -51713,6 +52470,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6406
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,19.5
       parent: 31
       type: Transform
@@ -51720,6 +52479,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6407
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,19.5
       parent: 31
       type: Transform
@@ -51727,11 +52488,15 @@ entities:
       type: ApcPowerReceiver
   - uid: 6435
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,23.5
       parent: 31
       type: Transform
   - uid: 6436
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,9.5
       parent: 31
       type: Transform
@@ -51739,6 +52504,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6463
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 44.5,23.5
       parent: 31
       type: Transform
@@ -51746,6 +52513,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6509
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,23.5
       parent: 31
       type: Transform
@@ -51753,6 +52522,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6511
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,13.5
       parent: 31
       type: Transform
@@ -51760,12 +52531,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 6527
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 48.5,21.5
       parent: 31
       type: Transform
   - uid: 6566
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,19.5
       parent: 31
       type: Transform
@@ -51773,6 +52548,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6897
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,6.5
       parent: 31
       type: Transform
@@ -51780,6 +52557,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6898
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,5.5
       parent: 31
       type: Transform
@@ -51787,6 +52566,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6899
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,5.5
       parent: 31
       type: Transform
@@ -51794,6 +52575,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 6900
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 45.5,1.5
       parent: 31
@@ -51802,12 +52585,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 6909
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 20.5,22.5
       parent: 31
       type: Transform
   - uid: 6921
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,23.5
       parent: 31
       type: Transform
@@ -51815,6 +52602,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 7067
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -11.5,-26.5
       parent: 31
@@ -51823,6 +52612,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 7083
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,17.5
       parent: 31
       type: Transform
@@ -51830,6 +52621,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 7171
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,26.5
       parent: 31
       type: Transform
@@ -51837,23 +52630,31 @@ entities:
       type: ApcPowerReceiver
   - uid: 7349
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-13.5
       parent: 31
       type: Transform
   - uid: 7350
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 18.5,-18.5
       parent: 31
       type: Transform
   - uid: 7586
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 8.5,16.5
       parent: 31
       type: Transform
   - uid: 7653
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-7.5
       parent: 31
       type: Transform
@@ -51861,12 +52662,16 @@ entities:
       type: ApcPowerReceiver
   - uid: 7723
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -14.5,-17.5
       parent: 31
       type: Transform
   - uid: 7724
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -38.5,13.5
       parent: 31
@@ -51875,6 +52680,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 7725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -34.5,13.5
       parent: 31
@@ -51883,29 +52690,39 @@ entities:
       type: ApcPowerReceiver
   - uid: 7747
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-14.5
       parent: 31
       type: Transform
   - uid: 7785
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -50.5,-11.5
       parent: 31
       type: Transform
   - uid: 7788
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -45.5,-11.5
       parent: 31
       type: Transform
   - uid: 7871
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -17.5,-11.5
       parent: 31
       type: Transform
   - uid: 8074
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,13.5
       parent: 31
       type: Transform
@@ -51913,6 +52730,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8075
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,13.5
       parent: 31
       type: Transform
@@ -51920,6 +52739,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8076
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 48.5,7.5
       parent: 31
@@ -51928,6 +52749,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8085
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,8.5
       parent: 31
       type: Transform
@@ -51935,6 +52758,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8086
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -0.5,10.5
       parent: 31
@@ -51943,6 +52768,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8270
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-23.5
       parent: 31
       type: Transform
@@ -51950,6 +52777,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8272
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 33.5,-19.5
       parent: 31
@@ -51958,6 +52787,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8273
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 44.5,-22.5
       parent: 31
@@ -51966,6 +52797,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8274
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 44.5,-26.5
       parent: 31
@@ -51974,6 +52807,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8275
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-29.5
       parent: 31
@@ -51982,6 +52817,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8276
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 51.5,-29.5
       parent: 31
@@ -51990,6 +52827,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8277
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 54.5,-26.5
       parent: 31
@@ -51998,6 +52837,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8278
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 54.5,-22.5
       parent: 31
@@ -52006,6 +52847,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8279
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,-19.5
       parent: 31
       type: Transform
@@ -52013,6 +52856,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8280
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-19.5
       parent: 31
       type: Transform
@@ -52020,6 +52865,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8734
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-23.5
       parent: 31
       type: Transform
@@ -52027,6 +52874,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8835
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 6.5,29.5
       parent: 31
@@ -52035,6 +52884,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8836
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,29.5
       parent: 31
@@ -52043,6 +52894,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8837
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 4.5,27.5
       parent: 31
@@ -52051,6 +52904,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 8838
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 2.5,27.5
       parent: 31
@@ -52059,6 +52914,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 9094
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,-4.5
       parent: 31
       type: Transform
@@ -52066,6 +52923,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 9121
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 9.5,-9.5
       parent: 31
@@ -52074,6 +52933,8 @@ entities:
       type: ApcPowerReceiver
   - uid: 9330
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,-9.5
       parent: 31
@@ -52082,100 +52943,134 @@ entities:
       type: ApcPowerReceiver
   - uid: 10062
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 19.5,27.5
       parent: 31
       type: Transform
   - uid: 10063
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 23.5,27.5
       parent: 31
       type: Transform
   - uid: 10301
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -9.5,-22.5
       parent: 31
       type: Transform
   - uid: 10302
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -12.5,-19.5
       parent: 31
       type: Transform
   - uid: 10309
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-31.5
       parent: 31
       type: Transform
   - uid: 10355
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -21.5,-9.5
       parent: 31
       type: Transform
   - uid: 10423
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 53.5,18.5
       parent: 31
       type: Transform
   - uid: 10767
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -39.5,-11.5
       parent: 31
       type: Transform
   - uid: 10879
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 56.5,-11.5
       parent: 31
       type: Transform
   - uid: 10880
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 53.5,-11.5
       parent: 31
       type: Transform
   - uid: 10881
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 47.5,-11.5
       parent: 31
       type: Transform
   - uid: 10882
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 48.5,-3.5
       parent: 31
       type: Transform
   - uid: 11007
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,19.5
       parent: 31
       type: Transform
   - uid: 11084
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 53.5,14.5
       parent: 31
       type: Transform
   - uid: 11133
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,26.5
       parent: 31
       type: Transform
   - uid: 11250
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -34.5,8.5
       parent: 31
       type: Transform
   - uid: 11255
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -2.5,23.5
       parent: 31
@@ -52184,6 +53079,8 @@ entities:
   entities:
   - uid: 9926
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-21.5
       parent: 31
       type: Transform
@@ -52198,6 +53095,8 @@ entities:
   entities:
   - uid: 8526
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-13.5
       parent: 31
       type: Transform
@@ -53101,6 +54000,23 @@ entities:
   - uid: 3735
     components:
     - pos: -15.5,-30.5
+      parent: 31
+      type: Transform
+- proto: RandomBoard
+  entities:
+  - uid: 786
+    components:
+    - pos: 27.5,0.5
+      parent: 31
+      type: Transform
+  - uid: 794
+    components:
+    - pos: 25.5,0.5
+      parent: 31
+      type: Transform
+  - uid: 1258
+    components:
+    - pos: 26.5,0.5
       parent: 31
       type: Transform
 - proto: RandomDrinkBottle
@@ -55594,14 +56510,14 @@ entities:
     - pos: 28.417616,0.5307963
       parent: 31
       type: Transform
+  - uid: 798
+    components:
+    - pos: 28.400833,0.5378499
+      parent: 31
+      type: Transform
   - uid: 933
     components:
     - pos: 50.498375,5.494252
-      parent: 31
-      type: Transform
-  - uid: 1215
-    components:
-    - pos: 28.417616,0.5307963
       parent: 31
       type: Transform
   - uid: 4123
@@ -55716,6 +56632,8 @@ entities:
   entities:
   - uid: 260
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-29.5
       parent: 31
       type: Transform
@@ -55725,6 +56643,8 @@ entities:
       type: DeviceLinkSink
   - uid: 11118
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,26.5
       parent: 31
       type: Transform
@@ -55733,6 +56653,8 @@ entities:
       type: DeviceLinkSink
   - uid: 11119
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,26.5
       parent: 31
       type: Transform
@@ -57429,6 +58351,8 @@ entities:
   entities:
   - uid: 10710
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,15.5
       parent: 31
       type: Transform
@@ -57979,21 +58903,6 @@ entities:
   - uid: 626
     components:
     - pos: -18.66321,-10.23793
-      parent: 31
-      type: Transform
-  - uid: 762
-    components:
-    - pos: 27.83949,0.7651713
-      parent: 31
-      type: Transform
-  - uid: 2464
-    components:
-    - pos: 27.855116,0.4995463
-      parent: 31
-      type: Transform
-  - uid: 2494
-    components:
-    - pos: 27.83949,0.6557963
       parent: 31
       type: Transform
   - uid: 3115
@@ -58813,11 +59722,6 @@ entities:
       type: Transform
 - proto: SurveillanceCameraRouterService
   entities:
-  - uid: 4910
-    components:
-    - pos: 25.5,1.5
-      parent: 31
-      type: Transform
   - uid: 8524
     components:
     - pos: 52.5,-9.5
@@ -60572,12 +61476,16 @@ entities:
   entities:
   - uid: 1444
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -28.5,2.5
       parent: 31
       type: Transform
   - uid: 1445
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -29.5,2.5
       parent: 31
@@ -60735,16 +61643,6 @@ entities:
       type: Transform
 - proto: TrashBag
   entities:
-  - uid: 798
-    components:
-    - pos: 26.417616,0.6089213
-      parent: 31
-      type: Transform
-  - uid: 812
-    components:
-    - pos: 26.667616,0.6089213
-      parent: 31
-      type: Transform
   - uid: 8951
     components:
     - rot: -1.5707963267948966 rad
@@ -61359,4896 +62257,6832 @@ entities:
   entities:
   - uid: 34
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-0.5
       parent: 31
       type: Transform
   - uid: 38
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,22.5
       parent: 31
       type: Transform
   - uid: 50
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,23.5
       parent: 31
       type: Transform
   - uid: 54
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-19.5
       parent: 31
       type: Transform
   - uid: 59
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,20.5
       parent: 31
       type: Transform
   - uid: 70
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -0.5,-20.5
       parent: 31
       type: Transform
   - uid: 74
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,23.5
       parent: 31
       type: Transform
   - uid: 83
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,2.5
       parent: 31
       type: Transform
   - uid: 84
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,13.5
       parent: 31
       type: Transform
   - uid: 89
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-14.5
       parent: 31
       type: Transform
   - uid: 105
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-18.5
       parent: 31
       type: Transform
   - uid: 121
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,26.5
       parent: 31
       type: Transform
   - uid: 122
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,26.5
       parent: 31
       type: Transform
   - uid: 147
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,26.5
       parent: 31
       type: Transform
   - uid: 163
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-1.5
       parent: 31
       type: Transform
   - uid: 185
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-28.5
       parent: 31
       type: Transform
   - uid: 219
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,6.5
       parent: 31
       type: Transform
   - uid: 247
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,-14.5
       parent: 31
       type: Transform
   - uid: 250
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,13.5
       parent: 31
       type: Transform
   - uid: 253
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-21.5
       parent: 31
       type: Transform
   - uid: 305
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,11.5
       parent: 31
       type: Transform
   - uid: 306
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,1.5
       parent: 31
       type: Transform
   - uid: 447
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,20.5
       parent: 31
       type: Transform
   - uid: 449
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,23.5
       parent: 31
       type: Transform
   - uid: 497
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,21.5
       parent: 31
       type: Transform
   - uid: 498
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,20.5
       parent: 31
       type: Transform
   - uid: 556
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,27.5
       parent: 31
       type: Transform
   - uid: 623
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-20.5
       parent: 31
       type: Transform
   - uid: 628
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,1.5
       parent: 31
       type: Transform
   - uid: 633
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 46.5,-14.5
       parent: 31
       type: Transform
   - uid: 643
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,1.5
       parent: 31
       type: Transform
   - uid: 690
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-16.5
       parent: 31
       type: Transform
   - uid: 691
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-16.5
       parent: 31
       type: Transform
   - uid: 698
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,11.5
       parent: 31
       type: Transform
   - uid: 701
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-28.5
       parent: 31
       type: Transform
   - uid: 706
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-32.5
       parent: 31
       type: Transform
   - uid: 707
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,-26.5
       parent: 31
       type: Transform
   - uid: 708
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,-26.5
       parent: 31
       type: Transform
   - uid: 709
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-26.5
       parent: 31
       type: Transform
   - uid: 723
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-20.5
       parent: 31
       type: Transform
   - uid: 730
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-0.5
       parent: 31
       type: Transform
   - uid: 737
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-24.5
       parent: 31
       type: Transform
   - uid: 745
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 46.5,-12.5
       parent: 31
       type: Transform
   - uid: 752
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -44.5,11.5
       parent: 31
       type: Transform
   - uid: 779
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,23.5
       parent: 31
       type: Transform
   - uid: 781
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,21.5
       parent: 31
       type: Transform
   - uid: 787
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,22.5
       parent: 31
       type: Transform
   - uid: 809
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-21.5
       parent: 31
       type: Transform
   - uid: 825
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,8.5
       parent: 31
       type: Transform
   - uid: 830
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 54.5,9.5
       parent: 31
       type: Transform
   - uid: 853
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-3.5
       parent: 31
       type: Transform
   - uid: 854
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 56.5,-6.5
       parent: 31
       type: Transform
   - uid: 859
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,-1.5
       parent: 31
       type: Transform
   - uid: 860
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 48.5,-1.5
       parent: 31
       type: Transform
   - uid: 861
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-26.5
       parent: 31
       type: Transform
   - uid: 865
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-19.5
       parent: 31
       type: Transform
   - uid: 868
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-1.5
       parent: 31
       type: Transform
   - uid: 869
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,-1.5
       parent: 31
       type: Transform
   - uid: 876
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-12.5
       parent: 31
       type: Transform
   - uid: 880
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,-6.5
       parent: 31
       type: Transform
   - uid: 881
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-7.5
       parent: 31
       type: Transform
   - uid: 882
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-6.5
       parent: 31
       type: Transform
   - uid: 883
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 53.5,-12.5
       parent: 31
       type: Transform
   - uid: 950
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-16.5
       parent: 31
       type: Transform
   - uid: 951
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-16.5
       parent: 31
       type: Transform
   - uid: 956
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,21.5
       parent: 31
       type: Transform
   - uid: 958
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-16.5
       parent: 31
       type: Transform
   - uid: 975
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,20.5
       parent: 31
       type: Transform
   - uid: 1035
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,22.5
       parent: 31
       type: Transform
   - uid: 1036
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-11.5
       parent: 31
       type: Transform
   - uid: 1072
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,4.5
       parent: 31
       type: Transform
   - uid: 1073
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,5.5
       parent: 31
       type: Transform
   - uid: 1074
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,-0.5
       parent: 31
       type: Transform
   - uid: 1075
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-0.5
       parent: 31
       type: Transform
   - uid: 1076
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,0.5
       parent: 31
       type: Transform
   - uid: 1077
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,0.5
       parent: 31
       type: Transform
   - uid: 1085
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-28.5
       parent: 31
       type: Transform
   - uid: 1098
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,0.5
       parent: 31
       type: Transform
   - uid: 1100
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,9.5
       parent: 31
       type: Transform
   - uid: 1120
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-11.5
       parent: 31
       type: Transform
   - uid: 1147
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,-28.5
       parent: 31
       type: Transform
   - uid: 1150
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,18.5
       parent: 31
       type: Transform
   - uid: 1152
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 29.5,22.5
       parent: 31
       type: Transform
   - uid: 1163
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,2.5
       parent: 31
       type: Transform
   - uid: 1168
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,2.5
       parent: 31
       type: Transform
   - uid: 1169
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,0.5
       parent: 31
       type: Transform
   - uid: 1182
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,19.5
       parent: 31
       type: Transform
   - uid: 1184
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 44.5,0.5
       parent: 31
       type: Transform
   - uid: 1195
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-11.5
       parent: 31
       type: Transform
   - uid: 1232
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,24.5
       parent: 31
       type: Transform
   - uid: 1257
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,2.5
       parent: 31
       type: Transform
   - uid: 1269
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,11.5
       parent: 31
       type: Transform
   - uid: 1270
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-2.5
       parent: 31
       type: Transform
   - uid: 1277
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,22.5
       parent: 31
       type: Transform
   - uid: 1290
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,16.5
       parent: 31
       type: Transform
   - uid: 1296
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,18.5
       parent: 31
       type: Transform
   - uid: 1317
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-1.5
       parent: 31
       type: Transform
   - uid: 1348
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,15.5
       parent: 31
       type: Transform
   - uid: 1377
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,5.5
       parent: 31
       type: Transform
   - uid: 1393
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,32.5
       parent: 31
       type: Transform
   - uid: 1408
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,33.5
       parent: 31
       type: Transform
   - uid: 1413
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,28.5
       parent: 31
       type: Transform
   - uid: 1415
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,9.5
       parent: 31
       type: Transform
   - uid: 1502
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,2.5
       parent: 31
       type: Transform
   - uid: 1503
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,2.5
       parent: 31
       type: Transform
   - uid: 1504
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,2.5
       parent: 31
       type: Transform
   - uid: 1545
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,7.5
       parent: 31
       type: Transform
   - uid: 1546
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,7.5
       parent: 31
       type: Transform
   - uid: 1557
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-26.5
       parent: 31
       type: Transform
   - uid: 1559
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,21.5
       parent: 31
       type: Transform
   - uid: 1560
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,22.5
       parent: 31
       type: Transform
   - uid: 1564
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,23.5
       parent: 31
       type: Transform
   - uid: 1565
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,20.5
       parent: 31
       type: Transform
   - uid: 1566
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,24.5
       parent: 31
       type: Transform
   - uid: 1567
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,24.5
       parent: 31
       type: Transform
   - uid: 1568
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,24.5
       parent: 31
       type: Transform
   - uid: 1574
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,1.5
       parent: 31
       type: Transform
   - uid: 1583
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,22.5
       parent: 31
       type: Transform
   - uid: 1584
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,22.5
       parent: 31
       type: Transform
   - uid: 1586
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,19.5
       parent: 31
       type: Transform
   - uid: 1600
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,1.5
       parent: 31
       type: Transform
   - uid: 1610
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,7.5
       parent: 31
       type: Transform
   - uid: 1611
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,7.5
       parent: 31
       type: Transform
   - uid: 1616
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-1.5
       parent: 31
       type: Transform
   - uid: 1617
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-2.5
       parent: 31
       type: Transform
   - uid: 1618
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-2.5
       parent: 31
       type: Transform
   - uid: 1619
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-2.5
       parent: 31
       type: Transform
   - uid: 1620
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-2.5
       parent: 31
       type: Transform
   - uid: 1621
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,-2.5
       parent: 31
       type: Transform
   - uid: 1622
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,-2.5
       parent: 31
       type: Transform
   - uid: 1623
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,-1.5
       parent: 31
       type: Transform
   - uid: 1624
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,-0.5
       parent: 31
       type: Transform
   - uid: 1625
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,0.5
       parent: 31
       type: Transform
   - uid: 1626
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,1.5
       parent: 31
       type: Transform
   - uid: 1627
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,0.5
       parent: 31
       type: Transform
   - uid: 1628
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,1.5
       parent: 31
       type: Transform
   - uid: 1632
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-1.5
       parent: 31
       type: Transform
   - uid: 1633
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-2.5
       parent: 31
       type: Transform
   - uid: 1635
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,-26.5
       parent: 31
       type: Transform
   - uid: 1636
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,-26.5
       parent: 31
       type: Transform
   - uid: 1642
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-26.5
       parent: 31
       type: Transform
   - uid: 1648
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-15.5
       parent: 31
       type: Transform
   - uid: 1649
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-15.5
       parent: 31
       type: Transform
   - uid: 1650
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-16.5
       parent: 31
       type: Transform
   - uid: 1651
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-11.5
       parent: 31
       type: Transform
   - uid: 1656
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,26.5
       parent: 31
       type: Transform
   - uid: 1658
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-12.5
       parent: 31
       type: Transform
   - uid: 1661
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,26.5
       parent: 31
       type: Transform
   - uid: 1664
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,26.5
       parent: 31
       type: Transform
   - uid: 1667
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-13.5
       parent: 31
       type: Transform
   - uid: 1680
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,26.5
       parent: 31
       type: Transform
   - uid: 1681
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-12.5
       parent: 31
       type: Transform
   - uid: 1687
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,0.5
       parent: 31
       type: Transform
   - uid: 1691
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,12.5
       parent: 31
       type: Transform
   - uid: 1699
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,26.5
       parent: 31
       type: Transform
   - uid: 1712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,7.5
       parent: 31
       type: Transform
   - uid: 1713
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,7.5
       parent: 31
       type: Transform
   - uid: 1717
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,6.5
       parent: 31
       type: Transform
   - uid: 1718
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-3.5
       parent: 31
       type: Transform
   - uid: 1719
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-4.5
       parent: 31
       type: Transform
   - uid: 1745
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,11.5
       parent: 31
       type: Transform
   - uid: 1746
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,7.5
       parent: 31
       type: Transform
   - uid: 1747
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,8.5
       parent: 31
       type: Transform
   - uid: 1749
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,7.5
       parent: 31
       type: Transform
   - uid: 1750
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,7.5
       parent: 31
       type: Transform
   - uid: 1751
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,7.5
       parent: 31
       type: Transform
   - uid: 1776
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,11.5
       parent: 31
       type: Transform
   - uid: 1783
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,12.5
       parent: 31
       type: Transform
   - uid: 1785
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,12.5
       parent: 31
       type: Transform
   - uid: 1786
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,12.5
       parent: 31
       type: Transform
   - uid: 1787
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,12.5
       parent: 31
       type: Transform
   - uid: 1788
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,12.5
       parent: 31
       type: Transform
   - uid: 1789
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,11.5
       parent: 31
       type: Transform
   - uid: 1790
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,10.5
       parent: 31
       type: Transform
   - uid: 1791
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,9.5
       parent: 31
       type: Transform
   - uid: 1792
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,8.5
       parent: 31
       type: Transform
   - uid: 1793
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,7.5
       parent: 31
       type: Transform
   - uid: 1794
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,6.5
       parent: 31
       type: Transform
   - uid: 1795
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,6.5
       parent: 31
       type: Transform
   - uid: 1797
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,10.5
       parent: 31
       type: Transform
   - uid: 1798
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,9.5
       parent: 31
       type: Transform
   - uid: 1799
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,8.5
       parent: 31
       type: Transform
   - uid: 1800
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,7.5
       parent: 31
       type: Transform
   - uid: 1801
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,6.5
       parent: 31
       type: Transform
   - uid: 1802
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,6.5
       parent: 31
       type: Transform
   - uid: 1805
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,11.5
       parent: 31
       type: Transform
   - uid: 1814
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,16.5
       parent: 31
       type: Transform
   - uid: 1815
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,15.5
       parent: 31
       type: Transform
   - uid: 1816
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,15.5
       parent: 31
       type: Transform
   - uid: 1817
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,15.5
       parent: 31
       type: Transform
   - uid: 1818
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,15.5
       parent: 31
       type: Transform
   - uid: 1819
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,15.5
       parent: 31
       type: Transform
   - uid: 1820
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,16.5
       parent: 31
       type: Transform
   - uid: 1821
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,17.5
       parent: 31
       type: Transform
   - uid: 1824
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,21.5
       parent: 31
       type: Transform
   - uid: 1826
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,21.5
       parent: 31
       type: Transform
   - uid: 1828
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,15.5
       parent: 31
       type: Transform
   - uid: 1829
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,22.5
       parent: 31
       type: Transform
   - uid: 1830
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,22.5
       parent: 31
       type: Transform
   - uid: 1831
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,22.5
       parent: 31
       type: Transform
   - uid: 1832
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,22.5
       parent: 31
       type: Transform
   - uid: 1833
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,22.5
       parent: 31
       type: Transform
   - uid: 1834
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,22.5
       parent: 31
       type: Transform
   - uid: 1836
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,28.5
       parent: 31
       type: Transform
   - uid: 1837
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,28.5
       parent: 31
       type: Transform
   - uid: 1839
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,27.5
       parent: 31
       type: Transform
   - uid: 1840
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,28.5
       parent: 31
       type: Transform
   - uid: 1841
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,30.5
       parent: 31
       type: Transform
   - uid: 1842
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,32.5
       parent: 31
       type: Transform
   - uid: 1843
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,32.5
       parent: 31
       type: Transform
   - uid: 1845
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,28.5
       parent: 31
       type: Transform
   - uid: 1846
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,27.5
       parent: 31
       type: Transform
   - uid: 1848
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,25.5
       parent: 31
       type: Transform
   - uid: 1849
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,22.5
       parent: 31
       type: Transform
   - uid: 1850
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,22.5
       parent: 31
       type: Transform
   - uid: 1851
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,22.5
       parent: 31
       type: Transform
   - uid: 1853
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,22.5
       parent: 31
       type: Transform
   - uid: 1854
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,22.5
       parent: 31
       type: Transform
   - uid: 1855
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,23.5
       parent: 31
       type: Transform
   - uid: 1856
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,24.5
       parent: 31
       type: Transform
   - uid: 1857
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,26.5
       parent: 31
       type: Transform
   - uid: 1858
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,27.5
       parent: 31
       type: Transform
   - uid: 1859
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,27.5
       parent: 31
       type: Transform
   - uid: 1860
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,27.5
       parent: 31
       type: Transform
   - uid: 1861
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,23.5
       parent: 31
       type: Transform
   - uid: 1862
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,27.5
       parent: 31
       type: Transform
   - uid: 1863
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,27.5
       parent: 31
       type: Transform
   - uid: 1864
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,27.5
       parent: 31
       type: Transform
   - uid: 1865
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,27.5
       parent: 31
       type: Transform
   - uid: 1866
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,23.5
       parent: 31
       type: Transform
   - uid: 1867
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,26.5
       parent: 31
       type: Transform
   - uid: 1869
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,24.5
       parent: 31
       type: Transform
   - uid: 1876
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,33.5
       parent: 31
       type: Transform
   - uid: 1890
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,32.5
       parent: 31
       type: Transform
   - uid: 1892
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,15.5
       parent: 31
       type: Transform
   - uid: 1893
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,15.5
       parent: 31
       type: Transform
   - uid: 1894
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,15.5
       parent: 31
       type: Transform
   - uid: 1895
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,15.5
       parent: 31
       type: Transform
   - uid: 1896
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,15.5
       parent: 31
       type: Transform
   - uid: 1897
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,15.5
       parent: 31
       type: Transform
   - uid: 1898
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,15.5
       parent: 31
       type: Transform
   - uid: 1899
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,16.5
       parent: 31
       type: Transform
   - uid: 1900
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,17.5
       parent: 31
       type: Transform
   - uid: 1901
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,18.5
       parent: 31
       type: Transform
   - uid: 1902
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,19.5
       parent: 31
       type: Transform
   - uid: 1903
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,19.5
       parent: 31
       type: Transform
   - uid: 1905
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,19.5
       parent: 31
       type: Transform
   - uid: 1906
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,19.5
       parent: 31
       type: Transform
   - uid: 1907
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,19.5
       parent: 31
       type: Transform
   - uid: 1908
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,19.5
       parent: 31
       type: Transform
   - uid: 1909
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,19.5
       parent: 31
       type: Transform
   - uid: 1910
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,18.5
       parent: 31
       type: Transform
   - uid: 1911
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,16.5
       parent: 31
       type: Transform
   - uid: 1920
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,22.5
       parent: 31
       type: Transform
   - uid: 1921
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,22.5
       parent: 31
       type: Transform
   - uid: 1922
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,22.5
       parent: 31
       type: Transform
   - uid: 1923
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,22.5
       parent: 31
       type: Transform
   - uid: 1924
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,22.5
       parent: 31
       type: Transform
   - uid: 1925
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,22.5
       parent: 31
       type: Transform
   - uid: 1926
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,23.5
       parent: 31
       type: Transform
   - uid: 1927
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,23.5
       parent: 31
       type: Transform
   - uid: 1928
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,23.5
       parent: 31
       type: Transform
   - uid: 1929
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,23.5
       parent: 31
       type: Transform
   - uid: 1930
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,23.5
       parent: 31
       type: Transform
   - uid: 1931
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,23.5
       parent: 31
       type: Transform
   - uid: 1932
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,23.5
       parent: 31
       type: Transform
   - uid: 1934
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,21.5
       parent: 31
       type: Transform
   - uid: 1935
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,20.5
       parent: 31
       type: Transform
   - uid: 1936
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,19.5
       parent: 31
       type: Transform
   - uid: 1937
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,18.5
       parent: 31
       type: Transform
   - uid: 1938
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,17.5
       parent: 31
       type: Transform
   - uid: 1939
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,21.5
       parent: 31
       type: Transform
   - uid: 1940
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,20.5
       parent: 31
       type: Transform
   - uid: 1941
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,19.5
       parent: 31
       type: Transform
   - uid: 1942
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,18.5
       parent: 31
       type: Transform
   - uid: 1943
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,17.5
       parent: 31
       type: Transform
   - uid: 1944
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,17.5
       parent: 31
       type: Transform
   - uid: 1945
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,17.5
       parent: 31
       type: Transform
   - uid: 1946
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,17.5
       parent: 31
       type: Transform
   - uid: 1947
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,17.5
       parent: 31
       type: Transform
   - uid: 1948
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,18.5
       parent: 31
       type: Transform
   - uid: 1950
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,8.5
       parent: 31
       type: Transform
   - uid: 1951
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,7.5
       parent: 31
       type: Transform
   - uid: 1952
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,6.5
       parent: 31
       type: Transform
   - uid: 1955
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,6.5
       parent: 31
       type: Transform
   - uid: 1960
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,12.5
       parent: 31
       type: Transform
   - uid: 1961
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,12.5
       parent: 31
       type: Transform
   - uid: 1964
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,15.5
       parent: 31
       type: Transform
   - uid: 1966
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,11.5
       parent: 31
       type: Transform
   - uid: 1967
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,9.5
       parent: 31
       type: Transform
   - uid: 1968
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,12.5
       parent: 31
       type: Transform
   - uid: 1970
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,18.5
       parent: 31
       type: Transform
   - uid: 1971
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,18.5
       parent: 31
       type: Transform
   - uid: 1974
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,16.5
       parent: 31
       type: Transform
   - uid: 1975
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,12.5
       parent: 31
       type: Transform
   - uid: 1976
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,12.5
       parent: 31
       type: Transform
   - uid: 1977
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,12.5
       parent: 31
       type: Transform
   - uid: 1978
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,14.5
       parent: 31
       type: Transform
   - uid: 1980
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,12.5
       parent: 31
       type: Transform
   - uid: 1981
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,11.5
       parent: 31
       type: Transform
   - uid: 1982
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,10.5
       parent: 31
       type: Transform
   - uid: 1983
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,9.5
       parent: 31
       type: Transform
   - uid: 1984
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,8.5
       parent: 31
       type: Transform
   - uid: 1985
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,7.5
       parent: 31
       type: Transform
   - uid: 1986
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,6.5
       parent: 31
       type: Transform
   - uid: 1987
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,6.5
       parent: 31
       type: Transform
   - uid: 1989
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,9.5
       parent: 31
       type: Transform
   - uid: 1991
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,6.5
       parent: 31
       type: Transform
   - uid: 1992
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,7.5
       parent: 31
       type: Transform
   - uid: 1993
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,8.5
       parent: 31
       type: Transform
   - uid: 1994
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,9.5
       parent: 31
       type: Transform
   - uid: 2004
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,7.5
       parent: 31
       type: Transform
   - uid: 2013
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-32.5
       parent: 31
       type: Transform
   - uid: 2040
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-26.5
       parent: 31
       type: Transform
   - uid: 2042
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-12.5
       parent: 31
       type: Transform
   - uid: 2043
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-12.5
       parent: 31
       type: Transform
   - uid: 2049
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 42.5,0.5
       parent: 31
       type: Transform
   - uid: 2101
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-5.5
       parent: 31
       type: Transform
   - uid: 2102
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-5.5
       parent: 31
       type: Transform
   - uid: 2103
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-5.5
       parent: 31
       type: Transform
   - uid: 2104
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-5.5
       parent: 31
       type: Transform
   - uid: 2105
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,2.5
       parent: 31
       type: Transform
   - uid: 2106
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,1.5
       parent: 31
       type: Transform
   - uid: 2107
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,-0.5
       parent: 31
       type: Transform
   - uid: 2108
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,0.5
       parent: 31
       type: Transform
   - uid: 2109
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-0.5
       parent: 31
       type: Transform
   - uid: 2110
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-0.5
       parent: 31
       type: Transform
   - uid: 2111
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-0.5
       parent: 31
       type: Transform
   - uid: 2114
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,2.5
       parent: 31
       type: Transform
   - uid: 2116
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,2.5
       parent: 31
       type: Transform
   - uid: 2156
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,-12.5
       parent: 31
       type: Transform
   - uid: 2184
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-11.5
       parent: 31
       type: Transform
   - uid: 2187
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-12.5
       parent: 31
       type: Transform
   - uid: 2229
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-5.5
       parent: 31
       type: Transform
   - uid: 2231
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-5.5
       parent: 31
       type: Transform
   - uid: 2232
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-5.5
       parent: 31
       type: Transform
   - uid: 2233
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-5.5
       parent: 31
       type: Transform
   - uid: 2234
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-4.5
       parent: 31
       type: Transform
   - uid: 2235
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-3.5
       parent: 31
       type: Transform
   - uid: 2236
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,1.5
       parent: 31
       type: Transform
   - uid: 2238
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,2.5
       parent: 31
       type: Transform
   - uid: 2239
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,0.5
       parent: 31
       type: Transform
   - uid: 2240
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-0.5
       parent: 31
       type: Transform
   - uid: 2241
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-0.5
       parent: 31
       type: Transform
   - uid: 2242
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-0.5
       parent: 31
       type: Transform
   - uid: 2284
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-25.5
       parent: 31
       type: Transform
   - uid: 2287
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-18.5
       parent: 31
       type: Transform
   - uid: 2293
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-23.5
       parent: 31
       type: Transform
   - uid: 2294
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-24.5
       parent: 31
       type: Transform
   - uid: 2303
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-20.5
       parent: 31
       type: Transform
   - uid: 2310
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-28.5
       parent: 31
       type: Transform
   - uid: 2324
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,26.5
       parent: 31
       type: Transform
   - uid: 2325
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,14.5
       parent: 31
       type: Transform
   - uid: 2348
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-13.5
       parent: 31
       type: Transform
   - uid: 2415
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,2.5
       parent: 31
       type: Transform
   - uid: 2416
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,20.5
       parent: 31
       type: Transform
   - uid: 2424
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-11.5
       parent: 31
       type: Transform
   - uid: 2427
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,22.5
       parent: 31
       type: Transform
   - uid: 2462
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 55.5,9.5
       parent: 31
       type: Transform
   - uid: 2474
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,22.5
       parent: 31
       type: Transform
   - uid: 2475
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,23.5
       parent: 31
       type: Transform
   - uid: 2476
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,22.5
       parent: 31
       type: Transform
   - uid: 2477
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,22.5
       parent: 31
       type: Transform
   - uid: 2478
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,24.5
       parent: 31
       type: Transform
   - uid: 2479
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,25.5
       parent: 31
       type: Transform
   - uid: 2490
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,21.5
       parent: 31
       type: Transform
   - uid: 2533
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,15.5
       parent: 31
       type: Transform
   - uid: 2535
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,17.5
       parent: 31
       type: Transform
   - uid: 2671
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,12.5
       parent: 31
       type: Transform
   - uid: 2878
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-18.5
       parent: 31
       type: Transform
   - uid: 3051
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,23.5
       parent: 31
       type: Transform
   - uid: 3053
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,14.5
       parent: 31
       type: Transform
   - uid: 3110
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 56.5,9.5
       parent: 31
       type: Transform
   - uid: 3130
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,11.5
       parent: 31
       type: Transform
   - uid: 3142
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,-15.5
       parent: 31
       type: Transform
   - uid: 3304
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,23.5
       parent: 31
       type: Transform
   - uid: 3314
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,11.5
       parent: 31
       type: Transform
   - uid: 3480
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,15.5
       parent: 31
       type: Transform
   - uid: 3535
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,20.5
       parent: 31
       type: Transform
   - uid: 3537
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,22.5
       parent: 31
       type: Transform
   - uid: 3538
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,24.5
       parent: 31
       type: Transform
   - uid: 3565
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,11.5
       parent: 31
       type: Transform
   - uid: 3627
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,27.5
       parent: 31
       type: Transform
   - uid: 3655
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 59.5,8.5
       parent: 31
       type: Transform
   - uid: 3675
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 48.5,14.5
       parent: 31
       type: Transform
   - uid: 3833
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,-15.5
       parent: 31
       type: Transform
   - uid: 3854
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,8.5
       parent: 31
       type: Transform
   - uid: 3858
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,7.5
       parent: 31
       type: Transform
   - uid: 3884
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,22.5
       parent: 31
       type: Transform
   - uid: 4079
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,20.5
       parent: 31
       type: Transform
   - uid: 4154
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,-2.5
       parent: 31
       type: Transform
   - uid: 4169
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-11.5
       parent: 31
       type: Transform
   - uid: 4171
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-11.5
       parent: 31
       type: Transform
   - uid: 4173
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-11.5
       parent: 31
       type: Transform
   - uid: 4204
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-24.5
       parent: 31
       type: Transform
   - uid: 4257
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 60.5,8.5
       parent: 31
       type: Transform
   - uid: 4258
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,-1.5
       parent: 31
       type: Transform
   - uid: 4265
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 49.5,14.5
       parent: 31
       type: Transform
   - uid: 4271
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,7.5
       parent: 31
       type: Transform
   - uid: 4272
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,8.5
       parent: 31
       type: Transform
   - uid: 4276
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,13.5
       parent: 31
       type: Transform
   - uid: 4277
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,14.5
       parent: 31
       type: Transform
   - uid: 4278
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,6.5
       parent: 31
       type: Transform
   - uid: 4292
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,14.5
       parent: 31
       type: Transform
   - uid: 4300
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,19.5
       parent: 31
       type: Transform
   - uid: 4326
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 70.5,11.5
       parent: 31
       type: Transform
   - uid: 4330
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-15.5
       parent: 31
       type: Transform
   - uid: 4374
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,10.5
       parent: 31
       type: Transform
   - uid: 4384
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-18.5
       parent: 31
       type: Transform
   - uid: 4385
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-22.5
       parent: 31
       type: Transform
   - uid: 4390
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 74.5,-6.5
       parent: 31
       type: Transform
   - uid: 4392
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 73.5,-6.5
       parent: 31
       type: Transform
   - uid: 4395
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-2.5
       parent: 31
       type: Transform
   - uid: 4396
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-6.5
       parent: 31
       type: Transform
   - uid: 4400
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 79.5,11.5
       parent: 31
       type: Transform
   - uid: 4404
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 71.5,-6.5
       parent: 31
       type: Transform
   - uid: 4406
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-5.5
       parent: 31
       type: Transform
   - uid: 4407
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,-12.5
       parent: 31
       type: Transform
   - uid: 4408
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,-12.5
       parent: 31
       type: Transform
   - uid: 4410
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,-11.5
       parent: 31
       type: Transform
   - uid: 4414
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 65.5,-6.5
       parent: 31
       type: Transform
   - uid: 4416
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,-6.5
       parent: 31
       type: Transform
   - uid: 4417
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 63.5,-6.5
       parent: 31
       type: Transform
   - uid: 4418
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,-10.5
       parent: 31
       type: Transform
   - uid: 4419
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,-4.5
       parent: 31
       type: Transform
   - uid: 4421
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 77.5,-6.5
       parent: 31
       type: Transform
   - uid: 4428
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 74.5,11.5
       parent: 31
       type: Transform
   - uid: 4429
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 78.5,-6.5
       parent: 31
       type: Transform
   - uid: 4430
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,-4.5
       parent: 31
       type: Transform
   - uid: 4431
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 79.5,-6.5
       parent: 31
       type: Transform
   - uid: 4432
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 75.5,-6.5
       parent: 31
       type: Transform
   - uid: 4434
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,5.5
       parent: 31
       type: Transform
   - uid: 4435
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,7.5
       parent: 31
       type: Transform
   - uid: 4441
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-12.5
       parent: 31
       type: Transform
   - uid: 4451
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 69.5,-6.5
       parent: 31
       type: Transform
   - uid: 4452
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,4.5
       parent: 31
       type: Transform
   - uid: 4455
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 73.5,11.5
       parent: 31
       type: Transform
   - uid: 4456
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 76.5,11.5
       parent: 31
       type: Transform
   - uid: 4461
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,6.5
       parent: 31
       type: Transform
   - uid: 4471
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,-2.5
       parent: 31
       type: Transform
   - uid: 4472
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,-0.5
       parent: 31
       type: Transform
   - uid: 4473
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,0.5
       parent: 31
       type: Transform
   - uid: 4474
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,1.5
       parent: 31
       type: Transform
   - uid: 4475
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,3.5
       parent: 31
       type: Transform
   - uid: 4476
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 68.5,-6.5
       parent: 31
       type: Transform
   - uid: 4477
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 67.5,-6.5
       parent: 31
       type: Transform
   - uid: 4494
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-19.5
       parent: 31
       type: Transform
   - uid: 4499
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-21.5
       parent: 31
       type: Transform
   - uid: 4502
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-10.5
       parent: 31
       type: Transform
   - uid: 4509
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-21.5
       parent: 31
       type: Transform
   - uid: 4517
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-26.5
       parent: 31
       type: Transform
   - uid: 4518
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-26.5
       parent: 31
       type: Transform
   - uid: 4523
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-1.5
       parent: 31
       type: Transform
   - uid: 4524
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 57.5,-6.5
       parent: 31
       type: Transform
   - uid: 4527
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-16.5
       parent: 31
       type: Transform
   - uid: 4531
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 53.5,-6.5
       parent: 31
       type: Transform
   - uid: 4540
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 71.5,11.5
       parent: 31
       type: Transform
   - uid: 4551
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 69.5,11.5
       parent: 31
       type: Transform
   - uid: 4552
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 78.5,11.5
       parent: 31
       type: Transform
   - uid: 4572
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-19.5
       parent: 31
       type: Transform
   - uid: 4573
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-20.5
       parent: 31
       type: Transform
   - uid: 4574
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,7.5
       parent: 31
       type: Transform
   - uid: 4579
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-16.5
       parent: 31
       type: Transform
   - uid: 4580
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-18.5
       parent: 31
       type: Transform
   - uid: 4581
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-18.5
       parent: 31
       type: Transform
   - uid: 4582
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-18.5
       parent: 31
       type: Transform
   - uid: 4584
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-22.5
       parent: 31
       type: Transform
   - uid: 4587
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-26.5
       parent: 31
       type: Transform
   - uid: 4588
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-26.5
       parent: 31
       type: Transform
   - uid: 4589
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 60.5,-6.5
       parent: 31
       type: Transform
   - uid: 4594
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-20.5
       parent: 31
       type: Transform
   - uid: 4601
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,11.5
       parent: 31
       type: Transform
   - uid: 4646
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-17.5
       parent: 31
       type: Transform
   - uid: 4648
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-22.5
       parent: 31
       type: Transform
   - uid: 4661
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-22.5
       parent: 31
       type: Transform
   - uid: 4674
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-21.5
       parent: 31
       type: Transform
   - uid: 4675
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,-18.5
       parent: 31
       type: Transform
   - uid: 4678
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-18.5
       parent: 31
       type: Transform
   - uid: 4689
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 72.5,-6.5
       parent: 31
       type: Transform
   - uid: 4716
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-17.5
       parent: 31
       type: Transform
   - uid: 4717
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-20.5
       parent: 31
       type: Transform
   - uid: 4740
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,24.5
       parent: 31
       type: Transform
   - uid: 4773
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,-1.5
       parent: 31
       type: Transform
   - uid: 4779
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 62.5,-6.5
       parent: 31
       type: Transform
   - uid: 4781
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,-3.5
       parent: 31
       type: Transform
   - uid: 4788
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,-6.5
       parent: 31
       type: Transform
   - uid: 4789
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 64.5,-6.5
       parent: 31
       type: Transform
   - uid: 4791
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,-5.5
       parent: 31
       type: Transform
   - uid: 4796
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 70.5,-6.5
       parent: 31
       type: Transform
   - uid: 4813
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-26.5
       parent: 31
       type: Transform
   - uid: 4814
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-27.5
       parent: 31
       type: Transform
   - uid: 4815
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-28.5
       parent: 31
       type: Transform
   - uid: 4816
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-29.5
       parent: 31
       type: Transform
   - uid: 4817
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-30.5
       parent: 31
       type: Transform
   - uid: 4818
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-31.5
       parent: 31
       type: Transform
   - uid: 4837
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-31.5
       parent: 31
       type: Transform
   - uid: 4838
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-31.5
       parent: 31
       type: Transform
   - uid: 4839
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-31.5
       parent: 31
       type: Transform
   - uid: 4840
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-31.5
       parent: 31
       type: Transform
   - uid: 4842
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,-31.5
       parent: 31
       type: Transform
   - uid: 4843
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-31.5
       parent: 31
       type: Transform
   - uid: 4855
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,24.5
       parent: 31
       type: Transform
   - uid: 4867
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,20.5
       parent: 31
       type: Transform
   - uid: 4894
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,6.5
       parent: 31
       type: Transform
   - uid: 4898
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,11.5
       parent: 31
       type: Transform
   - uid: 4931
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,19.5
       parent: 31
       type: Transform
   - uid: 4935
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-22.5
       parent: 31
       type: Transform
   - uid: 4936
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-26.5
       parent: 31
       type: Transform
   - uid: 4937
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-26.5
       parent: 31
       type: Transform
   - uid: 4938
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-26.5
       parent: 31
       type: Transform
   - uid: 4939
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-20.5
       parent: 31
       type: Transform
   - uid: 4941
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-21.5
       parent: 31
       type: Transform
   - uid: 4942
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-24.5
       parent: 31
       type: Transform
   - uid: 4944
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-26.5
       parent: 31
       type: Transform
   - uid: 4945
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,-26.5
       parent: 31
       type: Transform
   - uid: 4978
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,18.5
       parent: 31
       type: Transform
   - uid: 4979
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,19.5
       parent: 31
       type: Transform
   - uid: 4980
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,20.5
       parent: 31
       type: Transform
   - uid: 4988
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,21.5
       parent: 31
       type: Transform
   - uid: 4989
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,21.5
       parent: 31
       type: Transform
   - uid: 4990
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,21.5
       parent: 31
       type: Transform
   - uid: 4991
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,21.5
       parent: 31
       type: Transform
   - uid: 4993
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,23.5
       parent: 31
       type: Transform
   - uid: 5006
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,22.5
       parent: 31
       type: Transform
   - uid: 5036
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-20.5
       parent: 31
       type: Transform
   - uid: 5059
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,27.5
       parent: 31
       type: Transform
   - uid: 5060
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,26.5
       parent: 31
       type: Transform
   - uid: 5061
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,27.5
       parent: 31
       type: Transform
   - uid: 5062
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,25.5
       parent: 31
       type: Transform
   - uid: 5063
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 52.5,18.5
       parent: 31
       type: Transform
   - uid: 5101
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-18.5
       parent: 31
       type: Transform
   - uid: 5154
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-24.5
       parent: 31
       type: Transform
   - uid: 5176
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,22.5
       parent: 31
       type: Transform
   - uid: 5177
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,23.5
       parent: 31
       type: Transform
   - uid: 5178
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,25.5
       parent: 31
       type: Transform
   - uid: 5179
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,26.5
       parent: 31
       type: Transform
   - uid: 5180
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,26.5
       parent: 31
       type: Transform
   - uid: 5181
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,26.5
       parent: 31
       type: Transform
   - uid: 5182
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,26.5
       parent: 31
       type: Transform
   - uid: 5183
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,26.5
       parent: 31
       type: Transform
   - uid: 5193
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,23.5
       parent: 31
       type: Transform
   - uid: 5194
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,20.5
       parent: 31
       type: Transform
   - uid: 5195
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,25.5
       parent: 31
       type: Transform
   - uid: 5196
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,25.5
       parent: 31
       type: Transform
   - uid: 5233
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,15.5
       parent: 31
       type: Transform
   - uid: 5236
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,21.5
       parent: 31
       type: Transform
   - uid: 5237
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,22.5
       parent: 31
       type: Transform
   - uid: 5238
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,21.5
       parent: 31
       type: Transform
   - uid: 5239
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,23.5
       parent: 31
       type: Transform
   - uid: 5241
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,24.5
       parent: 31
       type: Transform
   - uid: 5242
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,22.5
       parent: 31
       type: Transform
   - uid: 5245
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,23.5
       parent: 31
       type: Transform
   - uid: 5252
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-27.5
       parent: 31
       type: Transform
   - uid: 5253
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-28.5
       parent: 31
       type: Transform
   - uid: 5254
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-29.5
       parent: 31
       type: Transform
   - uid: 5255
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-30.5
       parent: 31
       type: Transform
   - uid: 5256
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-30.5
       parent: 31
       type: Transform
   - uid: 5257
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-30.5
       parent: 31
       type: Transform
   - uid: 5294
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-32.5
       parent: 31
       type: Transform
   - uid: 5295
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-32.5
       parent: 31
       type: Transform
   - uid: 5296
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,-32.5
       parent: 31
       type: Transform
   - uid: 5297
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-32.5
       parent: 31
       type: Transform
   - uid: 5298
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-32.5
       parent: 31
       type: Transform
   - uid: 5315
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,21.5
       parent: 31
       type: Transform
   - uid: 5316
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,20.5
       parent: 31
       type: Transform
   - uid: 5318
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 42.5,24.5
       parent: 31
       type: Transform
   - uid: 5319
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,24.5
       parent: 31
       type: Transform
   - uid: 5320
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,24.5
       parent: 31
       type: Transform
   - uid: 5610
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,17.5
       parent: 31
       type: Transform
   - uid: 5672
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,-5.5
       parent: 31
       type: Transform
   - uid: 5674
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,11.5
       parent: 31
       type: Transform
   - uid: 5677
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,4.5
       parent: 31
       type: Transform
   - uid: 5679
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,2.5
       parent: 31
       type: Transform
   - uid: 5680
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 68.5,11.5
       parent: 31
       type: Transform
   - uid: 5719
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-8.5
       parent: 31
       type: Transform
   - uid: 5882
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -53.5,-11.5
       parent: 31
       type: Transform
   - uid: 5894
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,23.5
       parent: 31
       type: Transform
   - uid: 5939
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,18.5
       parent: 31
       type: Transform
   - uid: 5983
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -44.5,-8.5
       parent: 31
       type: Transform
   - uid: 6181
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 72.5,11.5
       parent: 31
       type: Transform
   - uid: 6210
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-12.5
       parent: 31
       type: Transform
   - uid: 6230
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 59.5,5.5
       parent: 31
       type: Transform
   - uid: 6231
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,5.5
       parent: 31
       type: Transform
   - uid: 6245
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,22.5
       parent: 31
       type: Transform
   - uid: 6253
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,18.5
       parent: 31
       type: Transform
   - uid: 6278
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,-9.5
       parent: 31
       type: Transform
   - uid: 6279
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,-11.5
       parent: 31
       type: Transform
   - uid: 6283
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 58.5,9.5
       parent: 31
       type: Transform
   - uid: 6284
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,8.5
       parent: 31
       type: Transform
   - uid: 6285
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 57.5,-12.5
       parent: 31
       type: Transform
   - uid: 6290
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,-6.5
       parent: 31
       type: Transform
   - uid: 6291
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-6.5
       parent: 31
       type: Transform
   - uid: 6292
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-5.5
       parent: 31
       type: Transform
   - uid: 6295
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-8.5
       parent: 31
       type: Transform
   - uid: 6307
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 51.5,18.5
       parent: 31
       type: Transform
   - uid: 6368
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 52.5,14.5
       parent: 31
       type: Transform
   - uid: 6388
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,6.5
       parent: 31
       type: Transform
   - uid: 6389
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,7.5
       parent: 31
       type: Transform
   - uid: 6390
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,12.5
       parent: 31
       type: Transform
   - uid: 6395
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,14.5
       parent: 31
       type: Transform
   - uid: 6416
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 47.5,23.5
       parent: 31
       type: Transform
   - uid: 6422
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 47.5,22.5
       parent: 31
       type: Transform
   - uid: 6441
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,11.5
       parent: 31
       type: Transform
   - uid: 6447
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,10.5
       parent: 31
       type: Transform
   - uid: 6454
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,6.5
       parent: 31
       type: Transform
   - uid: 6468
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,10.5
       parent: 31
       type: Transform
   - uid: 6474
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -52.5,-12.5
       parent: 31
       type: Transform
   - uid: 6475
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 48.5,6.5
       parent: 31
       type: Transform
   - uid: 6484
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,7.5
       parent: 31
       type: Transform
   - uid: 6485
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,8.5
       parent: 31
       type: Transform
   - uid: 6488
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,7.5
       parent: 31
       type: Transform
   - uid: 6491
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 44.5,14.5
       parent: 31
       type: Transform
   - uid: 6492
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,14.5
       parent: 31
       type: Transform
   - uid: 6493
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -52.5,-8.5
       parent: 31
       type: Transform
   - uid: 6494
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-8.5
       parent: 31
       type: Transform
   - uid: 6496
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,10.5
       parent: 31
       type: Transform
   - uid: 6498
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 44.5,10.5
       parent: 31
       type: Transform
   - uid: 6499
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,9.5
       parent: 31
       type: Transform
   - uid: 6500
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,23.5
       parent: 31
       type: Transform
   - uid: 6531
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,14.5
       parent: 31
       type: Transform
   - uid: 6535
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,13.5
       parent: 31
       type: Transform
   - uid: 6536
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,11.5
       parent: 31
       type: Transform
   - uid: 6537
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,10.5
       parent: 31
       type: Transform
   - uid: 6542
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 49.5,6.5
       parent: 31
       type: Transform
   - uid: 6553
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,18.5
       parent: 31
       type: Transform
   - uid: 6576
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -45.5,-12.5
       parent: 31
       type: Transform
   - uid: 6583
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,-10.5
       parent: 31
       type: Transform
   - uid: 6601
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,8.5
       parent: 31
       type: Transform
   - uid: 6608
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,13.5
       parent: 31
       type: Transform
   - uid: 6612
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-12.5
       parent: 31
       type: Transform
   - uid: 6615
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,22.5
       parent: 31
       type: Transform
   - uid: 6616
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,6.5
       parent: 31
       type: Transform
   - uid: 6622
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,6.5
       parent: 31
       type: Transform
   - uid: 6627
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,10.5
       parent: 31
       type: Transform
   - uid: 6628
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 42.5,10.5
       parent: 31
       type: Transform
   - uid: 6808
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 47.5,24.5
       parent: 31
       type: Transform
   - uid: 6809
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -43.5,-12.5
       parent: 31
       type: Transform
   - uid: 6810
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-7.5
       parent: 31
       type: Transform
   - uid: 6811
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-42.5
       parent: 31
       type: Transform
   - uid: 6814
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 46.5,24.5
       parent: 31
       type: Transform
   - uid: 6822
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,10.5
       parent: 31
       type: Transform
   - uid: 6837
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,10.5
       parent: 31
       type: Transform
   - uid: 6851
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,10.5
       parent: 31
       type: Transform
   - uid: 6862
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,9.5
       parent: 31
       type: Transform
   - uid: 6870
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 66.5,-6.5
       parent: 31
       type: Transform
   - uid: 6879
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,15.5
       parent: 31
       type: Transform
   - uid: 6883
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,30.5
       parent: 31
       type: Transform
   - uid: 6886
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 42.5,14.5
       parent: 31
       type: Transform
   - uid: 6889
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,7.5
       parent: 31
       type: Transform
   - uid: 6902
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 47.5,20.5
       parent: 31
       type: Transform
   - uid: 6905
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,18.5
       parent: 31
       type: Transform
   - uid: 6920
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,8.5
       parent: 31
       type: Transform
   - uid: 6926
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,8.5
       parent: 31
       type: Transform
   - uid: 6927
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 76.5,-6.5
       parent: 31
       type: Transform
   - uid: 6928
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 56.5,-12.5
       parent: 31
       type: Transform
   - uid: 6929
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,10.5
       parent: 31
       type: Transform
   - uid: 6948
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,-8.5
       parent: 31
       type: Transform
   - uid: 6949
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,-12.5
       parent: 31
       type: Transform
   - uid: 6953
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,-2.5
       parent: 31
       type: Transform
   - uid: 6954
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,9.5
       parent: 31
       type: Transform
   - uid: 6955
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 75.5,11.5
       parent: 31
       type: Transform
   - uid: 6956
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 77.5,11.5
       parent: 31
       type: Transform
   - uid: 6983
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,-22.5
       parent: 31
       type: Transform
   - uid: 6984
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,-26.5
       parent: 31
       type: Transform
   - uid: 6985
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,-21.5
       parent: 31
       type: Transform
   - uid: 6986
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,-27.5
       parent: 31
       type: Transform
   - uid: 6987
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-30.5
       parent: 31
       type: Transform
   - uid: 6990
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,-30.5
       parent: 31
       type: Transform
   - uid: 6992
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-27.5
       parent: 31
       type: Transform
   - uid: 7034
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-18.5
       parent: 31
       type: Transform
   - uid: 7047
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-20.5
       parent: 31
       type: Transform
   - uid: 7048
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-20.5
       parent: 31
       type: Transform
   - uid: 7049
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-18.5
       parent: 31
       type: Transform
   - uid: 7053
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 46.5,-13.5
       parent: 31
       type: Transform
   - uid: 7055
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,17.5
       parent: 31
       type: Transform
   - uid: 7060
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-26.5
       parent: 31
       type: Transform
   - uid: 7061
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-26.5
       parent: 31
       type: Transform
   - uid: 7062
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-20.5
       parent: 31
       type: Transform
   - uid: 7070
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 80.5,-3.5
       parent: 31
       type: Transform
   - uid: 7081
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-41.5
       parent: 31
       type: Transform
   - uid: 7084
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,24.5
       parent: 31
       type: Transform
   - uid: 7086
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,24.5
       parent: 31
       type: Transform
   - uid: 7094
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-41.5
       parent: 31
       type: Transform
   - uid: 7096
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,22.5
       parent: 31
       type: Transform
   - uid: 7100
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-42.5
       parent: 31
       type: Transform
   - uid: 7157
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,18.5
       parent: 31
       type: Transform
   - uid: 7162
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-2.5
       parent: 31
       type: Transform
   - uid: 7169
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-10.5
       parent: 31
       type: Transform
   - uid: 7181
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-4.5
       parent: 31
       type: Transform
   - uid: 7184
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-3.5
       parent: 31
       type: Transform
   - uid: 7223
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,2.5
       parent: 31
       type: Transform
   - uid: 7333
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-14.5
       parent: 31
       type: Transform
   - uid: 7339
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,9.5
       parent: 31
       type: Transform
   - uid: 7352
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 54.5,18.5
       parent: 31
       type: Transform
   - uid: 7441
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-32.5
       parent: 31
       type: Transform
   - uid: 7442
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-32.5
       parent: 31
       type: Transform
   - uid: 7467
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-29.5
       parent: 31
       type: Transform
   - uid: 7468
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-31.5
       parent: 31
       type: Transform
   - uid: 7475
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,19.5
       parent: 31
       type: Transform
   - uid: 7481
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-31.5
       parent: 31
       type: Transform
   - uid: 7483
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-33.5
       parent: 31
       type: Transform
   - uid: 7502
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-40.5
       parent: 31
       type: Transform
   - uid: 7503
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-18.5
       parent: 31
       type: Transform
   - uid: 7505
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-35.5
       parent: 31
       type: Transform
   - uid: 7506
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-36.5
       parent: 31
       type: Transform
   - uid: 7507
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-36.5
       parent: 31
       type: Transform
   - uid: 7508
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-34.5
       parent: 31
       type: Transform
   - uid: 7509
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-40.5
       parent: 31
       type: Transform
   - uid: 7531
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-40.5
       parent: 31
       type: Transform
   - uid: 7535
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-40.5
       parent: 31
       type: Transform
   - uid: 7541
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-37.5
       parent: 31
       type: Transform
   - uid: 7545
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-37.5
       parent: 31
       type: Transform
   - uid: 7546
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-37.5
       parent: 31
       type: Transform
   - uid: 7551
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-33.5
       parent: 31
       type: Transform
   - uid: 7555
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-40.5
       parent: 31
       type: Transform
   - uid: 7560
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-36.5
       parent: 31
       type: Transform
   - uid: 7563
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-37.5
       parent: 31
       type: Transform
   - uid: 7578
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-35.5
       parent: 31
       type: Transform
   - uid: 7583
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-34.5
       parent: 31
       type: Transform
   - uid: 7585
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-33.5
       parent: 31
       type: Transform
   - uid: 7592
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -14.5,-31.5
       parent: 31
       type: Transform
   - uid: 7601
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-32.5
       parent: 31
       type: Transform
   - uid: 7629
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,16.5
       parent: 31
       type: Transform
   - uid: 7633
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-24.5
       parent: 31
       type: Transform
   - uid: 7641
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-31.5
       parent: 31
       type: Transform
   - uid: 7681
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 60.5,-0.5
       parent: 31
       type: Transform
   - uid: 7683
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,13.5
       parent: 31
       type: Transform
   - uid: 7685
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -3.5,29.5
       parent: 31
       type: Transform
   - uid: 7698
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 48.5,-12.5
       parent: 31
       type: Transform
   - uid: 7699
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -3.5,30.5
       parent: 31
       type: Transform
   - uid: 7712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-11.5
       parent: 31
       type: Transform
   - uid: 7751
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,7.5
       parent: 31
       type: Transform
   - uid: 7752
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,6.5
       parent: 31
       type: Transform
   - uid: 7797
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-12.5
       parent: 31
       type: Transform
   - uid: 7805
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -53.5,-12.5
       parent: 31
       type: Transform
   - uid: 7816
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-20.5
       parent: 31
       type: Transform
   - uid: 7822
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,-12.5
       parent: 31
       type: Transform
   - uid: 7831
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -43.5,-8.5
       parent: 31
       type: Transform
   - uid: 7846
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,20.5
       parent: 31
       type: Transform
   - uid: 7942
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,21.5
       parent: 31
       type: Transform
   - uid: 7968
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,20.5
       parent: 31
       type: Transform
   - uid: 8019
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 57.5,9.5
       parent: 31
       type: Transform
   - uid: 8026
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -53.5,-8.5
       parent: 31
       type: Transform
   - uid: 8051
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-12.5
       parent: 31
       type: Transform
   - uid: 8058
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-20.5
       parent: 31
       type: Transform
   - uid: 8107
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,-0.5
       parent: 31
       type: Transform
   - uid: 8113
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,0.5
       parent: 31
       type: Transform
   - uid: 8114
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 53.5,0.5
       parent: 31
       type: Transform
   - uid: 8115
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,0.5
       parent: 31
       type: Transform
   - uid: 8116
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,-0.5
       parent: 31
       type: Transform
   - uid: 8117
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 55.5,-0.5
       parent: 31
       type: Transform
   - uid: 8118
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 56.5,-0.5
       parent: 31
       type: Transform
   - uid: 8121
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,8.5
       parent: 31
       type: Transform
   - uid: 8123
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 60.5,5.5
       parent: 31
       type: Transform
   - uid: 8126
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,6.5
       parent: 31
       type: Transform
   - uid: 8128
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,4.5
       parent: 31
       type: Transform
   - uid: 8129
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,5.5
       parent: 31
       type: Transform
   - uid: 8161
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 59.5,-6.5
       parent: 31
       type: Transform
   - uid: 8212
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,-12.5
       parent: 31
       type: Transform
   - uid: 8215
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-15.5
       parent: 31
       type: Transform
   - uid: 8220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,18.5
       parent: 31
       type: Transform
   - uid: 8287
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -50.5,-12.5
       parent: 31
       type: Transform
   - uid: 8289
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -51.5,-8.5
       parent: 31
       type: Transform
   - uid: 8311
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-33.5
       parent: 31
       type: Transform
   - uid: 8368
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-32.5
       parent: 31
       type: Transform
   - uid: 8381
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-23.5
       parent: 31
       type: Transform
   - uid: 8400
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,23.5
       parent: 31
       type: Transform
   - uid: 8401
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -8.5,23.5
       parent: 31
       type: Transform
   - uid: 8402
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,-7.5
       parent: 31
       type: Transform
   - uid: 8452
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-25.5
       parent: 31
       type: Transform
   - uid: 8455
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-27.5
       parent: 31
       type: Transform
   - uid: 8457
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-24.5
       parent: 31
       type: Transform
   - uid: 8458
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-25.5
       parent: 31
       type: Transform
   - uid: 8464
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-30.5
       parent: 31
       type: Transform
   - uid: 8465
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-29.5
       parent: 31
       type: Transform
   - uid: 8466
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-28.5
       parent: 31
       type: Transform
   - uid: 8470
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-27.5
       parent: 31
       type: Transform
   - uid: 8471
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,-27.5
       parent: 31
       type: Transform
   - uid: 8472
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-27.5
       parent: 31
       type: Transform
   - uid: 8473
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-25.5
       parent: 31
       type: Transform
   - uid: 8474
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,-25.5
       parent: 31
       type: Transform
   - uid: 8475
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-25.5
       parent: 31
       type: Transform
   - uid: 8477
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-27.5
       parent: 31
       type: Transform
   - uid: 8516
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-27.5
       parent: 31
       type: Transform
   - uid: 8517
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-25.5
       parent: 31
       type: Transform
   - uid: 8518
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-27.5
       parent: 31
       type: Transform
   - uid: 8519
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-25.5
       parent: 31
       type: Transform
   - uid: 8520
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-25.5
       parent: 31
       type: Transform
   - uid: 8521
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-25.5
       parent: 31
       type: Transform
   - uid: 8522
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-27.5
       parent: 31
       type: Transform
   - uid: 8523
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-27.5
       parent: 31
       type: Transform
   - uid: 8528
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-33.5
       parent: 31
       type: Transform
   - uid: 8529
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,-30.5
       parent: 31
       type: Transform
   - uid: 8530
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-33.5
       parent: 31
       type: Transform
   - uid: 8532
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-29.5
       parent: 31
       type: Transform
   - uid: 8534
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-28.5
       parent: 31
       type: Transform
   - uid: 8535
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-30.5
       parent: 31
       type: Transform
   - uid: 8536
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-30.5
       parent: 31
       type: Transform
   - uid: 8537
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-33.5
       parent: 31
       type: Transform
   - uid: 8538
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-32.5
       parent: 31
       type: Transform
   - uid: 8539
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-31.5
       parent: 31
       type: Transform
   - uid: 8540
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-30.5
       parent: 31
       type: Transform
   - uid: 8541
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-27.5
       parent: 31
       type: Transform
   - uid: 8542
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-26.5
       parent: 31
       type: Transform
   - uid: 8544
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-25.5
       parent: 31
       type: Transform
   - uid: 8545
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-33.5
       parent: 31
       type: Transform
   - uid: 8547
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-31.5
       parent: 31
       type: Transform
   - uid: 8548
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-30.5
       parent: 31
       type: Transform
   - uid: 8549
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-33.5
       parent: 31
       type: Transform
   - uid: 8550
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-33.5
       parent: 31
       type: Transform
   - uid: 8551
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-33.5
       parent: 31
       type: Transform
   - uid: 8552
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-29.5
       parent: 31
       type: Transform
   - uid: 8553
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-30.5
       parent: 31
       type: Transform
   - uid: 8554
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-30.5
       parent: 31
       type: Transform
   - uid: 8555
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-30.5
       parent: 31
       type: Transform
   - uid: 8557
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-22.5
       parent: 31
       type: Transform
   - uid: 8561
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-25.5
       parent: 31
       type: Transform
   - uid: 8562
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-25.5
       parent: 31
       type: Transform
   - uid: 8565
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-22.5
       parent: 31
       type: Transform
   - uid: 8756
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,12.5
       parent: 31
       type: Transform
   - uid: 8758
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,12.5
       parent: 31
       type: Transform
   - uid: 8759
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,7.5
       parent: 31
       type: Transform
   - uid: 8760
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,6.5
       parent: 31
       type: Transform
   - uid: 8806
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,20.5
       parent: 31
       type: Transform
   - uid: 8844
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,16.5
       parent: 31
       type: Transform
   - uid: 8936
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-31.5
       parent: 31
       type: Transform
   - uid: 9005
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-33.5
       parent: 31
       type: Transform
   - uid: 9075
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -44.5,-0.5
       parent: 31
       type: Transform
   - uid: 9088
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-21.5
       parent: 31
       type: Transform
   - uid: 9144
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,-29.5
       parent: 31
       type: Transform
   - uid: 9168
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -4.5,-28.5
       parent: 31
       type: Transform
   - uid: 9182
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-8.5
       parent: 31
       type: Transform
   - uid: 9183
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-6.5
       parent: 31
       type: Transform
   - uid: 9185
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-2.5
       parent: 31
       type: Transform
   - uid: 9186
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-0.5
       parent: 31
       type: Transform
   - uid: 9192
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,-28.5
       parent: 31
       type: Transform
   - uid: 9193
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-12.5
       parent: 31
       type: Transform
   - uid: 9203
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -4.5,-26.5
       parent: 31
       type: Transform
   - uid: 9205
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-6.5
       parent: 31
       type: Transform
   - uid: 9206
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-4.5
       parent: 31
       type: Transform
   - uid: 9253
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,-30.5
       parent: 31
       type: Transform
   - uid: 9258
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,-31.5
       parent: 31
       type: Transform
   - uid: 9286
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-32.5
       parent: 31
       type: Transform
   - uid: 9287
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-33.5
       parent: 31
       type: Transform
   - uid: 9288
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-30.5
       parent: 31
       type: Transform
   - uid: 9293
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-32.5
       parent: 31
       type: Transform
   - uid: 9304
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-43.5
       parent: 31
       type: Transform
   - uid: 9305
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-39.5
       parent: 31
       type: Transform
   - uid: 9306
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-38.5
       parent: 31
       type: Transform
   - uid: 9307
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-37.5
       parent: 31
       type: Transform
   - uid: 9308
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-36.5
       parent: 31
       type: Transform
   - uid: 9309
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-35.5
       parent: 31
       type: Transform
   - uid: 9310
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-34.5
       parent: 31
       type: Transform
   - uid: 9311
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-33.5
       parent: 31
       type: Transform
   - uid: 9312
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-32.5
       parent: 31
       type: Transform
   - uid: 9313
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-33.5
       parent: 31
       type: Transform
   - uid: 9314
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-34.5
       parent: 31
       type: Transform
   - uid: 9315
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-35.5
       parent: 31
       type: Transform
   - uid: 9316
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-36.5
       parent: 31
       type: Transform
   - uid: 9317
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-36.5
       parent: 31
       type: Transform
   - uid: 9318
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-36.5
       parent: 31
       type: Transform
   - uid: 9319
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-36.5
       parent: 31
       type: Transform
   - uid: 9320
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-37.5
       parent: 31
       type: Transform
   - uid: 9321
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-37.5
       parent: 31
       type: Transform
   - uid: 9329
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -34.5,19.5
       parent: 31
       type: Transform
   - uid: 9342
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-37.5
       parent: 31
       type: Transform
   - uid: 9345
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 57.5,-0.5
       parent: 31
       type: Transform
   - uid: 9348
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-37.5
       parent: 31
       type: Transform
   - uid: 9356
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-37.5
       parent: 31
       type: Transform
   - uid: 9368
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-22.5
       parent: 31
       type: Transform
   - uid: 9397
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-31.5
       parent: 31
       type: Transform
   - uid: 9398
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-37.5
       parent: 31
       type: Transform
   - uid: 9404
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-37.5
       parent: 31
       type: Transform
   - uid: 9405
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-36.5
       parent: 31
       type: Transform
   - uid: 9406
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-36.5
       parent: 31
       type: Transform
   - uid: 9407
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-36.5
       parent: 31
       type: Transform
   - uid: 9425
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-40.5
       parent: 31
       type: Transform
   - uid: 9426
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-40.5
       parent: 31
       type: Transform
   - uid: 9427
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-40.5
       parent: 31
       type: Transform
   - uid: 9428
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-39.5
       parent: 31
       type: Transform
   - uid: 9429
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-38.5
       parent: 31
       type: Transform
   - uid: 9434
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-30.5
       parent: 31
       type: Transform
   - uid: 9435
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-31.5
       parent: 31
       type: Transform
   - uid: 9436
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-33.5
       parent: 31
       type: Transform
   - uid: 9437
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,-33.5
       parent: 31
       type: Transform
   - uid: 9438
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-33.5
       parent: 31
       type: Transform
   - uid: 9446
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-30.5
       parent: 31
       type: Transform
   - uid: 9467
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-43.5
       parent: 31
       type: Transform
   - uid: 9468
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 9.5,-43.5
       parent: 31
       type: Transform
   - uid: 9470
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 7.5,-43.5
       parent: 31
       type: Transform
   - uid: 9471
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 8.5,-43.5
       parent: 31
       type: Transform
   - uid: 9472
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 10.5,-43.5
       parent: 31
       type: Transform
   - uid: 9475
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-43.5
       parent: 31
       type: Transform
   - uid: 9476
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-43.5
       parent: 31
       type: Transform
   - uid: 9511
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-8.5
       parent: 31
       type: Transform
   - uid: 9527
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,11.5
       parent: 31
       type: Transform
   - uid: 9538
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 62.5,11.5
       parent: 31
       type: Transform
   - uid: 9539
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,11.5
       parent: 31
       type: Transform
   - uid: 9540
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,10.5
       parent: 31
       type: Transform
   - uid: 9541
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 61.5,9.5
       parent: 31
       type: Transform
   - uid: 9542
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 67.5,11.5
       parent: 31
       type: Transform
   - uid: 9543
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 66.5,11.5
       parent: 31
       type: Transform
   - uid: 9545
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 65.5,11.5
       parent: 31
       type: Transform
   - uid: 9546
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 64.5,11.5
       parent: 31
       type: Transform
   - uid: 9547
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 63.5,11.5
       parent: 31
       type: Transform
   - uid: 9584
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-9.5
       parent: 31
       type: Transform
   - uid: 9586
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-39.5
       parent: 31
       type: Transform
   - uid: 9589
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -6.5,23.5
       parent: 31
       type: Transform
   - uid: 9600
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 44.5,24.5
       parent: 31
       type: Transform
   - uid: 9611
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-43.5
       parent: 31
       type: Transform
   - uid: 9612
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-44.5
       parent: 31
       type: Transform
   - uid: 9636
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-41.5
       parent: 31
       type: Transform
   - uid: 9637
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-42.5
       parent: 31
       type: Transform
   - uid: 9639
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-43.5
       parent: 31
       type: Transform
   - uid: 9640
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-45.5
       parent: 31
       type: Transform
   - uid: 9641
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-44.5
       parent: 31
       type: Transform
   - uid: 9642
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-45.5
       parent: 31
       type: Transform
   - uid: 9643
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-44.5
       parent: 31
       type: Transform
   - uid: 9644
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-43.5
       parent: 31
       type: Transform
   - uid: 9656
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-43.5
       parent: 31
       type: Transform
   - uid: 9657
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-43.5
       parent: 31
       type: Transform
   - uid: 9705
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -3.5,31.5
       parent: 31
       type: Transform
   - uid: 9721
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,32.5
       parent: 31
       type: Transform
   - uid: 9722
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,-0.5
       parent: 31
       type: Transform
   - uid: 9725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 59.5,-0.5
       parent: 31
       type: Transform
   - uid: 9730
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-9.5
       parent: 31
       type: Transform
   - uid: 9742
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,20.5
       parent: 31
       type: Transform
   - uid: 9765
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-33.5
       parent: 31
       type: Transform
   - uid: 9857
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 40.5,-14.5
       parent: 31
       type: Transform
   - uid: 9892
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -33.5,19.5
       parent: 31
       type: Transform
   - uid: 9924
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 29.5,19.5
       parent: 31
       type: Transform
   - uid: 9932
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,22.5
       parent: 31
       type: Transform
   - uid: 9944
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 40.5,-15.5
       parent: 31
       type: Transform
   - uid: 10019
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-15.5
       parent: 31
       type: Transform
   - uid: 10081
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 18.5,28.5
       parent: 31
       type: Transform
   - uid: 10082
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 18.5,25.5
       parent: 31
       type: Transform
   - uid: 10083
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 24.5,25.5
       parent: 31
       type: Transform
   - uid: 10084
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 23.5,25.5
       parent: 31
       type: Transform
   - uid: 10085
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 19.5,25.5
       parent: 31
       type: Transform
   - uid: 10086
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 24.5,28.5
       parent: 31
       type: Transform
   - uid: 10118
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 41.5,-14.5
       parent: 31
       type: Transform
   - uid: 10128
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 45.5,-14.5
       parent: 31
       type: Transform
   - uid: 10131
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,2.5
       parent: 31
       type: Transform
   - uid: 10135
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-34.5
       parent: 31
       type: Transform
   - uid: 10136
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-34.5
       parent: 31
       type: Transform
   - uid: 10142
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,11.5
       parent: 31
       type: Transform
   - uid: 10199
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-17.5
       parent: 31
       type: Transform
   - uid: 10200
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-17.5
       parent: 31
       type: Transform
   - uid: 10209
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,20.5
       parent: 31
       type: Transform
   - uid: 10211
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,20.5
       parent: 31
       type: Transform
   - uid: 10244
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-8.5
       parent: 31
       type: Transform
   - uid: 10304
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,-8.5
       parent: 31
       type: Transform
   - uid: 10308
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,-8.5
       parent: 31
       type: Transform
   - uid: 10326
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-8.5
       parent: 31
       type: Transform
   - uid: 10411
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-18.5
       parent: 31
       type: Transform
   - uid: 10413
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-18.5
       parent: 31
       type: Transform
   - uid: 10557
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-23.5
       parent: 31
       type: Transform
   - uid: 10593
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 46.5,-11.5
       parent: 31
       type: Transform
   - uid: 10709
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-22.5
       parent: 31
       type: Transform
   - uid: 10994
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-23.5
       parent: 31
       type: Transform
   - uid: 11038
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 47.5,21.5
       parent: 31
       type: Transform
   - uid: 11048
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 56.5,18.5
       parent: 31
       type: Transform
   - uid: 11093
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 56.5,14.5
       parent: 31
       type: Transform
   - uid: 11094
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 54.5,14.5
       parent: 31
       type: Transform
   - uid: 11114
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,30.5
       parent: 31
       type: Transform
   - uid: 11115
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,29.5
       parent: 31
       type: Transform
   - uid: 11116
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,28.5
       parent: 31
       type: Transform
   - uid: 11117
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,27.5
       parent: 31
       type: Transform
@@ -66256,2839 +69090,3949 @@ entities:
   entities:
   - uid: 11
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-40.5
       parent: 31
       type: Transform
   - uid: 26
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,-18.5
       parent: 31
       type: Transform
   - uid: 112
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-16.5
       parent: 31
       type: Transform
   - uid: 118
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-17.5
       parent: 31
       type: Transform
   - uid: 126
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-6.5
       parent: 31
       type: Transform
   - uid: 136
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-18.5
       parent: 31
       type: Transform
   - uid: 139
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-13.5
       parent: 31
       type: Transform
   - uid: 144
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,-1.5
       parent: 31
       type: Transform
   - uid: 165
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,1.5
       parent: 31
       type: Transform
   - uid: 217
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-18.5
       parent: 31
       type: Transform
   - uid: 251
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,16.5
       parent: 31
       type: Transform
   - uid: 268
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-13.5
       parent: 31
       type: Transform
   - uid: 343
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -12.5,2.5
       parent: 31
       type: Transform
   - uid: 400
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -27.5,-12.5
       parent: 31
       type: Transform
   - uid: 404
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-7.5
       parent: 31
       type: Transform
   - uid: 416
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-13.5
       parent: 31
       type: Transform
   - uid: 454
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,21.5
       parent: 31
       type: Transform
   - uid: 472
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,-23.5
       parent: 31
       type: Transform
   - uid: 477
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-6.5
       parent: 31
       type: Transform
   - uid: 484
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-23.5
       parent: 31
       type: Transform
   - uid: 527
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-3.5
       parent: 31
       type: Transform
   - uid: 528
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-1.5
       parent: 31
       type: Transform
   - uid: 551
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-6.5
       parent: 31
       type: Transform
   - uid: 582
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-3.5
       parent: 31
       type: Transform
   - uid: 596
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,26.5
       parent: 31
       type: Transform
   - uid: 603
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-10.5
       parent: 31
       type: Transform
   - uid: 610
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-7.5
       parent: 31
       type: Transform
   - uid: 612
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-7.5
       parent: 31
       type: Transform
   - uid: 641
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-13.5
       parent: 31
       type: Transform
   - uid: 659
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,8.5
       parent: 31
       type: Transform
   - uid: 663
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-8.5
       parent: 31
       type: Transform
   - uid: 670
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-25.5
       parent: 31
       type: Transform
   - uid: 671
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-19.5
       parent: 31
       type: Transform
   - uid: 685
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-8.5
       parent: 31
       type: Transform
   - uid: 687
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-8.5
       parent: 31
       type: Transform
   - uid: 688
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-10.5
       parent: 31
       type: Transform
   - uid: 734
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-13.5
       parent: 31
       type: Transform
   - uid: 777
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-14.5
       parent: 31
       type: Transform
   - uid: 784
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-13.5
       parent: 31
       type: Transform
   - uid: 796
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-4.5
       parent: 31
       type: Transform
   - uid: 827
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 44.5,-6.5
       parent: 31
       type: Transform
   - uid: 875
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-25.5
       parent: 31
       type: Transform
   - uid: 903
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-6.5
       parent: 31
       type: Transform
   - uid: 906
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-5.5
       parent: 31
       type: Transform
   - uid: 907
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-5.5
       parent: 31
       type: Transform
   - uid: 908
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-5.5
       parent: 31
       type: Transform
   - uid: 909
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-5.5
       parent: 31
       type: Transform
   - uid: 912
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-2.5
       parent: 31
       type: Transform
   - uid: 913
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-2.5
       parent: 31
       type: Transform
   - uid: 914
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-2.5
       parent: 31
       type: Transform
   - uid: 915
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-2.5
       parent: 31
       type: Transform
   - uid: 916
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,-2.5
       parent: 31
       type: Transform
   - uid: 919
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,-3.5
       parent: 31
       type: Transform
   - uid: 922
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,2.5
       parent: 31
       type: Transform
   - uid: 923
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,2.5
       parent: 31
       type: Transform
   - uid: 924
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,2.5
       parent: 31
       type: Transform
   - uid: 929
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-10.5
       parent: 31
       type: Transform
   - uid: 930
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-9.5
       parent: 31
       type: Transform
   - uid: 935
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-6.5
       parent: 31
       type: Transform
   - uid: 960
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-8.5
       parent: 31
       type: Transform
   - uid: 969
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-8.5
       parent: 31
       type: Transform
   - uid: 1003
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,2.5
       parent: 31
       type: Transform
   - uid: 1009
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,2.5
       parent: 31
       type: Transform
   - uid: 1048
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-23.5
       parent: 31
       type: Transform
   - uid: 1088
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-11.5
       parent: 31
       type: Transform
   - uid: 1091
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-10.5
       parent: 31
       type: Transform
   - uid: 1115
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,15.5
       parent: 31
       type: Transform
   - uid: 1124
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-9.5
       parent: 31
       type: Transform
   - uid: 1129
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-8.5
       parent: 31
       type: Transform
   - uid: 1170
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,18.5
       parent: 31
       type: Transform
   - uid: 1245
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,2.5
       parent: 31
       type: Transform
   - uid: 1255
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,1.5
       parent: 31
       type: Transform
   - uid: 1276
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,1.5
       parent: 31
       type: Transform
   - uid: 1291
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,0.5
       parent: 31
       type: Transform
   - uid: 1292
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-0.5
       parent: 31
       type: Transform
   - uid: 1294
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-1.5
       parent: 31
       type: Transform
   - uid: 1295
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-2.5
       parent: 31
       type: Transform
   - uid: 1310
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-3.5
       parent: 31
       type: Transform
   - uid: 1311
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-4.5
       parent: 31
       type: Transform
   - uid: 1318
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-5.5
       parent: 31
       type: Transform
   - uid: 1321
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-2.5
       parent: 31
       type: Transform
   - uid: 1335
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-1.5
       parent: 31
       type: Transform
   - uid: 1339
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-0.5
       parent: 31
       type: Transform
   - uid: 1340
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,0.5
       parent: 31
       type: Transform
   - uid: 1342
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,2.5
       parent: 31
       type: Transform
   - uid: 1349
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-18.5
       parent: 31
       type: Transform
   - uid: 1350
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,2.5
       parent: 31
       type: Transform
   - uid: 1353
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-21.5
       parent: 31
       type: Transform
   - uid: 1363
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,2.5
       parent: 31
       type: Transform
   - uid: 1364
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,2.5
       parent: 31
       type: Transform
   - uid: 1365
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-9.5
       parent: 31
       type: Transform
   - uid: 1378
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,1.5
       parent: 31
       type: Transform
   - uid: 1420
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-18.5
       parent: 31
       type: Transform
   - uid: 1426
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,1.5
       parent: 31
       type: Transform
   - uid: 1441
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -13.5,-20.5
       parent: 31
       type: Transform
   - uid: 1458
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-23.5
       parent: 31
       type: Transform
   - uid: 1461
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-6.5
       parent: 31
       type: Transform
   - uid: 1471
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-14.5
       parent: 31
       type: Transform
   - uid: 1476
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-9.5
       parent: 31
       type: Transform
   - uid: 1534
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-7.5
       parent: 31
       type: Transform
   - uid: 1579
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,1.5
       parent: 31
       type: Transform
   - uid: 1587
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,17.5
       parent: 31
       type: Transform
   - uid: 1588
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,15.5
       parent: 31
       type: Transform
   - uid: 1606
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-0.5
       parent: 31
       type: Transform
   - uid: 1612
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-3.5
       parent: 31
       type: Transform
   - uid: 1613
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,6.5
       parent: 31
       type: Transform
   - uid: 1630
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,2.5
       parent: 31
       type: Transform
   - uid: 1638
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,15.5
       parent: 31
       type: Transform
   - uid: 1639
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-8.5
       parent: 31
       type: Transform
   - uid: 1643
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-21.5
       parent: 31
       type: Transform
   - uid: 1644
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-19.5
       parent: 31
       type: Transform
   - uid: 1645
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-19.5
       parent: 31
       type: Transform
   - uid: 1646
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-19.5
       parent: 31
       type: Transform
   - uid: 1647
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,-19.5
       parent: 31
       type: Transform
   - uid: 1652
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-8.5
       parent: 31
       type: Transform
   - uid: 1653
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,25.5
       parent: 31
       type: Transform
   - uid: 1669
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,15.5
       parent: 31
       type: Transform
   - uid: 1670
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,24.5
       parent: 31
       type: Transform
   - uid: 1671
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,15.5
       parent: 31
       type: Transform
   - uid: 1672
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,15.5
       parent: 31
       type: Transform
   - uid: 1673
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,15.5
       parent: 31
       type: Transform
   - uid: 1674
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,17.5
       parent: 31
       type: Transform
   - uid: 1677
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,21.5
       parent: 31
       type: Transform
   - uid: 1679
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,15.5
       parent: 31
       type: Transform
   - uid: 1685
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-12.5
       parent: 31
       type: Transform
   - uid: 1690
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,13.5
       parent: 31
       type: Transform
   - uid: 1697
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,11.5
       parent: 31
       type: Transform
   - uid: 1768
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-7.5
       parent: 31
       type: Transform
   - uid: 1774
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,12.5
       parent: 31
       type: Transform
   - uid: 1775
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,11.5
       parent: 31
       type: Transform
   - uid: 1784
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,11.5
       parent: 31
       type: Transform
   - uid: 1811
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,2.5
       parent: 31
       type: Transform
   - uid: 1812
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,2.5
       parent: 31
       type: Transform
   - uid: 1813
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,2.5
       parent: 31
       type: Transform
   - uid: 1823
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,0.5
       parent: 31
       type: Transform
   - uid: 1825
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,15.5
       parent: 31
       type: Transform
   - uid: 1827
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,14.5
       parent: 31
       type: Transform
   - uid: 1835
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 11.5,26.5
       parent: 31
       type: Transform
   - uid: 2008
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-20.5
       parent: 31
       type: Transform
   - uid: 2017
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-21.5
       parent: 31
       type: Transform
   - uid: 2018
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-21.5
       parent: 31
       type: Transform
   - uid: 2019
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,-21.5
       parent: 31
       type: Transform
   - uid: 2021
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-21.5
       parent: 31
       type: Transform
   - uid: 2022
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-21.5
       parent: 31
       type: Transform
   - uid: 2023
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-21.5
       parent: 31
       type: Transform
   - uid: 2024
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-22.5
       parent: 31
       type: Transform
   - uid: 2025
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-23.5
       parent: 31
       type: Transform
   - uid: 2027
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-25.5
       parent: 31
       type: Transform
   - uid: 2028
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-11.5
       parent: 31
       type: Transform
   - uid: 2034
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-21.5
       parent: 31
       type: Transform
   - uid: 2035
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-22.5
       parent: 31
       type: Transform
   - uid: 2036
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-22.5
       parent: 31
       type: Transform
   - uid: 2057
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,10.5
       parent: 31
       type: Transform
   - uid: 2058
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,1.5
       parent: 31
       type: Transform
   - uid: 2059
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,7.5
       parent: 31
       type: Transform
   - uid: 2060
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,6.5
       parent: 31
       type: Transform
   - uid: 2061
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,6.5
       parent: 31
       type: Transform
   - uid: 2062
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,6.5
       parent: 31
       type: Transform
   - uid: 2063
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,6.5
       parent: 31
       type: Transform
   - uid: 2067
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,6.5
       parent: 31
       type: Transform
   - uid: 2068
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,7.5
       parent: 31
       type: Transform
   - uid: 2070
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,7.5
       parent: 31
       type: Transform
   - uid: 2071
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,8.5
       parent: 31
       type: Transform
   - uid: 2072
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,9.5
       parent: 31
       type: Transform
   - uid: 2073
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,10.5
       parent: 31
       type: Transform
   - uid: 2074
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,11.5
       parent: 31
       type: Transform
   - uid: 2075
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,12.5
       parent: 31
       type: Transform
   - uid: 2076
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,12.5
       parent: 31
       type: Transform
   - uid: 2077
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,12.5
       parent: 31
       type: Transform
   - uid: 2078
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,12.5
       parent: 31
       type: Transform
   - uid: 2079
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,12.5
       parent: 31
       type: Transform
   - uid: 2081
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,12.5
       parent: 31
       type: Transform
   - uid: 2083
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,12.5
       parent: 31
       type: Transform
   - uid: 2084
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,11.5
       parent: 31
       type: Transform
   - uid: 2085
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,11.5
       parent: 31
       type: Transform
   - uid: 2086
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,11.5
       parent: 31
       type: Transform
   - uid: 2089
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,7.5
       parent: 31
       type: Transform
   - uid: 2090
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,7.5
       parent: 31
       type: Transform
   - uid: 2091
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,6.5
       parent: 31
       type: Transform
   - uid: 2094
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,11.5
       parent: 31
       type: Transform
   - uid: 2112
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,2.5
       parent: 31
       type: Transform
   - uid: 2113
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,2.5
       parent: 31
       type: Transform
   - uid: 2121
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,2.5
       parent: 31
       type: Transform
   - uid: 2122
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,2.5
       parent: 31
       type: Transform
   - uid: 2123
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,2.5
       parent: 31
       type: Transform
   - uid: 2124
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,1.5
       parent: 31
       type: Transform
   - uid: 2135
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-3.5
       parent: 31
       type: Transform
   - uid: 2139
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-6.5
       parent: 31
       type: Transform
   - uid: 2140
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-12.5
       parent: 31
       type: Transform
   - uid: 2144
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-9.5
       parent: 31
       type: Transform
   - uid: 2162
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,-3.5
       parent: 31
       type: Transform
   - uid: 2163
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,-3.5
       parent: 31
       type: Transform
   - uid: 2164
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-3.5
       parent: 31
       type: Transform
   - uid: 2165
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-3.5
       parent: 31
       type: Transform
   - uid: 2166
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-3.5
       parent: 31
       type: Transform
   - uid: 2167
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-4.5
       parent: 31
       type: Transform
   - uid: 2168
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-5.5
       parent: 31
       type: Transform
   - uid: 2169
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-7.5
       parent: 31
       type: Transform
   - uid: 2176
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-7.5
       parent: 31
       type: Transform
   - uid: 2178
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-4.5
       parent: 31
       type: Transform
   - uid: 2214
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-6.5
       parent: 31
       type: Transform
   - uid: 2224
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,8.5
       parent: 31
       type: Transform
   - uid: 2226
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,13.5
       parent: 31
       type: Transform
   - uid: 2228
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-20.5
       parent: 31
       type: Transform
   - uid: 2243
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,1.5
       parent: 31
       type: Transform
   - uid: 2244
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,2.5
       parent: 31
       type: Transform
   - uid: 2246
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-3.5
       parent: 31
       type: Transform
   - uid: 2248
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-5.5
       parent: 31
       type: Transform
   - uid: 2249
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-6.5
       parent: 31
       type: Transform
   - uid: 2252
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -9.5,-2.5
       parent: 31
       type: Transform
   - uid: 2254
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-9.5
       parent: 31
       type: Transform
   - uid: 2255
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-7.5
       parent: 31
       type: Transform
   - uid: 2256
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-11.5
       parent: 31
       type: Transform
   - uid: 2257
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-12.5
       parent: 31
       type: Transform
   - uid: 2258
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-8.5
       parent: 31
       type: Transform
   - uid: 2259
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-12.5
       parent: 31
       type: Transform
   - uid: 2262
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-12.5
       parent: 31
       type: Transform
   - uid: 2265
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 21.5,-18.5
       parent: 31
       type: Transform
   - uid: 2267
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-11.5
       parent: 31
       type: Transform
   - uid: 2268
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-10.5
       parent: 31
       type: Transform
   - uid: 2270
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-11.5
       parent: 31
       type: Transform
   - uid: 2271
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-11.5
       parent: 31
       type: Transform
   - uid: 2273
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-11.5
       parent: 31
       type: Transform
   - uid: 2274
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-11.5
       parent: 31
       type: Transform
   - uid: 2275
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-12.5
       parent: 31
       type: Transform
   - uid: 2279
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-17.5
       parent: 31
       type: Transform
   - uid: 2285
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-17.5
       parent: 31
       type: Transform
   - uid: 2286
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-17.5
       parent: 31
       type: Transform
   - uid: 2289
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -12.5,-20.5
       parent: 31
       type: Transform
   - uid: 2295
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-17.5
       parent: 31
       type: Transform
   - uid: 2320
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-13.5
       parent: 31
       type: Transform
   - uid: 2327
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,14.5
       parent: 31
       type: Transform
   - uid: 2346
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-17.5
       parent: 31
       type: Transform
   - uid: 2347
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-13.5
       parent: 31
       type: Transform
   - uid: 2349
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-18.5
       parent: 31
       type: Transform
   - uid: 2351
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,-12.5
       parent: 31
       type: Transform
   - uid: 2352
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,-12.5
       parent: 31
       type: Transform
   - uid: 2359
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-28.5
       parent: 31
       type: Transform
   - uid: 2364
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-13.5
       parent: 31
       type: Transform
   - uid: 2365
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,-13.5
       parent: 31
       type: Transform
   - uid: 2366
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-13.5
       parent: 31
       type: Transform
   - uid: 2368
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-13.5
       parent: 31
       type: Transform
   - uid: 2369
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-13.5
       parent: 31
       type: Transform
   - uid: 2370
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-12.5
       parent: 31
       type: Transform
   - uid: 2371
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-11.5
       parent: 31
       type: Transform
   - uid: 2372
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-12.5
       parent: 31
       type: Transform
   - uid: 2373
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-9.5
       parent: 31
       type: Transform
   - uid: 2375
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-8.5
       parent: 31
       type: Transform
   - uid: 2376
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-8.5
       parent: 31
       type: Transform
   - uid: 2377
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,-9.5
       parent: 31
       type: Transform
   - uid: 2378
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-8.5
       parent: 31
       type: Transform
   - uid: 2379
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-8.5
       parent: 31
       type: Transform
   - uid: 2380
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-9.5
       parent: 31
       type: Transform
   - uid: 2381
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-10.5
       parent: 31
       type: Transform
   - uid: 2382
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-11.5
       parent: 31
       type: Transform
   - uid: 2388
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-7.5
       parent: 31
       type: Transform
   - uid: 2392
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-4.5
       parent: 31
       type: Transform
   - uid: 2396
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-7.5
       parent: 31
       type: Transform
   - uid: 2397
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-5.5
       parent: 31
       type: Transform
   - uid: 2399
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-5.5
       parent: 31
       type: Transform
   - uid: 2400
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-5.5
       parent: 31
       type: Transform
   - uid: 2407
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,2.5
       parent: 31
       type: Transform
   - uid: 2408
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,2.5
       parent: 31
       type: Transform
   - uid: 2410
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,2.5
       parent: 31
       type: Transform
   - uid: 2425
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-17.5
       parent: 31
       type: Transform
   - uid: 2426
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-13.5
       parent: 31
       type: Transform
   - uid: 2429
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -11.5,-23.5
       parent: 31
       type: Transform
   - uid: 2430
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-9.5
       parent: 31
       type: Transform
   - uid: 2431
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,8.5
       parent: 31
       type: Transform
   - uid: 2435
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-9.5
       parent: 31
       type: Transform
   - uid: 2436
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-3.5
       parent: 31
       type: Transform
   - uid: 2441
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-7.5
       parent: 31
       type: Transform
   - uid: 2442
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-5.5
       parent: 31
       type: Transform
   - uid: 2443
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-4.5
       parent: 31
       type: Transform
   - uid: 2444
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-3.5
       parent: 31
       type: Transform
   - uid: 2449
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -9.5,-23.5
       parent: 31
       type: Transform
   - uid: 2450
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -9.5,-24.5
       parent: 31
       type: Transform
   - uid: 2459
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,13.5
       parent: 31
       type: Transform
   - uid: 2460
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,13.5
       parent: 31
       type: Transform
   - uid: 2461
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-6.5
       parent: 31
       type: Transform
   - uid: 2463
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,13.5
       parent: 31
       type: Transform
   - uid: 2466
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-4.5
       parent: 31
       type: Transform
   - uid: 2467
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-5.5
       parent: 31
       type: Transform
   - uid: 2468
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-3.5
       parent: 31
       type: Transform
   - uid: 2469
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-3.5
       parent: 31
       type: Transform
   - uid: 2470
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-3.5
       parent: 31
       type: Transform
   - uid: 2471
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-3.5
       parent: 31
       type: Transform
   - uid: 2472
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-3.5
       parent: 31
       type: Transform
   - uid: 2473
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-2.5
       parent: 31
       type: Transform
   - uid: 2503
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,-27.5
       parent: 31
       type: Transform
   - uid: 2581
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-22.5
       parent: 31
       type: Transform
   - uid: 2661
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-12.5
       parent: 31
       type: Transform
   - uid: 2662
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,-12.5
       parent: 31
       type: Transform
   - uid: 2665
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-12.5
       parent: 31
       type: Transform
   - uid: 2666
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-12.5
       parent: 31
       type: Transform
   - uid: 2667
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-12.5
       parent: 31
       type: Transform
   - uid: 3376
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,18.5
       parent: 31
       type: Transform
   - uid: 3405
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-8.5
       parent: 31
       type: Transform
   - uid: 3416
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 17.5,-19.5
       parent: 31
       type: Transform
   - uid: 3592
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-23.5
       parent: 31
       type: Transform
   - uid: 3595
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,-23.5
       parent: 31
       type: Transform
   - uid: 3623
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,24.5
       parent: 31
       type: Transform
   - uid: 3875
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 9.5,23.5
       parent: 31
       type: Transform
   - uid: 3915
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-8.5
       parent: 31
       type: Transform
   - uid: 3916
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-7.5
       parent: 31
       type: Transform
   - uid: 3925
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,0.5
       parent: 31
       type: Transform
   - uid: 3926
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,-24.5
       parent: 31
       type: Transform
   - uid: 3955
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,7.5
       parent: 31
       type: Transform
   - uid: 3973
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,0.5
       parent: 31
       type: Transform
   - uid: 3993
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,-26.5
       parent: 31
       type: Transform
   - uid: 4004
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-7.5
       parent: 31
       type: Transform
   - uid: 4021
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-7.5
       parent: 31
       type: Transform
   - uid: 4050
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-7.5
       parent: 31
       type: Transform
   - uid: 4051
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-7.5
       parent: 31
       type: Transform
   - uid: 4052
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-7.5
       parent: 31
       type: Transform
   - uid: 4053
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-8.5
       parent: 31
       type: Transform
   - uid: 4064
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-0.5
       parent: 31
       type: Transform
   - uid: 4065
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-0.5
       parent: 31
       type: Transform
   - uid: 4066
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-0.5
       parent: 31
       type: Transform
   - uid: 4067
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-0.5
       parent: 31
       type: Transform
   - uid: 4068
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-0.5
       parent: 31
       type: Transform
   - uid: 4069
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-3.5
       parent: 31
       type: Transform
   - uid: 4070
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-3.5
       parent: 31
       type: Transform
   - uid: 4071
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-3.5
       parent: 31
       type: Transform
   - uid: 4072
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-6.5
       parent: 31
       type: Transform
   - uid: 4073
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-6.5
       parent: 31
       type: Transform
   - uid: 4074
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-6.5
       parent: 31
       type: Transform
   - uid: 4075
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-6.5
       parent: 31
       type: Transform
   - uid: 4076
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-6.5
       parent: 31
       type: Transform
   - uid: 4077
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-6.5
       parent: 31
       type: Transform
   - uid: 4080
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-1.5
       parent: 31
       type: Transform
   - uid: 4081
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-4.5
       parent: 31
       type: Transform
   - uid: 4091
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,-22.5
       parent: 31
       type: Transform
   - uid: 4094
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,-21.5
       parent: 31
       type: Transform
   - uid: 4209
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-17.5
       parent: 31
       type: Transform
   - uid: 4221
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-13.5
       parent: 31
       type: Transform
   - uid: 4246
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 5.5,-23.5
       parent: 31
       type: Transform
   - uid: 4295
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-13.5
       parent: 31
       type: Transform
   - uid: 4296
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,13.5
       parent: 31
       type: Transform
   - uid: 4312
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-9.5
       parent: 31
       type: Transform
   - uid: 4313
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-13.5
       parent: 31
       type: Transform
   - uid: 4331
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-21.5
       parent: 31
       type: Transform
   - uid: 4353
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 19.5,-19.5
       parent: 31
       type: Transform
   - uid: 4458
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,2.5
       parent: 31
       type: Transform
   - uid: 4506
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-10.5
       parent: 31
       type: Transform
   - uid: 4511
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-18.5
       parent: 31
       type: Transform
   - uid: 4520
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-18.5
       parent: 31
       type: Transform
   - uid: 4558
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-13.5
       parent: 31
       type: Transform
   - uid: 4609
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-16.5
       parent: 31
       type: Transform
   - uid: 4657
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-18.5
       parent: 31
       type: Transform
   - uid: 4725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-28.5
       parent: 31
       type: Transform
   - uid: 4726
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-28.5
       parent: 31
       type: Transform
   - uid: 4727
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-28.5
       parent: 31
       type: Transform
   - uid: 4734
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-41.5
       parent: 31
       type: Transform
   - uid: 4741
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 11.5,25.5
       parent: 31
       type: Transform
   - uid: 4742
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-29.5
       parent: 31
       type: Transform
   - uid: 4750
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-29.5
       parent: 31
       type: Transform
   - uid: 4751
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-30.5
       parent: 31
       type: Transform
   - uid: 4756
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-13.5
       parent: 31
       type: Transform
   - uid: 4778
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 5.5,-24.5
       parent: 31
       type: Transform
   - uid: 4836
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-13.5
       parent: 31
       type: Transform
   - uid: 4857
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-9.5
       parent: 31
       type: Transform
   - uid: 4885
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-19.5
       parent: 31
       type: Transform
   - uid: 4905
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 18.5,-19.5
       parent: 31
       type: Transform
   - uid: 4946
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-24.5
       parent: 31
       type: Transform
   - uid: 4950
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,-21.5
       parent: 31
       type: Transform
   - uid: 4951
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-21.5
       parent: 31
       type: Transform
   - uid: 4954
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-22.5
       parent: 31
       type: Transform
   - uid: 4981
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,18.5
       parent: 31
       type: Transform
   - uid: 4984
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,18.5
       parent: 31
       type: Transform
   - uid: 4985
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,18.5
       parent: 31
       type: Transform
   - uid: 4986
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,17.5
       parent: 31
       type: Transform
   - uid: 4987
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,16.5
       parent: 31
       type: Transform
   - uid: 5011
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,13.5
       parent: 31
       type: Transform
   - uid: 5114
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,-17.5
       parent: 31
       type: Transform
   - uid: 5118
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-13.5
       parent: 31
       type: Transform
   - uid: 5138
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-9.5
       parent: 31
       type: Transform
   - uid: 5142
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,21.5
       parent: 31
       type: Transform
   - uid: 5143
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,21.5
       parent: 31
       type: Transform
   - uid: 5152
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-12.5
       parent: 31
       type: Transform
   - uid: 5156
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-13.5
       parent: 31
       type: Transform
   - uid: 5192
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 34.5,38.5
       parent: 31
       type: Transform
   - uid: 5211
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-10.5
       parent: 31
       type: Transform
   - uid: 5221
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-15.5
       parent: 31
       type: Transform
   - uid: 5224
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-13.5
       parent: 31
       type: Transform
   - uid: 5225
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-17.5
       parent: 31
       type: Transform
   - uid: 5228
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-7.5
       parent: 31
       type: Transform
   - uid: 5609
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,18.5
       parent: 31
       type: Transform
   - uid: 5756
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-17.5
       parent: 31
       type: Transform
   - uid: 6095
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-12.5
       parent: 31
       type: Transform
   - uid: 6141
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-18.5
       parent: 31
       type: Transform
   - uid: 6524
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,18.5
       parent: 31
       type: Transform
   - uid: 6618
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,-17.5
       parent: 31
       type: Transform
   - uid: 6697
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-7.5
       parent: 31
       type: Transform
   - uid: 6965
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-11.5
       parent: 31
       type: Transform
   - uid: 6969
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-15.5
       parent: 31
       type: Transform
   - uid: 6970
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-16.5
       parent: 31
       type: Transform
   - uid: 7046
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-19.5
       parent: 31
       type: Transform
   - uid: 7089
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,14.5
       parent: 31
       type: Transform
   - uid: 7090
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,14.5
       parent: 31
       type: Transform
   - uid: 7160
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,-23.5
       parent: 31
       type: Transform
   - uid: 7244
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-9.5
       parent: 31
       type: Transform
   - uid: 7330
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-7.5
       parent: 31
       type: Transform
   - uid: 7357
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,17.5
       parent: 31
       type: Transform
   - uid: 7368
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-23.5
       parent: 31
       type: Transform
   - uid: 7406
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-21.5
       parent: 31
       type: Transform
   - uid: 7478
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,17.5
       parent: 31
       type: Transform
   - uid: 7501
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-39.5
       parent: 31
       type: Transform
   - uid: 7532
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-40.5
       parent: 31
       type: Transform
   - uid: 7534
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-40.5
       parent: 31
       type: Transform
   - uid: 7538
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-36.5
       parent: 31
       type: Transform
   - uid: 7539
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-36.5
       parent: 31
       type: Transform
   - uid: 7542
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-36.5
       parent: 31
       type: Transform
   - uid: 7544
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-36.5
       parent: 31
       type: Transform
   - uid: 7549
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-40.5
       parent: 31
       type: Transform
   - uid: 7553
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-37.5
       parent: 31
       type: Transform
   - uid: 7558
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,13.5
       parent: 31
       type: Transform
   - uid: 7569
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-36.5
       parent: 31
       type: Transform
   - uid: 7591
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-8.5
       parent: 31
       type: Transform
   - uid: 7598
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -29.5,-10.5
       parent: 31
       type: Transform
   - uid: 7607
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -30.5,-10.5
       parent: 31
       type: Transform
   - uid: 7675
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,16.5
       parent: 31
       type: Transform
   - uid: 7821
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-37.5
       parent: 31
       type: Transform
   - uid: 7952
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-20.5
       parent: 31
       type: Transform
   - uid: 8057
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,-16.5
       parent: 31
       type: Transform
   - uid: 8301
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-41.5
       parent: 31
       type: Transform
   - uid: 8312
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-19.5
       parent: 31
       type: Transform
   - uid: 8317
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-17.5
       parent: 31
       type: Transform
   - uid: 8365
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-17.5
       parent: 31
       type: Transform
   - uid: 8366
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 1.5,-30.5
       parent: 31
       type: Transform
   - uid: 8372
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-17.5
       parent: 31
       type: Transform
   - uid: 8421
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -8.5,-2.5
       parent: 31
       type: Transform
   - uid: 8449
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-26.5
       parent: 31
       type: Transform
   - uid: 8453
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-25.5
       parent: 31
       type: Transform
   - uid: 8454
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-28.5
       parent: 31
       type: Transform
   - uid: 8459
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-19.5
       parent: 31
       type: Transform
   - uid: 8462
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-20.5
       parent: 31
       type: Transform
   - uid: 8463
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-21.5
       parent: 31
       type: Transform
   - uid: 8467
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-18.5
       parent: 31
       type: Transform
   - uid: 8469
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-22.5
       parent: 31
       type: Transform
   - uid: 8480
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-21.5
       parent: 31
       type: Transform
   - uid: 8488
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-20.5
       parent: 31
       type: Transform
   - uid: 8489
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-24.5
       parent: 31
       type: Transform
   - uid: 8493
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-23.5
       parent: 31
       type: Transform
   - uid: 8494
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-19.5
       parent: 31
       type: Transform
   - uid: 8495
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-17.5
       parent: 31
       type: Transform
   - uid: 8718
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -32.5,-30.5
       parent: 31
       type: Transform
   - uid: 8750
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-20.5
       parent: 31
       type: Transform
   - uid: 8817
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,29.5
       parent: 31
       type: Transform
   - uid: 8818
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,29.5
       parent: 31
       type: Transform
   - uid: 8864
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-17.5
       parent: 31
       type: Transform
   - uid: 8896
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-17.5
       parent: 31
       type: Transform
   - uid: 8918
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-17.5
       parent: 31
       type: Transform
   - uid: 8930
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-17.5
       parent: 31
       type: Transform
   - uid: 8934
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-28.5
       parent: 31
       type: Transform
   - uid: 8945
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,2.5
       parent: 31
       type: Transform
   - uid: 9011
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-37.5
       parent: 31
       type: Transform
   - uid: 9029
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,14.5
       parent: 31
       type: Transform
   - uid: 9051
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,14.5
       parent: 31
       type: Transform
   - uid: 9073
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-14.5
       parent: 31
       type: Transform
   - uid: 9074
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-13.5
       parent: 31
       type: Transform
   - uid: 9097
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 39.5,-7.5
       parent: 31
       type: Transform
   - uid: 9112
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 39.5,-6.5
       parent: 31
       type: Transform
   - uid: 9119
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,8.5
       parent: 31
       type: Transform
   - uid: 9163
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-19.5
       parent: 31
       type: Transform
   - uid: 9169
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-2.5
       parent: 31
       type: Transform
   - uid: 9170
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,6.5
       parent: 31
       type: Transform
   - uid: 9191
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,15.5
       parent: 31
       type: Transform
   - uid: 9204
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 44.5,-5.5
       parent: 31
       type: Transform
   - uid: 9228
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,16.5
       parent: 31
       type: Transform
   - uid: 9252
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-17.5
       parent: 31
       type: Transform
   - uid: 9254
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-19.5
       parent: 31
       type: Transform
   - uid: 9255
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -12.5,-13.5
       parent: 31
       type: Transform
   - uid: 9256
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-39.5
       parent: 31
       type: Transform
   - uid: 9274
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-37.5
       parent: 31
       type: Transform
   - uid: 9289
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-41.5
       parent: 31
       type: Transform
   - uid: 9295
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-39.5
       parent: 31
       type: Transform
   - uid: 9296
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-40.5
       parent: 31
       type: Transform
   - uid: 9298
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-40.5
       parent: 31
       type: Transform
   - uid: 9299
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-40.5
       parent: 31
       type: Transform
   - uid: 9300
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-40.5
       parent: 31
       type: Transform
   - uid: 9301
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-39.5
       parent: 31
       type: Transform
   - uid: 9302
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-39.5
       parent: 31
       type: Transform
   - uid: 9303
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,-39.5
       parent: 31
       type: Transform
   - uid: 9346
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 42.5,-5.5
       parent: 31
       type: Transform
   - uid: 9347
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 41.5,-5.5
       parent: 31
       type: Transform
   - uid: 9454
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-42.5
       parent: 31
       type: Transform
   - uid: 9517
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-3.5
       parent: 31
       type: Transform
   - uid: 9518
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 40.5,-5.5
       parent: 31
       type: Transform
   - uid: 9519
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 39.5,-5.5
       parent: 31
       type: Transform
   - uid: 9530
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,-3.5
       parent: 31
       type: Transform
   - uid: 9531
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-18.5
       parent: 31
       type: Transform
   - uid: 9532
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,-3.5
       parent: 31
       type: Transform
   - uid: 9533
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,13.5
       parent: 31
       type: Transform
   - uid: 9566
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,7.5
       parent: 31
       type: Transform
   - uid: 9568
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,6.5
       parent: 31
       type: Transform
   - uid: 9581
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-23.5
       parent: 31
       type: Transform
   - uid: 9601
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-12.5
       parent: 31
       type: Transform
   - uid: 9602
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-13.5
       parent: 31
       type: Transform
   - uid: 9603
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-14.5
       parent: 31
       type: Transform
   - uid: 9604
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-15.5
       parent: 31
       type: Transform
   - uid: 9605
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-12.5
       parent: 31
       type: Transform
   - uid: 9606
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-16.5
       parent: 31
       type: Transform
   - uid: 9609
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-41.5
       parent: 31
       type: Transform
   - uid: 9610
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,6.5
       parent: 31
       type: Transform
   - uid: 9635
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-41.5
       parent: 31
       type: Transform
   - uid: 9683
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,6.5
       parent: 31
       type: Transform
   - uid: 9688
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,7.5
       parent: 31
       type: Transform
   - uid: 9702
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,14.5
       parent: 31
       type: Transform
   - uid: 9713
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-18.5
       parent: 31
       type: Transform
   - uid: 9715
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-18.5
       parent: 31
       type: Transform
   - uid: 9716
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-17.5
       parent: 31
       type: Transform
   - uid: 9717
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-18.5
       parent: 31
       type: Transform
   - uid: 9718
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-3.5
       parent: 31
       type: Transform
   - uid: 9736
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,16.5
       parent: 31
       type: Transform
   - uid: 9818
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,15.5
       parent: 31
       type: Transform
   - uid: 9820
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,14.5
       parent: 31
       type: Transform
   - uid: 9821
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,15.5
       parent: 31
       type: Transform
   - uid: 9833
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-24.5
       parent: 31
       type: Transform
   - uid: 9839
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 39.5,-10.5
       parent: 31
       type: Transform
   - uid: 9840
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-12.5
       parent: 31
       type: Transform
   - uid: 9841
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-12.5
       parent: 31
       type: Transform
   - uid: 9858
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,17.5
       parent: 31
       type: Transform
   - uid: 9866
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -33.5,8.5
       parent: 31
       type: Transform
   - uid: 9880
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-3.5
       parent: 31
       type: Transform
   - uid: 9916
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,6.5
       parent: 31
       type: Transform
   - uid: 9918
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-6.5
       parent: 31
       type: Transform
   - uid: 9919
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,26.5
       parent: 31
       type: Transform
   - uid: 9987
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,-13.5
       parent: 31
       type: Transform
   - uid: 10013
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,18.5
       parent: 31
       type: Transform
   - uid: 10034
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 20.5,-18.5
       parent: 31
       type: Transform
   - uid: 10035
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-9.5
       parent: 31
       type: Transform
   - uid: 10036
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-9.5
       parent: 31
       type: Transform
   - uid: 10037
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-9.5
       parent: 31
       type: Transform
   - uid: 10038
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,18.5
       parent: 31
       type: Transform
   - uid: 10129
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 39.5,-11.5
       parent: 31
       type: Transform
   - uid: 10219
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,6.5
       parent: 31
       type: Transform
   - uid: 10220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,6.5
       parent: 31
       type: Transform
   - uid: 10353
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 20.5,-19.5
       parent: 31
       type: Transform
   - uid: 10359
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -28.5,-10.5
       parent: 31
       type: Transform
   - uid: 10435
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,16.5
       parent: 31
       type: Transform
   - uid: 10436
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,16.5
       parent: 31
       type: Transform
   - uid: 10437
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,16.5
       parent: 31
       type: Transform
   - uid: 10440
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,18.5
       parent: 31
       type: Transform
   - uid: 10474
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -20.5,-4.5
       parent: 31
       type: Transform
   - uid: 10476
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -20.5,-5.5
       parent: 31
       type: Transform
   - uid: 10521
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-18.5
       parent: 31
       type: Transform
   - uid: 10533
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-18.5
       parent: 31
       type: Transform
   - uid: 10581
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -27.5,-10.5
       parent: 31
       type: Transform
   - uid: 10597
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 40.5,-13.5
       parent: 31
       type: Transform
   - uid: 10598
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 40.5,-11.5
       parent: 31
       type: Transform
   - uid: 10599
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 41.5,-11.5
       parent: 31
       type: Transform
   - uid: 10600
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 42.5,-11.5
       parent: 31
       type: Transform
   - uid: 10602
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 44.5,-11.5
       parent: 31
       type: Transform
   - uid: 10603
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 44.5,-10.5
       parent: 31
@@ -69097,196 +73041,274 @@ entities:
   entities:
   - uid: 419
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-9.5
       parent: 31
       type: Transform
   - uid: 539
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-8.5
       parent: 31
       type: Transform
   - uid: 542
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-18.5
       parent: 31
       type: Transform
   - uid: 1326
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-8.5
       parent: 31
       type: Transform
   - uid: 1384
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-25.5
       parent: 31
       type: Transform
   - uid: 1385
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-21.5
       parent: 31
       type: Transform
   - uid: 1655
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,21.5
       parent: 31
       type: Transform
   - uid: 1676
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,22.5
       parent: 31
       type: Transform
   - uid: 1678
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,23.5
       parent: 31
       type: Transform
   - uid: 1806
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,12.5
       parent: 31
       type: Transform
   - uid: 3881
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-13.5
       parent: 31
       type: Transform
   - uid: 3901
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-23.5
       parent: 31
       type: Transform
   - uid: 3903
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-22.5
       parent: 31
       type: Transform
   - uid: 3910
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,15.5
       parent: 31
       type: Transform
   - uid: 4006
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,20.5
       parent: 31
       type: Transform
   - uid: 5005
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-22.5
       parent: 31
       type: Transform
   - uid: 5145
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-14.5
       parent: 31
       type: Transform
   - uid: 5146
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-12.5
       parent: 31
       type: Transform
   - uid: 5147
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-16.5
       parent: 31
       type: Transform
   - uid: 5148
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-19.5
       parent: 31
       type: Transform
   - uid: 5214
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-10.5
       parent: 31
       type: Transform
   - uid: 7584
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-24.5
       parent: 31
       type: Transform
   - uid: 8854
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-23.5
       parent: 31
       type: Transform
   - uid: 9013
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-23.5
       parent: 31
       type: Transform
   - uid: 9087
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-8.5
       parent: 31
       type: Transform
   - uid: 9297
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-40.5
       parent: 31
       type: Transform
   - uid: 9376
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-20.5
       parent: 31
       type: Transform
   - uid: 9389
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,-20.5
       parent: 31
       type: Transform
   - uid: 9596
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-20.5
       parent: 31
       type: Transform
   - uid: 9822
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-9.5
       parent: 31
       type: Transform
   - uid: 10130
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-16.5
       parent: 31
       type: Transform
   - uid: 10133
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-15.5
       parent: 31
       type: Transform
   - uid: 10134
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-40.5
       parent: 31
       type: Transform
   - uid: 10137
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-33.5
       parent: 31
       type: Transform
   - uid: 10138
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-42.5
       parent: 31
       type: Transform
   - uid: 10417
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,15.5
       parent: 31
       type: Transform
   - uid: 10422
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,15.5
       parent: 31
       type: Transform
   - uid: 10601
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,-11.5
       parent: 31
       type: Transform
   - uid: 10606
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 44.5,-7.5
       parent: 31
       type: Transform
@@ -69433,366 +73455,112 @@ entities:
       type: Transform
     - location: library
       type: WarpPoint
-  - uid: 7640
+- proto: WarpPointBombing
+  entities:
+  - uid: 934
     components:
-    - pos: 49.5,-24.5
+    - pos: -36.5,14.5
       parent: 31
       type: Transform
-    - location: observatory
+    - location: chapel
       type: WarpPoint
-- proto: WarpPointBeaconCargo
-  entities:
   - uid: 2142
     components:
-    - pos: 27.5,19.5
+    - pos: 8.5,19.5
       parent: 31
       type: Transform
-    - text: salvage
-      type: NavMapBeacon
-    - location: salvage
-      type: WarpPoint
-    - type: BombingTarget
-  - uid: 5767
-    components:
-    - pos: 14.5,10.5
-      parent: 31
-      type: Transform
-    - type: BombingTarget
-  - uid: 11324
-    components:
-    - pos: 21.5,17.5
-      parent: 31
-      type: Transform
-    - text: cargo bay
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-- proto: WarpPointBeaconCommand
-  entities:
-  - uid: 7262
-    components:
-    - pos: 9.5,19.5
-      parent: 31
-      type: Transform
-    - text: hop's office
-      type: NavMapBeacon
     - location: hop's office
       type: WarpPoint
-    - type: BombingTarget
-  - uid: 7281
+  - uid: 4910
     components:
-    - pos: 12.5,24.5
+    - pos: 9.5,-9.5
       parent: 31
       type: Transform
-    - text: captain's room
-      type: NavMapBeacon
-    - location: captain's room
+    - location: medbay
       type: WarpPoint
-    - type: BombingTarget
-  - uid: 7954
-    components:
-    - pos: 3.5,30.5
-      parent: 31
-      type: Transform
-    - text: bridge
-      type: NavMapBeacon
-    - location: bridge
-      type: WarpPoint
-    - type: BombingTarget
-  - uid: 11269
-    components:
-    - pos: -1.5,17.5
-      parent: 31
-      type: Transform
-    - text: vault
-      type: NavMapBeacon
-    - location: vault
-      type: WarpPoint
-    - type: BombingTarget
-- proto: WarpPointBeaconEngineering
-  entities:
-  - uid: 7256
-    components:
-    - pos: 33.5,4.5
-      parent: 31
-      type: Transform
-    - text: lobby
-      type: NavMapBeacon
   - uid: 7261
-    components:
-    - pos: 48.5,8.5
-      parent: 31
-      type: Transform
-    - text: ame
-      type: NavMapBeacon
-    - location: ame
-      type: WarpPoint
-    - type: BombingTarget
-  - uid: 8316
-    components:
-    - pos: 38.5,15.5
-      parent: 31
-      type: Transform
-    - text: atmospherics
-      type: NavMapBeacon
-    - location: atmospherics
-      type: WarpPoint
-    - type: BombingTarget
-  - uid: 11313
-    components:
-    - pos: 32.5,-2.5
-      parent: 31
-      type: Transform
-    - text: locker room
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11314
-    components:
-    - pos: 47.5,4.5
-      parent: 31
-      type: Transform
-    - text: materials
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11315
-    components:
-    - pos: 58.5,2.5
-      parent: 31
-      type: Transform
-    - text: particle accelerator
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11325
-    components:
-    - pos: 27.5,1.5
-      parent: 31
-      type: Transform
-    - text: drone closet
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-- proto: WarpPointBeaconMedical
-  entities:
-  - uid: 9712
-    components:
-    - pos: 16.5,-8.5
-      parent: 31
-      type: Transform
-    - type: BombingTarget
-  - uid: 11309
-    components:
-    - pos: 9.5,-1.5
-      parent: 31
-      type: Transform
-    - text: lobby
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11310
-    components:
-    - pos: 8.5,-15.5
-      parent: 31
-      type: Transform
-    - text: cryo
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11311
-    components:
-    - pos: 13.5,-16.5
-      parent: 31
-      type: Transform
-    - text: morgue
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11312
     components:
     - pos: 16.5,-0.5
       parent: 31
       type: Transform
-    - text: chemistry
-      type: NavMapBeacon
     - location: chemistry
       type: WarpPoint
-  - uid: 11323
+  - uid: 7262
     components:
-    - pos: 21.5,-6.5
+    - pos: 13.5,-15.5
       parent: 31
       type: Transform
-    - text: locker room
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-- proto: WarpPointBeaconNeutral
-  entities:
-  - uid: 538
-    components:
-    - pos: -36.5,5.5
-      parent: 31
-      type: Transform
-    - text: evac
-      type: NavMapBeacon
-    - location: evac
+    - location: morgue
       type: WarpPoint
-  - uid: 7276
-    components:
-    - pos: -47.5,-10.5
-      parent: 31
-      type: Transform
-    - text: arrivals
-      type: NavMapBeacon
-    - location: arrivals
-      type: WarpPoint
-  - uid: 7280
-    components:
-    - pos: -25.5,-5.5
-      parent: 31
-      type: Transform
-    - text: dorms
-      type: NavMapBeacon
-    - location: dorms
-      type: WarpPoint
-  - uid: 11322
-    components:
-    - pos: 8.5,9.5
-      parent: 31
-      type: Transform
-    - text: eva
-      type: NavMapBeacon
-    - location: eva
-      type: WarpPoint
-    - type: BombingTarget
-- proto: WarpPointBeaconScience
-  entities:
-  - uid: 11316
-    components:
-    - pos: -9.5,-29.5
-      parent: 31
-      type: Transform
-    - text: xenoarch/anomalies
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11317
-    components:
-    - pos: -1.5,-28.5
-      parent: 31
-      type: Transform
-    - text: robotics
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11318
-    components:
-    - pos: -15.5,-22.5
-      parent: 31
-      type: Transform
-    - text: research & development
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-- proto: WarpPointBeaconSecurity
-  entities:
-  - uid: 10088
-    components:
-    - pos: -7.5,12.5
-      parent: 31
-      type: Transform
-    - type: BombingTarget
-  - uid: 11267
+  - uid: 9712
     components:
     - pos: -12.5,19.5
       parent: 31
       type: Transform
-    - text: armory
-      type: NavMapBeacon
     - location: armory
       type: WarpPoint
-    - type: BombingTarget
-  - uid: 11319
-    components:
-    - pos: -17.5,9.5
-      parent: 31
-      type: Transform
-    - text: permabrig
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11320
-    components:
-    - pos: -10.5,8.5
-      parent: 31
-      type: Transform
-    - text: cells
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 11321
-    components:
-    - pos: -13.5,15.5
-      parent: 31
-      type: Transform
-    - text: locker room
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-- proto: WarpPointBeaconService
-  entities:
-  - uid: 1136
-    components:
-    - pos: -4.5,-1.5
-      parent: 31
-      type: Transform
-    - text: bar
-      type: NavMapBeacon
-    - location: bar
-      type: WarpPoint
-  - uid: 1208
-    components:
-    - pos: -18.5,-0.5
-      parent: 31
-      type: Transform
-    - text: botany
-      type: NavMapBeacon
-    missingComponents:
-    - WarpPoint
-  - uid: 7275
-    components:
-    - pos: -36.5,15.5
-      parent: 31
-      type: Transform
-    - text: chapel
-      type: NavMapBeacon
-    - location: chapel
-      type: WarpPoint
-  - uid: 11268
-    components:
-    - pos: -11.5,-0.5
-      parent: 31
-      type: Transform
-    - text: kitchen
-      type: NavMapBeacon
-    - location: kitchen
-      type: WarpPoint
-  - uid: 11308
-    components:
-    - pos: -18.5,-7.5
-      parent: 31
-      type: Transform
-    - text: theatre
-      type: NavMapBeacon
-- proto: WarpPointBombing
-  entities:
   - uid: 10539
     components:
     - pos: -9.5,-20.5
       parent: 31
       type: Transform
     - location: science
+      type: WarpPoint
+  - uid: 11267
+    components:
+    - pos: 8.5,25.5
+      parent: 31
+      type: Transform
+    - location: captain's quarters
+      type: WarpPoint
+  - uid: 11308
+    components:
+    - pos: 3.5,30.5
+      parent: 31
+      type: Transform
+    - location: bridge
+      type: WarpPoint
+  - uid: 11309
+    components:
+    - pos: -1.5,17.5
+      parent: 31
+      type: Transform
+    - location: vault
+      type: WarpPoint
+  - uid: 11310
+    components:
+    - pos: 8.5,9.5
+      parent: 31
+      type: Transform
+    - location: eva room
+      type: WarpPoint
+  - uid: 11311
+    components:
+    - pos: 58.5,2.5
+      parent: 31
+      type: Transform
+    - location: singularity engine
+      type: WarpPoint
+  - uid: 11313
+    components:
+    - pos: 34.5,14.5
+      parent: 31
+      type: Transform
+    - location: atmospherics
+      type: WarpPoint
+  - uid: 11322
+    components:
+    - pos: 27.5,18.5
+      parent: 31
+      type: Transform
+    - location: salvage
+      type: WarpPoint
+  - uid: 11359
+    components:
+    - pos: 50.5,-5.5
+      parent: 31
+      type: Transform
+    - location: telecomms
       type: WarpPoint
 - proto: WaterCooler
   entities:

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -118,7 +118,7 @@ entities:
           version: 6
         3,0:
           ind: 3,0
-          tiles: HQAAAAADWQAAAAAAHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAACWQAAAAAAWQAAAAADWQAAAAACWQAAAAADeQAAAAAAAAAAAAAAAAAAAAAAHQAAAAADWQAAAAACHQAAAAADHQAAAAADHQAAAAACHQAAAAABeQAAAAAAWQAAAAADaAAAAAAAaAAAAAAAaAAAAAAAaAAAAAAAWQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAADWQAAAAAAWQAAAAABaAAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAACHQAAAAAAHQAAAAAAHQAAAAAAeQAAAAAAWQAAAAADaAAAAAAAaAAAAAAAaAAAAAAAaAAAAAAAWQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAWQAAAAAAWQAAAAADWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAADWQAAAAABWQAAAAADWQAAAAABeQAAAAAAAAAAAAAAAAAAAAAAWQAAAAABWQAAAAACWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAHQAAAAACHQAAAAADHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAHQAAAAABHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAADHQAAAAADeQAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAADHQAAAAACeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABHQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAHQAAAAADHQAAAAAAHQAAAAABeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: HQAAAAADWQAAAAAAHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAACWQAAAAAAWQAAAAADWQAAAAACWQAAAAADeQAAAAAAAAAAAAAAAAAAAAAAHQAAAAADWQAAAAACHQAAAAADHQAAAAADHQAAAAACHQAAAAABeQAAAAAAWQAAAAADaAAAAAAAaAAAAAAAaAAAAAAAaAAAAAAAWQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAADWQAAAAAAWQAAAAABaAAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAACHQAAAAAAHQAAAAAAHQAAAAAAeQAAAAAAWQAAAAADaAAAAAAAaAAAAAAAaAAAAAAAaAAAAAAAWQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAWQAAAAAAWQAAAAADWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAADWQAAAAABWQAAAAADWQAAAAABeQAAAAAAAAAAAAAAAAAAAAAAWQAAAAABWQAAAAACWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAHQAAAAACHQAAAAADHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAHQAAAAABHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAADHQAAAAADeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAaAAAAAAAaQAAAAAAaQAAAAAAaQAAAAAAaQAAAAAAaAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAADHQAAAAACeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABHQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAHQAAAAADHQAAAAAAHQAAAAABeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         2,-1:
           ind: 2,-1
@@ -6678,6 +6678,26 @@ entities:
       type: Transform
     - links:
       - 10218
+      type: DeviceLinkSink
+  - uid: 11369
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 58.5,10.5
+      parent: 31
+      type: Transform
+    - links:
+      - 11372
+      type: DeviceLinkSink
+  - uid: 11370
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 56.5,9.5
+      parent: 31
+      type: Transform
+    - links:
+      - 11371
       type: DeviceLinkSink
 - proto: BlockGameArcade
   entities:
@@ -19225,13 +19245,6 @@ entities:
     - pos: -20.539572,25.33725
       parent: 31
       type: Transform
-- proto: CableHVStack10
-  entities:
-  - uid: 4536
-    components:
-    - pos: 56.307724,8.484717
-      parent: 31
-      type: Transform
 - proto: CableMV
   entities:
   - uid: 96
@@ -23127,6 +23140,11 @@ entities:
     - pos: 57.5,7.5
       parent: 31
       type: Transform
+  - uid: 3110
+    components:
+    - pos: 59.5,12.5
+      parent: 31
+      type: Transform
   - uid: 3412
     components:
     - pos: -19.5,-31.5
@@ -24826,6 +24844,11 @@ entities:
     - pos: -19.5,-18.5
       parent: 31
       type: Transform
+  - uid: 9556
+    components:
+    - pos: 59.5,13.5
+      parent: 31
+      type: Transform
   - uid: 9597
     components:
     - rot: -1.5707963267948966 rad
@@ -25097,11 +25120,6 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: 34.5,30.5
-      parent: 31
-      type: Transform
-  - uid: 10518
-    components:
-    - pos: 60.5,11.5
       parent: 31
       type: Transform
   - uid: 10519
@@ -26983,11 +27001,6 @@ entities:
       type: Transform
 - proto: ClothingEyesGlassesMeson
   entities:
-  - uid: 4538
-    components:
-    - pos: 55.49048,8.459139
-      parent: 31
-      type: Transform
   - uid: 7582
     components:
     - pos: 43.506165,13.466041
@@ -28618,6 +28631,47 @@ entities:
           occludes: True
           ent: null
       type: ContainerContainer
+- proto: CrateEngineeringTeslaCoil
+  entities:
+  - uid: 11373
+    components:
+    - pos: 55.5,11.5
+      parent: 31
+      type: Transform
+  - uid: 11374
+    components:
+    - pos: 55.5,10.5
+      parent: 31
+      type: Transform
+  - uid: 11375
+    components:
+    - pos: 56.5,11.5
+      parent: 31
+      type: Transform
+  - uid: 11376
+    components:
+    - pos: 57.5,11.5
+      parent: 31
+      type: Transform
+- proto: CrateEngineeringTeslaGenerator
+  entities:
+  - uid: 6748
+    components:
+    - pos: 60.5,10.5
+      parent: 31
+      type: Transform
+- proto: CrateEngineeringTeslaGroundingRod
+  entities:
+  - uid: 11367
+    components:
+    - pos: 59.5,9.5
+      parent: 31
+      type: Transform
+  - uid: 11368
+    components:
+    - pos: 60.5,9.5
+      parent: 31
+      type: Transform
 - proto: CrateFilledSpawner
   entities:
   - uid: 1637
@@ -29183,6 +29237,13 @@ entities:
   - uid: 11357
     components:
     - pos: 50.5,-5.5
+      parent: 31
+      type: Transform
+- proto: DefaultStationBeaconTeslaEngine
+  entities:
+  - uid: 11380
+    components:
+    - pos: 56.5,10.5
       parent: 31
       type: Transform
 - proto: DefaultStationBeaconToolRoom
@@ -33069,7 +33130,7 @@ entities:
     - pos: 38.5,-5.5
       parent: 31
       type: Transform
-    - secondsUntilStateChange: -4580.918
+    - secondsUntilStateChange: -5334.276
       state: Closing
       type: Door
   - uid: 4019
@@ -45696,6 +45757,11 @@ entities:
     - pos: 28.5,-14.5
       parent: 31
       type: Transform
+  - uid: 3109
+    components:
+    - pos: 60.5,11.5
+      parent: 31
+      type: Transform
   - uid: 3152
     components:
     - pos: 47.5,-18.5
@@ -46134,12 +46200,6 @@ entities:
     - pos: 56.5,15.5
       parent: 31
       type: Transform
-  - uid: 6432
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 58.5,11.5
-      parent: 31
-      type: Transform
   - uid: 6440
     components:
     - pos: 43.5,18.5
@@ -46325,25 +46385,12 @@ entities:
       type: Transform
   - uid: 6873
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 58.5,13.5
+    - pos: 59.5,11.5
       parent: 31
       type: Transform
   - uid: 6875
     components:
     - pos: 54.5,15.5
-      parent: 31
-      type: Transform
-  - uid: 6878
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 57.5,11.5
-      parent: 31
-      type: Transform
-  - uid: 6881
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 58.5,12.5
       parent: 31
       type: Transform
   - uid: 6933
@@ -47777,12 +47824,6 @@ entities:
       pos: 61.5,-13.5
       parent: 31
       type: Transform
-  - uid: 4478
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 58.5,10.5
-      parent: 31
-      type: Transform
   - uid: 6467
     components:
     - rot: -1.5707963267948966 rad
@@ -47818,27 +47859,10 @@ entities:
       pos: 54.5,24.5
       parent: 31
       type: Transform
-  - uid: 6748
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 56.5,11.5
-      parent: 31
-      type: Transform
-  - uid: 6751
-    components:
-    - pos: 58.5,14.5
-      parent: 31
-      type: Transform
   - uid: 6841
     components:
     - rot: 3.141592653589793 rad
       pos: 58.5,15.5
-      parent: 31
-      type: Transform
-  - uid: 7071
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 59.5,11.5
       parent: 31
       type: Transform
   - uid: 7080
@@ -49956,11 +49980,6 @@ entities:
     - pos: 5.4978743,31.63788
       parent: 31
       type: Transform
-  - uid: 4636
-    components:
-    - pos: 56.74084,8.556389
-      parent: 31
-      type: Transform
   - uid: 11282
     components:
     - pos: -2.7462387,7.7338686
@@ -50637,19 +50656,19 @@ entities:
     - pos: 41.74788,13.772052
       parent: 31
       type: Transform
-  - uid: 3766
-    components:
-    - pos: 55.826782,8.452915
-      parent: 31
-      type: Transform
-  - uid: 5784
-    components:
-    - pos: 56.151474,8.687842
-      parent: 31
-      type: Transform
   - uid: 6874
     components:
     - pos: 41.718365,13.536064
+      parent: 31
+      type: Transform
+  - uid: 6878
+    components:
+    - pos: 55.67908,8.591436
+      parent: 31
+      type: Transform
+  - uid: 6881
+    components:
+    - pos: 55.257206,8.247686
       parent: 31
       type: Transform
   - uid: 11326
@@ -55033,6 +55052,11 @@ entities:
     - pos: -9.5,26.5
       parent: 31
       type: Transform
+  - uid: 3766
+    components:
+    - pos: 59.5,11.5
+      parent: 31
+      type: Transform
   - uid: 3836
     components:
     - rot: 1.5707963267948966 rad
@@ -55635,6 +55659,11 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: 35.5,-22.5
+      parent: 31
+      type: Transform
+  - uid: 7071
+    components:
+    - pos: 60.5,11.5
       parent: 31
       type: Transform
   - uid: 7118
@@ -56384,11 +56413,6 @@ entities:
       pos: -17.416342,-23.279646
       parent: 31
       type: Transform
-  - uid: 9556
-    components:
-    - pos: 55.526974,8.782967
-      parent: 31
-      type: Transform
   - uid: 10899
     components:
     - pos: 48.552956,-5.215438
@@ -57117,6 +57141,29 @@ entities:
         - On: Forward
         - Off: Off
       type: DeviceLinkSource
+- proto: SignalSwitchDirectional
+  entities:
+  - uid: 11371
+    components:
+    - pos: 57.5,9.5
+      parent: 31
+      type: Transform
+    - linkedPorts:
+        11370:
+        - On: Open
+        - Off: Close
+      type: DeviceLinkSource
+  - uid: 11372
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 58.5,11.5
+      parent: 31
+      type: Transform
+    - linkedPorts:
+        11369:
+        - On: Open
+        - Off: Close
+      type: DeviceLinkSource
 - proto: SignAnomaly
   entities:
   - uid: 10546
@@ -57247,6 +57294,12 @@ entities:
   - uid: 9549
     components:
     - pos: 80.5,2.5
+      parent: 31
+      type: Transform
+  - uid: 11379
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 55.5,9.5
       parent: 31
       type: Transform
 - proto: SignDirectionalBridge
@@ -57424,6 +57477,20 @@ entities:
   - uid: 7224
     components:
     - pos: 26.5,2.5
+      parent: 31
+      type: Transform
+- proto: SignElectrical
+  entities:
+  - uid: 11377
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 54.5,12.5
+      parent: 31
+      type: Transform
+  - uid: 11378
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 58.5,12.5
       parent: 31
       type: Transform
 - proto: SignElectricalMed
@@ -60124,11 +60191,6 @@ entities:
   - uid: 3106
     components:
     - pos: -12.5,11.5
-      parent: 31
-      type: Transform
-  - uid: 3109
-    components:
-    - pos: 56.5,8.5
       parent: 31
       type: Transform
   - uid: 3138
@@ -64865,14 +64927,6 @@ entities:
     - pos: 47.5,14.5
       parent: 31
       type: Transform
-  - uid: 3110
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: 56.5,9.5
-      parent: 31
-      type: Transform
   - uid: 3130
     components:
     - flags: PvsPriority
@@ -65384,6 +65438,13 @@ entities:
     - pos: 67.5,-6.5
       parent: 31
       type: Transform
+  - uid: 4478
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 55.5,12.5
+      parent: 31
+      type: Transform
   - uid: 4494
     components:
     - flags: PvsPriority
@@ -65452,6 +65513,20 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: 53.5,-6.5
+      parent: 31
+      type: Transform
+  - uid: 4536
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 54.5,10.5
+      parent: 31
+      type: Transform
+  - uid: 4538
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 58.5,12.5
       parent: 31
       type: Transform
   - uid: 4540
@@ -65564,6 +65639,13 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: 80.5,11.5
+      parent: 31
+      type: Transform
+  - uid: 4636
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 54.5,12.5
       parent: 31
       type: Transform
   - uid: 4646
@@ -66288,6 +66370,13 @@ entities:
     - pos: -39.5,-8.5
       parent: 31
       type: Transform
+  - uid: 5784
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 56.5,12.5
+      parent: 31
+      type: Transform
   - uid: 5882
     components:
     - flags: PvsPriority
@@ -66482,6 +66571,13 @@ entities:
       type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 47.5,22.5
+      parent: 31
+      type: Transform
+  - uid: 6432
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 57.5,12.5
       parent: 31
       type: Transform
   - uid: 6441
@@ -66713,6 +66809,13 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: 42.5,10.5
+      parent: 31
+      type: Transform
+  - uid: 6751
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 54.5,11.5
       parent: 31
       type: Transform
   - uid: 6808
@@ -68998,6 +69101,13 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: -6.5,-18.5
+      parent: 31
+      type: Transform
+  - uid: 10518
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 58.5,11.5
       parent: 31
       type: Transform
   - uid: 10557


### PR DESCRIPTION
## About the PR
- beacons, move bombing targets out of beacons so they still exist
- change drone storage from captain to command access
- replace jani shit from drone storage with board spawners

![00:30:27](https://github.com/space-wizards/space-station-14/assets/39013340/c03b2d9d-629a-4a49-adf4-1a65d26f6c53)
