### PR TITLE
Fix a bug where mobs can become stuck when transitioning to the standing state

### DIFF
--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -87,7 +87,7 @@ namespace Content.Shared.Standing
                 // Create a temporary sensor to continue registering contacts in the disabled collision layer
                 _fixtureSystem.TryCreateFixture(
                     uid,
-                    new PhysShapeCircle(0.35f),
+                    new PhysShapeCircle(0.1f),
                     StandingSensorFixtureName,
                     collisionLayer: (int) CollisionGroup.None,
                     collisionMask: StandingCollisionLayer,


### PR DESCRIPTION
## Technical details

The `StandingStateSystem` [disables](https://github.com/space-wizards/space-station-14/blob/1dd2cf1d2578bd6a1f2e0b8c66dbc5855707139a/Content.Shared/Standing/StandingStateSystem.cs#L74) the `MidImpassable` collision group when a mob becomes down. This basically allows downed moves to go under[^wtf] tables via any force, such as explosions, slipping, or being dragged. When later `StandingStateSystem` brings a downed mob to the standing position, it [re-enables](https://github.com/space-wizards/space-station-14/blob/1dd2cf1d2578bd6a1f2e0b8c66dbc5855707139a/Content.Shared/Standing/StandingStateSystem.cs#L126) the `MidImpassable` collision group.

[^wtf]: There is some level of confusion with whenever the down state allows going either over or under tables. Visually, downed mobs are rendered on top of tables, however [the comment](https://github.com/space-wizards/space-station-14/blob/1dd2cf1d2578bd6a1f2e0b8c66dbc5855707139a/Content.Shared/Standing/StandingStateSystem.cs#L65) states that the collision is disabled to allow mobs to go under tables, which kind of makes sense. However, downed mobs can't go under `HighImpassable` things, such as faxes lying on tables. And we can't disable the `HighImpassable` group from downed mobs because it would allow them to fit under airlocks similar to how mice work.

There is an issue, however. The `stand` can occur while a mob still clips through another `MidImpassable` fixture. When the mob attempts to move, the PhysicsSystem would detect a collision and push the mob to prevent the clipping. It appears that the push picks the shortest possible direction to solve the clipping. If the push direction is obstructed, the mob may end up pushed into another solid object, resulting in being stuck in between. Here is a short demonstration of the issue:

https://github.com/space-wizards/space-station-14/assets/1192090/6ca1cfe3-a53c-4475-8929-698575f231e0

---

To address the issue, I propose adding a sensor for the `MidImpassable` collision group. The sensor detects if the `stand` would result in clipping, allowing to delay the `MidImpassable` fixture restoration until the mob leaves the collision. Basically, it's almost identical to how the `ClimbSystem` works. Here is a demo of how the proposed solution works:

https://github.com/space-wizards/space-station-14/assets/1192090/946f457c-33a9-4485-8fbd-3039239746f6

<!--## Breaking changes

List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed a bug where players can become stuck when transitioning from lying down to a standing state.