### PR TITLE
TriggerOnSpawn + Admin toys

### DIFF
--- a/Content.Server/Explosion/Components/TriggerOnSpawnComponent.cs
+++ b/Content.Server/Explosion/Components/TriggerOnSpawnComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Server.Explosion.Components;
+
+[RegisterComponent]
+public sealed partial class TriggerOnSpawnComponent : Component
+{
+}

--- a/Content.Server/Explosion/Components/TriggerOnSpawnComponent.cs
+++ b/Content.Server/Explosion/Components/TriggerOnSpawnComponent.cs
@@ -1,5 +1,8 @@
 namespace Content.Server.Explosion.Components;
 
+/// <summary>
+/// calls the trigger when the object is initialized
+/// </summary>
 [RegisterComponent]
 public sealed partial class TriggerOnSpawnComponent : Component
 {

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -84,6 +84,7 @@ namespace Content.Server.Explosion.EntitySystems
             SubscribeLocalEvent<TriggerOnStepTriggerComponent, StepTriggeredEvent>(OnStepTriggered);
             SubscribeLocalEvent<TriggerOnSlipComponent, SlipEvent>(OnSlipTriggered);
             SubscribeLocalEvent<TriggerWhenEmptyComponent, OnEmptyGunShotEvent>(OnEmptyTriggered);
+            SubscribeLocalEvent<TriggerOnSpawnComponent, ComponentInit>(OnSpawnTriggered);
 
             SubscribeLocalEvent<SpawnOnTriggerComponent, TriggerEvent>(OnSpawnTrigger);
             SubscribeLocalEvent<DeleteOnTriggerComponent, TriggerEvent>(HandleDeleteTrigger);
@@ -217,6 +218,11 @@ namespace Content.Server.Explosion.EntitySystems
         private void OnEmptyTriggered(EntityUid uid, TriggerWhenEmptyComponent component, ref OnEmptyGunShotEvent args)
         {
             Trigger(uid, args.EmptyGun);
+        }
+
+        private void OnSpawnTriggered(EntityUid uid, TriggerOnSpawnComponent component, ComponentInit args)
+        {
+            Trigger(uid);
         }
 
         public bool Trigger(EntityUid trigger, EntityUid? user = null)

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -78,13 +78,13 @@ namespace Content.Server.Explosion.EntitySystems
             InitializeVoice();
             InitializeMobstate();
 
+            SubscribeLocalEvent<TriggerOnSpawnComponent, MapInitEvent>(OnSpawnTriggered);
             SubscribeLocalEvent<TriggerOnCollideComponent, StartCollideEvent>(OnTriggerCollide);
             SubscribeLocalEvent<TriggerOnActivateComponent, ActivateInWorldEvent>(OnActivate);
             SubscribeLocalEvent<TriggerImplantActionComponent, ActivateImplantEvent>(OnImplantTrigger);
             SubscribeLocalEvent<TriggerOnStepTriggerComponent, StepTriggeredEvent>(OnStepTriggered);
             SubscribeLocalEvent<TriggerOnSlipComponent, SlipEvent>(OnSlipTriggered);
             SubscribeLocalEvent<TriggerWhenEmptyComponent, OnEmptyGunShotEvent>(OnEmptyTriggered);
-            SubscribeLocalEvent<TriggerOnSpawnComponent, ComponentInit>(OnSpawnTriggered);
 
             SubscribeLocalEvent<SpawnOnTriggerComponent, TriggerEvent>(OnSpawnTrigger);
             SubscribeLocalEvent<DeleteOnTriggerComponent, TriggerEvent>(HandleDeleteTrigger);
@@ -194,6 +194,11 @@ namespace Content.Server.Explosion.EntitySystems
                 Trigger(uid);
         }
 
