### PR TITLE
Increase minimum requirement for lowpop maps

### DIFF
--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -2,8 +2,8 @@
   id: Atlas
   mapName: Atlas
   mapPath: /Maps/atlas.yml
-  minPlayers: 0
-  maxPlayers: 35
+  minPlayers: 5
+  maxPlayers: 20
   stations:
     Atlas:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -2,7 +2,7 @@
   id: Cluster
   mapName: 'Cluster'
   mapPath: /Maps/cluster.yml
-  minPlayers: 0
+  minPlayers: 10
   maxPlayers: 35
   stations:
     Cluster:

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -1,8 +1,8 @@
-﻿- type: gameMap
+- type: gameMap
   id: Omega
   mapName: 'Omega'
   mapPath: /Maps/omega.yml
-  minPlayers: 0
+  minPlayers: 10
   maxPlayers: 35
   stations:
     Omega:

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -3,7 +3,7 @@
   mapName: 'Reach'
   mapPath: /Maps/reach.yml
   minPlayers: 0
-  maxPlayers: 5
+  maxPlayers: 10
   stations:
     Reach:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -3,7 +3,7 @@
   mapName: 'Reach'
   mapPath: /Maps/reach.yml
   minPlayers: 0
-  maxPlayers: 10
+  maxPlayers: 5
   stations:
     Reach:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

It's an issue when lowpop maps get maps that are way too big for their population size, so i tweaked it so that theres a hierarchy of maps;
Reach > Atlas > Cluster/Omega