### PR TITLE
Add an Evac Shuttle busy event

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -336,11 +336,11 @@ namespace Content.Server.RoundEnd
             _gameTicker.RestartRound();
         }
 
-        private void ActivateCooldown()
+        public void ActivateCooldown(TimeSpan? cooldownDuration = null)
         {
             _cooldownTokenSource?.Cancel();
             _cooldownTokenSource = new();
-            Timer.Spawn(DefaultCooldownDuration, () =>
+            Timer.Spawn(cooldownDuration.GetValueOrDefault(DefaultCooldownDuration), () =>
             {
                 _cooldownTokenSource.Cancel();
                 _cooldownTokenSource = null;

--- a/Content.Server/StationEvents/Components/EvacShuttleBusyRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/EvacShuttleBusyRuleComponent.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using Content.Server.StationEvents.Events;
+
+namespace Content.Server.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(EvacShuttleBusyRule))]
+public sealed partial class EvacShuttleBusyRuleComponent : Component
+{
+    public int NumberPerSecond = 0;
+    public float UpdateRate => 1.0f / NumberPerSecond;
+    public float FrameTimeAccumulator = 0.0f;
+}

--- a/Content.Server/StationEvents/Events/EvacShuttleBusyRule.cs
+++ b/Content.Server/StationEvents/Events/EvacShuttleBusyRule.cs
@@ -22,7 +22,7 @@ namespace Content.Server.StationEvents.Events
             int time;
             string units;
             const string text = "evac-shuttle-busy-starting-announcement";
-            var countdownTime = TimeSpan.FromMinutes(60);
+            var countdownTime = TimeSpan.FromMinutes(99999999); // Obviously placeholder
             const string name = "Centcom";
 
             if (countdownTime.TotalSeconds < 60)

--- a/Content.Server/StationEvents/Events/EvacShuttleBusyRule.cs
+++ b/Content.Server/StationEvents/Events/EvacShuttleBusyRule.cs
@@ -1,0 +1,89 @@
+using System.Threading;
+using Content.Server.Chat.Systems;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.RoundEnd;
+using Content.Server.StationEvents.Components;
+using JetBrains.Annotations;
+
+namespace Content.Server.StationEvents.Events
+{
+    [UsedImplicitly]
+    public sealed class EvacShuttleBusyRule : StationEventSystem<EvacShuttleBusyRuleComponent>
+    {
+        [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
+        [Dependency] private readonly ChatSystem _chatSystem = default!;
+
+        protected override void Started(EntityUid uid, EvacShuttleBusyRuleComponent component,
+            GameRuleComponent gameRule, GameRuleStartedEvent args)
+        {
+            base.Started(uid, component, gameRule, args);
+
+            // I originally had these set up here but somehow time gets passed as 0 to Loc so IDEK.
+            int time;
+            string units;
+            const string text = "evac-shuttle-busy-starting-announcement";
+            var countdownTime = TimeSpan.FromMinutes(60);
+            const string name = "Centcom";
+
+            if (countdownTime.TotalSeconds < 60)
+            {
+                time = countdownTime.Seconds;
+                units = "eta-units-seconds";
+            }
+            else
+            {
+                time = countdownTime.Minutes;
+                units = "eta-units-minutes";
+            }
+
+            _chatSystem.DispatchGlobalAnnouncement(
+                Loc.GetString(
+                    text,
+                    ("time", time),
+                    ("units", Loc.GetString(units))
+                ),
+                name,
+                false,
+                null,
+                Color.Gold
+            );
+
+            _roundEndSystem.ActivateCooldown(countdownTime);
+        }
+
+        protected override void Ended(EntityUid uid, EvacShuttleBusyRuleComponent component, GameRuleComponent gameRule,
+            GameRuleEndedEvent args)
+        {
+            base.Ended(uid, component, gameRule, args);
+
+            const string text = "evac-shuttle-busy-ending-announcement";
+            const string name = "Centcom";
+
+            _chatSystem.DispatchGlobalAnnouncement(
+                Loc.GetString(text),
+                name,
+                false,
+                null,
+                Color.Gold
+            );
+        }
+
+        protected override void ActiveTick(EntityUid uid, EvacShuttleBusyRuleComponent component,
+            GameRuleComponent gameRule, float frameTime)
+        {
+            base.ActiveTick(uid, component, gameRule, frameTime);
+
+            var updates = 0;
+            component.FrameTimeAccumulator += frameTime;
+            if (component.FrameTimeAccumulator > component.UpdateRate)
+            {
+                updates = (int) (component.FrameTimeAccumulator / component.UpdateRate);
+                component.FrameTimeAccumulator -= component.UpdateRate * updates;
+            }
+
+            for (var i = 0; i < updates; i++)
+            {
+            }
+        }
+    }
+}

--- a/Resources/Locale/en-US/station-events/events/shuttle-busy.ftl
+++ b/Resources/Locale/en-US/station-events/events/shuttle-busy.ftl
@@ -1,0 +1,3 @@
+# Announcement text
+evac-shuttle-busy-starting-announcement = Attention crew, the emergency shuttle will be unavailable for the next { $time } { $units }
+evac-shuttle-busy-ending-announcement = The emergency shuttle is now available once again


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added a new event, Evac Shuttle Busy. The Shuttle has been called by another station and you're forced into a queue. The station will be unavailable until it is finished.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Frequently stations on the LRP side are quick to call the emergency shuttle rather than deal with the consequences of their collective actions. This event removes this option from the table temporarily and hopefully will encourage players to explore attempting to resurrect a station from a "doomed" state.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Utilises the RoundEndSystem to put a cooldown of `removed because everyone focused on the number` minutes on calling the evac shuttle. Being done this way should still allow Admins to force end a round.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
RoundEndSystem.ActivateCooldown was made public and given a default parameter to reduce breakages, but this could still occur.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: ZeroNationality
- add: Added the Evac Shuttle Busy event
