### PR TITLE
Executions

### DIFF
--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -44,7 +44,7 @@ public sealed class ExecutionSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
 
     private const float MeleeExecutionTimeModifier = 5.0f;
-    private const float GunExecutionTime = 10.0f;
+    private const float GunExecutionTime = 6.0f;
     private const float DamageModifier = 9.0f;
 
     /// <inheritdoc/>
@@ -365,6 +365,18 @@ public sealed class ExecutionSystem : EntitySystem
         // Gun successfully fired, deal damage
         _damageableSystem.TryChangeDamage(victim, damage * DamageModifier, true);
         _audioSystem.PlayEntity(component.SoundGunshot, Filter.Pvs(weapon), weapon, false, AudioParams.Default);
+        
+        // Popups
+        if (attacker != victim)
+        {
+            ShowExecutionPopup("execution-popup-gun-complete-internal", Filter.Entities(attacker), PopupType.Medium, attacker, victim, weapon);
+            ShowExecutionPopup("execution-popup-gun-complete-external", Filter.PvsExcept(attacker), PopupType.MediumCaution, attacker, victim, weapon);
+        }
+        else
+        {
+            ShowExecutionPopup("suicide-popup-gun-complete-internal", Filter.Entities(attacker), PopupType.Medium, attacker, victim, weapon);
+            ShowExecutionPopup("suicide-popup-gun-complete-external", Filter.PvsExcept(attacker), PopupType.MediumCaution, attacker, victim, weapon);
+        }
     }
 
     private void ShowExecutionPopup(string locString, Filter filter, PopupType type,

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -35,7 +35,6 @@ public sealed class ExecutionSystem : EntitySystem
     [Dependency] private readonly InteractionSystem _interactionSystem = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
-    [Dependency] private readonly SharedMeleeWeaponSystem _meleeSystem = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IComponentFactory _componentFactory = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
@@ -249,7 +248,7 @@ public sealed class ExecutionSystem : EntitySystem
             return;
         
         _damageableSystem.TryChangeDamage(victim, melee.Damage * DamageModifier, true);
-        _meleeSystem.PlayHitSound(victim, weapon, null, null, null);
+        _audioSystem.PlayEntity(melee.HitSound, Filter.Pvs(weapon), weapon, true, AudioParams.Default);
 
         if (attacker == victim)
         {

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -26,7 +26,8 @@ public sealed class ExecutionSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
     [Dependency] private readonly SharedMeleeWeaponSystem _meleeSystem = default!;
 
-    private const float ExecutionTime = 10.0f;
+    private const float MeleeExecutionTimeModifier = 5.0f;
+    private const float GunExecutionTime = 10.0f;
     private const float DamageModifier = 9.0f;
 
     /// <inheritdoc/>
@@ -144,6 +145,8 @@ public sealed class ExecutionSystem : EntitySystem
         if (!CanExecuteChecksMelee(weapon, victim, user))
             return;
 
+        var executionTime = Comp<MeleeWeaponComponent>(weapon).AttackRate * MeleeExecutionTimeModifier;
+
         _popupSystem.PopupEntity(Loc.GetString(
                 "execution-popup-melee-initial-internal", ("weapon", weapon), ("victim", victim)),
             user, Filter.Entities(user), true, PopupType.Medium);
@@ -152,7 +155,7 @@ public sealed class ExecutionSystem : EntitySystem
             user, Filter.PvsExcept(user), true, PopupType.MediumCaution);
         
         var doAfter =
-            new DoAfterArgs(EntityManager, user, ExecutionTime, new ExecutionDoAfterEvent(), weapon, target: victim, used: weapon)
+            new DoAfterArgs(EntityManager, user, executionTime, new ExecutionDoAfterEvent(), weapon, target: victim, used: weapon)
             {
                 BreakOnTargetMove = true,
                 BreakOnUserMove = true,
@@ -176,7 +179,7 @@ public sealed class ExecutionSystem : EntitySystem
             user, Filter.PvsExcept(user), true, PopupType.MediumCaution);
         
         var doAfter =
-            new DoAfterArgs(EntityManager, user, ExecutionTime, new ExecutionDoAfterEvent(), weapon, target: victim, used: weapon)
+            new DoAfterArgs(EntityManager, user, GunExecutionTime, new ExecutionDoAfterEvent(), weapon, target: victim, used: weapon)
             {
                 BreakOnTargetMove = true,
                 BreakOnUserMove = true,

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -114,8 +114,12 @@ public sealed class ExecutionSystem : EntitySystem
         if (_mobStateSystem.IsDead(victim, mobState))
             return false;
 
-        // You must be incapacitated to be executed
-        if (_actionBlockerSystem.CanInteract(victim, null))
+        // You must be incapacitated to execute someone else
+        if (victim != user && _actionBlockerSystem.CanInteract(victim, null))
+            return false;
+        
+        // You must be not incapacitated to execute yourself
+        if (victim == user && !_actionBlockerSystem.CanInteract(victim, null))
             return false;
 
         // All checks passed

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -54,14 +54,14 @@ public sealed class ExecutionSystem : EntitySystem
         var weapon = args.Using!.Value;
         var victim = args.Target;
 
-        if (!CanExecuteChecksMelee(weapon, victim, victim))
+        if (!CanExecuteWithMelee(weapon, victim, victim))
             return;
         
         UtilityVerb verb = new()
         {
             Act = () =>
             {
-                TryStartExecutionDoafterMelee(weapon, victim, attacker);
+                TryStartMeleeExecutionDoafter(weapon, victim, attacker);
             },
             Impact = LogImpact.High,
             Text = Loc.GetString("execution-verb-name"),
@@ -83,14 +83,14 @@ public sealed class ExecutionSystem : EntitySystem
         var weapon = args.Using!.Value;
         var victim = args.Target;
 
-        if (!CanExecuteChecksGun(weapon, victim, victim))
+        if (!CanExecuteWithGun(weapon, victim, victim))
             return;
         
         UtilityVerb verb = new()
         {
             Act = () =>
             {
-                TryStartExecutionDoafterGun(weapon, victim, attacker);
+                TryStartGunExecutionDoafter(weapon, victim, attacker);
             },
             Impact = LogImpact.High,
             Text = Loc.GetString("execution-verb-name"),
@@ -100,7 +100,7 @@ public sealed class ExecutionSystem : EntitySystem
         args.Verbs.Add(verb);
     }
 
-    private bool CanExecuteChecks(EntityUid weapon, EntityUid victim, EntityUid user)
+    private bool CanExecuteWithAny(EntityUid weapon, EntityUid victim, EntityUid user)
     {
         // No point executing someone if they can't take damage
         if (!TryComp<DamageableComponent>(victim, out var damage))
@@ -118,9 +118,9 @@ public sealed class ExecutionSystem : EntitySystem
         return true;
     }
 
-    private bool CanExecuteChecksMelee(EntityUid weapon, EntityUid victim, EntityUid user)
+    private bool CanExecuteWithMelee(EntityUid weapon, EntityUid victim, EntityUid user)
     {
-        if (!CanExecuteChecks(weapon, victim, user)) return false;
+        if (!CanExecuteWithAny(weapon, victim, user)) return false;
         
         // We must be able to actually hurt people with the weapon
         if (!TryComp<MeleeWeaponComponent>(weapon, out var melee) && melee!.Damage.GetTotal() > 0.0f)
@@ -129,9 +129,9 @@ public sealed class ExecutionSystem : EntitySystem
         return true;
     }
     
-    private bool CanExecuteChecksGun(EntityUid weapon, EntityUid victim, EntityUid user)
+    private bool CanExecuteWithGun(EntityUid weapon, EntityUid victim, EntityUid user)
     {
-        if (!CanExecuteChecks(weapon, victim, user)) return false;
+        if (!CanExecuteWithAny(weapon, victim, user)) return false;
         
         // We must be able to actually fire the gun and have it do damage
         if (!TryComp<GunComponent>(weapon, out var gun))
@@ -140,9 +140,9 @@ public sealed class ExecutionSystem : EntitySystem
         return true;
     }
     
-    private void TryStartExecutionDoafterMelee(EntityUid weapon, EntityUid victim, EntityUid user)
+    private void TryStartMeleeExecutionDoafter(EntityUid weapon, EntityUid victim, EntityUid user)
     {
-        if (!CanExecuteChecksMelee(weapon, victim, user))
+        if (!CanExecuteWithMelee(weapon, victim, user))
             return;
 
         var executionTime = Comp<MeleeWeaponComponent>(weapon).AttackRate * MeleeExecutionTimeModifier;
@@ -166,9 +166,9 @@ public sealed class ExecutionSystem : EntitySystem
         _doAfterSystem.TryStartDoAfter(doAfter);
     }
     
-    private void TryStartExecutionDoafterGun(EntityUid weapon, EntityUid victim, EntityUid user)
+    private void TryStartGunExecutionDoafter(EntityUid weapon, EntityUid victim, EntityUid user)
     {
-        if (!CanExecuteChecksGun(weapon, victim, user))
+        if (!CanExecuteWithGun(weapon, victim, user))
             return;
 
         _popupSystem.PopupEntity(Loc.GetString(
@@ -195,7 +195,7 @@ public sealed class ExecutionSystem : EntitySystem
         if (args.Handled || args.Cancelled || args.Used == null || args.Target == null)
             return false;
         
-        if (!CanExecuteChecks(args.Used.Value, args.Target.Value, uid))
+        if (!CanExecuteWithAny(args.Used.Value, args.Target.Value, uid))
             return false;
         
         // All checks passed
@@ -211,7 +211,7 @@ public sealed class ExecutionSystem : EntitySystem
         var weapon = args.Used!.Value;
         var victim = args.Target!.Value;
 
-        if (!CanExecuteChecksMelee(weapon, victim, attacker)) return;
+        if (!CanExecuteWithMelee(weapon, victim, attacker)) return;
 
         if (!TryComp<MeleeWeaponComponent>(weapon, out var melee) && melee!.Damage.GetTotal() > 0.0f)
             return;
@@ -236,6 +236,6 @@ public sealed class ExecutionSystem : EntitySystem
         var weapon = args.Used!.Value;
         var victim = args.Target!.Value;
 
-        if (!CanExecuteChecksGun(weapon, victim, attacker)) return;
+        if (!CanExecuteWithGun(weapon, victim, attacker)) return;
     }
 }

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -135,10 +135,6 @@ public sealed class ExecutionSystem : EntitySystem
         // The victim must be incapacitated to be executed
         if (victim != attacker && _actionBlockerSystem.CanInteract(victim, null))
             return false;
-        
-        // You must be not incapacitated to execute yourself
-        if (victim == attacker && !_actionBlockerSystem.CanInteract(victim, null))
-            return false;
 
         // All checks passed
         return true;

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -106,8 +106,12 @@ public sealed class ExecutionSystem : EntitySystem
         if (!TryComp<DamageableComponent>(victim, out var damage))
             return false;
         
+        // You can't execute something that cannot die
+        if (!TryComp<MobStateComponent>(victim, out var mobState))
+            return false;
+        
         // You're not allowed to execute dead people (no fun allowed)
-        if (TryComp<MobStateComponent>(victim, out var mobState) && _mobStateSystem.IsDead(victim, mobState))
+        if (_mobStateSystem.IsDead(victim, mobState))
             return false;
 
         // You must be incapacitated to be executed

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -71,7 +71,7 @@ public sealed class ExecutionSystem : EntitySystem
         var weapon = args.Using!.Value;
         var victim = args.Target;
 
-        if (!CanExecuteWithMelee(weapon, victim, victim))
+        if (!CanExecuteWithMelee(weapon, victim, attacker))
             return;
         
         UtilityVerb verb = new()
@@ -100,7 +100,7 @@ public sealed class ExecutionSystem : EntitySystem
         var weapon = args.Using!.Value;
         var victim = args.Target;
 
-        if (!CanExecuteWithGun(weapon, victim, victim))
+        if (!CanExecuteWithGun(weapon, victim, attacker))
             return;
         
         UtilityVerb verb = new()

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -145,7 +145,7 @@ public sealed class ExecutionSystem : EntitySystem
         if (!CanExecuteWithMelee(weapon, victim, user))
             return;
 
-        var executionTime = Comp<MeleeWeaponComponent>(weapon).AttackRate * MeleeExecutionTimeModifier;
+        var executionTime = (1.0f / Comp<MeleeWeaponComponent>(weapon).AttackRate) * MeleeExecutionTimeModifier;
 
         _popupSystem.PopupEntity(Loc.GetString(
                 "execution-popup-melee-initial-internal", ("weapon", weapon), ("victim", victim)),

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Interaction;
 using Content.Server.Kitchen.Components;
+using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.Database;
@@ -39,6 +40,7 @@ public sealed class ExecutionSystem : EntitySystem
     [Dependency] private readonly IComponentFactory _componentFactory = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    [Dependency] private readonly GunSystem _gunSystem = default!;
 
     private const float MeleeExecutionTimeModifier = 5.0f;
     private const float GunExecutionTime = 6.0f;
@@ -155,8 +157,8 @@ public sealed class ExecutionSystem : EntitySystem
     {
         if (!CanExecuteWithAny(weapon, victim, user)) return false;
         
-        // We must be able to actually fire the gun and have it do damage
-        if (!TryComp<GunComponent>(weapon, out var gun))
+        // We must be able to actually fire the gun
+        if (!TryComp<GunComponent>(weapon, out var gun) && _gunSystem.CanShoot(gun!))
             return false;
 
         return true;

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -1,0 +1,107 @@
+using Content.Server.Kitchen.Components;
+using Content.Shared.Damage;
+using Content.Shared.Database;
+using Content.Shared.DoAfter;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Verbs;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Weapons.Ranged.Components;
+
+namespace Content.Server.Execution;
+
+/// <summary>
+///     Verb for violently murdering cuffed creatures.
+/// </summary>
+public sealed class ExecutionSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+        
+        SubscribeLocalEvent<SharpComponent, GetVerbsEvent<UtilityVerb>>(OnGetInteractionVerbsMelee);
+        SubscribeLocalEvent<GunComponent, GetVerbsEvent<UtilityVerb>>(OnGetInteractionVerbsGun);
+    }
+
+    private void OnGetInteractionVerbsMelee(
+        EntityUid uid, 
+        SharpComponent component,
+        GetVerbsEvent<UtilityVerb> args)
+    {
+        if (args.Hands == null || args.Using == null || !args.CanAccess || !args.CanInteract)
+            return;
+        
+        UtilityVerb verb = new()
+        {
+            Act = () =>
+            {
+                TryStartExecutionDoafterMelee(args.Using!.Value, args.Target, args.User);
+            },
+            Impact = LogImpact.High,
+            Text = Loc.GetString("execution-verb-name"),
+            Message = Loc.GetString("execution-verb-message"),
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private void OnGetInteractionVerbsGun(
+        EntityUid uid, 
+        GunComponent component,
+        GetVerbsEvent<UtilityVerb> args)
+    {
+        if (args.Hands == null || args.Using == null || !args.CanAccess || !args.CanInteract)
+            return;
+
+        UtilityVerb verb = new()
+        {
+            Act = () =>
+            {
+                TryStartExecutionDoafterGun(args.Using!.Value, args.Target, args.User);
+            },
+            Impact = LogImpact.High,
+            Text = Loc.GetString("execution-verb-name"),
+            Message = Loc.GetString("execution-verb-message"),
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private bool TryStartExecutionDoafterCommonChecks(EntityUid weapon, EntityUid victim, EntityUid user)
+    {
+        // No point executing someone if they can't take damage
+        if (!TryComp<DamageableComponent>(victim, out var damage))
+            return false;
+        
+        // You're not allowed to execute dead people (no fun allowed)
+        if (TryComp<MobStateComponent>(victim, out var mobState) && !_mobStateSystem.IsDead(victim, mobState))
+            return false;
+
+        // All checks passed
+        return true;
+    }
+    
+    private void TryStartExecutionDoafterMelee(EntityUid weapon, EntityUid victim, EntityUid user)
+    {
+        if (!TryStartExecutionDoafterCommonChecks(weapon, victim, user))
+            return;
+        
+        // We must be able to actually fire the gun and have it do damage
+        if (!TryComp<GunComponent>(weapon, out var gun))
+            return;
+    }
+    
+    private void TryStartExecutionDoafterGun(EntityUid weapon, EntityUid victim, EntityUid user)
+    {
+        if (!TryStartExecutionDoafterCommonChecks(weapon, victim, user))
+            return;
+        
+        // We must be able to actually hurt people with the weapon
+        if (!TryComp<MeleeWeaponComponent>(weapon, out var melee) && melee!.Damage.GetTotal() > 0.0f)
+            return;
+    }
+}

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -114,7 +114,7 @@ public sealed class ExecutionSystem : EntitySystem
         args.Verbs.Add(verb);
     }
 
-    private bool CanExecuteWithAny(EntityUid weapon, EntityUid victim, EntityUid user)
+    private bool CanExecuteWithAny(EntityUid weapon, EntityUid victim, EntityUid attacker)
     {
         // No point executing someone if they can't take damage
         if (!TryComp<DamageableComponent>(victim, out var damage))
@@ -127,13 +127,17 @@ public sealed class ExecutionSystem : EntitySystem
         // You're not allowed to execute dead people (no fun allowed)
         if (_mobStateSystem.IsDead(victim, mobState))
             return false;
+        
+        // You must be able to attack people to execute
+        if (!_actionBlockerSystem.CanAttack(attacker, victim))
+            return false;
 
         // The victim must be incapacitated to be executed
-        if (victim != user && _actionBlockerSystem.CanInteract(victim, null))
+        if (victim != attacker && _actionBlockerSystem.CanInteract(victim, null))
             return false;
         
         // You must be not incapacitated to execute yourself
-        if (victim == user && !_actionBlockerSystem.CanInteract(victim, null))
+        if (victim == attacker && !_actionBlockerSystem.CanInteract(victim, null))
             return false;
 
         // All checks passed

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -1,7 +1,5 @@
-using System.Numerics;
 using Content.Server.Interaction;
 using Content.Server.Kitchen.Components;
-using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.Database;
@@ -20,7 +18,6 @@ using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -314,29 +314,35 @@ public sealed class ExecutionSystem : EntitySystem
         
         // Information about the ammo like damage
         SoundSpecifier? shootSound = component.SoundGunshot;
-        DamageSpecifier? damage = null;
+        DamageSpecifier damage = new DamageSpecifier();
 
         // Get some information from IShootable
-        var ammo_uid = ev.Ammo[0].Entity;
+        var ammoUid = ev.Ammo[0].Entity;
         switch (ev.Ammo[0].Shootable)
         {
             case CartridgeAmmoComponent cartridge:
                 // Get the damage value
                 var prototype = _prototypeManager.Index<EntityPrototype>(cartridge.Prototype);
                 prototype.TryGetComponent<ProjectileComponent>(out var projectileA, _componentFactory); // sloth forgive me
-                damage = projectileA!.Damage * cartridge.Count;
-                
+                if (projectileA != null)
+                {
+                    damage = projectileA.Damage * cartridge.Count;
+                }
+
                 // Expend the cartridge
                 cartridge.Spent = true;
-                _appearanceSystem.SetData(ammo_uid!.Value, AmmoVisuals.Spent, true);
-                Dirty(ammo_uid.Value, cartridge);
+                _appearanceSystem.SetData(ammoUid!.Value, AmmoVisuals.Spent, true);
+                Dirty(ammoUid.Value, cartridge);
                 
                 break;
             
             case AmmoComponent newAmmo:
-                TryComp<ProjectileComponent>(ammo_uid, out var projectileB);
-                damage = projectileB!.Damage;
-                Del(ammo_uid);
+                TryComp<ProjectileComponent>(ammoUid, out var projectileB);
+                if (projectileB != null)
+                {
+                    damage = projectileB.Damage;
+                }
+                Del(ammoUid);
                 break;
             
             case HitscanPrototype hitscan:

--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -90,8 +90,8 @@ public sealed class ExecutionSystem : EntitySystem
         if (!TryStartExecutionDoafterCommonChecks(weapon, victim, user))
             return;
         
-        // We must be able to actually fire the gun and have it do damage
-        if (!TryComp<GunComponent>(weapon, out var gun))
+        // We must be able to actually hurt people with the weapon
+        if (!TryComp<MeleeWeaponComponent>(weapon, out var melee) && melee!.Damage.GetTotal() > 0.0f)
             return;
     }
     
@@ -100,8 +100,8 @@ public sealed class ExecutionSystem : EntitySystem
         if (!TryStartExecutionDoafterCommonChecks(weapon, victim, user))
             return;
         
-        // We must be able to actually hurt people with the weapon
-        if (!TryComp<MeleeWeaponComponent>(weapon, out var melee) && melee!.Damage.GetTotal() > 0.0f)
+        // We must be able to actually fire the gun and have it do damage
+        if (!TryComp<GunComponent>(weapon, out var gun))
             return;
     }
 }

--- a/Content.Shared/Execution/DoafterEvent.cs
+++ b/Content.Shared/Execution/DoafterEvent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Execution;
+
+[Serializable, NetSerializable]
+public sealed partial class ExecutionDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -736,7 +736,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         return true;
     }
 
-    private void PlayHitSound(EntityUid target, EntityUid? user, string? type, SoundSpecifier? hitSoundOverride, SoundSpecifier? hitSound)
+    public void PlayHitSound(EntityUid target, EntityUid? user, string? type, SoundSpecifier? hitSoundOverride, SoundSpecifier? hitSound)
     {
         var playedSound = false;
 

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -5,8 +5,10 @@ execution-popup-gun-initial-internal = You ready the muzzle of {THE($weapon)} ag
 execution-popup-gun-initial-external = {$attacker} readies the muzzle of {THE($weapon)} against {$victim}'s head.
 execution-popup-gun-complete-internal = You blast {$victim} in the head!
 execution-popup-gun-complete-external = {$attacker} blasts {$victim} in the head!
+execution-popup-gun-clumsy-internal = You miss {$victim}'s head and shoot your foot instead!
+execution-popup-gun-clumsy-external = {$attacker} misses {$victim} and shoots {POSS-ADJ($attacker)} foot instead!
 
 execution-popup-melee-initial-internal = You ready {THE($weapon)} against {$victim}'s throat.
-execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ($weapon)} against the throat of {$victim}.
+execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ(attacker)} {$weapon} against the throat of {$victim}.
 execution-popup-melee-complete-internal = You slit the throat of {$victim}!
 execution-popup-melee-complete-external = {$attacker} slits the throat of {$victim}!

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -1,10 +1,10 @@
 execution-verb-name = Execute
 execution-verb-message = Use your weapon to execute someone.
 
-execution-popup-gun-initial-internal = You ready the muzzle of {THE($weapon)} against {$target}'s head.
-execution-popup-gun-initial-external = {$attacker} readies the muzzle of {THE($weapon)} against {$target}'s head.
+execution-popup-gun-initial-internal = You ready the muzzle of {THE($weapon)} against {$victim}'s head.
+execution-popup-gun-initial-external = {$attacker} readies the muzzle of {THE($weapon)} against {$victim}'s head.
 execution-popup-gun-complete = {$attacker} blasts {$target} in the head!
 
-execution-popup-knife-initial-internal = You ready {THE($weapon)} against {$target}'s throat.
-execution-popup-knife-initial-external = {$attacker} readies {POSS-ADJ($weapon)} against the throat of {$target}.
-execution-popup-knife-complete = {$attacker} slits the throat of {$target}!
+execution-popup-melee-initial-internal = You ready {THE($weapon)} against {$victim}'s throat.
+execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ($weapon)} against the throat of {$victim}.
+execution-popup-melee-complete = {$attacker} slits the throat of {$target}!

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -1,6 +1,11 @@
 execution-verb-name = Execute
 execution-verb-message = Use your weapon to execute someone.
 
+# All the below localisation strings have access to the following variables
+# attacker (the person committing the execution)
+# victim (the person being executed)
+# weapon (the weapon used for the execution)
+
 execution-popup-gun-initial-internal = You ready the muzzle of {THE($weapon)} against {$victim}'s head.
 execution-popup-gun-initial-external = {$attacker} readies the muzzle of {THE($weapon)} against {$victim}'s head.
 execution-popup-gun-complete-internal = You blast {$victim} in the head!
@@ -8,7 +13,17 @@ execution-popup-gun-complete-external = {$attacker} blasts {$victim} in the head
 execution-popup-gun-clumsy-internal = You miss {$victim}'s head and shoot your foot instead!
 execution-popup-gun-clumsy-external = {$attacker} misses {$victim} and shoots {POSS-ADJ($attacker)} foot instead!
 
+suicide-popup-gun-initial-internal = You place the muzzle of {THE($weapon)} in your mouth.
+suicide-popup-gun-initial-external = {$attacker} places the muzzle of {THE($weapon)} in {POSS-ADJ($attacker)} mouth.
+suicide-popup-gun-complete-internal = You shoot yourself in the head!
+suicide-popup-gun-complete-external = {$attacker} shoots {REFLEXIVE($attacker)} in the head!
+
 execution-popup-melee-initial-internal = You ready {THE($weapon)} against {$victim}'s throat.
 execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ(attacker)} {$weapon} against the throat of {$victim}.
 execution-popup-melee-complete-internal = You slit the throat of {$victim}!
 execution-popup-melee-complete-external = {$attacker} slits the throat of {$victim}!
+
+suicide-popup-melee-initial-internal = You ready {THE($weapon)} against your throat.
+suicide-popup-melee-initial-external = {$attacker} readies {POSS-ADJ(attacker)} {$weapon} against their throat.
+suicide-popup-melee-complete-internal = You slit your throat with {THE($weapon)}.
+suicide-popup-melee-complete-external = {$attacker} slits their throat with {THE($weapon)}.

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -1,0 +1,10 @@
+execution-verb-name = Execute
+execution-verb-message = Use your weapon to execute someone.
+
+execution-popup-gun-initial-internal = You ready the muzzle of {THE($weapon)} against {$target}'s head.
+execution-popup-gun-initial-external = {$attacker} readies the muzzle of {THE($weapon)} against {$target}'s head.
+execution-popup-gun-complete = {$attacker} blasts {$target} in the head!
+
+execution-popup-knife-initial-internal = You ready {THE($weapon)} against {$target}'s throat.
+execution-popup-knife-initial-external = {$attacker} readies {POSS-ADJ($weapon)} against the throat of {$target}.
+execution-popup-knife-complete = {$attacker} slits the throat of {$target}!

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -12,7 +12,7 @@ execution-popup-gun-complete-internal = You blast {$victim} in the head!
 execution-popup-gun-complete-external = {$attacker} blasts {$victim} in the head!
 execution-popup-gun-clumsy-internal = You miss {$victim}'s head and shoot your foot instead!
 execution-popup-gun-clumsy-external = {$attacker} misses {$victim} and shoots {POSS-ADJ($attacker)} foot instead!
-execution-popup-gun-empty = {CAPITALIZE(THE($weapon))} clicks. 
+execution-popup-gun-empty = {CAPITALIZE(THE($weapon))} clicks.
 
 suicide-popup-gun-initial-internal = You place the muzzle of {THE($weapon)} in your mouth.
 suicide-popup-gun-initial-external = {$attacker} places the muzzle of {THE($weapon)} in {POSS-ADJ($attacker)} mouth.
@@ -26,5 +26,5 @@ execution-popup-melee-complete-external = {$attacker} slits the throat of {$vict
 
 suicide-popup-melee-initial-internal = You ready {THE($weapon)} against your throat.
 suicide-popup-melee-initial-external = {$attacker} readies {POSS-ADJ($attacker)} {$weapon} against {POSS-ADJ($attacker)} throat.
-suicide-popup-melee-complete-internal = You slit your throat with {THE($weapon)}.
-suicide-popup-melee-complete-external = {$attacker} slits their throat with {THE($weapon)}.
+suicide-popup-melee-complete-internal = You slit your throat with {THE($weapon)}!
+suicide-popup-melee-complete-external = {$attacker} slits {POSS-ADJ($attacker)} throat with {THE($weapon)}!

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -12,7 +12,7 @@ execution-popup-gun-complete-internal = You blast {$victim} in the head!
 execution-popup-gun-complete-external = {$attacker} blasts {$victim} in the head!
 execution-popup-gun-clumsy-internal = You miss {$victim}'s head and shoot your foot instead!
 execution-popup-gun-clumsy-external = {$attacker} misses {$victim} and shoots {POSS-ADJ($attacker)} foot instead!
-execution-popup-gun-empty = {THE($weapon)} clicks. 
+execution-popup-gun-empty = {CAPITALIZE(THE($weapon))} clicks. 
 
 suicide-popup-gun-initial-internal = You place the muzzle of {THE($weapon)} in your mouth.
 suicide-popup-gun-initial-external = {$attacker} places the muzzle of {THE($weapon)} in {POSS-ADJ($attacker)} mouth.

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -12,6 +12,7 @@ execution-popup-gun-complete-internal = You blast {$victim} in the head!
 execution-popup-gun-complete-external = {$attacker} blasts {$victim} in the head!
 execution-popup-gun-clumsy-internal = You miss {$victim}'s head and shoot your foot instead!
 execution-popup-gun-clumsy-external = {$attacker} misses {$victim} and shoots {POSS-ADJ($attacker)} foot instead!
+execution-popup-gun-empty = {THE($weapon)} clicks. 
 
 suicide-popup-gun-initial-internal = You place the muzzle of {THE($weapon)} in your mouth.
 suicide-popup-gun-initial-external = {$attacker} places the muzzle of {THE($weapon)} in {POSS-ADJ($attacker)} mouth.

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -19,11 +19,11 @@ suicide-popup-gun-complete-internal = You shoot yourself in the head!
 suicide-popup-gun-complete-external = {$attacker} shoots {REFLEXIVE($attacker)} in the head!
 
 execution-popup-melee-initial-internal = You ready {THE($weapon)} against {$victim}'s throat.
-execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ(attacker)} {$weapon} against the throat of {$victim}.
+execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ($attacker)} {$weapon} against the throat of {$victim}.
 execution-popup-melee-complete-internal = You slit the throat of {$victim}!
 execution-popup-melee-complete-external = {$attacker} slits the throat of {$victim}!
 
 suicide-popup-melee-initial-internal = You ready {THE($weapon)} against your throat.
-suicide-popup-melee-initial-external = {$attacker} readies {POSS-ADJ(attacker)} {$weapon} against their throat.
+suicide-popup-melee-initial-external = {$attacker} readies {POSS-ADJ($attacker)} {$weapon} against {POSS-ADJ($attacker)} throat.
 suicide-popup-melee-complete-internal = You slit your throat with {THE($weapon)}.
 suicide-popup-melee-complete-external = {$attacker} slits their throat with {THE($weapon)}.

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -3,8 +3,10 @@ execution-verb-message = Use your weapon to execute someone.
 
 execution-popup-gun-initial-internal = You ready the muzzle of {THE($weapon)} against {$victim}'s head.
 execution-popup-gun-initial-external = {$attacker} readies the muzzle of {THE($weapon)} against {$victim}'s head.
-execution-popup-gun-complete = {$attacker} blasts {$target} in the head!
+execution-popup-gun-complete-internal = You blast {$victim} in the head!
+execution-popup-gun-complete-external = {$attacker} blasts {$victim} in the head!
 
 execution-popup-melee-initial-internal = You ready {THE($weapon)} against {$victim}'s throat.
 execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ($weapon)} against the throat of {$victim}.
