### PR TITLE
Station Map window edges

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
@@ -2,6 +2,7 @@
                xmlns:ui="clr-namespace:Content.Client.Medical.CrewMonitoring"
                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                Title="{Loc 'crew-monitoring-user-interface-title'}"
+               Resizable="False"
                SetSize="1210 700"
                MinSize="1210 700">
     <BoxContainer Orientation="Vertical">
@@ -13,7 +14,7 @@
                         <Label Name="StationName" Text="Unknown station" Align="Center" Margin="0 5 0 3"/>
                     </PanelContainer>
                 </controls:StripeBack>
-                
+
                 <ScrollContainer Name="SensorScroller"
                                  VerticalExpand="True"
                                  SetWidth="520"

--- a/Content.Client/Pinpointer/UI/StationMapWindow.xaml
+++ b/Content.Client/Pinpointer/UI/StationMapWindow.xaml
@@ -2,6 +2,7 @@
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:ui="clr-namespace:Content.Client.Pinpointer.UI"
                       Title="{Loc 'station-map-window-title'}"
+                      Resizable="False"
                       SetSize="666 700"
                       MinSize="666 700">
     <BoxContainer Orientation="Vertical">

--- a/Content.Client/Pinpointer/UI/StationMapWindow.xaml
+++ b/Content.Client/Pinpointer/UI/StationMapWindow.xaml
@@ -3,20 +3,20 @@
                       xmlns:ui="clr-namespace:Content.Client.Pinpointer.UI"
                       Title="{Loc 'station-map-window-title'}"
                       Resizable="False"
-                      SetSize="666 700"
-                      MinSize="666 700">
+                      SetSize="668 713"
+                      MinSize="668 713">
     <BoxContainer Orientation="Vertical">
-        <BoxContainer Orientation="Horizontal" VerticalExpand="True" HorizontalExpand="True">
+        <BoxContainer Orientation="Horizontal"  HorizontalExpand="True" Margin="0 8 0 10" VerticalAlignment="Top">
             <ui:NavMapControl Name="NavMapScreen"/>
         </BoxContainer>
 
         <!-- Footer -->
         <BoxContainer Orientation="Vertical">
             <PanelContainer StyleClasses="LowDivider" />
-            <BoxContainer Orientation="Horizontal" Margin="10 2 5 0" VerticalAlignment="Bottom">
+            <BoxContainer Orientation="Horizontal" Margin="10 0 5 0" VerticalAlignment="Bottom">
                 <Label Text="{Loc 'station-map-user-interface-flavor-left'}" StyleClasses="WindowFooterText" />
                 <Label Text="{Loc 'station-map-user-interface-flavor-right'}" StyleClasses="WindowFooterText"
-                        HorizontalAlignment="Right" HorizontalExpand="True"  Margin="0 0 5 0" />
+                        HorizontalAlignment="Right" HorizontalExpand="True"  Margin="0 0 0 0" />
                 <TextureRect StyleClasses="NTLogoDark" Stretch="KeepAspectCentered"
                         VerticalAlignment="Center" HorizontalAlignment="Right" SetSize="19 19"/>
             </BoxContainer>

--- a/Content.Client/Pinpointer/UI/StationMapWindow.xaml
+++ b/Content.Client/Pinpointer/UI/StationMapWindow.xaml
@@ -16,7 +16,7 @@
             <BoxContainer Orientation="Horizontal" Margin="10 0 5 0" VerticalAlignment="Bottom">
                 <Label Text="{Loc 'station-map-user-interface-flavor-left'}" StyleClasses="WindowFooterText" />
                 <Label Text="{Loc 'station-map-user-interface-flavor-right'}" StyleClasses="WindowFooterText"
-                        HorizontalAlignment="Right" HorizontalExpand="True"  Margin="0 0 0 0" />
+                        HorizontalAlignment="Right" HorizontalExpand="True"  Margin="0 0 2 0" />
                 <TextureRect StyleClasses="NTLogoDark" Stretch="KeepAspectCentered"
                         VerticalAlignment="Center" HorizontalAlignment="Right" SetSize="19 19"/>
             </BoxContainer>

--- a/Content.Client/Pinpointer/UI/StationMapWindow.xaml
+++ b/Content.Client/Pinpointer/UI/StationMapWindow.xaml
@@ -2,6 +2,23 @@
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:ui="clr-namespace:Content.Client.Pinpointer.UI"
                       Title="{Loc 'station-map-window-title'}"
