### PR TITLE
The Flatpacker 1001 can now make flatpacks for computers.

### DIFF
--- a/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml.cs
+++ b/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml.cs
@@ -70,19 +70,14 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
         else if (_currentBoard != null)
         {
             //todo double trycomp is kinda stinky.
+            Dictionary<string, int> cost;
             if (_entityManager.TryGetComponent<MachineBoardComponent>(_currentBoard, out var machineBoardComp) &&
-                machineBoardComp.Prototype != null)
-            {
-                var cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker),
-                    (_currentBoard.Value, machineBoardComp));
-                PackButton.Disabled = !_materialStorage.CanChangeMaterialAmount(_owner, cost);
-            }
-            else if (_entityManager.TryGetComponent<ComputerBoardComponent>(_currentBoard, out var computerBoardComp) &&
-                     computerBoardComp.Prototype != null)
-            {
-                var cost = _flatpack.GetFlatpackCreationCostForComputer((_owner, flatpacker));
-                PackButton.Disabled = !_materialStorage.CanChangeMaterialAmount(_owner, cost);
-            }
+                machineBoardComp.Prototype is not null)
+                cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker), (_currentBoard.Value, machineBoardComp));
+            else
+                cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker));
+
+            PackButton.Disabled = !_materialStorage.CanChangeMaterialAmount(_owner, cost);
         }
 
         if (_currentBoard == itemSlot.Item)
@@ -94,28 +89,30 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
         _currentBoard = itemSlot.Item;
         CostHeaderLabel.Visible = _currentBoard != null;
 
