### PR TITLE
Examine prediction

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -81,11 +81,12 @@ namespace Content.Client.Construction
 
         private void HandleConstructionGhostExamined(EntityUid uid, ConstructionGhostComponent component, ExaminedEvent args)
         {
-            if (component.Prototype == null) return;
+            if (component.Prototype == null)
+                return;
 
             args.PushMarkup(Loc.GetString(
                 "construction-ghost-examine-message",
-                ("name", component.Prototype.Name)));
+                ("name", component.Prototype.Name)), group: nameof(ConstructionGhostComponent));
 
             if (!_prototypeManager.TryIndex(component.Prototype.Graph, out ConstructionGraphPrototype? graph))
                 return;
@@ -98,9 +99,8 @@ namespace Content.Client.Construction
                 return;
             }
 
-            foreach (ConstructionGraphStep step in edge.Steps)
+            foreach (var step in edge.Steps)
             {
-                args.Message.PushNewline();
                 step.DoExamine(args);
             }
         }

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -86,7 +86,7 @@ namespace Content.Client.Construction
 
             args.PushMarkup(Loc.GetString(
                 "construction-ghost-examine-message",
-                ("name", component.Prototype.Name)), group: nameof(ConstructionGhostComponent));
+                ("name", component.Prototype.Name)));
 
             if (!_prototypeManager.TryIndex(component.Prototype.Graph, out ConstructionGraphPrototype? graph))
                 return;

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -84,24 +84,27 @@ namespace Content.Client.Construction
             if (component.Prototype == null)
                 return;
 
-            args.PushMarkup(Loc.GetString(
-                "construction-ghost-examine-message",
-                ("name", component.Prototype.Name)));
-
-            if (!_prototypeManager.TryIndex(component.Prototype.Graph, out ConstructionGraphPrototype? graph))
-                return;
-
-            var startNode = graph.Nodes[component.Prototype.StartNode];
-
-            if (!graph.TryPath(component.Prototype.StartNode, component.Prototype.TargetNode, out var path) ||
-                !startNode.TryGetEdge(path[0].Name, out var edge))
+            using (args.PushGroup(nameof(ConstructionGhostComponent)))
             {
-                return;
-            }
+                args.PushMarkup(Loc.GetString(
+                    "construction-ghost-examine-message",
+                    ("name", component.Prototype.Name)));
 
-            foreach (var step in edge.Steps)
-            {
-                step.DoExamine(args);
+                if (!_prototypeManager.TryIndex(component.Prototype.Graph, out ConstructionGraphPrototype? graph))
+                    return;
+
+                var startNode = graph.Nodes[component.Prototype.StartNode];
+
+                if (!graph.TryPath(component.Prototype.StartNode, component.Prototype.TargetNode, out var path) ||
+                    !startNode.TryGetEdge(path[0].Name, out var edge))
+                {
+                    return;
+                }
+
+                foreach (var step in edge.Steps)
+                {
+                    step.DoExamine(args);
+                }
             }
         }
 

--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -366,13 +366,14 @@ namespace Content.Client.Examine
             var canSeeClearly = !HasComp<BlurryVisionComponent>(playerEnt);
 
             OpenTooltip(playerEnt.Value, entity, centeredOnCursor, false, knowTarget: canSeeClearly);
-            if (IsClientSide(entity)
-                || _client.RunLevel == ClientRunLevel.SinglePlayerGame) // i.e. a replay
-            {
-                message = GetExamineText(entity, playerEnt);
-                UpdateTooltipInfo(playerEnt.Value, entity, message);
-            }
-            else
+
+            // Always update tooltip info from client first.
+            // If we get it wrong, server will correct us later anyway.
+            // This will usually be correct (barring server-only components, which generally only adds, not replaces text)
+            message = GetExamineText(entity, playerEnt);
+            UpdateTooltipInfo(playerEnt.Value, entity, message);
+
+            if (!IsClientSide(entity))
             {
                 // Ask server for extra examine info.
                 if (entity != _lastExaminedEntity)
@@ -383,7 +384,6 @@ namespace Content.Client.Examine
             }
 
             RaiseLocalEvent(entity, new ClientExaminedEvent(entity, playerEnt.Value));
-
             _lastExaminedEntity = entity;
         }
 

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -110,6 +110,7 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnExamined(EntityUid uid, GasTankComponent component, ExaminedEvent args)
         {
+            using(args.PushGroup(nameof(GasTankComponent)));
             if (args.IsInDetailsRange)
                 args.PushMarkup(Loc.GetString("comp-gas-tank-examine", ("pressure", Math.Round(component.Air?.Pressure ?? 0))));
             if (component.IsConnected)

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasRecyclerSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasRecyclerSystem.cs
@@ -51,20 +51,23 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 return;
             }
 
-            if (comp.Reacting)
+            using (args.PushGroup(nameof(GasRecyclerComponent)))
             {
-                args.PushMarkup(Loc.GetString("gas-recycler-reacting"));
-            }
-            else
-            {
-                if (inlet.Air.Pressure < comp.MinPressure)
+                if (comp.Reacting)
                 {
-                    args.PushMarkup(Loc.GetString("gas-recycler-low-pressure"));
+                    args.PushMarkup(Loc.GetString("gas-recycler-reacting"));
                 }
-
-                if (inlet.Air.Temperature < comp.MinTemp)
+                else
                 {
-                    args.PushMarkup(Loc.GetString("gas-recycler-low-temperature"));
+                    if (inlet.Air.Pressure < comp.MinPressure)
+                    {
+                        args.PushMarkup(Loc.GetString("gas-recycler-low-pressure"));
+                    }
+
+                    if (inlet.Air.Temperature < comp.MinTemp)
+                    {
+                        args.PushMarkup(Loc.GetString("gas-recycler-low-temperature"));
+                    }
                 }
             }
         }

--- a/Content.Server/Botany/Systems/BotanySystem.Seed.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Seed.cs
@@ -90,10 +90,13 @@ public sealed partial class BotanySystem : EntitySystem
         if (!TryGetSeed(component, out var seed))
             return;
 
-        var name = Loc.GetString(seed.DisplayName);
-        args.PushMarkup(Loc.GetString($"seed-component-description", ("seedName", name)));
-        args.PushMarkup(Loc.GetString($"seed-component-plant-yield-text", ("seedYield", seed.Yield)));
-        args.PushMarkup(Loc.GetString($"seed-component-plant-potency-text", ("seedPotency", seed.Potency)));
+        using (args.PushGroup(nameof(SeedComponent)))
+        {
+            var name = Loc.GetString(seed.DisplayName);
+            args.PushMarkup(Loc.GetString($"seed-component-description", ("seedName", name)));
+            args.PushMarkup(Loc.GetString($"seed-component-plant-yield-text", ("seedYield", seed.Yield)));
+            args.PushMarkup(Loc.GetString($"seed-component-plant-potency-text", ("seedPotency", seed.Potency)));
+        }
     }
 
     #region SeedPrototype prototype stuff

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -77,59 +77,62 @@ public sealed class PlantHolderSystem : EntitySystem
 
         var (_, component) = entity;
 
