### PR TITLE
Remove "uncloneable" trait

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -44,13 +44,6 @@
     - type: Muted
 
 - type: trait
-  id: Uncloneable
-  name: trait-uncloneable-name
-  description: trait-uncloneable-desc
-  components:
-    - type: Uncloneable
-
-- type: trait
   id: WheelchairBound
   name: trait-wheelchair-bound-name
   description: trait-wheelchair-bound-desc


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Since we're phasing out cloning and its going for good in the near future, might as well remove the trait since no one uses it anyways.

**Changelog**

:cl: Ubaser
- remove: The uncloneable trait has been removed.
