### PR TITLE
Revs Refactor: Flashing is temporary, but head revs have more cool tools

### DIFF
--- a/Content.Server/Revolutionary/RevolutionarySystem.cs
+++ b/Content.Server/Revolutionary/RevolutionarySystem.cs
@@ -1,0 +1,58 @@
+﻿using Content.Server.NodeContainer;
+using Content.Shared.CCVar;
+using Content.Shared.Revolutionary;
+using Content.Shared.Revolutionary.Components;
+using Robust.Shared.Configuration;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Revolutionary;
+
+public sealed class RevolutionarySystem : SharedRevolutionarySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IConfigurationManager _configManager = default!;
+    [Dependency] private readonly IRobustRandom _robustRandom = default!;
+
+    public override void Update(float frameTime)
+    {
+        var curTime = _gameTiming.CurTime;
+
+        var enumerator = EntityQueryEnumerator<RevolutionaryComponent>();
+
+        while (enumerator.MoveNext(out var uid, out var controller))
+        {
+            if (controller.NextFlashEscapeTime > curTime)
+                continue;
+
+            AttemptToFreeFromBeingFlashed(uid, curTime, controller);
+        }
+    }
+
+    /// <summary>
+    /// Randomly attempts to free someone from being flashed. If successful, they cease being a revolutionary.
+    /// If unsuccessful, the next time they attempt to free themselves will be more likely to succeed.
+    /// </summary>
+    public void AttemptToFreeFromBeingFlashed(EntityUid uid, TimeSpan curTime, RevolutionaryComponent rev)
+    {
+        var baseChance = _configManager.GetCVar(CCVars.BaseChanceOfFlashWearingOff);
+        var incChance = _configManager.GetCVar(CCVars.IncrementChanceOfFlashWearingOff);
+        var chance = baseChance + incChance * rev.EscapeAttemptsSoFar;
+
+        if (_robustRandom.Prob(chance))
+        {
+            RaiseLocalEvent(uid, new FreedFromControlMessage());
+
+            return;
+        }
+
+        rev.NextFlashEscapeTime = curTime + TimeSpan.FromSeconds(_configManager.GetCVar(CCVars.TimeBetweenFlashWearOffAttempts));
+        rev.EscapeAttemptsSoFar++;
+    }
+
+    public void ResetRevFlashedTimer(RevolutionaryComponent rev)
+    {
+        rev.NextFlashEscapeTime = _timing.CurTime + TimeSpan.FromSeconds(_configManager.GetCVar(CCVars.TimeBeforeFlashCanExpire));
+    }
+}

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1951,15 +1951,15 @@ namespace Content.Shared.CCVar
          */
 
         public static readonly CVarDef<float> TimeBeforeFlashCanExpire =
-            CVarDef.Create("antagonists.revolutionaries.time_before_flash_can_wear_off_seconds", 900.0f);
+            CVarDef.Create("antagonists.revolutionaries.time_before_flash_can_wear_off_seconds", 900.0f); // 15 minutes
 
         public static readonly CVarDef<float> TimeBetweenFlashWearOffAttempts =
-            CVarDef.Create("antagonists.revolutionaries.time_between_wear_off_attempts", 60.0f);
+            CVarDef.Create("antagonists.revolutionaries.time_between_wear_off_attempts", 60.0f); // 1 minute
 
         public static readonly CVarDef<float> BaseChanceOfFlashWearingOff =
-            CVarDef.Create("antagonists.revolutionaries.base_chance_flash_wearing_off", 0.05f);
+            CVarDef.Create("antagonists.revolutionaries.base_chance_flash_wearing_off", 0.0056f); // Approximately 50% chance of breaking free after 30 minutes
 
         public static readonly CVarDef<float> IncrementChanceOfFlashWearingOff =
-            CVarDef.Create("antagonists.revolutionaries.increment_chance_flash_wearing_off", 0.05f);
+            CVarDef.Create("antagonists.revolutionaries.increment_chance_flash_wearing_off", 0.0056f);
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1945,5 +1945,21 @@ namespace Content.Shared.CCVar
 
         public static readonly CVarDef<bool> GatewayGeneratorEnabled =
             CVarDef.Create("gateway.generator_enabled", true);
+
+        /*
+         * Antagonist rules
+         */
+
+        public static readonly CVarDef<float> TimeBeforeFlashCanExpire =
+            CVarDef.Create("antagonists.revolutionaries.time_before_flash_can_wear_off_seconds", 900.0f);
+
+        public static readonly CVarDef<float> TimeBetweenFlashWearOffAttempts =
+            CVarDef.Create("antagonists.revolutionaries.time_between_wear_off_attempts", 60.0f);
+
+        public static readonly CVarDef<float> BaseChanceOfFlashWearingOff =
+            CVarDef.Create("antagonists.revolutionaries.base_chance_flash_wearing_off", 0.05f);
+
+        public static readonly CVarDef<float> IncrementChanceOfFlashWearingOff =
+            CVarDef.Create("antagonists.revolutionaries.increment_chance_flash_wearing_off", 0.05f);
     }
 }

