### PR TITLE
unique satchel grid

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
@@ -70,13 +70,13 @@
   id: BoxForensicPad
   description: A box of forensic pads.
   components:
-  - type: Storage
-    grid:
-    - 0,0,4,3
+  - type: Item
+    shape:
+    - 0,0,1,1
   - type: StorageFill
     contents:
-      - id: ForensicPad
-        amount: 10
+    - id: ForensicPad
+      amount: 9
   - type: Sprite
     layers:
       - state: box_security

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -6,6 +6,11 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Satchels/satchel.rsi
+  - type: Storage
+    grid:
+    - 0,0,1,3
+    - 3,0,6,3
+    - 8,0,9,3
 
 - type: entity
   parent: ClothingBackpackSatchel

--- a/Resources/Prototypes/Entities/Objects/Specific/Forensics/forensics.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Forensics/forensics.yml
@@ -5,7 +5,7 @@
   description: A forensic pad for collecting fingerprints or fibers.
   components:
   - type: Item
-    size: Small
+    size: Tiny
   - type: ForensicPad
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
something i brainstormed ages ago during gridinv.

Satchels now consist of a single 4x4 grid and two 2x4 grids.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Satchels have been bag reskins for as long as they have existed. Duffels get the luxury of capacity buffs and slowdown, but satchels don't really have anything unique about them.

This adjusts satchels to be comprised of 3 smaller grids instead of one large one. Notably,
- Satchels now have more capacity than bags, 32 compared to a bag's 28.
- That capacity only allows for more smaller items, as you can't fit two 4x4 items inside the bag, like you could otherwise

This makes satchels ideal for people who just want to squeeze a few more knickknacks into their bag. This is just a little experiment.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/12bad96e-90e0-45a1-8016-9ccabae4e109)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

:cl:
- tweak: Satchels have a larger carrying capacity that is divided into pockets.