### PR TITLE
Fix autodrobe inventory

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -27,9 +27,9 @@
     ClothingHeadHatPumpkin: 2
     ClothingHeadHatShrineMaidenWig: 2
     ClothingOuterSuitShrineMaiden: 2
+    Gohei: 2
     ClothingHeadHatRedRacoon: 2
     ClothingOuterRedRacoon: 2
-    Gohei: 2
     ClothingHeadPaperSack: 2
     ClothingHeadPaperSackSmile: 2
     ClothingEyesBlindfold: 1


### PR DESCRIPTION
sorryyyyyyy i accidentaly splitted shrine maiden uniform and gohei before
now its again 3 shrine maiden things in the row