### PR TITLE
Add map recenter target

### DIFF
--- a/Content.Client/Pinpointer/UI/NavMapControl.cs
+++ b/Content.Client/Pinpointer/UI/NavMapControl.cs
@@ -58,6 +58,7 @@ public partial class NavMapControl : MapGridControl
     private bool _draggin;
     private Vector2 _startDragPosition = default!;
     private bool _recentering = false;
+    private Vector2 _recentering_target = Vector2.Zero;
     private float _updateTimer = 0.25f;
     private Dictionary<Color, Color> _sRGBLookUp = new Dictionary<Color, Color>();
     public Color _backgroundColor;
@@ -145,7 +146,7 @@ public partial class NavMapControl : MapGridControl
 
         _recenter.OnPressed += args =>
         {
-            _recentering = true;
+            ForceRecenter();
         };
 
         ForceNavMapUpdate();
@@ -154,6 +155,7 @@ public partial class NavMapControl : MapGridControl
     public void ForceRecenter()
     {
         _recentering = true;
+        _recentering_target = Vector2.Zero;
     }
 
     public void ForceNavMapUpdate()
@@ -279,11 +281,11 @@ public partial class NavMapControl : MapGridControl
         if (_recentering)
         {
             var frameTime = Timing.FrameTime;
-            var diff = _offset * (float) frameTime.TotalSeconds;
+            var diff = (_offset - _recentering_target) * (float) frameTime.TotalSeconds;
 
-            if (_offset.LengthSquared() < RecenterMinimum)
+            if ((_offset - _recentering_target).LengthSquared() < RecenterMinimum)
             {
-                _offset = Vector2.Zero;
+                _offset = _recentering_target;
                 _recentering = false;
                 _recenter.Disabled = true;
             }

--- a/Content.Client/Pinpointer/UI/StationMapWindow.xaml.cs
+++ b/Content.Client/Pinpointer/UI/StationMapWindow.xaml.cs
@@ -15,7 +15,7 @@ public sealed partial class StationMapWindow : FancyWindow
         NavMapScreen.MapUid = mapUid;
 
         if (trackedEntity != null)
-            NavMapScreen.TrackedCoordinates.Add(new EntityCoordinates(trackedEntity.Value, Vector2.Zero), (true, Color.Red));
+            NavMapScreen.TrackedCoordinates.Add(new EntityCoordinates(trackedEntity.Value, Vector2.Zero), (true, Color.Cyan));
 
         if (IoCManager.Resolve<IEntityManager>().TryGetComponent<MetaDataComponent>(mapUid, out var metadata))
         {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
IMO, the "Recenter" button on station map should center the map view on player position. This PR aims to do that.

Also, clicking on crew names in the health scanner should focus view on said crew.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
By setting `_recentering_target`, the map view center will pan to that.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
