### PR TITLE
Revert "Cryoxadone and doxarubixadone now work on the dead"

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -168,7 +168,6 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#0091ff"
-  worksOnTheDead: true
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: -5
@@ -199,7 +198,6 @@
   physicalDesc: reagent-physical-desc-bubbling
   flavor: medicine
   color: "#32cd32"
-  worksOnTheDead: true
   metabolisms:
     Medicine:
       effects:


### PR DESCRIPTION
# About

Reverts space-wizards/space-station-14#23558

Making cyrox and doxa able to heal damage off of dead players has transformed cryo from a niche method of chemical administration into a revival powerhouse. The main issues are thus:
- Cryo allows for administering some of the most potent healing chemicals in the game while simultaneously preventing rotting with no limit or restriction. It even applies to cellular damage via doxa, which means you can literally heal a dead body to 0 damage in all groups with no risk or time pressure.
- The changes still don't make cryo useful for it's intended purpose, only for the new purpose of healing unrevivable dead bodies. It essentially just serves as a budget cloner with somehow even less material balance than the biomass-based system.
- Because of how the supply of chemicals are unlimited, cryox/doxa completely outclass all of the more limited options for repairing damage on dead bodies (ointment, sutures, bruise packs, etc)

None of these changes in the original PR should even be considered until we have a better system for overall chemical balance. Chemicals are precariously balanced on overdoses and relative healing numbers. The fact that none of these factors are relevant for cryo healing dead bodies AND it nullifies all rot mechanics makes this a blatantly overpowered combo.

For a final piece, death is an important part of the game. Being able to kill players and them staying dead is important for antagonist balance as well as round flow. Players should be able to die and choose ghost roles without having to worry about being revived out of the blue 20 minutes later. We already have an abundance of mechanics that halt rotting (body bags, morgues, stasis bed, temperature, etc) as well as decently-balanced physical healing items that can be used to heal bodies reasonably damaged bodies.

Cloning was intentionally removed for a reason: it is not conducive to a system where healing and balancing different options matters. We shouldn't be encouraging a stale meta that is just cloning in a (slightly taller) skin.

### Changelog
:cl:
- remove: Cryoxadone and Doxarubixadone no longer work on the dead.