### PR TITLE
robotech vendor changes

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -4,6 +4,7 @@
     CableApcStack: 4
     SciFlash: 4
     ProximitySensor: 3
+    ClothingEyesHudDiagnostic: 2
     RemoteSignaller: 3
     Igniter: 3 # its more ordnance but yeah
     HandheldHealthAnalyzer: 3
@@ -12,5 +13,6 @@
     #Bonesetter: 2 add when robotics
     NitrousOxideTankFilled: 2
     ClothingMaskBreathMedical: 5
+    ClothingHeadHatWeldingMaskFlame: 1
     Screwdriver: 2
     Crowbar: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -14,5 +14,6 @@
     NitrousOxideTankFilled: 2
     ClothingMaskBreathMedical: 5
     ClothingHeadHatWeldingMaskFlame: 1
+    Welder: 1
     Screwdriver: 2
     Crowbar: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
adds flame welding mask, welding tool and 2 diagnostic huds to the robotech deluxe

## Why / Balance
closes #23741
diagnostic huds are unobtainable i believe outside of one map that has it spawn in engineering, and they're useful for roboticistsas they can see the health of cyborgs
welding mask and welding tool are also good for roboticists so they can patch up their borgs

## Technical details
3

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/3df244e5-23eb-4a64-8c9e-0cfd3d16af40)

https://github.com/space-wizards/space-station-14/assets/45323883/b616299f-8d59-41f8-b291-9952668117d8



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Robotech deluxe vending machines now contain 2 diagnostic HUDs, a flame welding mask, and a welding tool.
