### PR TITLE
Add a T-ray and Gas analyzer to the default engineer belt.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -25,6 +25,8 @@
       - id: Wirecutter
       - id: Welder
       - id: Multitool
+      - id: trayScanner
+      - id: GasAnalyzer
 
 - type: entity
   id: ClothingBeltChiefEngineerFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -135,7 +135,6 @@
     contents:
       - id: ClothingHandsGlovesColorYellow
       - id: ClothingMaskGas
-      - id: trayScanner
       - id: RCD
       - id: RCDAmmo
 


### PR DESCRIPTION

## About the PR
Engineers now get a t-ray and gas analyzer if their starting belt, simple as that.

## Why / Balance
It's easy to forget to grab these roundstart and there's a somewhat limited amount in the vendor/lockers, especially on stations using the hardsuit locker which does not contain a t-ray.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/140123969/1e2709a8-62e8-4ea6-818a-abf1576e4a0f)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Engineers now start the shift with a t-ray and gas analyzer in their toolbelt.
