### PR TITLE
Restore correct table-bonk behaviour with clumsy mobs.

### DIFF
--- a/Content.Shared/Climbing/Systems/BonkSystem.cs
+++ b/Content.Shared/Climbing/Systems/BonkSystem.cs
@@ -36,7 +36,7 @@ public sealed partial class BonkSystem : EntitySystem
 
     private void OnBonkDoAfter(EntityUid uid, Components.BonkableComponent component, BonkDoAfterEvent args)
     {
-        if (args.Handled || args.Cancelled || args.Args.Target == null || args.Args.Target != args.Args.User)
+        if (args.Handled || args.Cancelled || args.Args.Target == null)
             return;
 
         TryBonk(args.Args.User, uid, component);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixed a bug I accidentally introduced in the table-bonk system of clumsy mobs, where they could no longer get hurt at all. 

## Why / Balance
Clumsy mobs are supposed to be hurt when climbing on tables. Instead, when a clumsy mob tried to climb, nothing happened after the DoAfter. 

## Technical details
The Target of a BonkDoAfterEvent is the object being climbed on, not a target mob that the bonk should apply to. Removed an inappropriate conditional that was comparing Target vs User of the event. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- fix: Climbing onto tables is once again a dangerous prospect for a Clown.
