### PR TITLE
Make Puddle drawable by syringes and droppers.

### DIFF
--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -161,5 +161,7 @@
     examinable: false
   - type: ExaminableSolution
     solution: puddle
+  - type: DrawableSolution
+    solution: puddle
   - type: BadDrink
   - type: IgnoresFingerprints


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? --> This makes puddles drawable by syringe or dropper, so now you dont have to rely on a mop + bucket or damp rag + beaker combo to soak up those potentially useful floor chemicals. This is very useful to science for reagent spewing artifacts. Or maybe a detetive wants to do some fancy forensices and collect blood samples from a crime scene. Also could be used by syndicate agents to extract tiny amounts of useful chemicals from uncleaned spills.


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
We can drink right from puddles, but we cant sample from them into beakers. It makes sense to be able to use droppers and syringes on puddles to take samples.


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I've just added a DrawableSolution component to the base Puddle prototype.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->


## Future stuff
MelV on discord proposed having some kind of machine or tool that can suck up puddles into an internal storage you can later draw from. Might be cool to have an alternative to the spray nozzle that can fill the backpack watertank from puddles. Thats beyond the scope of this PR but something I might tackle in the near future.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: You can now draw chemical mixtures directly from puddles and spills!
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