-        if (component.Seed == null)
+        using (args.PushGroup(nameof(PlantHolderComponent)))
         {
-            args.PushMarkup(Loc.GetString("plant-holder-component-nothing-planted-message"));
-        }
-        else if (!component.Dead)
-        {
-            var displayName = Loc.GetString(component.Seed.DisplayName);
-            args.PushMarkup(Loc.GetString("plant-holder-component-something-already-growing-message",
+            if (component.Seed == null)
+            {
+                args.PushMarkup(Loc.GetString("plant-holder-component-nothing-planted-message"));
+            }
+            else if (!component.Dead)
+            {
+                var displayName = Loc.GetString(component.Seed.DisplayName);
+                args.PushMarkup(Loc.GetString("plant-holder-component-something-already-growing-message",
                     ("seedName", displayName),
                     ("toBeForm", displayName.EndsWith('s') ? "are" : "is")));
 
-            if (component.Health <= component.Seed.Endurance / 2)
-            {
-                args.PushMarkup(Loc.GetString(
-                    "plant-holder-component-something-already-growing-low-health-message",
-                    ("healthState",
-                        Loc.GetString(component.Age > component.Seed.Lifespan
-                            ? "plant-holder-component-plant-old-adjective"
-                            : "plant-holder-component-plant-unhealthy-adjective"))));
+                if (component.Health <= component.Seed.Endurance / 2)
+                {
+                    args.PushMarkup(Loc.GetString(
+                        "plant-holder-component-something-already-growing-low-health-message",
+                        ("healthState",
+                            Loc.GetString(component.Age > component.Seed.Lifespan
+                                ? "plant-holder-component-plant-old-adjective"
+                                : "plant-holder-component-plant-unhealthy-adjective"))));
+                }
             }
-        }
-        else
-        {
-            args.PushMarkup(Loc.GetString("plant-holder-component-dead-plant-matter-message"));
-        }
+            else
+            {
+                args.PushMarkup(Loc.GetString("plant-holder-component-dead-plant-matter-message"));
+            }
 
-        if (component.WeedLevel >= 5)
-            args.PushMarkup(Loc.GetString("plant-holder-component-weed-high-level-message"));
+            if (component.WeedLevel >= 5)
+                args.PushMarkup(Loc.GetString("plant-holder-component-weed-high-level-message"));
 
-        if (component.PestLevel >= 5)
-            args.PushMarkup(Loc.GetString("plant-holder-component-pest-high-level-message"));
+            if (component.PestLevel >= 5)
+                args.PushMarkup(Loc.GetString("plant-holder-component-pest-high-level-message"));
 
-        args.PushMarkup(Loc.GetString($"plant-holder-component-water-level-message",
-            ("waterLevel", (int) component.WaterLevel)));
-        args.PushMarkup(Loc.GetString($"plant-holder-component-nutrient-level-message",
-            ("nutritionLevel", (int) component.NutritionLevel)));
+            args.PushMarkup(Loc.GetString($"plant-holder-component-water-level-message",
+                ("waterLevel", (int) component.WaterLevel)));
+            args.PushMarkup(Loc.GetString($"plant-holder-component-nutrient-level-message",
+                ("nutritionLevel", (int) component.NutritionLevel)));
 
-        if (component.DrawWarnings)
-        {
-            if (component.Toxins > 40f)
-                args.PushMarkup(Loc.GetString("plant-holder-component-toxins-high-warning"));
+            if (component.DrawWarnings)
+            {
+                if (component.Toxins > 40f)
+                    args.PushMarkup(Loc.GetString("plant-holder-component-toxins-high-warning"));
 
-            if (component.ImproperLight)
-                args.PushMarkup(Loc.GetString("plant-holder-component-light-improper-warning"));
+                if (component.ImproperLight)
+                    args.PushMarkup(Loc.GetString("plant-holder-component-light-improper-warning"));
 
-            if (component.ImproperHeat)
-                args.PushMarkup(Loc.GetString("plant-holder-component-heat-improper-warning"));
+                if (component.ImproperHeat)
+                    args.PushMarkup(Loc.GetString("plant-holder-component-heat-improper-warning"));
 
-            if (component.ImproperPressure)
-                args.PushMarkup(Loc.GetString("plant-holder-component-pressure-improper-warning"));
+                if (component.ImproperPressure)
+                    args.PushMarkup(Loc.GetString("plant-holder-component-pressure-improper-warning"));
 
-            if (component.MissingGas > 0)
-                args.PushMarkup(Loc.GetString("plant-holder-component-gas-missing-warning"));
+                if (component.MissingGas > 0)
+                    args.PushMarkup(Loc.GetString("plant-holder-component-gas-missing-warning"));
+            }
         }
     }
 

--- a/Content.Server/Construction/Conditions/MachineFrameComplete.cs
+++ b/Content.Server/Construction/Conditions/MachineFrameComplete.cs
@@ -46,7 +46,7 @@ namespace Content.Server.Construction.Conditions
             if (entityManager.EntitySysManager.GetEntitySystem<MachineFrameSystem>().IsComplete(machineFrame))
                 return false;
 
-            args.Message.AddMarkup(Loc.GetString("construction-condition-machine-frame-requirement-label") + "\n");
+            args.PushMarkup(Loc.GetString("construction-condition-machine-frame-requirement-label"));
             foreach (var (part, required) in machineFrame.Requirements)
             {
                 var amount = required - machineFrame.Progress[part];
@@ -54,10 +54,9 @@ namespace Content.Server.Construction.Conditions
                 if(amount == 0)
                     continue;
 
-                args.Message.AddMarkup(Loc.GetString("construction-condition-machine-frame-required-element-entry",
+                args.PushMarkup(Loc.GetString("construction-condition-machine-frame-required-element-entry",
                                            ("amount", amount),
-                                           ("elementName", Loc.GetString(part)))
-                                       + "\n");
+                                           ("elementName", Loc.GetString(part))));
             }
 
             foreach (var (material, required) in machineFrame.MaterialRequirements)
@@ -67,10 +66,9 @@ namespace Content.Server.Construction.Conditions
                 if(amount == 0)
                     continue;
 
-                args.Message.AddMarkup(Loc.GetString("construction-condition-machine-frame-required-element-entry",
+                args.PushMarkup(Loc.GetString("construction-condition-machine-frame-required-element-entry",
                                            ("amount", amount),
-                                           ("elementName", Loc.GetString(material)))
-                                       + "\n");
+                                           ("elementName", Loc.GetString(material))));
             }
 
             foreach (var (compName, info) in machineFrame.ComponentRequirements)
@@ -80,10 +78,9 @@ namespace Content.Server.Construction.Conditions
                 if(amount == 0)
                     continue;
 
-                args.Message.AddMarkup(Loc.GetString("construction-condition-machine-frame-required-element-entry",
+                args.PushMarkup(Loc.GetString("construction-condition-machine-frame-required-element-entry",
                                                 ("amount", info.Amount),
-                                                ("elementName", Loc.GetString(info.ExamineName)))
-                                  + "\n");
+                                                ("elementName", Loc.GetString(info.ExamineName))));
             }
 
             foreach (var (tagName, info) in machineFrame.TagRequirements)
@@ -93,10 +90,10 @@ namespace Content.Server.Construction.Conditions
                 if(amount == 0)
                     continue;
 
-                args.Message.AddMarkup(Loc.GetString("construction-condition-machine-frame-required-element-entry",
-                                           ("amount", info.Amount),
-                                           ("elementName", Loc.GetString(info.ExamineName)))
-                                       + "\n");
+                args.PushMarkup(Loc.GetString("construction-condition-machine-frame-required-element-entry",
+                                    ("amount", info.Amount),
+                                    ("elementName", Loc.GetString(info.ExamineName)))
+                                + "\n");
             }
 
             return true;

