### PR TITLE
Fix admins unable to hide the coordinates debug monitor

### DIFF
--- a/Content.Client/DebugMon/DebugMonitorSystem.cs
+++ b/Content.Client/DebugMon/DebugMonitorSystem.cs
@@ -19,7 +19,5 @@ public sealed class DebugMonitorSystem : EntitySystem
     {
         if (!_admin.IsActive() && _cfg.GetCVar(CCVars.DebugCoordinatesAdminOnly))
             _userInterface.DebugMonitors.SetMonitor(DebugMonitor.Coords, false);
-        else
-            _userInterface.DebugMonitors.SetMonitor(DebugMonitor.Coords, true);
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fix a tiny bug related to the F3 debug thingy.

**Reproduction**: Being an admin, press F3 to open debug monitors, then in the console type either `monitor -all` or `monitor Coords` to hide the coordinates monitor

**Expected behavior**: The coordinates monitor should hide

**Actual behavior**: The coordinates monitor visibility gets reset each frame, keeping it always visible

## Media

<img width="302" alt="image" src="https://github.com/space-wizards/space-station-14/assets/1192090/0f043909-adea-4e21-b623-4e5e083b1074">

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
