### PR TITLE
Tweak Spell of All-Consuming Cleanliness

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -62,4 +62,4 @@
     - 0,0,19,9
     quickInsert: true
     areaInsert: true
-    areaInsertRadius: 1000
+    areaInsertRadius: 5


### PR DESCRIPTION
Changed from 1000 to 5 radius to prevent it from exploding servers.
Tested this with a large amount of garbage and only had minor hiccup.


## About the PR
Fixes #23510.