### PR TITLE
Minor change to vending machine inventory

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
@@ -34,3 +34,5 @@
     DrinkWhiskeyBottleFull: 5
     DrinkWineBottleFull: 5
     DrinkChampagneBottleFull: 2 #because the premium drink
+  emaggedInventory:
+    DrinkPoisonWinebottleFull: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
@@ -10,4 +10,5 @@
     ClothingUniformJumpskirtChef:  2
     ClothingHeadHatChef: 2
     ClothingShoesColorBlack: 2
+    ClothingShoesChef: 2
     ClothingBeltChef: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sovietsoda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sovietsoda.yml
@@ -2,5 +2,5 @@
   id: BodaInventory
   startingInventory:
     DrinkSodaWaterCan: 10 #typically hacked product. Default product is "soda"
-  emaggedInventory:
+  contrabandInventory:
     DrinkColaCan: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR changes the inventory of three vending machines

Now, to get 10 cans of Cosmo Cola from the "BODA" vending machine, you don’t need an emag, you can now hack it manually (I changed the inventory emag to contraband)

In chefdrop you can take chef's shoes, which appeared in some locations but not in the machine

Now you can emag boozeomat and get 2 bottles of poison vein

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
In general, I don’t see any particular harm to the balance, poisoned wine can kill if you drink it completely, 10 cans of cola will not destroy the bartender, and the chef’s shoes do not provide any particular advantage

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
