### PR TITLE
crusher rebalanceing

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -68,7 +68,7 @@
   parent: BaseWeaponCrusher
   id: WeaponCrusherDagger
   name: crusher dagger
-  description: A scaled down version of a proto-kinetic crusher, usually used in a last ditch scenario.
+  description: A scaled down version of a proto-kinetic crusher. Uses kinetic energy to vibrate the blade at high speeds.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Melee/crusher_dagger.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -99,7 +99,7 @@
   - type: LeechOnMarker
     leech:
       groups:
-        Brute: -30
+        Brute: -21
   - type: MeleeWeapon
     attackRate: 1.2
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -98,7 +98,7 @@
   - type: LeechOnMarker
     leech:
       groups:
-        Brute: -25
+        Brute: -30
   - type: MeleeWeapon
     attackRate: 1.25
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -101,7 +101,6 @@
       groups:
         Brute: -21
   - type: MeleeWeapon
-    attackRate: 1.2
   - type: Tag
     tags:
       - Pickaxe

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -43,6 +43,7 @@
     capacity: 1
     count: 1
   - type: MeleeWeapon
+    attackRate: 1.5
     wideAnimationRotation: -135
     damage:
       types:
@@ -100,7 +101,7 @@
       groups:
         Brute: -30
   - type: MeleeWeapon
-    attackRate: 1.25
+    attackRate: 1.2
   - type: Tag
     tags:
       - Pickaxe

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -74,8 +74,9 @@
     sprite: Objects/Weapons/Melee/crusher_dagger.rsi
     state: icon
   - type: MeleeWeapon
+    autoAttack: true
     wideAnimationRotation: -135
-    attackRate: 1.5
+    attackRate: 2
     damage:
       types:
         Slash: 15
@@ -97,7 +98,7 @@
   - type: LeechOnMarker
     leech:
       groups:
-        Brute: -30
+        Brute: -25
   - type: MeleeWeapon
     attackRate: 1.25
   - type: Tag


### PR DESCRIPTION
makes it worthwhile as a rare salv drop, forgot to add this when we added this.
crusher axe attacks faster than glaive
glaive lifesteal is down to 21 brute so 7 of each group instead of 10