### PR TITLE
Appraisal tools check for cargo bounty completion

### DIFF
--- a/Resources/Locale/en-US/cargo/price-gun-component.ftl
+++ b/Resources/Locale/en-US/cargo/price-gun-component.ftl
@@ -1,3 +1,4 @@
 ﻿price-gun-pricing-result = The device deems {THE($object)} to be worth {$price} spesos.
 price-gun-verb-text = Appraisal
 price-gun-verb-message = Appraise {THE($object)}.
+price-gun-bounty-complete = The device confirms that the bounty contained within is completed.

--- a/Resources/Prototypes/Entities/Objects/Tools/appraisal.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/appraisal.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   id: AppraisalTool
   name: appraisal tool
-  description: A beancounter's best friend, with a quantum connection to the galactic market and the ability to appraise even the toughest items.
+  description: A beancounter's best friend, with a quantum connection to the galactic market and the ability to appraise even the toughest items. It will also tell you if a crate contains a completed bounty.
   components:
   - type: Sprite
     sprite: Objects/Tools/appraisal-tool.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The appraisal tool will now tell you if a scanned crate contains a completed cargo bounty.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Cargo techs can now confirm that the crate they're about to sell will actually satisfy the bounty.

## Media

Video of it in action: https://streamable.com/p6vrfz


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: The appraisal tool will now tell you if a crate contains a completed cargo bounty.

