### PR TITLE
Expose preset in status

### DIFF
--- a/Content.Server/GameTicking/GameTicker.StatusShell.cs
+++ b/Content.Server/GameTicking/GameTicker.StatusShell.cs
@@ -27,7 +27,7 @@ namespace Content.Server.GameTicking
         ///     For access to the round ID in status responses.
         /// </summary>
         [Dependency] private readonly SharedGameTicker _gameTicker = default!;
-        
+
         private void InitializeStatusShell()
         {
             IoCManager.Resolve<IStatusHost>().OnStatusRequest += GetStatusResponse;
@@ -35,6 +35,8 @@ namespace Content.Server.GameTicking
 
         private void GetStatusResponse(JsonNode jObject)
         {
+            var preset = CurrentPreset ?? Preset;
+
             // This method is raised from another thread, so this better be thread safe!
             lock (_statusShellLock)
             {
@@ -45,6 +47,8 @@ namespace Content.Server.GameTicking
                 jObject["soft_max_players"] = _cfg.GetCVar(CCVars.SoftMaxPlayers);
                 jObject["panic_bunker"] = _cfg.GetCVar(CCVars.PanicBunkerEnabled);
                 jObject["run_level"] = (int) _runLevel;
+                if (preset != null)
+                    jObject["preset"] = Loc.GetString(preset.ModeTitle);
                 if (_runLevel >= GameRunLevel.InRound)
                 {
                     jObject["round_start_time"] = _roundStartDateTime.ToString("o");


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

To be used in the discord bot's status command https://github.com/space-wizards/wizard-cogs/pull/7

Should use the same logic as the Lobby menu, so it won't expose the actual preset if its hidden behind secret

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/space-wizards/space-station-14/assets/34938708/5fdacffc-c3b1-4c81-973b-7682962aa218)
Example on the bot