### PR TITLE
Fixes the eye protection requirement of welding tools being inverted

### DIFF
--- a/Content.Server/Eye/Blinding/EyeProtection/EyeProtectionSystem.cs
+++ b/Content.Server/Eye/Blinding/EyeProtection/EyeProtectionSystem.cs
@@ -60,7 +60,7 @@ namespace Content.Server.Eye.Blinding.EyeProtection
         }
         private void OnWelderToggled(EntityUid uid, RequiresEyeProtectionComponent component, ItemToggledEvent args)
         {
-            component.Toggled = _itemToggle.IsActivated(uid);
+            component.Toggled = args.Activated;
         }
     }
 }


### PR DESCRIPTION
## About the PR
Fixes #23606 
Self-explanatory! We wanted to do this when we were first informed, but then we ended up forgetting. Oops. Anyway here's a fix

## Why / Balance
Welding without protection should have consequences we think?

## Technical details
This bug was caused by #23422 , wherein `ItemToggleDoneEvent` was removed in favor of rolling it into `ItemToggledEvent`. Most things simply worked, as they cared only about `args.Enabled`. The eye protection system, however, did it's own thing: it checked `IsActivated()` from `SharedItemToggleSystem`. `ItemToggleDoneEvent` was sent after the item was already toggled and marked as activated, so this unorthodox method worked for that. However, `ItemToggledEvent` on the other hand is sent *before* that toggle goes through! So thus: eye protection requirements have their toggle inverted; attempting to weld with a welder that's off will blind you, but welding with an active welder wont.

This is a one-line fix; all we had to do was change the relevant method to check `args.Activated` instead.

## Media
![dotnet_bDVdql18WE](https://github.com/space-wizards/space-station-14/assets/6356337/9230e7e0-30b7-47c4-b263-e51fa7225af5)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- fix: Attempting to weld without protection will now cause eye damage proper. Additionally, attempting to weld with a welder that's off when you aren't wearing protection will no longer blind you. It's the bright light that hurts your eyes, not the underwhelming lack of it!

