### PR TITLE
Cleans up/condenses a bunch of RandomSpriteComponent yaml entries

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -184,11 +184,8 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           tendie: ""
-      - enum.DamageStateVisualLayers.Base:
           lizard: ""
-      - enum.DamageStateVisualLayers.Base:
           star: ""
-      - enum.DamageStateVisualLayers.Base:
           corgi: ""
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -108,7 +108,6 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           icon: ""
-      - enum.DamageStateVisualLayers.Base:
           white: ""
   - type: Construction
     graph: Egg

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -277,7 +277,6 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           stick: ""
-      - enum.DamageStateVisualLayers.Base:
           stick2: ""
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -751,7 +751,6 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           bacon-cooked: ""
-      - enum.DamageStateVisualLayers.Base:
           bacon2-cooked: ""
   - type: SolutionContainerManager
     solutions:
@@ -867,7 +866,6 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           chicken-fried: ""
-      - enum.DamageStateVisualLayers.Base:
           chicken2-fried: ""
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
@@ -15,9 +15,7 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           shard1: ""
-      - enum.DamageStateVisualLayers.Base:
           shard2: ""
-      - enum.DamageStateVisualLayers.Base:
           shard3: ""
   - type: SpaceGarbage
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -14,9 +14,7 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           shard1: ""
-      - enum.DamageStateVisualLayers.Base:
           shard2: ""
-      - enum.DamageStateVisualLayers.Base:
           shard3: ""
   - type: MeleeWeapon
     attackRate: 1.5

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -274,21 +274,13 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           book0: ""
-      - enum.DamageStateVisualLayers.Base:
           book1: ""
-      - enum.DamageStateVisualLayers.Base:
           book2: ""
-      - enum.DamageStateVisualLayers.Base:
           book3: ""
-      - enum.DamageStateVisualLayers.Base:
           book4: ""
-      - enum.DamageStateVisualLayers.Base:
           book5: ""
-      - enum.DamageStateVisualLayers.Base:
           book6: ""
-      - enum.DamageStateVisualLayers.Base:
           book7: ""
-      - enum.DamageStateVisualLayers.Base:
           book8: ""
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
@@ -69,41 +69,22 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           pill1: ""
-      - enum.DamageStateVisualLayers.Base:
           pill2: ""
-      - enum.DamageStateVisualLayers.Base:
           pill3: ""
-      - enum.DamageStateVisualLayers.Base:
           pill4: ""
-      - enum.DamageStateVisualLayers.Base:
           pill5: ""
-      - enum.DamageStateVisualLayers.Base:
           pill6: ""
-      - enum.DamageStateVisualLayers.Base:
           pill7: ""
-      - enum.DamageStateVisualLayers.Base:
           pill8: ""
-      - enum.DamageStateVisualLayers.Base:
           pill9: ""
-      - enum.DamageStateVisualLayers.Base:
           pill10: ""
-      - enum.DamageStateVisualLayers.Base:
           pill11: ""
-      - enum.DamageStateVisualLayers.Base:
           pill12: ""
-      - enum.DamageStateVisualLayers.Base:
           pill13: ""
-      - enum.DamageStateVisualLayers.Base:
           pill14: ""
-      - enum.DamageStateVisualLayers.Base:
           pill15: ""
-      - enum.DamageStateVisualLayers.Base:
           pill16: ""
-      - enum.DamageStateVisualLayers.Base:
           pill17: ""
-      - enum.DamageStateVisualLayers.Base:
           pill18: ""
-      - enum.DamageStateVisualLayers.Base:
           pill19: ""
-      - enum.DamageStateVisualLayers.Base:
           pill20: ""

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -118,63 +118,34 @@
     available: #yaml hero
     - enum.ArtifactsVisualLayers.Base:
         ancientball1: ""
-    - enum.ArtifactsVisualLayers.Base:
         ancientball2: ""
-    - enum.ArtifactsVisualLayers.Base:
         ancientball3: ""
-    - enum.ArtifactsVisualLayers.Base:
         ancientball4: ""
-    - enum.ArtifactsVisualLayers.Base:
         ancientball5: ""
-    - enum.ArtifactsVisualLayers.Base:
         ancientball6: ""
-    - enum.ArtifactsVisualLayers.Base:
         eldritchball1: ""
-    - enum.ArtifactsVisualLayers.Base:
         eldritchball2: ""
-    - enum.ArtifactsVisualLayers.Base:
         eldritchball3: ""
-    - enum.ArtifactsVisualLayers.Base:
         eldritchball4: ""
-    - enum.ArtifactsVisualLayers.Base:
         eldritchball5: ""
-    - enum.ArtifactsVisualLayers.Base:
         eldritchball6: ""
