### PR TITLE
Adds steel tiles to construction module

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -110,3 +110,12 @@
   - type: Stack
     lingering: true
     count: 0
+
+- type: entity
+  parent: FloorTileItemSteel
+  id: FloorTileItemSteelLingering0
+  suffix: Lingering, 0
+  components:
+  - type: Stack
+    lingering: true
+    count: 0

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -248,6 +248,7 @@
     - SheetSteelLingering0
     - SheetGlassLingering0
     - PartRodMetalLingering0
+    - FloorTileItemSteelLingering0
 
 - type: entity
   id: BorgModuleRCD


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The construction module now has a fourth slot for steel tiles.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Will save materials when plugging hull breaches and allows a borg to fix missing tiles

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- tweak: The construction module for cyborgs now also gives access to steel tiles.

