### PR TITLE
Hide ruins spawns

### DIFF
--- a/Content.Server/Shuttles/Components/GridSpawnComponent.cs
+++ b/Content.Server/Shuttles/Components/GridSpawnComponent.cs
@@ -23,6 +23,11 @@ public record struct GridSpawnGroup
     public int MinCount = 1;
     public int MaxCount = 1;
 
+    /// <summary>
+    /// Hide the IFF of the grid.
+    /// </summary>
+    public bool Hide = false;
+
     public GridSpawnGroup()
     {
     }

--- a/Content.Server/Shuttles/Components/GridSpawnComponent.cs
+++ b/Content.Server/Shuttles/Components/GridSpawnComponent.cs
@@ -28,6 +28,11 @@ public record struct GridSpawnGroup
     /// </summary>
     public bool Hide = false;
 
+    /// <summary>
+    /// Should we set the metadata name of a grid. Useful for admin purposes.
+    /// </summary>
+    public bool NameGrid = false;
+
     public GridSpawnGroup()
     {
     }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -104,6 +104,12 @@ public sealed partial class ShuttleSystem
                     {
                         valid = false;
                     }
+
+                    if (group.NameGrid)
+                    {
+                        var name = path.FilenameWithoutExtension;
+                        _metadata.SetEntityName(ent[0], name);
+                    }
                 }
                 else
                 {

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -3,6 +3,7 @@ using Content.Server.Station.Components;
 using Content.Server.Station.Events;
 using Content.Shared.Cargo.Components;
 using Content.Shared.CCVar;
+using Content.Shared.Shuttles.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
@@ -87,6 +88,13 @@ public sealed partial class ShuttleSystem
 
                 if (_loader.TryLoad(mapId, path.ToString(), out var ent) && ent.Count == 1)
                 {
+                    if (group.Hide)
+                    {
+                        var iffComp = EnsureComp<IFFComponent>(ent[0]);
+                        iffComp.Flags |= IFFFlags.Hide;
+                        Dirty(ent[0], iffComp);
+                    }
+
                     if (TryComp<ShuttleComponent>(ent[0], out var shuttle))
                     {
                         TryFTLProximity(ent[0], shuttle, targetGrid.Value);

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -53,6 +53,8 @@
           - /Maps/Shuttles/mining.yml
         ruins:
           hide: true
+          minCount: 2
+          maxCount: 2
           paths:
           - /Maps/Ruins/derelict.yml
           - /Maps/Ruins/djstation.yml
@@ -77,6 +79,8 @@
           - /Maps/Shuttles/mining.yml
         ruins:
           hide: true
+          minCount: 2
+          maxCount: 2
           paths:
           - /Maps/Ruins/derelict.yml
           - /Maps/Ruins/djstation.yml

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -52,6 +52,7 @@
           paths:
           - /Maps/Shuttles/mining.yml
         ruins:
+          hide: true
           paths:
           - /Maps/Ruins/derelict.yml
           - /Maps/Ruins/djstation.yml
@@ -59,7 +60,7 @@
           - /Maps/Ruins/relaystation.yml
           - /Maps/Ruins/whiteship_ancient.yml
           - /Maps/Ruins/whiteship_bluespacejumper.yml
-          
+
 
 
 - type: entity
@@ -75,6 +76,7 @@
           paths:
           - /Maps/Shuttles/mining.yml
         ruins:
+          hide: true
           paths:
           - /Maps/Ruins/derelict.yml
           - /Maps/Ruins/djstation.yml

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -53,6 +53,7 @@
           - /Maps/Shuttles/mining.yml
         ruins:
           hide: true
+          nameGrid: true
           minCount: 2
           maxCount: 2
           paths:
@@ -79,6 +80,7 @@
           - /Maps/Shuttles/mining.yml
         ruins:
           hide: true
+          nameGrid: true
           minCount: 2
           maxCount: 2
           paths:


### PR DESCRIPTION
secret cl:

- Add names to ruin spawns for admin use.
- Hide them from IFF so it's a surprise.
- 2 spawns.