### PR TITLE
Bluespace Anomaly Admin Logs

### DIFF
--- a/Content.Server/Anomaly/Effects/BluespaceAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/BluespaceAnomalySystem.cs
@@ -1,7 +1,9 @@
 ﻿using System.Linq;
 using System.Numerics;
 using Content.Server.Anomaly.Components;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Anomaly.Components;
+using Content.Shared.Database;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Teleportation.Components;
 using Robust.Shared.Audio;
@@ -13,6 +15,7 @@ namespace Content.Server.Anomaly.Effects;
 public sealed class BluespaceAnomalySystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedTransformSystem _xform = default!;
@@ -43,6 +46,8 @@ public sealed class BluespaceAnomalySystem : EntitySystem
         _random.Shuffle(coords);
         for (var i = 0; i < allEnts.Count; i++)
         {
+
+            _adminLogger.Add(LogType.Teleport, $"{ToPrettyString(allEnts[i])} has been shuffled to {coords[i]} by the {ToPrettyString(uid)} at {xform.Coordinates}");
             _xform.SetWorldPosition(allEnts[i], coords[i], xformQuery);
         }
     }
@@ -62,6 +67,9 @@ public sealed class BluespaceAnomalySystem : EntitySystem
             var randomY = _random.NextFloat(gridBounds.Bottom, gridBounds.Top);
 
             var pos = new Vector2(randomX, randomY);
+
+            _adminLogger.Add(LogType.Teleport, $"{ToPrettyString(ent)} has been teleported to {pos} by the supercritical {ToPrettyString(uid)} at {mapPos}");
+
             _xform.SetWorldPosition(ent, pos);
             _audio.PlayPvs(component.TeleportSound, ent);
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Added admin log messages for when players are teleported by bluespace anomaly pulses and supercriticality events.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Per admin request on issue #21156

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds admin log messages to the BluespaceAnomalySystem's OnPulse and OnSupercritical methods.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

<img width="1545" alt="2024-01-11_10-49-55" src="https://github.com/space-wizards/space-station-14/assets/12456621/a52bca07-b2f9-4289-92df-15b571f22e1e">


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

Not player facing, no changelog.