--- a/Content.Server/Defusable/Systems/DefusableSystem.cs
+++ b/Content.Server/Defusable/Systems/DefusableSystem.cs
@@ -66,25 +66,28 @@ public sealed class DefusableSystem : SharedDefusableSystem
         if (!args.IsInDetailsRange)
             return;
 
-        if (!comp.Usable)
+        using (args.PushGroup(nameof(DefusableComponent)))
         {
-            args.PushMarkup(Loc.GetString("defusable-examine-defused", ("name", uid)));
-        }
-        else if (comp.Activated && TryComp<ActiveTimerTriggerComponent>(uid, out var activeComp))
-        {
-            if (comp.DisplayTime)
+            if (!comp.Usable)
             {
-                args.PushMarkup(Loc.GetString("defusable-examine-live", ("name", uid),
-                    ("time", MathF.Floor(activeComp.TimeRemaining))));
+                args.PushMarkup(Loc.GetString("defusable-examine-defused", ("name", uid)));
+            }
+            else if (comp.Activated && TryComp<ActiveTimerTriggerComponent>(uid, out var activeComp))
+            {
+                if (comp.DisplayTime)
+                {
+                    args.PushMarkup(Loc.GetString("defusable-examine-live", ("name", uid),
+                        ("time", MathF.Floor(activeComp.TimeRemaining))));
+                }
+                else
+                {
+                    args.PushMarkup(Loc.GetString("defusable-examine-live-display-off", ("name", uid)));
+                }
             }
             else
             {
-                args.PushMarkup(Loc.GetString("defusable-examine-live-display-off", ("name", uid)));
+                args.PushMarkup(Loc.GetString("defusable-examine-inactive", ("name", uid)));
             }
-        }
-        else
-        {
-            args.PushMarkup(Loc.GetString("defusable-examine-inactive", ("name", uid)));
         }
 
         args.PushMarkup(Loc.GetString("defusable-examine-bolts", ("down", comp.Bolted)));

--- a/Content.Server/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/DrainSystem.cs
@@ -216,7 +216,7 @@ public sealed class DrainSystem : SharedDrainSystem
         var text = drainSolution.AvailableVolume != 0
             ? Loc.GetString("drain-component-examine-volume", ("volume", drainSolution.AvailableVolume))
             : Loc.GetString("drain-component-examine-hint-full");
-        args.Message.AddMarkup($"\n\n{text}");
+        args.PushMarkup(text);
     }
 
     private void OnInteract(Entity<DrainComponent> entity, ref AfterInteractUsingEvent args)

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -43,10 +43,13 @@ public sealed partial class PuddleSystem
 
     private void OnExamined(Entity<SpillableComponent> entity, ref ExaminedEvent args)
     {
-        args.PushMarkup(Loc.GetString("spill-examine-is-spillable"));
+        using (args.PushGroup(nameof(SpillableComponent)))
+        {
+            args.PushMarkup(Loc.GetString("spill-examine-is-spillable"));
 
-        if (HasComp<MeleeWeaponComponent>(entity))
-            args.PushMarkup(Loc.GetString("spill-examine-spillable-weapon"));
+            if (HasComp<MeleeWeaponComponent>(entity))
+                args.PushMarkup(Loc.GetString("spill-examine-spillable-weapon"));
+        }
     }
 
     private void OnOverflow(Entity<SpillableComponent> entity, ref SolutionContainerOverflowEvent args)

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -361,23 +361,27 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
     private void HandlePuddleExamined(Entity<PuddleComponent> entity, ref ExaminedEvent args)
     {
-        if (TryComp<StepTriggerComponent>(entity, out var slippery) && slippery.Active)
+        using (args.PushGroup(nameof(PuddleComponent)))
         {
-            args.PushMarkup(Loc.GetString("puddle-component-examine-is-slipper-text"));
-        }
+            if (TryComp<StepTriggerComponent>(entity, out var slippery) && slippery.Active)
+            {
+                args.PushMarkup(Loc.GetString("puddle-component-examine-is-slipper-text"));
+            }
 
-        if (HasComp<EvaporationComponent>(entity) &&
-            _solutionContainerSystem.ResolveSolution(entity.Owner, entity.Comp.SolutionName, ref entity.Comp.Solution, out var solution))
-        {
-            if (CanFullyEvaporate(solution))
-                args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating"));
-            else if (solution.GetTotalPrototypeQuantity(EvaporationReagents) > FixedPoint2.Zero)
-                args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-partial"));
+            if (HasComp<EvaporationComponent>(entity) &&
+                _solutionContainerSystem.ResolveSolution(entity.Owner, entity.Comp.SolutionName,
+                    ref entity.Comp.Solution, out var solution))
+            {
+                if (CanFullyEvaporate(solution))
+                    args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating"));
+                else if (solution.GetTotalPrototypeQuantity(EvaporationReagents) > FixedPoint2.Zero)
+                    args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-partial"));
+                else
+                    args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-no"));
+            }
             else
                 args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-no"));
         }
-        else
-            args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-no"));
     }
 
     private void OnAnchorChanged(Entity<PuddleComponent> entity, ref AnchorStateChangedEvent args)

--- a/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
@@ -59,7 +59,7 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
     {
         if (!args.IsInDetailsRange)
             return;
-
+        
         if (TryComp<MindContainerComponent>(uid, out var mind) && mind.HasMind)
         {
             args.PushMarkup(Loc.GetString(component.ExamineTextMindPresent));

--- a/Content.Server/Holiday/Christmas/RandomGiftSystem.cs
+++ b/Content.Server/Holiday/Christmas/RandomGiftSystem.cs
@@ -44,8 +44,7 @@ public sealed class RandomGiftSystem : EntitySystem
             return;
 
         var name = _prototype.Index<EntityPrototype>(component.SelectedEntity).Name;
-        args.Message.PushNewline();
-        args.Message.AddText(Loc.GetString("gift-packin-contains", ("name", name)));
+        args.PushText(Loc.GetString("gift-packin-contains", ("name", name)));
     }
 
     private void OnUseInHand(EntityUid uid, RandomGiftComponent component, UseInHandEvent args)

--- a/Content.Server/Holosign/HolosignSystem.cs
+++ b/Content.Server/Holosign/HolosignSystem.cs
@@ -25,11 +25,14 @@ public sealed class HolosignSystem : EntitySystem
         var charges = UsesRemaining(component, battery);
         var maxCharges = MaxUses(component, battery);
 
-        args.PushMarkup(Loc.GetString("limited-charges-charges-remaining", ("charges", charges)));
-
-        if (charges > 0 && charges == maxCharges)
+        using (args.PushGroup(nameof(HolosignProjectorComponent)))
         {
-            args.PushMarkup(Loc.GetString("limited-charges-max-charges"));
+            args.PushMarkup(Loc.GetString("limited-charges-charges-remaining", ("charges", charges)));
+
+            if (charges > 0 && charges == maxCharges)
+            {
+                args.PushMarkup(Loc.GetString("limited-charges-max-charges"));
+            }
         }
     }
 

--- a/Content.Server/Labels/Label/LabelSystem.cs
+++ b/Content.Server/Labels/Label/LabelSystem.cs
@@ -100,25 +100,28 @@ namespace Content.Server.Labels
             if (comp.LabelSlot.Item is not {Valid: true} item)
                 return;
 
