### PR TITLE
Prevent ejection of cleaning module's holofan powercell

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -25,6 +25,21 @@
 
 - type: entity
   parent: Holoprojector
+  id: HoloprojectorBorg
+  suffix: borg
+  components:
+  - type: HolosignProjector
+    chargeUse: 240
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellMicroreactor
+        disableEject: true
+        swap: false
+
+- type: entity
+  parent: Holoprojector
   id: HolofanProjector
   name: holofan projector
   description: Stop suicidal passengers from killing everyone during atmos emergencies.

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -306,7 +306,7 @@
   - type: ItemBorgModule
     items:
     - AdvMopItem
-    - Holoprojector
+    - HoloprojectorBorg
     - SprayBottleSpaceCleaner
 
 # medical modules


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds a holosign prototype for the advanced cleaning module that has a micro reactor power cell installed. This power cell can't be ejected or swapped.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The powercell of the advanced cleaning module's holofan currently can't be replaced or recharged. If it's either empty or ejected the borg will need a completely new cleaning module installed to be able to use it again.
New prototype regenerates 1 charge every 20 seconds and power cell can't be ejected or swapped.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- fix: The cyborg cleaning module's holofan battery now recharges and can't be ejected anymore.

