### PR TITLE
fix pda pai ejection slot image

### DIFF
--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -41,7 +41,7 @@ namespace Content.Client.PDA
             FlashLightToggleButton.IconTexture = new SpriteSpecifier.Texture(new("/Textures/Interface/light.png"));
             EjectPenButton.IconTexture = new SpriteSpecifier.Texture(new("/Textures/Interface/pencil.png"));
             EjectIdButton.IconTexture = new SpriteSpecifier.Texture(new("/Textures/Interface/eject.png"));
-            EjectPaiButton.IconTexture = new SpriteSpecifier.Texture(new("/Textures/Interface/PAI.png"));
+            EjectPaiButton.IconTexture = new SpriteSpecifier.Texture(new("/Textures/Interface/pai.png"));
             ProgramCloseButton.IconTexture = new SpriteSpecifier.Texture(new("/Textures/Interface/Nano/cross.svg.png"));
 
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
fixes this
![image](https://github.com/space-wizards/space-station-14/assets/45323883/c1c5e8ea-1192-4b1e-abed-075e18e257c1)


## Why / Balance
bugfix

## Technical details
in the code it was referenced as PAI.png but it's called pai.png

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no
**Changelog**
nope
