### PR TITLE
Fix Floodlight Collision

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -206,9 +206,7 @@
           bounds: "-0.2, -0.5, 0.2, 0.5"
         density: 50
         mask:
-        - MachineMask
-        layer:
-        - MachineLayer
+        - HighImpassable
   - type: PointLight
     enabled: false
     radius: 8
@@ -278,6 +276,4 @@
           bounds: "-0.2, -0.5, 0.2, 0.5"
         density: 50
         mask:
-        - MachineMask
-        layer:
-        - MachineLayer
+        - HighImpassable


### PR DESCRIPTION
## About the PR
Updated the floodlight and broken floodlight so they no longer collide with mobs.

## Why / Balance
https://github.com/space-wizards/space-station-14/issues/9336 It could be used to push players around when thrown.

## Technical details
Updated mask from MachineMask to HighImpassable
Removed layer

## Media
https://github.com/space-wizards/space-station-14/assets/30051988/46d58063-2df0-4e66-b472-90114d5a0b87
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
