### PR TITLE
Unlimited markings for humans and slimes.

### DIFF
--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -46,15 +46,6 @@
     HeadTop: # the cat ear joke
       points: 0
       required: false
-    Chest:
-      points: 1
-      required: false
-    Legs:
-      points: 2
-      required: false
-    Arms:
-      points: 2
-      required: false
 
 - type: humanoidBaseSprite
   id: MobHumanoidEyes

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -35,12 +35,6 @@
     FacialHair:
       points: 1
       required: false
-    Legs:
-      points: 2
-      required: false
-    Arms:
-      points: 4
-      required: false
 
 - type: humanoidBaseSprite
   id: MobSlimeMarkingFollowSkin


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I have deleted the limiter for markings for both human and slime.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
My main reasoning is the fact that with the beatiful addition of bandages marking, you cant exactly equip all of them, there is also the second point that the lizards do have unlimited markings so i personally think it would make sense to make it bit fair.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- remove: Removes marking limiter for human and slimes.


