### PR TITLE
Nerf lava firestacks

### DIFF
--- a/Resources/Prototypes/Entities/Tiles/lava.yml
+++ b/Resources/Prototypes/Entities/Tiles/lava.yml
@@ -14,6 +14,7 @@
       tags:
         - Catwalk
   - type: Lava
+    fireStacks: 0.5
   - type: Transform
     anchored: true
   - type: SyncSprite

--- a/Resources/Prototypes/Entities/Tiles/lava.yml
+++ b/Resources/Prototypes/Entities/Tiles/lava.yml
@@ -14,7 +14,7 @@
       tags:
         - Catwalk
   - type: Lava
-    fireStacks: 0.5
+    fireStacks: 0.75
   - type: Transform
     anchored: true
   - type: SyncSprite

--- a/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
+++ b/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
@@ -14,6 +14,7 @@
       tags:
       - Catwalk
   - type: Lava
+    fireStacks: 0.5
   - type: Transform
     anchored: true
   - type: SyncSprite

--- a/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
+++ b/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
@@ -14,7 +14,7 @@
       tags:
       - Catwalk
   - type: Lava
-    fireStacks: 0.5
+    fireStacks: 0.75
   - type: Transform
     anchored: true
   - type: SyncSprite


### PR DESCRIPTION
## About the PR
Nerfs the amount of firestacks lava & liquid plasma give you (from 2 to 0.75.)

## Why / Balance
Stepping on lava right now is basically instant death, which *really* sucks with pixel movement considering even the slightest graze of it (or stepping into it for like half a second) will result in you catching on fire and at *minimum* coming out at like 70-80 damage.

1 felt too strong (you'd still come out with like 30-40 damage minimum) so I landed on 0.75. It doesn't feel *quite* right, but it should probably be fine enough.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Made lava & liquid plasma significantly less lethal.