-    - enum.ArtifactsVisualLayers.Base:
         martianball1: ""
-    - enum.ArtifactsVisualLayers.Base:
         martianball2: ""
-    - enum.ArtifactsVisualLayers.Base:
         martianball3: ""
-    - enum.ArtifactsVisualLayers.Base:
         martianball4: ""
-    - enum.ArtifactsVisualLayers.Base:
         martianball5: ""
-    - enum.ArtifactsVisualLayers.Base:
         martianball6: ""
-    - enum.ArtifactsVisualLayers.Base:
         precursorball1: ""
-    - enum.ArtifactsVisualLayers.Base:
         precursorball2: ""
-    - enum.ArtifactsVisualLayers.Base:
         precursorball3: ""
-    - enum.ArtifactsVisualLayers.Base:
         precursorball4: ""
-    - enum.ArtifactsVisualLayers.Base:
         precursorball5: ""
-    - enum.ArtifactsVisualLayers.Base:
         precursorball6: ""
-    - enum.ArtifactsVisualLayers.Base:
         wizardball1: ""
-    - enum.ArtifactsVisualLayers.Base:
         wizardball2: ""
-    - enum.ArtifactsVisualLayers.Base:
         wizardball3: ""
-    - enum.ArtifactsVisualLayers.Base:
         wizardball4: ""
-    - enum.ArtifactsVisualLayers.Base:
         wizardball5: ""
-    - enum.ArtifactsVisualLayers.Base:
         wizardball6: ""
   - type: Appearance
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -33,25 +33,15 @@
     available:
       - skin:
           basic_icon_base-1: ""
-      - skin:
           basic_icon_base-2: ""
-      - skin:
           basic_icon_base-3: ""
-      - skin:
           basic_icon_base-4: ""
-      - skin:
           basic_icon_base-5: ""
-      - skin:
           basic_icon_base-6: ""
-      - skin:
           basic_icon_base-7: ""
-      - skin:
           basic_icon_base-8: ""
-      - skin:
           basic_icon_base-9: ""
-      - skin:
           basic_icon_base-10: ""
-      - skin:
           basic_icon_base-11: ""
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Structures/Decoration/flesh_blockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/flesh_blockers.yml
@@ -26,9 +26,7 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           closed: ""
-      - enum.DamageStateVisualLayers.Base:
           ajar: ""
-      - enum.DamageStateVisualLayers.Base:
           open: ""
   - type: Damageable
   - type: Destructible

--- a/Resources/Prototypes/Entities/Tiles/basalt.yml
+++ b/Resources/Prototypes/Entities/Tiles/basalt.yml
@@ -73,11 +73,7 @@
       available:
         - 0:
             basalt1: ""
-        - 0:
             basalt2: ""
-        - 0:
             basalt3: ""
-        - 0:
             basalt4: ""
-        - 0:
             basalt5: ""

--- a/Resources/Prototypes/Entities/Tiles/shadow_basalt.yml
+++ b/Resources/Prototypes/Entities/Tiles/shadow_basalt.yml
@@ -73,11 +73,7 @@
       available:
         - 0:
             basalt1: ""
-        - 0:
             basalt2: ""
-        - 0:
             basalt3: ""
-        - 0:
             basalt4: ""
-        - 0:
             basalt5: ""


### PR DESCRIPTION
# **what to hell is THIS garabge**
![image](https://github.com/space-wizards/space-station-14/assets/6356337/1a10505b-822e-4a1e-bd72-aed83db5986c)

look at that!!!! it doesn't even fit on the screen!!!!

but look! with the help of lavender robold (and a little bit of #23393 . okay, mostly #23393 actually), and the power of ctrl+shift+f, you, too, can condense your YAML spaghetti to something more reasonable! take a look at this!!!
![image](https://github.com/space-wizards/space-station-14/assets/6356337/20d4d53c-0eee-4505-85ca-b5064c3c8f96)

do you see that!!! it fits on a 1080p display now!! your ctrl+v hotkey, it's *already* thanking you, the yamlcoder!

## About the PR
This PR does a bunch of cleanup to `RandomSpriteComponent` entries. Namely, anything that relies on group randomization for randomizing singular layers has been smushed down to instead rely on layer-specific randomization (added in #23393), as layer-specific randomization is, as demonstrated above, *far* saner to look at and work with. Guardians specifically are pretty much the only thing that actually have good reason to be using group randomization for sprite randomization, and thus are untouched (as specific-layer randomization does not replicate the behavior they rely on)

## Why / Balance
YAMLcoders shouldn't need to jam on their ctrl+V hotkey?

## Technical details
See about section

## Media
See PR header

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
All backend; no changelog
