### PR TITLE
ChemMaster buffer preserves list ordering

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -140,7 +140,7 @@ namespace Content.Server.Chemistry.EntitySystems
             if (fromBuffer) // Buffer to container
             {
                 amount = FixedPoint2.Min(amount, containerSolution.AvailableVolume);
-                amount = bufferSolution.RemoveReagent(id, amount);
+                amount = bufferSolution.RemoveReagent(id, amount, preserveOrder: true);
                 _solutionContainerSystem.TryAddReagent(containerSoln.Value, id, amount, out var _);
             }
             else // Container to buffer
@@ -158,7 +158,7 @@ namespace Content.Server.Chemistry.EntitySystems
             if (fromBuffer)
             {
                 if (_solutionContainerSystem.TryGetSolution(chemMaster.Owner, SharedChemMaster.BufferSolutionName, out _, out var bufferSolution))
-                    bufferSolution.RemoveReagent(id, amount);
+                    bufferSolution.RemoveReagent(id, amount, preserveOrder: true);
                 else
                     return;
             }

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -466,7 +466,7 @@ namespace Content.Shared.Chemistry.Components
         /// </summary>
         /// <param name="toRemove">The reagent to be removed.</param>
         /// <returns>How much reagent was actually removed. Zero if the reagent is not present on the solution.</returns>
-        public FixedPoint2 RemoveReagent(ReagentQuantity toRemove)
+        public FixedPoint2 RemoveReagent(ReagentQuantity toRemove, bool preserveOrder = false)
         {
             if (toRemove.Quantity <= FixedPoint2.Zero)
                 return FixedPoint2.Zero;
@@ -483,7 +483,11 @@ namespace Content.Shared.Chemistry.Components
 
                 if (newQuantity <= 0)
                 {
-                    Contents.RemoveSwap(i);
+                    if (!preserveOrder)
+                        Contents.RemoveSwap(i);
+                    else
+                        Contents.RemoveAt(i);
+
                     Volume -= curQuantity;
                     ValidateSolution();
                     return curQuantity;
@@ -516,9 +520,9 @@ namespace Content.Shared.Chemistry.Components
         /// <param name="reagentId">The reagent to be removed.</param>
         /// <param name="quantity">The amount of reagent to remove.</param>
         /// <returns>How much reagent was actually removed. Zero if the reagent is not present on the solution.</returns>
-        public FixedPoint2 RemoveReagent(ReagentId reagentId, FixedPoint2 quantity)
+        public FixedPoint2 RemoveReagent(ReagentId reagentId, FixedPoint2 quantity, bool preserveOrder = false)
         {
-            return RemoveReagent(new ReagentQuantity(reagentId, quantity));
+            return RemoveReagent(new ReagentQuantity(reagentId, quantity), preserveOrder);
         }
 
         public void RemoveAllSolution()


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The ChemMaster now maintains list ordering when you remove a reagent from the buffer, instead of replacing it with the last item inserted into the buffer.

## Why / Balance
Quality of Life for Chemists, helps you keep track of where your Chems are instead of the last one deciding to dart to the front or middle. Helps with pill creation so you don't accidentally delete the Chemical you want to make a pill out of while clearing your buffer.

## Technical details
RemoveReagent() now has an optional parameter to preserve the order of reagents. ChemMasterSystem uses this to preserve the order. Only the ChemMaster uses it as it causes a minor performance hit since this operation is not O(1) and it is not useful for other reagent removals to maintain their orders.

## Media

https://github.com/space-wizards/space-station-14/assets/57879983/8489d89b-e643-4e1e-ae89-4b2c27f46057

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: The ChemMaster buffer no longer shuffles list ordering when removing a reagent.
