### PR TITLE
Kobold noises! Gently the kobolds (and monkeys)! Monkey YAML cleanup!

### DIFF
--- a/Resources/Locale/en-US/accent/accents.ftl
+++ b/Resources/Locale/en-US/accent/accents.ftl
@@ -107,3 +107,14 @@ accent-words-crab-3 = Clack?
 accent-words-crab-4 = Tipi-tap!
 accent-words-crab-5 = Clik-tap.
 accent-words-crab-6 = Cliliick.
+
+# Kobold
+accent-words-kobold-1 = Yip!
+accent-words-kobold-2 = Grrar.
+accent-words-kobold-3 = Yap!
+accent-words-kobold-4 = Bip.
+accent-words-kobold-5 = Screet?
+accent-words-kobold-6 = Gronk!
+accent-words-kobold-7 = Hiss!
+accent-words-kobold-8 = Eeee!
+accent-words-kobold-9 = Yip.

--- a/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
@@ -30,6 +30,7 @@ petting-success-hamster = You pet {THE($target)} on {POSS-ADJ($target)} fluffy l
 petting-success-bear = You reluctantly pet {THE($target)} on {POSS-ADJ($target)} mystical head.
 petting-success-slimes = You pet {THE($target)} on {POSS-ADJ($target)} mucous surface.
 petting-success-snake = You pet {THE($target)} on {POSS-ADJ($target)} scaly large head.
+petting-success-monkey = You pet {THE($target)} on {POSS-ADJ($target)} mischevious little head.
 
 petting-failure-generic = You reach out to pet {THE($target)}, but {SUBJECT($target)} {CONJUGATE-BE($target)} aloof towards you.
 
