### PR TITLE
Action, Action Container, and Action Upgrade changes

### DIFF
--- a/Content.Server/Commands/ActionCommands.cs
+++ b/Content.Server/Commands/ActionCommands.cs
@@ -31,13 +31,13 @@ internal sealed class UpgradeActionCommand : IConsoleCommand
         var actionUpgrade = _entMan.EntitySysManager.GetEntitySystem<ActionUpgradeSystem>();
         var id = args[0];
 
-        if (!EntityUid.TryParse(id, out var uid))
+        if (!NetEntity.TryParse(id, out var nuid))
         {
             shell.WriteLine(Loc.GetString("upgradeaction-command-incorrect-entityuid-format"));
             return;
         }
 
-        if (!_entMan.EntityExists(uid))
+        if (!_entMan.TryGetEntity(nuid, out var uid))
         {
             shell.WriteLine(Loc.GetString("upgradeaction-command-entity-does-not-exist"));
             return;

--- a/Content.Server/Commands/ActionCommands.cs
+++ b/Content.Server/Commands/ActionCommands.cs
@@ -31,13 +31,13 @@ internal sealed class UpgradeActionCommand : IConsoleCommand
         var actionUpgrade = _entMan.EntitySysManager.GetEntitySystem<ActionUpgradeSystem>();
         var id = args[0];
 
-        if (!NetEntity.TryParse(id, out var nuid))
+        if (!EntityUid.TryParse(id, out var uid))
         {
             shell.WriteLine(Loc.GetString("upgradeaction-command-incorrect-entityuid-format"));
             return;
         }
 
-        if (!_entMan.TryGetEntity(nuid, out var uid))
+        if (!_entMan.EntityExists(uid))
         {
             shell.WriteLine(Loc.GetString("upgradeaction-command-entity-does-not-exist"));
             return;
@@ -51,7 +51,7 @@ internal sealed class UpgradeActionCommand : IConsoleCommand
 
         if (args.Length == 1)
         {
-            if (!actionUpgrade.TryUpgradeAction(uid, actionUpgradeComponent))
+            if (!actionUpgrade.TryUpgradeAction(uid, out _, actionUpgradeComponent))
             {
                 shell.WriteLine(Loc.GetString("upgradeaction-command-cannot-level-up"));
                 return;
@@ -74,7 +74,7 @@ internal sealed class UpgradeActionCommand : IConsoleCommand
                 return;
             }
 
-            if (!actionUpgrade.TryUpgradeAction(uid, actionUpgradeComponent, level))
+            if (!actionUpgrade.TryUpgradeAction(uid, out _, actionUpgradeComponent, level))
                 shell.WriteLine(Loc.GetString("upgradeaction-command-cannot-level-up"));
         }
     }

--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -242,7 +242,7 @@ public sealed class ActionContainerSystem : EntitySystem
 
         DebugTools.AssertOwner(uid, comp);
         comp ??= EnsureComp<ActionsContainerComponent>(uid);
-        if (!comp.Container.Insert(actionId))
+        if (!_container.Insert(actionId, comp.Container))
         {
             Log.Error($"Failed to insert action {ToPrettyString(actionId)} into {ToPrettyString(uid)}");
             return false;
@@ -294,7 +294,7 @@ public sealed class ActionContainerSystem : EntitySystem
         if (_timing.ApplyingState && component.NetSyncEnabled)
             return; // The game state should handle the container removal & action deletion.
 
-        component.Container.Shutdown();
+        _container.ShutdownContainer(component.Container);
     }
 
     private void OnEntityInserted(EntityUid uid, ActionsContainerComponent component, EntInsertedIntoContainerMessage args)

--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -339,9 +339,6 @@ public sealed class ActionContainerSystem : EntitySystem
 
     private void OnActionAdded(EntityUid uid, ActionsContainerComponent component, ActionAddedEvent args)
     {
-        if (!HasComp<ActionsContainerComponent>(uid))
-            EnsureComp<ActionsContainerComponent>(uid);
-
         if (_mind.TryGetMind(uid, out var mind, out _))
         {
             if (!HasComp<ActionsContainerComponent>(mind))

--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -339,12 +339,27 @@ public sealed class ActionContainerSystem : EntitySystem
 
     private void OnActionAdded(EntityUid uid, ActionsContainerComponent component, ActionAddedEvent args)
     {
+        ActionsContainerComponent? mindActionContainerComp = null;
         if (_mind.TryGetMind(uid, out var mind, out _))
+        {
+            if (!TryComp<ActionsContainerComponent>(mind, out var mindActionContainerComponent))
+                mindActionContainerComp = EnsureComp<ActionsContainerComponent>(mind);
+
+            mindActionContainerComp ??= mindActionContainerComponent;
+
             _actions.GrantContainedAction(uid, mind, args.Action);
+        }
         else if (TryComp<MindComponent>(uid, out var mindComp))
         {
-            if (mindComp.OwnedEntity != null)
-                _actions.GrantContainedAction(mindComp.OwnedEntity.Value, uid, args.Action);
+            if (mindComp.OwnedEntity == null)
+                return;
+
+            if (!TryComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value, out var mindActionContainerComponent))
+                mindActionContainerComp = EnsureComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value);
+
+            mindActionContainerComp ??= mindActionContainerComponent;
+
+            _actions.GrantContainedAction(mindComp.OwnedEntity.Value, uid, args.Action);
         }
     }
 }

