### PR TITLE
Fix double sound for shutters

### DIFF
--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -167,10 +167,19 @@ public sealed class PryingSystem : EntitySystem
             return;
         }
 
-        // TODO: When we get airlock prediction make this predicted.
+        // TODO: When we get airlock prediction make this fully predicted.
         // When that happens also fix the checking function in the Client AirlockSystem.
         if (args.Used != null && comp != null)
-            _audioSystem.PlayPvs(comp.UseSound, args.Used.Value);
+        {
+            if (HasComp<AirlockComponent>(uid))
+            {
+                _audioSystem.PlayPvs(comp.UseSound, args.Used.Value);
+            }
+            else
+            {
+                _audioSystem.PlayPredicted(comp.UseSound, args.Used.Value, args.User);
+            }
+        }
 
         var ev = new PriedEvent(args.User);
         RaiseLocalEvent(uid, ref ev);


### PR DESCRIPTION
Resolves #23935
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This pr fixes the double prying sound for things that ain't airlocks

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
#23818  fixed an issue where people could pry airlocks open even if they should not be able to if the conditions were right at the time the prying started. Due to prediction not existing for airlocks, the check on whether the airlock could be pried open is set to always fail on the client so the client would never play the audio.

 To make sure that sound still played for airlocks I changed PlayPredicted to PlayPvs but forgot that there are things that can be pried open like shutters that aren't airlocks. 

As a fix the system checks if the door has the airlock component to decide whether to use PlayPvs rather than PlayPredicted. This should be removed once airlocks get prediction.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- fix: Opening shutters is no longer extremely loud. 