### PR TITLE
let terminator endoskeleton pry doors

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/terminator.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/terminator.yml
@@ -175,6 +175,10 @@
         Structural: 5
   - type: Puller
     needsHands: false
+  - type: Prying
+    pryPowered: true
+    force: true
+    useSound: /Audio/Items/crowbar.ogg
   - type: Tag
     tags:
     - DoorBumpOpener

--- a/Resources/Prototypes/Entities/Mobs/Player/terminator.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/terminator.yml
@@ -178,7 +178,6 @@
   - type: Prying
     pryPowered: true
     force: true
-    useSound: /Audio/Items/crowbar.ogg
   - type: Tag
     tags:
     - DoorBumpOpener


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
title, lets terminator endoskeleton pry doors like xenos/zombies

## Why / Balance
doesn't feel good to have to break down doors with no other way to get inside
still slow but not *as* slow
also firelocks countered it completely
also very bad if an endoskeleton ever got lost in near-station space

## Media
![image](https://github.com/space-wizards/space-station-14/assets/57039557/8e84c409-71ba-45c7-8273-7ec71f371007)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Terminator endoskeletons have learned how to pry doors.
