### PR TITLE
Nerf and Add More Reagent Slimes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -508,9 +508,6 @@
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
         color: "#D2FFFA"
-  - type: MeleeChemicalInjector
-    solution: bloodstream
-    transferAmount: 5
 
 - type: entity
   id: ReagentSlimeRobustHarvest

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -264,7 +264,7 @@
     animation: WeaponArcBite
     damage:
       types:
-        Slash: 15
+        Slash: 8
   - type: MeleeChemicalInjector
     solution: bloodstream
     transferAmount: 5
@@ -310,6 +310,10 @@
         - ReagentSlimeToxin
         - ReagentSlimeNapalm
         - ReagentSlimeOmnizine
+        - ReagentSlimeMuteToxin
+        - ReagentSlimeNorepinephricAcid
+        - ReagentSlimeEphedrine
+        - ReagentSlimeRobustHarvest
       chance: 1
 
 - type: entity
@@ -345,6 +349,9 @@
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
         color: "#AAAAAA"
+  - type: MeleeChemicalInjector
+    solution: bloodstream
+    transferAmount: 1
 
 - type: entity
   id: ReagentSlimeNocturine
@@ -362,6 +369,9 @@
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
         color: "#128e80"
+  - type: MeleeChemicalInjector
+    solution: bloodstream
+    transferAmount: 3
 
 - type: entity
   id: ReagentSlimeTHC
@@ -447,3 +457,74 @@
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
         color: "#fcf7f9"
+
+- type: entity
+  id: ReagentSlimeMuteToxin
+  parent: ReagentSlime
+  suffix: Mute Toxin
+  components:
+  - type: Bloodstream
+    bloodReagent: MuteToxin
+  - type: PointLight
+    color: "#0f0f0f"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#0f0f0f"
+
+- type: entity
+  id: ReagentSlimeNorepinephricAcid
+  parent: ReagentSlime
+  suffix: Norepinephric Acid
+  components:
+  - type: Bloodstream
+    bloodReagent: NorepinephricAcid
+  - type: PointLight
+    color: "#96a8b5"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#96a8b5"
+
+- type: entity
+  id: ReagentSlimeEphedrine
+  parent: ReagentSlime
+  suffix: Ephedrine
+  components:
+  - type: Bloodstream
+    bloodReagent: Ephedrine
+  - type: PointLight
+    color: "#D2FFFA"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#D2FFFA"
+  - type: MeleeChemicalInjector
+    solution: bloodstream
+    transferAmount: 5
+
+- type: entity
+  id: ReagentSlimeRobustHarvest
+  parent: ReagentSlime
+  suffix: Robust Harvest
+  components:
+  - type: Bloodstream
+    bloodReagent: RobustHarvest
+  - type: PointLight
+    color: "#3e901c"
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/elemental.rsi
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+        color: "#3e901c"


### PR DESCRIPTION
## About the PR
Reduces reagent slime damage from 15 slash to 8 slash.
Changes nocturine slimes injection per hit from 5 to 3.
Changes pax slimes injection per hit from 5 to 1.
Adds 4 more reagent slimes, those being Mute Toxin, Norepinephric Acid, Ephedrine and Robust Harvest.

## Why / Balance
- I feel like the whole danger of reagent slimes should be the chemical they contain, not the fact they could crit you in 7 plain hits.
- Nocturine slimes used to be able to 2 shot someone, they fall over and are quickly killed while asleep because of the high damage. Now it takes 3-4 rapid hits from a noct slime to sleep someone and there's much more time for someone to come help you.
- Pax slimes used to be able to entirely fuck someone over with just one hit and a couple chain hits after, as it used to be 10 seconds of inability to fight back, per hit plus it stacked. This makes it so if you're able to get away from the pax slime, you're able to get in the fight again within a reasonable amount of time, but if it's actively hitting you, you're done for.

The 4 new slimes are just for variety and more fun.
- Mute Toxin can quickly quell an officer's calls for help and leave people unable to communicate for a while after a fight with one, causing uncoordinated chaos.
- Norepinephric Acid will blind a person in 4-5 rapid hits, causing them to have to think fast and adapt to the situation, also it'd cause some friendly fire hopefully.
- Ephedrine slimes can be absolutely devastating if you sustain rapid damage by it, 3 hits nearly killing someone, 4 will kill you within the minute. These promote either last stand type actions as you realize your health is ticking down but you have enough time to bring a slime or two with you, or since you instantly get a speed boost from taking a hit, you'll just be able to evade and run from it till you find a ranged weapon.
- Robust Harvest was something that just seemed interesting and situational. It helps to balance out the pool of slimes so none of the more powerful ones spawn constantly. But it also can have some neat interactions with the rare Diona player.


## Media
I ran general tests to get the feel of the major changes and complied them into this one video.

The first section (0:00) is a basic fight spawning from a critical anomaly, showcasing that the slimes can still be very viscous if you play carelessly.
The second part (2:39) is displaying the noct and pax changes, where both can still be deadly.
The third (5:09) is showing off the ephedrine slime as it's the most notable of the new four, both in it's ability to quickly seal one's fate and with how easy it is to simply run away from.

https://youtu.be/FGuuMmnaRV4

- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
I'm unsure if the balance changes require a changelog.

:cl:
- add: Added four new reagent slimes, Mute Toxin, Norepinephric Acid, Ephedrine, and Robust Harvest.