### PR TITLE
fixed flippo lighter sprites in vending machines

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -125,10 +125,10 @@
   - type: Sprite
     sprite: Objects/Tools/lighters.rsi
     layers:
-    - state: zippo_top
-      map: ["top"]
     - state: zippo_icon_base
       map: ["base"]
+    - state: zippo_top
+      map: ["top"]
     - state: zippo_open
       map: ["open"]
       visible: false
@@ -201,10 +201,10 @@
   - type: Sprite
     sprite: Objects/Tools/lighters.rsi
     layers:
-    - state: zippo_top
-      map: ["top"]
     - state: zippo_engraved_icon_base
       map: ["base"]
+    - state: zippo_top
+      map: ["top"]
     - state: zippo_engraved_open
       map: ["open"]
       visible: false


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
fixes #23679 
<!-- What did you change in this PR? -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: ShadyCigs now properly display flippo lighter icons!
