### PR TITLE
decelerator nerf and projectile penetration mini refactor

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -71,17 +71,20 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 
         component.DamagedEntity = true;
 
-        if (component.CanPenetrate)
+        if (component.DeleteOnCollide)
+            QueueDel(uid);
+
+        if (component.DamageAfterCollide)
         {
             component.DamagedEntity = false;
 
-            if (component.DeleteOnCollide && !HasComp<MobStateComponent>(target))
-                QueueDel(uid);
+            if (component.CanOnlyPenetrateMobs)
+            {
+                if (!HasComp<MobStateComponent>(target))
+                    QueueDel(uid);
+            }
         }
-        else if (component.DeleteOnCollide)
-        {
-            QueueDel(uid);
-        }
+
 
         if (component.ImpactEffect != null && TryComp<TransformComponent>(uid, out var xform))
         {

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -5,9 +5,7 @@ using Content.Shared.Camera;
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.Projectiles;
-using Robust.Server.GameObjects;
 using Robust.Shared.Physics.Events;
-using Content.Shared.Mobs.Components;
 using Robust.Shared.Player;
 
 namespace Content.Server.Projectiles;
@@ -71,20 +69,11 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 
         component.DamagedEntity = true;
 
+        var afterProjectileHitEvent = new AfterProjectileHitEvent(component.Damage, target, args.OtherFixture);
+        RaiseLocalEvent(uid, ref afterProjectileHitEvent);
+
         if (component.DeleteOnCollide)
             QueueDel(uid);
-
-        if (component.DamageAfterCollide)
-        {
-            component.DamagedEntity = false;
-
-            if (component.CanOnlyPenetrateMobs)
-            {
-                if (!HasComp<MobStateComponent>(target))
-                    QueueDel(uid);
-            }
-        }
-
 
         if (component.ImpactEffect != null && TryComp<TransformComponent>(uid, out var xform))
         {

--- a/Content.Shared/Projectiles/CanPenetrateComponent.cs
+++ b/Content.Shared/Projectiles/CanPenetrateComponent.cs
@@ -1,0 +1,42 @@
+using Content.Shared.FixedPoint;
+using Content.Shared.Physics;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Projectiles;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CanPenetrateComponent : Component
+{
+    /// <summary>
+    ///     Should the projectile keep the ability to deal damage after colliding.
+    /// </summary>
+    [DataField]
+    public bool DamageAfterCollide = true;
+
+    /// <summary>
+    ///     The CollisionLayer, up to and including the one set, the projectile is allowed to penetrate.
+    /// </summary>
+    ///<remarks>
+    ///     Can penetrate everything if this value is not set.
+    /// </remarks>
+    [DataField]
+    public CollisionGroup? PenetrationLayer;
+
+    /// <summary>
+    ///     How many times the projectile is allowed to deal damage.
+    /// </summary>
+    /// <remarks>
+    ///     Can deal damage on every collision if this value is not set.
+    /// </remarks>
+    [DataField]
+    public float? PenetrationPower;
+
+    /// <summary>
+    ///     Modifies the damage of a projectile after it has penetrated an entity.
+    /// </summary>
+    /// <remarks>
+    ///     Won't modify the projectile's damage if this value is not set.
+    /// </remarks>
+    [DataField]
+    public FixedPoint2? DamageModifier;
+}

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -66,7 +66,9 @@ public sealed partial class ProjectileComponent : Component
     [DataField]
     public bool IgnoreResistances = false;
 
-    // Get that juicy FPS hit sound
+    /// <summary>
+    ///     Get that juicy FPS hit sound.
+    /// </summary>
     [DataField]
     public SoundSpecifier? SoundHit;
 
@@ -77,7 +79,7 @@ public sealed partial class ProjectileComponent : Component
     public bool ForceSound = false;
 
     /// <summary>
-    ///     Whether this projectile will only collide with entities if it was shot from a gun (if <see cref="Weapon"/> is not null)
+    ///     Whether this projectile will only collide with entities if it was shot from a gun (if <see cref="Weapon"/> is not null).
     /// </summary>
     [DataField]
     public bool OnlyCollideWhenShot = false;

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -9,37 +9,37 @@ namespace Content.Shared.Projectiles;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ProjectileComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("impactEffect", customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
+    [ViewVariables(VVAccess.ReadWrite), DataField(customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string? ImpactEffect;
 
     /// <summary>
     ///     User that shot this projectile.
     /// </summary>
-    [DataField("shooter"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public EntityUid? Shooter;
 
     /// <summary>
     ///     Weapon used to shoot.
     /// </summary>
-    [DataField("weapon"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public EntityUid? Weapon;
 
     /// <summary>
     ///     The projectile spawns inside the shooter most of the time, this prevents entities from shooting themselves.
     /// </summary>
-    [DataField("ignoreShooter"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool IgnoreShooter = true;
 
     /// <summary>
     ///     The amount of damage the projectile will do.
     /// </summary>
-    [DataField("damage", required: true)] [ViewVariables(VVAccess.ReadWrite)]
+    [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite)]
     public DamageSpecifier Damage = new();
 
     /// <summary>
     ///     If the target should be deleted on collision.
     /// </summary>
-    [DataField("deleteOnCollide")]
+    [DataField]
     public bool DeleteOnCollide = true;
 
     /// <summary>

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -9,8 +9,11 @@ namespace Content.Shared.Projectiles;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ProjectileComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField(customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string? ImpactEffect;
+    /// <summary>
+    ///     The effect that appears when a projectile collides with an entity.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public EntProtoId? ImpactEffect;
 
     /// <summary>
     ///     User that shot this projectile.
@@ -64,7 +67,8 @@ public sealed partial class ProjectileComponent : Component
     public bool IgnoreResistances = false;
 
     // Get that juicy FPS hit sound
-    [DataField] public SoundSpecifier? SoundHit;
+    [DataField]
+    public SoundSpecifier? SoundHit;
 
     /// <summary>
     ///     Force the projectiles sound to play rather than potentially playing the entity's sound.

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -13,46 +13,74 @@ public sealed partial class ProjectileComponent : Component
     public string? ImpactEffect;
 
     /// <summary>
-    /// User that shot this projectile.
+    ///     User that shot this projectile.
     /// </summary>
     [DataField("shooter"), AutoNetworkedField]
     public EntityUid? Shooter;
 
     /// <summary>
-    /// Weapon used to shoot.
+    ///     Weapon used to shoot.
     /// </summary>
     [DataField("weapon"), AutoNetworkedField]
     public EntityUid? Weapon;
 
+    /// <summary>
+    ///     The projectile spawns inside the shooter most of the time, this prevents entities from shooting themselves.
+    /// </summary>
     [DataField("ignoreShooter"), AutoNetworkedField]
     public bool IgnoreShooter = true;
 
+    /// <summary>
+    ///     The amount of damage the projectile will do.
+    /// </summary>
     [DataField("damage", required: true)] [ViewVariables(VVAccess.ReadWrite)]
     public DamageSpecifier Damage = new();
 
+    /// <summary>
+    ///     If the target should be deleted on collision.
+    /// </summary>
     [DataField("deleteOnCollide")]
     public bool DeleteOnCollide = true;
 
-    [DataField("canPenetrate")]
-    public bool CanPenetrate = false;
+    /// <summary>
+    ///     If the projectile should keep the ability to deal damage after colliding.
+    /// </summary>
+    [DataField]
+    public bool DamageAfterCollide = false;
 
-    [DataField("ignoreResistances")]
+    /// <summary>
+    ///     Penetrate the target only if it has the MobStateComponent.
+    /// </summary>
+    /// <remarks>
+    ///     DeleteOnCollide needs to be false for this to work.
+    /// </remarks>
+    [DataField]
+    public bool CanOnlyPenetrateMobs = false;
+
+    /// <summary>
+    ///     Ignore all damage resistances the target has.
+    /// </summary>
+    [DataField]
     public bool IgnoreResistances = false;
 
     // Get that juicy FPS hit sound
-    [DataField("soundHit")] public SoundSpecifier? SoundHit;
+    [DataField] public SoundSpecifier? SoundHit;
 
-    [DataField("soundForce")]
+    /// <summary>
+    ///     Force the projectiles sound to play rather than potentially playing the entity's sound.
+    /// </summary>
+    [DataField]
     public bool ForceSound = false;
 
     /// <summary>
     ///     Whether this projectile will only collide with entities if it was shot from a gun (if <see cref="Weapon"/> is not null)
     /// </summary>
-    [DataField("onlyCollideWhenShot")]
+    [DataField]
     public bool OnlyCollideWhenShot = false;
 
     /// <summary>
     ///     Whether this projectile has already damaged an entity.
     /// </summary>
+    [DataField]
     public bool DamagedEntity;
 }

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -2,7 +2,6 @@ using Content.Shared.Damage;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Projectiles;
 
@@ -40,25 +39,10 @@ public sealed partial class ProjectileComponent : Component
     public DamageSpecifier Damage = new();
 
     /// <summary>
-    ///     If the target should be deleted on collision.
+    ///     If the projectile should be deleted on collision.
     /// </summary>
     [DataField]
     public bool DeleteOnCollide = true;
-
-    /// <summary>
-    ///     If the projectile should keep the ability to deal damage after colliding.
-    /// </summary>
-    [DataField]
-    public bool DamageAfterCollide = false;
-
-    /// <summary>
-    ///     Penetrate the target only if it has the MobStateComponent.
-    /// </summary>
-    /// <remarks>
-    ///     DeleteOnCollide needs to be false for this to work.
-    /// </remarks>
-    [DataField]
-    public bool CanOnlyPenetrateMobs = false;
 
     /// <summary>
     ///     Ignore all damage resistances the target has.

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -172,7 +172,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         if (!TryComp<CanPenetrateComponent>(uid, out var damageAfterCollide))
             return;
 
-        //Delete the projectile if it hits an entity with a CollisionLayer bigger higher than it's PenetrationLayer.
+        //Delete the projectile if it hits an entity with a CollisionLayer that has a higher value than it's PenetrationLayer.
         //This allows a projectile to only penetrate a specific set of entities.
         if (damageAfterCollide.PenetrationLayer != null)
         {
@@ -197,7 +197,8 @@ public abstract partial class SharedProjectileSystem : EntitySystem
             component.Damage *= damageAfterCollide.DamageModifier.Value;
 
         //Overrides the original DeleteOnCollide if the projectile passes all penetration checks.
-        //This is to prevent having to set DeleteOnCollide to false every time you want to make a projectile penetrate.
+        //This is to prevent having to set DeleteOnCollide to false on every prototype
+        //you want to give the ability to penetrate entities.
         if(component.DeleteOnCollide)
             component.DeleteOnCollide = false;
     }

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -4,12 +4,14 @@ using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization;
@@ -32,6 +34,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ProjectileComponent, PreventCollideEvent>(PreventCollision);
+        SubscribeLocalEvent<ProjectileComponent, AfterProjectileHitEvent>(AfterProjectileHit);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ProjectileHitEvent>(OnEmbedProjectileHit);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ThrowDoHitEvent>(OnEmbedThrowDoHit);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ActivateInWorldEvent>(OnEmbedActivate);
@@ -160,6 +163,44 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     {
         args.Cancel("pacified-cannot-throw-embed");
     }
+
+    /// <summary>
+    /// Checks if the projectile is allowed to penetrate the target it hit.
+    /// </summary>
+    private void AfterProjectileHit(EntityUid uid, ProjectileComponent component, ref AfterProjectileHitEvent args)
+    {
+        if (!TryComp<CanPenetrateComponent>(uid, out var damageAfterCollide))
+            return;
+
+        //Delete the projectile if it hits an entity with a CollisionLayer bigger higher than it's PenetrationLayer.
+        //This allows a projectile to only penetrate a specific set of entities.
+        if (damageAfterCollide.PenetrationLayer != null)
+        {
+            if (args.Fixture.CollisionLayer > (int) damageAfterCollide.PenetrationLayer ||
+                damageAfterCollide.PenetrationPower == 0)
+            {
+                QueueDel(uid);
+                return;
+            }
+        }
+
+        //Allow the projectile to deal damage again.
+        if(damageAfterCollide.DamageAfterCollide)
+            component.DamagedEntity = false;
+
+        //If the projectile has a limit on the amount of penetrations, reduce it.
+        if (damageAfterCollide.PenetrationPower != null)
+            damageAfterCollide.PenetrationPower -= 1;
+
+        //Apply the penetration damage modifier if the projectile has one.
+        if (damageAfterCollide.DamageModifier != null)
+            component.Damage *= damageAfterCollide.DamageModifier.Value;
+
+        //Overrides the original DeleteOnCollide if the projectile passes all penetration checks.
+        //This is to prevent having to set DeleteOnCollide to false every time you want to make a projectile penetrate.
+        if(component.DeleteOnCollide)
+            component.DeleteOnCollide = false;
+    }
 }
 
 [Serializable, NetSerializable]
@@ -186,3 +227,9 @@ public record struct ProjectileReflectAttemptEvent(EntityUid ProjUid, Projectile
 /// </summary>
 [ByRefEvent]
 public record struct ProjectileHitEvent(DamageSpecifier Damage, EntityUid Target, EntityUid? Shooter = null);
+
+/// <summary>
+/// Raised after a projectile has dealt it's damage.
+/// </summary>
+[ByRefEvent]
+public record struct AfterProjectileHitEvent(DamageSpecifier Damage, EntityUid Target, Fixture Fixture);

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
@@ -9,11 +9,11 @@
     state: buckshot
   - type: Projectile
     deleteOnCollide: false
-    damageAfterCollide: true
-    canOnlyPenetrateMobs: true
     damage:
       types:
         Blunt: 4
+  - type: CanPenetrate
+    penetrationLayer: MobLayer
   - type: StaminaDamageOnCollide
     damage: 55
   - type: TimedDespawn
@@ -30,11 +30,11 @@
     state: buckshot
   - type: Projectile
     deleteOnCollide: false
-    damageAfterCollide: true
-    canOnlyPenetrateMobs: true
     damage:
       types:
         Piercing: 45
+  - type: CanPenetrate
+    penetrationLayer: MobLayer
   - type: TimedDespawn
     lifetime: 0.25
 
@@ -49,12 +49,12 @@
     state: buckshot-flare
   - type: Projectile
     deleteOnCollide: false
-    damageAfterCollide: true
-    canOnlyPenetrateMobs: true
     damage:
       types:
         Blunt: 1
         Heat: 2
+  - type: CanPenetrate
+    penetrationLayer: MobLayer
   - type: IgniteOnCollide
     fireStacks: 3
     count: 10

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
@@ -9,6 +9,7 @@
     state: buckshot
   - type: Projectile
     deleteOnCollide: false
+    damageAfterCollide: true
     canOnlyPenetrateMobs: true
     damage:
       types:
@@ -29,6 +30,7 @@
     state: buckshot
   - type: Projectile
     deleteOnCollide: false
+    damageAfterCollide: true
     canOnlyPenetrateMobs: true
     damage:
       types:
@@ -47,6 +49,7 @@
     state: buckshot-flare
   - type: Projectile
     deleteOnCollide: false
+    damageAfterCollide: true
     canOnlyPenetrateMobs: true
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
@@ -9,7 +9,7 @@
     state: buckshot
   - type: Projectile
     deleteOnCollide: false
-    canPenetrate: true
+    canOnlyPenetrateMobs: true
     damage:
       types:
         Blunt: 4
@@ -29,7 +29,7 @@
     state: buckshot
   - type: Projectile
     deleteOnCollide: false
-    canPenetrate: true
+    canOnlyPenetrateMobs: true
     damage:
       types:
         Piercing: 45
@@ -47,7 +47,7 @@
     state: buckshot-flare
   - type: Projectile
     deleteOnCollide: false
-    canPenetrate: true
+    canOnlyPenetrateMobs: true
     damage:
       types:
         Blunt: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -210,7 +210,7 @@
         Heat: 5
     soundHit:
       path: "/Audio/Weapons/Guns/Hits/taser_hit.ogg"
-    soundForce: true
+    forceSound: true
   - type: StunOnCollide
     stunAmount: 5
     knockdownAmount: 5
@@ -256,7 +256,7 @@
         Heat: 5
     soundHit:
       path: "/Audio/Weapons/tap.ogg"
-    soundForce: true
+    forceSound: true
 
 - type: entity
   name : disabler bolt practice
@@ -296,7 +296,7 @@
         Heat: 1
     soundHit:
       path: "/Audio/Weapons/tap.ogg"
-    soundForce: true
+    forceSound: true
 
 - type: entity
   name: emitter bolt
@@ -865,7 +865,7 @@
         Heat: 2
     soundHit:
       path: "/Audio/Weapons/tap.ogg"
-    soundForce: true
+    forceSound: true
 
 - type: entity
   name: tesla gun lightning

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -13,13 +13,13 @@
         map: [ "unshaded" ]
     - type: Projectile
       deleteOnCollide: false
-      damageAfterCollide: true
       impactEffect: null
       soundHit:
         path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
       damage:
         types:
           Radiation: 25
+    - type: CanPenetrate
     - type: Physics
     - type: Fixtures
       fixtures:
@@ -69,7 +69,6 @@
     - Energy
   - type: Projectile
     deleteOnCollide: false
-    damageAfterCollide: true
     impactEffect: null
     soundHit:
       path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -13,7 +13,7 @@
         map: [ "unshaded" ]
     - type: Projectile
       deleteOnCollide: false
-      canPenetrate: true
+      damageAfterCollide: true
       impactEffect: null
       soundHit:
         path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
@@ -64,5 +64,19 @@
       state: particle0
       shader: unshaded
       map: [ "unshaded" ]
+  - type: Reflective
+    reflective:
+    - Energy
+  - type: Projectile
+    deleteOnCollide: false
+    damageAfterCollide: true
+    impactEffect: null
+    soundHit:
+      path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
+    damage:
+      types:
+        Radiation: 10
+  - type: TimedDespawn
+    lifetime: 0.6
   - type: SinguloFood
     energy: -10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
resolves #23956 
Nerfs the particle decelerator's projectile damage and lifetime, it now also belongs to the "Energy" type and can be reflected by reflective entities.

Fixes some projectile collision stuff that made it so bullet grenade projectiles were able to penetrate walls.
The reason this is in this PR is because while adjusting the decelerator projectile values I noticed it had a component value that it shouldn't have. This is probably because I named that component value wrongly when I added it with the bullet grenades ,which made it get added particle projectiles. To fix a bug with decelerator projectiles the logic got changed but this broke the bullet grenade projectiles.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The damage was way too high for a tool that isn't even supposed to be a weapon, the projectiles penetrating walls with a range of around 75 tiles makes it even worse.
Damage lowered from 25 to 10 and projectile lifetime reduced from 3 to 0.6 seconds, the lowered lifetime should still allow it to be used on singularities, because it's still a range of around 15 tiles.
The projectile has been made reflective so energy shields and swords can reflect it so there is a way to defend yourself against the wall penetrating projectiles.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added a new event handler that checks if a projectile should penetrate based on the values gives to the new CanPenetrateComponent.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- tweak: The particle decelerator's projectile now deals less damage, has a shorter lifespan and can be reflected by objects that reflect energy projectiles.
- fix: Bullet grenade projectiles no longer penetrate walls.
