### PR TITLE
syndicate monkey changes, new nukeop monkey

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -456,6 +456,27 @@
     Telecrystal: 8
   categories:
   - UplinkUtility
+  conditions:
+    - !type:StoreWhitelistCondition
+      blacklist:
+        tags:
+          - NukeOpsUplink
+
+- type: listing
+  id: UplinkReinforcementRadioSyndicateMonkeyNukeops # Version for Nukeops that spawns a syndicate monkey with the NukeOperative component.
+  name: uplink-reinforcement-radio-monkey-name
+  description: uplink-reinforcement-radio-monkey-desc
+  productEntity: ReinforcementRadioSyndicateMonkeyNukeops
+  icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkUtility
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - NukeOpsUplink
 
 - type: listing
   id: UplinkStealthBox

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1198,10 +1198,10 @@
 
 - type: entity
   name: monkey
-  id: MobMonkeySyndicateAgent
+  id: MobBaseSyndicateMonkey
   parent: MobBaseAncestor
   description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
-  suffix: syndicate
+  suffix: syndicate base
   components:
   - type: NameIdentifier
     group: Monkey
@@ -1222,10 +1222,23 @@
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [SyndicateOperativeGearMonkey]
-  # make the player a traitor once its taken
+  
+- type: entity
+  id: MobMonkeySyndicateAgent
+  parent: MobBaseSyndicateMonkey
+  suffix: syndicate agent
+  components:
+    # make the player a traitor once its taken
   - type: AutoTraitor
     giveUplink: false
     giveObjectives: false
+
+- type: entity
+  id: MobMonkeySyndicateAgentNukeops # Reinforcement exclusive to nukeops uplink
+  parent: MobBaseSyndicateMonkey
+  suffix: NukeOps
+  components:
+  - type: NukeOperative
 
 - type: entity
   name: kobold

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -43,6 +43,7 @@
 - type: entity
   parent: ReinforcementRadioSyndicateMonkey
   id: ReinforcementRadioSyndicateMonkeyNukeops # Reinforcement radio exclusive to nukeops uplink
+  suffix: NukeOps
   components:
   - type: GhostRoleMobSpawner
     prototype: MobMonkeySyndicateAgentNukeops

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -29,7 +29,7 @@
 
 - type: entity
   parent: ReinforcementRadioSyndicate
-  id: ReinforcementRadioSyndicateMonkey # Reinforcement radio exclusive to nukeops uplink
+  id: ReinforcementRadioSyndicateMonkey
   name: syndicate monkey reinforcement radio
   description: Calls in a specially trained monkey to assist you.
   components:
@@ -39,6 +39,13 @@
     rules: ghost-role-information-syndicate-monkey-reinforcement-rules
   - type: GhostRoleMobSpawner
     prototype: MobMonkeySyndicateAgent
+
+- type: entity
+  parent: ReinforcementRadioSyndicateMonkey
+  id: ReinforcementRadioSyndicateMonkeyNukeops # Reinforcement radio exclusive to nukeops uplink
+  components:
+  - type: GhostRoleMobSpawner
+    prototype: MobMonkeySyndicateAgentNukeops
 
 - type: entity
   parent: ReinforcementRadioSyndicate


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
so that nukies and syndicate borgs can see who nukie monkeys are, mainly for syndiborgs so they recognize syndicate monkeys as agents with their laws

this does not change syndicate agent monkeys, they still get traitor

nukie monkey has same loadout as syndicate agent monkey

## Technical details
adds syndicate monkey base, syndicate agent and nukeop monkey inherit it

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/c01216b1-cc23-4005-b769-1aad841e40da)
monkey has syndicate icon

https://cdn.discordapp.com/attachments/561607258337706042/1193996869551005766/2024-01-08_14-08-02.mp4?ex=65aebf3d&is=659c4a3d&hm=6456202372f170bee98058a8b7b1701279bcaf62c7a598dc49b7e4d3de36f646&
video above 10mb

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
nope

**Changelog**
no