### PR TITLE
Slightly nerf rigged boxing gloves

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -83,9 +83,9 @@
   suffix: Rigged
   components:
   - type: StaminaDamageOnHit
-    damage: 30
+    damage: 24
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 1.2
     damage:
       types:
         Blunt: 8


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Changes boxing glove weapon stats:

Stamina damage per hit, 30 > 24
Attack speed, 1.5 > 1.2 (seconds)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The aim of this PR is to make rigged boxing gloves not as strong with combos and weapon alternation while putting the stamina damage to slow in-line with the values stun batons have when accounting for attack speed.

This should resolve most issues players are having with rigged boxing gloves.
The main issues are how fast they apply a slow from the beginning of the fight, the reason why is because after you have a significant speed advantage over someone they cannot:
* Run away
* Dodge attacks

Leaving them to sink in damage from other potentially high performing sources (like an e-sword for example)

The second biggest issue is how attack speed is handled when alternating between left and right hand to switch between weapons, or comboing in other words, the attack speed reduction should leave rigged boxing gloves slightly faster but not fast enough to be overly effective in combos.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
none
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: BurninDreamer
- tweak: Rigged boxing gloves had their weapon stats reduced from 30 stamina damage to 24 and their attack speed from 1.5/s to 1.2/s