### PR TITLE
L shape drill + Surgical Tool Rotation fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -22,6 +22,7 @@
     state: cautery
   - type: Item
     sprite: Objects/Specific/Medical/Surgery/cautery.rsi
+    storedRotation: 90
   - type: MeleeWeapon
     damage:
        types:
@@ -42,6 +43,9 @@
     state: drill
   - type: Item
     sprite: Objects/Specific/Medical/Surgery/drill.rsi
+    shape:
+    - 0,0,1,0
+    - 1,1,1,1
   - type: MeleeWeapon
     damage:
       types:
@@ -69,6 +73,7 @@
     state: scalpel
   - type: Item
     sprite: Objects/Specific/Medical/Surgery/scalpel.rsi
+    storedRotation: 90
   - type: MeleeWeapon
     attackRate: 1.5
     damage:
@@ -127,6 +132,7 @@
     state: retractor
   - type: Item
     sprite: Objects/Specific/Medical/Surgery/scissors.rsi
+    storedRotation: 90
 
 - type: entity
   name: hemostat
@@ -138,6 +144,7 @@
     state: hemostat
   - type: Item
     heldPrefix: hemostat
+    storedRotation: 90
 
   # - type: entity
   #   name: bone setter
@@ -162,6 +169,7 @@
     state: saw
   - type: Item
     sprite: Objects/Specific/Medical/Surgery/saw.rsi
+    storedRotation: 90
   - type: Tool
     qualities:
       - Sawing
@@ -199,6 +207,7 @@
     state: electric
   - type: Item
     heldPrefix: electric
+    storedRotation: 90
   - type: MeleeWeapon
     damage:
       groups:
@@ -220,6 +229,7 @@
     state: advanced
   - type: Item
     heldPrefix: advanced
+    storedRotation: 90
   - type: MeleeWeapon
     attackRate: 1.5
     damage:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixed the orientation of surgical tools in the Grid Inventory, and made the Surgical Drill an L shape like CHIMP/Pistols are.

## Why / Balance
Prettier Grid Inventory, Drill is shaped like Pistols

## Media
![image](https://github.com/space-wizards/space-station-14/assets/57879983/7727de27-2ba8-45cb-90f4-f2758e110d4c)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
no cl
