### PR TITLE
Observation kit sunglasses actually look like sunglasses now.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -199,13 +199,7 @@
   - type: ShowSecurityIcons
 
 - type: entity
-  parent: ClothingEyesBase
+  parent: ClothingEyesGlassesSunglasses
   id: ClothingEyesGlassesHiddenSecurity
-  name: sun glasses
-  description: A pair of black sunglasses.
   components:
-  - type: Sprite
-    sprite: Clothing/Eyes/Glasses/secglasses.rsi
-  - type: Clothing
-    sprite: Clothing/Eyes/Glasses/secglasses.rsi
   - type: ShowSecurityIcons

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -201,5 +201,6 @@
 - type: entity
   parent: ClothingEyesGlassesSunglasses
   id: ClothingEyesGlassesHiddenSecurity
+  suffix: Syndicate
   components:
   - type: ShowSecurityIcons


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Based on the original PR, im pretty sure the observational kit was supposed to be stealth as seen in the image below. Either way, it is very suspicious for a passenger to be walking around with security glasses that aren't even named like security glasses.

![image](https://github.com/space-wizards/space-station-14/assets/134914314/cde546e7-fab4-4e67-add8-69227a88b548)

**Changelog**

:cl: Ubaser
- fix: The syndicate observational kit sunglasses now looks and acts like normal sunglasses on top of its special feature.
