### PR TITLE
Command beacon QOL recolor

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -119,7 +119,7 @@
   components:
   - type: NavMapBeacon
     text: command
-    color: "#334E6D"
+    color: "#FFFF00"
 
 - type: entity
   parent: DefaultStationBeaconCommand


### PR DESCRIPTION
## About the PR
I'm lifting this one change from #23446 because not a single person has yet said anything against this part of it anywhere, there is no reason to wait on this QoL change while the other parts are worked out

Changes the color of the following station beacons from dark blue to bright yellow: Command, Bridge, Vault, HOP's Office, Captain's Quarters. 
Their current color is very difficult to read due to how dark it is over a dark background

## Media
Before:
![Screenshot from 2024-01-04 12-01-44](https://github.com/space-wizards/space-station-14/assets/35878406/5eddb52e-96ad-407c-a01c-4cf510e31911)
After:
![Screenshot from 2024-01-04 12-00-36](https://github.com/space-wizards/space-station-14/assets/35878406/23485b16-e91b-4d29-a670-3199bc3b36d5)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase