### PR TITLE
make flashes use audio range

### DIFF
--- a/Content.Server/Flash/Components/FlashComponent.cs
+++ b/Content.Server/Flash/Components/FlashComponent.cs
@@ -5,6 +5,7 @@ namespace Content.Server.Flash.Components
     [RegisterComponent, Access(typeof(FlashSystem))]
     public sealed partial class FlashComponent : Component
     {
+
         [DataField("duration")]
         [ViewVariables(VVAccess.ReadWrite)]
         public int FlashDuration { get; set; } = 5000;
@@ -23,7 +24,10 @@ namespace Content.Server.Flash.Components
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("sound")]
-        public SoundSpecifier Sound { get; set; } = new SoundPathSpecifier("/Audio/Weapons/flash.ogg");
+        public SoundSpecifier Sound { get; set; } = new SoundPathSpecifier("/Audio/Weapons/flash.ogg")
+        {
+            Params = AudioParams.Default.WithVolume(1f).WithMaxDistance(3f)
+        };
 
         public bool Flashing;
     }

--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -173,7 +173,7 @@ namespace Content.Server.Flash
             }
             if (sound != null)
             {
-                _audio.PlayPvs(sound, source);
+                _audio.PlayPvs(sound, source, AudioParams.Default.WithVolume(1f).WithMaxDistance(3f));
             }
         }
 


### PR DESCRIPTION
so currently flashes broadcast the audio to everyone in pvs range. this makes it have a range of a few feet so you cant hear it from very far at all

🆑 
- tweak: Flashes cannot be heard from more than a few meters away.
