### PR TITLE
medsec hud is no longer a filler

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -29,6 +29,9 @@
   - type: ShowHealthIcons
     damageContainers: 
     - Biological
+  - type: Tag
+    tags:
+    - HudMedical
 
 - type: entity
   parent: ClothingEyesBase
@@ -41,6 +44,9 @@
   - type: Clothing
     sprite: Clothing/Eyes/Hud/sec.rsi
   - type: ShowSecurityIcons
+  - type: Tag
+    tags:
+    - HudSecurity
 
 - type: entity
   parent: ClothingEyesBase
@@ -135,13 +141,19 @@
   parent: ClothingEyesBase
   id: ClothingEyesHudMedSec
   name: medsec hud
-  description: Filler
+  description: An eye display that looks like a mixture of medical and security huds.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/medsec.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Hud/medsec.rsi
+  - type: Construction
+    graph: HudMedSec
+    node: medsecHud
   - type: ShowSecurityIcons
+  - type: ShowHealthBars
+    damageContainers: 
+    - Biological
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Recipes/Construction/Graphs/clothing/medsec_hud.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/clothing/medsec_hud.yml
@@ -1,0 +1,43 @@
+﻿- type: constructionGraph
+  id: HudMedSec
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: medsecHud
+          steps:
+            - tag: HudMedical
+              name: medical hud
+              icon:
+                sprite: Clothing/Eyes/Hud/med.rsi
+                state: icon
+              doAfter: 5
+            - tag: HudSecurity
+              name: security hud
+              icon:
+                sprite: Clothing/Eyes/Hud/sec.rsi
+                state: icon
+              doAfter: 5
+            - material: Cable
+              amount: 5
+              doAfter: 5
+            - tag: Radio
+              name: radio
+              icon:
+                sprite: Objects/Devices/communication.rsi
+                state: walkietalkie
+              doAfter: 5
+            - tag: CapacitorStockPart
+              name: capacitor
+              icon:
+                sprite: Objects/Misc/stock_parts.rsi
+                state: capacitor
+              doAfter: 5
+            - tag: CapacitorStockPart
+              name: capacitor
+              icon:
+                sprite: Objects/Misc/stock_parts.rsi
+                state: capacitor
+              doAfter: 5
+    - node: medsecHud
+      entity: ClothingEyesHudMedSec

--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -63,3 +63,14 @@
   description: A pair of clown shoes upgraded with banana peels.
   icon: { sprite: Clothing/Shoes/Specific/clown_banana.rsi, state: icon }
   objectType: Item
+
+- type: construction
+  name: medsec hud
+  id: ClothingEyesHudMedSec
+  graph: HudMedSec
+  startNode: start
+  targetNode: medsecHud
+  category: construction-category-clothing
+  description: Two huds joined by arms
+  icon: { sprite: Clothing/Eyes/Hud/medsec.rsi, state: icon }
+  objectType: Item

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -565,6 +565,7 @@
 
 - type: Tag
   id: HudSecurity
+
 - type: Tag
   id: GuideEmbeded
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -561,6 +561,11 @@
   id: Grenade
 
 - type: Tag
+  id: HudMedical
+
+- type: Tag
+  id: HudSecurity
+- type: Tag
   id: GuideEmbeded
 
 - type: Tag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR suggests adding the ability to create medsec hud and the medical hud property to the latter(lol)
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
medsec hud has been a simple admin filler for quite some time now, but has a working HP bar system implemented thanks to the great 21980 PR.
Medsec hud can be useful for both medical and security departments: the former to record who they are treating and maybe make some decisions based on that. And the latter to make sure they don't cripple a criminal too badly.

Its cost is quite high, so it's not available to everyone. It seems like a nice addition to the gameplay for hud connoisseurs.

Why is this done manually and not by machine? The answer is simple - head displays are not created or learned, and adding learning them for the sake of 1 item seems wrong.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![изображение](https://github.com/space-wizards/space-station-14/assets/93311212/555e54be-1779-4d83-8956-ead7f7bc3a1e)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: prescription for medsec hud
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
