### PR TITLE
Limits the minimum base skin color brightness for species with Hue coloration

### DIFF
--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -5,6 +5,8 @@ public static class SkinColor
     public const float MaxTintedHuesSaturation = 0.1f;
     public const float MinTintedHuesLightness = 0.85f;
 
+    public const float MinHuesLightness = 0.175f;
+
     public static Color ValidHumanSkinTone => Color.FromHsv(new Vector4(0.07f, 0.2f, 1f, 1f));
 
     /// <summary>
@@ -138,13 +140,35 @@ public static class SkinColor
         return Color.ToHsl(color).Y <= MaxTintedHuesSaturation && Color.ToHsl(color).Z >= MinTintedHuesLightness;
     }
 
+    /// <summary>
+    ///     This takes in a color, and returns a color guaranteed to be above MinHuesLightness
+    /// </summary>
+    /// <param name="color"></param>
+    /// <returns>Either the color as-is if it's above MinHuesLightness, or the color with luminosity increased above MinHuesLightness</returns> 
+    public static Color MakeHueValid(Color color)
+    {
+        var manipulatedColor = Color.ToHsv(color);
+        manipulatedColor.Z = Math.Max(manipulatedColor.Z, MinHuesLightness);
+        return Color.FromHsv(manipulatedColor);
+    }
+
+    /// <summary>
+    ///     Verify if this color is above a minimum luminosity
+    /// </summary>
+    /// <param name="color"></param>
+    /// <returns>True if valid, false if not</returns>
+    public static bool VerifyHues(Color color)
+    {
+        return Color.ToHsv(color).Z >= MinHuesLightness;
+    }
+
     public static bool VerifySkinColor(HumanoidSkinColor type, Color color)
     {
         return type switch
         {
             HumanoidSkinColor.HumanToned => VerifyHumanSkinTone(color),
             HumanoidSkinColor.TintedHues => VerifyTintedHues(color),
-            HumanoidSkinColor.Hues => true,
+            HumanoidSkinColor.Hues => VerifyHues(color),
             _ => false,
         };
     }
@@ -155,6 +179,7 @@ public static class SkinColor
         {
             HumanoidSkinColor.HumanToned => ValidHumanSkinTone,
             HumanoidSkinColor.TintedHues => ValidTintedHuesSkinTone(color),
+            HumanoidSkinColor.Hues => MakeHueValid(color),
             _ => color
         };
     }


### PR DESCRIPTION
## About the PR
This PR does exactly what it says on the tin.

## Why / Balance
![image](https://github.com/space-wizards/space-station-14/assets/6356337/6d74c968-5fa9-448c-9201-789731e8ac72)
This above image is outright appalling. Players can turn themselves into a void way too easily. While we strongly believe that players should have as much freedom as possible with character generation, the above image is something that we're pretty confident most people can agree simply shouldn't be possible.

## Technical details
This adds a pair of functions to `Content.Shared/Humanoid/SkinColor.cs`; one checks if the input color has a value above a certain threshold of brightness, the other will bump up an input color if it's below a certain threshold of brightness. The functions for validating skin color will call these functions for species that have the hue skinColoration (such as reptilians).

## Media
![image](https://github.com/space-wizards/space-station-14/assets/6356337/669a7b39-bf45-4d12-acf8-b575bb3fd847)

This is the new minimum skinColor! 

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
There are very few players who would be affected by this, and as such, changelog is omitted (but we can add a CL if other maints desire)
