### PR TITLE
Can emag artifact crusher

### DIFF
--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Body.Systems;
+using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Stack;
@@ -6,6 +7,7 @@ using Content.Server.Storage.Components;
 using Content.Server.Xenoarchaeology.XenoArtifacts;
 using Content.Shared.Body.Components;
 using Content.Shared.Damage;
+using Content.Shared.Emag.Systems;
 using Content.Shared.Verbs;
 using Content.Shared.Xenoarchaeology.Equipment;
 using Robust.Shared.Collections;
@@ -23,6 +25,7 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
     [Dependency] private readonly BodySystem _body = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly StackSystem _stack = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -31,6 +34,7 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
 
         SubscribeLocalEvent<ArtifactCrusherComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<ArtifactCrusherComponent, PowerChangedEvent>(OnPowerChanged);
+        SubscribeLocalEvent<ArtifactCrusherComponent, GotEmaggedEvent>(OnEmagged);
     }
 
     private void OnGetVerbs(Entity<ArtifactCrusherComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
@@ -38,7 +42,8 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
         if (!args.CanAccess || !args.CanInteract || args.Hands == null || ent.Comp.Crushing)
             return;
 
-        if (!TryComp<EntityStorageComponent>(ent, out var entityStorageComp) || entityStorageComp.Contents.ContainedEntities.Count == 0)
+        if (!TryComp<EntityStorageComponent>(ent, out var entityStorageComp) ||
+            entityStorageComp.Contents.ContainedEntities.Count == 0)
             return;
 
         if (!this.IsPowered(ent, EntityManager))
@@ -59,12 +64,21 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
             StopCrushing(ent);
     }
 
-    public void StartCrushing(Entity<ArtifactCrusherComponent, EntityStorageComponent> ent)
+    private void OnEmagged(Entity<ArtifactCrusherComponent> ent, ref GotEmaggedEvent args)
     {
-        var (_, crusher, _) = ent;
+        ent.Comp.AutoLock = true;
+        args.Handled = true;
+    }
+
+public void StartCrushing(Entity<ArtifactCrusherComponent, EntityStorageComponent> ent)
+    {
+        var (uid, crusher, _) = ent;
 
         if (crusher.Crushing)
             return;
+
+        if (crusher.AutoLock)
+            _popup.PopupEntity(Loc.GetString("artifact-crusher-autolock-enable"), uid);
 
         crusher.Crushing = true;
         crusher.NextSecond = _timing.CurTime + TimeSpan.FromSeconds(1);

--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
@@ -34,7 +34,6 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
 
         SubscribeLocalEvent<ArtifactCrusherComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<ArtifactCrusherComponent, PowerChangedEvent>(OnPowerChanged);
-        SubscribeLocalEvent<ArtifactCrusherComponent, OnAttemptEmagEvent>(OnAttemptEmag);
         SubscribeLocalEvent<ArtifactCrusherComponent, GotEmaggedEvent>(OnEmagged);
     }
 
@@ -71,7 +70,7 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
         args.Handled = true;
     }
 
