### PR TITLE
Cerberus has AI

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -54,9 +54,12 @@
         Slash: 7
   - type: InputMover
   - type: MobMover
+  - type: HTN
+    rootTask:
+      task: SimpleHostileCompound
   - type: NpcFactionMember
     factions:
-    - SimpleNeutral
+    - Syndicate
   - type: InteractionPopup
     successChance: 0.5
     interactSuccessString: petting-success-corrupted-corgi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When a player playing as cerberus disconnects; it will default to hostile AI.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Cerberus should be able to assist the chaplain even if the player disconnects

:cl: Whisper
- add: Cerberus now has hostile AI
