### PR TITLE
Shader cleanup - applies DRY to various shaders in the game

### DIFF
--- a/Resources/Textures/Shaders/greyscale.swsl
+++ b/Resources/Textures/Shaders/greyscale.swsl
@@ -1,6 +1,5 @@
 ﻿void fragment() {
     highp vec4 color = zTexture(UV);
-    highp float grey = dot(color.rgb, vec3(0.299, 0.587, 0.114));
 
-    COLOR = vec4(vec3(grey), color.a);
+    COLOR = vec4(vec3(zGrayscale(color.rgb)), color.a);
 }

--- a/Resources/Textures/Shaders/greyscale_fullscreen.swsl
+++ b/Resources/Textures/Shaders/greyscale_fullscreen.swsl
@@ -3,7 +3,5 @@ uniform sampler2D SCREEN_TEXTURE;
 void fragment() {
     highp vec4 color = zTextureSpec(SCREEN_TEXTURE, UV);
 
-    highp float grey = dot(color.rgb, vec3(0.299, 0.587, 0.114));
-
-    COLOR = vec4(vec3(grey), color.a);
+    COLOR = vec4(vec3(zGrayscale(color.rgb)), color.a);
 }

--- a/Resources/Textures/Shaders/outline.swsl
+++ b/Resources/Textures/Shaders/outline.swsl
@@ -34,10 +34,6 @@ uniform highp float light_boost; // = 4.0;
 uniform highp float light_gamma; // = 1.0;
 uniform highp float light_whitepoint; // = 1.0;
 
