### PR TITLE
Fixes round restart audio clipping

### DIFF
--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -144,6 +144,10 @@ public sealed class BackgroundAudioSystem : EntitySystem
             return;
         }
 
-        _audio.PlayGlobal(file, Filter.Local(), false, _lobbyParams.WithVolume(_lobbyParams.Volume + SharedAudioSystem.GainToVolume(_configManager.GetCVar(CCVars.LobbyMusicVolume))));
+        var volume = _lobbyParams.WithVolume(_lobbyParams.Volume +
+                                             SharedAudioSystem.GainToVolume(
+                                                 _configManager.GetCVar(CCVars.LobbyMusicVolume)));
+
+        _audio.PlayGlobal(file, Filter.Local(), false, volume);
     }
 }

--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -1,6 +1,7 @@
 using Content.Client.GameTicking.Managers;
 using Content.Client.Lobby;
 using Content.Shared.CCVar;
+using Content.Shared.GameTicking;
 using JetBrains.Annotations;
 using Robust.Client;
 using Robust.Client.State;
@@ -39,6 +40,8 @@ public sealed class BackgroundAudioSystem : EntitySystem
         _client.PlayerLeaveServer += OnLeave;
 
         _gameTicker.LobbySongUpdated += LobbySongUpdated;
+
+        SubscribeNetworkEvent<RoundRestartCleanupEvent>(PlayRestartSound);
     }
 
     public override void Shutdown()
@@ -128,5 +131,19 @@ public sealed class BackgroundAudioSystem : EntitySystem
     private void EndLobbyMusic()
     {
         LobbyStream = _audio.Stop(LobbyStream);
+    }
+
+    private void PlayRestartSound(RoundRestartCleanupEvent ev)
+    {
+        if (!_configManager.GetCVar(CCVars.LobbyMusicEnabled))
+            return;
+
+        var file = _gameTicker.RestartSound;
+        if (string.IsNullOrEmpty(file))
+        {
+            return;
+        }
+
+        _audio.PlayGlobal(file, Filter.Local(), false, _lobbyParams.WithVolume(_lobbyParams.Volume + SharedAudioSystem.GainToVolume(_configManager.GetCVar(CCVars.LobbyMusicVolume))));
     }
 }

--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -35,6 +35,7 @@ namespace Content.Client.GameTicking.Managers
         [ViewVariables] public bool AreWeReady { get; private set; }
         [ViewVariables] public bool IsGameStarted { get; private set; }
         [ViewVariables] public string? LobbySong { get; private set; }
+        [ViewVariables] public string? RestartSound { get; private set; }
         [ViewVariables] public string? LobbyBackground { get; private set; }
         [ViewVariables] public bool DisallowedLateJoin { get; private set; }
         [ViewVariables] public string? ServerInfoBlob { get; private set; }
@@ -151,6 +152,7 @@ namespace Content.Client.GameTicking.Managers
         {
             // Force an update in the event of this song being the same as the last.
             SetLobbySong(message.LobbySong, true);
+            RestartSound = message.RestartSound;
 
             // Don't open duplicate windows (mainly for replays).
             if (_window?.RoundId == message.RoundId)

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -385,9 +385,10 @@ namespace Content.Server.GameTicking
 
             // This ordering mechanism isn't great (no ordering of minds) but functions
             var listOfPlayerInfoFinal = listOfPlayerInfo.OrderBy(pi => pi.PlayerOOCName).ToArray();
+            var sound = _audio.GetSound(new SoundCollectionSpecifier("RoundEnd"));
 
             RaiseNetworkEvent(new RoundEndMessageEvent(gamemodeTitle, roundEndText, roundDuration, RoundId,
-                listOfPlayerInfoFinal.Length, listOfPlayerInfoFinal, LobbySong, _audio.GetSound(new SoundCollectionSpecifier("RoundEnd"))));
+                listOfPlayerInfoFinal.Length, listOfPlayerInfoFinal, LobbySong, sound));
         }
 
         private async void SendRoundEndDiscordMessage()

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -387,7 +387,7 @@ namespace Content.Server.GameTicking
             var listOfPlayerInfoFinal = listOfPlayerInfo.OrderBy(pi => pi.PlayerOOCName).ToArray();
 
             RaiseNetworkEvent(new RoundEndMessageEvent(gamemodeTitle, roundEndText, roundDuration, RoundId,
-                listOfPlayerInfoFinal.Length, listOfPlayerInfoFinal, LobbySong));
+                listOfPlayerInfoFinal.Length, listOfPlayerInfoFinal, LobbySong, _audio.GetSound(new SoundCollectionSpecifier("RoundEnd"))));
         }
 
         private async void SendRoundEndDiscordMessage()

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -175,7 +175,8 @@ namespace Content.Shared.GameTicking
             int roundId,
             int playerCount,
             RoundEndPlayerInfo[] allPlayersEndInfo,
-            string? lobbySong)
+            string? lobbySong,
+            string? restartSound)
         {
             GamemodeTitle = gamemodeTitle;
             RoundEndText = roundEndText;
@@ -184,6 +185,7 @@ namespace Content.Shared.GameTicking
             PlayerCount = playerCount;
             AllPlayersEndInfo = allPlayersEndInfo;
             LobbySong = lobbySong;
+            RestartSound = restartSound;
         }
     }
 

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -166,6 +166,10 @@ namespace Content.Shared.GameTicking
         public int PlayerCount { get; }
         public RoundEndPlayerInfo[] AllPlayersEndInfo { get; }
         public string? LobbySong;
+
+        /// <summary>
+        /// Sound gets networked due to how entity lifecycle works between client / server and to avoid clipping.
+        /// </summary>
         public string? RestartSound;
 
         public RoundEndMessageEvent(


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Another pass at fixing round restart audio based on using the background audio system client-side.

IDK why I'm addicted to mucking around with the lobby screen

## Technical details
Partial revert of my prior PR (turns out transmitting it out to clients _is_ smarter)

## Media
Can't link sound effects here :(

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Lobby restart sound effects no longer cut-off.
