### PR TITLE
Mothroach gib threshold and resilience increase

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -459,7 +459,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
-        damage: 100
+        damage: 60
       behaviors:
       - !type:GibBehavior { }
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -363,6 +363,17 @@
     whitelistRequired: false
     name: ghost-role-information-mothroach-name
     description: ghost-role-information-mothroach-description
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.2
+        density: 120
+        mask:
+        - SmallMobMask
+        layer:
+        - SmallMobLayer
   - type: GhostTakeoverAvailable
   - type: Speech
     speechVerb: Moth

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -393,8 +393,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      25: Critical
-      45: Dead
+      40: Critical
+      60: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed : 2.5
     baseSprintSpeed : 4
@@ -443,6 +443,14 @@
     prototype: Mothroach
   - type: TypingIndicator
     proto: moth
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 100
+      behaviors:
+      - !type:GibBehavior { }
 
 - type: entity
   name: mallard duck #Quack
@@ -2550,7 +2558,7 @@
   - type: NpcFactionMember
     factions:
     - Syndicate
-   
+
 - type: entity
   name: space cat
   id: MobCatSpace


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Mothroaches now have the same mobStates and mass as hamsters and they get gibbed at a higher blunt damage threshold.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Mothroaches are quite big, so they should probably at least be as resilient as a hamster, the mass increase lowers the damage they take from mousetraps from 32 to 18.
Mothroaches inherited the cockroaches gib threshold of 10 blunt, I increased this to 60 so that if you beat them to death or throw a few mousetraps at them they will still be gibbed.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- tweak: Mothroaches are now a little bit more resilient, making them less prone to being gibbed.
