### PR TITLE
Disable magnet wrecks

### DIFF
--- a/Content.Server/Salvage/Magnet/SalvageMagnetDataComponent.cs
+++ b/Content.Server/Salvage/Magnet/SalvageMagnetDataComponent.cs
@@ -44,7 +44,7 @@ public sealed partial class SalvageMagnetDataComponent : Component
     public List<int> Offered = new();
 
     [DataField]
-    public int OfferCount = 6;
+    public int OfferCount = 3;
 
     [DataField]
     public int ActiveSeed;

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -167,10 +167,12 @@ public sealed partial class SalvageSystem
             // Fuck with the seed to mix wrecks and asteroids.
             seed = (int) (seed / 10f) * 10;
 
+            /* Asteroid only for now chump.
             if (i >= data.Comp.OfferCount / 2)
             {
                 seed++;
             }
+            */
 
             data.Comp.Offered.Add(seed);
         }


### PR DESCRIPTION
Until we can manage these code-wise better and not rely upon people who aren't even around anymore to balance them.

:cl:
- tweak: Disable magnet wrecks TEMPORARILY pending further re-balancing.