-            if (!args.IsInDetailsRange)
+            using (args.PushGroup(nameof(PaperLabelComponent)))
             {
-                args.PushMarkup(Loc.GetString("comp-paper-label-has-label-cant-read"));
-                return;
+                if (!args.IsInDetailsRange)
+                {
+                    args.PushMarkup(Loc.GetString("comp-paper-label-has-label-cant-read"));
+                    return;
+                }
+
+                if (!EntityManager.TryGetComponent(item, out PaperComponent? paper))
+                    // Assuming yaml has the correct entity whitelist, this should not happen.
+                    return;
+
+                if (string.IsNullOrWhiteSpace(paper.Content))
+                {
+                    args.PushMarkup(Loc.GetString("comp-paper-label-has-label-blank"));
+                    return;
+                }
+
+                args.PushMarkup(Loc.GetString("comp-paper-label-has-label"));
+                var text = paper.Content;
+                args.PushMarkup(text.TrimEnd());
             }
-
-            if (!EntityManager.TryGetComponent(item, out PaperComponent? paper))
-                // Assuming yaml has the correct entity whitelist, this should not happen.
-                return;
-
-            if (string.IsNullOrWhiteSpace(paper.Content))
-            {
-                args.PushMarkup(Loc.GetString("comp-paper-label-has-label-blank"));
-                return;
-            }
-
-            args.PushMarkup(Loc.GetString("comp-paper-label-has-label"));
-            var text = paper.Content;
-            args.PushMarkup(text.TrimEnd());
         }
 
         private void OnContainerModified(EntityUid uid, PaperLabelComponent label, ContainerModifiedMessage args)

--- a/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
@@ -47,28 +47,31 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
 
     private void OnEmergencyExamine(EntityUid uid, EmergencyLightComponent component, ExaminedEvent args)
     {
-        args.PushMarkup(
-            Loc.GetString("emergency-light-component-on-examine",
-                ("batteryStateText",
-                    Loc.GetString(component.BatteryStateText[component.State]))));
+        using (args.PushGroup(nameof(EmergencyLightComponent)))
+        {
+            args.PushMarkup(
+                Loc.GetString("emergency-light-component-on-examine",
+                    ("batteryStateText",
+                        Loc.GetString(component.BatteryStateText[component.State]))));
 
-        // Show alert level on the light itself.
-        if (!TryComp<AlertLevelComponent>(_station.GetOwningStation(uid), out var alerts))
-            return;
+            // Show alert level on the light itself.
+            if (!TryComp<AlertLevelComponent>(_station.GetOwningStation(uid), out var alerts))
+                return;
 
-        if (alerts.AlertLevels == null)
-            return;
+            if (alerts.AlertLevels == null)
+                return;
 
-        var name = alerts.CurrentLevel;
+            var name = alerts.CurrentLevel;
 
-        var color = Color.White;
-        if (alerts.AlertLevels.Levels.TryGetValue(alerts.CurrentLevel, out var details))
-            color = details.Color;
+            var color = Color.White;
+            if (alerts.AlertLevels.Levels.TryGetValue(alerts.CurrentLevel, out var details))
+                color = details.Color;
 
-        args.PushMarkup(
-            Loc.GetString("emergency-light-component-on-examine-alert",
-                ("color", color.ToHex()),
-                ("level", name)));
+            args.PushMarkup(
+                Loc.GetString("emergency-light-component-on-examine-alert",
+                    ("color", color.ToHex()),
+                    ("level", name)));
+        }
     }
 
     private void OnEmergencyLightEvent(EntityUid uid, EmergencyLightComponent component, EmergencyLightEvent args)

--- a/Content.Server/Light/EntitySystems/LightReplacerSystem.cs
+++ b/Content.Server/Light/EntitySystems/LightReplacerSystem.cs
@@ -33,23 +33,27 @@ public sealed class LightReplacerSystem : EntitySystem
 
     private void OnExamined(EntityUid uid, LightReplacerComponent component, ExaminedEvent args)
     {
-        if (!component.InsertedBulbs.ContainedEntities.Any())
+        using (args.PushGroup(nameof(LightReplacerComponent)))
         {
-            args.PushMarkup(Loc.GetString("comp-light-replacer-no-lights"));
-            return;
-        }
-        args.PushMarkup(Loc.GetString("comp-light-replacer-has-lights"));
-        var groups = new Dictionary<string, int>();
-        var metaQuery = GetEntityQuery<MetaDataComponent>();
-        foreach (var bulb in component.InsertedBulbs.ContainedEntities)
-        {
-            var metaData = metaQuery.GetComponent(bulb);
-            groups[metaData.EntityName] = groups.GetValueOrDefault(metaData.EntityName) + 1;
-        }
+            if (!component.InsertedBulbs.ContainedEntities.Any())
+            {
+                args.PushMarkup(Loc.GetString("comp-light-replacer-no-lights"));
+                return;
+            }
 
-        foreach (var (name, amount) in groups)
-        {
-            args.PushMarkup(Loc.GetString("comp-light-replacer-light-listing", ("amount", amount), ("name", name)));
+            args.PushMarkup(Loc.GetString("comp-light-replacer-has-lights"));
+            var groups = new Dictionary<string, int>();
+            var metaQuery = GetEntityQuery<MetaDataComponent>();
+            foreach (var bulb in component.InsertedBulbs.ContainedEntities)
+            {
+                var metaData = metaQuery.GetComponent(bulb);
+                groups[metaData.EntityName] = groups.GetValueOrDefault(metaData.EntityName) + 1;
+            }
+
+            foreach (var (name, amount) in groups)
+            {
+                args.PushMarkup(Loc.GetString("comp-light-replacer-light-listing", ("amount", amount), ("name", name)));
+            }
         }
     }
 

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -208,10 +208,13 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
         var container = _itemSlotsSystem.GetItemOrNull(entity.Owner, entity.Comp.SolutionContainerName);
         if (args.IsInDetailsRange && container != null && _solutionContainerSystem.TryGetFitsInDispenser(container.Value, out _, out var containerSolution))
         {
-            args.PushMarkup(Loc.GetString("cryo-pod-examine", ("beaker", Name(container.Value))));
-            if (containerSolution.Volume == 0)
+            using (args.PushGroup(nameof(CryoPodComponent)))
             {
-                args.PushMarkup(Loc.GetString("cryo-pod-empty-beaker"));
+                args.PushMarkup(Loc.GetString("cryo-pod-examine", ("beaker", Name(container.Value))));
+                if (containerSolution.Volume == 0)
+                {
+                    args.PushMarkup(Loc.GetString("cryo-pod-empty-beaker"));
+                }
             }
         }
     }

--- a/Content.Server/Morgue/CrematoriumSystem.cs
+++ b/Content.Server/Morgue/CrematoriumSystem.cs
@@ -47,17 +47,24 @@ public sealed class CrematoriumSystem : EntitySystem
         if (!TryComp<AppearanceComponent>(uid, out var appearance))
             return;
 
