### PR TITLE
Fix Vote Relay

### DIFF
--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -171,7 +171,7 @@ namespace Content.Server.Voting
                     chatMgr.DispatchServerAnnouncement(Loc.GetString("cmd-customvote-on-finished-win",("winner", args[(int) eventArgs.Winner])));
                 }
 
-                for (int i = 0; i < eventArgs.Votes.Count - 1; i++)
+                for (int i = 0; i < eventArgs.Votes.Count; i++)
                 {
                     var oldName = payload.Embeds[0].Fields[i].Name;
                     var newValue = eventArgs.Votes[i].ToString();


### PR DESCRIPTION
Pretty sure this is it. Brain may not work right, but I think this is it.
Could not test with an actual webhook, but the embed data was processed correctly with the last option showing the votes.

## About the PR
Updated VoteCommand.cs to resolve an off by one error that resulted in the last vote option showing as 0.