### PR TITLE
Flatpacker Tweaks

### DIFF
--- a/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml
+++ b/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml
@@ -8,20 +8,21 @@
     <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True" Margin="10">
         <BoxContainer SizeFlagsStretchRatio="2" Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
             <BoxContainer Orientation="Vertical">
-                <SpriteView Name="MachineSprite" Scale="4 4" HorizontalAlignment="Center" MinSize="128 128"/>
+                <SpriteView Name="MachineSprite" Scale="4 4" HorizontalAlignment="Center" VerticalExpand="True" MinSize="128 128"/>
                 <RichTextLabel Name="MachineNameLabel" HorizontalAlignment="Center" StyleClasses="LabelKeyText"/>
             </BoxContainer>
             <Control MinHeight="10"/>
             <Button Name="PackButton" Text="{Loc 'flatpacker-ui-pack-button'}" MaxWidth="150" Margin="0 0 0 10"/>
-            <BoxContainer Orientation="Vertical" VerticalExpand="True">
+            <BoxContainer Orientation="Vertical" VerticalExpand="True" RectClipContent="True">
                 <Label Name="CostHeaderLabel" Text="{Loc 'flatpacker-ui-cost-label'}" HorizontalAlignment="Left"/>
                 <PanelContainer VerticalExpand="True"
                                 HorizontalExpand="True">
                     <PanelContainer.PanelOverride>
                         <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
                     </PanelContainer.PanelOverride>
-                    <BoxContainer Orientation="Vertical" VerticalExpand="True">
-                        <RichTextLabel Name="CostLabel" HorizontalAlignment="Center"/>
+                    <BoxContainer Orientation="Vertical" VerticalAlignment="Center">
+                        <RichTextLabel Name="CostLabel" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <RichTextLabel Name="InsertLabel" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </BoxContainer>
                 </PanelContainer>
             </BoxContainer>

--- a/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml.cs
+++ b/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml.cs
@@ -92,7 +92,6 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
 
         _currentBoard = itemSlot.Item;
         CostHeaderLabel.Visible = _currentBoard != null;
-        MachineNameLabel.Visible = _currentBoard != null;
         InsertLabel.Visible = _currentBoard == null;
 
         if (_currentBoard is not null)
@@ -100,7 +99,7 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
             string? prototype = null;
             Dictionary<string, int>? cost = null;
 
-            if (machineBoardComp != null)
+            if (machineBoardComp != null || _entityManager.TryGetComponent(_currentBoard, out machineBoardComp))
             {
                 prototype = machineBoardComp.Prototype;
                 cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker), (_currentBoard.Value, machineBoardComp));
@@ -124,6 +123,7 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
         {
             _machinePreview = _entityManager.Spawn(NoBoardEffectId);
             CostLabel.SetMessage(Loc.GetString("flatpacker-ui-no-board-label"));
+            MachineNameLabel.SetMessage(" ");
             PackButton.Disabled = true;
         }
 

--- a/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml.cs
+++ b/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml.cs
@@ -27,6 +27,9 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
 
     private readonly EntityUid _owner;
 
+    [ValidatePrototypeId<EntityPrototype>]
+    public const string NoBoardEffectId = "FlatpackerNoBoardEffect";
+
     private EntityUid? _currentBoard = EntityUid.Invalid;
     private EntityUid? _machinePreview;
 
@@ -47,6 +50,7 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
         PackButton.OnPressed += _ => PackButtonPressed?.Invoke();
 
         MaterialStorageControl.SetOwner(uid);
+        InsertLabel.SetMarkup(Loc.GetString("flatpacker-ui-insert-board"));
     }
 
     protected override void FrameUpdate(FrameEventArgs args)
@@ -63,15 +67,15 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
             !_itemSlots.TryGetSlot(_owner, flatpacker.SlotId, out var itemSlot))
             return;
 
+        MachineBoardComponent? machineBoardComp = null;
         if (flatpacker.Packing)
         {
             PackButton.Disabled = true;
         }
         else if (_currentBoard != null)
         {
-            //todo double trycomp is kinda stinky.
             Dictionary<string, int> cost;
-            if (_entityManager.TryGetComponent<MachineBoardComponent>(_currentBoard, out var machineBoardComp) &&
+            if (_entityManager.TryGetComponent(_currentBoard, out machineBoardComp) &&
                 machineBoardComp.Prototype is not null)
                 cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker), (_currentBoard.Value, machineBoardComp));
             else
@@ -88,16 +92,18 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
 
         _currentBoard = itemSlot.Item;
         CostHeaderLabel.Visible = _currentBoard != null;
+        MachineNameLabel.Visible = _currentBoard != null;
+        InsertLabel.Visible = _currentBoard == null;
 
         if (_currentBoard is not null)
         {
             string? prototype = null;
             Dictionary<string, int>? cost = null;
 
-            if (_entityManager.TryGetComponent<MachineBoardComponent>(_currentBoard, out var machineBoard))
+            if (machineBoardComp != null)
             {
-                prototype = machineBoard.Prototype;
-                cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker), (_currentBoard.Value, machineBoard));
+                prototype = machineBoardComp.Prototype;
+                cost = _flatpack.GetFlatpackCreationCost((_owner, flatpacker), (_currentBoard.Value, machineBoardComp));
             }
             else if (_entityManager.TryGetComponent<ComputerBoardComponent>(_currentBoard, out var computerBoard))
             {
@@ -116,8 +122,7 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
         }
         else
         {
-            _machinePreview = null;
-            MachineNameLabel.SetMessage(" ");
+            _machinePreview = _entityManager.Spawn(NoBoardEffectId);
             CostLabel.SetMessage(Loc.GetString("flatpacker-ui-no-board-label"));
             PackButton.Disabled = true;
         }
