### PR TITLE
add TryGetPrimaryDepartment to jobs system

### DIFF
--- a/Content.IntegrationTests/Tests/Minds/JobTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/JobTests.cs
@@ -5,8 +5,8 @@ using System.Linq;
 namespace Content.IntegrationTests.Tests.Station;
 
 [TestFixture]
-[TestOf(typeof(SharedJobsSystem))]
-public sealed class JobsTest
+[TestOf(typeof(SharedJobSystem))]
+public sealed class JobTest
 {
     /// <summary>
     /// Ensures that every job belongs to at most 1 primary department.

--- a/Content.IntegrationTests/Tests/Minds/JobTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/JobTests.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
+using Robust.Shared.Prototypes;
 using System.Linq;
 
 namespace Content.IntegrationTests.Tests.Station;
@@ -34,7 +35,7 @@ public sealed class JobTest
                 var primaries = 0;
                 foreach (var department in departments)
                 {
-                    if (!departments.Roles.ContainsKey(job.ID))
+                    if (!department.Roles.Contains(job.ID))
                         continue;
 
                     primaries++;

--- a/Content.IntegrationTests/Tests/Minds/JobTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/JobTests.cs
@@ -1,0 +1,47 @@
+using Content.Shared.Roles;
+using Content.Shared.Roles.Jobs;
+using System.Linq;
+
+namespace Content.IntegrationTests.Tests.Station;
+
+[TestFixture]
+[TestOf(typeof(SharedJobsSystem))]
+public sealed class JobsTest
+{
+    /// <summary>
+    /// Ensures that every job belongs to at most 1 primary department.
+    /// Having no primary department is ok.
+    /// </summary>
+    [Test]
+    public async Task PrimaryDepartmentsTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var prototypeManager = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            // only checking primary departments so don't bother with others
+            var departments = prototypeManager.EnumeratePrototypes<DepartmentPrototype>()
+                .Where(department => department.Primary)
+                .ToList();
+            var jobs = prototypeManager.EnumeratePrototypes<JobPrototype>();
+            foreach (var job in jobs)
+            {
+                // not actually using the jobs system since that will return the first department
+                // and we need to test that there is never more than 1, so it not sorting them is correct
+                var primaries = 0;
+                foreach (var department in departments)
+                {
+                    if (!departments.Roles.ContainsKey(job.ID))
+                        continue;
+
+                    primaries++;
+                    Assert.That(primaries, Is.EqualTo(1), $"The job {job.ID} has more than 1 primary department!");
+                }
+            }
+        });
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -23,4 +23,11 @@ public sealed partial class DepartmentPrototype : IPrototype
     [ViewVariables(VVAccess.ReadWrite),
      DataField("roles", customTypeSerializer: typeof(PrototypeIdListSerializer<JobPrototype>))]
     public List<string> Roles = new();
+
+    /// <summary>
+    /// Whether this is a primary department or not.
+    /// For example, CE's primary department is engineering since Command has primary: false.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool Primary = true;
 }

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -84,7 +84,8 @@ public abstract class SharedJobSystem : EntitySystem
     public bool TryGetPrimaryDepartment(string jobProto, [NotNullWhen(true)] out DepartmentPrototype? departmentPrototype)
     {
         // not sorting it since there should only be 1 primary department for a job.
-        var departmentProtos = _protoManager.EnumeratePrototypes<DepartmentPrototype>().ToList();
+        // this is enforced by the job tests.
+        var departmentProtos = _protoManager.EnumeratePrototypes<DepartmentPrototype>();
 
         foreach (var department in departmentProtos)
         {

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -76,6 +76,29 @@ public abstract class SharedJobSystem : EntitySystem
         return false;
     }
 
+    /// <summary>
+    /// Like <see cref="TryGetDepartment"/> but ignores any non-primary departments.
+    /// For example, with CE it will return Engineering but with captain it will
+    /// not return anything, since Command is not a primary department.
+    /// </summary>
+    public bool TryGetPrimaryDepartment(string jobProto, [NotNullWhen(true)] out DepartmentPrototype? departmentPrototype)
+    {
+        // not sorting it since there should only be 1 primary department for a job.
+        var departmentProtos = _protoManager.EnumeratePrototypes<DepartmentPrototype>().ToList();
+
+        foreach (var department in departmentProtos)
+        {
+            if (department.Primary && department.Roles.Contains(jobProto))
+            {
+                departmentPrototype = department;
+                return true;
+            }
+        }
+
+        departmentPrototype = null;
+        return false;
+    }
+
     public bool MindHasJobWithId(EntityUid? mindId, string prototypeId)
     {
         return CompOrNull<JobComponent>(mindId)?.Prototype == prototypeId;

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -43,6 +43,7 @@
   - HeadOfSecurity
   - ResearchDirector
   - Quartermaster
+  primary: false
 
 - type: department
   id: Engineering
@@ -95,3 +96,4 @@
   - Reporter
   - Zookeeper
   - Psychologist
+  primary: false


### PR DESCRIPTION
## About the PR
add notion of primary departments

a primary department is the actual physical department a job belongs to, but excluding hop and command since they dont have one.

engi med sec etc are primary departments, command and station specific are not.

## Why / Balance
for turf war

## Technical details
unit test is idk

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun