### PR TITLE
Cryo Burn Chem - Aloxadone

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -126,3 +126,6 @@ reagent-desc-insuzine = Rapidly repairs dead tissue caused by electrocution, but
 
 reagent-name-necrosol = necrosol
 reagent-desc-necrosol = A necrotic substance that seems to be able to heal frozen corpses
+
+reagent-name-aloxadone = aloxadone
+reagent-desc-aloxadone = A cryogenics chemical. Used to treat severe third degree burns via regeneration of the burnt tissue. Works regardless of the patient being alive or dead.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1136,3 +1136,25 @@
               Burn: -5
             types:
               Poison: -2
+
+- type: reagent
+  id : Aloxadone
+  name: reagent-name-aloxadone
+  group: Medicine
+  desc: reagent-desc-aloxadone
+  physicalDesc: reagent-physical-desc-soothing
+  flavor: medicine
+  color: "#89f77f"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:Temperature
+          max: 213.0
+        damage:
+          types:
+            Heat: -3.0
+            Shock: -3.0
+            Caustic: -1.0

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -562,3 +562,16 @@
       amount: 2
   products:
     Necrosol: 2
+
+- type: reaction
+  id: Aloxadone
+  impact: Medium
+  reactants:
+    Cryoxadone:
+      amount: 1
+    Aloe:
+      amount: 2
+    Sigynate:
+      amount: 2
+  products:
+      Aloxadone: 4


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
A more specific and balance-oriented approach to dead-Cryogenics medicines, this is a Cyrogenics burn medicine that employs the same resource gating that Regenerative Meshes do, revolving mostly around the production of Aloe and Sigynate, and addresses the previous concerns of "basically re-adding cloning" by not touching any damage types that cause perma-death (Poison, Radiation, Bloodloss, and Genetic), but still allowing it to process on the dead. Same as #23849 but I messed up the merge conflict resolution on that one oopsie

## Why / Balance
As Aloe is the main material balancer of Meshes, it is also mainly used in the recipe balance decisions here. For 40u Aloe you could heal 1600 Burn damage with Regenerative Meshes, equally split across all types, and this was the main factor I considered for balance. In the recipe for this chemical, 40u of Aloe will get you 1120 Burn damage healed overall, specifically filtered into 480 heat, 480 shock, and 160 caustic. This makes it worse than producing Sutures if you need to treat Caustic damage (40% effectiveness), and also is completely unable to help heal Cold damage, making Regenerative Meshes better in some areas. Regenerative Meshes also have the advantage of being able to be applied anywhere at any time and do not require any specific set-up that is vulnerable to sabotage/explosions to use, which I believe makes up for the 80 extra heat/shock you receive from this chemical.

Sigynate is also used in the reaction as it is the other significant gate for Regenerative Meshes, but mostly serves as a time gate for that recipe, as most players can not make Sigynate very fast and its components are currently not limited in any way besides water. The Cryoxadone reactant is used because it is basic stable Cryogenics medicine, and is also similarly water-gated, as well as requiring Chemistry be supplied with Plasma, which provides another (albeit more minor) resource gate.

Similar to cryo pods, Stasis Beds also now prevent rot while the patient is treated, leading to similar body management scenarios (both allow treatment of burns while rot is blocked, both no longer block rot when power is lost).

Besides all the balance talk, this also provides more of a reason to use and think about Cryogenics, as well as providing an alternative (but not cheaper) method of treating the large amounts of burns that have become much more common with recent changes to heat and firestacks. I believe it also makes better Medbay roleplay to be using the Cryo Pods to treat burn victims moreso than having 5+ (I have seen up to 20) people crowd around a body all applying Regenerative Meshes and what is basically just only skin cream (Ointment/Aloe Cream).

Cold damage is also omitted for both balance reasons (the new chemical only heals half the burn overall if mixed compared to Regenerative Meshes) and I don't think it really makes roleplay sense to put someone in a super cold Cryo Tube to heal cold damage.

## Media
![Aloxadone](https://github.com/space-wizards/space-station-14/assets/57879983/fe2e1b50-4ed7-4dcc-b21a-a60eaf6fcfe4)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Added Aloxadone, a cryogenics chemical for treating patients with third degree burns.
