### PR TITLE
Fixes construction graphs proccing while being microwaved

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -380,6 +380,13 @@ namespace Content.Server.Construction
                     if (ev is not OnTemperatureChangeEvent)
                         break;
 
+                    // Some things, like microwaves, might need to block the temperature construction step from kicking in, or override it entirely.
+                    var tempEvent = new OnConstructionTemperatureEvent();
+                    RaiseLocalEvent(uid, tempEvent, true);
+
+                    if (tempEvent.Result is not null)
+                        return tempEvent.Result.Value;
+
                     // prefer using InternalTemperature since that's more accurate for cooking.
                     float temp;
                     if (TryComp<InternalTemperatureComponent>(uid, out var internalTemp))
@@ -588,11 +595,12 @@ namespace Content.Server.Construction
             /// </summary>
             Completed
         }
+    }
 
         /// <summary>
         ///     Specifies the result after attempting to handle a specific step with an event.
         /// </summary>
-        private enum HandleResult : byte
+        public enum HandleResult : byte
         {
             /// <summary>
             ///     The interaction wasn't handled or validated.
@@ -617,5 +625,9 @@ namespace Content.Server.Construction
         }
 
         #endregion
+
+    public sealed class OnConstructionTemperatureEvent : HandledEntityEventArgs
+    {
+        public HandleResult? Result;
     }
 }

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -597,34 +597,34 @@ namespace Content.Server.Construction
         }
     }
 
+    /// <summary>
+    ///     Specifies the result after attempting to handle a specific step with an event.
+    /// </summary>
+    public enum HandleResult : byte
+    {
         /// <summary>
-        ///     Specifies the result after attempting to handle a specific step with an event.
+        ///     The interaction wasn't handled or validated.
         /// </summary>
-        public enum HandleResult : byte
-        {
-            /// <summary>
-            ///     The interaction wasn't handled or validated.
-            /// </summary>
-            False,
+        False,
 
-            /// <summary>
-            ///     The interaction would be handled successfully. Nothing was modified.
-            /// </summary>
-            Validated,
+        /// <summary>
+        ///     The interaction would be handled successfully. Nothing was modified.
+        /// </summary>
+        Validated,
 
-            /// <summary>
-            ///     The interaction was handled successfully.
-            /// </summary>
-            True,
+        /// <summary>
+        ///     The interaction was handled successfully.
+        /// </summary>
+        True,
 
-            /// <summary>
-            ///     The interaction is waiting on a DoAfter now.
-            ///     This means the interaction started the DoAfter.
-            /// </summary>
-            DoAfter,
-        }
+        /// <summary>
+        ///     The interaction is waiting on a DoAfter now.
+        ///     This means the interaction started the DoAfter.
+        /// </summary>
+        DoAfter,
+    }
 
-        #endregion
+    #endregion
 
     public sealed class OnConstructionTemperatureEvent : HandledEntityEventArgs
     {

--- a/Content.Server/Kitchen/Components/ActivelyMicrowavedComponent.cs
+++ b/Content.Server/Kitchen/Components/ActivelyMicrowavedComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Kitchen;
+
+namespace Content.Server.Kitchen.Components;
+
+/// <summary>
+/// Attached to an object that's actively being microwaved
+/// </summary>
+[RegisterComponent]
+public sealed partial class ActivelyMicrowavedComponent : Component
+{
+}


### PR DESCRIPTION
## About the PR
In laymen's terms, this stops chefs from getting free steaks with every meat-based dish they prepare!

This fixes a bug caused by #21887 wherein microwaves now applying a semi-physically-accurate level of heat caused items with temperature construction graphs attached (such as raw meat) to complete the construction graph. This did not invalidate the microwave's current recipe, which lead to meat being duplicated into a free steak, along with whatever the recipe in the microwave was.

## Why / Balance
Chefs maybe shouldn't get a free steak with every meat-based dish?

## Technical details
This works by adding a new event to the construction graph system's `temperatureChangeStep`, the `OnConstructionTemperatureEvent`. If something ends up modifying this event's `Result`, then the temperature change step will immediately return whatever `Result` is.

This is paired with a new component, `ActivelyMicrowaved`. This is added when an object is actively being microwaved, and removed once it's done. When this component is present on an entity, it will listen to `OnConstructionTemperatureEvent`, and set its `Result` to `False`, causing the temperature change step to simply not proc.

## Media
![dotnet_v4mHSWjSFf](https://github.com/space-wizards/space-station-14/assets/6356337/7e69f2a9-4e23-4a06-801c-c1fb6a501594)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- fix: Microwave recipes involving objects that have a temperature-based construction graph recipe associated with them (for example, raw meat -> steak) will no longer produce both the construction graph recipe and the microwave recipe. In laymen's terms, burgers no longer come with a whole free steak.
- fix: The microwave UI now updates in realtime when items are inserted/removed.
