### PR TITLE
dedicated burn and shock meds

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -117,3 +117,9 @@ reagent-desc-bruizine = Originally developed as a cough medicine, it turns out t
 
 reagent-name-holywater = holy water
 reagent-desc-holywater = The cleanest and purest of waters straight from the hands of god, is known to magically heal wounds.
+
+reagent-name-pyrazine = pyrazine
+reagent-desc-pyrazine = Efficiently heals burns from the hottest of fires. Causes massive internal bleeding when overdosed.
+
+reagent-name-insuzine = insuzine
+reagent-desc-insuzine = Rapidly repairs dead tissue caused by electrocution, but cools you slightly. Completely freezes the patient when overdosed.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1027,3 +1027,83 @@
             Heat: -0.2
             Shock: -0.2
             Cold: -0.2
+
+- type: reagent
+  id: Pyrazine
+  name: reagent-name-pyrazine
+  group: Medicine
+  desc: reagent-desc-pyrazine
+  physicalDesc: reagent-physical-desc-thick
+  flavor: syrupy
+  color: "#aa4308"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.1 # slow metabolism to not be a godly combat med, its for treating burn victims efficiently
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Heat: -1
+      # od causes massive bleeding
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+        damage:
+          types:
+            Slash: 0.5
+            Piercing: 0.5
+      - !type:ChemVomit
+        conditions:
+        - !type:ReagentThreshold
+          min: 15
+        probability: 0.1
+      - !type:Emote
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+        emote: Scream
+        probability: 0.2
+
+- type: reagent
+  id: Insuzine
+  name: reagent-name-insuzine
+  group: Medicine
+  desc: reagent-desc-insuzine
+  physicalDesc: reagent-physical-desc-frosty
+  flavor: metallic
+  color: "#8147ff"
+  metabolisms:
+    Medicine:
+      effects:
+      # heals shocks and removes shock chems
+      - !type:HealthChange
+        damage:
+          types:
+            Shock: -4
+      - !type:AdjustReagent
+        reagent: Licoxide
+        amount: -4
+      - !type:AdjustReagent
+        reagent:  Tazinide
+        amount: -4
+      # makes you a little chilly when not oding
+      - !type:AdjustTemperature
+        amount: -5000
+      # od makes you freeze to death
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 12
+        damage:
+          types:
+            Cold: 2
+      - !type:AdjustTemperature
+        conditions:
+        - !type:ReagentThreshold
+          min: 12
+        amount: -30000
+      - !type:Jitter
+        conditions:
+        - !type:ReagentThreshold
+          min: 12

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -517,3 +517,34 @@
       amount: 1
   products:
     Diphenhydramine: 3
+
+- type: reaction
+  id: Pyrazine
+  impact: Medium
+  minTemp: 540
+  reactants:
+    Leporazine:
+      amount: 1
+    Dermaline:
+      amount: 1
+    Carbon:
+      amount: 1
+  products:
+    Pyrazine: 3
+
+- type: reaction
+  id: Insuzine
+  impact: Medium
+  minTemp: 433
+  reactants:
+    Leporazine:
+      amount: 1
+    Kelotane:
+      amount: 1
+    Silicon:
+      amount: 1
+    Benzene:
+      amount: 1
+  products:
+    Insuzine: 3
+    Ash: 1


### PR DESCRIPTION
## About the PR
adds dedicated burn and shock meds, Pyrazine and Insuzine (feel free to suggest better names :trollface:)

they are both derived from leporazine in some way

it might be worth letting pyrazine (or both) work on corpses since unloading a few incendiary shells on a naked urist gives 600+ heat damage :trollface:

## Why / Balance
right now there are dedicated cold (leporazine) and caustic (sigynate) along with meds for every brute kind. burn and shock are desperately needed, since people that come into med with it usually have a lot (being lit on fire, getting in a laser fight, trying to tide into a room, electric anomaly, etc.). in these situations you would always have to use dermatane meaning wasting any airloss med and being overall bad

pyrazine heals slowly but is extremely efficient (20 heat damage per unit over 10 seconds)
its slow so you dont chug pyrazine before going into a fight to instantly heal everything, for combat its roughly on par with derma

insuzine heals a lot of shock at normal speed since you usually dont need it in combat
its also a counter to licoxide since funny

their od's are very deadly (bleeding to death and freezing to death respectively)

## Technical details
no

## Media
![18:41:18](https://github.com/space-wizards/space-station-14/assets/39013340/e917eebc-3c4a-489c-b0aa-ff572391e11f)

![18:44:49](https://github.com/space-wizards/space-station-14/assets/39013340/444b2de3-8baf-4e3f-9bc9-a5fb902e3d18)

cooking it and their effects work trust

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: New specialized burn medicines Pyrazine and Insuzine can be made, for heat and shock damage respectively.
