### PR TITLE
Cryoxadone and doxarubixadone now work on the dead

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -168,6 +168,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#0091ff"
+  worksOnTheDead: true
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: -5
@@ -198,6 +199,7 @@
   physicalDesc: reagent-physical-desc-bubbling
   flavor: medicine
   color: "#32cd32"
+  worksOnTheDead: true
   metabolisms:
     Medicine:
       effects:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR allows cryoxadone and doxarubixadone to work on the dead. (thanks to #23298)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Cryopods in their current state are heavily underused. They are rarely setup and even when used, they are less effective than active treatment when the patient is alive. This PR changes that, allowing cryonic medicines to be used on dead bodies. This will help cryopods become more used and will also allow the possibility to treat severely damaged corpses faster or treat corpses with damage that cannot be healed via normal means. These types of patients include explosion victims (400+ brute and burn, for example) and patients that have been poisoned/irradiated to death (making it impossible to treat them via normal means as normal medicines do not metabolize while the patient is dead).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Cryoxadone and doxarubixadone now work on dead patients.