### PR TITLE
head revolutionaries are now blue

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -7,7 +7,6 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Mind;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.Systems;
-using Content.Server.Objectives;
 using Content.Server.Popups;
 using Content.Server.Revolutionary.Components;
 using Content.Server.Roles;
@@ -43,7 +42,6 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
-    [Dependency] private readonly ObjectivesSystem _objectives = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly RoleSystem _role = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
@@ -104,18 +102,28 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             ev.AddLine(Loc.GetString(Outcomes[index]));
 
             ev.AddLine(Loc.GetString("rev-headrev-count", ("initialCount", headrev.HeadRevs.Count)));
-            foreach (var player in headrev.HeadRevs.Values)
+            foreach (var player in headrev.HeadRevs)
             {
-                var title = _objectives.GetTitle(player);
-                if (title == null)
-                    continue;
-
                 // TODO: when role entities are a thing this has to change
-                var count = CompOrNull<RevolutionaryRoleComponent>(player)?.ConvertedCount ?? 0;
-                ev.AddLine(Loc.GetString("rev-headrev-player", ("title", title), ("count", count)));
+                var count = CompOrNull<RevolutionaryRoleComponent>(player.Value)?.ConvertedCount ?? 0;
+
+                _mind.TryGetSession(player.Value, out var session);
+                var username = session?.Name;
+                if (username != null)
+                {
+                    ev.AddLine(Loc.GetString("rev-headrev-name-user",
+                    ("name", player.Key),
+                    ("username", username), ("count", count)));
+                }
+                else
+                {
+                    ev.AddLine(Loc.GetString("rev-headrev-name",
+                    ("name", player.Key), ("count", count)));
+                }
 
                 // TODO: someone suggested listing all alive? revs maybe implement at some point
             }
+            break;
         }
     }
 

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -123,7 +123,6 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
                 // TODO: someone suggested listing all alive? revs maybe implement at some point
             }
-            break;
         }
     }
 

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -55,7 +55,12 @@ rev-headrev-count = {$initialCount ->
     *[other] There were {$initialCount} Head Revolutionaries:
 }
 
-rev-headrev-player = {$title} converted {$count} {$count ->
+rev-headrev-name-user = [color=#5e9cff]{$name}[/color] ([color=gray]{$username}[/color]) converted {$count} {$count ->
     [one] person
     *[other] people
-}.
+}
+
+rev-headrev-name = [color=#5e9cff]{$name}[/color] converted {$count} {$count ->
+    [one] person
+    *[other] people
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
the round summary title is now blue

## Why / Balance
it was blue before the convert count update, looks cool

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/45e83872-a5ac-4e4f-9813-ad0a0dfde101)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
no
