### PR TITLE
Add a check for item size in the microwave system

### DIFF
--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.DeviceLinking;
+using Content.Shared.Item;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
@@ -73,6 +74,9 @@ namespace Content.Server.Kitchen.Components
 
         [DataField, ViewVariables(VVAccess.ReadWrite)]
         public int Capacity = 10;
+
+        [DataField("maxItemSize")]
+        public ProtoId<ItemSizePrototype> MaxItemSize = "Normal";
     }
 
     public sealed class BeingMicrowavedEvent : HandledEntityEventArgs

--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -75,7 +75,7 @@ namespace Content.Server.Kitchen.Components
         [DataField, ViewVariables(VVAccess.ReadWrite)]
         public int Capacity = 10;
 
-        [DataField("maxItemSize")]
+        [DataField]
         public ProtoId<ItemSizePrototype> MaxItemSize = "Normal";
     }
 

--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -75,7 +75,7 @@ namespace Content.Server.Kitchen.Components
         [DataField, ViewVariables(VVAccess.ReadWrite)]
         public int Capacity = 10;
 
-        [DataField]
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
         public ProtoId<ItemSizePrototype> MaxItemSize = "Normal";
     }
 

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -283,8 +283,18 @@ namespace Content.Server.Kitchen.EntitySystems
                 return;
             }
 
-            if (!HasComp<ItemComponent>(args.Used))
+            if (TryComp<ItemComponent>(args.Used, out var item))
             {
+                // check if size of an item you're trying to put in is too big
+                if (_item.GetSizePrototype(item.Size) > _item.GetSizePrototype(ent.Comp.MaxItemSize))
+                {
+                    _popupSystem.PopupEntity(Loc.GetString("microwave-component-interact-item-too-big", ("item", args.Used)), ent, args.User);
+                    return;
+                }
+            }
+            else
+            {
+                // check if thing you're trying to put in isn't an item
                 _popupSystem.PopupEntity(Loc.GetString("microwave-component-interact-using-transfer-fail"), ent, args.User);
                 return;
             }
@@ -293,15 +303,6 @@ namespace Content.Server.Kitchen.EntitySystems
             {
                 _popupSystem.PopupEntity(Loc.GetString("microwave-component-interact-full"), ent, args.User);
                 return;
-            }
-
-            if (TryComp<ItemComponent>(args.Used, out var item))
-            {
-                if (_item.GetSizePrototype(item.Size) > _item.GetSizePrototype(ent.Comp.MaxItemSize))
-                {
-                    _popupSystem.PopupEntity(Loc.GetString("microwave-component-interact-item-too-big", ("item", args.Used)), ent, args.User);
-                    return;
-                }
             }
 
             args.Handled = true;

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -51,6 +51,7 @@ namespace Content.Server.Kitchen.EntitySystems
         [Dependency] private readonly TemperatureSystem _temperature = default!;
         [Dependency] private readonly UserInterfaceSystem _userInterface = default!;
         [Dependency] private readonly HandsSystem _handsSystem = default!;
+        [Dependency] private readonly SharedItemSystem _item = default!;
 
         public override void Initialize()
         {
@@ -292,6 +293,15 @@ namespace Content.Server.Kitchen.EntitySystems
             {
                 _popupSystem.PopupEntity(Loc.GetString("microwave-component-interact-full"), ent, args.User);
                 return;
+            }
+
+            if (TryComp<ItemComponent>(args.Used, out var item))
+            {
+                if (_item.GetSizePrototype(item.Size) > _item.GetSizePrototype(ent.Comp.MaxItemSize))
+                {
+                    _popupSystem.PopupEntity(Loc.GetString("microwave-component-interact-item-too-big", ("item", args.Used)), ent, args.User);
+                    return;
+                }
             }
 
             args.Handled = true;

--- a/Resources/Locale/en-US/kitchen/components/microwave-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/microwave-component.ftl
@@ -11,6 +11,7 @@ microwave-component-suicide-multi-head-message = You cook your heads!
 microwave-component-suicide-message = You cook your head!
 microwave-component-upgrade-cook-time = cook time
 microwave-component-interact-full = It's full.
+microwave-component-interact-item-too-big = { CAPITALIZE(THE($item)) } is too big to fit in the microwave!
 
 ## Bound UI
 


### PR DESCRIPTION
## About the PR
This update tackles issue #23800 where the microwave was allowing oversized items, like a large pet carrier, to be placed inside. In MicrowaveSystem.cs, I've made adjustments to now verify the size of the item before allowing it into the microwave. If the item surpasses the specified maximum size in MicrowaveComponent.cs, a popup will notify the player.

## Why / Balance
The modification aims to enhance common sense when using the microwave. Oversized items should not fit into the microwave, aligning with player expectations. This change doesn't significantly impact game balance but contributes to a more immersive experience. Resolves #23800.

## Technical details
The added code in MicrowaveSystem.cs checks the size of the item before allowing it to be placed in the microwave. The MicrowaveComponent.cs introduces a new field, MaxItemSize, to define the maximum size an item can have to be eligible for microwaving.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No breaking changes are introduced with this pull request.

**Changelog**
:cl:
- fix: Prevent oversized items from being placed in the microwave.
