### PR TITLE
Use default panic bunker messages on Leviathan and Lizard

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/leviathan.toml
+++ b/Resources/ConfigPresets/WizardsDen/leviathan.toml
@@ -7,6 +7,7 @@ hostname = "[EN] Wizard's Den Leviathan [US East 1]"
 panic_bunker.enabled = false
 panic_bunker.disable_with_admins = false
 panic_bunker.enable_without_admins = false
+panic_bunker.custom_reason = ""
 
 [hub]
 tags = "lang:en,region:am_n_e,rp:low"

--- a/Resources/ConfigPresets/WizardsDen/lizard.toml
+++ b/Resources/ConfigPresets/WizardsDen/lizard.toml
@@ -7,6 +7,7 @@ hostname = "[EN] Wizard's Den Lizard [US West]"
 panic_bunker.enabled = false
 panic_bunker.disable_with_admins = false
 panic_bunker.enable_without_admins = false
+panic_bunker.custom_reason = ""
 
 [hub]
 tags = "lang:en,region:am_n_w,rp:low"


### PR DESCRIPTION
Doesn't make sense to use the custom ones that direct people to leviathan/lizard