-        if (_currentBoard != null &&
-            _entityManager.TryGetComponent<MachineBoardComponent>(_currentBoard, out var machineBoard) &&
-            machineBoard.Prototype != null)
+        if (_currentBoard is not null)
         {
-            var proto = _prototypeManager.Index<EntityPrototype>(machineBoard.Prototype);
-            _machinePreview = _entityManager.Spawn(proto.ID);
-            _spriteSystem.ForceUpdate(_machinePreview.Value);
-            MachineNameLabel.SetMessage(proto.Name);
-            var cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker),
-                (_currentBoard.Value, machineBoard));
-            CostLabel.SetMarkup(GetCostString(cost));
-        }
-        else if (_currentBoard != null &&
-                 _entityManager.TryGetComponent<ComputerBoardComponent>(_currentBoard, out var computerBoard) &&
-                 computerBoard.Prototype != null)
-        {
-            var proto = _prototypeManager.Index<EntityPrototype>(computerBoard.Prototype);
-            _machinePreview = _entityManager.Spawn(proto.ID);
-            _spriteSystem.ForceUpdate(_machinePreview.Value);
-            MachineNameLabel.SetMessage(proto.Name);
-            var cost = _flatpack.GetFlatpackCreationCostForComputer((_owner, flatpacker));
-            CostLabel.SetMarkup(GetCostString(cost));
+            string? prototype = null;
+            Dictionary<string, int>? cost = null;
+
+            if (_entityManager.TryGetComponent<MachineBoardComponent>(_currentBoard, out var machineBoard))
+            {
+                prototype = machineBoard.Prototype;
+                cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker), (_currentBoard.Value, machineBoard));
+            }
+            else if (_entityManager.TryGetComponent<ComputerBoardComponent>(_currentBoard, out var computerBoard))
+            {
+                prototype = computerBoard.Prototype;
+                cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker));
+            }
+
+            if (prototype is not null && cost is not null)
+            {
+                var proto = _prototypeManager.Index<EntityPrototype>(prototype);
+                _machinePreview = _entityManager.Spawn(proto.ID);
+                _spriteSystem.ForceUpdate(_machinePreview.Value);
+                MachineNameLabel.SetMessage(proto.Name);
+                CostLabel.SetMarkup(GetCostString(cost));
+            }
         }
         else
         {

--- a/Content.Server/Construction/FlatpackSystem.cs
+++ b/Content.Server/Construction/FlatpackSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Construction;
 using Content.Shared.Construction.Components;
 using Content.Shared.Containers.ItemSlots;
 using Robust.Shared.Timing;
+using YamlDotNet.Serialization.NodeTypeResolvers;
 
 namespace Content.Server.Construction;
 
@@ -33,16 +34,17 @@ public sealed class FlatpackSystem : SharedFlatpackSystem
         if (!_itemSlots.TryGetSlot(uid, comp.SlotId, out var itemSlot) || itemSlot.Item is not { } machineBoard)
             return;
 
-        if (TryComp<MachineBoardComponent>(machineBoard, out var boardComp))
-        {
-            if (!MaterialStorage.CanChangeMaterialAmount(uid, GetFlatpackCreationCost(ent, (machineBoard, boardComp))))
-                return;
-        }
-        else
-        {
-            if (!MaterialStorage.CanChangeMaterialAmount(uid, GetFlatpackCreationCostForComputer(ent)))
-                return;
-        }
+        Dictionary<string, int>? cost = null;
+        if (TryComp<MachineBoardComponent>(machineBoard, out var machineBoardComponent))
+            cost = GetFlatpackCreationCost(ent, (machineBoard, machineBoardComponent));
+        if (TryComp<ComputerBoardComponent>(machineBoard, out var computerBoardComponent))
+            cost = GetFlatpackCreationCost(ent);
+
+        if (cost is null)
+            return;
+
+        if (!MaterialStorage.CanChangeMaterialAmount(uid, cost))
+            return;
 
         comp.Packing = true;
         comp.PackEndTime = _timing.CurTime + comp.PackDuration;
@@ -73,21 +75,20 @@ public sealed class FlatpackSystem : SharedFlatpackSystem
         if (!_itemSlots.TryGetSlot(uid, comp.SlotId, out var itemSlot) || itemSlot.Item is not { } machineBoard)
             return;
 
-        if (TryComp<MachineBoardComponent>(machineBoard, out var boardComp)) {
-            var materialCost = GetFlatpackCreationCost(ent, (machineBoard, boardComp));
-            if (!MaterialStorage.TryChangeMaterialAmount((ent, null), materialCost))
-                return;
-            var flatpack = Spawn(comp.BaseFlatpackPrototype, Transform(ent).Coordinates);
-            SetupFlatpack(flatpack, (machineBoard, boardComp));
-        }
-        else if (TryComp<ComputerBoardComponent>(machineBoard, out var computerBoardComponent))
-        {
-            var materialCost = GetFlatpackCreationCostForComputer(ent);
-            if (!MaterialStorage.TryChangeMaterialAmount((ent, null), materialCost))
-                return;
-            var flatpack = Spawn(comp.BaseFlatpackPrototype, Transform(ent).Coordinates);
-            SetupFlatpack(flatpack, (machineBoard, computerBoardComponent));
-        }
+        Dictionary<string, int>? cost = null;
+        if (TryComp<MachineBoardComponent>(machineBoard, out var machineBoardComponent))
+            cost = GetFlatpackCreationCost(ent, (machineBoard, machineBoardComponent));
+        if (TryComp<ComputerBoardComponent>(machineBoard, out var computerBoardComponent))
+            cost = GetFlatpackCreationCost(ent);
+
+        if (cost is null)
+            return;
+
+        if (!MaterialStorage.TryChangeMaterialAmount((ent, null), cost))
+            return;
+
+        var flatpack = Spawn(comp.BaseFlatpackPrototype, Transform(ent).Coordinates);
+        SetupFlatpack(flatpack, machineBoard);
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/Construction/Components/ComputerBoardComponent.cs
+++ b/Content.Shared/Construction/Components/ComputerBoardComponent.cs
@@ -1,7 +1,7 @@
 ﻿using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Server.Construction.Components
+namespace Content.Shared.Construction.Components
 {
     /// <summary>
     /// Used for construction graphs in building computers.

--- a/Content.Shared/Construction/Components/FlatpackCreatorComponent.cs
+++ b/Content.Shared/Construction/Components/FlatpackCreatorComponent.cs
@@ -42,9 +42,17 @@ public sealed partial class FlatpackCreatorComponent : Component
 
     /// <summary>
     /// A default cost applied to all flatpacks outside of the cost of constructing the machine.
+    /// This one is applied to machines specifically.
     /// </summary>
     [DataField]
-    public Dictionary<ProtoId<MaterialPrototype>, int> BaseMaterialCost = new();
+    public Dictionary<ProtoId<MaterialPrototype>, int> BaseMachineCost = new();
+
+    /// <summary>
+    /// A default cost applied to all flatpacks outside of the cost of constructing the machine.
+    /// This one is applied to computers specifically.
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<MaterialPrototype>, int> BaseComputerCost = new();
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string SlotId = "board_slot";

--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -115,13 +115,17 @@ public abstract class SharedFlatpackSystem : EntitySystem
         ent.Comp.PackEndTime += args.PausedTime;
     }
 
-    public void SetupFlatpack(Entity<FlatpackComponent?> ent, Entity<MachineBoardComponent?> machineBoard)
+    public void SetupFlatpack(Entity<FlatpackComponent?> ent, EntityUid? board)
     {
-        if (!Resolve(ent, ref ent.Comp) || !Resolve(machineBoard, ref machineBoard.Comp))
+        if (!Resolve(ent, ref ent.Comp))
             return;
 
-        if (machineBoard.Comp.Prototype is not { } machinePrototypeId)
-            return;
+        EntProtoId machinePrototypeId;
+        string? entityPrototype;
+        if (TryComp<MachineBoardComponent>(board, out var machineBoard) && machineBoard.Prototype is not null)
+            machinePrototypeId = machineBoard.Prototype;
+        else if (TryComp<ComputerBoardComponent>(board, out var computerBoard) && computerBoard.Prototype is not null)
+            machinePrototypeId = computerBoard.Prototype;
 
         var comp = ent.Comp!;
         var machinePrototype = PrototypeManager.Index(machinePrototypeId);
@@ -133,39 +137,21 @@ public abstract class SharedFlatpackSystem : EntitySystem
         comp.Entity = machinePrototypeId;
         Dirty(ent, comp);
 
-        Appearance.SetData(ent, FlatpackVisuals.Machine, MetaData(machineBoard).EntityPrototype?.ID ?? string.Empty);
-    }
-
-    public void SetupFlatpack(Entity<FlatpackComponent?> ent, Entity<ComputerBoardComponent?> machineBoard)
-    {
-        if (!Resolve(ent, ref ent.Comp) || !Resolve(machineBoard, ref machineBoard.Comp))
+        if (board is null)
             return;
 
-        if (machineBoard.Comp.Prototype is not { } machinePrototypeId)
-            return;
-
-        var comp = ent.Comp!;
-        var machinePrototype = PrototypeManager.Index(machinePrototypeId);
-
-        var meta = MetaData(ent);
-        _metaData.SetEntityName(ent, Loc.GetString("flatpack-entity-name", ("name", machinePrototype.Name)), meta);
-        _metaData.SetEntityDescription(ent, Loc.GetString("flatpack-entity-description", ("name", machinePrototype.Name)), meta);
-
-        comp.Entity = machinePrototypeId;
-        Dirty(ent, comp);
-
-        Appearance.SetData(ent, FlatpackVisuals.Machine, MetaData(machineBoard).EntityPrototype?.ID ?? string.Empty);
+        Appearance.SetData(ent, FlatpackVisuals.Machine, MetaData(board.Value).EntityPrototype?.ID ?? string.Empty);
     }
 
     public Dictionary<string, int> GetFlatpackCreationCost(Entity<FlatpackCreatorComponent> entity, Entity<MachineBoardComponent>? machineBoard = null)
     {
         Dictionary<string, int> cost = new();
-        if (machineBoard is not null)
-            cost = MachinePart.GetMachineBoardMaterialCost(machineBoard.Value, -1);
-
         Dictionary<ProtoId<MaterialPrototype>, int> baseCost;
         if (machineBoard is not null)
+        {
+            cost = MachinePart.GetMachineBoardMaterialCost(machineBoard.Value, -1);
             baseCost = entity.Comp.BaseMachineCost;
+        }
         else
             baseCost = entity.Comp.BaseComputerCost;
 

--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -157,22 +157,19 @@ public abstract class SharedFlatpackSystem : EntitySystem
         Appearance.SetData(ent, FlatpackVisuals.Machine, MetaData(machineBoard).EntityPrototype?.ID ?? string.Empty);
     }
 
-    public Dictionary<string, int> GetFlatpackCreationCost(Entity<FlatpackCreatorComponent> entity, Entity<MachineBoardComponent> machineBoard)
+    public Dictionary<string, int> GetFlatpackCreationCost(Entity<FlatpackCreatorComponent> entity, Entity<MachineBoardComponent>? machineBoard = null)
     {
-        var cost = MachinePart.GetMachineBoardMaterialCost(machineBoard, -1);
-        foreach (var (mat, amount) in entity.Comp.BaseMaterialCost)
-        {
-            cost.TryAdd(mat, 0);
-            cost[mat] -= amount;
-        }
+        Dictionary<string, int> cost = new();
+        if (machineBoard is not null)
+            cost = MachinePart.GetMachineBoardMaterialCost(machineBoard.Value, -1);
 
-        return cost;
-    }
+        Dictionary<ProtoId<MaterialPrototype>, int> baseCost;
+        if (machineBoard is not null)
+            baseCost = entity.Comp.BaseMachineCost;
+        else
+            baseCost = entity.Comp.BaseComputerCost;
 
-    public Dictionary<string, int> GetFlatpackCreationCostForComputer(Entity<FlatpackCreatorComponent> entity)
-    {
-        var cost = new Dictionary<string, int> {["Glass"] = -200}; // glass for the computer screen
-        foreach (var (mat, amount) in entity.Comp.BaseMaterialCost)
+        foreach (var (mat, amount) in baseCost)
         {
             cost.TryAdd(mat, 0);
             cost[mat] -= amount;

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -1,4 +1,4 @@
-  - type: entity
+- type: entity
   parent: BaseItem
   id: BaseFlatpack
   name: base flatpack

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -1,4 +1,4 @@
-- type: entity
+  - type: entity
   parent: BaseItem
   id: BaseFlatpack
   name: base flatpack
@@ -26,6 +26,13 @@
       security: "#DE3A3A"
       science: "#D381C9"
       supply: "#A46106"
+      cpu_command: "#334E6D"
+      cpu_medical: "#52B4E9"
+      cpu_service: "#9FED58"
+      cpu_engineering: "#EFB341"
+      cpu_security: "#DE3A3A"
+      cpu_science: "#D381C9"
+      cpu_supply: "#A46106"
   - type: StaticPrice
     price: 500
   - type: Tag

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -68,6 +68,7 @@
         whitelist:
           components:
           - MachineBoard
+          - ComputerBoard
   - type: ContainerContainer
     containers:
       machine_board: !type:Container

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -31,9 +31,13 @@
           True: { visible: true }
           False: { visible: false }
   - type: FlatpackCreator
-    baseMaterialCost:
+    baseMachineCost:
       Steel: 600
       Plastic: 200
+    baseComputerCost:
+      Steel: 600
+      Plastic: 200
+      Glass: 200
   - type: Machine
     board: FlatpackerMachineCircuitboard
   - type: MaterialStorage


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Computer boards can now be inserted into the flatpacker 1001 and used to create computer flatpacks just like with machine boards.
They cost 2 glass sheets + the default per machine cost.

## Why / Balance
A lot of useful things on the station that one would want to flatpack are computers. Setting up xenoarchaeology, for example, requires a computer.

## Technical details
* Altered the MachineFlatpacker prototype to accept computer boards as well as machine boards.
* Moved ComputerBoardComponent from Content.Sever to Content.Shared.
* Altered SharedFlatpackSystem to add method GetFlatpackCreationCostForComputer(...), which returns the cost of creating a computer flatpack (2 glass sheets + default per machine cost).
* Altered FlatpackCreatorMenu.xaml.cs to handle the situation in which the board contained within the Flatpacker has a ComputerBoardComponent instead of a MachineBoardComponent, using the GetFlatpackCreationCostForComputer(...) method instead of the GetFlatpackCreationCost(...) method.
* Altered SharedFlatpackSystem methods which concern the cost of flatpack creation to work with computer boards instead of just machine boards, via the GetFlatpackCreationCostForComputer(...) method.
* Duplicated SetupFlatpack(...) method in SharedFlatpackSystem to create overloaded method which takes an argument of Entity\<ComputerBoardComponent\> - this method sets up a flatpack and gets the protoype from the ComputerBoardComponent instead of the MachineBoardComponent.

## Media
https://github.com/space-wizards/space-station-14/assets/66873282/bbc11aa7-3be5-4c38-918c-e9594525e4f6

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
* ComputerBoardComponent has been moved from Content.Server to Content.Shared.
* SharedFlatpackSystem has new method GetFlatpackCreationCostForComputer(...).
* SharedFlatpackSystem has new overloaded method for SetupFlatpack.

**Changelog**
:cl:
- tweak: The flatpacker 1001 can now create flatpacks for computers.
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