+        private void OnSpawnTriggered(EntityUid uid, TriggerOnSpawnComponent component, MapInitEvent args)
+        {
+            Trigger(uid);
+        }
+
         private void OnActivate(EntityUid uid, TriggerOnActivateComponent component, ActivateInWorldEvent args)
         {
             Trigger(uid, args.User);
@@ -218,11 +223,6 @@ namespace Content.Server.Explosion.EntitySystems
         private void OnEmptyTriggered(EntityUid uid, TriggerWhenEmptyComponent component, ref OnEmptyGunShotEvent args)
         {
             Trigger(uid, args.EmptyGun);
-        }
-
-        private void OnSpawnTriggered(EntityUid uid, TriggerOnSpawnComponent component, ComponentInit args)
-        {
-            Trigger(uid);
         }
 
         public bool Trigger(EntityUid trigger, EntityUid? user = null)

--- a/Resources/Prototypes/Entities/Effects/admin_triggers.yml
+++ b/Resources/Prototypes/Entities/Effects/admin_triggers.yml
@@ -1,11 +1,12 @@
 - type: entity
   id: AdminInstantEffectBase
+  abstract: true
   name: instant effect
   components:
   - type: Sprite
-    sprite: /Textures/Effects/weather.rsi
+    sprite: /Textures/Objects/Fun/goldbikehorn.rsi
     visible: false
-    state: rain
+    state: icon
   - type: TriggerOnSpawn
 
 - type: entity

--- a/Resources/Prototypes/Entities/Effects/admin_triggers.yml
+++ b/Resources/Prototypes/Entities/Effects/admin_triggers.yml
@@ -17,8 +17,7 @@
   - type: EmpOnTrigger
     range: 4
     energyConsumption: 50000
-  - type: TimedDespawn # wtf, it broken checks if DeleteOnTrigger
-    lifetime: 3
+  - type: DeleteOnTrigger
 
 - type: entity
   id: AdminInstantEffectFlash

--- a/Resources/Prototypes/Entities/Effects/admin_triggers.yml
+++ b/Resources/Prototypes/Entities/Effects/admin_triggers.yml
@@ -9,15 +9,16 @@
     state: icon
   - type: TriggerOnSpawn
 
-- type: entity
-  id: AdminInstantEffectEMP
-  suffix: EMP
-  parent: AdminInstantEffectBase
-  components:
-  - type: EmpOnTrigger
-    range: 4
-    energyConsumption: 50000
-  - type: DeleteOnTrigger
+# for some unknown reason breaks checks. TO DO - fix
+#- type: entity
+#  id: AdminInstantEffectEMP
+#  suffix: EMP
+#  parent: AdminInstantEffectBase
+#  components:
+#  - type: EmpOnTrigger
+#    range: 4
+#    energyConsumption: 50000
+#  - type: DeleteOnTrigger
 
 - type: entity
   id: AdminInstantEffectFlash

--- a/Resources/Prototypes/Entities/Effects/admin_triggers.yml
+++ b/Resources/Prototypes/Entities/Effects/admin_triggers.yml
@@ -7,18 +7,18 @@
     sprite: /Textures/Objects/Fun/goldbikehorn.rsi
     visible: false
     state: icon
-  - type: TriggerOnSpawn
+  - type: TriggerOnSpawn   
+  - type: TimedDespawn
+    lifetime: 5
 
-# for some unknown reason breaks checks. TO DO - fix
-#- type: entity
-#  id: AdminInstantEffectEMP
-#  suffix: EMP
-#  parent: AdminInstantEffectBase
-#  components:
-#  - type: EmpOnTrigger
-#    range: 4
-#    energyConsumption: 50000
-#  - type: DeleteOnTrigger
+- type: entity
+  id: AdminInstantEffectEMP
+  suffix: EMP
+  parent: AdminInstantEffectBase
+  components:
+  - type: EmpOnTrigger
+    range: 4
+    energyConsumption: 50000
 
 - type: entity
   id: AdminInstantEffectFlash
@@ -29,7 +29,6 @@
     range: 7
   - type: SpawnOnTrigger 
     proto: GrenadeFlashEffect
-  - type: DeleteOnTrigger
   
 - type: entity
   id: AdminInstantEffectSmoke3
@@ -44,7 +43,6 @@
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/Smoke-grenade.ogg
-  - type: DeleteOnTrigger
   
 - type: entity
   id: AdminInstantEffectSmoke10
@@ -59,7 +57,6 @@
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/Smoke-grenade.ogg
-  - type: DeleteOnTrigger
   
 - type: entity
   id: AdminInstantEffectSmoke30
@@ -74,7 +71,6 @@
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/Smoke-grenade.ogg
-  - type: DeleteOnTrigger
 
 - type: entity
   id: AdminInstantEffectTearGas
@@ -88,15 +84,12 @@
       reagents:
       - ReagentId: TearGas
         Quantity: 50
-  - type: DeleteOnTrigger
 
 - type: entity
   id: AdminInstantEffectGravityWell
   suffix: Gravity Well
   parent: AdminInstantEffectBase
-  components:    
-  - type: TimedDespawn
-    lifetime: 7
+  components: 
   - type: SoundOnTrigger
     removeOnTrigger: true
     sound:

--- a/Resources/Prototypes/Entities/Effects/admin_triggers.yml
+++ b/Resources/Prototypes/Entities/Effects/admin_triggers.yml
@@ -17,7 +17,8 @@
   - type: EmpOnTrigger
     range: 4
     energyConsumption: 50000
-  - type: DeleteOnTrigger
+  - type: TimedDespawn # wtf, it broken checks if DeleteOnTrigger
+    lifetime: 3
 
 - type: entity
   id: AdminInstantEffectFlash

--- a/Resources/Prototypes/Entities/Effects/admin_triggers.yml
+++ b/Resources/Prototypes/Entities/Effects/admin_triggers.yml
@@ -1,0 +1,117 @@
+- type: entity
+  id: AdminInstantEffectBase
+  name: instant effect
+  components:
+  - type: Sprite
+    sprite: /Textures/Effects/weather.rsi
+    visible: false
+    state: rain
+  - type: TriggerOnSpawn
+
+- type: entity
+  id: AdminInstantEffectEMP
+  suffix: EMP
+  parent: AdminInstantEffectBase
+  components:
+  - type: EmpOnTrigger
+    range: 4
+    energyConsumption: 50000
+  - type: DeleteOnTrigger
+
+- type: entity
+  id: AdminInstantEffectFlash
+  suffix: Flash
+  parent: AdminInstantEffectBase
+  components:
+  - type: FlashOnTrigger
+    range: 7
+  - type: SpawnOnTrigger 
+    proto: GrenadeFlashEffect
+  - type: DeleteOnTrigger
+  
+- type: entity
+  id: AdminInstantEffectSmoke3
+  suffix: Smoke (03 sec)
+  parent: AdminInstantEffectBase
+  components:
+  - type: SmokeOnTrigger
+    duration: 3
+    spreadAmount: 1
+  - type: SoundOnTrigger
+    sound: /Audio/Effects/smoke.ogg
+  - type: TimerTriggerVisuals
+    primingSound:
+      path: /Audio/Effects/Smoke-grenade.ogg
+  - type: DeleteOnTrigger
+  
+- type: entity
+  id: AdminInstantEffectSmoke10
+  suffix: Smoke (10 sec)
+  parent: AdminInstantEffectBase
+  components:
+  - type: SmokeOnTrigger
+    duration: 10
+    spreadAmount: 30
+  - type: SoundOnTrigger
+    sound: /Audio/Effects/smoke.ogg
+  - type: TimerTriggerVisuals
+    primingSound:
+      path: /Audio/Effects/Smoke-grenade.ogg
+  - type: DeleteOnTrigger
+  
+- type: entity
+  id: AdminInstantEffectSmoke30
+  suffix: Smoke (30 sec)
+  parent: AdminInstantEffectBase
+  components:
+  - type: SmokeOnTrigger
+    duration: 30
+    spreadAmount: 50
+  - type: SoundOnTrigger
+    sound: /Audio/Effects/smoke.ogg
+  - type: TimerTriggerVisuals
+    primingSound:
+      path: /Audio/Effects/Smoke-grenade.ogg
+  - type: DeleteOnTrigger
+
+- type: entity
+  id: AdminInstantEffectTearGas
+  suffix: Tear Gas
+  parent: AdminInstantEffectBase
+  components:
+  - type: SmokeOnTrigger
+    duration: 10
+    spreadAmount: 30
+    solution:
+      reagents:
+      - ReagentId: TearGas
+        Quantity: 50
+  - type: DeleteOnTrigger
+
+- type: entity
+  id: AdminInstantEffectGravityWell
+  suffix: Gravity Well
+  parent: AdminInstantEffectBase
+  components:    
+  - type: TimedDespawn
+    lifetime: 7
+  - type: SoundOnTrigger
+    removeOnTrigger: true
+    sound:
+      path: /Audio/Effects/Grenades/Supermatter/supermatter_start.ogg
+      volume: 5
+  - type: AmbientSound
+    enabled: true
+    volume: -5
+    range: 14
+    sound:
+      path: /Audio/Effects/Grenades/Supermatter/supermatter_loop.ogg
+  - type: GravityWell
+    maxRange: 8
+    baseRadialAcceleration: 10
+    baseTangentialAcceleration: 0
+    gravPulsePeriod: 0.01
+  - type: SingularityDistortion
+    intensity: 10
+    falloffPower: 1.5
+      


### PR DESCRIPTION
## About the PR
A number of instant effects have been added to the game that admins can trigger at a target location. Effects such as EMP explosions, flashes, smoke clouds and other grenade effects that were previously inconvenient for spawn

## Why / Balance
Game masters will be happy

## Technical details
Added a new kind of TriggerOnSpawn trigger that triggers effects as soon as it is created!

## Media

https://github.com/space-wizards/space-station-14/assets/96445749/b29c8790-f409-47d7-8ded-3ba67b6604f2

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl for player, no fun

ADMIN:
- add: added "admin instant effects", that allow you to create the effects of emp explosions, smoke grenades, flashes and more