-        if (_appearance.TryGetData<bool>(uid, CrematoriumVisuals.Burning, out var isBurning, appearance) && isBurning)
+        using (args.PushGroup(nameof(CrematoriumComponent)))
         {
-            args.PushMarkup(Loc.GetString("crematorium-entity-storage-component-on-examine-details-is-burning", ("owner", uid)));
-        }
-        if (_appearance.TryGetData<bool>(uid, StorageVisuals.HasContents, out var hasContents, appearance) && hasContents)
-        {
-            args.PushMarkup(Loc.GetString("crematorium-entity-storage-component-on-examine-details-has-contents"));
-        }
-        else
-        {
-            args.PushMarkup(Loc.GetString("crematorium-entity-storage-component-on-examine-details-empty"));
+            if (_appearance.TryGetData<bool>(uid, CrematoriumVisuals.Burning, out var isBurning, appearance) &&
+                isBurning)
+            {
+                args.PushMarkup(Loc.GetString("crematorium-entity-storage-component-on-examine-details-is-burning",
+                    ("owner", uid)));
+            }
+
+            if (_appearance.TryGetData<bool>(uid, StorageVisuals.HasContents, out var hasContents, appearance) &&
+                hasContents)
+            {
+                args.PushMarkup(Loc.GetString("crematorium-entity-storage-component-on-examine-details-has-contents"));
+            }
+            else
+            {
+                args.PushMarkup(Loc.GetString("crematorium-entity-storage-component-on-examine-details-empty"));
+            }
         }
     }
 

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -135,19 +135,19 @@ public sealed class DrinkSystem : EntitySystem
             return;
 
         // put Empty / Xu after Opened, or start a new line
-        args.Message.AddMarkup(hasOpenable ? " - " : "\n");
+        args.AddMarkup(hasOpenable ? " - " : "\n");
 
         var empty = IsEmpty(entity, entity.Comp);
         if (empty)
         {
-            args.Message.AddMarkup(Loc.GetString("drink-component-on-examine-is-empty"));
+            args.AddMarkup(Loc.GetString("drink-component-on-examine-is-empty"));
             return;
         }
 
         if (TryComp<ExaminableSolutionComponent>(entity, out var comp))
         {
             //provide exact measurement for beakers
-            args.Message.AddMarkup(Loc.GetString("drink-component-on-examine-exact-volume", ("amount", DrinkVolume(entity, entity.Comp))));
+            args.AddMarkup(Loc.GetString("drink-component-on-examine-exact-volume", ("amount", DrinkVolume(entity, entity.Comp))));
         }
         else
         {
@@ -159,7 +159,7 @@ public sealed class DrinkSystem : EntitySystem
                 > 33 => HalfEmptyOrHalfFull(args),
                 _ => "drink-component-on-examine-is-mostly-empty",
             };
-            args.Message.AddMarkup(Loc.GetString(remainingString));
+            args.AddMarkup(Loc.GetString(remainingString));
         }
     }
 

--- a/Content.Server/Paper/PaperSystem.cs
+++ b/Content.Server/Paper/PaperSystem.cs
@@ -79,20 +79,24 @@ namespace Content.Server.Paper
             if (!args.IsInDetailsRange)
                 return;
 
-            if (paperComp.Content != "")
-                args.PushMarkup(
-                    Loc.GetString(
-                        "paper-component-examine-detail-has-words", ("paper", uid)
-                    )
-                );
-
-            if (paperComp.StampedBy.Count > 0)
+            using (args.PushGroup(nameof(PaperComponent)))
             {
-                var commaSeparated = string.Join(", ", paperComp.StampedBy.Select(s => Loc.GetString(s.StampedName)));
-                args.PushMarkup(
-                    Loc.GetString(
-                        "paper-component-examine-detail-stamped-by", ("paper", uid), ("stamps", commaSeparated))
-                );
+                if (paperComp.Content != "")
+                    args.PushMarkup(
+                        Loc.GetString(
+                            "paper-component-examine-detail-has-words", ("paper", uid)
+                        )
+                    );
+
+                if (paperComp.StampedBy.Count > 0)
+                {
+                    var commaSeparated =
+                        string.Join(", ", paperComp.StampedBy.Select(s => Loc.GetString(s.StampedName)));
+                    args.PushMarkup(
+                        Loc.GetString(
+                            "paper-component-examine-detail-stamped-by", ("paper", uid), ("stamps", commaSeparated))
+                    );
+                }
             }
         }
 

--- a/Content.Server/Payload/EntitySystems/PayloadSystem.cs
+++ b/Content.Server/Payload/EntitySystems/PayloadSystem.cs
@@ -121,19 +121,22 @@ public sealed class PayloadSystem : EntitySystem
 
     private void OnExamined(EntityUid uid, PayloadCaseComponent component, ExaminedEvent args)
     {
-        if (!args.IsInDetailsRange)
+        using (args.PushGroup(nameof(PayloadCaseComponent)))
         {
-            args.PushMarkup(Loc.GetString("payload-case-not-close-enough", ("ent", uid)));
-            return;
-        }
+            if (!args.IsInDetailsRange)
+            {
+                args.PushMarkup(Loc.GetString("payload-case-not-close-enough", ("ent", uid)));
+                return;
+            }
 
-        if (GetAllPayloads(uid).Any())
-        {
-            args.PushMarkup(Loc.GetString("payload-case-has-payload", ("ent", uid)));
-        }
-        else
-        {
-            args.PushMarkup(Loc.GetString("payload-case-does-not-have-payload", ("ent", uid)));
+            if (GetAllPayloads(uid).Any())
+            {
+                args.PushMarkup(Loc.GetString("payload-case-has-payload", ("ent", uid)));
+            }
+            else
+            {
+                args.PushMarkup(Loc.GetString("payload-case-does-not-have-payload", ("ent", uid)));
+            }
         }
     }
 

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -172,8 +172,13 @@ public sealed class RadioDeviceSystem : EntitySystem
             return;
 
         var proto = _protoMan.Index<RadioChannelPrototype>(component.BroadcastChannel);
-        args.PushMarkup(Loc.GetString("handheld-radio-component-on-examine", ("frequency", proto.Frequency)));
-        args.PushMarkup(Loc.GetString("handheld-radio-component-chennel-examine", ("channel", proto.LocalizedName)));
+
+        using (args.PushGroup(nameof(RadioMicrophoneComponent)))
+        {
+            args.PushMarkup(Loc.GetString("handheld-radio-component-on-examine", ("frequency", proto.Frequency)));
+            args.PushMarkup(Loc.GetString("handheld-radio-component-chennel-examine",
+                ("channel", proto.LocalizedName)));
+        }
     }
 
     private void OnListen(EntityUid uid, RadioMicrophoneComponent component, ListenEvent args)

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -64,22 +64,26 @@ public sealed class ThrusterSystem : EntitySystem
         // Powered is already handled by other power components
         var enabled = Loc.GetString(component.Enabled ? "thruster-comp-enabled" : "thruster-comp-disabled");
 
-        args.PushMarkup(enabled);
-
-        if (component.Type == ThrusterType.Linear &&
-            EntityManager.TryGetComponent(uid, out TransformComponent? xform) &&
-            xform.Anchored)
+        using (args.PushGroup(nameof(ThrusterComponent)))
         {
-            var nozzleDir = Loc.GetString("thruster-comp-nozzle-direction",
-                ("direction", xform.LocalRotation.Opposite().ToWorldVec().GetDir().ToString().ToLowerInvariant()));
+            args.PushMarkup(enabled);
 
-            args.PushMarkup(nozzleDir);
+            if (component.Type == ThrusterType.Linear &&
+                EntityManager.TryGetComponent(uid, out TransformComponent? xform) &&
+                xform.Anchored)
+            {
+                var nozzleDir = Loc.GetString("thruster-comp-nozzle-direction",
+                    ("direction", xform.LocalRotation.Opposite().ToWorldVec().GetDir().ToString().ToLowerInvariant()));
 
-            var exposed = NozzleExposed(xform);
+                args.PushMarkup(nozzleDir);
 
-            var nozzleText = Loc.GetString(exposed ? "thruster-comp-nozzle-exposed" : "thruster-comp-nozzle-not-exposed");
+                var exposed = NozzleExposed(xform);
 
-            args.PushMarkup(nozzleText);
+                var nozzleText =
+                    Loc.GetString(exposed ? "thruster-comp-nozzle-exposed" : "thruster-comp-nozzle-not-exposed");
+
+                args.PushMarkup(nozzleText);
+            }
         }
     }
 

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -52,11 +52,15 @@ namespace Content.Server.Stunnable.Systems
             var onMsg = _itemToggle.IsActivated(entity.Owner)
             ? Loc.GetString("comp-stunbaton-examined-on")
             : Loc.GetString("comp-stunbaton-examined-off");
