### PR TITLE
Blindness hotfix (content side)

### DIFF
--- a/Content.Client/Eye/Blinding/BlindOverlay.cs
+++ b/Content.Client/Eye/Blinding/BlindOverlay.cs
@@ -85,7 +85,6 @@ namespace Content.Client.Eye.Blinding
                 _circleMaskShader?.SetParameter("Zoom", content.Zoom.X);
             }
 
-            _circleMaskShader?.SetParameter("SCREEN_TEXTURE", ScreenTexture);
             _greyscaleShader?.SetParameter("SCREEN_TEXTURE", ScreenTexture);
 
             var worldHandle = args.WorldHandle;

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -4,7 +4,7 @@
   path: "/Textures/Shaders/circle_mask.swsl"
   params:
     CircleRadius: 15.0
-    CircleMinDist: 0.25
+    CircleMinDist: 0.0
     CirclePow: 0.5
     CircleMax: 4.0
     CircleMult: 0.5

--- a/Resources/Textures/Shaders/cataracts.swsl
+++ b/Resources/Textures/Shaders/cataracts.swsl
@@ -60,7 +60,6 @@ void fragment() {
     highp float distortionZoom = pow(Zoom, DistortionZoomPow);
 
     highp float centergradient = zCircleGradient(aspect, FRAGCOORD.xy, DistortionGradientMax, DistortionCenterRadius / distortionZoom, DistortionCenterMinDist / distortionZoom, DistortionCenterPow);
-    //highp vec2 coord = (FRAGCOORD.xy * SCREEN_PIXEL_SIZE.xy) * aspect * centergradient * 0.0001;
     highp vec2 coord = (FRAGCOORD.xy * SCREEN_PIXEL_SIZE.xy) * centergradient * DistortionCoordScalar;
     highp vec2 offset = vec2((zFBM(coord * NoiseScalar + timesin) - 0.5) * centergradient, (zFBM(coord * NoiseScalar + timecos) - 0.5) * centergradient);
     COLOR = zTextureSpec(SCREEN_TEXTURE, Pos + (offset * DistortionScalar));

--- a/Resources/Textures/Shaders/cataracts.swsl
+++ b/Resources/Textures/Shaders/cataracts.swsl
@@ -24,6 +24,7 @@ uniform highp float Zoom;
 
 // Base distortion
 uniform highp float DistortionScalar; // Scales the total distortion applied to the final image.
+const highp float DistortionCoordScalar = 0.1125; //Scales the coordinates for the distortion texture
 const highp float DistortionCenterRadius = 200.0; // radius of the gradient used to tone down the distortion effect
 const highp float DistortionCenterMinDist = 0.25; // minimum distance from the center of the screen for the distortion to appear at all
 const highp float DistortionCenterPow = 1.1; // the exponent used for the distortion center
@@ -58,14 +59,15 @@ void fragment() {
 
     highp float distortionZoom = pow(Zoom, DistortionZoomPow);
 
-    highp float centergradient = zCircleGradient(aspect * 0.5, FRAGCOORD.xy, DistortionGradientMax, DistortionCenterRadius / distortionZoom, DistortionCenterMinDist / distortionZoom, DistortionCenterPow);
-    highp vec2 coord = (FRAGCOORD.xy * SCREEN_PIXEL_SIZE.xy) * aspect * centergradient * 0.0001; // That magic number on the end there is due to how tiny the FBM noise is. It's incredibly noisy.
+    highp float centergradient = zCircleGradient(aspect, FRAGCOORD.xy, DistortionGradientMax, DistortionCenterRadius / distortionZoom, DistortionCenterMinDist / distortionZoom, DistortionCenterPow);
+    //highp vec2 coord = (FRAGCOORD.xy * SCREEN_PIXEL_SIZE.xy) * aspect * centergradient * 0.0001;
+    highp vec2 coord = (FRAGCOORD.xy * SCREEN_PIXEL_SIZE.xy) * centergradient * DistortionCoordScalar;
     highp vec2 offset = vec2((zFBM(coord * NoiseScalar + timesin) - 0.5) * centergradient, (zFBM(coord * NoiseScalar + timecos) - 0.5) * centergradient);
     COLOR = zTextureSpec(SCREEN_TEXTURE, Pos + (offset * DistortionScalar));
 
     highp float cloudyZoom = pow(Zoom, CloudinessZoomPow);
 
-    highp float cloudygradient = zCircleGradient(aspect * 0.5, FRAGCOORD.xy, CloudinessGradientMax, CloudinessCenterRadius / cloudyZoom, CloudinessCenterMinDist / cloudyZoom, CloudinessCenterPow) * CloudinessScalar;
+    highp float cloudygradient = zCircleGradient(aspect, FRAGCOORD.xy, CloudinessGradientMax, CloudinessCenterRadius / cloudyZoom, CloudinessCenterMinDist / cloudyZoom, CloudinessCenterPow) * CloudinessScalar;
     COLOR.rgb = mix(COLOR.rgb, vec3(zGrayscale(COLOR.rgb)), min(cloudygradient * CloudinessGrayscaleMult, CloudinessGrayscaleMax));
     COLOR.rgb = pow(COLOR.rgb, vec3((cloudygradient * CloudinessScalar + 1.0)));
 

--- a/Resources/Textures/Shaders/circle_mask.swsl
+++ b/Resources/Textures/Shaders/circle_mask.swsl
@@ -1,8 +1,7 @@
-uniform sampler2D SCREEN_TEXTURE;
 uniform highp float Zoom;
 
 uniform highp float CircleRadius; //= 15.0; // radius of the circular gradient
-uniform highp float CircleMinDist; //= 0.25; // minimum distance from the center of the screen for the gradient
+uniform highp float CircleMinDist; //= 0.0; // minimum distance from the center of the screen for the gradient
 uniform highp float CirclePow; //= 0.5; // the exponent used for the gradient
 uniform highp float CircleMax; //= 4.0; // Maximum value for the gradient used for the gradient. Don't worry, the end result gets clamped.
 uniform highp float CircleMult; //= 0.5; // Multiplier for the total value of the circle gradient.
@@ -12,6 +11,6 @@ void fragment(){
     highp vec2 aspect = vec2(1.0/SCREEN_PIXEL_SIZE.x, 1.0/SCREEN_PIXEL_SIZE.y);
     highp float actualZoom = Zoom;
 
-    highp float circle = zCircleGradient(aspect * 0.5, FRAGCOORD.xy, CircleMax, CircleRadius / actualZoom, /*CircleMinDist / actualZoom*/ 0.0, CirclePow) * CircleMult;
+    highp float circle = zCircleGradient(aspect, FRAGCOORD.xy, CircleMax, CircleRadius / actualZoom, CircleMinDist / actualZoom, CirclePow) * CircleMult;
     COLOR = mix(vec4(0.0), vec4(vec3(0.0), 1.0), clamp(circle, 0.0, 1.0));
 }


### PR DESCRIPTION
## About the PR
Blindness and eye blurriness currently completely breaks for anyone not running at 1080p with integer scaling enabled and lowres viewport disabled. So this fixes it!

Requires space-wizards/RobustToolbox/pull/4804

## Why / Balance
Consistency between user settings is good we think

## Technical details
The engine side of this PR makes the math for `zCircleGradient()` properly take into account the active screen resolution. As a byproduct, it now takes in the pixel size, rather than the centerpoint of the screen.

Additionally:
A left-over from prototyping in `circle_mask` (the `SCREEN_TEXTURE` that never gets used) has been removed.
Circle mask no longer just sends 0 as the minimum distance, and now actually sends the minimum distance variable (it was commented out since we were testing what the total blindness effect looked like without the minimum distance, then just kinda forgot about that)

## Media
![dotnet_fCQKGoHpV0](https://github.com/space-wizards/space-station-14/assets/6356337/b43dd4dc-673d-46f9-978e-b9c4003265b7)

![image](https://github.com/space-wizards/space-station-14/assets/6356337/05cac231-c82b-4c2d-b305-0da5da7ec1b7)
![image](https://github.com/space-wizards/space-station-14/assets/6356337/d9553ed5-c3fb-46ca-9ead-e0f6a8997d46)

### Yes this passes the compatibility mode smoke test
![image](https://github.com/space-wizards/space-station-14/assets/6356337/98047c8d-8919-4c50-9615-a63dbf00b9dd)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Calls to `zCircleGradient()` should now be passing the pixel size rather than the target centerpoint.

**Changelog**

:cl: Bhijn and Myr
- fix: The blindness and eye damage effects now properly take screen resolution into account, and are no longer way wider than intended.

