### PR TITLE
fix damage type for arachnid melee

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -44,7 +44,7 @@
       collection: AlienClaw
     damage:
       types:
-        Pierce: 5
+        Piercing: 5
   # Visual & Audio
   - type: DamageVisuals
     damageOverlayGroups:


### PR DESCRIPTION
resolves #24098

changes arachnid damage type from Pierce (doesnt actually exist) to Piercing (correct damage type)