--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -30,6 +30,7 @@ public sealed class ActionContainerSystem : EntitySystem
         SubscribeLocalEvent<ActionsContainerComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<ActionsContainerComponent, EntRemovedFromContainerMessage>(OnEntityRemoved);
         SubscribeLocalEvent<ActionsContainerComponent, EntInsertedIntoContainerMessage>(OnEntityInserted);
+        SubscribeLocalEvent<ActionsContainerComponent, ActionAddedEvent>(OnActionAdded);
         SubscribeLocalEvent<ActionsContainerComponent, MindAddedMessage>(OnMindAdded);
         SubscribeLocalEvent<ActionsContainerComponent, MindRemovedMessage>(OnMindRemoved);
     }
@@ -38,7 +39,6 @@ public sealed class ActionContainerSystem : EntitySystem
     {
         if(!_mind.TryGetMind(uid, out var mindId, out _))
             return;
-
         if (!TryComp<ActionsContainerComponent>(mindId, out var mindActionContainerComp))
             return;
 
@@ -175,6 +175,61 @@ public sealed class ActionContainerSystem : EntitySystem
     }
 
     /// <summary>
+    /// Transfers an actions from one container to another, while changing the attached entity.
+    /// </summary>
+    /// <remarks>
+    /// This will actually remove and then re-grant the action.
+    /// Useful where you need to transfer from one container to another but also change the attached entity (ie spellbook > mind > user)
+    /// </remarks>
+    public void TransferActionWithNewAttached(
+        EntityUid actionId,
+        EntityUid newContainer,
+        EntityUid newAttached,
+        BaseActionComponent? action = null,
+        ActionsContainerComponent? container = null)
+    {
+        if (!_actions.ResolveActionData(actionId, ref action))
+            return;
+
+        if (action.Container == newContainer)
+            return;
+
+        var attached = newAttached;
+        if (!AddAction(newContainer, actionId, action, container))
+            return;
+
+        DebugTools.AssertEqual(action.Container, newContainer);
+        _actions.AddActionDirect(newAttached, actionId, action: action);
+
+        DebugTools.AssertEqual(action.AttachedEntity, attached);
+    }
+
+    /// <summary>
+    /// Transfers all actions from one container to another, while changing the attached entity.
+    /// </summary>
+    /// <remarks>
+    /// This will actually remove and then re-grant the action.
+    /// Useful where you need to transfer from one container to another but also change the attached entity (ie spellbook > mind > user)
+    /// </remarks>
+    public void TransferAllActionsWithNewAttached(
+        EntityUid from,
+        EntityUid to,
+        EntityUid newAttached,
+        ActionsContainerComponent? oldContainer = null,
+        ActionsContainerComponent? newContainer = null)
+    {
+        if (!Resolve(from, ref oldContainer) || !Resolve(to, ref newContainer))
+            return;
+
+        foreach (var action in oldContainer.Container.ContainedEntities.ToArray())
+        {
+            TransferActionWithNewAttached(action, to, newAttached, container: newContainer);
+        }
+
+        DebugTools.AssertEqual(oldContainer.Container.Count, 0);
+    }
+
+    /// <summary>
     /// Adds a pre-existing action to an action container. If the action is already in some container it will first remove it.
     /// </summary>
     public bool AddAction(EntityUid uid, EntityUid actionId, BaseActionComponent? action = null, ActionsContainerComponent? comp = null)
