### PR TITLE
more tarantula changes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2022,6 +2022,8 @@
       Male: UnisexArachnid
       Female: UnisexArachnid
       Unsexed: UnisexArachnid
+  - type: TypingIndicator
+    proto: spider
   - type: Tag
     tags:
     - DoorBumpOpener

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -615,28 +615,12 @@
     rootTask:
       task: SimpleHostileCompound
   - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 130
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
   - type: DamageStateVisuals
     states:
       Alive:
         Base: shiva
       Dead:
         Base: shiva_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatSpider
-      amount: 2
-  - type: CombatMode
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -650,11 +634,6 @@
       types:
         Piercing: 8
         Poison: 8
-  - type: ReplacementAccent
-    accent: xeno
-  - type: NoSlip
-  - type: Spider
-  - type: IgnoreSpiderWeb
   - type: Grammar
     attributes:
       proper: true
@@ -663,6 +642,8 @@
     tags:
     - CannotSuicide
     - VimPilot
+    - DoorBumpOpener
+    - FootstepSound
   - type: StealTarget
     stealGroup: AnimalShiva
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -268,6 +268,8 @@
       Male: UnisexArachnid
       Female: UnisexArachnid
       Unsexed: UnisexArachnid
+  - type: TypingIndicator
+    proto: spider
 
 - type: entity
   id: MobSpiderSpaceSalvage


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- tarantulas and space spiders now have a spider typing indicator
- removes duplicate components from shiva that were the same on tarantula prototype
- adds footstep sounds and doorbumpopener to shiva

## Why / Balance
slime mobs have typing indicator so tarnatulas should too and yaml cleanup is nice

## Technical details
3

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/b5064135-2d24-4dda-9001-7683fbf76cd9)
shiva
![image](https://github.com/space-wizards/space-station-14/assets/45323883/f33e3cf1-57bc-481f-869b-4bbbaf804297)
space spider
![image](https://github.com/space-wizards/space-station-14/assets/45323883/83652870-2808-4e11-a6fa-c34ebae6a780)
tarantula
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
🆑
- tweak: Tarantulas and space spiders now have the arachnid speech bubble.