@@ -49,6 +50,7 @@ petting-failure-holo = You reach out to pet {THE($target)}, but {POSS-ADJ($targe
 petting-failure-dragon = You raise your hand, but as {THE($target)} roars, you decide you'd rather not be toasty carp food.
 petting-failure-hamster = You reach out to pet {THE($target)}, but {SUBJECT($target)} attempts to bite your finger and only your quick reflexes save you from an almost fatal injury.
 petting-failure-bear = You reach out to pet {THE($target)}, but {SUBJECT($target)} growls, making you think twice.
+petting-failure-monkey = You reach out to pet {THE($target)}, but {SUBJECT($target)} almost bites your fingers!
 
 ## Petting silicons
 

--- a/Resources/Locale/en-US/station-events/events/random-sentience.ftl
+++ b/Resources/Locale/en-US/station-events/events/random-sentience.ftl
@@ -34,4 +34,5 @@ station-event-random-sentience-flavor-mechanical = mechanical
 station-event-random-sentience-flavor-organic = organic
 station-event-random-sentience-flavor-corgi = corgi
 station-event-random-sentience-flavor-primate = primate
+station-event-random-sentience-flavor-kobold = kobold
 station-event-random-sentience-flavor-slime = slime

--- a/Resources/Prototypes/Accents/full_replacements.yml
+++ b/Resources/Prototypes/Accents/full_replacements.yml
@@ -153,3 +153,16 @@
   - accent-words-crab-4
   - accent-words-crab-5
   - accent-words-crab-6
+
+- type: accent
+  id: kobold
+  fullReplacements:
+  - accent-words-kobold-1
+  - accent-words-kobold-2
+  - accent-words-kobold-3
+  - accent-words-kobold-4
+  - accent-words-kobold-5
+  - accent-words-kobold-6
+  - accent-words-kobold-7
+  - accent-words-kobold-8
+  - accent-words-kobold-9

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1207,10 +1207,6 @@
   - type: AutoTraitor
     giveUplink: false
     giveObjectives: false
-  - type: Tag
-    tags:
-    - VimPilot
-    - DoorBumpOpener
 
 - type: entity
   name: kobold

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1047,16 +1047,13 @@
     - SimpleHostile
 
 - type: entity
-  name: monkey
-  id: MobMonkey
+  name: genetic ancestor
+  id: MobBaseAncestor
   parent: SimpleMobBase
-  description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
+  description: The genetic bipedal ancestor of... Uh... Something. Yeah, there's definitely something on the station that descended from whatever this is.
+  abstract: true
   components:
   - type: CombatMode
-  - type: NameIdentifier
-    group: Monkey
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-primate
   - type: Inventory
     templateId: monkey
     speciesId: monkey
@@ -1107,12 +1104,9 @@
   - type: GenericVisualizer
     visuals:
       enum.CreamPiedVisuals.Creamed:
-        clownedon: # Not 'creampied' bc I can already see Skyrat complaining about conflicts.
+        clownedon:
           True: {visible: true}
           False: {visible: false}
-  - type: Speech
-    speechSounds: Monkey
-    speechVerb: Monkey
   - type: Body
     prototype: Primate
     requiredLegs: 1 # TODO: More than 1 leg
@@ -1120,12 +1114,20 @@
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Monkey_burning
+  - type: InteractionPopup
+    successChance: 0.9
+    interactSuccessString: petting-success-monkey
+    interactFailureString: petting-failure-monkey
+    interactSuccessSpawn: EffectHearts
+    interactSuccessSound:
+      path: /Audio/Animals/ferret_happy.ogg
+    interactFailureSound:
+      path: /Audio/Items/wirecutter.ogg
   - type: Butcherable
     butcheringType: Spike
     spawned:
     - id: FoodMeat
       amount: 3
-  - type: MonkeyAccent
   - type: Puller
     needsHands: false
   - type: CanHostGuardian
@@ -1138,6 +1140,27 @@
   - type: HTN
     rootTask:
       task: SimpleHostileCompound
+  - type: IdExaminable
+  - type: Tag
+    tags:
+    - VimPilot
+    - DoorBumpOpener
+
+- type: entity
+  name: monkey
+  id: MobMonkey
+  parent: MobBaseAncestor
+  description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
+  components:
+  - type: NameIdentifier
+    group: Monkey
+  - type: Speech
+    speechSounds: Monkey
+    speechVerb: Monkey
+  - type: MonkeyAccent
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-primate
+  - type: AlwaysRevolutionaryConvertible
   - type: GhostRole
     prob: 0.05
     makeSentient: true
@@ -1153,19 +1176,54 @@
         Burn: 3
     clumsySound:
       path: /Audio/Animals/monkey_scream.ogg
-  - type: IdExaminable
-  - type: AlwaysRevolutionaryConvertible
+
+- type: entity
+  name: monkey
+  id: MobMonkeySyndicateAgent
+  parent: MobBaseAncestor
+  description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
+  suffix: syndicate
+  components:
+  - type: NameIdentifier
+    group: Monkey
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-primate
+  - type: Speech
+    speechSounds: Monkey
+    speechVerb: Monkey
+  - type: MonkeyAccent
+  - type: NpcFactionMember
+    factions:
+    - Syndicate
+  - type: GhostRole
+    prob: 0.05
+    makeSentient: true
+    name: ghost-role-information-monkey-name
+    description: ghost-role-information-monkey-description
+  - type: GhostTakeoverAvailable
+  - type: Loadout
+    prototypes: [SyndicateOperativeGearMonkey]
+  # make the player a traitor once its taken
+  - type: AutoTraitor
+    giveUplink: false
+    giveObjectives: false
+  - type: Tag
+    tags:
+    - VimPilot
+    - DoorBumpOpener
 
 - type: entity
   name: kobold
   id: MobKobold
-  parent: MobMonkey
+  parent: MobBaseAncestor
   description: Cousins to the sentient race of lizard people, kobolds blend in with their natural habitat and are as nasty as monkeys; ready to pull out your hair and stab you to death.
   components:
   - type: NameIdentifier
     group: Kobold
   - type: LizardAccent
-  - type: Speech # I don't know how to get it to work and i want someone to make them speak like a lizard with normal accents (or optionally another language altogether)
+  - type: ReplacementAccent
+    accent: kobold
+  - type: Speech
     speechSounds: Lizard
     speechVerb: Reptilian
   - type: Vocal
@@ -1173,10 +1231,20 @@
       Male: UnisexReptilian
       Female: UnisexReptilian
       Unsexed: UnisexReptilian
+  - type: InteractionPopup
+    successChance: 0.9
+    interactSuccessString: petting-success-monkey
+    interactFailureString: petting-failure-monkey
+    interactSuccessSpawn: EffectHearts
+    interactSuccessSound:
+      path: /Audio/Animals/lizard_happy.ogg
+    interactFailureSound:
+      path: /Audio/Items/wirecutter.ogg
   - type: MobThresholds
     thresholds:
       0: Alive
-      40: Dead
+      40: Critical
+      80: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.5
     baseSprintSpeed: 5
@@ -1239,6 +1307,10 @@
     spawned:
     - id: FoodMeat
       amount: 2
+  - type: AlwaysRevolutionaryConvertible
+  - type: GhostTakeoverAvailable
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-kobold
   - type: GhostRole
     prob: 0.1
     makeSentient: true
@@ -1790,108 +1862,6 @@
         damage: 50
       behaviors:
       - !type:ExplodeBehavior
-
-- type: entity
-  name: monkey
-  id: MobMonkeySyndicateAgent
-  parent: SimpleMobBase # doesn't parent off monkeys to be able to not have the clumsy component
-  description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
-  suffix: syndicate
-  components:
-  - type: CombatMode
-  - type: NameIdentifier
-    group: Monkey
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-primate
-  - type: Inventory
-    templateId: monkey
-    speciesId: monkey
-  - type: InventorySlots
-  - type: Cuffable
-  - type: RotationVisuals
-    defaultRotation: 90
-    horizontalRotation: 90
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 80
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Strippable
-  - type: UserInterface
-    interfaces:
-    - key: enum.StrippingUiKey.Key
-      type: StrippableBoundUserInterface
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: monkey
-      sprite: Mobs/Animals/monkey.rsi
-    - map: [ "jumpsuit" ]
-    - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
-      color: "#ffffff"
-      sprite: Objects/Misc/handcuffs.rsi
-      state: body-overlay-2
-      visible: false
-    - map: [ "outerClothing" ]
-    - map: [ "id" ]
-    - map: [ "mask" ]
-    - map: [ "head" ]
-    - map: [ "clownedon" ]
-      sprite: "Effects/creampie.rsi"
-      state: "creampie_human"
-      visible: false
-  - type: Hands
-  - type: GenericVisualizer
-    visuals:
-      enum.CreamPiedVisuals.Creamed:
-        clownedon: # Not 'creampied' bc I can already see Skyrat complaining about conflicts.
-          True: {visible: true}
-          False: {visible: false}
-  - type: Speech
-    speechSounds: Monkey
-    speechVerb: Monkey
-  - type: Body
-    prototype: Primate
-    requiredLegs: 1 # TODO: More than 1 leg
-  - type: CreamPied
-  - type: FireVisuals
-    sprite: Mobs/Effects/onfire.rsi
-    normalState: Monkey_burning
-  - type: Butcherable
-    butcheringType: Spike
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: MonkeyAccent
-  - type: Puller
-  - type: CanHostGuardian
-  - type: NpcFactionMember
-    factions:
-    - Syndicate
-  - type: GhostRole
-    prob: 0.05
-    makeSentient: true
-    name: ghost-role-information-monkey-name
-    description: ghost-role-information-monkey-description
-  - type: GhostTakeoverAvailable
-  - type: IdExaminable
-  - type: Loadout
-    prototypes: [SyndicateOperativeGearMonkey]
-  - type: Tag
-    tags:
-    - VimPilot
-    - DoorBumpOpener
-  # make the player a traitor once its taken
-  - type: AutoTraitor
-    giveUplink: false
-    giveObjectives: false
 
   # I have included a snake_hiss.ogg sound file so if you want to use that be my guest
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1307,6 +1307,15 @@
     spawned:
     - id: FoodMeat
       amount: 2
+  - type: Clumsy
+    clumsyDamage:
+      types:
+        Blunt: 2
+        Piercing: 7
+      groups:
+        Burn: 3
+    clumsySound:
+      path: /Audio/Voice/Reptilian/reptilian_scream.ogg
   - type: AlwaysRevolutionaryConvertible
   - type: GhostTakeoverAvailable
   - type: SentienceTarget


### PR DESCRIPTION
## About the PR
This PR primarily serves as a cleanup of monkey YAML; monkeys and kobolds now inherit from a shared base mob (`MobBaseAncestor`), which contains a bunch of baseline properties shared by all monkeys and monkey-likes. This has interesting implications. Notably, syndicate monkeys are no longer a shonky crusty out-of-date copy-paste of monkeys, and kobolds are now able to have their own noises due to them now being free of `MonkeyAccent`!

While we're at it, we also made a *very* important change: you can now gently the kobolds (and monkeys, too). (In laymen's terms: instead of left-clicking monkeys/kobolds opening the strip menu, you will now pet them, just like many other mobs.)

Additionally, monkeys and kobolds can now pilot VIM; previously, only the syndicate monkeys had this, which honestly seems inconsistent, considering that syndicate monkeys are supposed to just be normal monkeys without clumsiness, and VIM is supposed to be pilotable by all small critters.

Another tiny change: Kobolds no longer instantly die upon hitting 40 damage, but rather, fall into crit at 40 damage, and die at 80. This is still less than half the health of monkeys, but their behavior when being robusted is now far more in-line with what one would expect from a mob; the instadeath at 40 was pretty shonky!

## Why / Balance
The cleanup makes sure that changes to monkeys can now be properly managed. Changes intended for all types of monkeys no longer need double-checking to make sure that they apply to all monkey variants, and changes intended only for one type of monkey can now properly apply only to that specific type. This PR makes good use of this, and gives kobolds their own unique noises, satisfying another check in #23207 in the process!

Additionally, the ability to gently kobolds is a feature that every game featuring kobolds should have. If you cannot gently the kobolds, then your game is completely unplayable!!! /s

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
### KOBOLD NOISES
![dotnet_eKuD3upB9c](https://github.com/space-wizards/space-station-14/assets/6356337/d4427c3e-16e8-43ec-bf71-93b05e693f38)

### GENTLY THE KOBOLDS (and monkeys, too!)
![uNlMSSifVJ](https://github.com/space-wizards/space-station-14/assets/6356337/17ec4d93-01d0-4f3b-b844-39c79a9065d5)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Any prototypes inheriting from `MobMonkey` should ideally inherit from `MobBaseAncestor` instead.

**Changelog**

:cl: Bhijn and Myr
- add: You can now gently the kobolds (and monkeys, too!)
- tweak: Kobolds now have their own unique speech!
- tweak: All monkeys and monkey-likes (kobolds, for instance) can now pilot VIM
- tweak: Kobolds no longer instantly die at 40 damage, but rather, fall into crit at that threshold. They now die at 80 damage.

