### PR TITLE
Fixes food duplicating in the microwave

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -501,7 +501,7 @@ namespace Content.Server.Kitchen.EntitySystems
                 //this means the microwave has finished cooking.
                 AddTemperature(microwave, Math.Max(frameTime + active.CookTimeRemaining, 0), active?.PortionedRecipe.Item1!); //Though there's still a little bit more heat to pump out
 
-                if (active?.PortionedRecipe.Item1 != null)
+                if (active != null && active.PortionedRecipe.Item1 != null)
                 {
                     var coords = Transform(uid).Coordinates;
                     for (var i = 0; i < active.PortionedRecipe.Item2; i++)

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -103,7 +103,7 @@ namespace Content.Server.Kitchen.EntitySystems
         /// </summary>
         /// <param name="component">The microwave that is heating up.</param>
         /// <param name="time">The time on the microwave, in seconds.</param>
-        private void AddTemperature(MicrowaveComponent component, float time, FoodRecipePrototype recipe)
+        private void AddTemperature(MicrowaveComponent component, float time, FoodRecipePrototype? recipe)
         {
             var heatToAdd = time * component.BaseHeatMultiplier;
             foreach (var entity in component.Storage.ContainedEntities)
@@ -494,14 +494,14 @@ namespace Content.Server.Kitchen.EntitySystems
                 active.CookTimeRemaining -= frameTime;
                 if (active.CookTimeRemaining > 0)
                 {
-                    AddTemperature(microwave, frameTime, active?.PortionedRecipe.Item1!);
+                    AddTemperature(microwave, frameTime, active?.PortionedRecipe.Item1);
                     continue;
                 }
 
                 //this means the microwave has finished cooking.
-                AddTemperature(microwave, Math.Max(frameTime + active.CookTimeRemaining, 0), active?.PortionedRecipe.Item1!); //Though there's still a little bit more heat to pump out
+                AddTemperature(microwave, Math.Max(frameTime + active.CookTimeRemaining, 0), active?.PortionedRecipe.Item1); //Though there's still a little bit more heat to pump out
 
-                if (active != null && active.PortionedRecipe.Item1 != null)
+                if (active?.PortionedRecipe.Item1 != null)
                 {
                     var coords = Transform(uid).Coordinates;
                     for (var i = 0; i < active.PortionedRecipe.Item2; i++)


### PR DESCRIPTION

## About the PR
Fixes #23774 

## Technical details
Any active ingredient doesn't get cooked, this prevents the duplication as seen in the issue above. Raw food that is not in a recipe inside the microwave will get cooked normally.

## Media
previous functionality:
https://github.com/space-wizards/space-station-14/assets/73014819/5bf69184-d90f-4491-b52c-f613bb84c812

New functionality:
https://github.com/space-wizards/space-station-14/assets/73014819/1bc5918c-2a7f-427d-b8bf-7593d7127fd0

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: fixes raw food getting duplicated in the microwave
