### PR TITLE
Two more station beacons

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -223,8 +223,8 @@
   id: DefaultStationBeaconLawOffice
   suffix: Law Office
   components:
-    - type: NavMapBeacon
-      text: law office
+  - type: NavMapBeacon
+    text: law office
 
 - type: entity
   parent: DefaultStationBeaconSecurity
@@ -541,16 +541,16 @@
   id: DefaultStationBeaconAISatellite
   suffix: AI Satellite
   components:
-    - type: NavMapBeacon
-      text: AI satellite
+  - type: NavMapBeacon
+    text: AI satellite
 
 - type: entity
   parent: DefaultStationBeaconAI
   id: DefaultStationBeaconAICore
   suffix: AI Core
   components:
-    - type: NavMapBeacon
-      text: AI core
+  - type: NavMapBeacon
+    text: AI core
 
 - type: entity
   parent: DefaultStationBeacon

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -554,6 +554,14 @@
 
 - type: entity
   parent: DefaultStationBeacon
+  id: DefaultStationBeaconEvac
+  suffix: Evac
+  components:
+    - type: NavMapBeacon
+      text: evac
+
+- type: entity
+  parent: DefaultStationBeacon
   id: DefaultStationBeaconEVAStorage
   suffix: EVA Storage
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -231,8 +231,8 @@
   id: DefaultStationBeaconSecurityCheckpoint
   suffix: Sec Checkpoint
   components:
-    - type: NavMapBeacon
-      text: checkpoint
+  - type: NavMapBeacon
+    text: checkpoint
 
 - type: entity
   parent: DefaultStationBeacon
@@ -565,8 +565,8 @@
   id: DefaultStationBeaconEvac
   suffix: Evac
   components:
-    - type: NavMapBeacon
-      text: evac
+  - type: NavMapBeacon
+    text: evac
 
 - type: entity
   parent: DefaultStationBeacon

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -227,6 +227,14 @@
       text: law office
 
 - type: entity
+  parent: DefaultStationBeaconSecurity
+  id: DefaultStationBeaconSecurityCheckpoint
+  suffix: Sec Checkpoint
+  components:
+    - type: NavMapBeacon
+      text: checkpoint
+
+- type: entity
   parent: DefaultStationBeacon
   id: DefaultStationBeaconMedical
   suffix: Medical


### PR DESCRIPTION
## About the PR
Adds `Evac` and Security `Checkpoint` station beacon prototypes, so no one ends up mapping these with custom beacons that can't be modified en-masse, if they are ever to be renamed recolored etc
