### PR TITLE
Patch Cargo Lathe Abuse

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -66,8 +66,6 @@
     sprite: Clothing/Shoes/Boots/magboots-science.rsi
   - type: Magboots
     toggleAction: ActionToggleMagbootsSci
-  - type: StaticPrice
-    price: 400
 
 - type: entity
   parent: ClothingShoesBootsMag

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -740,6 +740,8 @@
         Glass: 200
       chemicalComposition:
         Silicon: 20
+    - type: StaticPrice
+      price: 40
 
 - type: entity
   id: ThrusterMachineCircuitboard
@@ -784,6 +786,8 @@
         Glass: 200
       chemicalComposition:
         Silicon: 20
+    - type: StaticPrice
+      price: 40
 
 - type: entity
   id: PortableGeneratorJrPacmanMachineCircuitboard
@@ -803,6 +807,8 @@
         Glass: 200
       chemicalComposition:
         Silicon: 20
+    - type: StaticPrice
+      price: 40
 
 - type: entity
   id: ReagentGrinderMachineCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
@@ -31,6 +31,8 @@
       tags:
         - DroneUsable
         - WallmountSubstationElectronics
+    - type: StaticPrice
+      price: 40
 
 # Wallmount Generator
 - type: entity
@@ -49,6 +51,8 @@
     tags:
       - DroneUsable
       - WallmountGeneratorElectronics
+    - type: StaticPrice
+      price: 20
 
 # APU
 - type: entity
@@ -64,6 +68,8 @@
       tags:
         - DroneUsable
         - WallmountGeneratorAPUElectronics
+    - type: StaticPrice
+      price: 40
 
 # Solar Tracker Electronics
 - type: entity
@@ -79,3 +85,5 @@
       tags:
         - DroneUsable
         - SolarTrackerElectronics
+    - type: StaticPrice
+      price: 85

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
@@ -27,12 +27,12 @@
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: charger_APC
+    - type: StaticPrice
+      price: 40
     - type: Tag
       tags:
         - DroneUsable
         - WallmountSubstationElectronics
-    - type: StaticPrice
-      price: 40
 
 # Wallmount Generator
 - type: entity
@@ -44,6 +44,8 @@
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: charger_APC
+  - type: StaticPrice
+    price: 20
   - type: PhysicalComposition
     materialComposition:
       Glass: 90
@@ -51,8 +53,6 @@
     tags:
       - DroneUsable
       - WallmountGeneratorElectronics
-    - type: StaticPrice
-      price: 20
 
 # APU
 - type: entity
@@ -64,12 +64,12 @@
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: charger_APC
+    - type: StaticPrice
+      price: 40
     - type: Tag
       tags:
         - DroneUsable
         - WallmountGeneratorAPUElectronics
-    - type: StaticPrice
-      price: 40
 
 # Solar Tracker Electronics
 - type: entity
@@ -81,9 +81,9 @@
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: generic
+    - type: StaticPrice
+      price: 85
     - type: Tag
       tags:
         - DroneUsable
         - SolarTrackerElectronics
-    - type: StaticPrice
-      price: 85

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -34,7 +34,7 @@
       cpu_science: "#D381C9"
       cpu_supply: "#A46106"
   - type: StaticPrice
-    price: 500
+    price: 250
   - type: Tag
     tags:
     - DroneUsable

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -57,7 +57,7 @@
       tags:
         - HolofanProjector
     - type: StaticPrice
-      price: 250
+      price: 130
 
 - type: entity
   parent: Holoprojector
@@ -75,7 +75,7 @@
       tags:
         - HolofanProjector
     - type: StaticPrice
-      price: 80
+      price: 50
 
 - type: entity
   parent: HoloprojectorSecurity

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
@@ -81,6 +81,8 @@
   - type: Tag
     tags:
     - KeyedInstrument
+  - type: StaticPrice
+    price: 90
 
 - type: entity
   parent: BaseHandheldInstrument

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -68,7 +68,7 @@
   description: A large tower shield. Good for controlling crowds.
   components:
     - type: StaticPrice
-      price: 100
+      price: 90
 
 - type: entity
   name: riot laser shield

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -38,7 +38,7 @@
     - type: DoAfter
     - type: UseDelay
     - type: StaticPrice
-      price: 100
+      price: 30
     - type: GuideHelp
       guides:
       - Medical Doctor

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -44,7 +44,7 @@
     stackType: Ointment
     count: 10
   - type: StackPrice
-    price: 10
+    price: 5
 
 - type: entity
   id: Ointment1
@@ -130,7 +130,7 @@
     stackType: Brutepack
     count: 10
   - type: StackPrice
-    price: 10
+    price: 5
 
 - type: entity
   id: Brutepack1

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -7,7 +7,7 @@
   components:
   - type: Sprite
   - type: StaticPrice
-    price: 60
+    price: 20
 
 # Cautery
 
