### PR TITLE
Fix emergency flare not igniting through verb menu.

### DIFF
--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -99,6 +99,9 @@ namespace Content.Server.Light.EntitySystems
                     _item.SetHeldPrefix(ent, "lit", component: item);
                 }
 
+                var isHotEvent = new IsHotEvent() {IsHot = true};
+                RaiseLocalEvent(ent, isHotEvent);
+
                 component.CurrentState = ExpendableLightState.Lit;
                 component.StateExpiryTime = component.GlowDuration;
 
@@ -175,8 +178,6 @@ namespace Content.Server.Light.EntitySystems
             if (args.Handled)
                 return;
 
-            var isHotEvent = new IsHotEvent() {IsHot = true};
-            RaiseLocalEvent(ent, isHotEvent);
             if (TryActivate(ent))
                 args.Handled = true;
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
resolves #24020 
An expendable light source that is supposed to ignite the surrounding area when turned on now also ignites when turned on through the verb menu.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Moved the IsHotEvent to TryActivate instead of OnExpLightUse.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- fix: Expendable light sources turned on through the verb menu now ignite the surrounding area.

