### PR TITLE
Action for closing prs submitted by the submitters master branch

### DIFF
--- a/.github/workflows/close-master-pr.yml
+++ b/.github/workflows/close-master-pr.yml
@@ -1,0 +1,15 @@
+name: Close PR's from submitters master branch
+
+on:
+  pull_request_target:
+    types: [ opened, ready_for_review ]
+    
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    if: github.head_ref == 'master'
+    
+    steps:    
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: "Thank you for your contrubution to the Space Station 14 repository. Unfortunately it looks like you submitted your pull request from the master branch.\n We suggest you follow [our git usage documentation](https://docs.spacestation14.com/en/general-development/setup/git-for-the-ss14-developer.html) for intructions on how to make a new branch."

--- a/.github/workflows/close-master-pr.yml
+++ b/.github/workflows/close-master-pr.yml
@@ -12,4 +12,4 @@ jobs:
     steps:    
     - uses: superbrothers/close-pull-request@v3
       with:
-        comment: "Thank you for your contrubution to the Space Station 14 repository. Unfortunately it looks like you submitted your pull request from the master branch.\n We suggest you follow [our git usage documentation](https://docs.spacestation14.com/en/general-development/setup/git-for-the-ss14-developer.html) for intructions on how to make a new branch."
+        comment: "Thank you for your contribution to the Space Station 14 repository. Unfortunately it looks like you submitted your pull request from the master branch. We suggest you follow [our git usage documentation](https://docs.spacestation14.com/en/general-development/setup/git-for-the-ss14-developer.html) \n\n You can move your current work from the master branch to another branch by doing `git branch <branch_name` and resetting the master branch."

--- a/.github/workflows/close-master-pr.yml
+++ b/.github/workflows/close-master-pr.yml
@@ -1,4 +1,4 @@
-name: Close PR's from submitters master branch
+name: Close PR's on master
 
 on:
   pull_request_target:
@@ -7,9 +7,21 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-    if: github.head_ref == 'master'
+    if: ${{github.head_ref == 'master' || github.head_ref == 'main' || github.head_ref == 'develop'}}
     
     steps:    
     - uses: superbrothers/close-pull-request@v3
       with:
-        comment: "Thank you for your contribution to the Space Station 14 repository. Unfortunately it looks like you submitted your pull request from the master branch. We suggest you follow [our git usage documentation](https://docs.spacestation14.com/en/general-development/setup/git-for-the-ss14-developer.html) \n\n You can move your current work from the master branch to another branch by doing `git branch <branch_name` and resetting the master branch."
+        comment: "Thank you for contributing to the Space Station 14 repository. Unfortunately, it looks like you submitted your pull request from the master branch. We suggest you follow [our git usage documentation](https://docs.spacestation14.com/en/general-development/setup/git-for-the-ss14-developer.html) \n\n You can move your current work from the master branch to another branch by doing `git branch <branch_name` and resetting the master branch."
+
+    # If you prefer to just comment on the pr and not close it, uncomment the bellow and comment the above
+      
+    # - uses: actions/github-script@v7
+    #   with:
+    #     script: |
+    #       github.rest.issues.createComment({
+    #         issue_number: ${{ github.event.number }},
+    #         owner: context.repo.owner,
+    #         repo: context.repo.repo,
+    #         body: "Thank you for contributing to the Space Station 14 repository. Unfortunately, it looks like you submitted your pull request from the master branch. We suggest you follow [our git usage documentation](https://docs.spacestation14.com/en/general-development/setup/git-for-the-ss14-developer.html) \n\n You can move your current work from the master branch to another branch by doing `git branch <branch_name` and resetting the master branch. \n\n This pr won't be automatically closed. However, a maintainer may close it for this reason."
+    #       })


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Makes a github action to close new pr's from the master branch
### With auto closing
![image](https://github.com/space-wizards/space-station-14/assets/34938708/62e5a727-04ff-44f7-a066-667a29430c31)

### Without
![image](https://github.com/space-wizards/space-station-14/assets/34938708/fb3fbf7a-6a30-4266-9663-becac88e4784)


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

![image](https://github.com/space-wizards/space-station-14/assets/34938708/b79c9725-c511-4175-90e9-f62dd3c1d14f)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

Feature prs from master branches are automatically closed

I think you can bypass this action by just manually reopening the pr.

Will need to be ported to all other projects since ya know... actions