### PR TITLE
Ore crab drops nerf

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -118,9 +118,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          SpaceQuartz:
-            min: 4
-            max: 6
+          SpaceQuartz1:
+            min: 2
+            max: 4
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -150,8 +150,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           SteelOre1:
-            min: 4
-            max: 6
+            min: 2
+            max: 4
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -181,8 +181,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           UraniumOre1:
-            min: 3
-            max: 6
+            min: 1
+            max: 3
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: PointLight
@@ -214,8 +214,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           SilverOre1:
-            min: 4
-            max: 6
+            min: 1
+            max: 3
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
me when i found out about issues through someone's l33t gamer guide and not a bug report.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The quartz ore crab had the wrong prototype and straight up dropped 4-6 stacks of quartz _ore_ per each one. Absolutely bonkers.

The other ones are pretty bad. For an infinitely respawning enemies, getting a full stack of rare materials like uranium and silver is ludicrous. This nerfs them down to be a bit more sane.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Reduced ore drop rates from anomaly ore crabs.
