### PR TITLE
Dims the light source of service lights

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -145,8 +145,8 @@
   - type: LightBulb
     bulb: Bulb
     color: "#CCFF60"
-    lightEnergy: 1.0
-    lightRadius: 2
+    lightEnergy: 0.45
+    lightRadius: 1.5
     lightSoftness: 3
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/service_light.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/service_light.yml
@@ -12,9 +12,10 @@
       map: ["enum.PoweredLightLayers.Base"]
     state: off
   - type: PointLight
-    radius: 1
-    energy: 1
-    softness: 1
+    radius: 1.5
+    energy: 0.45
+    softness: 3
+    offset: "0, 0"
     enabled: false
   - type: PoweredLight
     bulb: Bulb


### PR DESCRIPTION
## About the PR
This is just a set of simple value tweaks to the light source of service lights

## Why / Balance
Service lights are honestly obnoxiously bright at the moment. They're supposed to be a mere indicator light, yet they are *extremely* bright to the point where they reliably overpower standard room lighting. They're bright enough to genuinely serve as the primary lights for a given room! So this PR makes them emit a far more reasonable amount of light. They still don't blink like their sprite does, but they're no longer an eyesore when they're active.

## Technical details
N/A

## Media

### BEFORE:
![293865292-16663132-7a18-4748-8ef5-64c25e31a3a3](https://github.com/space-wizards/space-station-14/assets/6356337/6526a304-6cb0-49b0-8f15-4cf944980a82)

### AFTER:
![image](https://github.com/space-wizards/space-station-14/assets/6356337/c795b99e-31aa-4534-b2a5-a45515170c39)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- tweak: Service lights have had their overall brightness toned down.

