### PR TITLE
Aspid Playercount Tweak

### DIFF
--- a/Resources/Prototypes/Maps/aspid.yml
+++ b/Resources/Prototypes/Maps/aspid.yml
@@ -2,8 +2,8 @@
   id: Aspid
   mapName: 'NCS Aspid'
   mapPath: /Maps/aspid.yml
-  minPlayers: 35
-  maxPlayers: 60
+  minPlayers: 25
+  maxPlayers: 55
   stations:
     Aspid:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/aspid.yml
+++ b/Resources/Prototypes/Maps/aspid.yml
@@ -2,8 +2,8 @@
   id: Aspid
   mapName: 'NCS Aspid'
   mapPath: /Maps/aspid.yml
-  minPlayers: 25
-  maxPlayers: 70
+  minPlayers: 35
+  maxPlayers: 60
   stations:
     Aspid:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Reduced Aspid's max player count to 55 (it was 70)
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I don't honestly know why aspid was nearly maxpop before, it definitely doesn't support 70 people properly (with 3 medical beds and 4 EVA suits). Also, Barratry was removed, so, this should hopefully fill the "crappy station" shaped hole barratry left. 
![image_2024-01-09_191959230](https://github.com/space-wizards/space-station-14/assets/108914677/1da211b0-3130-40b5-9b52-1571d4f907b6)

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
🆑
- tweak: Aspid is no longer a high-pop map.
<!--