-execution-popup-melee-complete = {$attacker} slits the throat of {$target}!
+execution-popup-melee-complete-internal = You slit the throat of {$victim}!
+execution-popup-melee-complete-external = {$attacker} slits the throat of {$victim}!


### PR DESCRIPTION
## About the PR
Adds an Execute verb that lets you murder cuffed people (or yourself!) with melee weapons or guns.
This is mostly for dramatic/roleplay purposes, such as a televised execution of heads by the revolutionaries.

Clumsy people can also botch executions and hurt themselves instead.

I've tested it, you can indeed play Russian Roulette. Or Buckshot Roulette.

## Why / Balance
All executions do 9x more damage than the weapon would do usually, and ignore resistances.
Executions have a doafter and cannot miss as long as the doafter completes.

Melee executions are balanced by their attack speed. Faster attack speed means a faster execution.
Gun executions always take six seconds. Might change this idk.

## Technical details
Any entity with the `Sharp` and `MeleeWeapon` components or the `Gun` component can execute, as long as the total damage isn't `0`. This makes it possible to execute with all knives, spears, and axes, since they can butcher. You can't execute with plushies, sadly.

The gun execution part of the code is pretty shit, I'm not gonna lie. To achieve some special behaviors for executions, some code had to be repeated. Also, I committed a great sin by getting a component from an entity prototype. I'm sorry Sloth (no I'm not).

**Changelog**
:cl:
- add: You can now dramatically execute cuffed people.
- add: You can now kill yourself with guns.