### PR TITLE
Adds current panic bunker status to the server's /status API

### DIFF
--- a/Content.Server/GameTicking/GameTicker.StatusShell.cs
+++ b/Content.Server/GameTicking/GameTicker.StatusShell.cs
@@ -43,6 +43,7 @@ namespace Content.Server.GameTicking
                 jObject["round_id"] = _gameTicker.RoundId;
                 jObject["players"] = _playerManager.PlayerCount;
                 jObject["soft_max_players"] = _cfg.GetCVar(CCVars.SoftMaxPlayers);
+                jObject["panic_bunker"] = _cfg.GetCVar(CCVars.PanicBunkerEnabled);
                 jObject["run_level"] = (int) _runLevel;
                 if (_runLevel >= GameRunLevel.InRound)
                 {


### PR DESCRIPTION
## About the PR
This PR is fairly straight-forward: this just adds whether or not the panic bunker is enabled in the `/status` API

## Why / Balance
Something that's immensely confusing for new players is when they try connecting to servers for the first time, only to be met with an immediate wall in the form of the panic bunker. There is no indication at all that the panic bunker is present before you download the server's assets, wait for the client to load, and eventually attempt to connect directly.

Adding the panic bunker status to the API will *directly*  pave the way to have panic bunker status be displayed right in the launcher, which would be a massive UX improvement, especially for new players who would otherwise be confused if they try joining what appears to be a public server.

## Technical details
This adds a `panic_bunker` bool to `/status`'s response that reports whether or not the panic bunker is up.

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

Unless there's any hub-scrapers or status API fetchers that explicitly rely on the JSON being in a specific order. In which case what the fuck are you doing please just parse the JSON normally

**Changelog**

No player-facing changes