### PR TITLE
Diagnostic Hud can see health silicon

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -11,6 +11,7 @@
   - type: ShowHealthBars
     damageContainers: 
     - Inorganic
+    - Silicon
 
 - type: entity
   parent: ClothingEyesBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added the ability to see the health of Borg through the diagnostic HUD
<!-- What did you change in this PR? -->

## Why / Balance
Because the diagnostic scale should show the health of the robots
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
I added the necessary tag to the hud.yml file (or what is it)
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<img width="156" alt="Screenshot_1" src="https://github.com/space-wizards/space-station-14/assets/131034301/d1695df2-03d3-4006-8760-9b6e9cd16ebc">

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
The hud diagnostic drivers have been updated and can now show the health of Borgs
-->

**Changelog**
🆑
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
- add: The hud diagnostic drivers have been updated and can now show the health of Borgs
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: The hud diagnostic drivers have been updated and can now show the health of Borgs
-->
