### PR TITLE
Some thief steal target tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -10,8 +10,6 @@
     sprite: Objects/Devices/encryption_keys.rsi
   - type: Sprite
     sprite: Objects/Devices/encryption_keys.rsi
-  - type: StealTarget
-    stealGroup: EncryptionKey
 
 - type: entity
   parent: EncryptionKey

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -139,7 +139,9 @@
     energy: 1.6
     color: "#c94242"
   - type: Computer
-    board: CargoShuttleConsoleCircuitboard
+    board: CargoShuttleConsoleCircuitboard  
+  - type: StealTarget
+    stealGroup: CargoShuttleConsoleCircuitboard
 
 - type: entity
   parent: BaseComputerShuttle
@@ -168,7 +170,9 @@
       color: "#c94242"
     - type: Computer
       board: SalvageShuttleConsoleCircuitboard
-
+    - type: StealTarget
+      stealGroup: SalvageShuttleConsoleCircuitboard
+      
 - type: entity
   parent: BaseComputer
   id: ComputerIFF
@@ -856,7 +860,9 @@
       color: "#b89f25"
     - type: AccessReader
       access: [["Salvage"]]
-
+    - type: StealTarget
+      stealGroup: SalvageExpeditionsComputerCircuitboard
+      
 - type: entity
   parent: BaseComputer
   id: ComputerSurveillanceCameraMonitor

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -698,7 +698,9 @@
       whitelist:
         tags:
           - Sheet
-
+    - type: StealTarget
+      stealGroup: AmmoTechFabCircuitboard
+      
 - type: entity
   id: MedicalTechFab
   parent: BaseLathe
@@ -766,7 +768,9 @@
       - SyringeCryostasis
   - type: Machine
     board: MedicalTechFabCircuitboard
-
+  - type: StealTarget
+    stealGroup: MedicalTechFabCircuitboard
+    
 - type: entity
   parent: BaseLathe
   id: UniformPrinter

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -71,7 +71,6 @@
     TechnologyDiskStealCollectionObjective: 1        #rnd
     FigurineStealCollectionObjective: 0.3          #service
     IDCardsStealCollectionObjective: 1
-    EncryptionKeyStealCollectionObjective: 1
     CannabisStealCollectionObjective: 1
     LAMPStealCollectionObjective: 2 #only for moth
 

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -145,18 +145,6 @@
 - type: entity
   noSpawn: true
   parent: BaseThiefStealCollectionObjective
-  id: EncryptionKeyStealCollectionObjective
-  components:
-  - type: StealCondition
-    stealGroup: EncryptionKey
-    minCollectionSize: 5
-    maxCollectionSize: 15
-  - type: Objective
-    difficulty: 0.7
-
-- type: entity
-  noSpawn: true
-  parent: BaseThiefStealCollectionObjective
   id: CannabisStealCollectionObjective
   components:
   - type: NotJobRequirement


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
removed the task of stealing encryption keys because it was too easy (you can get them from vending).

all tasks that require stealing a circuitboard mechanism are now considered completed if the player has stolen the machine itself. This is necessary for correct work of the thief's pinpointer https://github.com/space-wizards/space-station-14/pull/23325

## Media
- [x]  this PR does not require an ingame showcase

**Changelog**

:cl:
- remove: Removed Encryption key thief steal objective.