### PR TITLE
fix radiators leaking heat into atmos blocked tiles

### DIFF
--- a/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
@@ -22,7 +22,7 @@ public sealed class HeatExchangerSystem : EntitySystem
     [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
-    [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     float tileLoss;
 
@@ -58,10 +58,13 @@ public sealed class HeatExchangerSystem : EntitySystem
 
         // make sure that the tile the device is on isn't blocked by a wall or something similar.
         var xform = Transform(uid);
-        if (TryComp<MapGridComponent>(xform.GridUid, out var mapGrid) &&
-            _atmosphereSystem.IsTileAirBlocked(xform.GridUid.Value, _map.LocalToTile(uid, mapGrid, xform.Coordinates)))
+        if (_transform.TryGetGridTilePosition(uid, out var tile))
         {
-            return;
+            // TryGetGridTilePosition() already returns false if GridUid is null, but the null checker isn't smart enough yet
+            if (xform.GridUid != null && _atmosphereSystem.IsTileAirBlocked(xform.GridUid.Value, tile))
+            {
+                return;
+            }
         }
 
         var dt = args.dt;

--- a/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
@@ -11,9 +11,7 @@ using Content.Shared.Atmos;
 using Content.Shared.CCVar;
 using Content.Shared.Interaction;
 using JetBrains.Annotations;
-using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
-using Robust.Shared.Map.Components;
 
 namespace Content.Server.Atmos.EntitySystems;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
radiators had an issue where it'd treat a null environment mixture the same regardless of whether or not it was just space or it was a blocked tile like a wall. This means you can create compact radiator setups by just covering it will a wall, which doesn't really make sense.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun
