### PR TITLE
Special Ammo Normalization

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -54,7 +54,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 1
+        Blunt: 3
         Heat: 7
   - type: IgnitionSource
     ignited: true
@@ -176,5 +176,5 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 3
+        Radiation: 5
         Piercing: 5


### PR DESCRIPTION
Changes special shotgun ammo to be consistent with current handgun balance.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed shotgun pellet damage values for special ammo to be on par with regular shells, as well as normalized the damage values as made sense.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Incendiary ammo is underutilized by sec and ineffective in space, adding some blunt to help may make it more appealing to use. Same issue is true with radioactive shells

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
A few more lines of code.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None I think.
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Normalized researched secfab shotgun ammo damages to align with the rest of the ammo sizes.

