### PR TITLE
Button for admins to become invisible to other players.

### DIFF
--- a/Content.Client/Administration/UI/Tabs/AdminTab/AdminTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/AdminTab/AdminTab.xaml
@@ -16,6 +16,8 @@
             <cc:UICommandButton Command="callshuttle" Text="{Loc admin-player-actions-window-shuttle}" WindowType="{x:Type at:AdminShuttleWindow}"/>
             <cc:CommandButton Command="adminlogs" Text="{Loc admin-player-actions-window-admin-logs}"/>
             <cc:CommandButton Command="faxui" Text="{Loc admin-player-actions-window-admin-fax}"/>
+            <cc:CommandButton Command="changevisibility 2" Text="{Loc admin-player-actions-window-mark-visible}"/>
+            <cc:CommandButton Command="changevisibility 7" Text="{Loc admin-player-actions-window-mark-invisible}"/>
         </GridContainer>
     </BoxContainer>
 </Control>

--- a/Content.Server/Administration/Commands/ChangeVisibilityCommand.cs
+++ b/Content.Server/Administration/Commands/ChangeVisibilityCommand.cs
@@ -1,0 +1,48 @@
+﻿using Content.Shared.Administration;
+using Robust.Server.GameObjects;
+using Robust.Shared.Console;
+
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class ChangeVisibilityCommand : LocalizedCommands
+{
+    [Dependency] private readonly IEntityManager _entities = default!;
+
+    public override string Command => "changevisibility";
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var player = shell.Player;
+        if (player == null)
+        {
+            shell.WriteLine(Loc.GetString("shell-only-players-can-run-this-command"));
+            return;
+        }
+
+        if (player.AttachedEntity == null)
+        {
+            shell.WriteLine(Loc.GetString("shell-must-be-attached-to-entity"));
+            return;
+        }
+
+        if (args.Length != 1)
+        {
+            shell.WriteLine(Loc.GetString("shell-need-exactly-one-argument"));
+            return;
+        }
+
+        if (!int.TryParse(args[0], out var layer))
+        {
+            shell.WriteLine(Loc.GetString("shell-argument-must-be-number"));
+            return;
+        }
+
+        if (!_entities.TryGetComponent<VisibilityComponent>(player.AttachedEntity, out var visibilityComponent))
+        {
+            shell.WriteLine(Loc.GetString("cmd-visibility-no-visibility-component"));
+            return;
+        }
+
+        _entities.System<VisibilitySystem>().SetLayer((EntityUid) player.AttachedEntity, visibilityComponent, layer);
+    }
+}

--- a/Resources/Locale/en-US/administration/commands/change-visibility.ftl
+++ b/Resources/Locale/en-US/administration/commands/change-visibility.ftl
@@ -1,0 +1,1 @@
+﻿cmd-visibility-no-visibility-component = You do not have a visibility component. You can not use this command.

--- a/Resources/Locale/en-US/administration/ui/tabs/admin-tab/player-actions-window.ftl
+++ b/Resources/Locale/en-US/administration/ui/tabs/admin-tab/player-actions-window.ftl
@@ -8,3 +8,5 @@ admin-player-actions-window-shuttle = (Re)call Shuttle
 admin-player-actions-window-admin-logs = Admin Logs
 admin-player-actions-window-admin-notes = Admin Notes
 admin-player-actions-window-admin-fax = Admin Fax
+admin-player-actions-window-mark-visible = Mark ghost visible
+admin-player-actions-window-mark-invisible = Mark ghost invisible


### PR DESCRIPTION
## About the PR
Adds a button for aghosts to become invisible

## Why / Balance
Admins are often cursed to be orbitied. Also kind of resolves #20158. 

## Technical details
Adds a new command called `changevisibility` which changes the visibility of the current attachted entity. Fails if there isn't a visibility component (For example: a normal character). 
Also adds two buttons to the admin panel which both execute `changevisibility 2` and `changevisibility 7` respectively. Aghosts who are not marked invisible, will not see aghosts who are marked invisible. I plan on changing this, but currently don't know how, which is why this is marked as a draft.
## Media
https://cdn.discordapp.com/attachments/1182777817105190982/1191716616124243988/Base_Profile_2024.01.02_-_13.13.26.04.mp4?ex=65a67396&is=6593fe96&hm=9d1b4ed8d6e462999de514938eef0941cdd375816a12bbbcaa68fbc2e65d8ebe&
(I still don't know how to embed video)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
No player facing changelog
