### PR TITLE
refill welders from wall dispensers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
@@ -79,3 +79,5 @@
         reagents:
         - ReagentId: WeldingFuel
           Quantity: 1000
+  - type: ReagentTank
+    tankType: Fuel


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Closes #23364

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Allows engineers to quickly refill welders without needing a separate liquid container.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Welders can be refilled directly from wall fuel dispensers
