### PR TITLE
Show how close bodies are to rotting

### DIFF
--- a/Content.Server/Atmos/Rotting/RottingSystem.cs
+++ b/Content.Server/Atmos/Rotting/RottingSystem.cs
@@ -125,30 +125,27 @@ public sealed class RottingSystem : EntitySystem
 
     private void OnPerishableExamined(Entity<PerishableComponent> perishable, ref ExaminedEvent args)
     {
-        var stage = PerishStage(perishable);
-        if (stage < 1 || stage > 3)
+        int maxStages = 3;
+        int stage = PerishStage(perishable, maxStages);
+        if (stage < 1 || stage > maxStages)
         {
             // We dont push an examined string if it hasen't started "perishing" or it's already rotting
             return;
         }
 
-        var description = stage switch
-        {
-            >= 3 => "perishable-almost-rotting",
-            >= 2 => "perishable-ripe",
-               _ => "perishable-fresh"
-        };
+        var description = "perishable-" + stage;
         args.PushMarkup(Loc.GetString(description));
     }
 
     /// <summary>
-    /// Return close to rotting the thing is. 0 if it hasn't started decaying at all, >=1 otherwise.
+    /// Return an integer from 0 to maxStage representing how close to rotting an entity is. Used to
+    /// generate examine messages for items that are starting to rot.
     /// </summary>
-    public int PerishStage(Entity<PerishableComponent> perishable)
+    public int PerishStage(Entity<PerishableComponent> perishable, int maxStages)
     {
         if (perishable.Comp.RotAfter.TotalSeconds == 0 || perishable.Comp.RotAccumulator.TotalSeconds == 0)
             return 0;
-        return (int) (1 + 3 * perishable.Comp.RotAccumulator.TotalSeconds / perishable.Comp.RotAfter.TotalSeconds);
+        return (int)(1 + maxStages * perishable.Comp.RotAccumulator.TotalSeconds / perishable.Comp.RotAfter.TotalSeconds);
     }
 
     private void OnExamined(EntityUid uid, RottingComponent component, ExaminedEvent args)

--- a/Resources/Locale/en-US/disease/miasma.ftl
+++ b/Resources/Locale/en-US/disease/miasma.ftl
@@ -1,7 +1,7 @@
 ammonia-smell = Something smells pungent!
-perishable-fresh = [color=green]It still looks fresh.[/color]
-perishable-ripe = [color=orangered]It looks somewhat fresh.[/color]
-perishable-almost-rotting= [color=red]It doesn't look fresh anymore.[/color]
+perishable-1 = [color=green]It still looks fresh.[/color]
+perishable-2 = [color=orangered]It looks somewhat fresh.[/color]
+perishable-3 = [color=red]It doesn't look fresh anymore.[/color]
 rotting-rotting = [color=orange]It's rotting![/color]
 rotting-bloated = [color=orangered]It's bloated![/color]
 rotting-extremely-bloated = [color=red]It's extremely bloated![/color]

--- a/Resources/Locale/en-US/disease/miasma.ftl
+++ b/Resources/Locale/en-US/disease/miasma.ftl
@@ -1,4 +1,7 @@
 ammonia-smell = Something smells pungent!
+perishable-fresh = [color=green]It still looks fresh.[/color]
+perishable-ripe = [color=orangered]It looks ripe.[/color]
+perishable-almost-rotting= [color=red]It's starting to look bad.[/color]
 rotting-rotting = [color=orange]It's rotting![/color]
 rotting-bloated = [color=orangered]It's bloated![/color]
 rotting-extremely-bloated = [color=red]It's extremely bloated![/color]

--- a/Resources/Locale/en-US/disease/miasma.ftl
+++ b/Resources/Locale/en-US/disease/miasma.ftl
@@ -1,7 +1,7 @@
 ammonia-smell = Something smells pungent!
 perishable-fresh = [color=green]It still looks fresh.[/color]
-perishable-ripe = [color=orangered]It looks ripe.[/color]
-perishable-almost-rotting= [color=red]It's starting to look bad.[/color]
+perishable-ripe = [color=orangered]It looks somewhat fresh.[/color]
+perishable-almost-rotting= [color=red]It doesn't look fresh anymore.[/color]
 rotting-rotting = [color=orange]It's rotting![/color]
 rotting-bloated = [color=orangered]It's bloated![/color]
 rotting-extremely-bloated = [color=red]It's extremely bloated![/color]


### PR DESCRIPTION
## About the PR
When examining a dead body, you will be able to see of close it is to rotting.

 - "It still looks fresh.", in the first third of the pre-rot period
 - ~"It looks ripe."~ "It looks somewhat fresh." , in the second third
 - ~"It's starting to look bad."~ "It doesn't look fresh anymore.", in the last third

## Why / Balance
This could help players prioritize medical care.

## Technical details

I ~completely stole~ took inspiration from the OnExamined of RottingComponent, but this time I did it with the Generic Entity<T> thing.

## Media
![not_decaying](https://github.com/space-wizards/space-station-14/assets/262623/828aee87-736b-419e-89b3-918a595b934f)
![bad](https://github.com/space-wizards/space-station-14/assets/262623/48f6927c-3311-4d10-a66e-dcad7f8a904b)
![ripe](https://github.com/space-wizards/space-station-14/assets/262623/8cfdd131-c547-42d1-bb28-3d261e0b4cd7)
![fresh](https://github.com/space-wizards/space-station-14/assets/262623/83c2452b-f243-4f19-84d7-bc9be6b19d27)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- add: Examining bodies now shows how close they are to rotting.
