### PR TITLE
remove ame parts from cargo

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -1,29 +1,9 @@
 - type: cargoProduct
-  id: EngineAmeShielding
-  icon:
-    sprite: Objects/Power/AME/ame_part.rsi
-    state: box
-  product: CrateEngineeringAMEShielding
-  cost: 6000
-  category: Engineering
-  group: market
-
-- type: cargoProduct
   id: EngineAmeJar
   icon:
     sprite: Objects/Power/AME/ame_jar.rsi
     state: jar
   product: CrateEngineeringAMEJar
-  cost: 2000
-  category: Engineering
-  group: market
-
-- type: cargoProduct
-  id: EngineAmeControl
-  icon:
-    sprite: Structures/Power/Generation/ame.rsi
-    state: control
-  product: CrateEngineeringAMEControl
   cost: 2000
   category: Engineering
   group: market


### PR DESCRIPTION
they can still order fuel but the size of the ame cannot exceed the stations preset amount

🆑 
- tweak: AME parts can no longer be bought from cargo