### PR TITLE
Bed rotation fix

### DIFF
--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -61,12 +61,13 @@ internal sealed class BuckleSystem : SharedBuckleSystem
             !buckled ||
             args.Sprite == null)
         {
-            _rotationVisualizerSystem.SetHorizontalAngle((uid, rotVisuals), rotVisuals.DefaultRotation);
+            _rotationVisualizerSystem.SetHorizontalAngle((uid, rotVisuals), rotVisuals.HorizontalRotation);
             return;
         }
 
         // Animate strapping yourself to something at a given angle
         // TODO: Dump this when buckle is better
-        _rotationVisualizerSystem.AnimateSpriteRotation(uid, args.Sprite, rotVisuals.HorizontalRotation, 0.125f);
+        //_rotationVisualizerSystem.AnimateSpriteRotation(uid, args.Sprite, rotVisuals.HorizontalRotation, 0.125f);
+        _rotationVisualizerSystem.AnimateSpriteRotation(uid, args.Sprite, rotVisuals.DefaultRotation, 0.125f);
     }
 }

--- a/Content.Client/Rotation/RotationVisualizerSystem.cs
+++ b/Content.Client/Rotation/RotationVisualizerSystem.cs
@@ -29,10 +29,12 @@ public sealed class RotationVisualizerSystem : SharedRotationVisualsSystem
         switch (state)
         {
             case RotationState.Vertical:
-                AnimateSpriteRotation(uid, args.Sprite, component.VerticalRotation, component.AnimationTime);
+                component.DefaultRotation = component.VerticalRotation;
+                AnimateSpriteRotation(uid, args.Sprite, component.DefaultRotation, component.AnimationTime);
                 break;
             case RotationState.Horizontal:
-                AnimateSpriteRotation(uid, args.Sprite, component.HorizontalRotation, component.AnimationTime);
+                component.DefaultRotation = (-component.HorizontalRotation);
+                AnimateSpriteRotation(uid, args.Sprite, component.DefaultRotation, component.AnimationTime);
                 break;
         }
     }

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -344,6 +344,7 @@ public abstract partial class SharedBuckleSystem
         if (!CanBuckle(buckleUid, userUid, strapUid, out var strapComp, buckleComp))
             return false;
 
+        //straps the player into the object (bed, etc)
         if (!StrapTryAdd(strapUid, buckleUid, buckleComp, false, strapComp))
         {
             var message = Loc.GetString(buckleUid == userUid
@@ -353,11 +354,14 @@ public abstract partial class SharedBuckleSystem
                 _popup.PopupEntity(message, userUid, userUid);
             return false;
         }
-
+        //updates the visuals to show player on the object
         if (TryComp<AppearanceComponent>(buckleUid, out var appearance))
             Appearance.SetData(buckleUid, BuckleVisuals.Buckled, true, appearance);
+        //rotates the player to the right rotation
 
-        _rotationVisuals.SetHorizontalAngle(buckleUid,  strapComp.Rotation);
+        //THIS IS 100% THE ISSUE: _rotationVisuals.SetHorizontalAngle(buckleUid, strapComp.Rotation);
+        //SETTING IT TO Angle.FromDegrees(-90), makes us lay correctly, it just doesnt work for chairs/atv, etc.
+        _rotationVisuals.SetHorizontalAngle(buckleUid, strapComp.Rotation);
 
         ReAttach(buckleUid, strapUid, buckleComp, strapComp);
         SetBuckledTo(buckleUid, strapUid, strapComp, buckleComp);

--- a/Content.Shared/Buckle/SharedBuckleSystem.Strap.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Strap.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Construction;
 using Content.Shared.Destructible;
@@ -27,7 +27,7 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<StrapComponent, GetVerbsEvent<InteractionVerb>>(AddStrapVerbs);
         SubscribeLocalEvent<StrapComponent, ContainerGettingInsertedAttemptEvent>(OnStrapContainerGettingInsertedAttempt);
         SubscribeLocalEvent<StrapComponent, InteractHandEvent>(OnStrapInteractHand);
-        SubscribeLocalEvent<StrapComponent, DestructionEventArgs>((_,c,_) => StrapRemoveAll(c));
+        SubscribeLocalEvent<StrapComponent, DestructionEventArgs>((_, c, _) => StrapRemoveAll(c));
         SubscribeLocalEvent<StrapComponent, BreakageEventArgs>((_, c, _) => StrapRemoveAll(c));
 
         SubscribeLocalEvent<StrapComponent, DragDropTargetEvent>(OnStrapDragDropTarget);

--- a/Content.Shared/Buckle/SharedBuckleSystem.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedBuckleSystem : EntitySystem
         if (buckleTransform.ParentUid != strapUid)
             return;
 
-        _transform.SetLocalRotation(buckleUid, Angle.Zero, buckleTransform);
+        _transform.SetLocalRotation(buckleUid, strapComp.Rotation, buckleTransform);
         _joints.SetRelay(buckleUid, strapUid);
 
         switch (strapComp.Position)
@@ -90,5 +90,4 @@ public abstract partial class SharedBuckleSystem : EntitySystem
                 _standing.Down(buckleUid, false, false);
                 break;
         }
