### PR TITLE
allow users to click a button ingame and in lobby to view round-end-s…

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -69,6 +69,12 @@ namespace Content.Client.Lobby
                 _lobby.CharacterPreview.UpdateUI();
             };
 
+            //wire up the anonymous class for our Show Round End button:
+            _lobby.ShowRoundSummaryButton.OnPressed += _ =>
+            {
+                _gameTicker.DisplayRoundEndSummary();
+            };
+
             LayoutContainer.SetAnchorPreset(_lobby, LayoutContainer.LayoutPreset.Wide);
             _lobby.ServerName.Text = _baseClient.GameInfo?.ServerName; //The eye of refactor gazes upon you...
             UpdateLobbyUi();

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -78,8 +78,8 @@
                     <controls:HSpacer Spacing="10" />
                     <!-- Voting & misc button bar -->
                     <BoxContainer Orientation="Horizontal" MinSize="0 40" HorizontalAlignment="Right">
-                        <Button Name="AHelpButton" Access="Public" Text="{Loc 'ui-lobby-ahelp-button'}"
-                                StyleClasses="ButtonBig" />
+                        <Button Name="ShowRoundSummaryButton" Access="Public" Text="{Loc 'ui-lobby-showsummary-button'}" StyleClasses="ButtonBig" />
+                        <Button Name="AHelpButton" Access="Public" Text="{Loc 'ui-lobby-ahelp-button'}" StyleClasses="ButtonBig" />
                         <vote:VoteCallMenuButton Name="CallVoteButton" StyleClasses="ButtonBig" />
                         <Button Name="OptionsButton" Access="Public" StyleClasses="ButtonBig"
                                 Text="{Loc 'ui-lobby-options-button'}" />

--- a/Content.Client/Options/UI/EscapeMenu.xaml
+++ b/Content.Client/Options/UI/EscapeMenu.xaml
@@ -1,4 +1,4 @@
-﻿<ui1:EscapeMenu xmlns="https://spacestation14.io"
+<ui1:EscapeMenu xmlns="https://spacestation14.io"
             xmlns:changelog="clr-namespace:Content.Client.Changelog"
             xmlns:ui="clr-namespace:Content.Client.Voting.UI"
             xmlns:ui1="clr-namespace:Content.Client.Options.UI"
@@ -13,6 +13,7 @@
         <Button Access="Public" Name="GuidebookButton" Text="{Loc 'ui-escape-guidebook'}" />
         <Button Access="Public" Name="WikiButton" Text="{Loc 'ui-escape-wiki'}" />
         <Button Access="Public" Name="DisconnectButton" Text="{Loc 'ui-escape-disconnect'}" />
+        <Button Access="Public" Name="ShowRoundSummaryButton" Text="{Loc 'ui-show-roundend'}" />
         <Button Access="Public" Name="QuitButton" Text="{Loc 'ui-escape-quit'}" />
     </BoxContainer>
 </ui1:EscapeMenu>

--- a/Content.Client/UserInterface/Systems/EscapeMenu/EscapeUIController.cs
+++ b/Content.Client/UserInterface/Systems/EscapeMenu/EscapeUIController.cs
@@ -1,4 +1,6 @@
-﻿using Content.Client.Gameplay;
+using Content.Client.Gameplay;
+using Content.Client.GameTicking.Managers;
+using Content.Client.RoundEnd;
 using Content.Client.UserInterface.Controls;
 using Content.Client.UserInterface.Systems.Guidebook;
 using Content.Client.UserInterface.Systems.Info;
@@ -26,7 +28,11 @@ public sealed class EscapeUIController : UIController, IOnStateEntered<GameplayS
     [Dependency] private readonly OptionsUIController _options = default!;
     [Dependency] private readonly GuidebookUIController _guidebook = default!;
 
-    private Options.UI.EscapeMenu? _escapeWindow;
+    public Options.UI.EscapeMenu? _escapeWindow = default!;
+
+    //this object is used when the player clicks on the "Show round end summary" button
+        //init out here, so that we arent creating a new instance of the object on every click - we're reusing the same object
+    private ClientGameTicker cgtTickingManager = new ClientGameTicker();
 
     private MenuButton? EscapeButton => UIManager.GetActiveUIWidgetOrNull<MenuBar.Widgets.GameTopMenuBar>()?.EscapeButton;
 
@@ -102,6 +108,13 @@ public sealed class EscapeUIController : UIController, IOnStateEntered<GameplayS
         {
             _guidebook.ToggleGuidebook();
         };
+
+        //wire up the anonymous class for our Show Round End button:
+        _escapeWindow.ShowRoundSummaryButton.OnPressed += _ =>
+        {
+            cgtTickingManager.DisplayRoundEndSummary();
+        };
+
 
         // Hide wiki button if we don't have a link for it.
         _escapeWindow.WikiButton.Visible = _cfg.GetCVar(CCVars.InfoLinksWiki) != "";

--- a/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
@@ -7,4 +7,4 @@ ui-escape-guidebook = Guidebook
 ui-escape-wiki = Wiki
 ui-escape-disconnect = Disconnect
 ui-escape-quit = Quit
-
+ui-show-roundend = Round-End Summary

--- a/Resources/Locale/en-US/lobby/lobby-gui.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-gui.ftl
@@ -6,3 +6,4 @@ ui-lobby-observe-button = Observe
 ui-lobby-ready-up-button = Ready Up
 ui-lobby-online-players-block = Online Players
 ui-lobby-server-info-block = Server Info
+ui-lobby-showsummary-button = Round-End Summary


### PR DESCRIPTION
## About the PR
I added functionality for players to view the Round-End Summary again, after closing it.
Can be done in-game, after round end, and from the lobby.

## Why / Balance
No balance changes made.
This change was made after I spotted a few complaints (and had some myself) about not being able to pull up the round-end summary after closing it. No balance changes made, it's simply a button click that displays the UI again.

## Technical details
I'm simply storing the data from the round end summary, then showing the form again once the user clicks a button.

## Media
Here are 2 videos of the feature in action:
Part 1 shows the new option in the escape menu when the round ends:
https://github.com/space-wizards/space-station-14/assets/146375585/3dd87dab-5b52-4a50-bd55-9eaea4ce17d1

Part 2 shows the new button on the Lobby screen, when the player is returned to the lobby:
https://github.com/space-wizards/space-station-14/assets/146375585/1dce70fb-f8f7-4612-8f7d-f6c628eb1c9b

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No breaking changes

**Changelog**
Added functionality for players to view the Round-End Summary again, after closing it. Can be done in-game after the round ends, and from the Lobby screen. Note that the EscapeUI button is visible throughout the game, but wont do anything until the round ends. I'm unable to hide it at will, as I was advised to change the way that I did it previously (Where I used the same EscapeUI object to access the same instance of the window that was being displayed when the user pressed ESC).

:cl:
- add: Added functionality for users to see the Round-End-Summary again, after closing it. Press F10 to see the option after round-end (While in-game, between restart). The option will also appear on Lobby screen, above the OOC chat.
