### PR TITLE
Fixed Lizard swipe

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -44,7 +44,7 @@
       collection: AlienClaw
     damage:
       types:
-        Piercing: 5
+        Slash: 5
   # Visual & Audio
   - type: DamageVisuals
     damageOverlayGroups:

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -44,7 +44,7 @@
       collection: AlienClaw
     damage:
       types:
-        Slash: 5
+        Piercing: 5
   # Visual & Audio
   - type: DamageVisuals
     damageOverlayGroups:

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -47,7 +47,7 @@
     animation: WeaponArcPunch
     damage:
       types:
-        Piercing: 5
+        Slash: 5
   - type: Temperature
     heatDamageThreshold: 400
     coldDamageThreshold: 285


### PR DESCRIPTION
## About the PR
It recently came to my attention that lizards on their melee attack did piercing damage instead of slashing damage, this PR switches that. (Thank you Aexxie for informing me of this terror)

## Why / Balance
Reptilian melee (unarmed) is now a claw swipe

## Technical details
Changed Prototypes/Entities/Mobs/Species for reptilians, flipped piercing to slash on them

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: 
tweak: Tweaked reptilian unarmed attacks to deal the correct damage types