### PR TITLE
minor science tree changes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -121,6 +121,7 @@
       - LightReplacer
       - TrashBag
       - PowerCellSmall
+      - PowerCellMedium
       - VehicleWheelchairFolded
       - RollerBedSpawnFolded
       - CheapRollerBedSpawnFolded
@@ -273,7 +274,6 @@
       - SignalTrigger
       - VoiceTrigger
       - Igniter
-      - PowerCellMedium
       - PowerCellMicroreactor
       - PowerCellHigh
       - WeaponPistolCHIMP

--- a/Resources/Prototypes/Research/biochemical.yml
+++ b/Resources/Prototypes/Research/biochemical.yml
@@ -61,18 +61,20 @@
   - BorgModuleDiagnosis
   - BorgModuleDefibrillator
 
-- type: technology
-  id: Virology
-  name: research-technology-virology
-  icon:
-    sprite: Structures/Machines/diagnoser.rsi
-    state: icon
-  discipline: Biochemical
-  tier: 1
-  cost: 5000
-  recipeUnlocks:
-  - VaccinatorMachineCircuitboard
-  - DiagnoserMachineCircuitboard
+# doesn't do anything right now
+#
+#- type: technology
+#  id: Virology
+#  name: research-technology-virology
+#  icon:
+#    sprite: Structures/Machines/diagnoser.rsi
+#    state: icon
+#  discipline: Biochemical
+#  tier: 1
+#  cost: 5000
+#  recipeUnlocks:
+#  - VaccinatorMachineCircuitboard
+#  - DiagnoserMachineCircuitboard
 
 # Tier 2
 

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -20,12 +20,12 @@
   name: research-technology-advanced-powercells
   icon:
     sprite: Objects/Power/power_cells.rsi
-    state: medium
+    state: high
   discipline: Industrial
   tier: 1
   cost: 5000
   recipeUnlocks:
-  - PowerCellMedium
+  - PowerCellHigh
 
 - type: technology
   id: CompactPower
@@ -149,20 +149,6 @@
   recipeUnlocks:
   - HolofanProjector
   - PortableScrubberMachineCircuitBoard
-
-- type: technology
-  id: SuperPowercells
-  name: research-technology-super-powercells
-  icon:
-    sprite: Objects/Power/power_cells.rsi
-    state: high
-  discipline: Industrial
-  tier: 2
-  cost: 7500
-  recipeUnlocks:
-  - PowerCellHigh
-  technologyPrerequisites:
-  - AdvancedPowercells
 
 - type: technology
   id: AdvancedToolsTechnology

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -194,4 +194,4 @@
   recipeUnlocks:
   - PowerCellMicroreactor
   technologyPrerequisites:
-  - SuperPowercells
+  - AdvancedPowercells


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
roundstart medium batteries in autolathe
move high batteries to T1
comment out virology because useless for now

## Why / Balance
#ideamen discussion
doesn't really make sense that medium batteries are a tech at all and that high batteries are a t2 considering their restricted usefulness

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
no

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Science no longer needs to research medium batteries, and high batteries are now T1.