### PR TITLE
Revert "Remove spacepens"

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -8,6 +8,7 @@
     contents:
       - id: ClothingMaskBreath
       - id: EmergencyOxygenTankFilled
+      - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
@@ -27,6 +28,7 @@
     contents:
       - id: ClothingMaskBreath
       - id: ExtendedEmergencyOxygenTankFilled
+      - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
@@ -47,6 +49,7 @@
     contents:
       - id: ClothingMaskGasSecurity
       - id: EmergencyOxygenTankFilled
+      - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
@@ -67,6 +70,7 @@
     contents:
       - id: ClothingMaskBreathMedical
       - id: EmergencyOxygenTankFilled
+      - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
@@ -92,6 +96,7 @@
     contents:
       - id: ClothingMaskBreath
       - id: EmergencyFunnyOxygenTankFilled
+      - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE
@@ -110,6 +115,7 @@
     contents:
       - id: ClothingMaskGasSyndicate
       - id: ExtendedEmergencyOxygenTankFilled
+      - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
       - id: FoodTinMRE

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -7,6 +7,7 @@
     FoodCondimentPacketKetchup: 5
   emaggedInventory:
     KitchenKnife: 2
+    SpaceMedipen: 3
     ClothingMaskBreath: 3
     EmergencyOxygenTankFilled: 3
     DrinkNukieCan: 2

--- a/Resources/ServerInfo/Guidebook/Survival.xml
+++ b/Resources/ServerInfo/Guidebook/Survival.xml
@@ -12,6 +12,7 @@ In the event of a serious emergency, there're a few things you can do to help en
 - If entering critical condition, use the emergency medipen from your emergency box, it'll make sure you don't end up unable to do anything. Emergency medipens can also be used to revive people currently in crit on the floor, and to prolong the amount of time you have to deal with poisons/etc.
 <Box>
 <GuideEntityEmbed Entity="EmergencyMedipen"/>
+<GuideEntityEmbed Entity="SpaceMedipen"/>
 </Box>
 - Your emergency box contains a breath mask and oxygen tank, which can help you survive longer in a spacing situation. If you're one of the slimepeople, be aware that nitrogen replaces oxygen for you and you don't start with one of those in your emergency canister.
 <Box>

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -155,6 +155,3 @@ TransmitterSubspaceStockPart: null
 
 # 2024-01-10
 ClothingHeadHatHoodRad: null
-
-# 2024-01-12
-SpaceMedipen: null


### PR DESCRIPTION
Reverts space-wizards/space-station-14#23970

This issue has two functions, first to serve as a base for future discussion on the topic of space pens via many links, citations and interpretations on collected points for and against the removal of space pens. Swift merging is just as unwanted by me as swift closing, so I advise the reviewer(s) to let the PR sit in stasis, accumulating feedback for a week or so.

The second is to, obviously, revert spacepen removal, now with, hopefully, a clear grasp on why they are being removed or reintroduced. 

## Why?

Primarily I believe the arguments presented for the removal of space pens were insufficient to justify the removal of space pens without the introduction of an alternative or converting space pens to a better mechanic (e.g. medipen refiller, fillable in o2 kits, etc.) or the introduction of medical overhaul (woundmed).

