### PR TITLE
Cuttable speaker wire for vending machines

### DIFF
--- a/Content.Server/Speech/Components/SpeechWireAction.cs
+++ b/Content.Server/Speech/Components/SpeechWireAction.cs
@@ -1,0 +1,45 @@
+using Content.Server.Popups;
+using Content.Server.Wires;
+using Content.Shared.Speech;
+using Content.Shared.Wires;
+
+namespace Content.Server.Speech;
+
+public sealed partial class SpeechWireAction : ComponentWireAction<SpeechComponent>
+{
+    private SpeechSystem _speech = default!;
+    private PopupSystem _popup = default!;
+
+    public override Color Color { get; set; } = Color.Green;
+    public override string Name { get; set; } = "wire-name-speech";
+
+    public override object? StatusKey { get; } = SpeechWireActionKey.StatusKey;
+
+    public override StatusLightState? GetLightState(Wire wire, SpeechComponent component)
+        => component.Enabled ? StatusLightState.On : StatusLightState.Off;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _speech = EntityManager.System<SpeechSystem>();
+        _popup = EntityManager.System<PopupSystem>();
+    }
+
+    public override bool Cut(EntityUid user, Wire wire, SpeechComponent component)
+    {
+        _speech.SetSpeech(wire.Owner, false, component);
+        return true;
+    }
+
+    public override bool Mend(EntityUid user, Wire wire, SpeechComponent component)
+    {
+        _speech.SetSpeech(wire.Owner, true, component);
+        return true;
+    }
+
+    public override void Pulse(EntityUid user, Wire wire, SpeechComponent component)
+    {
+        _popup.PopupEntity(Loc.GetString("wire-speech-pulse", ("name", wire.Owner)), wire.Owner);
+    }
+}

--- a/Content.Shared/Speech/EntitySystems/SharedSpeechWireAction.cs
+++ b/Content.Shared/Speech/EntitySystems/SharedSpeechWireAction.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Speech;
+
+[Serializable, NetSerializable]
+public enum SpeechWireActionKey : byte
+{
+    StatusKey,
+}

--- a/Content.Shared/Speech/SpeechSystem.cs
+++ b/Content.Shared/Speech/SpeechSystem.cs
@@ -19,7 +19,9 @@ namespace Content.Shared.Speech
             if (component.Enabled == value)
                 return;
 
-            Dirty(component);
+            component.Enabled = value;
+
+            Dirty(uid, component);
         }
 
         private void OnSpeakAttempt(SpeakAttemptEvent args)

--- a/Resources/Locale/en-US/speech/speech-wire-action.ftl
+++ b/Resources/Locale/en-US/speech/speech-wire-action.ftl
@@ -1,0 +1,1 @@
+wire-speech-pulse = {CAPITALIZE(THE($name))} emits a buzzing sound

--- a/Resources/Locale/en-US/wires/wire-names.ftl
+++ b/Resources/Locale/en-US/wires/wire-names.ftl
@@ -62,3 +62,4 @@ wire-name-bomb-delay = DLAY
 wire-name-bomb-proceed = PRCD
 wire-name-bomb-boom = BOOM
 wire-name-bomb-bolt = BOLT
+wire-name-speech = SPKR

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -39,6 +39,7 @@
   - !type:AccessWireAction
   - !type:VendingMachineContrabandWireAction
   - !type:VendingMachineEjectItemWireAction
+  - !type:SpeechWireAction
 
 - type: wireLayout
   id: AirAlarm


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds a new wire to the vending machine hacking interface, conceptually connecting the processor to the machine's speaker. Cutting the wire prevents the machine from playing any advertisements or thanking the user after dispensing an item. Pulsing the wire makes the speaker buzz (by popup text rather than a potentially spammable sound).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Adding more content to the wire hacking system, and if players are really tired of hearing the machines, they can do something about it.

Additionally, the same WireAction could be used on other hackable devices that can "speak" in the future (currently there aren't any).

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This is implemented fairly generically as SpeechWireAction which controls the enabled/disabled state of the entity's SpeechComponent, which handles intercepting outgoing chat messages. This means that it should work on other devices that speak in the same way, such as intercoms and TVs, should those ever become hackable.

As a bonus, SpeechSystem.SetSpeech now actually works. Previously it never actually changed the component's value.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/85356/32725038-194b-467a-bd14-fd00ea9e6b94

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Vending machines can now be hacked to disable advertising.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