-public void StartCrushing(Entity<ArtifactCrusherComponent, EntityStorageComponent> ent)
+    public void StartCrushing(Entity<ArtifactCrusherComponent, EntityStorageComponent> ent)
     {
         var (uid, crusher, _) = ent;
 
@@ -79,7 +78,7 @@ public void StartCrushing(Entity<ArtifactCrusherComponent, EntityStorageComponen
             return;
 
         if (crusher.AutoLock)
-            _popup.PopupEntity(Loc.GetString("artifact-crusher-autolock-enable"), uid);
+            _popup.PopupEntity(Loc.GetString("artifact-crusher-autolocks-enable"), uid);
 
         crusher.Crushing = true;
         crusher.NextSecond = _timing.CurTime + TimeSpan.FromSeconds(1);

--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
@@ -34,6 +34,7 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
 
         SubscribeLocalEvent<ArtifactCrusherComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<ArtifactCrusherComponent, PowerChangedEvent>(OnPowerChanged);
+        SubscribeLocalEvent<ArtifactCrusherComponent, OnAttemptEmagEvent>(OnAttemptEmag);
         SubscribeLocalEvent<ArtifactCrusherComponent, GotEmaggedEvent>(OnEmagged);
     }
 

--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
@@ -7,7 +7,6 @@ using Content.Server.Storage.Components;
 using Content.Server.Xenoarchaeology.XenoArtifacts;
 using Content.Shared.Body.Components;
 using Content.Shared.Damage;
-using Content.Shared.Emag.Systems;
 using Content.Shared.Verbs;
 using Content.Shared.Xenoarchaeology.Equipment;
 using Robust.Shared.Collections;
@@ -34,7 +33,6 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
 
         SubscribeLocalEvent<ArtifactCrusherComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
         SubscribeLocalEvent<ArtifactCrusherComponent, PowerChangedEvent>(OnPowerChanged);
-        SubscribeLocalEvent<ArtifactCrusherComponent, GotEmaggedEvent>(OnEmagged);
     }
 
     private void OnGetVerbs(Entity<ArtifactCrusherComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
@@ -62,12 +60,6 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
     {
         if (!args.Powered)
             StopCrushing(ent);
-    }
-
-    private void OnEmagged(Entity<ArtifactCrusherComponent> ent, ref GotEmaggedEvent args)
-    {
-        ent.Comp.AutoLock = true;
-        args.Handled = true;
     }
 
     public void StartCrushing(Entity<ArtifactCrusherComponent, EntityStorageComponent> ent)

--- a/Content.Shared/Xenoarchaeology/Equipment/ArtifactCrusherComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/ArtifactCrusherComponent.cs
@@ -101,6 +101,12 @@ public sealed partial class ArtifactCrusherComponent : Component
     /// </summary>
     [DataField]
     public (EntityUid, AudioComponent)? CrushingSoundEntity;
+
+    /// <summary>
+    /// When enabled, stops the artifact crusher from being opened when it is being crushed.
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public bool AutoLock = false;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -21,6 +21,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
 
         SubscribeLocalEvent<ArtifactCrusherComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<ArtifactCrusherComponent, StorageAfterOpenEvent>(OnStorageAfterOpen);
+        SubscribeLocalEvent<ArtifactCrusherComponent, StorageOpenAttemptEvent>(OnStorageOpenAttempt);
         SubscribeLocalEvent<ArtifactCrusherComponent, ExaminedEvent>(OnExamine);
     }
 
@@ -31,11 +32,14 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
 
     private void OnStorageAfterOpen(Entity<ArtifactCrusherComponent> ent, ref StorageAfterOpenEvent args)
     {
-        if (ent.Comp.AutoLock)
-            return;
-
         StopCrushing(ent);
         ContainerSystem.EmptyContainer(ent.Comp.OutputContainer);
+    }
+
+    private void OnStorageOpenAttempt(Entity<ArtifactCrusherComponent> ent, ref StorageOpenAttemptEvent args)
+    {
+        if (ent.Comp.AutoLock && ent.Comp.Crushing)
+            args.Cancelled = true;
     }
 
     private void OnExamine(Entity<ArtifactCrusherComponent> ent, ref ExaminedEvent args)

--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Examine;
 using Content.Shared.Storage.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
@@ -20,6 +21,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
 
         SubscribeLocalEvent<ArtifactCrusherComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<ArtifactCrusherComponent, StorageAfterOpenEvent>(OnStorageAfterOpen);
+        SubscribeLocalEvent<ArtifactCrusherComponent, ExaminedEvent>(OnExamine);
     }
 
     private void OnInit(Entity<ArtifactCrusherComponent> ent, ref ComponentInit args)
