### PR TITLE
Fix iron naming, add specific materials for ores

### DIFF
--- a/Content.Server/Gateway/Components/GatewayGeneratorComponent.cs
+++ b/Content.Server/Gateway/Components/GatewayGeneratorComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class GatewayGeneratorComponent : Component
     /// </summary>
     public List<ProtoId<BiomeMarkerLayerPrototype>> LootLayers = new()
     {
-        "OreTin",
+        "OreIron",
         "OreQuartz",
         "OreGold",
         "OreSilver",

--- a/Resources/Locale/en-US/materials/materials.ftl
+++ b/Resources/Locale/en-US/materials/materials.ftl
@@ -26,5 +26,14 @@ materials-web = silk
 materials-bones = bone
 materials-coal = coal
 
+# Ores
+materials-raw-iron = raw iron
+materials-raw-quartz = raw quartz
+materials-raw-gold = raw gold
+materials-raw-silver = raw silver
+materials-raw-plasma = raw plasma
+materials-raw-uranium = raw uranium
+materials-raw-bananium = raw bananium
+
 # Material Reclaimer
 material-reclaimer-upgrade-process-rate = process rate

--- a/Resources/Locale/en-US/materials/units.ftl
+++ b/Resources/Locale/en-US/materials/units.ftl
@@ -14,6 +14,8 @@ materials-unit-bunch = bunch
 materials-unit-slab = slab
 # webs of silk
 materials-unit-web = web
+# chunks of ore
+materials-unit-chunk = chunk
 
 # bills of spesos... not very good but they are not (yet?) used for crafting anything
 # also the lathe/atm would need bigger denominations to output...

--- a/Resources/Locale/en-US/salvage/salvage-magnet.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-magnet.ftl
@@ -7,7 +7,7 @@ salvage-asteroid-name = Asteroid
 salvage-expedition-window-progression = Progression
 
 salvage-magnet-resources = {$resource ->
-    [OreTin] Tin
+    [OreIron] Iron
     [OreCoal] Coal
     [OreQuartz] Quartz
     [OreGold] Gold

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -48,7 +48,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Gold: 500
+      RawGold: 500
 
 - type: entity
   parent: GoldOre
@@ -61,7 +61,7 @@
 - type: entity
   parent: OreBase
   id: SteelOre
-  name: steel ore
+  name: iron ore
   suffix: Full
   components:
   - type: Stack
@@ -71,7 +71,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Steel: 500
+      RawIron: 500
 
 - type: entity
   id: SteelOre1
@@ -94,7 +94,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Plasma: 500
+      RawPlasma: 500
 
 - type: entity
   parent: PlasmaOre
@@ -117,7 +117,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Silver: 500
+      RawSilver: 500
 
 - type: entity
   parent: SilverOre
@@ -140,7 +140,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Glass: 500
+      RawQuartz: 500
 
 - type: entity
   parent: SpaceQuartz
@@ -163,7 +163,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Uranium: 500
+      RawUranium: 500
 
 - type: entity
   parent: UraniumOre
@@ -186,7 +186,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Bananium: 500
+      RawBananium: 500
 
 - type: entity
   parent: BananiumOre

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -988,9 +988,7 @@
     - type: Machine
       board: OreProcessorMachineCircuitboard
     - type: MaterialStorage
-      dropOnDeconstruct: false #should drop ores instead of ingots/sheets
       ignoreColor: true
-      canEjectStoredMaterials: false
       whitelist:
         tags:
           - Ore

--- a/Resources/Prototypes/Procedural/Magnet/asteroid.yml
+++ b/Resources/Prototypes/Procedural/Magnet/asteroid.yml
@@ -1,7 +1,7 @@
 - type: weightedRandom
   id: AsteroidOre
   weights:
-    OreTin: 1.0
+    OreIron: 1.0
     OreQuartz: 1.0
     OreCoal: 1.0
     OreGold: 0.25

--- a/Resources/Prototypes/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates.yml
@@ -1,6 +1,6 @@
 # Low value
 - type: biomeMarkerLayer
-  id: OreTin
+  id: OreIron
   entityMask:
     AsteroidRock: AsteroidRockTin
     WallRock: WallRockTin

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -119,11 +119,11 @@
 # Ores - these are guaranteed
 # - Low value
 - type: salvageLoot
-  id: OreTin
+  id: OreIron
   guaranteed: true
   loots:
     - !type:BiomeMarkerLoot
-      proto: OreTin
+      proto: OreIron
 
 - type: salvageLoot
   id: OreCoal

--- a/Resources/Prototypes/Reagents/Materials/ores.yml
+++ b/Resources/Prototypes/Reagents/Materials/ores.yml
@@ -1,0 +1,61 @@
+- type: material
+  id: RawIron
+  stackEntity: SteelOre1
+  name: materials-raw-iron
+  unit: materials-unit-chunk
+  icon: { sprite: Objects/Materials/ore.rsi, state: iron }
+  price: 0.05
+
+- type: material
+  id: RawQuartz
+  stackEntity: SpaceQuartz1
+  name: materials-raw-quartz
+  unit: materials-unit-chunk
+  icon: { sprite: Objects/Materials/ore.rsi, state: spacequartz }
+  color: "#a8ccd7"
+  price: 0.075
+
+- type: material
+  id: RawGold
+  stackEntity: GoldOre1
+  name: materials-raw-gold
+  unit: materials-unit-chunk
+  icon: { sprite: Objects/Materials/ore.rsi, state: gold }
+  color: "#FFD700"
+  price: 0.2
+
+- type: material
+  id: RawSilver
+  stackEntity: SilverOre1
+  name: materials-raw-silver
+  unit: materials-unit-chunk
+  icon: { sprite: Objects/Materials/ore.rsi, state: silver }
+  color: "#C0C0C0"
+  price: 0.15
+
+- type: material
+  id: RawPlasma
+  stackEntity: PlasmaOre1
+  name: materials-raw-plasma
+  unit: materials-unit-chunk
+  icon: { sprite: Objects/Materials/ore.rsi, state: plasma }
+  color: "#7e009e"
+  price: 0.2
+
+- type: material
+  id: RawUranium
+  stackEntity: UraniumOre1
+  name: materials-raw-uranium
+  unit: materials-unit-chunk
+  icon: { sprite: Objects/Materials/ore.rsi, state: uranium }
+  color: "#32a852"
+  price: 0.2
+
+- type: material
+  id: RawBananium
+  stackEntity: BananiumOre1
+  name: materials-raw-bananium
+  unit: materials-unit-chunk
+  icon: { sprite: Objects/Materials/ore.rsi, state: bananium }
+  color: "#32a852"
+  price: 0.2

--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -4,14 +4,14 @@
   applyMaterialDiscount: false
   completetime: 2
   materials:
-    Steel: 100
+    RawIron: 100
 
 - type: latheRecipe
   id: SheetSteel30
   result: SheetSteel
   completetime: 2
   materials:
-    Steel: 3000
+    RawIron: 3000
     Coal: 1000
 
 - type: latheRecipe
@@ -20,14 +20,14 @@
   applyMaterialDiscount: false
   completetime: 2
   materials:
-    Glass: 100
+    RawQuartz: 100
 
 - type: latheRecipe
   id: SheetGlass30
   result: SheetGlass
   completetime: 2
   materials:
-    Glass: 3000
+    RawQuartz: 3000
 
 - type: latheRecipe
   id: SheetRGlass
@@ -68,56 +68,56 @@
   result: SheetPlasma
   completetime: 2
   materials:
-    Plasma: 3000
+    RawPlasma: 3000
 
 - type: latheRecipe
   id: SheetUranium30
   result: SheetUranium
   completetime: 2
   materials:
-    Uranium: 3000
+    RawUranium: 3000
 
 - type: latheRecipe
   id: IngotGold30
   result: IngotGold
   completetime: 2
   materials:
-    Gold: 3000
+    RawGold: 3000
 
 - type: latheRecipe
   id: IngotSilver30
   result: IngotSilver
   completetime: 2
   materials:
-    Silver: 3000
+    RawSilver: 3000
 
 - type: latheRecipe
   id: MaterialBananium10
   result: MaterialBananium
   completetime: 2
   materials:
-    Bananium: 3000
+    RawBananium: 3000
 
 - type: latheRecipe
   id: SheetUranium1
   result: SheetUranium1
   completetime: 2
   materials:
-    Uranium: 500
+    RawUranium: 500
 
 - type: latheRecipe
   id: IngotGold1
   result: IngotGold1
   completetime: 2
   materials:
-    Gold: 500
+    RawGold: 500
 
 - type: latheRecipe
   id: IngotSilver1
   result: IngotSilver1
   completetime: 2
   materials:
-    Silver: 500
+    RawSilver: 500
 
 - type: latheRecipe
   id: SheetPlastic
@@ -132,7 +132,7 @@
   result: MaterialBananium1
   completetime: 2
   materials:
-    Bananium: 500
+    RawBananium: 500
 
 - type: latheRecipe
   id: MaterialSheetMeat

--- a/Resources/Prototypes/Stacks/Materials/ore.yml
+++ b/Resources/Prototypes/Stacks/Materials/ore.yml
@@ -8,7 +8,7 @@
 
 - type: stack
   id: SteelOre
-  name: steel ore
+  name: iron ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: iron }
   spawn: SteelOre1
   maxCount: 30


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Standardizes the ore form of steel sheets to be _IRON_, as it should be. Essentially renames all the steel ore/tin shit to just iron ore.

Additionally adds materials for the raw forms of ores, which lets us actually display them and remove them from the ore processor correctly. Epic!

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Unstandardized names are lame. BLECH

Not being able to remove ores and sheets being made out of sheets is lame. BLECH

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/a9db8332-4e19-4597-bb9c-36ab37ce2bc8)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
Renames OreTin biome and loot prototypes to OreIron

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Fixed inconsistency in iron ore naming in various places.
- tweak: The ore processor can now eject raw ores.