-    }
-}
+    }}

--- a/Content.Shared/Rotation/RotationVisualsComponent.cs
+++ b/Content.Shared/Rotation/RotationVisualsComponent.cs
@@ -9,14 +9,16 @@ public sealed partial class RotationVisualsComponent : Component
     /// <summary>
     /// Default value of <see cref="HorizontalRotation"/>
     /// </summary>
+    ///
+    //should we not be changing the default rotation to be either horizontal or vertical?
     [DataField]
-    public Angle DefaultRotation = Angle.FromDegrees(90);
+    public Angle DefaultRotation = Angle.Zero; //should this not be 0 degrees? as the character stands up by default (as opposed to 90 degrees - laying down)
 
     [DataField]
-    public Angle VerticalRotation = 0;
+    public Angle VerticalRotation = Angle.Zero;
 
     [DataField, AutoNetworkedField]
-    public Angle HorizontalRotation = Angle.FromDegrees(90);
+    public Angle HorizontalRotation = Angle.FromDegrees(180); //this should be -90, because the beds are all at rotation -90, regular 90 degrees will have you facing the wrong way
 
     [DataField]
     public float AnimationTime = 0.125f;
@@ -39,5 +41,5 @@ public enum RotationState
     /// <summary>
     ///     Laying down
     /// </summary>
-    Horizontal,
+    Horizontal
 }

--- a/Content.Shared/Rotation/SharedRotationVisualsSystem.cs
+++ b/Content.Shared/Rotation/SharedRotationVisualsSystem.cs
@@ -4,17 +4,24 @@ public abstract class SharedRotationVisualsSystem : EntitySystem
 {
     /// <summary>
     /// Sets the rotation an entity will have when it is "horizontal"
+    /// <question>
+    ///     why are we doing this? We're setting the horizontal angle to 90 degrees, when the object already has a Horizontal rotation 90 degrees
+    ///         instead, should we not be changing the default rotation to be either horizontal or vertical?
+    /// </question>
     /// </summary>
     public void SetHorizontalAngle(Entity<RotationVisualsComponent?> ent, Angle angle)
     {
         if (!Resolve(ent, ref ent.Comp, false))
             return;
 
-        if (ent.Comp.HorizontalRotation.Equals(angle))
+        if (ent.Comp.DefaultRotation.Equals(angle))
             return;
 
-        ent.Comp.HorizontalRotation = angle;
-        Dirty(ent);
+        //ent.Comp.HorizontalRotation = angle;
+        ent.Comp.DefaultRotation = ent.Comp.HorizontalRotation;
+
+        //why do we do this here, but not in the method below?
+        //Dirty(ent);
     }
 
 
@@ -24,6 +31,7 @@ public abstract class SharedRotationVisualsSystem : EntitySystem
     public void ResetHorizontalAngle(Entity<RotationVisualsComponent?> ent)
     {
         if (Resolve(ent, ref ent.Comp, false))
-            SetHorizontalAngle(ent, ent.Comp.DefaultRotation);
+            //SetHorizontalAngle(ent, ent.Comp.DefaultRotation); //redo this shit, it's so lazy
+            ent.Comp.DefaultRotation = ent.Comp.VerticalRotation;
     }
 }

--- a/Content.Shared/Rotation/SharedRotationVisualsSystem.cs
+++ b/Content.Shared/Rotation/SharedRotationVisualsSystem.cs
@@ -21,7 +21,7 @@ public abstract class SharedRotationVisualsSystem : EntitySystem
         ent.Comp.DefaultRotation = ent.Comp.HorizontalRotation;
 
         //why do we do this here, but not in the method below?
-        //Dirty(ent);
+        Dirty(ent);
     }
 
 


### PR DESCRIPTION
## About the PR
I reworked the buckling and rotation systems. 
Unsure how tbh, but previous changes that someone made in the last week somehow cause the game to put players at a weird angle when they're strapped to beds (either by themselves or others).
The code looked 100% perfect though - even when debugging - but through magic and no-sleep, I have managed to resolve the issue.

## Why / Balance
No balance changes made.
This was changed because the current code/game causes players to be placed at a weird angle, which breaks immersion. This is just a basic QoL update, to fix player rotation when on beds.

## Technical details
I reworked the system that handles buckling and strapping players to objects like beds, chairs, etc.

## Media
Here's a video of my fix at work:
https://github.com/space-wizards/space-station-14/assets/146375585/91e8b221-fd02-49de-b29a-6205e9c09858

Here's a video of the issue currently in prod [Specifically the LRP Leviathan server]:
https://github.com/space-wizards/space-station-14/assets/146375585/5dddc165-7c7c-4449-8c37-f3bc87a22771

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No breaking changes

**Changelog**

:cl:
- fix: I reworked the buckling system, so players are no longer strapped to beds at a weird angle. All is right with the world.
