### PR TITLE
Add Flippo lighter to the cig vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -12,6 +12,7 @@
     Matchbox: 5
     PackPaperRollingFilters: 3
     CheapLighter: 4
-    Lighter: 1
+    Lighter: 2
+    FlippoLighter: 2
   emaggedInventory:
     CigPackSyndicate: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

I'm pretty sure it was an oversight that they made it unobtainable in #23020. In ss13 zippo lights were available in the cig vend, so that's promptly what i did. I also made it so that you get normal lighters per vend since people obsessed about them.

**Changelog**

:cl: Ubaser
- fix: You can obtain Flippo lighters in the cig vend.
