### PR TITLE
Limit hydraulic clamps to one DoAfter at a time

### DIFF
--- a/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
+++ b/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using System.Threading;
+using Content.Shared.DoAfter;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 
@@ -47,4 +48,7 @@ public sealed partial class MechGrabberComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite)]
     public Container ItemContainer = default!;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public DoAfterId? DoAfter;
 }

--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -128,6 +128,9 @@ public sealed class MechGrabberSystem : EntitySystem
         if (args.Handled || args.Target is not {} target)
             return;
 
+        if (args.Target == args.User || component.DoAfter != null)
+            return;
+
         if (TryComp<PhysicsComponent>(target, out var physics) && physics.BodyType == BodyType.Static ||
             HasComp<WallMountComponent>(target) ||
             HasComp<MobStateComponent>(target))
@@ -152,15 +155,19 @@ public sealed class MechGrabberSystem : EntitySystem
 
         args.Handled = true;
         component.AudioStream = _audio.PlayPvs(component.GrabSound, uid).Value.Entity;
-        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.GrabDelay, new GrabberDoAfterEvent(), uid, target: target, used: uid)
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, component.GrabDelay, new GrabberDoAfterEvent(), uid, target: target, used: uid)
         {
             BreakOnTargetMove = true,
             BreakOnUserMove = true
-        });
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs, out component.DoAfter);
     }
 
     private void OnMechGrab(EntityUid uid, MechGrabberComponent component, DoAfterEvent args)
     {
+        component.DoAfter = null;
+
         if (args.Cancelled)
         {
             component.AudioStream = _audio.Stop(component.AudioStream);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixes #23754 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Prevents overloading the hydraulic clamp by starting a lot of DoAfters when nearly full.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Just tracks the DoAfterId to assure only one DoAfter at a time. I also saw you could start a DoAfter on yourself, so I just put an extra check in there for if you misclick.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no cl