### PR TITLE
Checking for used utensils actually happens now

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -422,7 +422,7 @@ public sealed class FoodSystem : EntitySystem
     {
         utensils = new List<EntityUid>();
 
-        if (component.Utensil != UtensilType.None)
+        if (component.Utensil == UtensilType.None)
             return true;
 
         if (!Resolve(user, ref hands, false))


### PR DESCRIPTION
## About the PR
The code that checks which utensils are being used will now actually run when someone tries to eat a food that specifies a utensil for eating with.

The code was previously one gigantic no-op, explicitly checking against "None" when the food specified None, and not running at all when it _did_ specify actual utensils.

## Why / Balance
~~it's a secret~~

## Media
- [X] This PR does not require an ingame showcase


**Changelog**
no cl no fun
