### PR TITLE
Desk bells can be rung with activate

### DIFF
--- a/Content.Server/Interaction/Components/InteractionPopupComponent.cs
+++ b/Content.Server/Interaction/Components/InteractionPopupComponent.cs
@@ -76,4 +76,10 @@ public sealed partial class InteractionPopupComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan LastInteractTime;
+
+    /// <summary>
+    /// If set to true, activate interactions will also trigger the component.
+    /// </summary>
+    [DataField]
+    public bool OnActivate;
 }

--- a/Content.Server/Interaction/InteractionPopupSystem.cs
+++ b/Content.Server/Interaction/InteractionPopupSystem.cs
@@ -20,6 +20,7 @@ public sealed class InteractionPopupSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
@@ -83,7 +84,7 @@ public sealed class InteractionPopupSystem : EntitySystem
                 sfx = component.InteractSuccessSound;
 
             if (component.InteractSuccessSpawn != null)
-                Spawn(component.InteractSuccessSpawn, Transform(uid).MapPosition);
+                Spawn(component.InteractSuccessSpawn, _transform.GetMapCoordinates(uid));
         }
         else
         {
@@ -94,7 +95,7 @@ public sealed class InteractionPopupSystem : EntitySystem
                 sfx = component.InteractFailureSound;
 
             if (component.InteractFailureSpawn != null)
-                Spawn(component.InteractFailureSpawn, Transform(uid).MapPosition);
+                Spawn(component.InteractFailureSpawn, _transform.GetMapCoordinates(uid));
         }
 
         if (component.MessagePerceivedByOthers != null)

--- a/Resources/Prototypes/Entities/Objects/Misc/desk_bell.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/desk_bell.yml
@@ -14,6 +14,7 @@
     params:
       variation: 0.03
       volume: 3
+    onActivate: true
   - type: EmitSoundOnUse
     sound:
       collection: DeskBell


### PR DESCRIPTION
Important

## Technical details
`InteractopPopup` has a new `onActivate` data field that allows it to be triggered on activate.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
