### PR TITLE
Anti Anomaly zones

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -140,7 +140,7 @@ public sealed partial class AnomalySystem
                 var zoneTile = _transform.GetGridTilePositionOrDefault(uid, gridComp);
 
                 var delta = (zoneTile - tile);
-                if (delta.LengthSquared() < zone.ZoneRadius * zone.ZoneRadius)
+                if (delta.LengthSquared < zone.ZoneRadius * zone.ZoneRadius)
                 {
                     valid = false;
                     break;

--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -101,8 +101,6 @@ public sealed partial class AnomalySystem
         var targetCoords = xform.Coordinates;
         var gridBounds = gridComp.LocalAABB.Scale(_configuration.GetCVar(CCVars.AnomalyGenerationGridBoundsScale));
 
-        var antiAnomalyZonesQueue = AllEntityQuery<AntiAnomalyZoneComponent>();
-
         for (var i = 0; i < 25; i++)
         {
             var randomX = Random.Next((int) gridBounds.Left, (int) gridBounds.Right);
@@ -135,28 +133,25 @@ public sealed partial class AnomalySystem
             if (!valid)
                 continue;
 
-            targetCoords = gridComp.GridTileToLocal(tile);
-
             // don't spawn in AntiAnomalyZones
+            var antiAnomalyZonesQueue = AllEntityQuery<AntiAnomalyZoneComponent>();
             while (antiAnomalyZonesQueue.MoveNext(out var uid, out var zone))
             {
-                targetCoords.TryDelta(EntityManager, _transform, Transform(uid).Coordinates, out var delta);
+                var zoneTile = _transform.GetGridTilePositionOrDefault(uid, gridComp);
 
-                if (delta.Length() < zone.ZoneRadius)
+                var delta = (zoneTile - tile);
+                //targetCoords.TryDelta(EntityManager, _transform, Transform(uid).Coordinates, out var delta);
+
+                if (delta.Length < zone.ZoneRadius)
                 {
                     valid = false;
                     break;
                 }
-                //EntityCoordinates coord = new EntityCoordinates(grid, new Vector2(randomX, randomY));
-                //MapCoordinates randomCoord = new MapCoordinates(new Vector2(randomX, randomY), Transform(grid).MapID);
-                //if (randomCoord.InRange(_transform.GetMapCoordinates(uid), zone.ZoneRadius)){
-                //    valid = false;
-                //    break;
-                //};
             }
             if (!valid)
                 continue;
 
+            targetCoords = gridComp.GridTileToLocal(tile);
             break;
         }
 

--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -140,8 +140,6 @@ public sealed partial class AnomalySystem
                 var zoneTile = _transform.GetGridTilePositionOrDefault(uid, gridComp);
 
                 var delta = (zoneTile - tile);
-                //targetCoords.TryDelta(EntityManager, _transform, Transform(uid).Coordinates, out var delta);
-
                 if (delta.Length < zone.ZoneRadius)
                 {
                     valid = false;

--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -140,7 +140,7 @@ public sealed partial class AnomalySystem
                 var zoneTile = _transform.GetGridTilePositionOrDefault(uid, gridComp);
 
                 var delta = (zoneTile - tile);
-                if (delta.Length < zone.ZoneRadius)
+                if (delta.LengthSquared() < zone.ZoneRadius * zone.ZoneRadius)
                 {
                     valid = false;
                     break;

--- a/Content.Server/Anomaly/Components/AntiAnomalyZoneComponent.cs
+++ b/Content.Server/Anomaly/Components/AntiAnomalyZoneComponent.cs
@@ -1,0 +1,15 @@
+
+namespace Content.Server.Anomaly.Components;
+
+/// <summary>
+/// prohibits the possibility of anomalies appearing in the specified radius around the entity
+/// </summary>
+[RegisterComponent, Access(typeof(AnomalySystem))]
+public sealed partial class AntiAnomalyZoneComponent : Component
+{
+    /// <summary>
+    /// the radius in which anomalies cannot appear
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float ZoneRadius = 10;
+}

--- a/Resources/Prototypes/Entities/Markers/anti_anomaly_zone.yml
+++ b/Resources/Prototypes/Entities/Markers/anti_anomaly_zone.yml
@@ -1,0 +1,33 @@
+- type: entity
+  name: anti anomaly zone
+  description: Anomalies will not be able to appear within a 10 block radius of this point.
+  id: AntiAnomalyZone
+  suffix: "range 10"
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    sprite: Structures/Specific/Anomalies/ice_anom.rsi
+    layers:
+      - state: anom
+      - sprite: Markers/cross.rsi
+        state: pink
+  - type: AntiAnomalyZone
+    zoneRadius: 10
+
+- type: entity
+  parent: AntiAnomalyZone
+  id: AntiAnomalyZone20
+  suffix: "range 20"
+  description: Anomalies will not be able to appear within a 20 block radius of this point.
+  components:
+  - type: AntiAnomalyZone
+    zoneRadius: 20
+    
+- type: entity
+  parent: AntiAnomalyZone
+  id: AntiAnomalyZone50
+  suffix: "range 50"
+  description: Anomalies will not be able to appear within a 50 block radius of this point.
+  components:
+  - type: AntiAnomalyZone
+    zoneRadius: 50


### PR DESCRIPTION
![image](https://github.com/space-wizards/space-station-14/assets/96445749/e6421af0-36c0-4c0e-9cca-6b9b4509472d)

## About the PR
<!-- What did you change in this PR? -->
Adds markers to the game that block the ability to spawn anomalies in a certain radius around them.
this works for both the anomaly generator and random events

This is needed for mappers to block anomalies from appearing in secrets or arrivals.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/96445749/1bdb747b-6ced-49ca-819a-0f4ee6562b63)

https://github.com/space-wizards/space-station-14/assets/96445749/adcf0e06-555e-487c-8cdb-d0de52b8450b

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

