### PR TITLE
Fix error when switching to a screen without an inventory gui widget

### DIFF
--- a/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
@@ -57,8 +57,8 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
         if (UIManager.ActiveScreen == null)
             return;
 
-        var inventoryGui = UIManager.GetActiveUIWidget<InventoryGui>();
-        RegisterInventoryButton(inventoryGui.InventoryButton);
+        if (UIManager.GetActiveUIWidgetOrNull<InventoryGui>() is { } inventoryGui)
+            RegisterInventoryButton(inventoryGui.InventoryButton);
     }
 
     public void OnStateEntered(GameplayState state)


### PR DESCRIPTION
## About the PR
This broke the mapping editor downstream. Again.
The error happens because this runs on any screen load, even those that may not contain an inventory button.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
