### PR TITLE
buff syndicate assault borgs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -517,7 +517,7 @@
   id: BorgModuleOperative
   parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule ]
   name: operative cyborg module
-  description: A module that comes with a crowbar, a Cobra pistol, an Emag and a syndicate pinpointer.
+  description: A module that comes with a crowbar, an Emag and a syndicate pinpointer.
   components:
     - type: Sprite
       layers:
@@ -526,7 +526,6 @@
     - type: ItemBorgModule
       items:
         - Crowbar
-        - WeaponPistolCobra
         - Emag
         - PinpointerSyndicateNuclear
 
@@ -534,7 +533,7 @@
   id: BorgModuleEsword
   parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule ]
   name: energy sword cyborg module
-  description: A module that comes with an energy sword.
+  description: A module that comes with a double energy sword.
   components:
     - type: Sprite
       layers:
@@ -542,7 +541,7 @@
         - state: icon-tools
     - type: ItemBorgModule
       items:
-        - EnergySword
+        - EnergySwordDouble
         - PinpointerSyndicateNuclear
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -84,7 +84,7 @@
   name: L6C ROW
   id: WeaponLightMachineGunL6C
   parent: BaseItem
-  description: A L6 SAW modified for cyborg use. Feeds .30 rifle ammo from an internal 100 round magazine.
+  description: A L6 SAW for use by cyborgs. Creates .30 rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
     - type: Gun
       minAngle: 4
@@ -111,7 +111,13 @@
     - type: ContainerContainer
       containers:
         ballistic-ammo: !type:Container
-    - type: BallisticAmmoProvider
+    - type: ProjectileBatteryAmmoProvider
       proto: CartridgeLightRifle
-      capacity: 100
+      fireCost: 100
+    - type: Battery
+      maxCharge: 10000
+      startingCharge: 10000
+    - type: BatterySelfRecharger
+      autoRecharge: true
+      autoRechargeRate: 25
     - type: AmmoCounter


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
see title
makes the L6 self-charge at 1 shot per 4 seconds and replaces the energy sword with a double energy sword
also removes the cobra since it had no reason to be there

## Why / Balance
right now, syndicate cyborgs are definitely too weak for their 65TC cost
borgs are supposed to be specialists and excel at specific tasks (perhaps better than the crew) while being bad at others, and the assault cyborg's niche is supposed to be combat, so i made it actually good at it
i believe having a self-charging L6 and a desword, which syndies and nukies normally can't obtain, is fine for it, since it's a borg; also see engiborgs and the advanced tools module with its self-charging RCD
i have also considered replacing the crowbar with syndicate jaws of life, but jaws are not a combat item, so i decided against it
the emag and crowbar should be kept because otherwise the borg has a very high chance of just getting stuck somewhere and can't operate alone

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
tested, trust

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

- tweak: Syndicate assault cyborgs now get a dual energy sword and a self-charging L6.