-highp float grayscale(highp vec3 col) {
-	return mix(0.0, 1.0, (col.r * 0.299) + (col.g * 0.587) + (col.b * 0.114)); //These luminance values are taken from Rec. ITU-R BT.601-7. This isn't suitable for player-facing grayscaling due to SDTV having a funky colorspace, but it's perfect for outlines.
-}
-
 void fragment() {
 	highp vec4 col = zTexture(UV);
 	highp vec2 ps = TEXTURE_PIXEL_SIZE;
@@ -78,7 +74,7 @@ void fragment() {
     maxa = max(a, maxa);
     mina = min(a, mina);
 
-	lowp float sampledLight = outline_fullbright ? 1.0 : clamp( (pow( grayscale(lightSample.rgb) * light_whitepoint, light_gamma) / light_whitepoint ) * light_boost, 0.0, 1.0);
+	lowp float sampledLight = outline_fullbright ? 1.0 : clamp( (pow( zGrayscale_BT601(lightSample.rgb) * light_whitepoint, light_gamma) / light_whitepoint ) * light_boost, 0.0, 1.0);
 	COLOR = mix(col, outline_color * vec4(vec3(1.0), sampledLight), maxa - col.a);
 	lightSample = vec3(1.0);
 }

--- a/Resources/Textures/Shaders/paperstamp.swsl
+++ b/Resources/Textures/Shaders/paperstamp.swsl
@@ -3,30 +3,6 @@
 // affected by the widget layout/position.
 uniform highp vec2 objCoord;
 
-// Magic, well-known 2d random function; makes perlin-like noise
-highp vec2 random(highp vec2 uv){
-    uv = vec2( dot(uv, vec2(127.1,311.7) ),
-               dot(uv, vec2(269.5,183.3) ) );
-    return -1.0 + 2.0 * fract(sin(uv) * 43758.5453123);
-}
-
-highp float noise(highp vec2 uv) {
-    highp vec2 uv_i = floor(uv);
-    highp vec2 uv_f = fract(uv);
-
-    highp vec2 t = smoothstep(0.0, 1.0, uv_f);
-
-    // Sample the random function and run a bilinear filter to smooth it out
-    highp float tl = dot( random(uv_i + vec2(0.0,0.0) ), uv_f - vec2(0.0,0.0) );
-    highp float tr = dot( random(uv_i + vec2(1.0,0.0) ), uv_f - vec2(1.0,0.0) );
-    highp float bl = dot( random(uv_i + vec2(0.0,1.0) ), uv_f - vec2(0.0,1.0) );
-    highp float br = dot( random(uv_i + vec2(1.0,1.0) ), uv_f - vec2(1.0,1.0) );
-
-    highp float tA = mix( tl, tr, t.x );
-    highp float tB = mix( bl, br, t.x );
-    return mix( tA, tB, t.y ) + 0.5;
-}
-
 void fragment() {
     // Stamps have orientation, and the texture sampling is nearest
     // pixel, so run a bilinear filter to smooth out the edges.
@@ -45,8 +21,8 @@ void fragment() {
 
     // Add a bit of noise to mimic imperfect contact with the paper
     {
-        highp float stampNoise = noise((FRAGCOORD.xy - objCoord) * vec2(0.03, 0.03)) *
-                           noise((FRAGCOORD.xy - objCoord) * vec2(0.08, 0.08));
+        highp float stampNoise = zNoise((FRAGCOORD.xy - objCoord) * vec2(0.03, 0.03)) *
+                           zNoise((FRAGCOORD.xy - objCoord) * vec2(0.08, 0.08));
         COLOR.a *= min(0.9, 0.4 + smoothstep(0.05, 0.3, stampNoise));
     }
 }

--- a/Resources/Textures/Shaders/radiation.swsl
+++ b/Resources/Textures/Shaders/radiation.swsl
@@ -6,46 +6,14 @@ uniform highp vec2 renderScale;
 uniform highp float life;
 uniform highp float range;
 
-highp vec2 random(highp vec2 uv){
-    uv = vec2( dot(uv, vec2(127.1,311.7) ),
-               dot(uv, vec2(269.5,183.3) ) );
-    return -1.0 + 2.0 * fract(sin(uv) * 43758.5453123);
-}
-
-highp float noise(highp vec2 uv) {
-    highp vec2 uv_index = floor(uv);
-    highp vec2 uv_fract = fract(uv);
-
-    highp vec2 blur = smoothstep(0.0, 1.0, uv_fract);
-
-    return mix( mix( dot( random(uv_index + vec2(0.0,0.0) ), uv_fract - vec2(0.0,0.0) ),
-                     dot( random(uv_index + vec2(1.0,0.0) ), uv_fract - vec2(1.0,0.0) ), blur.x),
-                mix( dot( random(uv_index + vec2(0.0,1.0) ), uv_fract - vec2(0.0,1.0) ),
-                     dot( random(uv_index + vec2(1.0,1.0) ), uv_fract - vec2(1.0,1.0) ), blur.x), blur.y) * 0.5 + 0.5;
-}
-
-highp float fbm(highp vec2 uv) {
-    const int octaves = 6;
-    highp float amplitude = 0.5;
-    highp float frequency = 3.0;
-    highp float value = 0.0;
-
-    for(int i = 0; i < octaves; i++) {
-        value += amplitude * noise(frequency * uv);
-        amplitude *= 0.5;
-        frequency *= 2.0;
-    }
-    return value;
-}
-
 void fragment() {
 	highp vec2 finalCoords = (FRAGCOORD.xy - positionInput) / (renderScale * 32.0);
 	highp float distanceToCenter = length(finalCoords);
 	highp float nlife = pow(sin(clamp(life, 0.0, 1.0) * 3.141592), 0.5);
 	highp float on = ((range - distanceToCenter) / range);
 	highp float n = on;
-	highp vec2 fcOffset = vec2(fbm(finalCoords.xy + life / 2.0),fbm(finalCoords.yx + life / 2.0));
-	n *= fbm((finalCoords + fcOffset) / (nlife / (n * 1.5))) * 1.1;
+	highp vec2 fcOffset = vec2(zFBM(finalCoords.xy + life / 2.0),zFBM(finalCoords.yx + life / 2.0));
+	n *= zFBM((finalCoords + fcOffset) / (nlife / (n * 1.5))) * 1.1;
 	n *= clamp(nlife, 0.0, 1.0);
 	highp float a = 0.0; // Alpha
 	highp float p = 0.0; // Position between L and R stops

--- a/Resources/Textures/Shaders/rainbow.swsl
+++ b/Resources/Textures/Shaders/rainbow.swsl
@@ -14,48 +14,44 @@ const highp float CenterColorRadius = 250.0; // radius of the gradient used to t
 const highp float CenterColorMinDist = 0.2; // minimum distance from the center of the screen for the color to appear at all
 const highp float CenterColorPow = 1.25; // the exponent used for the color's center
 
-// hash(),  noise(), and hsv2rgb_smooth() were converted from shadertoy examples, which were released under the MIT License:
+// noise() and hsv2rgb_smooth() were converted from shadertoy examples, which were released under the MIT License:
 // The MIT License
 // Copyright © 2013 Inigo Quilez
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // https://www.youtube.com/c/InigoQuilez
 // https://iquilezles.org
-highp vec2 hash( highp vec2 p ) {
-	p = vec2( dot(p,vec2(127.1,311.7)), dot(p,vec2(269.5,183.3)) );
-	return -1.0 + 2.0*fract(sin(p)*43758.5453123);
-}
 
 highp float noise( highp vec2 p ) {
     const highp float K1 = 0.366025404;
     const highp float K2 = 0.211324865;
 
-	highp vec2  i = floor( p + (p.x+p.y)*K1 );
+    highp vec2  i = floor( p + (p.x+p.y)*K1 );
     highp vec2  a = p - i + (i.x+i.y)*K2;
     highp float m = step(a.y,a.x); 
     highp vec2  o = vec2(m,1.0-m);
     highp vec2  b = a - o + K2;
-	highp vec2  c = a - 1.0 + 2.0*K2;
+    highp vec2  c = a - 1.0 + 2.0*K2;
     highp vec3  h = max( 0.5-vec3(dot(a,a), dot(b,b), dot(c,c) ), 0.0 );
-	highp vec3  n = h*h*h*h*vec3( dot(a,hash(i+0.0)), dot(b,hash(i+o)), dot(c,hash(i+1.0)));
+    highp vec3  n = h*h*h*h*vec3( dot(a,zRandom(i+0.0)), dot(b,zRandom(i+o)), dot(c,zRandom(i+1.0)));
     return dot( n, vec3(70.0) );
 }
 
 highp vec3 hsv2rgb_smooth( highp vec3 c ) {
     highp vec3 rgb = clamp( abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),6.0)-3.0)-1.0, 0.0, 1.0 );
-	rgb = rgb*rgb*(3.0-2.0*rgb);
-	return c.z * mix( vec3(1.0), rgb, c.y);
+    rgb = rgb*rgb*(3.0-2.0*rgb);
+    return c.z * mix( vec3(1.0), rgb, c.y);
 }
 
 
 highp float mixNoise(highp vec2 point, highp float phase) {
     highp float time = TIME * TimeScale + phase;
-	highp float a = noise( NoiseScale * point - time);
+    highp float a = noise( NoiseScale * point - time);
     highp float b = noise( NoiseScale * point + time );
     return mix(a,b,0.5);
 }
 
 highp float genGradient(highp vec2 center, highp vec2 coord, highp float radius, highp float dist, highp float power) {
-    return pow(min(max((length(center - coord) / radius) - dist, 0.0), 1.0), power);
+    return pow(clamp((length(center - coord) / radius) - dist, 0.0, 1.0), power);
 }
 
 void fragment() {


### PR DESCRIPTION
## About the PR
This PR is fairly straight-forward: this cleans up a bunch of commonly-duplicated code across the shaders currently in the game, making use of the new zLibrary functions we've added in space-wizards/RobustToolbox/pull/4784

Oh also apparently compatibility mode *dOES* have clamp(). so uh. Yeah we replaced the `min(max())` we did in the drug shader with a `clamp()`

## Why / Balance
Cleaner code is good we think??

## Technical details
Grayscale can now be done as part of zLibrary via `zGrayscale(vec3)` (though you can explicitly use either `zGrayscale_BT709()` or `zGrayscale_BT601()` if you'd like to explicitly use either of those colorspaces for your grayscaling. `zGrayscale()` defaults to the former for now, but that could potentially change in the future)

The hash function that kept being copy-pasted across shaders can now be done via `zRandom(vec2)`

The generic bilinear noise function that also cropped up quite a few times across shaders is now doable via `zNoise(vec2)`

The FBM noise function present in radiation.swsl is now doable via `zFBM(vec2)`

## Media

### Everything affected remains the same! (Wow! Incredible!)
![image](https://github.com/space-wizards/space-station-14/assets/6356337/76f07244-7110-48fa-9087-7974fabe0697)

### The compatibility smoke test has passed! (Woah!!!!)
![image](https://github.com/space-wizards/space-station-14/assets/6356337/56622d82-3525-4ef0-90a0-02f41823bba2)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

No player-facing changes