@@ -187,7 +242,7 @@ public sealed class ActionContainerSystem : EntitySystem
 
         DebugTools.AssertOwner(uid, comp);
         comp ??= EnsureComp<ActionsContainerComponent>(uid);
-        if (!_container.Insert(actionId, comp.Container))
+        if (!comp.Container.Insert(actionId))
         {
             Log.Error($"Failed to insert action {ToPrettyString(actionId)} into {ToPrettyString(uid)}");
             return false;
@@ -239,7 +294,7 @@ public sealed class ActionContainerSystem : EntitySystem
         if (_timing.ApplyingState && component.NetSyncEnabled)
             return; // The game state should handle the container removal & action deletion.
 
-        _container.ShutdownContainer(component.Container);
+        component.Container.Shutdown();
     }
 
     private void OnEntityInserted(EntityUid uid, ActionsContainerComponent component, EntInsertedIntoContainerMessage args)
@@ -280,6 +335,17 @@ public sealed class ActionContainerSystem : EntitySystem
         var ev = new ActionRemovedEvent(args.Entity, data);
         RaiseLocalEvent(uid, ref ev);
         data.Container = null;
+    }
+
+    private void OnActionAdded(EntityUid uid, ActionsContainerComponent component, ActionAddedEvent args)
+    {
+        if (_mind.TryGetMind(uid, out var mind, out _))
+            _actions.GrantContainedAction(uid, mind, args.Action);
+        else if (TryComp<MindComponent>(uid, out var mindComp))
+        {
+            if (mindComp.OwnedEntity != null)
+                _actions.GrantContainedAction(mindComp.OwnedEntity.Value, uid, args.Action);
+        }
     }
 }
 

--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -341,8 +341,11 @@ public sealed class ActionContainerSystem : EntitySystem
     {
         if (_mind.TryGetMind(uid, out var mind, out _))
         {
-            if (!HasComp<ActionsContainerComponent>(mind))
-                EnsureComp<ActionsContainerComponent>(mind);
+            if (_netMan.IsServer)
+            {
+                if (!HasComp<ActionsContainerComponent>(mind))
+                    EnsureComp<ActionsContainerComponent>(mind);
+            }
 
             _actions.GrantContainedAction(uid, mind, args.Action);
         }
@@ -351,8 +354,11 @@ public sealed class ActionContainerSystem : EntitySystem
             if (mindComp.OwnedEntity == null)
                 return;
 
-            if (!HasComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value))
-                EnsureComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value);
+            if (_netMan.IsServer)
+            {
+                if (!HasComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value))
+                    EnsureComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value);
+            }
 
             _actions.GrantContainedAction(mindComp.OwnedEntity.Value, uid, args.Action);
         }

--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -339,23 +339,8 @@ public sealed class ActionContainerSystem : EntitySystem
 
     private void OnActionAdded(EntityUid uid, ActionsContainerComponent component, ActionAddedEvent args)
     {
-        if (_mind.TryGetMind(uid, out var mind, out _))
-        {
-            if (!HasComp<ActionsContainerComponent>(mind))
-                EnsureComp<ActionsContainerComponent>(mind);
-
-            _actions.GrantContainedAction(uid, mind, args.Action);
-        }
-        else if (TryComp<MindComponent>(uid, out var mindComp))
-        {
-            if (mindComp.OwnedEntity == null)
-                return;
-
-            if (!HasComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value))
-                EnsureComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value);
-
+        if (TryComp<MindComponent>(uid, out var mindComp) && mindComp.OwnedEntity != null && HasComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value))
             _actions.GrantContainedAction(mindComp.OwnedEntity.Value, uid, args.Action);
-        }
     }
 }
 

