### PR TITLE
Doors will no longer be pried open once the doafter finishes if they shouldn't.

### DIFF
--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -167,8 +167,6 @@ public sealed class PryingSystem : EntitySystem
             return;
         }
 
-        // PryingComponent? comp = null;
-
         // TODO: When we get airlock prediction make this predicted.
         // When that happens also fix the checking function in the Client AirlockSystem.
         if (args.Used != null && comp != null)

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -158,10 +158,21 @@ public sealed class PryingSystem : EntitySystem
         if (args.Target is null)
             return;
 
-        PryingComponent? comp = null;
+        TryComp<PryingComponent>(args.Used, out var comp);
 
+        if (!CanPry(uid, args.User, out var message, comp))
+        {
+            if (message != null)
+                Popup.PopupEntity(Loc.GetString(message), uid, args.User);
+            return;
+        }
+
+        // PryingComponent? comp = null;
+
+        // TODO: When we get airlock prediction make this predicted.
+        // When that happens also fix the checking function in the Client AirlockSystem.
         if (args.Used != null && Resolve(args.Used.Value, ref comp))
-            _audioSystem.PlayPredicted(comp.UseSound, args.Used.Value, args.User);
+            _audioSystem.PlayPvs(comp.UseSound, args.Used.Value);
 
         var ev = new PriedEvent(args.User);
         RaiseLocalEvent(uid, ref ev);

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -171,7 +171,7 @@ public sealed class PryingSystem : EntitySystem
 
         // TODO: When we get airlock prediction make this predicted.
         // When that happens also fix the checking function in the Client AirlockSystem.
-        if (args.Used != null && Resolve(args.Used.Value, ref comp))
+        if (args.Used != null && comp != null)
             _audioSystem.PlayPvs(comp.UseSound, args.Used.Value);
 
         var ev = new PriedEvent(args.User);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I fix another bug of my own creation where doors which had their prying doafter start would be pried unconditionally even if the conditions were no longer suitable.

For example people could pry doors open if the power had gone out and the power had come back by the time they were finished.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It bug. I fix.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I just made it so the function that fires once the doafter finished checks if it can still pry the door. 

Also that function no longer uses PlayPredicted. Because prediction does not exist for airlocks the prying check on the client will always fail. As a result the sound cannot be predicted.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- fix: You can no longer pry powered/bolted airlocks if you started prying before they were powered/bolted.