### PR TITLE
Cryoxadone no longer heals toxin

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -189,7 +189,6 @@
               Airloss: -6
               Brute: -4
               Burn: -6
-              Toxin: -4
 
 - type: reagent
   id: Doxarubixadone


### PR DESCRIPTION
## About the PR
Cryoxadone no longer heals poison/radiation damage

## Why / Balance
Previously 200+ poison damage was an intentional and effective, albeit tricky to pull off at times method of ensuring someone would stay dead. With the introduction of cryo healing the dead this is no longer the case and thus I have made this pr.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Poison damage is once again a reliable and clean way to permanently kill a target.
