### PR TITLE
Pneumatic cannon accuracy buff

### DIFF
--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -2,6 +2,8 @@ using System.Numerics;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Gravity;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Projectiles;
 using Content.Shared.Tag;
@@ -118,7 +120,11 @@ public sealed class ThrowingSystem : EntitySystem
         // Estimate time to arrival so we can apply OnGround status and slow it much faster.
         var time = direction.Length() / strength;
         comp.ThrownTime = _gameTiming.CurTime;
-        comp.LandTime = time < FlyTime ? default : comp.ThrownTime + TimeSpan.FromSeconds(time - FlyTime);
+        // did we launch this with something stronger than our hands?
+        if (TryComp<HandsComponent>(comp.Thrower, out var hands) && strength > hands.ThrowForceMultiplier)
+            comp.LandTime = comp.ThrownTime + TimeSpan.FromSeconds(time);
+        else
+            comp.LandTime = time < FlyTime ? default : comp.ThrownTime + TimeSpan.FromSeconds(time - FlyTime);
         comp.PlayLandSound = playSound;
 
         ThrowingAngleComponent? throwingAngle = null;


### PR DESCRIPTION
## About the PR
Pie cannons and pneumatic cannons launching breakable or spillable objects would previously break or spill the object far too close to where they were launched from, in some cases directly under the player's feet if they were aiming too close. This PR simply removes the minimum flight time from the equation if the item is launched with greater force than hand-throwing it, allowing the launched item to consistently reach the cursor.

Closes #23991.

## Why / Balance
Because you're shooting things at targets, not your own shoes!

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/space-wizards/space-station-14/assets/502797/fb32ac2d-deeb-40ae-ab5c-7b01213d5a8e)


**Changelog**
:cl:
- fix: Pie cannons and pneumatic cannons no longer hit your own feet when aiming at close range. Clowns rejoice!