--- a/Content.Shared/Revolutionary/Components/RevolutionaryComponent.cs
+++ b/Content.Shared/Revolutionary/Components/RevolutionaryComponent.cs
@@ -1,6 +1,8 @@
 using Robust.Shared.GameStates;
 using Content.Shared.StatusIcon;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Revolutionary.Components;
 
@@ -15,4 +17,20 @@ public sealed partial class RevolutionaryComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public ProtoId<StatusIconPrototype> RevStatusIcon = "RevolutionaryFaction";
+
+    /// <summary>
+    /// The time at which the rev will try and escape their flashed state
+    /// </summary>
+    [DataField("flashStartEscapeTime", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan NextFlashEscapeTime = TimeSpan.Zero;
+
+    /// <summary>
+    /// How many times has the rev attempted to escape? This is set to zero if they're re-flashed.
+    /// </summary>
+    public int EscapeAttemptsSoFar;
+}
+
+[Serializable, NetSerializable]
+public sealed class FreedFromControlMessage : EntityEventArgs
+{
 }

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -6,7 +6,7 @@ using Content.Shared.Stunnable;
 
 namespace Content.Shared.Revolutionary;
 
-public sealed class SharedRevolutionarySystem : EntitySystem
+public abstract class SharedRevolutionarySystem : EntitySystem
 {
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedStunSystem _sharedStun = default!;
@@ -15,6 +15,7 @@ public sealed class SharedRevolutionarySystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<MindShieldComponent, MapInitEvent>(MindShieldImplanted);
+        SubscribeLocalEvent<RevolutionaryComponent, FreedFromControlMessage>(FreedFromControl);
     }
 
     /// <summary>
@@ -28,13 +29,23 @@ public sealed class SharedRevolutionarySystem : EntitySystem
             return;
         }
 
-        if (HasComp<RevolutionaryComponent>(uid))
-        {
-            var stunTime = TimeSpan.FromSeconds(4);
-            var name = Identity.Entity(uid, EntityManager);
-            RemComp<RevolutionaryComponent>(uid);
-            _sharedStun.TryParalyze(uid, stunTime, true);
-            _popupSystem.PopupEntity(Loc.GetString("rev-break-control", ("name", name)), uid);
-        }
+        FreeFromControl(uid);
+    }
+
+    private void FreedFromControl(EntityUid uid, RevolutionaryComponent comp, FreedFromControlMessage ev)
+    {
+        FreeFromControl(uid);
+    }
+
+    private void FreeFromControl(EntityUid uid)
+    {
+        if (!HasComp<RevolutionaryComponent>(uid))
+            return;
+
+        var stunTime = TimeSpan.FromSeconds(4);
+        var name = Identity.Entity(uid, EntityManager);
+        RemComp<RevolutionaryComponent>(uid);
+        _sharedStun.TryParalyze(uid, stunTime, true);
+        _popupSystem.PopupEntity(Loc.GetString("rev-break-control", ("name", name)), uid);
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
By default, this PR changes the rev gamemode by making flashes only _temporarily_ convert somebody to a revolutionary. How temporarily? By default:

AFTER FIFTEEN MINUTES: the rev has a 0.0056% chance for the flash to wear off.
EACH MINUTE AFTERWARDS: this chance increases by 0.0056%.
And so on.

Mathematically this means that breaking free in 20 minutes is about a 1/10 chance, and in 30 minutes is about a coin-flip.

This means that revs have to try and bring about the death of the heads _reasonably quickly_ once they begin flashing people.

HOWEVER, a head rev is also at liberty to re-flash all their revs. So a small team of revs can be kept flashed and safe.

## Why / Balance
This is a pretty major change to how revs work that might well badly destabilize the game mode so I'll just preface this with the fact that the key numbers for how this work are exposed to admin cvar, and thus it can be turned on/off at will.

The revolutionary round mode is a classic SS13 mode but it was raised at the latest maintenance meeting related to it being a bit wonky on MRP, etc.

#23329 proposes making mildshields rarer to try and prevent Sec from just rushing to mindshield the station at a hint of revs. This doesn't fix any of the basic problems with revs: it being highly disruptive in on MRP, it causing stalemates and the only route Sec have to winning against revs (other than mass murder) is to get mindshields, which rely on, amongst other things, Cargo not being a giant hole into space.

What this change does do is give Sec another win condition versus revolutionaries: time. A competently defended station _can_ come back from a wave of flashed greytiders.

The intent of this change would be to make a revolution round promote a sneaky few head revs flashing a small core team early, plotting their overflow, then going big and loud. If a head rev wastes a flash on some scientist or atmos tech who is then forgotten about and not given orders for over fifteen minutes, that flashed player is free to go back to having a normal round, not being stuck as a directionless antag. And this provides a non-murderhobo way of solving a rev round.

This is only a proposal (I'm only baby contributor pls no hate) and I'm wanting to add more to this PR to round it out over the next few days.

## Technical details
A new server-side RevolutionarySystem, a new event, some small refactors. I've run this through on Contributor VC to make sure I'm not doing something very dumb.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

TBD, it's 5am

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

TBD, it's 5am
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