--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -339,13 +339,10 @@ public sealed class ActionContainerSystem : EntitySystem
 
     private void OnActionAdded(EntityUid uid, ActionsContainerComponent component, ActionAddedEvent args)
     {
-        ActionsContainerComponent? mindActionContainerComp = null;
         if (_mind.TryGetMind(uid, out var mind, out _))
         {
-            if (!TryComp<ActionsContainerComponent>(mind, out var mindActionContainerComponent))
-                mindActionContainerComp = EnsureComp<ActionsContainerComponent>(mind);
-
-            mindActionContainerComp ??= mindActionContainerComponent;
+            if (!HasComp<ActionsContainerComponent>(mind))
+                EnsureComp<ActionsContainerComponent>(mind);
 
             _actions.GrantContainedAction(uid, mind, args.Action);
         }
@@ -354,10 +351,8 @@ public sealed class ActionContainerSystem : EntitySystem
             if (mindComp.OwnedEntity == null)
                 return;
 
-            if (!TryComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value, out var mindActionContainerComponent))
-                mindActionContainerComp = EnsureComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value);
-
-            mindActionContainerComp ??= mindActionContainerComponent;
+            if (!HasComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value))
+                EnsureComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value);
 
             _actions.GrantContainedAction(mindComp.OwnedEntity.Value, uid, args.Action);
         }

--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -339,13 +339,13 @@ public sealed class ActionContainerSystem : EntitySystem
 
     private void OnActionAdded(EntityUid uid, ActionsContainerComponent component, ActionAddedEvent args)
     {
+        if (!HasComp<ActionsContainerComponent>(uid))
+            EnsureComp<ActionsContainerComponent>(uid);
+
         if (_mind.TryGetMind(uid, out var mind, out _))
         {
-            if (_netMan.IsServer)
-            {
-                if (!HasComp<ActionsContainerComponent>(mind))
-                    EnsureComp<ActionsContainerComponent>(mind);
-            }
+            if (!HasComp<ActionsContainerComponent>(mind))
+                EnsureComp<ActionsContainerComponent>(mind);
 
             _actions.GrantContainedAction(uid, mind, args.Action);
         }
@@ -354,11 +354,8 @@ public sealed class ActionContainerSystem : EntitySystem
             if (mindComp.OwnedEntity == null)
                 return;
 
-            if (_netMan.IsServer)
-            {
-                if (!HasComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value))
-                    EnsureComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value);
-            }
+            if (!HasComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value))
+                EnsureComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value);
 
             _actions.GrantContainedAction(mindComp.OwnedEntity.Value, uid, args.Action);
         }

--- a/Content.Shared/Actions/ActionUpgradeComponent.cs
+++ b/Content.Shared/Actions/ActionUpgradeComponent.cs
@@ -11,6 +11,7 @@ public sealed partial class ActionUpgradeComponent : Component
     /// <summary>
     ///     Current Level of the action.
     /// </summary>
+    [ViewVariables]
     public int Level = 1;
 
     /// <summary>

