### PR TITLE
Fix borg becoming emag immune if emag attempted with panel closed.

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -76,6 +76,9 @@ public sealed class AccessReaderSystem : EntitySystem
 
     private void OnEmagged(EntityUid uid, AccessReaderComponent reader, ref GotEmaggedEvent args)
     {
+        if (!reader.Enabled && reader.AccessLog.Count == 0)
+            return;
+
         args.Handled = true;
         reader.Enabled = false;
         reader.AccessLog.Clear();

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -76,9 +76,6 @@ public sealed class AccessReaderSystem : EntitySystem
 
     private void OnEmagged(EntityUid uid, AccessReaderComponent reader, ref GotEmaggedEvent args)
     {
-        if (!reader.Enabled && reader.AccessLog.Count == 0)
-            return;
-
         args.Handled = true;
         reader.Enabled = false;
         reader.AccessLog.Clear();

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Emag.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Tag;
 
 namespace Content.Shared.Emag.Systems;
@@ -81,6 +82,13 @@ public sealed class EmagSystem : EntitySystem
 
         var emaggedEvent = new GotEmaggedEvent(user);
         RaiseLocalEvent(target, ref emaggedEvent);
+
+        //Don't add EmaggedComponent to the borg if only the lock, and not the borg itself, has been emagged.
+        if (TryComp<EmagSiliconLawComponent>(target, out var emagSiliconLawComponent))
+        {
+            if(emagSiliconLawComponent.OwnerName == null)
+                return emaggedEvent.Handled;
+        }
 
         if (emaggedEvent.Handled && !emaggedEvent.Repeatable)
             EnsureComp<EmaggedComponent>(target);

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -84,7 +84,7 @@ public sealed class EmagSystem : EntitySystem
         RaiseLocalEvent(target, ref onAttemptEmagEvent);
 
         // prevent emagging if attempt fails
-        if (!onAttemptEmagEvent.Handled)
+        if (onAttemptEmagEvent.Handled)
             return false;
 
         var emaggedEvent = new GotEmaggedEvent(user);

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -80,15 +80,15 @@ public sealed class EmagSystem : EntitySystem
         if (HasComp<EmaggedComponent>(target))
             return false;
 
+        var onAttemptEmagEvent = new OnAttemptEmagEvent(user);
+        RaiseLocalEvent(target, ref onAttemptEmagEvent);
+
+        // prevent emagging if attempt fails
+        if (!onAttemptEmagEvent.Handled)
+            return false;
+
         var emaggedEvent = new GotEmaggedEvent(user);
         RaiseLocalEvent(target, ref emaggedEvent);
-
-        //Don't add EmaggedComponent to the borg if only the lock, and not the borg itself, has been emagged.
-        if (TryComp<EmagSiliconLawComponent>(target, out var emagSiliconLawComponent))
-        {
-            if(emagSiliconLawComponent.OwnerName == null)
-                return emaggedEvent.Handled;
-        }
 
         if (emaggedEvent.Handled && !emaggedEvent.Repeatable)
             EnsureComp<EmaggedComponent>(target);
@@ -98,3 +98,6 @@ public sealed class EmagSystem : EntitySystem
 
 [ByRefEvent]
 public record struct GotEmaggedEvent(EntityUid UserUid, bool Handled = false, bool Repeatable = false);
+
+[ByRefEvent]
+public record struct OnAttemptEmagEvent(EntityUid UserUid, bool Handled = false);

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -16,9 +16,10 @@ public abstract class SharedSiliconLawSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<EmagSiliconLawComponent, GotEmaggedEvent>(OnGotEmagged);
+        SubscribeLocalEvent<EmagSiliconLawComponent, OnAttemptEmagEvent>(OnAttemptEmag);
     }
 
-    protected virtual void OnGotEmagged(EntityUid uid, EmagSiliconLawComponent component, ref GotEmaggedEvent args)
+    protected virtual void OnAttemptEmag(EntityUid uid, EmagSiliconLawComponent component, ref OnAttemptEmagEvent args)
     {
         if (component.RequireOpenPanel &&
             TryComp<WiresPanelComponent>(uid, out var panel) &&
@@ -27,7 +28,11 @@ public abstract class SharedSiliconLawSystem : EntitySystem
             _popup.PopupClient(Loc.GetString("law-emag-require-panel"), uid, args.UserUid);
             return;
         }
+        args.Handled = true;
+    }
 
+    protected virtual void OnGotEmagged(EntityUid uid, EmagSiliconLawComponent component, ref GotEmaggedEvent args)
+    {
         component.OwnerName = Name(args.UserUid);
         args.Handled = true;
     }

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -26,9 +26,9 @@ public abstract class SharedSiliconLawSystem : EntitySystem
             !panel.Open)
         {
             _popup.PopupClient(Loc.GetString("law-emag-require-panel"), uid, args.UserUid);
-            return;
+            args.Handled = true;
         }
-        args.Handled = true;
+
     }
 
     protected virtual void OnGotEmagged(EntityUid uid, EmagSiliconLawComponent component, ref GotEmaggedEvent args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
resolves #22673 
resolves #21740 
resolves #21577 

Borgs that got emagged with their panel closed would still get the EmaggedComponent because of the emag on the access lock succeeding. This would make the borg itself not get any of the emag effects and permanently make it unable to be emagged. 

This PR makes it so the borg only can get emagged if the panel is open, fixing the above issue.


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a new OnAttemptEmag event that gets raised before an attempt at emagging is done.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- fix: Attempting to emag a borg with a closed panel won't permanently make it unable to be emagged anymore.
