### PR TITLE
Ensure correct number of thieves are selected

### DIFF
--- a/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
@@ -81,11 +81,19 @@ public sealed class ThiefRuleSystem : GameRuleSystem<ThiefRuleComponent>
         var startThiefCount = Math.Min(component.MaxAllowThief, component.StartCandidates.Count);
         var thiefPool = _antagSelection.FindPotentialAntags(component.StartCandidates, component.ThiefPrototypeId);
         //TO DO: When voxes specifies are added, increase their chance of becoming a thief by 4 times >:)
-        var selectedThieves = _antagSelection.PickAntag(_random.Next(1, startThiefCount), thiefPool);
 
-        foreach(var thief in selectedThieves)
+        //Add 1, as Next() is exclusive of maxValue
+        var numberOfThievesToSelect = _random.Next(1, startThiefCount + 1);
+
+        //While we dont have the correct number of thieves, and there are potential thieves remaining
+        while (component.ThievesMinds.Count < numberOfThievesToSelect && thiefPool.Count > 0)
         {
-            MakeThief(component, thief, component.PacifistThieves);
+            Log.Info($"{numberOfThievesToSelect} thieves required, {component.ThievesMinds.Count} currently chosen, {thiefPool.Count} potentials");
+            var selectedThieves = _antagSelection.PickAntag(numberOfThievesToSelect - component.ThievesMinds.Count, thiefPool);
+            foreach (var thief in selectedThieves)
+            {
+                MakeThief(component, thief, component.PacifistThieves);
+            }
         }
     }
 


### PR DESCRIPTION
## About the PR
Thief selection was selecting 1 fewer thieves than it should have (best case)
Also was not selecting additional thieves if any of its first selections failed.

## Why / Balance
Currently only selecting 2 thieves (best case), should make more effort to select the correct amount.

## Technical details
Add 1 to the _random.Next maxValue to account for it being exclusive
Add while loop (bleh) to ensure either the correct number of thieves has been selected, or there are no more potential thieves to select

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Ensure correct number of thieves
