### PR TITLE
Increase zombie prying time for bolted doors

### DIFF
--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -173,6 +173,9 @@ public sealed class AirlockSystem : SharedAirlockSystem
     {
         if (_power.IsPowered(uid))
             args.PryTimeModifier *= component.PoweredPryModifier;
+
+        if (_bolts.IsBolted(uid))
+            args.PryTimeModifier *= component.BoltedPryModifier;
     }
 
     private void OnBeforePry(EntityUid uid, AirlockComponent component, ref BeforePryEvent args)

--- a/Content.Shared/Doors/Components/AirlockComponent.cs
+++ b/Content.Shared/Doors/Components/AirlockComponent.cs
@@ -135,5 +135,12 @@ public sealed partial class AirlockComponent : Component
     [DataField]
     public float DenyAnimationTime = 0.3f;
 
+    /// <summary>
+    /// Pry modifier for a bolted airlock.
+    /// Currently only zombies can pry bolted airlocks.
+    /// </summary>
+    [DataField]
+    public float BoltedPryModifier = 3f;
+
     #endregion Graphics
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Closes #23165

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

It's strange that it takes the same time for zombies to pry open bolted versus unbolted doors. This encourages survivors to bolt doors to possibly buy them some extra time against the horde.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Simply adds a new pry time modifier for bolted status. This currently only affects zombies, as nothing else seems to have the ability to pry open bolted doors.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Zombies now take longer to pry open bolted doors.
