### PR TITLE
Make mobs with userids not gibbable by shuttles.

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -9,6 +9,8 @@ using Content.Shared.Buckle.Components;
 using Content.Shared.Doors.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Maps;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
 using Content.Shared.Parallax;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Systems;
@@ -79,6 +81,7 @@ public sealed partial class ShuttleSystem
 
     private HashSet<EntityUid> _lookupEnts = new();
 
+    private EntityQuery<MindContainerComponent> _mindContainerQuery;
     private EntityQuery<BodyComponent> _bodyQuery;
     private EntityQuery<BuckleComponent> _buckleQuery;
     private EntityQuery<GhostComponent> _ghostQuery;
@@ -88,6 +91,7 @@ public sealed partial class ShuttleSystem
 
     private void InitializeFTL()
     {
+        _mindContainerQuery = GetEntityQuery<MindContainerComponent>();
         _bodyQuery = GetEntityQuery<BodyComponent>();
         _buckleQuery = GetEntityQuery<BuckleComponent>();
         _ghostQuery = GetEntityQuery<GhostComponent>();
@@ -735,6 +739,10 @@ public sealed partial class ShuttleSystem
 
                 if (_bodyQuery.TryGetComponent(ent, out var mob))
                 {
+                    if(_mindContainerQuery.TryGetComponent(ent, out var mindContainer) && CompOrNull<MindComponent>(mindContainer.Mind)?.UserId != null)
+                    {
+                        continue;
+                    }
                     var gibs = _bobby.GibBody(ent, body: mob);
                     immune.UnionWith(gibs);
                     continue;


### PR DESCRIPTION
## About the PR
Player mobs are not gibbed by shuttles on FTL arrival.

## Why / Balance
People keep getting gibbed by the arrivals shuttle. There's no way to see when the arrivals shuttle is about to arrive to avoid it, unless you're in one of those rare places where you can see the arrivals timer. Even so, since arrivals can also arrive in other docks, it got ridiculous enough.

## Technical details
If there's an userid on the mob's mindcomponent, don't gib.

## Media
Only one character possessed, only one character spared.
![image](https://github.com/space-wizards/space-station-14/assets/3650235/855ae53d-75c6-4a0b-843d-e642cda0e832)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl:
- tweak: Player characters are not gibbed by shuttles anymore.
