### PR TITLE
Fix error when trying to delete a ExplosionVisualsTextureComponent.LightEntity that doesn't exist

### DIFF
--- a/Content.Client/Explosion/ExplosionOverlaySystem.cs
+++ b/Content.Client/Explosion/ExplosionOverlaySystem.cs
@@ -5,7 +5,6 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Graphics.RSI;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Utility;
 
 namespace Content.Client.Explosion;
 
@@ -53,7 +52,7 @@ public sealed class ExplosionOverlaySystem : EntitySystem
 
     private void OnCompRemove(EntityUid uid, ExplosionVisualsComponent component, ComponentRemove args)
     {
-        if (TryComp(uid, out ExplosionVisualsTexturesComponent? textures))
+        if (TryComp(uid, out ExplosionVisualsTexturesComponent? textures) && !Deleted(textures.LightEntity))
             QueueDel(textures.LightEntity);
     }
 


### PR DESCRIPTION
## About the PR
As seen on https://github.com/space-wizards/space-station-14/actions/runs/7367076454/job/20049928568
`- Pair 4 Test #79: Payload.ModularGrenadeTests.AssembleAndDetonateGrenade`

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
