### PR TITLE
Stop the inevitability of death from misgendering you

### DIFF
--- a/Resources/Locale/en-US/disease/miasma.ftl
+++ b/Resources/Locale/en-US/disease/miasma.ftl
@@ -1,7 +1,7 @@
 ammonia-smell = Something smells pungent!
-perishable-1 = [color=green]It still looks fresh.[/color]
-perishable-2 = [color=orangered]It looks somewhat fresh.[/color]
-perishable-3 = [color=red]It doesn't look fresh anymore.[/color]
-rotting-rotting = [color=orange]It's rotting![/color]
-rotting-bloated = [color=orangered]It's bloated![/color]
-rotting-extremely-bloated = [color=red]It's extremely bloated![/color]
+perishable-1 = [color=green]{ CAPITALIZE(SUBJECT($target)) } still {CONJUGATE-BASIC($target, "look", "looks")} fresh.[/color]
+perishable-2 = [color=orangered]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BASIC($target, "look", "looks")} somewhat fresh.[/color]
+perishable-3 = [color=red]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BASIC($target, "do not", "doesn't")} {CONJUGATE-BASIC($target, "look", "looks")} fresh anymore.[/color]
+rotting-rotting = [color=orange]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BE($target)} rotting![/color]
+rotting-bloated = [color=orangered]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BE($target)} bloated![/color]
+rotting-extremely-bloated = [color=red]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BE($target)} extremely bloated![/color]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Two main fixes:
- actually resets the perishable accumulator properly so that live players don't appear to be starting to go bad.
- change all the rotting and perishable messages to use fluent subject and conjugation (no more "it's bloated" it now says "he is bloated")

fixes #23940

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed rotting examine text appearing on revived players.
