### PR TITLE
Fix defibs resetting rot timer + slimes not having perishable

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -214,6 +214,7 @@ public sealed class DefibrillatorSystem : EntitySystem
 
         ICommonSession? session = null;
 
+        var dead = true;
         if (_rotting.IsRotten(target))
         {
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-rotten"),
@@ -229,6 +230,7 @@ public sealed class DefibrillatorSystem : EntitySystem
                 damageableComponent.TotalDamage < threshold)
             {
                 _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
+                dead = false;
             }
 
             if (_mind.TryGetMind(target, out _, out var mind) &&
@@ -248,7 +250,7 @@ public sealed class DefibrillatorSystem : EntitySystem
             }
         }
 
-        var sound = _mobState.IsDead(target, mob) || session == null
+        var sound = dead || session == null
             ? component.FailureSound
             : component.SuccessSound;
         _audio.PlayPvs(sound, uid);

--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -223,9 +223,15 @@ public sealed class DefibrillatorSystem : EntitySystem
         {
             if (_mobState.IsDead(target, mob))
                 _damageable.TryChangeDamage(target, component.ZapHeal, true, origin: uid);
-            _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
 
-            if (_mind.TryGetMind(target, out var mindId, out var mind) &&
+            if (_mobThreshold.TryGetThresholdForState(target, MobState.Dead, out var threshold) &&
+                TryComp<DamageableComponent>(target, out var damageableComponent) &&
+                damageableComponent.TotalDamage < threshold)
+            {
+                _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
+            }
+
+            if (_mind.TryGetMind(target, out _, out var mind) &&
                 mind.Session is { } playerSession)
             {
                 session = playerSession;

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -27,7 +27,6 @@
     - FootstepSound
     - DoorBumpOpener
     - SpiderCraft
-  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -284,6 +284,7 @@
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 310.15
     thermalRegulationTemperatureThreshold: 25
+  - type: Perishable
   - type: Butcherable
     butcheringType: Spike # TODO human.
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -28,7 +28,6 @@
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
         color: "#75b1f0"
-  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -28,7 +28,6 @@
   - type: Body
     prototype: Dwarf
     requiredLegs: 2
-  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -14,7 +14,6 @@
     sprite: Mobs/Species/Human/parts.rsi
     state: full
   - type: Thirst
-  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -28,7 +28,6 @@
     speechVerb: Moth
   - type: TypingIndicator
     proto: moth
-  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -21,7 +21,6 @@
   - type: Body
     prototype: Reptilian
     requiredLegs: 2
-  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -97,7 +97,6 @@
   - type: Inventory
     speciesId: vox
   - type: InventorySlots
-  - type: Perishable
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Defibs reset rot timer because they force a state change even when it gets reverted immediately. Very sad!
Slimes weren't perishable which i know people pretended like was some cool species trait but was honestly just a really weird niche that invalidates a core part of medical. I'm also 99 percent sure it was a bug.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Being able to reset rotting without actually reviving people means that you can stop rotting permanently with no tools. Just zap a person once every 10 minutes and boom no more rot at no cost.

Rotting is pretty important to medical gameplay and revival at a whole and shouldn't be trivially subverted. Slimes being able to subvert rotting by merely existing is really strange and honestly shouldn't be a thing. They're the only player species with this feature and the only thing it enables is for Med to perform a hail mary revival half an hour after they die, which really shouldn't be happening.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Defibrillators no longer reset the rot timer when failing to revive a body.
- tweak: Slimes now rot.
