### PR TITLE
Makes Eggs drawable with a syringe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -24,6 +24,8 @@
         reagents:
         - ReagentId: Egg
           Quantity: 6
+  - type: DrawableSolution
+    solution: food
   - type: SolutionSpiker
     sourceSolution: food
     ignoreEmpty: true


### PR DESCRIPTION
## About the PR
Eggs can now be emptied by syringe.

## Why / Balance
Eggs could be injected but, being always 6/6, that never worked. Empty eggs can now be used for fun surprises to throw at people. Or things.

## Technical details
Yaml adds component.

## Media
N/A

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Eggs can be drawn from with a syringe.
