### PR TITLE
refueling lit welder explosion fix

### DIFF
--- a/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
@@ -27,7 +27,7 @@ namespace Content.Server.Damage.Systems
             if (args.Handled)
                 return;
 
-            if (!TryComp<ItemToggleComponent>(uid, out var itemToggle))
+            if (!TryComp<ItemToggleComponent>(args.Used, out var itemToggle))
                 return;
 
             if (component.WeldingDamage is {} weldingDamage

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
@@ -81,3 +81,9 @@
           Quantity: 1000
   - type: ReagentTank
     tankType: Fuel
+  - type: DamageOnToolInteract
+    tools:
+    - Welding
+    weldingDamage:
+      types:
+        Heat: 20


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Refueling with a lit welder will ignite the fuel tank like it used to.
I also added the DamageOnToolInteract component to the wall dispensers to give them similar behavior.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Bugfix.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed refueling a lit welder not detonating the fuel tank