### PR TITLE
Remove a couple translations to the archaic accent

### DIFF
--- a/Resources/Locale/en-US/accent/archaic.ftl
+++ b/Resources/Locale/en-US/accent/archaic.ftl
@@ -62,9 +62,6 @@ accent-archaic-replacement-18 = perchance
 accent-archaic-replaced-19 = this
 accent-archaic-replacement-19 = thee
 
-accent-archaic-replaced-20 = nothing
-accent-archaic-replacement-20 = naught
-
 accent-archaic-replaced-21 = yes
 accent-archaic-replacement-21 = aye
 
@@ -259,9 +256,6 @@ accent-archaic-replacement-92 = defile
 
 accent-archaic-replaced-93 = ruined
 accent-archaic-replacement-93 = defiled
-
-accent-archaic-replaced-94 = before
-accent-archaic-replacement-94 = ere
 
 accent-archaic-replaced-95 = pretend
 accent-archaic-replacement-95 = feign
@@ -494,9 +488,6 @@ accent-archaic-replacement-170 = believe
 accent-archaic-replaced-171 = indeed
 accent-archaic-replacement-171 = certainly
 
-accent-archaic-replaced-172 = help
-accent-archaic-replacement-172 = assist
-
 accent-archaic-replaced-173 = now
 accent-archaic-replacement-173 = immediately
 
@@ -661,9 +652,6 @@ accent-archaic-replacement-228 = drink
 
 accent-archaic-replaced-229 = pop
 accent-archaic-replacement-229 = drink
-
-accent-archaic-replaced-230 = how
-accent-archaic-replacement-230 = in what way
 
 accent-archaic-replaced-231 = wants
 accent-archaic-replacement-231 = wishes

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -286,7 +286,6 @@
     accent-archaic-replaced-17: accent-archaic-replacement-17
     accent-archaic-replaced-18: accent-archaic-replacement-18
     accent-archaic-replaced-19: accent-archaic-replacement-19
-    accent-archaic-replaced-20: accent-archaic-replacement-20
     accent-archaic-replaced-21: accent-archaic-replacement-21
     accent-archaic-replaced-22: accent-archaic-replacement-22
     accent-archaic-replaced-23: accent-archaic-replacement-23
@@ -351,7 +350,6 @@
     accent-archaic-replaced-91: accent-archaic-replacement-91
     accent-archaic-replaced-92: accent-archaic-replacement-92
     accent-archaic-replaced-93: accent-archaic-replacement-93
-    accent-archaic-replaced-94: accent-archaic-replacement-94
     accent-archaic-replaced-95: accent-archaic-replacement-95
     accent-archaic-replaced-96: accent-archaic-replacement-96
     accent-archaic-replaced-97: accent-archaic-replacement-97
@@ -429,7 +427,6 @@
     accent-archaic-replaced-169: accent-archaic-replacement-169
     accent-archaic-replaced-170: accent-archaic-replacement-170
     accent-archaic-replaced-171: accent-archaic-replacement-171
-    accent-archaic-replaced-172: accent-archaic-replacement-172
     accent-archaic-replaced-173: accent-archaic-replacement-173
     accent-archaic-replaced-174: accent-archaic-replacement-174
     accent-archaic-replaced-175: accent-archaic-replacement-175
@@ -486,7 +483,6 @@
     accent-archaic-replaced-227: accent-archaic-replacement-227
     accent-archaic-replaced-228: accent-archaic-replacement-228
     accent-archaic-replaced-229: accent-archaic-replacement-229
-    accent-archaic-replaced-230: accent-archaic-replacement-230
     accent-archaic-replaced-231: accent-archaic-replacement-231
     accent-archaic-replaced-232: accent-archaic-replacement-232
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

They were bad translations and were confusing to use ingame or just felt bad. Back when i reworked the accent, i had gotten very tired and stressed since it was a huge project so i may have overlooked some.
