### PR TITLE
buff holo and mild structural adjustment

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -13,23 +13,25 @@
   id: StructuralMetallicStrong
   coefficients:
     Shock: 1.2
+    Structural: 0.5
   flatReductions:
-    Blunt: 25
-    Slash: 25
-    Piercing: 25
-    Heat: 25
-    Structural: 40
+    Blunt: 20
+    Slash: 20
+    Piercing: 20
+    Heat: 20
+    Structural: 15
 
 - type: damageModifierSet
   id: StructuralMetallic
   coefficients:
     Shock: 1.2
+    Structural: 0.5
   flatReductions:
     Blunt: 10
     Slash: 10
     Piercing: 10
     Heat: 10
-    Structural: 20
+    Structural: 10
 
 - type: damageModifierSet
   id: PerforatedMetallic
@@ -89,7 +91,7 @@
     Slash: 5
     Piercing: 5
     Heat: 5
-    Structural: 10
+    Structural: 5
 
 - type: damageModifierSet
   id: RGlass
@@ -99,12 +101,13 @@
     Piercing: 0.6
     Heat: 0.5
     Shock: 0
+    Structural: 0.5
   flatReductions:
     Blunt: 5
     Slash: 5
     Piercing: 5
     Heat: 5
-    Structural: 12.5
+    Structural: 10
 
 - type: damageModifierSet
   id: Wood

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -81,13 +81,14 @@
       proto: guardian
     - type: Pullable
     - type: MeleeWeapon
-      hidden: true
-      angle: 30
+      hidden: false
+      altDisarm: false
       animation: WeaponArcFist
-      attackRate: 1.5
+      attackRate: 1.8
       damage:
         types:
           Blunt: 20
+          Structural: 20
     - type: MeleeSpeech
     - type: UserInterface
       interfaces:
@@ -129,9 +130,6 @@
           map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
           color: "#40a7d7"
           shader: unshaded
-    - type: NpcFactionMember
-      factions:
-        - Syndicate
     - type: HTN
       rootTask:
         task: SimpleHumanoidHostileCompound


### PR DESCRIPTION
buffs holo parasite by giving it structural and wideswing back. changes structural by lowering its flat reduction but giving it a low coeff to make it take less damage. this should feel the same for most things but let you break stuff open with great effort now. holo can break down solid walls in 14 hits and airlocks in 21. holo also doesnt possess ai anymore so it wont randomly out you by attacking people from inside your body

🆑 
- tweak: Holoparasite can wideswing, do structural, and won't out you by randomly attacking before it's possessed. 
- tweak: Structural damage has been adjusted to allow more weapons to damage sturdier structures.