@@ -48,6 +48,8 @@
         Piercing: 10
     soundHit:
       path: /Audio/Items/drill_hit.ogg
+  - type: StaticPrice
+    price: 40
 
 # Scalpel
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -9,7 +9,7 @@
     sprite: Objects/Specific/Robotics/borgmodule.rsi
   - type: BorgModule
   - type: StaticPrice
-    price: 250
+    price: 100
   - type: Tag
     tags:
     - BorgModuleGeneric

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -44,7 +44,7 @@
       maxFillLevels: 6
       fillBaseName: jug
     - type: StaticPrice
-      price: 80
+      price: 60
     - type: Label
       originalName: jug
 

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -201,7 +201,7 @@
     maxFillLevels: 6
     fillBaseName: beakerlarge
   - type: StaticPrice
-    price: 40
+    price: 20
 
 - type: entity
   name: cryostasis beaker

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -27,3 +27,5 @@
       path: /Audio/Weapons/Guns/Casings/casing_fall_2.ogg
       params:
         volume: -1
+  - type: StaticPrice
+    price: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -17,8 +17,6 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
-    price: 10
 
 - type: entity
   id: CartridgeLightRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -17,8 +17,6 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
-    price: 10
 
 - type: entity
   id: CartridgeMagnum

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -17,8 +17,6 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
-    price: 10
 
 - type: entity
   id: CartridgePistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -17,8 +17,6 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
-    price: 10
 
 - type: entity
   id: CartridgeRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -213,6 +213,8 @@
       shader: unshaded
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
+  - type: StaticPrice
+    price: 420
   - type: Gun
     selectedMode: SemiAuto
     availableModes:
@@ -230,6 +232,8 @@
   - type: HitscanBatteryAmmoProvider
     proto: RedLaserPractice
     fireCost: 62.5
+  - type: StaticPrice
+    price: 300
 
 - type: entity
   name: pulse pistol
@@ -475,6 +479,8 @@
     magState: mag
     steps: 5
     zeroVisible: true
+  - type: StaticPrice
+    price: 260
 
 - type: entity
   name: practice disabler
@@ -495,6 +501,8 @@
       quickEquip: false
       slots:
         - Belt
+    - type: StaticPrice
+      price: 100
     - type: ProjectileBatteryAmmoProvider
       proto: BulletDisablerPractice
       fireCost: 100
@@ -649,6 +657,8 @@
   - type: Construction
     graph: UpgradeWeaponPistolCHIMP
     node: start
+  - type: StaticPrice
+    price: 100
 
 - type: entity
   name: experimental C.H.I.M.P. handcannon

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -65,7 +65,7 @@
           True: {state: stunbaton_on}
           False: {state: stunbaton_off}
   - type: StaticPrice
-    price: 100
+    price: 80
   - type: Riggable
   - type: SolutionContainerManager
     solutions:
@@ -109,7 +109,7 @@
     malus: 0.225
   - type: Appearance
   - type: StaticPrice
-    price: 100
+    price: 80
   - type: GuideHelp
     guides:
     - Security

--- a/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
@@ -69,7 +69,7 @@
             True: {visible: false}
             False: {visible: true}
     - type: StaticPrice
-      price: 200
+      price: 120
 
 - type: entity
   parent: RollerBed


### PR DESCRIPTION
## About the PR
Reduces the selling price of several cargo abusable lathe-produced items, even through tech trees.

## Why / Balance
Infinite money glitches are stupid.

- Flatpack: $500 -> $250
- Force Field Projector: $250 -> $130
- Laser Rifle: $500 -> $420
- Disabler SMG: $500 -> $260
- Synthesizer: $200 -> $90
- Practice Laser Rifle: $500 -> $300
- All Cyborg Modules: $250 -> $100
- Practice Disabler: $500 -> $100
- Holobarrier Projector: $80 -> $50
- Science Magboots: $400 -> $200
- Rollerbeds: $200 -> $120
- Stun Baton: $100 -> $80
- Truncheon: $100 -> $80
- Surgery Drill: $60 -> $40
- Bruise Pack: $10 -> $5
- Ointment: $10 -> $5
- Jug: $80 -> $60
- C.H.I.M.P Handcannon: $500 -> $100
- Riot Shield: $100 -> $90
- Solar Tracker Electronics: $100 -> $85
- All Portable Generator Machine Boards: $100 -> $40
- Wallmount APU Electronics: $100 -> $40
- Wallmount Substation Electronics: $100 -> $40
- Wallmount Generator Electronics: $100 -> $20
- All Surgery Tools (Excluding Drill): $60 -> $20
- Large Beaker: $40 -> $20
- All Types of Craftable Bullets: $10 -> $1

## Technical details
Nothing extremely notable but I ripped out the sell price of each individual branch of round (.35, .45, .20, etc) and just put it on the base parent they all pull from instead.

## Media
- [X] This PR does not require an ingame showcase

**Changelog**
N/A