### PR TITLE
Give throwing a cooldown

### DIFF
--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -57,6 +57,18 @@ public sealed partial class HandsComponent : Component
     ///     Used by the client.
     /// </summary>
     public readonly Dictionary<HandLocation, HashSet<string>> RevealedLayers = new();
+
+    /// <summary>
+    ///     The time at which throws will be allowed again.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan NextThrowTime;
+
+    /// <summary>
+    ///     The minimum time inbetween throws.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan ThrowCooldown = TimeSpan.FromSeconds(0.5f);
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #22127

tacks a half second cooldown onto throwing.
also fixes the stack-splitting throwing (not that anything uses it afaik) because i noticed it while testing.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
exploited mechanic number 2,732,541

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun