### PR TITLE
Wire up the slime people TypingIndicator to use the existing slime speech.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -120,6 +120,8 @@
     description: ghost-role-information-slimes-description
   - type: Speech
     speechVerb: Slime
+  - type: TypingIndicator
+    proto: slime
 
 - type: entity
   name: blue slime

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -20,6 +20,8 @@
   - type: Speech
     speechVerb: Slime
     speechSounds: Slime
+  - type: TypingIndicator
+    proto: slime
   - type: Vocal
     sounds:
       Male: MaleSlime

--- a/Resources/Prototypes/typing_indicator.yml
+++ b/Resources/Prototypes/typing_indicator.yml
@@ -33,3 +33,8 @@
   id: spider
   typingState: spider0
   offset: 0, 0.125
+
+- type: typingIndicator
+  id: slime
+  typingState: slime0
+  offset: 0, 0.125


### PR DESCRIPTION
## About the PR
After seeing the lizard speech bubble PR, I figured a good first step for myself would be to wire up the existing slime speech for slimes. Pretty basic, just yml changes.

## Why / Balance
Other mobs get cool speech bubbles, why not slimes!

## Media

https://github.com/space-wizards/space-station-14/assets/87243814/1c57edf8-8f61-4d2e-be14-5fb613acd2a0

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Give slimes their custom speech bubble!
