### PR TITLE
Tesla Artifact Effect

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -664,3 +664,13 @@
     maxSpawns: 1
     spawns:
     - id: Singularity
+
+- type: artifactEffect
+  id: EffectTesla
+  targetDepth: 10
+  effectHint: artifact-effect-hint-destruction
+  components:
+  - type: SpawnArtifact
+    maxSpawns: 1
+    spawns:
+    - id: TeslaEnergyBall


### PR DESCRIPTION
## About the PR
There is now duplicate of the singularity artifact node that spawns a tesla instead. It has the same effect hint and same target depth.

## Why / Balance
We already have one for the singulo, so adding the tesla as well is just really funny.

## Media

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**