-            args.PushMarkup(onMsg);
 
-            var chargeMessage = Loc.GetString("stunbaton-component-on-examine-charge",
-                ("charge", (int) (entity.Comp.CurrentCharge / entity.Comp.MaxCharge * 100)));
-            args.PushMarkup(chargeMessage);
+            using (args.PushGroup(nameof(BatteryComponent)))
+            {
+                args.PushMarkup(onMsg);
+
+                var chargeMessage = Loc.GetString("stunbaton-component-on-examine-charge",
+                    ("charge", (int) (entity.Comp.CurrentCharge / entity.Comp.MaxCharge * 100)));
+                args.PushMarkup(chargeMessage);
+            }
         }
 
         private void ToggleDone(Entity<StunbatonComponent> entity, ref ItemToggledEvent args)

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Server.Stunnable.Systems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<BatteryComponent, ExaminedEvent>(OnExamined);
+            SubscribeLocalEvent<StunbatonComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<StunbatonComponent, SolutionContainerChangedEvent>(OnSolutionChange);
             SubscribeLocalEvent<StunbatonComponent, StaminaDamageOnHitAttemptEvent>(OnStaminaHitAttempt);
             SubscribeLocalEvent<StunbatonComponent, ItemToggleActivateAttemptEvent>(TryTurnOn);
@@ -47,20 +47,12 @@ namespace Content.Server.Stunnable.Systems
             }
         }
 
-        private void OnExamined(Entity<BatteryComponent> entity, ref ExaminedEvent args)
+        private void OnExamined(Entity<StunbatonComponent> entity, ref ExaminedEvent args)
         {
             var onMsg = _itemToggle.IsActivated(entity.Owner)
             ? Loc.GetString("comp-stunbaton-examined-on")
             : Loc.GetString("comp-stunbaton-examined-off");
-
-            using (args.PushGroup(nameof(BatteryComponent)))
-            {
-                args.PushMarkup(onMsg);
-
-                var chargeMessage = Loc.GetString("stunbaton-component-on-examine-charge",
-                    ("charge", (int) (entity.Comp.CurrentCharge / entity.Comp.MaxCharge * 100)));
-                args.PushMarkup(chargeMessage);
-            }
+            args.PushMarkup(onMsg);
         }
 
         private void ToggleDone(Entity<StunbatonComponent> entity, ref ItemToggledEvent args)

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -99,24 +99,27 @@ namespace Content.Server.Tools
 
         private void OnWelderExamine(Entity<WelderComponent> entity, ref ExaminedEvent args)
         {
-            if (_itemToggle.IsActivated(entity.Owner))
+            using (args.PushGroup(nameof(WelderComponent)))
             {
-                args.PushMarkup(Loc.GetString("welder-component-on-examine-welder-lit-message"));
-            }
-            else
-            {
-                args.PushMarkup(Loc.GetString("welder-component-on-examine-welder-not-lit-message"));
-            }
+                if (_itemToggle.IsActivated(entity.Owner))
+                {
+                    args.PushMarkup(Loc.GetString("welder-component-on-examine-welder-lit-message"));
+                }
+                else
+                {
+                    args.PushMarkup(Loc.GetString("welder-component-on-examine-welder-not-lit-message"));
+                }
 
-            if (args.IsInDetailsRange)
-            {
-                var (fuel, capacity) = GetWelderFuelAndCapacity(entity.Owner, entity.Comp);
+                if (args.IsInDetailsRange)
+                {
+                    var (fuel, capacity) = GetWelderFuelAndCapacity(entity.Owner, entity.Comp);
 
-                args.PushMarkup(Loc.GetString("welder-component-on-examine-detailed-message",
-                    ("colorName", fuel < capacity / FixedPoint2.New(4f) ? "darkorange" : "orange"),
-                    ("fuelLeft", fuel),
-                    ("fuelCapacity", capacity),
-                    ("status", string.Empty))); // Lit status is handled above
+                    args.PushMarkup(Loc.GetString("welder-component-on-examine-detailed-message",
+                        ("colorName", fuel < capacity / FixedPoint2.New(4f) ? "darkorange" : "orange"),
+                        ("fuelLeft", fuel),
+                        ("fuelCapacity", capacity),
+                        ("status", string.Empty))); // Lit status is handled above
+                }
             }
         }
 

--- a/Content.Server/Xenoarchaeology/Equipment/Systems/TraversalDistorterSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/TraversalDistorterSystem.cs
@@ -73,7 +73,8 @@ public sealed class TraversalDistorterSystem : EntitySystem
                 examine = Loc.GetString("traversal-distorter-desc-out");
                 break;
         }
-        args.Message.AddMarkup(examine);
+        
+        args.PushMarkup(examine);
     }
 
     private void OnRefreshParts(EntityUid uid, TraversalDistorterComponent component, RefreshPartsEvent args)

--- a/Content.Shared/Charges/Systems/SharedChargesSystem.cs
+++ b/Content.Shared/Charges/Systems/SharedChargesSystem.cs
@@ -17,11 +17,13 @@ public abstract class SharedChargesSystem : EntitySystem
         if (!args.IsInDetailsRange)
             return;
 
-        args.PushMarkup(Loc.GetString("limited-charges-charges-remaining", ("charges", comp.Charges)));
-        if (comp.Charges == comp.MaxCharges)
+        using (args.PushGroup(nameof(LimitedChargesComponent)))
         {
-            args.PushMarkup(Loc.GetString("limited-charges-max-charges"));
-            return;
+            args.PushMarkup(Loc.GetString("limited-charges-charges-remaining", ("charges", comp.Charges)));
+            if (comp.Charges == comp.MaxCharges)
+            {
+                args.PushMarkup(Loc.GetString("limited-charges-max-charges"));
+            }
         }
     }
 

--- a/Content.Shared/Construction/MachinePartSystem.cs
+++ b/Content.Shared/Construction/MachinePartSystem.cs
@@ -28,33 +28,37 @@ namespace Content.Shared.Construction
         {
             if (!args.IsInDetailsRange)
                 return;
-            args.PushMarkup(Loc.GetString("machine-board-component-on-examine-label"));
-            foreach (var (part, amount) in component.Requirements)
-            {
-                args.PushMarkup(Loc.GetString("machine-board-component-required-element-entry-text",
-                                                ("amount", amount),
-                                                ("requiredElement", Loc.GetString(_prototype.Index<MachinePartPrototype>(part).Name))));
-            }
 
-            foreach (var (material, amount) in component.MaterialRequirements)
+            using (args.PushGroup(nameof(MachineBoardComponent)))
             {
-                args.PushMarkup(Loc.GetString("machine-board-component-required-element-entry-text",
-                                                ("amount", amount),
-                                                ("requiredElement", Loc.GetString(material.Name))));
-            }
+                args.PushMarkup(Loc.GetString("machine-board-component-on-examine-label"));
+                foreach (var (part, amount) in component.Requirements)
+                {
+                    args.PushMarkup(Loc.GetString("machine-board-component-required-element-entry-text",
+                        ("amount", amount),
+                        ("requiredElement", Loc.GetString(_prototype.Index<MachinePartPrototype>(part).Name))));
+                }
 
-            foreach (var (_, info) in component.ComponentRequirements)
-            {
-                args.PushMarkup(Loc.GetString("machine-board-component-required-element-entry-text",
-                                                ("amount", info.Amount),
-                                                ("requiredElement", Loc.GetString(info.ExamineName))));
-            }
+                foreach (var (material, amount) in component.MaterialRequirements)
+                {
+                    args.PushMarkup(Loc.GetString("machine-board-component-required-element-entry-text",
+                        ("amount", amount),
+                        ("requiredElement", Loc.GetString(material.Name))));
+                }
 
-            foreach (var (_, info) in component.TagRequirements)
-            {
-                args.PushMarkup(Loc.GetString("machine-board-component-required-element-entry-text",
-                                                ("amount", info.Amount),
-                                                ("requiredElement", Loc.GetString(info.ExamineName))));
+                foreach (var (_, info) in component.ComponentRequirements)
+                {
+                    args.PushMarkup(Loc.GetString("machine-board-component-required-element-entry-text",
+                        ("amount", info.Amount),
+                        ("requiredElement", Loc.GetString(info.ExamineName))));
+                }
+
+                foreach (var (_, info) in component.TagRequirements)
+                {
+                    args.PushMarkup(Loc.GetString("machine-board-component-required-element-entry-text",
+                        ("amount", info.Amount),
+                        ("requiredElement", Loc.GetString(info.ExamineName))));
+                }
             }
         }
 
@@ -62,9 +66,14 @@ namespace Content.Shared.Construction
         {
             if (!args.IsInDetailsRange)
                 return;
-            args.PushMarkup(Loc.GetString("machine-part-component-on-examine-rating-text", ("rating", component.Rating)));
-            args.PushMarkup(Loc.GetString("machine-part-component-on-examine-type-text", ("type",
-                Loc.GetString(_prototype.Index<MachinePartPrototype>(component.PartType).Name))));
+
+            using (args.PushGroup(nameof(MachinePartComponent)))
+            {
+                args.PushMarkup(Loc.GetString("machine-part-component-on-examine-rating-text",
+                    ("rating", component.Rating)));
+                args.PushMarkup(Loc.GetString("machine-part-component-on-examine-type-text", ("type",
+                    Loc.GetString(_prototype.Index<MachinePartPrototype>(component.PartType).Name))));
+            }
         }
 
         public Dictionary<string, int> GetMachineBoardMaterialCost(Entity<MachineBoardComponent> entity, int coefficient = 1)

--- a/Content.Shared/Construction/Steps/ArbitraryInsertConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/ArbitraryInsertConstructionGraphStep.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.Construction.Steps
             if (string.IsNullOrEmpty(Name))
                 return;
 
-            examinedEvent.Message.AddMarkup(Loc.GetString("construction-insert-arbitrary-entity", ("stepName", Name)));
+            examinedEvent.PushMarkup(Loc.GetString("construction-insert-arbitrary-entity", ("stepName", Name)));
         }
 
         public override ConstructionGuideEntry GenerateGuideEntry()

--- a/Content.Shared/Construction/Steps/ComponentConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/ComponentConstructionGraphStep.cs
@@ -20,7 +20,7 @@ namespace Content.Shared.Construction.Steps
 
         public override void DoExamine(ExaminedEvent examinedEvent)
         {
-            examinedEvent.Message.AddMarkup(string.IsNullOrEmpty(Name)
+            examinedEvent.PushMarkup(string.IsNullOrEmpty(Name)
                 ? Loc.GetString(
                     "construction-insert-entity-with-component",
                     ("componentName", Component))// Terrible.

--- a/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
@@ -20,7 +20,7 @@ namespace Content.Shared.Construction.Steps
         {
             var material = IoCManager.Resolve<IPrototypeManager>().Index<StackPrototype>(MaterialPrototypeId);
 
-            examinedEvent.PushMarkup(Loc.GetString("construction-insert-material-entity", ("amount", Amount), ("materialName", material.Name)),);
+            examinedEvent.PushMarkup(Loc.GetString("construction-insert-material-entity", ("amount", Amount), ("materialName", material.Name)));
         }
 
         public override bool EntityValid(EntityUid uid, IEntityManager entityManager, IComponentFactory compFactory)

--- a/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
@@ -20,7 +20,9 @@ namespace Content.Shared.Construction.Steps
         {
             var material = IoCManager.Resolve<IPrototypeManager>().Index<StackPrototype>(MaterialPrototypeId);
 
-            examinedEvent.Message.AddMarkup(Loc.GetString("construction-insert-material-entity", ("amount", Amount), ("materialName", material.Name)));
+            examinedEvent.PushMarkup(
+                Loc.GetString("construction-insert-material-entity", ("amount", Amount), ("materialName", material.Name)),
+                group: nameof(ConstructionGraphStep));
         }
 
         public override bool EntityValid(EntityUid uid, IEntityManager entityManager, IComponentFactory compFactory)

--- a/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
@@ -20,9 +20,7 @@ namespace Content.Shared.Construction.Steps
         {
             var material = IoCManager.Resolve<IPrototypeManager>().Index<StackPrototype>(MaterialPrototypeId);
 
-            examinedEvent.PushMarkup(
-                Loc.GetString("construction-insert-material-entity", ("amount", Amount), ("materialName", material.Name)),
-                group: nameof(ConstructionGraphStep));
+            examinedEvent.PushMarkup(Loc.GetString("construction-insert-material-entity", ("amount", Amount), ("materialName", material.Name)),);
         }
 
         public override bool EntityValid(EntityUid uid, IEntityManager entityManager, IComponentFactory compFactory)

--- a/Content.Shared/Dice/SharedDiceSystem.cs
+++ b/Content.Shared/Dice/SharedDiceSystem.cs
@@ -48,8 +48,12 @@ public abstract class SharedDiceSystem : EntitySystem
     private void OnExamined(EntityUid uid, DiceComponent dice, ExaminedEvent args)
     {
         //No details check, since the sprite updates to show the side.
-        args.PushMarkup(Loc.GetString("dice-component-on-examine-message-part-1", ("sidesAmount", dice.Sides)));
-        args.PushMarkup(Loc.GetString("dice-component-on-examine-message-part-2", ("currentSide", dice.CurrentValue)));
+        using (args.PushGroup(nameof(DiceComponent)))
+        {
+            args.PushMarkup(Loc.GetString("dice-component-on-examine-message-part-1", ("sidesAmount", dice.Sides)));
+            args.PushMarkup(Loc.GetString("dice-component-on-examine-message-part-2",
+                ("currentSide", dice.CurrentValue)));
+        }
     }
 
     public void SetCurrentSide(EntityUid uid, int side, DiceComponent? die = null)

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -185,19 +185,22 @@ public abstract partial class SharedHandsSystem : EntitySystem
         var held = EnumerateHeld(uid, handsComp)
             .Where(x => !HasComp<HandVirtualItemComponent>(x)).ToList();
 
-        if (!held.Any())
+        using (args.PushGroup(nameof(HandsComponent)))
         {
-            args.PushText(Loc.GetString("comp-hands-examine-empty",
-                ("user", Identity.Entity(uid, EntityManager))));
-            return;
+            if (!held.Any())
+            {
+                args.PushText(Loc.GetString("comp-hands-examine-empty",
+                    ("user", Identity.Entity(uid, EntityManager))));
+                return;
+            }
+
+            var heldList = ContentLocalizationManager.FormatList(held
+                .Select(x => Loc.GetString("comp-hands-examine-wrapper",
+                    ("item", Identity.Entity(x, EntityManager)))).ToList());
+
+            args.PushMarkup(Loc.GetString("comp-hands-examine",
+                ("user", Identity.Entity(uid, EntityManager)),
+                ("items", heldList)));
         }
-
-        var heldList = ContentLocalizationManager.FormatList(held
-            .Select(x => Loc.GetString("comp-hands-examine-wrapper",
-                ("item", Identity.Entity(x, EntityManager)))).ToList());
-
-        args.PushMarkup(Loc.GetString("comp-hands-examine",
-            ("user", Identity.Entity(uid, EntityManager)),
-            ("items", heldList)));
     }
 }

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -112,8 +112,9 @@ public abstract class SharedItemSystem : EntitySystem
 
     private void OnExamine(EntityUid uid, ItemComponent component, ExaminedEvent args)
     {
+        // show at end of message generally
         args.PushMarkup(Loc.GetString("item-component-on-examine-size",
-            ("size", GetItemSizeLocale(component.Size))));
+            ("size", GetItemSizeLocale(component.Size))), priority: -1);
     }
 
     public ItemSizePrototype GetSizePrototype(ProtoId<ItemSizePrototype> id)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -265,16 +265,20 @@ public abstract partial class SharedGunSystem
         var (count, _) = GetChamberMagazineCountCapacity(uid, component);
         string boltState;
 
