### PR TITLE
Restart votes have max player count check

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1228,6 +1228,12 @@ namespace Content.Shared.CCVar
             CVarDef.Create("vote.restart_enabled", true, CVar.SERVERONLY);
 
         /// <summary>
+        ///     Config for when the restart vote should be allowed to be called
+        /// </summary>
+        public static readonly CVarDef<int> VoteRestartMinPlayers =
+            CVarDef.Create("vote.restart_min_players", 20, CVar.SERVERONLY);
+
+        /// <summary>
         ///     See vote.enabled, but specific to preset votes
         /// </summary>
         public static readonly CVarDef<bool> VotePresetEnabled =

--- a/Resources/Locale/en-US/voting/managers/vote-manager.ftl
+++ b/Resources/Locale/en-US/voting/managers/vote-manager.ftl
@@ -6,6 +6,7 @@ ui-vote-initiator-server = The server
 ui-vote-restart-title = Restart round
 ui-vote-restart-succeeded = Restart vote succeeded.
 ui-vote-restart-failed = Restart vote failed (need { TOSTRING($ratio, "P0") }).
+ui-vote-restart-fail-too-many-players = Restart vote failed - Less than { $maxPlayers } players in game required to call restart vote.
 ui-vote-restart-yes = Yes
 ui-vote-restart-no = No
 ui-vote-restart-abstain = Abstain


### PR DESCRIPTION
## About the PR
Follow on from the restart vote abuse issue raised on: #23404. I used one of the ideas on PJB's comment, suggesting a min player count required to cast votes. It set it to 20 but can be altered easily in cvar.

## Why / Balance
Because I'm already over seeing the restart vote 3-10 times almost every round. Its just being abused by people that are dead and don't want to let the round play out. Verbal admin deterrents are ineffective.

## Technical details
Wrapped the existing callRestartVote code if an condition that checks current player count exceeds a cvar value for players. 
Current players > cvar (currently set to 20) 

## Media
<img width="617" alt="image" src="https://github.com/space-wizards/space-station-14/assets/47093363/ecf1a476-72ed-42b9-ae56-ea0fcf8cdd72">

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
New ftl line, not really sure if that's breaking but might need to be added on other languages?

**Changelog**

:cl: Repo
- fix: No more restart vote spam.

