### PR TITLE
Aghost Now Can Drop Things Wherever They Want

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
+using Content.Shared.Tag;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 
@@ -8,6 +9,7 @@ namespace Content.Shared.Hands.EntitySystems;
 
 public abstract partial class SharedHandsSystem
 {
+    [Dependency] private readonly TagSystem _tagSystem = default!;
     private void InitializeDrop()
     {
         SubscribeLocalEvent<HandsComponent, EntRemovedFromContainerMessage>(HandleEntityRemoved);
@@ -28,6 +30,12 @@ public abstract partial class SharedHandsSystem
 
         if (TryComp(args.Entity, out HandVirtualItemComponent? @virtual))
             _virtualSystem.Delete((args.Entity, @virtual), uid);
+    }
+
+    private bool ShouldIgnoreRestrictions(EntityUid user)
+    {
+        //Checks if the Entity is something that shouldn't care about drop distance or walls ie Aghost
+        return !_tagSystem.HasTag(user, "BypassDropChecks");
     }
 
     /// <summary>
@@ -153,20 +161,24 @@ public abstract partial class SharedHandsSystem
     }
 
     /// <summary>
-    ///     Calculates the final location a dropped item will end up at, accounting for max drop range and collision along the targeted drop path.
+    ///     Calculates the final location a dropped item will end up at, accounting for max drop range and collision along the targeted drop path, Does a check to see if a user should bypass those checks as well.
     /// </summary>
     private Vector2 GetFinalDropCoordinates(EntityUid user, MapCoordinates origin, MapCoordinates target)
     {
         var dropVector = target.Position - origin.Position;
         var requestedDropDistance = dropVector.Length();
+        var dropLength = dropVector.Length();
 
-        if (dropVector.Length() > SharedInteractionSystem.InteractionRange)
+        if (ShouldIgnoreRestrictions(user))
         {
-            dropVector = dropVector.Normalized() * SharedInteractionSystem.InteractionRange;
-            target = new MapCoordinates(origin.Position + dropVector, target.MapId);
-        }
+            if (dropVector.Length() > SharedInteractionSystem.InteractionRange)
+            {
+                dropVector = dropVector.Normalized() * SharedInteractionSystem.InteractionRange;
+                target = new MapCoordinates(origin.Position + dropVector, target.MapId);
+            }
 
-        var dropLength = _interactionSystem.UnobstructedDistance(origin, target, predicate: e => e == user);
+            dropLength = _interactionSystem.UnobstructedDistance(origin, target, predicate: e => e == user);
+        }
 
         if (dropLength < requestedDropDistance)
             return origin.Position + dropVector.Normalized() * dropLength;

--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -81,3 +81,8 @@ Entries:
   - {message: 'Fixed not being able to right click in AHelps and the players and objects tabs.', type: Fix}
   id: 13
   time: '2023-12-21T06:34:00.0000000+00:00'
+- author: Geekyhobo
+  changes:
+    - {message: 'Fixed AGhosts not being able to drop items past the default range.', type: Fix}
+  id: 13
+  time: '2024-1-4T01:30:00.0000000+00:00'

--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -84,5 +84,5 @@ Entries:
 - author: Geekyhobo
   changes:
     - {message: 'Fixed AGhosts not being able to drop items past the default range.', type: Fix}
-  id: 13
+  id: 14
   time: '2024-1-4T01:30:00.0000000+00:00'

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -11,6 +11,7 @@
     - InstantDoAfters
     - CanPilot
     - BypassInteractionRangeChecks
+    - BypassDropChecks
   - type: Input
     context: "aghost"
   - type: Ghost

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -224,6 +224,9 @@
   id: BypassInteractionRangeChecks
 
 - type: Tag
+  id: BypassDropChecks
+
+- type: Tag
   id: CableCoil
 
 - type: Tag

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -225,6 +225,7 @@
 
 - type: Tag
   id: BypassInteractionRangeChecks
+  
 - type: Tag
   id: CableCoil
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -221,11 +221,10 @@
   id: BulletFoam
 
 - type: Tag
-  id: BypassInteractionRangeChecks
-
-- type: Tag
   id: BypassDropChecks
 
+- type: Tag
+  id: BypassInteractionRangeChecks
 - type: Tag
   id: CableCoil
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Aghosts can now drop things wherever they please

## Why / Balance
Closes #19225, Admin QOL

## Technical details
Adds a tag that can be added that ignores the range and obstruction check when something leaves a players hands

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
- 
https://github.com/space-wizards/space-station-14/assets/66805063/f09ee58d-f219-4c68-9453-a1a62f741879

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: 
- fix: Fixed AGhosts not being able to drop items past the default range.