-                      Resizable="False">
-    <ui:NavMapControl Name="NavMapScreen"/>
+                      SetSize="666 700"
+                      MinSize="666 700">
+    <BoxContainer Orientation="Vertical">
+        <BoxContainer Orientation="Horizontal" VerticalExpand="True" HorizontalExpand="True">
+            <ui:NavMapControl Name="NavMapScreen"/>
+        </BoxContainer>
+
+        <!-- Footer -->
+        <BoxContainer Orientation="Vertical">
+            <PanelContainer StyleClasses="LowDivider" />
+            <BoxContainer Orientation="Horizontal" Margin="10 2 5 0" VerticalAlignment="Bottom">
+                <Label Text="{Loc 'station-map-user-interface-flavor-left'}" StyleClasses="WindowFooterText" />
+                <Label Text="{Loc 'station-map-user-interface-flavor-right'}" StyleClasses="WindowFooterText"
+                        HorizontalAlignment="Right" HorizontalExpand="True"  Margin="0 0 5 0" />
+                <TextureRect StyleClasses="NTLogoDark" Stretch="KeepAspectCentered"
+                        VerticalAlignment="Center" HorizontalAlignment="Right" SetSize="19 19"/>
+            </BoxContainer>
+        </BoxContainer>
+    </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Power/PowerMonitoringWindow.xaml
+++ b/Content.Client/Power/PowerMonitoringWindow.xaml
@@ -3,6 +3,7 @@
                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                Title="{Loc 'power-monitoring-window-title'}"
+               Resizable="False"
                SetSize="1120 750"
                MinSize="1120 750">
     <BoxContainer Orientation="Vertical">
@@ -36,7 +37,7 @@
                     <TextureRect Stretch="KeepAspectCentered"
                                  TexturePath="/Textures/Interface/NavMap/beveled_hexagon.png"
                                  SetSize="16 16"
-                                 Modulate="#ff4500"                               
+                                 Modulate="#ff4500"
                                  Margin="20 0 5 0"/>
                     <Label Text="{Loc 'power-monitoring-window-label-smes'}"/>
                     <TextureRect Stretch="KeepAspectCentered"
@@ -53,7 +54,7 @@
                     <Label Text="{Loc 'power-monitoring-window-label-apc'}"/>
                 </BoxContainer>
             </BoxContainer>
-            
+
             <!-- Power status -->
             <BoxContainer Orientation="Vertical" VerticalExpand="True" SetWidth="440" Margin="0 0 10 10">
 
@@ -101,7 +102,7 @@
                 </BoxContainer>
             </BoxContainer>
         </BoxContainer>
-    
+
         <!-- Footer -->
         <BoxContainer Orientation="Vertical">
             <PanelContainer StyleClasses="LowDivider" />

--- a/Resources/Locale/en-US/pinpointer/station_map.ftl
+++ b/Resources/Locale/en-US/pinpointer/station_map.ftl
@@ -1,4 +1,6 @@
 station-map-window-title = Station map
+station-map-user-interface-flavor-left = Don't panic
+station-map-user-interface-flavor-right = v1.42
 
 nav-beacon-window-title = Station Beacon
 nav-beacon-toggle-visible = Visible


### PR DESCRIPTION
## About the PR
Station Maps now have proper edges like the Crew Monitor and Power Monitor. 
All of these windows are also no longer resizable. This never actually did anything useful, just increased the blank space around the edges and potentially annoyed the player who grabbed it too close to the edge when trying to move it

Fixes #15998

## Media

Before
![Screenshot from 2024-01-13 12-54-36](https://github.com/space-wizards/space-station-14/assets/35878406/504e83b5-290a-4749-8b68-3c38875ce37f)

After
![image](https://github.com/space-wizards/space-station-14/assets/35878406/76e3615e-f98b-4e24-8cca-30d42487a034)

[Screenshot from 2024-01-13 12-53-50](https://github.com/space-wizards/space-station-14/assets/35878406/f8c8577c-44c6-469d-8226-e343b31d1138)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- tweak: The empty space around Map UI window edges is no longer resizable.
- fix: Station Map ui now has proper edges.
