### PR TITLE
Species' melee changes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -39,12 +39,12 @@
     bloodReagent: CopperBlood
   # Damage (Others)
   - type: MeleeWeapon
-    animation: WeaponArcClaw
+    animation: WeaponArcBite
     soundHit:
       collection: AlienClaw
     damage:
       types:
-        Slash: 5
+        Pierce: 5
   # Visual & Audio
   - type: DamageVisuals
     damageOverlayGroups:

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -44,7 +44,7 @@
     soundHit:
       path: /Audio/Weapons/pierce.ogg
     angle: 30
-    animation: WeaponArcPunch
+    animation: WeaponArcClaw
     damage:
       types:
         Slash: 5


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Addresses some issues [this PR](https://github.com/space-wizards/space-station-14/pull/23953) neglected to address. Here is what changed:
- Lizards now have the `WeaponArcClaw` melee animation rather than `WeaponArcPunch`
- Spiders now have the `WeaponArcBite` melee animation rather than `WeaponArcClaw`
- Spiders now deal pierce damage, as intended prior to the mixup.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Lizards use their claws to attack, so it should only make sense that that is the animation used. Spiders would likely bite their adversaries, and their fangs would do piercing damage, rather than slash. It was also not intended for spiders to have slashing damage in the first place.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Aexxie
- fix: Lizards' punch animation now matches their damage type
- fix: Spiders now deal piercing damage instead of slash damage when unarmed, as intended. Their animation has been changed to the biting animation as well.