### PR TITLE
Remove salvage mobs being able to be ghost roles.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   name: basic
   id: MobSpaceBasic
   parent: SimpleSpaceMobBase
@@ -110,20 +110,12 @@
     interactFailureString: petting-failure-bear
     interactSuccessSound:
       path: /Audio/Animals/sloth_squeak.ogg
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-space-bear-name
-    description: ghost-role-information-space-bear-description
 
 - type: entity
   id: MobBearSpaceSalvage
   parent: MobBearSpace
   suffix: "Salvage Ruleset"
   components:
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-salvage-bear-name
-    description: ghost-role-information-salvage-bear-description
   - type: SalvageMobRestrictions
 
 - type: entity
@@ -181,20 +173,12 @@
     interfaces:
     - key: enum.StrippingUiKey.Key
       type: StrippableBoundUserInterface
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-space-kangaroo-name
-    description: ghost-role-information-space-kangaroo-description
 
 - type: entity
   id: MobKangarooSpaceSalvage
   parent: MobKangarooSpace
   suffix: "Salvage Ruleset"
   components:
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-salvage-kangaroo-name
-    description: ghost-role-information-salvage-kangaroo-description
   - type: SalvageMobRestrictions
 
 - type: entity
@@ -276,10 +260,6 @@
     color: "#4faffb"
   - type: NoSlip
   - type: IgnoreSpiderWeb
-  - type: GhostRole
-    prob: 0.30
-    name: ghost-role-information-space-spider-name
-    description: ghost-role-information-space-spider-description
   - type: Speech
     speechVerb: Arachnid
 
@@ -288,10 +268,6 @@
   parent: MobSpiderSpace
   suffix: "Salvage Ruleset"
   components:
-  - type: GhostRole
-    prob: 0.30
-    name: ghost-role-information-salvage-spider-name
-    description: ghost-role-information-salvage-spider-description
   - type: SalvageMobRestrictions
 
 - type: entity
@@ -377,10 +353,6 @@
       radius: 1.1
       energy: 1.5
       color: "#4faffb"
-    - type: GhostRole
-      prob: 0.25
-      name: ghost-role-information-space-cobra-name
-      description: ghost-role-information-space-cobra-description
     - type: Stealth
       enabledOnDeath: false
       maxVisibility: 1.2
@@ -393,8 +365,4 @@
   parent: MobCobraSpace
   suffix: "Salvage Ruleset"
   components:
-    - type: GhostRole
-      prob: 0.25
-      name: ghost-role-information-salvage-cobra-name
-      description: ghost-role-information-salvage-cobra-description
     - type: SalvageMobRestrictions

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -74,11 +74,6 @@
           Quantity: 5
   - type: MeleeChemicalInjector
     solution: melee
-  - type: GhostRole
-    prob: 0.33
-    makeSentient: true
-    name: ghost-role-information-space-tick-name
-    description: ghost-role-information-space-tick-description
   - type: GhostTakeoverAvailable
   - type: ReplacementAccent
     accent: genericAggressive
@@ -91,9 +86,6 @@
   parent: MobTick
   suffix: "Salvage Ruleset"
   components:
-  - type: GhostRole
-    name: ghost-role-information-salvage-tick-name
-    description: ghost-role-information-salvage-tick-description
   - type: GhostTakeoverAvailable
   - type: SalvageMobRestrictions
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Following maintainer consensus, this is being removed for a number of reasons:
- players abusing the role to go to the station and cause chaos
- it's not particularly fun for players
- other reasons that i forgot

**Changelog**

:cl: Ubaser
- remove: Salvage mobs can no longer be ghost roles.