--- a/Content.Shared/Actions/ActionUpgradeSystem.cs
+++ b/Content.Shared/Actions/ActionUpgradeSystem.cs
@@ -21,7 +21,7 @@ public sealed class ActionUpgradeSystem : EntitySystem
 
     private void OnActionUpgradeEvent(EntityUid uid, ActionUpgradeComponent component, ActionUpgradeEvent args)
     {
-        if (!CanLevelUp(args.NewLevel, component.EffectedLevels, out var newActionProto)
+        if (!CanUpgrade(args.NewLevel, component.EffectedLevels, out var newActionProto)
             || !_actions.TryGetActionData(uid, out var actionComp))
             return;
 
@@ -56,8 +56,9 @@ public sealed class ActionUpgradeSystem : EntitySystem
         _entityManager.DeleteEntity(uid);
     }
 
-    public bool TryUpgradeAction(EntityUid? actionId, ActionUpgradeComponent? actionUpgradeComponent = null, int newLevel = 0)
+    public bool TryUpgradeAction(EntityUid? actionId, out EntityUid? upgradeActionId, ActionUpgradeComponent? actionUpgradeComponent = null, int newLevel = 0)
     {
+        upgradeActionId = null;
         if (!TryGetActionUpgrade(actionId, out var actionUpgradeComp))
             return false;
 
@@ -68,21 +69,26 @@ public sealed class ActionUpgradeSystem : EntitySystem
         if (newLevel < 1)
             newLevel = actionUpgradeComponent.Level + 1;
 
-        if (!CanLevelUp(newLevel, actionUpgradeComponent.EffectedLevels, out _))
+        if (!CanLevelUp(newLevel, actionUpgradeComponent.EffectedLevels))
             return false;
 
-        UpgradeAction(actionId, actionUpgradeComp);
+        actionUpgradeComponent.Level = newLevel;
+
+        // If it can level up but can't upgrade, still return true and return current actionId as the upgradeId.
+        if (!CanUpgrade(newLevel, actionUpgradeComponent.EffectedLevels, out var newActionProto))
+        {
+            upgradeActionId = actionId;
+            DebugTools.AssertNotNull(upgradeActionId);
+            return true;
+        }
+
+        upgradeActionId = UpgradeAction(actionId, actionUpgradeComp, newActionProto, newLevel);
+        DebugTools.AssertNotNull(upgradeActionId);
         return true;
     }
 
-    // TODO: Add checks for branching upgrades
-    private bool CanLevelUp(
-        int newLevel,
-        Dictionary<int, EntProtoId> levelDict,
-        [NotNullWhen(true)]out EntProtoId? newLevelProto)
+    private bool CanLevelUp(int newLevel, Dictionary<int, EntProtoId> levelDict)
     {
-        newLevelProto = null;
-
         if (levelDict.Count < 1)
             return false;
 
@@ -91,25 +97,47 @@ public sealed class ActionUpgradeSystem : EntitySystem
 
         foreach (var (level, proto) in levelDict)
         {
-            if (newLevel != level || newLevel > finalLevel)
+            if (newLevel > finalLevel)
                 continue;
 
-            canLevel = true;
-            newLevelProto = proto;
-            DebugTools.AssertNotNull(newLevelProto);
-            break;
+            if ((newLevel <= finalLevel && newLevel != level) || newLevel == level)
+            {
+                canLevel = true;
+                break;
+            }
         }
 
         return canLevel;
     }
 
+    private bool CanUpgrade(int newLevel, Dictionary<int, EntProtoId> levelDict,  [NotNullWhen(true)]out EntProtoId? newLevelProto)
+    {
+        var canUpgrade = false;
+        newLevelProto = null;
+
+        var finalLevel = levelDict.Keys.ToList()[levelDict.Keys.Count - 1];
+
+        foreach (var (level, proto) in levelDict)
+        {
+            if (newLevel != level || newLevel > finalLevel)
+                continue;
+
+            canUpgrade = true;
+            newLevelProto = proto;
+            DebugTools.AssertNotNull(newLevelProto);
+            break;
+        }
+
+        return canUpgrade;
+    }
+
     /// <summary>
     ///     Raises a level by one
     /// </summary>
-    public void UpgradeAction(EntityUid? actionId, ActionUpgradeComponent? actionUpgradeComponent = null, int newLevel = 0)
+    public EntityUid? UpgradeAction(EntityUid? actionId, ActionUpgradeComponent? actionUpgradeComponent = null, EntProtoId? newActionProto = null, int newLevel = 0)
     {
         if (!TryGetActionUpgrade(actionId, out var actionUpgradeComp))
-            return;
+            return null;
 
         actionUpgradeComponent ??= actionUpgradeComp;
         DebugTools.AssertNotNull(actionUpgradeComponent);
@@ -118,7 +146,47 @@ public sealed class ActionUpgradeSystem : EntitySystem
         if (newLevel < 1)
             newLevel = actionUpgradeComponent.Level + 1;
 
-        RaiseActionUpgradeEvent(newLevel, actionId.Value);
+        actionUpgradeComponent.Level = newLevel;
+        // RaiseActionUpgradeEvent(newLevel, actionId.Value);
+
+        if (!CanUpgrade(newLevel, actionUpgradeComponent.EffectedLevels, out var newActionPrototype)
+            || !_actions.TryGetActionData(actionId, out var actionComp))
+            return null;
+
+        newActionProto ??= newActionPrototype;
+        DebugTools.AssertNotNull(newActionProto);
+
+        var originalContainer = actionComp.Container;
+        var originalAttachedEntity = actionComp.AttachedEntity;
+
+        _actionContainer.RemoveAction(actionId.Value, actionComp);
+
+        EntityUid? upgradedActionId = null;
+        if (originalContainer != null
+            && TryComp<ActionsContainerComponent>(originalContainer.Value, out var actionContainerComp))
+        {
+            upgradedActionId = _actionContainer.AddAction(originalContainer.Value, newActionProto, actionContainerComp);
+
+            if (originalAttachedEntity != null)
+                _actions.GrantContainedActions(originalAttachedEntity.Value, originalContainer.Value);
+            else
+                _actions.GrantContainedActions(originalContainer.Value, originalContainer.Value);
+        }
+        else if (originalAttachedEntity != null)
+        {
+            upgradedActionId = _actionContainer.AddAction(originalAttachedEntity.Value, newActionProto);
+        }
+
+        if (!TryComp<ActionUpgradeComponent>(upgradedActionId, out var upgradeComp))
+            return null;
+
+        upgradeComp.Level = newLevel;
+
+        // TODO: Preserve ordering of actions
+
+        _entityManager.DeleteEntity(actionId);
+
+        return upgradedActionId.Value;
     }
 
     private void RaiseActionUpgradeEvent(int level, EntityUid actionId)

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -691,6 +691,24 @@ public abstract class SharedActionsSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    ///     Grants the provided action from the container to the target entity. If the target entity has no action
+    /// component, this will give them one.
+    /// </summary>
+    /// <param name="performer"></param>
+    /// <param name="container"></param>
+    /// <param name="actionId"></param>
+    public void GrantContainedAction(Entity<ActionsComponent?> performer, Entity<ActionsContainerComponent?> container, EntityUid actionId)
+    {
+        if (!Resolve(container, ref container.Comp))
+            return;
+
+        performer.Comp ??= EnsureComp<ActionsComponent>(performer);
+
+        if (TryGetActionData(actionId, out var action))
+            AddActionDirect(performer, actionId, performer.Comp, action);
+    }
+
     public IEnumerable<(EntityUid Id, BaseActionComponent Comp)> GetActions(EntityUid holderId, ActionsComponent? actions = null)
     {
         if (!Resolve(holderId, ref actions, false))
@@ -721,6 +739,18 @@ public abstract class SharedActionsSystem : EntitySystem
             if (action.Container == container)
                 RemoveAction(performer, actionId, comp);
         }
+    }
+
+    /// <summary>
+    ///     Removes a single provided action provided by another entity.
+    /// </summary>
+    public void RemoveProvidedAction(EntityUid performer, EntityUid container, EntityUid actionId, ActionsComponent? comp = null)
+    {
+        if (!Resolve(performer, ref comp, false) || !TryGetActionData(actionId, out var action))
+            return;
+
+        if (action.Container == container)
+            RemoveAction(performer, actionId, comp);
     }
 
     public void RemoveAction(EntityUid? actionId)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Some actions need a new attached entity if transferred, so that's why TransferActionWithNewAttached and TransferAllActionsWithNewAttached were added to Action Container System.

