### PR TITLE
syndicate agents are now red

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -3,7 +3,7 @@
 traitor-round-end-codewords = The codewords were: [color=White]{$codewords}[/color]
 traitor-round-end-agent-name = traitor
 
-objective-issuer-syndicate = [color=#87cefa]The Syndicate[/color]
+objective-issuer-syndicate = [color=crimson]The Syndicate[/color]
 
 # Shown at the end of a round of Traitor
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
change objective issuer syndicate to red color instead of blue

## Why / Balance
syndies are red, not blue
And it looks better compared to blue

## Technical details
0

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/0f153e69-fde4-454e-91d5-3aff530e18ca)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No

**Changelog**
nope