### PR TITLE
light ciggies with fire structures

### DIFF
--- a/Content.Shared/Temperature/Components/AlwaysHotComponent.cs
+++ b/Content.Shared/Temperature/Components/AlwaysHotComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Temperature.Systems;
+
+namespace Content.Shared.Temperature.Components;
+
+/// <summary>
+/// Makes the entity always set <c>IsHotEvent.IsHot</c> to true, no matter what.
+/// </summary>
+[RegisterComponent, Access(typeof(AlwaysHotSystem))]
+public sealed partial class AlwaysHotComponent : Component
+{
+}

--- a/Content.Shared/Temperature/Systems/AlwaysHotSystem.cs
+++ b/Content.Shared/Temperature/Systems/AlwaysHotSystem.cs
@@ -1,0 +1,19 @@
+using Content.Shared.Temperature;
+using Content.Shared.Temperature.Components;
+
+namespace Content.Shared.Temperature.Systems;
+
+public sealed class AlwaysHotSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AlwaysHotComponent, IsHotEvent>(OnIsHot);
+    }
+
+    private void OnIsHot(Entity<AlwaysHotComponent> ent, ref IsHotEvent args)
+    {
+        args.IsHot = true;
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
@@ -29,6 +29,7 @@
     range: 5
     sound:
       path: /Audio/Ambience/Objects/fireplace.ogg
+  - type: AlwaysHot
 
 - type: entity
   id: LegionnaireBonfire

--- a/Resources/Prototypes/Entities/Structures/Decoration/fireplace.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/fireplace.yml
@@ -45,3 +45,4 @@
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
+  - type: AlwaysHot


### PR DESCRIPTION
## About the PR
fireplaces and bonfires can be used to light ciggies

## Why / Balance
makes sense that a roaring fire can be used to light your joint

## Technical details
added `AlwaysHot` component/system which set IsHot to true :trollface:

## Media
![23:58:51](https://github.com/space-wizards/space-station-14/assets/39013340/30181b74-7058-4b1d-ab51-c2bb737e135d)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun