### PR TITLE
Fix player rolling agent and operative at the same time

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -713,6 +713,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                     {
                         nukeOp = _random.PickAndTake(medPrefList);
                         everyone.Remove(nukeOp);
+                        prefList.Remove(nukeOp);
                         Logger.InfoS("preset", "Insufficient preferred nukeop commanders, picking an agent");
                     }
 


### PR DESCRIPTION
Adds one line removing the nukie agent from the operative list on being successfully picked. (Commander gets removed from lists on being picked but the agent isn't, which seemed weird)

Probably resolves #23135.

