### PR TITLE
More Buildable Furniture + Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -348,4 +348,7 @@
   - type: Rotatable
   - type: Sprite
     state: steel-bench
+  - type: Construction
+    graph: Seat
+    node: chairSteelBench
 

--- a/Resources/Prototypes/Entities/Structures/Furniture/dresser.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/dresser.yml
@@ -40,6 +40,11 @@
   - type: Tag
     tags:
     - Wooden
+  - type: Anchorable
+  - type: Rotatable
+  - type: Construction
+    graph: Dresser
+    node: dresser
 
 - type: entity
   id: DresserFilled

--- a/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
@@ -66,7 +66,7 @@
     graph: FilingCabinet
     node: filingCabinet
   - type: StaticPrice
-    price: 15
+    price: 20
 
 - type: entity
   name: tall cabinet

--- a/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
@@ -65,6 +65,8 @@
   - type: Construction
     graph: FilingCabinet
     node: filingCabinet
+  - type: StaticPrice
+    price: 15
 
 - type: entity
   name: tall cabinet
@@ -152,6 +154,8 @@
   - type: Construction
     graph: FilingCabinet
     node: chestDrawer
+  - type: StaticPrice
+    price: 15
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
@@ -43,6 +43,28 @@
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/metalbreak.ogg
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 2
+  - type: Construction
+    graph: FilingCabinet
+    node: filingCabinet
 
 - type: entity
   name: tall cabinet
@@ -58,6 +80,9 @@
     - state: tallcabinet-open
       map: ["openLayer"]
   - type: Appearance
+  - type: Construction
+    graph: FilingCabinet
+    node: tallCabinet
 
 - type: entity
   name: chest drawer
@@ -105,6 +130,28 @@
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/metalbreak.ogg
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 2
+  - type: Construction
+    graph: FilingCabinet
+    node: chestDrawer
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/dresser.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/dresser.yml
@@ -1,0 +1,26 @@
+- type: constructionGraph
+  id: Dresser
+  start: start
+  graph:
+    - node: start
+      actions:
+        - !type:DestroyEntity {}
+      edges:
+        - to: dresser
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: WoodPlank
+              amount: 3
+              doAfter: 2
+    - node: dresser
+      entity: Dresser
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: MaterialWoodPlank
+              amount: 3
+          steps:
+            - tool: Prying
+              doAfter: 3

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/filing_cabinet.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/filing_cabinet.yml
@@ -1,0 +1,57 @@
+- type: constructionGraph
+  id: FilingCabinet
+  start: start
+  graph:
+    - node: start
+      actions:
+        - !type:DestroyEntity {}
+      edges:
+        - to: filingCabinet
+          steps:
+            - material: Steel
+              amount: 4
+              doAfter: 3
+        - to: tallCabinet
+          steps:
+            - material: Steel
+              amount: 4
+              doAfter: 3
+        - to: chestDrawer
+          steps:
+            - material: Steel
+              amount: 3
+              doAfter: 3
+
+    - node: filingCabinet
+      entity: filingCabinet
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 4
+          steps:
+            - tool: Screwing
+              doAfter: 4
+    - node: tallCabinet
+      entity: filingCabinetTall
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 4
+          steps:
+            - tool: Screwing
+              doAfter: 4
+    - node: chestDrawer
+      entity: filingCabinetDrawer
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 3
+          steps:
+            - tool: Screwing
+              doAfter: 4

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
@@ -58,6 +58,11 @@
               doAfter: 1
             - material: MetalRod
               amount: 2
+        - to: chairSteelBench
+          steps:
+            - material: Steel
+              amount: 2
+              doAfter: 1
 
     - node: chair
       entity: Chair
@@ -174,6 +179,18 @@
               amount: 1
             - !type:SpawnPrototype
               prototype: PartRodMetal1
+              amount: 2
+          steps:
+            - tool: Screwing
+              doAfter: 1
+
+    - node: chairSteelBench
+      entity: SteelBench
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
               amount: 2
           steps:
             - tool: Screwing

--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -186,6 +186,23 @@
   conditions:
     - !type:TileNotBlocked
 
+- type: construction
+  name: steel bench
+  id: ChairSteelBench
+  graph: Seat
+  startNode: start
+  targetNode: chairSteelBench
+  category: construction-category-furniture
+  description: A long chair made for a metro. Really standard design.
+  icon:
+    sprite: Structures/Furniture/chairs.rsi
+    state: steel-bench
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
 #tables
 - type: construction
   name: steel table
@@ -358,7 +375,7 @@
   conditions:
     - !type:TileNotBlocked
 
-#beds
+#bedroom
 - type: construction
   id: Bed
   name: bed
@@ -410,6 +427,23 @@
   conditions:
     - !type:TileNotBlocked
 
+- type: construction
+  id: Dresser
+  name: dresser
+  description: Wooden dresser, can store things inside itself.
+  graph: Dresser
+  startNode: start
+  targetNode: dresser
+  category: construction-category-furniture
+  icon:
+    sprite: Structures/Furniture/furniture.rsi
+    state: dresser
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
 #racks
 - type: construction
   id: Rack
@@ -428,6 +462,7 @@
   conditions:
     - !type:TileNotBlocked
 
+#misc
 - type: construction
   id: MeatSpike
   name: meat spike

--- a/Resources/Prototypes/Recipes/Construction/storage.yml
+++ b/Resources/Prototypes/Recipes/Construction/storage.yml
@@ -1,0 +1,51 @@
+#bureaucracy
+- type: construction
+  id: FilingCabinet
+  name: filing cabinet
+  description: A cabinet for all your filing needs.
+  graph: FilingCabinet
+  startNode: start
+  targetNode: filingCabinet
+  category: construction-category-storage
+  icon:
+    sprite: Structures/Storage/cabinets.rsi
+    state: filingcabinet
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: TallCabinet
+  name: tall cabinet
+  description: A cabinet for all your filing needs.
+  graph: FilingCabinet
+  startNode: start
+  targetNode: tallCabinet
+  category: construction-category-storage
+  icon:
+    sprite: Structures/Storage/cabinets.rsi
+    state: tallcabinet
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ChestDrawer
+  name: chest drawer
+  description: A small drawer for all your filing needs, Now with wheels!
+  graph: FilingCabinet
+  startNode: start
+  targetNode: chestDrawer
+  category: construction-category-storage
+  icon:
+    sprite: Structures/Storage/cabinets.rsi
+    state: chestdrawer
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked


### PR DESCRIPTION
## About the PR
Allows construction/deconstruction of benches, dressers, and all three types of filing cabinets. And makes some tweaks to make  them nicer to work with.

- Bench: Buildable with two steel. Deconstructable with a screwdriver.

- Dresser: Buildable with three wood. Deconstructable with a crowbar. Now can be unanchored.

- Filing/Tall Cabinet: Buildable with four steel. Deconstructable with a screwdriver. Now can be broken with force. Sells for 20.

- Chest Drawer: Buildable with three steel. Deconstructable with a screwdriver. Now can be broken with force. Sells for 15.

## Why / Balance
Allows people to furnish their custom rooms or workplaces a little bit more without having to steal anything from other locations.

Also I did check and nothing here can be abused by cargo.

## Media
- [X] This PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added the ability to construct benches, dressers, and filing cabinets.
