### PR TITLE
Gauze recipe in medfab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -768,6 +768,7 @@
     staticRecipes:
       - Brutepack
       - Ointment
+      - Gauze
       - HandLabeler
       - Defibrillator
       - HandheldHealthAnalyzer

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -65,6 +65,13 @@
     Plastic: 25
 
 - type: latheRecipe
+  id: Gauze
+  result: Gauze1
+  completetime: 1
+  materials:
+    Cloth: 200
+
+- type: latheRecipe
   id: HandheldCrewMonitor
   result: HandheldCrewMonitorEmpty
   completetime: 2


### PR DESCRIPTION
## About the PR
Gauze can now be crafted in medical fabricators for 2 cloth.

## Why / Balance
To speed up the production of gauze in the medical department, no more cutting up clothes and crafting bandages by hand.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/140123969/8761cd68-88d1-4520-8d63-94ed3683631c)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: After realizing their employees have been forced to make medical supplies by hand, Centcomm has added a gauze option to their medical fabricators.