### PR TITLE
Fix remote solution injection

### DIFF
--- a/Content.Server/Chemistry/Components/SolutionInjectOnCollideComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionInjectOnCollideComponent.cs
@@ -1,29 +1,27 @@
 ﻿using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
 
-namespace Content.Server.Chemistry.Components
+namespace Content.Server.Chemistry.Components;
+
+/// <summary>
+/// On colliding with an entity that has a bloodstream will dump its solution onto them.
+/// </summary>
+[RegisterComponent]
+public sealed partial class SolutionInjectOnCollideComponent : Component
 {
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("transferAmount")]
+    public FixedPoint2 TransferAmount = FixedPoint2.New(1);
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float TransferEfficiency { get => _transferEfficiency; set => _transferEfficiency = Math.Clamp(value, 0, 1); }
+
+    [DataField("transferEfficiency")]
+    private float _transferEfficiency = 1f;
+
     /// <summary>
-    /// On colliding with an entity that has a bloodstream will dump its solution onto them.
+    /// If anything covers any of these slots then the injection fails.
     /// </summary>
-    [RegisterComponent]
-    internal sealed partial class SolutionInjectOnCollideComponent : Component
-    {
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("transferAmount")]
-        public FixedPoint2 TransferAmount { get; set; } = FixedPoint2.New(1);
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float TransferEfficiency { get => _transferEfficiency; set => _transferEfficiency = Math.Clamp(value, 0, 1); }
-
-        [DataField("transferEfficiency")]
-        private float _transferEfficiency = 1f;
-
-        /// <summary>
-        /// If anything covers any of these slots then the injection fails.
-        /// </summary>
-        [DataField("blockSlots"), ViewVariables(VVAccess.ReadWrite)]
-        public SlotFlags BlockSlots = SlotFlags.MASK;
-    }
+    [DataField("blockSlots"), ViewVariables(VVAccess.ReadWrite)]
+    public SlotFlags BlockSlots = SlotFlags.MASK;
 }

--- a/Content.Server/Chemistry/EntitySystems/SolutionInjectOnCollideSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionInjectOnCollideSystem.cs
@@ -6,48 +6,47 @@ using Content.Shared.Inventory;
 using JetBrains.Annotations;
 using Robust.Shared.Physics.Events;
 
-namespace Content.Server.Chemistry.EntitySystems
+namespace Content.Server.Chemistry.EntitySystems;
+
+public sealed class SolutionInjectOnCollideSystem : EntitySystem
 {
-    [UsedImplicitly]
-    internal sealed class SolutionInjectOnCollideSystem : EntitySystem
+    [Dependency] private readonly SolutionContainerSystem _solutionContainersSystem = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
+    [Dependency] private readonly InventorySystem _inventorySystem = default!;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly SolutionContainerSystem _solutionContainersSystem = default!;
-        [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
-        [Dependency] private readonly InventorySystem _inventorySystem = default!;
+        base.Initialize();
+        SubscribeLocalEvent<SolutionInjectOnCollideComponent, StartCollideEvent>(HandleInjection);
+    }
 
-        public override void Initialize()
+    private void HandleInjection(Entity<SolutionInjectOnCollideComponent> ent, ref StartCollideEvent args)
+    {
+        var component = ent.Comp;
+        var target = args.OtherEntity;
+
+        if (!args.OtherBody.Hard ||
+            !args.OurBody.Hard ||
+            !EntityManager.TryGetComponent<BloodstreamComponent>(target, out var bloodstream) ||
+            !_solutionContainersSystem.TryGetInjectableSolution(ent.Owner, out var solution, out _))
         {
-            base.Initialize();
-            SubscribeLocalEvent<SolutionInjectOnCollideComponent, StartCollideEvent>(HandleInjection);
+            return;
         }
 
-        private void HandleInjection(Entity<SolutionInjectOnCollideComponent> ent, ref StartCollideEvent args)
+        if (component.BlockSlots != 0x0)
         {
-            var component = ent.Comp;
-            var target = args.OtherEntity;
+            var containerEnumerator = _inventorySystem.GetSlotEnumerator(target, component.BlockSlots);
 
-            if (!args.OtherBody.Hard ||
-                !EntityManager.TryGetComponent<BloodstreamComponent>(target, out var bloodstream) ||
-                !_solutionContainersSystem.TryGetInjectableSolution(ent.Owner, out var solution, out _))
-            {
+            // TODO add a helper method for this?
+            if (containerEnumerator.MoveNext(out _))
                 return;
-            }
-
-            if (component.BlockSlots != 0x0)
-            {
-                var containerEnumerator = _inventorySystem.GetSlotEnumerator(target, component.BlockSlots);
-
-                // TODO add a helper method for this?
-                if (containerEnumerator.MoveNext(out _))
-                    return;
-            }
-
-            var solRemoved = _solutionContainersSystem.SplitSolution(solution.Value, component.TransferAmount);
-            var solRemovedVol = solRemoved.Volume;
-
-            var solToInject = solRemoved.SplitSolution(solRemovedVol * component.TransferEfficiency);
-
-            _bloodstreamSystem.TryAddToChemicals(target, solToInject, bloodstream);
         }
+
+        var solRemoved = _solutionContainersSystem.SplitSolution(solution.Value, component.TransferAmount);
+        var solRemovedVol = solRemoved.Volume;
+
+        var solToInject = solRemoved.SplitSolution(solRemovedVol * component.TransferEfficiency);
+
+        _bloodstreamSystem.TryAddToChemicals(target, solToInject, bloodstream);
     }
 }


### PR DESCRIPTION
Checks if its own fixture is hard so the fly-by fixture can't also proc it.

Line 29 is the changed line the rest is just file-scoped namespace.

:cl:
- fix: Fix solution injections considering the fly-by sound range and not the collision range.
