### PR TITLE
Lizards get more marking availability

### DIFF
--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -50,7 +50,7 @@
       required: true
       defaultMarkings: [ LizardSnoutRound ]
     HeadTop:
-      points: 1
+      points: 2
       required: false
     HeadSide:
       points: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

The main reason i feel that lizards only had one head marking limited, was because there was limited variety that had a lot of clipping. This now gives extra variety to lizard character creation as seen in the images below.

Even if people abuse this addition to add a large number of markings that clip, the same actually goes for diona and there hasn't been much of an issue.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**EXAMPLES:**

![image](https://github.com/space-wizards/space-station-14/assets/134914314/8b3aac5c-89c6-4178-a899-03cb921cb242)

![image](https://github.com/space-wizards/space-station-14/assets/134914314/b1e97c60-3788-4577-8056-95512d8ffb91)

![image](https://github.com/space-wizards/space-station-14/assets/134914314/765bca82-8e60-4886-84f9-5d249cda4b86)

![image](https://github.com/space-wizards/space-station-14/assets/134914314/35dc8917-7646-47e4-a61d-0cd4fd408c4e)

**Changelog**

:cl: Ubaser
- tweak: Reptilians can now use up to two (top) head markings.

