### PR TITLE
Wheelchair users can bump open doors

### DIFF
--- a/Content.Shared/Vehicle/SharedVehicleSystem.cs
+++ b/Content.Shared/Vehicle/SharedVehicleSystem.cs
@@ -146,6 +146,8 @@ public abstract partial class SharedVehicleSystem : EntitySystem
 
             _joints.ClearJoints(args.BuckledEntity);
 
+            _tagSystem.AddTag(uid, "DoorBumpOpener");
+
             return;
         }
 
@@ -161,6 +163,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         // Entity is no longer riding
         RemComp<RiderComponent>(args.BuckledEntity);
         RemComp<RelayInputMoverComponent>(args.BuckledEntity);
+        _tagSystem.RemoveTag(uid, "DoorBumpOpener");
 
         Appearance.SetData(uid, VehicleVisuals.HideRider, false);
         // Reset component
@@ -205,7 +208,6 @@ public abstract partial class SharedVehicleSystem : EntitySystem
 
         // Audiovisual feedback
         _ambientSound.SetAmbience(uid, true);
-        _tagSystem.AddTag(uid, "DoorBumpOpener");
         _modifier.RefreshMovementSpeedModifiers(uid);
     }
 
@@ -220,7 +222,6 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         // Disable vehicle
         component.HasKey = false;
         _ambientSound.SetAmbience(uid, false);
-        _tagSystem.RemoveTag(uid, "DoorBumpOpener");
         _modifier.RefreshMovementSpeedModifiers(uid);
     }
 

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -386,9 +386,6 @@
     friction: 0.8
     baseWalkSpeed: 3.5
     baseSprintSpeed: 4.3
-  - type: Tag
-    tags:
-      - DoorBumpOpener
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Wheelchair riders can just bump into doors to open them, similar to any other vehicle.

I didn't see any GitHub issue, but it was mentioned on the Discord here:
https://discord.com/channels/310555209753690112/1194193593561264199

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The DoorBumpOpener tag was being added upon inserting a key. This change adds the tag when buckling into the vehicle.
This allows keyless vehicles to work as expected, but it also stops the weird behavior of being able to push a riderless vehicle into a door to open it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Wheelchair users can bump open doors