Secondarily the arguments from the original PR were also all over the place, [Discord with a discussion held in contributor chat](https://discord.com/channels/310555209753690112/770682801607278632/1195274995044192339) and perhaps more that I'm unaware of, the [Github PR](https://github.com/space-wizards/space-station-14/pull/23970) with quite a long list of comments, and now after the PR is merged [a thread in the Discord bugs-feedback channel](https://discord.com/channels/310555209753690112/1196166705655840801), what does this mean? Acquiring a concrete theoretical understanding of the situation is harder than it could be, so this PR is intended as a better ground for feedback after the PR has been merged and tested in-game while providing better theoretical information.


## Points presented for the removal, taken from Discord

Here I will present points taken from a Discord discussion held in contributor chat, while avoiding making counterarguments to the points and complimenting them with sources and clarifications where possible.

1. * [Space pens are a relic of the past and have been introduced in order to combat old and hyperlethal spacing.](https://discord.com/channels/310555209753690112/770682801607278632/1195275066477383690)
* * Space pens were introduced in #7880, previously killing you in around 12 seconds, and a space damage nerf was introduced in #8482 decreasing the TTK to 60 seconds. We also used to have extremely fast spacing and even buggier space wind before, making space inadvertently stronger.

2. * [Space pens are used exclusively to completely ignore spacing or survive evac shuttle for free.](https://discord.com/channels/310555209753690112/770682801607278632/1195275197599711293)
* * Space pens are efficiently used in the evac shuttle but they are by no means a "free" way to survive through it, spacepens being used to "ignore spacing" while not intended due to the chronological introduction of spacing changes, does work well as a feature.

3. * [Space pens should have some downsides to using them.](https://discord.com/channels/310555209753690112/770682801607278632/1195276675525660672)
* * Indeed, space pens used to have downsides, #8192 buffed space pens to have cold and brute healing while reducing the effects of the overdose, then #9926 increased the amount of barozine within space medipens to 20 from 10 but replaced the guaranteed poison damage with a 30% chance to deal 0.5 heat damage, also adjusting the overdose threshold to 30 from 15. 

4. * [Emergency EVA suits are common and also protect from spacing.](https://discord.com/channels/310555209753690112/770682801607278632/1195277650646806540)
* * Emergency EVA suits while do protect from spacing still suffer from temperature damage, they are also "common" but never accessible despite sounding like a contradiction, whether that's good or bad I'll leave up to the reviewer(s), emergency suits are also spawning with an 80% chance instead of a 100% chance in emergency lockers.

5. * [Spacepens can be used as weapons, so more damage will lead to more weaponization.](https://discord.com/channels/310555209753690112/770682801607278632/1195279117520740375)
* * This can be worked around in several different ways, [self injection was proposed](https://discord.com/channels/310555209753690112/770682801607278632/1195279079897833483), but there are more options such as careful maneuvering with overdose thresholds, overall I don't see this as an issue.

6. * [Spacepens are primarily used for cheese strategies and underused for their intended purpose.](https://discord.com/channels/310555209753690112/770682801607278632/1195280852200984646)
* * Spacepens can be used for cheese strategies, but they are also very common with their intended use, this also does not clarify what "cheese strategies" are and if they're actually bad or not, Devi [claims](https://discord.com/channels/310555209753690112/770682801607278632/1195281997002723338) that intended use is, in fact, common.

7. * [Spacepens make emergency EVA suits useless because of their strength.](https://discord.com/channels/310555209753690112/770682801607278632/1195282439220760618)
* * Spacepens while do outperform EVA suits in a lot of scenarios, are not useful at all when it comes to prolonged spacing scenarios, in these scenarios an emergency EVA shines brighter than spacepens, Ilya264 also [states](https://github.com/space-wizards/space-station-14/pull/23970#issuecomment-1889284877) this in the Github PR.

8. * [Players should be running away from deadly vacuumed environments, not going in due to the encouragement space pens give.](https://discord.com/channels/310555209753690112/770682801607278632/1195326764885475340)
* * Spacepens while encourage this kind of utilization, do not fully uphold this playstyle.

9. * [You can do a lot more things than you should while using the space invulnerability period the spacepen gives you](https://discord.com/channels/310555209753690112/770682801607278632/1195282813327507536)

* * The amount of extra time a spacepen gives you in space is indeed too much if the space pen is designed as an exclusively emergency defensive tool to make it out of space before you crit.

10. * [If space damage were to stay as-is then space pens could be removed as they no longer serve their full purpose](https://discord.com/channels/310555209753690112/770682801607278632/1195328920749355078)
* * Spinoff on point №1

## Points presented for the removal, taken from the Github PR

11. * [SS13 doesn't have space pens and has deadlier space](https://github.com/space-wizards/space-station-14/pull/23970#issuecomment-1889133501)
* * SS14 is not SS13, so comparisons like these have to be taken with a grain of salt.

12. * [Medical refactor is en-route and will heavily alter how spacepens should be balanced](https://github.com/space-wizards/space-station-14/pull/23970#pullrequestreview-1819990249)
* * Addressed in the "Why?" section, also its trivial to reintroduce space pens (like with this PR) or remove them, so no harm either way.

## Points against the removal of space pens, nerfs, reworks and other changes included, taken from Discord

Same thing as with the changes for the removal of space pens, I will attempt to avoid presenting arguments or counterarguments for the points.

1. * [If space pens were to stay they would need greater drawbacks.](https://discord.com/channels/310555209753690112/770682801607278632/1195278619270991945)
* * Interacts with point №3 and №5 for removal, also proposed several times throughout discussions taking many forms. Bhjin [claims](https://discord.com/channels/310555209753690112/770682801607278632/1195279463051690014) that making space pen medicine a potentially strong poison could be made interesting.

2. * [If space pens were to stay they could be made pressure-resistant instead of pressure-proof.](https://discord.com/channels/310555209753690112/770682801607278632/1195278988998885438)
* * Flareguy [claims](https://discord.com/channels/310555209753690112/770682801607278632/1195280467059036161) that this would rid the item of it's "when to use" aspect, making it a no-brainer to use if you're spaced.

3. * [Removing space pens may lead to spaced arrivals becoming a death sentence more often.](https://discord.com/channels/310555209753690112/770682801607278632/1195324897753313290)
* * Arrivals isn't supposed to be spaced but commonly is anyway, also crowbars from arrivals are taken roundstart almost every time.
4. * [Firelocks are a mess.](https://discord.com/channels/310555209753690112/770682801607278632/1195327096705257572)
* * Open a firelock, it closes within like 3 seconds, don't have a crowbar or you didn't make it in fast enough? That means you're in for a wild and fun ride.

## Points against the removal of space pens, nerfs, reworks and other changes included, taken from the Github PR

5. * [Space pens are a good form of skill expression.](https://github.com/space-wizards/space-station-14/pull/23970#issuecomment-1888924897)
* * Stated several times in the PR by different commenters, but yes, indeed, navigating from bag > survival box > locating pen and using it all in a critical moment is a pretty neat form of skill expression for most players.

6. * [The removal of space pens does not exactly fix the issue of space being weak.](https://github.com/space-wizards/space-station-14/pull/23970#issuecomment-1889163074)
* * Stated several times in the PR and Discord, space pens while do make space weaker don't actually solve the hypothetical issue of space being weak, you just don't have a get out of jail free card once per round now.

7. * [You only get one space pen for the entire round.](https://github.com/space-wizards/space-station-14/pull/23970#issuecomment-1889573604)
* * Stated several times in the PR and Discord, you indeed only get one per survival box and there is a singular survival box per player, unless you go out of your way to get more space pens it's unlikely you'll have more than the one you get, having this limited item can lead to some interesting decisionmaking.

8. * The first bit of damage matters more than the last, space pens mitigate that.
* * Think of it this way, if you take space damage mid-fight or mid-escape you take damage and start bleeding, because of that you start to lose speed, but because you lose speed you can't move out of the spacing fast enough leading to a damage snowball.

9. * Spacing is strong as-is, it really is despite the seemingly weak damage.
* * Elaboration in the comment I was referencing at the top of the PR.

10. * Low space damage leads to more fun.

* *  You want to do things, not sit there tending to wounds after getting spaced or running back and forth to medbay, or being constantly hindered by a hardsuit, or just not going at all because you're 90% sure you'll die if you try to go through the spaced area. Spacepens strike a good balance where you may use the one-time consumable to temporarily ignore space damage which also leads to decision-making, it's good. Proper understanding of your capabilities and the ability to act fast in a spaced area also allows for more gameplay opportunities as well leading to great scenarios like a secoff temporarily going outside the station into space to arrest a criminal without having a hardsuit, not having space pens makes scenarios like these either limited to exceptionally good players, which isn't very good, or flat out impossible.

Now then, I probably missed or boiled down some points made about this and did not include discussion taken from the Discord feedback thread and perhaps future space pen discussions, but this does bring up quite a lot of points.

Now then, a lot of these points seem to fall into a problematic territory, that being: "what is good design?"
In the absence of a clear answer to this question from a party with sufficient authority (maintainer), or at the very least me not being able to find one, I will now bring up my own version localized to space damage and space pens which is...

## The mentioned comment.

This is going to be taken from the original PR with little-to-no changes, so some context may be obscured.

"I don't think space should be deadlier than it is right now, space pens included.

Why? SS14 is a videogame first and foremost, death is of course intended, but what is a death that contributes to gameplay or can be considered "fun"?

Spacing and small spaced sections are common right now, despite weak space damage and spacepens being a common consumable, buffing space damage will lead to the relative "strength" of spacing methods increasing, leading to a possible shift in player thinking when it comes to playing antags that have easy spacing methods (see: ninja, traitor, nukie)
In other words, players will space even more.

Death by spacing is, I hope, agreeably one of the least "fun" methods of death, you're not dying in a fight, you're not dying to someone at all, you're not being enveloped by the plasmafire you just unleashed, you're not dying as a part of a joke, your death is caused by a passive gameplay element that something, or someone, caused in hopes of putting themselves into a better "active" gameplay position later on, as an example you'd see nukies spacing everything they can to create:

Spaced areas, constant firelock prying, the need to use hardsuits or emergency suits to traverse without taking passive damage, and more leads to...

Movement disruption. Aforementioned antags can extract a lot of value in "active" gameplay from this, the potential chase tailing the antag in question will be slowed, granting you more time and making some actions like relocating from point A to point B easier.
If you've ever played FTL you know why nebula sectors are good; you get more time to act and prepare to act.

Dead people don't act and take away time from others. If you kill a crewmember, they're dead until revival, the dead crewmember cannot act against you in any way and if they become alive that has a cost; medical resources and equipment, medical personnel, time from whoever is willing to heal you and or bring you to medbay.
You're taking away time, resources and player-work by racking up spacing kills and spacing damage, speaking of...

Spacing damage, you're wasting time and resources of the station by causing a spacing. It's easier to fight injured players as it is easier to steal from people buckled in medbeds, or medical doctors healing the person in a medbed, just as spacing damage denies resources that may eventually run out.

The list is obviously not complete, and there may be variable tactical or strategical advantages that spacing, and space damage grant the hypothetical antagonist, speaking of the list as a whole...

These are some pretty strong advantages already, despite being incomplete. And yet these are all "passive" gameplay factors that come out of spacing, I've intentionally left out tactical (e.g. spacing security before breaking in) and strategical (e.g. nukie plan dictates dedicated nukie goes out to space everything under the sun while avoiding direct combat) use cases of spacing, which is, reminder, extremely common.

Now then, back to dying, how does a death by spacing look like for the completely unprepared? The room they're in, assuming they're alone, gets spaced and they make an attempt to make it out or cry for help, in the end they get taxed for the majority of their health or die assuming they don't have a crowbar, or their room doesn't have an emergency suit, a scenario like this, despite sounding edge-case-y, could easily occur in maint.

Old spacing was brought up a lot [here](https://github.com/space-wizards/space-station-14/pull/23970), but even if we had 1:1 old spacing from Packedstation in the modern day it would be miles worse because of the hardsuit nerfs, introduction of easier spacing methods, hardbombs, antagonists that play heavily on spacing (nukies came after spacing nerfs, let alone ninja), larger maps, materials being harder to carry in bulk.
The game not being balanced for low-pop Packed and Saltern to address the elephant in the room.
Old spacing would be a nightmare if it was reintroduced right now.

This doesn't sound way too bad in theory, yet in gameplay practice this unfolds very fast and is nowhere near the level of gameplay a death by fight with an antagonist brings even with our miserably low TTK.

Spacing is strong as-is, it doesn't need buffs."

~~And that's about it, here's some sillies I thought of while writing this up to expend the shitposting potential of comments.~~

~~"at dire times like these i ask myself the question.... have i truly become john argument the arguer"~~
~~"I LOVE PACKEDSTATION I LOVE PRE-NERF HARDSUITS I LOVE DYING TO SPACE WITHIN 5 SECONDS HUZZAAAAH"~~
~~"i wonder how many effortpost golden stars i would receive if this was on a forum~~

### Remarks
1. Several times during discussion in contributor chat a revert was proposed if changes are deemed unsatisfactory.
2. When "taken from Discord" is mentioned, I'm referring to the discussion in contributor chat, it does not include takes from general or the dedicated bugs-feedback thread.
3. Yeah I know there's like a 10:1 downvote:upvote ratio on the original PR, that's cool and is valid-ish feedback but just vibe checks of "do you like this or not" aren't exactly enough for discussions like these.