### PR TITLE
Easy Ramen Noodles

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -2166,10 +2166,12 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 30
+        maxVol: 40
         reagents:
         - ReagentId: DryRamen
-          Quantity: 30
+          Quantity: 25
+        - ReagentId: Soysauce
+          Quantity: 5
   - type: Sprite
     sprite: Objects/Consumable/Drinks/ramen.rsi
   - type: Tag
@@ -2186,10 +2188,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 30
+        maxVol: 40
         reagents:
         - ReagentId: DryRamen
-          Quantity: 30
+          Quantity: 25
         - ReagentId: CapsaicinOil
           Quantity: 5
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -2166,7 +2166,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 40
+        maxVol: 40 #big cup
         reagents:
         - ReagentId: DryRamen
           Quantity: 25

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -867,7 +867,7 @@
     Water:
       amount: 2
   products:
-    HotRamen: 5
+    HotRamen: 6
 
 - type: reaction
   id: Pilk

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -863,11 +863,11 @@
   minTemp: 323.15
   reactants:
     DryRamen:
-      amount: 3
+      amount: 5
     Water:
-      amount: 1
+      amount: 2
   products:
-    HotRamen: 3
+    HotRamen: 5
 
 - type: reaction
   id: Pilk


### PR DESCRIPTION
## About the PR
Chang's ramen noodle cups now have sufficient space (40u total) for 10ml of boiling water as per the instructions, along with the regular noodle cup coming pre-flavored with some soy sauce.
The noodles reaction is now 5u:2u dry noodles:water to produce 6u of hot noodles, this means that the present 25u dry noodles will become 30u hot noodles upon being heated with water.
There should probably be an accessible way to heat these, bothering the chef to microwave your instant noodles is lame.

## Why / Balance
Previously the dry noodle cup was completely full due to the noodles which were already present and nothing could be added, such as water. This is now changed.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

🆑
- tweak: Chang's instant ramen cups have been slightly enlarged to accommodate 10ml of boiling water, as per the instructions.