@@ -125,13 +130,14 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
         MachineSprite.SetEntity(_machinePreview);
     }
 
-    //todo beautify
     private string GetCostString(Dictionary<string, int> costs)
     {
-        var orderedCosts = costs.OrderBy(p => p.Value);
+        var orderedCosts = costs.OrderBy(p => p.Value).ToArray();
         var msg = new FormattedMessage();
-        foreach (var (mat, amount) in orderedCosts)
+        for (var i = 0; i < orderedCosts.Length; i++)
         {
+            var (mat, amount) = orderedCosts[i];
+
             var matProto = _prototypeManager.Index<MaterialPrototype>(mat);
 
             var sheetVolume = _materialStorage.GetSheetVolume(matProto);
@@ -144,9 +150,10 @@ public sealed partial class FlatpackCreatorMenu : FancyWindow
                 ("material", Loc.GetString(matProto.Name)));
 
             msg.AddMarkup(text);
-            msg.PushNewline();
+
+            if (i != orderedCosts.Length - 1)
+                msg.PushNewline();
         }
-        msg.Pop();
 
         return msg.ToMarkup();
     }

--- a/Content.Server/Construction/FlatpackSystem.cs
+++ b/Content.Server/Construction/FlatpackSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Construction;
 using Content.Shared.Construction.Components;
 using Content.Shared.Containers.ItemSlots;
 using Robust.Shared.Timing;
-using YamlDotNet.Serialization.NodeTypeResolvers;
 
 namespace Content.Server.Construction;
 
@@ -37,7 +36,7 @@ public sealed class FlatpackSystem : SharedFlatpackSystem
         Dictionary<string, int>? cost = null;
         if (TryComp<MachineBoardComponent>(machineBoard, out var machineBoardComponent))
             cost = GetFlatpackCreationCost(ent, (machineBoard, machineBoardComponent));
-        if (TryComp<ComputerBoardComponent>(machineBoard, out var computerBoardComponent))
+        if (HasComp<ComputerBoardComponent>(machineBoard))
             cost = GetFlatpackCreationCost(ent);
 
         if (cost is null)
@@ -78,7 +77,7 @@ public sealed class FlatpackSystem : SharedFlatpackSystem
         Dictionary<string, int>? cost = null;
         if (TryComp<MachineBoardComponent>(machineBoard, out var machineBoardComponent))
             cost = GetFlatpackCreationCost(ent, (machineBoard, machineBoardComponent));
-        if (TryComp<ComputerBoardComponent>(machineBoard, out var computerBoardComponent))
+        if (HasComp<ComputerBoardComponent>(machineBoard))
             cost = GetFlatpackCreationCost(ent);
 
         if (cost is null)
@@ -89,6 +88,7 @@ public sealed class FlatpackSystem : SharedFlatpackSystem
 
         var flatpack = Spawn(comp.BaseFlatpackPrototype, Transform(ent).Coordinates);
         SetupFlatpack(flatpack, machineBoard);
+        Del(machineBoard);
     }
 
     public override void Update(float frameTime)

--- a/Resources/Locale/en-US/construction/components/flatpack.ftl
+++ b/Resources/Locale/en-US/construction/components/flatpack.ftl
@@ -8,4 +8,5 @@ flatpacker-ui-title = Flatpacker 1001
 flatpacker-ui-materials-label = Materials
 flatpacker-ui-cost-label = Packing Cost
 flatpacker-ui-no-board-label = No board present!
+flatpacker-ui-insert-board = Insert a board to begin.
 flatpacker-ui-pack-button = Pack

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -32,12 +32,10 @@
           False: { visible: false }
   - type: FlatpackCreator
     baseMachineCost:
-      Steel: 600
-      Plastic: 200
+      Steel: 750
     baseComputerCost:
-      Steel: 600
-      Plastic: 200
-      Glass: 200
+      Steel: 500
+      Glass: 250
   - type: Machine
     board: FlatpackerMachineCircuitboard
   - type: MaterialStorage
@@ -85,3 +83,13 @@
     - board_slot
   - type: StaticPrice
     price: 2000
+
+- type: entity
+  id: FlatpackerNoBoardEffect
+  categories:
+  - hideSpawnMenu
+  components:
+  - type: Sprite
+    sprite: Structures/Machines/autolathe.rsi
+    state: icon
+    color: "#222222"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- add a label telling people to insert a board (nothing told them to do this)
- change the no board menu to look less barren
- center text in the cost box
- lower costs slightly
- Make boards be consumed on pack

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Main balance change is consuming boards on packing. Previously, they were reusable. This is mostly okay, as most machines don't really pose a huge issue being in large quantities. However, especially with the addition of computers to the flatpacker, duping rare equipment and boards such as salvage magnets, research servers, ID console boards, communication console boards, etc is a pretty notable issue.

I lowered the price a tad, not really enough to offset it, but just to throw a small bone.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/65a1d667-9ef5-44a6-a718-846d84dee3c4)
![image](https://github.com/space-wizards/space-station-14/assets/98561806/de5f129d-31c8-42fd-87cc-7a36128c3a26)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: The flatpacker now consumes boards when packing them.