### PR TITLE
Fixes NPCs that lack a UseDelay component failing to interact with objects

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Interactions/InteractWithOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Interactions/InteractWithOperator.cs
@@ -18,8 +18,7 @@ public sealed partial class InteractWithOperator : HTNOperator
     {
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
 
-        if (!_entManager.TryGetComponent<UseDelayComponent>(owner, out var useDelay) ||
-            _entManager.System<UseDelaySystem>().IsDelayed((owner, useDelay)) ||
+        if (_entManager.TryGetComponent<UseDelayComponent>(owner, out var useDelay) && _entManager.System<UseDelaySystem>().IsDelayed((owner, useDelay)) ||
             !blackboard.TryGetValue<EntityUid>(TargetKey, out var moveTarget, _entManager) ||
             !_entManager.TryGetComponent<TransformComponent>(moveTarget, out var targetXform))
         {


### PR DESCRIPTION
## About the PR
Title. This fixes an oversight that fell through the cracks of the UseDelay + ItemCooldown merge, where NPCs that lack a UseDelay component (most of them) end up approaching objects they want to interact with, only to just stand there, menacingly. This is because `InteractWithOperator` was incorrectly returning when the NPC lacks a UseDelay component. Straight-forward thing to fix!

## Why / Balance
Kobolds waving sharp objects around is good we think?

## Technical details
`if(!trygetcomponent<usedelaycomponent>() || isdelayed())` -> `if(trygetcomponent<usedelaycomponent>() && isdelayed())`
Simple simple

## Media


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- fix: NPCs are now capable of interacting with the world again. Or in laymen's terms, monkeys and kobolds will now be able to pick up weapons they see.

