### PR TITLE
Add a neck gaiter into HOS's dresser

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
@@ -61,6 +61,7 @@
       - id: ClothingUniformJumpsuitHoSAlt
       - id: ClothingUniformJumpskirtHosFormal
       - id: ClothingUniformJumpsuitHosFormal
+      - id: ClothingMaskNeckGaiter
 
 - type: entity
   id: DresserQuarterMasterFilled


### PR DESCRIPTION
## About the PR
Add a neck gaiter into HOS's dresser.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I wholeheartedly support @deepdarkdepths' suggestion. The addition of a neck gaiter to HOS's dresser complements HOS's style perfectly.
In addition, a neck gaiter was previously present in HOS's locker but was removed during the dresser update.
Closes #23998

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: The HOS's dresser now contains a neck gaiter.