### PR TITLE
Remove flashes from science and reduce their charges.

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -2,7 +2,6 @@
   id: RoboticsInventory
   startingInventory:
     CableApcStack: 4
-    SciFlash: 4
     ProximitySensor: 3
     ClothingEyesHudDiagnostic: 2
     RemoteSignaller: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -131,8 +131,8 @@
         shader: unshaded
     - type: Flash
     - type: LimitedCharges
-      maxCharges: 5
-      charges: 5
+      maxCharges: 3
+      charges: 3
     - type: MeleeWeapon
       wideAnimationRotation: 180
       damage:
@@ -158,16 +158,6 @@
     - type: GuideHelp
       guides:
       - Security
-
-- type: entity
-  name: flash
-  parent: Flash
-  suffix: 2 charges
-  id: SciFlash
-  components:
-    - type: LimitedCharges
-      maxCharges: 2
-      charges: 2
 
 - type: entity
   name: portable flasher

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -471,7 +471,6 @@
     staticRecipes:
     - MMI
     - PositronicBrain
-    - SciFlash
     - BorgModuleCable
     - BorgModuleFireExtinguisher
     - BorgModuleGPS

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
@@ -27,23 +27,9 @@
         doAfter: 1
         store: part-container
 
-      - component: Flash
-        name: flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
-      - component: Flash
-        name: second flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
       - tool: Screwing
         doAfter: 0.5
-    
+
     - to: engineer
       steps:
       - assemblyId: engineer

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
@@ -40,20 +40,6 @@
         doAfter: 1
         store: part-container
 
-      - component: Flash
-        name: flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
-      - component: Flash
-        name: second flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
       - tool: Screwing
         doAfter: 0.5
 
@@ -66,20 +52,6 @@
         amount: 1
         doAfter: 1
         store: part-container
-
-      - component: Flash
-        name: flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
-      - component: Flash
-        name: second flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
 
       - tool: Screwing
         doAfter: 0.5
@@ -94,20 +66,6 @@
         doAfter: 1
         store: part-container
 
-      - component: Flash
-        name: flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
-      - component: Flash
-        name: second flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
       - tool: Screwing
         doAfter: 0.5
 
@@ -121,20 +79,6 @@
         doAfter: 1
         store: part-container
 
-      - component: Flash
-        name: flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
-      - component: Flash
-        name: second flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
       - tool: Screwing
         doAfter: 0.5
 
@@ -147,20 +91,6 @@
         amount: 1
         doAfter: 1
         store: part-container
-
-      - component: Flash
-        name: flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
-
-      - component: Flash
-        name: second flash
-        store: part-container
-        icon:
-          sprite: Objects/Weapons/Melee/flash.rsi
-          state: flash
 
       - tool: Screwing
         doAfter: 0.5

--- a/Resources/Prototypes/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/robotics.yml
@@ -7,15 +7,6 @@
     Glass: 300
 
 - type: latheRecipe
-  id: SciFlash
-  result: SciFlash
-  completetime: 2
-  materials:
-    Glass: 100
-    Plastic: 200
-    Steel: 100
-
-- type: latheRecipe
   id: CyborgEndoskeleton
   result: CyborgEndoskeleton
   completetime: 3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes flashes from the robotics department.
Reduces flash charges to 3 uses

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
As science currently has an unlimited supply of flashes, the Revolutionary gameplay boils down to converting a scientist and getting them to empty the robotics vendor for you, and then mass produce extra flashes from the exosuit fabricator once those are depleted. The current drawback of these flashes being worth only two conversions is not enough when you can print a virtually infinite supply of them.
This results in the station being overrun by revolutionaries before the heads and security can do anything about it, which causes a number of issues to arise. Security is forced into a position where they need to metagame the revolutionaries and secure cargo almost immediately in order to stand a chance due to the speed at which they can overtake the station, and Heads are incentivized to see any non-mindshielded crew as a revolutionary even if they are not due to how the limitless flash stock allows headrevs to simply overtake departments and flash everyone in loudly.

Removing flashes from science and reducing their effectiveness forces the early revolutionary crew to work together and take down either a head or a security officer in order to acquire more flashes and more power. This will incentivize teamwork amongst the revolutionaries and generally reduce the odds of any peculiar crew being part of the revolution, allowing heads to choose to trust some key members of their departments and encouraging security to use mindshields wisely instead of just jabbing the first tider they see to get information on the revolution.
Once security is breached and taken out, the sectech is still full of flashes which the headrevs can use to convert remaining crew, giving them a concrete goal to work towards.

Reducing flash charges will encourage the head revolutionaries to actually think about who they want on their team instead of simply dumping all their charges as soon as they can for numbers. This also encourages headrevs to work together and either try to overtake a department for headquarters and an easy head takedown or spread the love between different skillsets in order to stage a coup. Balance-wise, three conversions per headrev should be more than enough to convert a whole department or get an initial team going to take down heads.

## Technical details
N/A

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
N/A
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: Jajsha
- tweak: Flashes are no longer found in robotics, and are no longer required for the construction of cyborgs.
- tweak: Flashes now have three charges.
-->
