### PR TITLE
Pie tins returned from all pies in all situations, add lathe recipes for pie tin and some other basic kitchenwares

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
@@ -89,6 +89,10 @@ namespace Content.Server.Nutrition.EntitySystems
             // Fill last slice with the rest of the solution
             FillSlice(sliceUid, solution);
 
+            // If the food has a trash, we should return it now
+            // Good for things like pies which always use pie tins
+            Spawn(food.Trash, transform.Coordinates);
+
             DeleteFood(uid, user);
             return true;
         }

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -20,6 +20,8 @@
           Quantity: 11
         - ReagentId: Vitamin
           Quantity: 5
+  - type: Food #All pies here made with a pie tin; unless you're some kind of savage, you're probably not destroying this when you eat or slice the pie!
+    trash: FoodPlateTin
   - type: SliceableFood
     count: 4
   - type: Tag
@@ -132,8 +134,6 @@
       - sweet
       - banana
       - creamy
-  - type: Food
-    trash: FoodPlateTin
   - type: Sprite
     layers:
     - state: tin

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
@@ -151,5 +151,5 @@
     - Trash
   - type: PhysicalComposition
     materialComposition:
-      Steel: 100
+      Steel: 60
   - type: SpaceGarbage

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -110,10 +110,18 @@
       - ExteriorLightTube
       - LightBulb
       - Bucket
+      - DrinkMug
+      - DrinkMugMetal
+      - DrinkGlass
+      - DrinkShotGlass
+      - DrinkGlassCoupeShaped
       - FoodPlate
       - FoodPlateSmall
       - FoodPlatePlastic
       - FoodPlateSmallPlastic
+      - FoodBowlBig
+      - FoodPlateTin
+      - FoodKebabSkewer
       - SprayBottle
       - PowerCellSmall
       - VehicleWheelchairFolded

--- a/Resources/Prototypes/Recipes/Lathes/cooking.yml
+++ b/Resources/Prototypes/Recipes/Lathes/cooking.yml
@@ -36,6 +36,20 @@
     Glass: 50
 
 - type: latheRecipe
+  id: DrinkShotGlass
+  result: DrinkShotGlass
+  completetime: 0.4
+  materials:
+    Glass: 25
+
+- type: latheRecipe
+  id: DrinkGlassCoupeShaped
+  result: DrinkGlassCoupeShaped
+  completetime: 0.8
+  materials:
+    Glass: 50
+
+- type: latheRecipe
   id: FoodPlate
   result: FoodPlate
   completetime: 0.8
@@ -62,3 +76,24 @@
   completetime: 0.4
   materials:
     Plastic: 50
+
+- type: latheRecipe
+  id: FoodBowlBig
+  result: FoodBowlBig
+  completetime: 0.8
+  materials:
+    Glass: 100
+
+- type: latheRecipe
+  id: FoodPlateTin
+  result: FoodPlateTin
+  completetime: 0.4
+  materials:
+    Steel: 50
+
+- type: latheRecipe
+  id: FoodKebabSkewer
+  result: FoodKebabSkewer
+  completetime: 0.4
+  materials:
+    Steel: 50

--- a/Resources/Prototypes/Recipes/Lathes/cooking.yml
+++ b/Resources/Prototypes/Recipes/Lathes/cooking.yml
@@ -19,35 +19,35 @@
   result: DrinkMug
   completetime: 0.8
   materials:
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: DrinkMugMetal
   result: DrinkMugMetal
   completetime: 0.8
   materials:
-    Steel: 50
+    Steel: 100
 
 - type: latheRecipe
   id: DrinkGlass
   result: DrinkGlass
   completetime: 0.8
   materials:
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: DrinkShotGlass
   result: DrinkShotGlass
   completetime: 0.4
   materials:
-    Glass: 25
+    Glass: 100
 
 - type: latheRecipe
   id: DrinkGlassCoupeShaped
   result: DrinkGlassCoupeShaped
   completetime: 0.8
   materials:
-    Glass: 50
+    Glass: 100
 
 - type: latheRecipe
   id: FoodPlate
@@ -89,11 +89,11 @@
   result: FoodPlateTin
   completetime: 0.4
   materials:
-    Steel: 50
+    Steel: 100
 
 - type: latheRecipe
   id: FoodKebabSkewer
   result: FoodKebabSkewer
   completetime: 0.4
   materials:
-    Steel: 50
+    Steel: 100


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- All pies now have a pie tin as their Trash, instead of just the banana cream pie.
- A SliceableFood whose Food has a trash will now spawn that Trash when the last slice is cut.
- Added pie tins, kebab skewers, bowls, and some basic drinkware to the Autolathe.

## Why / Balance
I personally found it very odd that the pie tin was unrecoverable, especially when the pie was sliced up. These changes will allow Chefs to cook more than five pies in a shift without ordering a Dinnerware restock. While I was at it, I made pie tins, bowls, kebab skewers, and the Bar's glasswares printable for similar reasons. This should help alleviate the sticker shock of spending $3000+ on a Booze-o-Mat restock just because the clown came by and blew up a vape at the bar, without making the restocks obsolete.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![2023-12-30_01-39-10](https://github.com/space-wizards/space-station-14/assets/502797/52cf9f43-680a-4d0a-99cd-23f71a2df277)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Slicing food inside of a container now tries to add the slices to the container.
- tweak: All pies now have a pie tin "trash", returned upon eating the pie or slicing it up fully.
- add: Pie tins, bowls, kebab skewers, and basic glasswares may now be printed at the Autolathe.