### PR TITLE
ERT, DeathSquad and Central Command Officer Inital Infected immunity

### DIFF
--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -273,6 +273,10 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         {
             if (player.AttachedEntity == null || !HasComp<HumanoidAppearanceComponent>(player.AttachedEntity) || HasComp<ZombieImmuneComponent>(player.AttachedEntity))
                 continue;
+
+            if (HasComp<InitialInfectedExemptComponent>(player.AttachedEntity))
+                continue; // used (for example) on ERT
+
             playerList.Add(player);
 
             var pref = (HumanoidCharacterProfile) _prefs.GetPreferences(player.UserId).SelectedCharacter;

--- a/Content.Server/Zombies/InitialInfectedExemptComponent.cs
+++ b/Content.Server/Zombies/InitialInfectedExemptComponent.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Server.Zombies;
+
+[RegisterComponent]
+public partial class InitialInfectedExemptComponent : Component
+{
+
+}

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -16,6 +16,7 @@
         - NamesLastMilitary
     - type: RandomHumanoidSpawner
       settings: DeathSquad
+    - type: InitialInfectedExempt
 
 - type: randomHumanoidSettings
   id: DeathSquad
@@ -32,6 +33,7 @@
       nameSegments:
         - NamesFirstMilitaryLeader
         - NamesLastMilitary
+    - type: InitialInfectedExempt
 
 
 ## ERT Leader
@@ -50,6 +52,7 @@
       - NamesLastMilitary
     - type: RandomHumanoidSpawner
       settings: ERTLeader
+    - type: InitialInfectedExempt
 
 - type: randomHumanoidSettings
   id: ERTLeader
@@ -66,6 +69,7 @@
       nameSegments:
       - NamesFirstMilitaryLeader
       - NamesLastMilitary
+    - type: InitialInfectedExempt
 
 - type: entity
   id: RandomHumanoidSpawnerERTLeaderEVA
@@ -78,6 +82,7 @@
       state: ertleadereva
     - type: RandomHumanoidSpawner
       settings: ERTLeaderEVA
+    - type: InitialInfectedExempt
 
 - type: randomHumanoidSettings
   id: ERTLeaderEVA
@@ -90,6 +95,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTLeaderGearEVA ]
+    - type: InitialInfectedExempt
 
 - type: entity
   id: RandomHumanoidSpawnerERTLeaderEVALecter
@@ -98,6 +104,7 @@
   components:
     - type: RandomHumanoidSpawner
       settings: ERTLeaderEVALecter
+    - type: InitialInfectedExempt
 
 - type: randomHumanoidSettings
   id: ERTLeaderEVALecter
@@ -110,6 +117,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTLeaderGearEVALecter ]
+    - type: InitialInfectedExempt
 
 ## ERT Janitor
 
@@ -144,6 +152,7 @@
       - NamesLastMilitary
     - type: Loadout
       prototypes: [ ERTJanitorGear ]
+    - type: InitialInfectedExempt
 
 - type: entity
   id: RandomHumanoidSpawnerERTJanitorEVA
@@ -168,6 +177,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTJanitorGearEVA ]
+    - type: InitialInfectedExempt
 
 ## ERT Engineer
 
@@ -202,6 +212,7 @@
       - NamesLastMilitary
     - type: Loadout
       prototypes: [ ERTEngineerGear ]
+    - type: InitialInfectedExempt
 
 - type: entity
   id: RandomHumanoidSpawnerERTEngineerEVA
@@ -226,6 +237,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTEngineerGearEVA ]
+    - type: InitialInfectedExempt
 
 ## ERT Security
 
@@ -260,6 +272,7 @@
       - NamesLastMilitary
     - type: Loadout
       prototypes: [ ERTSecurityGear ]
+    - type: InitialInfectedExempt
 
 - type: entity
   id: RandomHumanoidSpawnerERTSecurityEVA
@@ -284,6 +297,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTSecurityGearEVA ]
+    - type: InitialInfectedExempt
 
 - type: entity
   id: RandomHumanoidSpawnerERTSecurityEVALecter
@@ -304,6 +318,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTSecurityGearEVALecter ]
+    - type: InitialInfectedExempt
 
 ## ERT Medic
 
@@ -338,6 +353,7 @@
       - NamesLastMilitary
     - type: Loadout
       prototypes: [ ERTMedicalGear ]
+    - type: InitialInfectedExempt
 
 - type: entity
   id: RandomHumanoidSpawnerERTMedicalEVA
@@ -362,6 +378,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTMedicalGearEVA ]
+    - type: InitialInfectedExempt
 
 ## CBURN
 
@@ -375,6 +392,7 @@
       state: cburn
     - type: RandomHumanoidSpawner
       settings: CBURNAgent
+    - type: InitialInfectedExempt
 
 - type: randomHumanoidSettings
   id: CBURNAgent
@@ -390,6 +408,7 @@
       nameSegments:
       - NamesFirstMilitary
       - NamesLastMilitary
+    - type: InitialInfectedExempt
 ## Central Command
 
 - type: entity
@@ -401,6 +420,7 @@
       state: centcom
     - type: RandomHumanoidSpawner
       settings: CentcomOfficial
+    - type: InitialInfectedExempt
 
 - type: randomHumanoidSettings
   id: CentcomOfficial
@@ -412,6 +432,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ CentcomGear ]
+    - type: InitialInfectedExempt
 
 ## Syndicate
 


### PR DESCRIPTION
## About the PR
Makes ERT, DeathSquad and Central Command officers immune to being II

## Why / Balance
Requested by Lucky because it often ruins events.

## Technical details
I added a component which makes the entity that has that component unable to roll II. This component has been added to the ERT, DeathSquad and CC Officers roles.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
No CL.