-        if (component.BoltClosed != null)
+        using (args.PushGroup(nameof(ChamberMagazineAmmoProviderComponent)))
         {
-            if (component.BoltClosed == true)
-                boltState = Loc.GetString("gun-chamber-bolt-open-state");
-            else
-                boltState = Loc.GetString("gun-chamber-bolt-closed-state");
-            args.PushMarkup(Loc.GetString("gun-chamber-bolt", ("bolt", boltState), ("color", component.BoltClosed.Value ? Color.FromHex("#94e1f2") : Color.FromHex("#f29d94"))));
-        }
+            if (component.BoltClosed != null)
+            {
+                if (component.BoltClosed == true)
+                    boltState = Loc.GetString("gun-chamber-bolt-open-state");
+                else
+                    boltState = Loc.GetString("gun-chamber-bolt-closed-state");
+                args.PushMarkup(Loc.GetString("gun-chamber-bolt", ("bolt", boltState),
+                    ("color", component.BoltClosed.Value ? Color.FromHex("#94e1f2") : Color.FromHex("#f29d94"))));
+            }
 
-        args.PushMarkup(Loc.GetString("gun-magazine-examine", ("color", AmmoExamineColor), ("count", count)));
+            args.PushMarkup(Loc.GetString("gun-magazine-examine", ("color", AmmoExamineColor), ("count", count)));
+        }
     }
 
     private bool TryTakeChamberEntity(EntityUid uid, [NotNullWhen(true)] out EntityUid? entity)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -14,8 +14,13 @@ public abstract partial class SharedGunSystem
         if (!args.IsInDetailsRange || !component.ShowExamineText)
             return;
 
-        args.PushMarkup(Loc.GetString("gun-selected-mode-examine", ("color", ModeExamineColor), ("mode", GetLocSelector(component.SelectedMode))));
-        args.PushMarkup(Loc.GetString("gun-fire-rate-examine", ("color", FireRateExamineColor), ("fireRate", $"{component.FireRate:0.0}")));
+        using (args.PushGroup(nameof(GunComponent)))
+        {
+            args.PushMarkup(Loc.GetString("gun-selected-mode-examine", ("color", ModeExamineColor),
+                ("mode", GetLocSelector(component.SelectedMode))));
+            args.PushMarkup(Loc.GetString("gun-fire-rate-examine", ("color", FireRateExamineColor),
+                ("fireRate", $"{component.FireRate:0.0}")));
+        }
     }
 
     private string GetLocSelector(SelectiveFire mode)

--- a/Content.Shared/Wires/SharedWiresSystem.cs
+++ b/Content.Shared/Wires/SharedWiresSystem.cs
@@ -15,18 +15,21 @@ public abstract class SharedWiresSystem : EntitySystem
 
     private void OnExamine(EntityUid uid, WiresPanelComponent component, ExaminedEvent args)
     {
-        if (!component.Open)
+        using (args.PushGroup(nameof(WiresPanelComponent)))
         {
-            args.PushMarkup(Loc.GetString("wires-panel-component-on-examine-closed"));
-        }
-        else
-        {
-            args.PushMarkup(Loc.GetString("wires-panel-component-on-examine-open"));
-
-            if (TryComp<WiresPanelSecurityComponent>(uid, out var wiresPanelSecurity) &&
-                wiresPanelSecurity.Examine != null)
+            if (!component.Open)
             {
-                args.PushMarkup(Loc.GetString(wiresPanelSecurity.Examine));
+                args.PushMarkup(Loc.GetString("wires-panel-component-on-examine-closed"));
+            }
+            else
+            {
+                args.PushMarkup(Loc.GetString("wires-panel-component-on-examine-open"));
+
+                if (TryComp<WiresPanelSecurityComponent>(uid, out var wiresPanelSecurity) &&
+                    wiresPanelSecurity.Examine != null)
+                {
+                    args.PushMarkup(Loc.GetString(wiresPanelSecurity.Examine));
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

the point of this PR primarily was to just remove the hardcoded check for clientside entity in examinesystem and allow it to deliver a predicted examine message

of course nothing is that simple, see technical details

fixes a small bug with power cells where stunbaton was subscribing to batterycomp examine insteadof stunbaton examine for some reason

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

smoooooooooooooth

respooooooooooooonsive

prediiiiiiiiiiictable behaaaaaaaaavior

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

so, the bulk of the changes are essentially about ensuring that the order that examine messages are placed in is consistent, so that it can be done by both client and server deterministically.

there are three layers of sorting/grouping done here:
- by explicit priority (a new arg in pushmarkup et al), previous system didnt support this at all but its possible now so added it
- by "group" (see below)
- by ordinal string comparison

"message groups" are the main weirdness added here. basically, since we want to sort by string comparison/priority, we need a way to ensure that certain messages that belong together stay together, if a system is adding multiple pieces of text dynamically (e.g. machine board stuff) or if different systems/handlers want to group stuff together (e.g. construction graph/condition stuff)

by calling `using(args.PushGroup(name))` we can ensure a couple things:
- we can ensure the members within the group are properly grouped together and in the expected order
- we can expect that the group -as a whole- is in a deterministic position (because we can sort by the group name)
- the group is properly popped at the end even with mid-function returns or exceptions (bc `IDisposable`)

it does mean some extra boilerplate in handlers which add multiple pieces of text, and thats the majority of changes here

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/19853115/5398c307-8bcc-430b-abea-7f7a3d07bb96

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

- if you have an `ExaminedEvent` handler that calls `Push/AddMarkup` multiple times, wrap it in a `using(args.PushGroup(nameof(ComponentNameHere))` block

- accessing the message in examinedevent directly is no longer allowed, just call the functions on `ExaminedEvent` themselves

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Examining entities is now predicted, meaning that you will be shown most information immediately.
- fix: Fixed a bug where power cells would list their charge twice.