### PR TITLE
add secret weight prototype cvar

### DIFF
--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -2,8 +2,10 @@ using Content.Server.GameTicking.Presets;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
+using Content.Shared.CCVar;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Configuration;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -11,6 +13,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
     protected override void Started(EntityUid uid, SecretRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
@@ -32,7 +35,8 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     {
         // TODO: This doesn't consider what can't start due to minimum player count,
         // but currently there's no way to know anyway as they use cvars.
-        var preset = _prototypeManager.Index<WeightedRandomPrototype>("Secret").Pick(_random);
+        var presetString = _configurationManager.GetCVar(CCVars.SecretWeightPrototype);
+        var preset = _prototypeManager.Index<WeightedRandomPrototype>(presetString).Pick(_random);
         Logger.InfoS("gamepreset", $"Selected {preset} for secret.");
 
         var rules = _prototypeManager.Index<GamePresetPrototype>(preset).Rules;

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -351,6 +351,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> RoundRestartTime =
             CVarDef.Create("game.round_restart_time", 120f, CVar.SERVERONLY);
 
+        /// <summary>
+        /// The prototype to use for secret weights. 
+        /// </summary>
+        public static readonly CVarDef<string> SecretWeightPrototype =
+            CVarDef.Create("game.secret_weight_prototype", "Secret", CVar.SERVERONLY);
+
         /*
          * Discord
          */


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Resolves #23116. SecretRuleSystem now uses the prototype ID defined at game.secret_weight_prototype rather than being hardcoded to "Secret".

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
So it can be changed server-to-server on the same codebase. May break something if any downstream has their secret prototype renamed for some reason but it's trivial to fix. 
