### PR TITLE
Syndicate cyborg changes/fixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -248,14 +248,14 @@
       factions:
         - Syndicate
     - type: Access
-      enabled: false
-      groups:
-      - Syndicate
+      tags:
+       - NuclearOperative
+       - SyndicateAgent
     - type: Lock
       locked: true
     - type: ActivatableUIRequiresLock
     - type: AccessReader
-      access: ["Syndicate"]
+      access: [["SyndicateAgent"], ["NuclearOperative"]]
     - type: SiliconLawProvider
       laws: SyndicateStatic
     - type: IntrinsicRadioTransmitter

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -248,6 +248,14 @@
       factions:
         - Syndicate
     - type: Access
+      enabled: false
+      groups:
+      - Syndicate
+    - type: Lock
+      locked: true
+    - type: ActivatableUIRequiresLock
+    - type: AccessReader
+      access: ["Syndicate"]
     - type: SiliconLawProvider
       laws: SyndicateStatic
     - type: IntrinsicRadioTransmitter
@@ -257,5 +265,4 @@
     - type: ActiveRadio
       channels:
         - Syndicate
-    - type: NoSlip
-    - type: MovementAlwaysTouching
+    - type: ShowSyndicateIcons

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -266,3 +266,4 @@
       channels:
         - Syndicate
     - type: ShowSyndicateIcons
+    - type: MovementAlwaysTouching

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -136,6 +136,9 @@
     containers:
     - part-container
     - cell_slot
+  - type: Lock
+    locked: true
+  - type: ActivatableUIRequiresLock
   - type: Flashable
   - type: Damageable
     damageContainer: Silicon
@@ -218,9 +221,6 @@
     enabled: false
     groups:
     - AllAccess
-  - type: Lock
-    locked: true
-  - type: ActivatableUIRequiresLock
   - type: AccessReader
     access: [["Command"], ["Research"]]
   - type: ShowSecurityIcons
@@ -237,9 +237,6 @@
       tags:
        - NuclearOperative
        - SyndicateAgent
-    - type: Lock
-      locked: true
-    - type: ActivatableUIRequiresLock
     - type: AccessReader
       access: [["SyndicateAgent"], ["NuclearOperative"]]
     - type: SiliconLawProvider

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -230,20 +230,6 @@
   parent: BaseBorgChassis
   abstract: true
   components:
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 200
-          behaviors:
-            - !type:PlaySoundBehavior
-              sound: /Audio/Effects/metalbreak.ogg
-            - !type:EmptyContainersBehaviour
-              containers:
-                - borg_brain
-                - borg_module
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
     - type: NpcFactionMember
       factions:
         - Syndicate

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -268,7 +268,7 @@
   id: BorgChassisSyndicateAssault
   parent: BaseBorgChassisSyndicate
   name: syndicate assault cyborg
-  description: A lean, mean killing machine with access to a varity of deadly modules.
+  description: A lean, mean killing machine with access to a variety of deadly modules.
   components:
     - type: Sprite
       layers:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -517,7 +517,7 @@
   id: BorgModuleOperative
   parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule ]
   name: operative cyborg module
-  description: A module that comes with a crowbar, a Cobra pistol, an Emag and a pinpointer.
+  description: A module that comes with a crowbar, a Cobra pistol, an Emag and a syndicate pinpointer.
   components:
     - type: Sprite
       layers:
@@ -528,7 +528,7 @@
         - Crowbar
         - WeaponPistolCobra
         - Emag
-        - PinpointerNuclear
+        - PinpointerSyndicateNuclear
 
 - type: entity
   id: BorgModuleEsword
@@ -543,7 +543,7 @@
     - type: ItemBorgModule
       items:
         - EnergySword
-        - PinpointerNuclear
+        - PinpointerSyndicateNuclear
 
 - type: entity
   id: BorgModuleL6C
@@ -558,4 +558,4 @@
     - type: ItemBorgModule
       items:
         - WeaponLightMachineGunL6C
-        - PinpointerNuclear
+        - PinpointerSyndicateNuclear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- syndicate cyborgs now have syndicate and nukeop access
- syndicate cyborgs now have a locking mechanism on their chassis, syndicate access required
- syndicate cyborgs can now see who the nukies are
- syndicate assault cyborgs now have a syndicate pinpointer instead of a crew pinpointer

## Why / Balance
syndicate borgs not having syndicate access made no sense
syndicate borgs not having a locking mechanism made them less secure than normal borgs
and syndie borgs seeing who syndicates has the same reason as to why nanotrasen borgs can see crew icons

## Technical details
removed NoSlip component from syndie borg too because base cyborg already has that component

## Media
https://cdn.discordapp.com/attachments/561607258337706042/1193721824312299581/2024-01-07_20-00-04.mp4?ex=65adbf15&is=659b4a15&hm=9067621960f99db7e282d1300ba2afdee9f45d5e04e9b1b40e1ba36a4f402592&
video larger than 10mb
![image](https://github.com/space-wizards/space-station-14/assets/45323883/02f7b633-7c45-47c7-90c4-51825de5ed73)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
nope

**Changelog**
:cl:
- tweak: Syndicate cyborgs can now see who syndicate agents are, and they now have a lock on their chassis that needs syndicate access to open.