@@ -29,8 +31,16 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
 
     private void OnStorageAfterOpen(Entity<ArtifactCrusherComponent> ent, ref StorageAfterOpenEvent args)
     {
+        if (ent.Comp.AutoLock)
+            return;
+
         StopCrushing(ent);
         ContainerSystem.EmptyContainer(ent.Comp.OutputContainer);
+    }
+
+    private void OnExamine(Entity<ArtifactCrusherComponent> ent, ref ExaminedEvent args)
+    {
+        args.PushMarkup(ent.Comp.AutoLock ? Loc.GetString("artifact-crusher-examine-autolocks") : Loc.GetString("artifact-crusher-examine-no-autolocks"));
     }
 
     public void StopCrushing(Entity<ArtifactCrusherComponent> ent, bool early = true)

--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Examine;
 using Content.Shared.Storage.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
+using Content.Shared.Emag.Systems;
 
 namespace Content.Shared.Xenoarchaeology.Equipment;
 
@@ -23,6 +24,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
         SubscribeLocalEvent<ArtifactCrusherComponent, StorageAfterOpenEvent>(OnStorageAfterOpen);
         SubscribeLocalEvent<ArtifactCrusherComponent, StorageOpenAttemptEvent>(OnStorageOpenAttempt);
         SubscribeLocalEvent<ArtifactCrusherComponent, ExaminedEvent>(OnExamine);
+        SubscribeLocalEvent<ArtifactCrusherComponent, GotEmaggedEvent>(OnEmagged);
     }
 
     private void OnInit(Entity<ArtifactCrusherComponent> ent, ref ComponentInit args)
@@ -34,6 +36,12 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
     {
         StopCrushing(ent);
         ContainerSystem.EmptyContainer(ent.Comp.OutputContainer);
+    }
+
+    private void OnEmagged(Entity<ArtifactCrusherComponent> ent, ref GotEmaggedEvent args)
+    {
+        ent.Comp.AutoLock = true;
+        args.Handled = true;
     }
 
     private void OnStorageOpenAttempt(Entity<ArtifactCrusherComponent> ent, ref StorageOpenAttemptEvent args)

--- a/Resources/Locale/en-US/artifacts/artifact-crusher.ftl
+++ b/Resources/Locale/en-US/artifacts/artifact-crusher.ftl
@@ -1,0 +1,3 @@
+artifact-crusher-examine-no-autolocks = The machine's autolocks are [color=green]disabled[/color].
+artifact-crusher-examine-autolocks = The machine's autolocks are [color=red]enabled[/color].
+artifact-crusher-autolocks-enable = The machine's locks snap shut!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Can now emag artifact crusher.
Normally when someone is inside an artifact crusher, they will still be able to leave when it is crushing. They can just open the door and the machine will halt.
When emagged, the artifact crusher will lock shut for the duration of the crushing. It will not trap someone inside forever - once the crushing is over the locks will release. However the person inside is probably dead by the time this happens.
<!-- What did you change in this PR? -->

## Why / Balance
Someone who is stuck inside when the machine starts crushing cannot escape by themselves, and will be gibbed.
However the gibbing takes 10 seconds, and someone outside can unbolt the machine, which cause the crushing to stop, and the door will unlock and they can escape.
The artifact crusher is a large conspicuous machine, and examining it will tell you if it is emagged (it will say "Autolocks enabled", see the video).
It is far less dangerous than an emagged recycler, which will instagib anyone who walks into it,

## Technical details
* Added AutoLock field to ArtifactCrusherComponent.
* SharedArtifactCrusherSystem susbcribes to OnStorageOpenAttempt and cancels it is the machine is crushing and the autolocks are enabled.
* SharedArtifactCrusherSystem subscribes to OnExamineEvent to add examine text about the crusher's autolocks being enabled or disabled.
* SharedArtifactCrusherSystem subscribes to GotEmaggedEvent to set AutoLock to true when emagged.

## Media

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
https://github.com/space-wizards/space-station-14/assets/66873282/756dacd0-1898-4ad3-b746-a000660da4a1
- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
* ArtifactCrusherComponent has new field, AutoLock. This determines if the machine can be opened while it is crushing.
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- add: Emagging the artifact crusher now stops it from being opened while it is crushing.
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