Action Container System also listens for the ActionAddedEvent now to grant actions in the Mind Action Container to the player.

Added TransferActionWithNewAttached and TransferAllActionsWithNewAttached and OnActionAdded event method to ActionContainerSystem. These are needed where the action needs to have a different attached entity for usage.  Fixed a bug with not being able to upgrade actions between levels.  Added a way to grant and remove a singular action.

There were some issues upgrading actions and those were fixed.

Most of these are needed for the upcoming magic refactor. I originally included them as part of that PR but it's better that I atomize it down like this.

Will be required for #22568

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

TransferActionWithNewAttached and TransferAllActionsWithNewAttached do the same thing as TransferAction and TransferAllActions but allow you to pass a new attached entity as needed, for those actions that require the attached entity. This is useful for transferring actions from a Spellbook to a Mind, but the Body (Player entity) needs to be the caster.

Action Container System also needed to know when an action was added so that if it was added to the mind action container it will automatically grant the action to the player.

Actions now have a way to grant and ungrant a singular action rather than all of them, as needed.

Previously there was a bug preventing actions from being leveled up if they didn't have a prototype attached to an in between level. ex)
Fireball (standard action granted, level 1)
Action Upgrade => Fireball II (action upgraded from prototype, level 2)
Action Upgrade => Fireball III (action upgraded from prototype, level 4)

It was preventing the action to level up from Level 2 => Level 3 since there was no prototype given. Now it accounts for that so you can have that filler level between Level 2 and 4.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
