### PR TITLE
Add nuclear bomb warp point

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
@@ -83,6 +83,9 @@
       Nuke: !type:ContainerSlot
   - type: StealTarget
     stealGroup: NuclearBomb
+  - type: WarpPoint
+    follow: true
+    location: nuclear bomb
 
 - type: entity
   parent: NuclearBomb


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Add ghost warp point to nuclear bomb

## Why / Balance
Had a round where observers couldn't find out where the bomb was

**Changelog**
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: New ghost warp point: nuclear bomb