### PR TITLE
DamageSpecifier Total => GetTotal

### DIFF
--- a/Content.IntegrationTests/Tests/Construction/Interaction/WindowRepair.cs
+++ b/Content.IntegrationTests/Tests/Construction/Interaction/WindowRepair.cs
@@ -18,14 +18,14 @@ public sealed class WindowRepair : InteractionTest
         var comp = Comp<DamageableComponent>();
         var damageType = Server.ResolveDependency<IPrototypeManager>().Index<DamageTypePrototype>("Blunt");
         var damage = new DamageSpecifier(damageType, FixedPoint2.New(10));
-        Assert.That(comp.Damage.Total, Is.EqualTo(FixedPoint2.Zero));
+        Assert.That(comp.Damage.GetTotal(), Is.EqualTo(FixedPoint2.Zero));
         await Server.WaitPost(() => sys.TryChangeDamage(SEntMan.GetEntity(Target), damage, ignoreResistances: true));
         await RunTicks(5);
-        Assert.That(comp.Damage.Total, Is.GreaterThan(FixedPoint2.Zero));
+        Assert.That(comp.Damage.GetTotal(), Is.GreaterThan(FixedPoint2.Zero));
 
         // Repair the entity
         await Interact(Weld);
-        Assert.That(comp.Damage.Total, Is.EqualTo(FixedPoint2.Zero));
+        Assert.That(comp.Damage.GetTotal(), Is.EqualTo(FixedPoint2.Zero));
 
         // Validate that we can still deconstruct the entity (i.e., that welding deconstruction is not blocked).
         await Interact(

--- a/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
+++ b/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
@@ -298,7 +298,7 @@ namespace Content.IntegrationTests.Tests
                 Assert.That(damageResult, Is.Not.Null,
                     "Received null damageResult when attempting to damage restock box.");
 
-                Assert.That((int) damageResult!.Total, Is.GreaterThan(0),
+                Assert.That((int) damageResult!.GetTotal(), Is.GreaterThan(0),
                     "Box damage result was not greater than 0.");
 #pragma warning restore NUnit2045
             });

--- a/Content.Server/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Server/Bed/Sleep/SleepingSystem.cs
@@ -80,14 +80,14 @@ namespace Content.Server.Bed.Sleep
         }
 
         /// <summary>
-        /// Wake up if we take an instance of more than 2 damage.
+        /// Wake up on taking an instance of damage at least the value of WakeThreshold.
         /// </summary>
         private void OnDamageChanged(EntityUid uid, SleepingComponent component, DamageChangedEvent args)
         {
             if (!args.DamageIncreased || args.DamageDelta == null)
                 return;
 
-            if (args.DamageDelta.Total >= component.WakeThreshold)
+            if (args.DamageDelta.GetTotal() >= component.WakeThreshold)
                 TryWaking(uid, component);
         }
 

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -187,7 +187,7 @@ public sealed class BloodstreamSystem : EntitySystem
 
         // Does the calculation of how much bleed rate should be added/removed, then applies it
         var oldBleedAmount = component.BleedAmount;
-        var total = bloodloss.Total;
+        var total = bloodloss.GetTotal();
         var totalFloat = total.Float();
         TryModifyBleedAmount(uid, totalFloat, component);
 

--- a/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
+++ b/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Damage;
+using Content.Shared.Damage;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
@@ -90,7 +90,7 @@ public sealed class DamageForceSaySystem : EntitySystem
 
     private void OnDamageChanged(EntityUid uid, DamageForceSayComponent component, DamageChangedEvent args)
     {
-        if (args.DamageDelta == null || !args.DamageIncreased || args.DamageDelta.Total < component.DamageThreshold)
+        if (args.DamageDelta == null || !args.DamageIncreased || args.DamageDelta.GetTotal() < component.DamageThreshold)
             return;
 
         if (component.ValidDamageGroups != null)

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -36,7 +36,7 @@ namespace Content.Server.Damage.Systems
 
             // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
             if (dmg != null && HasComp<MobStateComponent>(args.Target))
-                _adminLogger.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total:damage} damage from collision");
+                _adminLogger.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.GetTotal():damage} damage from collision");
 
             if (dmg is { Empty: false })
             {

--- a/Content.Server/Damage/Systems/DamagePopupSystem.cs
+++ b/Content.Server/Damage/Systems/DamagePopupSystem.cs
@@ -20,7 +20,7 @@ public sealed class DamagePopupSystem : EntitySystem
         if (args.DamageDelta != null)
         {
             var damageTotal = args.Damageable.TotalDamage;
-            var damageDelta = args.DamageDelta.Total;
+            var damageDelta = args.DamageDelta.GetTotal();
 
             var msg = component.Type switch
             {

--- a/Content.Server/KillTracking/KillTrackingSystem.cs
+++ b/Content.Server/KillTracking/KillTrackingSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.NPC.HTN;
+using Content.Server.NPC.HTN;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
@@ -27,7 +27,7 @@ public sealed class KillTrackingSystem : EntitySystem
         {
             foreach (var key in component.LifetimeDamage.Keys)
             {
-                component.LifetimeDamage[key] -= args.DamageDelta.Total;
+                component.LifetimeDamage[key] -= args.DamageDelta.GetTotal();
             }
 
             return;
@@ -35,7 +35,7 @@ public sealed class KillTrackingSystem : EntitySystem
 
         var source = GetKillSource(args.Origin);
         var damage = component.LifetimeDamage.GetValueOrDefault(source);
-        component.LifetimeDamage[source] = damage + args.DamageDelta.Total;
+        component.LifetimeDamage[source] = damage + args.DamageDelta.GetTotal();
     }
 
     private void OnMobStateChanged(EntityUid uid, KillTrackerComponent component, MobStateChangedEvent args)

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -135,7 +135,7 @@ namespace Content.Server.Light.EntitySystems
 
                         var burnMsg = Loc.GetString("powered-light-component-burn-hand");
                         _popupSystem.PopupEntity(burnMsg, uid, userUid);
-                        _adminLogger.Add(LogType.Damaged, $"{ToPrettyString(args.User):user} burned their hand on {ToPrettyString(args.Target):target} and received {damage.Total:damage} damage");
+                        _adminLogger.Add(LogType.Damaged, $"{ToPrettyString(args.User):user} burned their hand on {ToPrettyString(args.Target):target} and received {damage.GetTotal():damage} damage");
                         _audio.PlayEntity(light.BurnHandSound, Filter.Pvs(uid), uid, true);
 
                         args.Handled = true;

--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -84,7 +84,7 @@ public sealed class HealingSystem : EntitySystem
         if (healed == null && healing.BloodlossModifier != 0)
             return;
 
-        var total = healed?.Total ?? FixedPoint2.Zero;
+        var total = healed?.GetTotal() ?? FixedPoint2.Zero;
 
         // Re-verify that we can heal the damage.
 

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -331,7 +331,7 @@ public sealed class NPCUtilitySystem : EntitySystem
             {
                 if (TryComp<MeleeWeaponComponent>(targetUid, out var melee))
                 {
-                    return melee.Damage.Total.Float() * melee.AttackRate / 100f;
+                    return melee.Damage.GetTotal().Float() * melee.AttackRate / 100f;
                 }
 
                 return 0f;

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -58,7 +58,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 
             _adminLogger.Add(LogType.BulletHit,
                 HasComp<ActorComponent>(target) ? LogImpact.Extreme : LogImpact.High,
-                $"Projectile {ToPrettyString(uid):projectile} shot by {ToPrettyString(component.Shooter!.Value):user} hit {otherName:target} and dealt {modifiedDamage.Total:damage} damage");
+                $"Projectile {ToPrettyString(uid):projectile} shot by {ToPrettyString(component.Shooter!.Value):user} hit {otherName:target} and dealt {modifiedDamage.GetTotal():damage} damage");
         }
 
         if (!deleted)

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
@@ -120,7 +120,7 @@ public sealed partial class RevenantSystem : EntitySystem
         if (!HasComp<CorporealComponent>(uid) || args.DamageDelta == null)
             return;
 
-        var essenceDamage = args.DamageDelta.Total.Float() * component.DamageToEssenceCoefficient * -1;
+        var essenceDamage = args.DamageDelta.GetTotal().Float() * component.DamageToEssenceCoefficient * -1;
         ChangeEssenceAmount(uid, essenceDamage, component);
     }
 

--- a/Content.Server/UserInterface/StatValuesCommand.cs
+++ b/Content.Server/UserInterface/StatValuesCommand.cs
@@ -190,9 +190,9 @@ public sealed class StatValuesCommand : IConsoleCommand
             values.Add(new[]
             {
                 proto.ID,
-                (comp.Damage.Total * comp.AttackRate).ToString(),
+                (comp.Damage.GetTotal() * comp.AttackRate).ToString(),
                 comp.AttackRate.ToString(CultureInfo.CurrentCulture),
-                comp.Damage.Total.ToString(),
+                comp.Damage.GetTotal().ToString(),
                 comp.Range.ToString(CultureInfo.CurrentCulture),
             });
         }

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -167,7 +167,7 @@ namespace Content.Server.VendingMachines
                 component.DispenseOnHitChance == null || args.DamageDelta == null)
                 return;
 
-            if (args.DamageIncreased && args.DamageDelta.Total >= component.DispenseOnHitThreshold &&
+            if (args.DamageIncreased && args.DamageDelta.GetTotal() >= component.DispenseOnHitThreshold &&
                 _random.Prob(component.DispenseOnHitChance.Value))
             {
                 if (component.DispenseOnHitCooldown > 0f)

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -272,12 +272,12 @@ public sealed partial class GunSystem : SharedGunSystem
                             if (user != null)
                             {
                                 Logs.Add(LogType.HitScanHit,
-                                    $"{ToPrettyString(user.Value):user} hit {hitName:target} using hitscan and dealt {dmg.Total:damage} damage");
+                                    $"{ToPrettyString(user.Value):user} hit {hitName:target} using hitscan and dealt {dmg.GetTotal():damage} damage");
                             }
                             else
                             {
                                 Logs.Add(LogType.HitScanHit,
-                                    $"{hitName:target} hit by hitscan dealing {dmg.Total:damage} damage");
+                                    $"{hitName:target} hit by hitscan dealing {dmg.GetTotal():damage} damage");
                             }
                         }
                     }
@@ -369,7 +369,7 @@ public sealed partial class GunSystem : SharedGunSystem
         // 3. Nothing
         var playedSound = false;
 
-        if (!forceWeaponSound && modifiedDamage != null && modifiedDamage.Total > 0 && TryComp<RangedDamageSoundComponent>(otherEntity, out var rangedSound))
+        if (!forceWeaponSound && modifiedDamage != null && modifiedDamage.GetTotal() > 0 && TryComp<RangedDamageSoundComponent>(otherEntity, out var rangedSound))
         {
             var type = SharedMeleeWeaponSystem.GetHighestDamageSound(modifiedDamage, ProtoManager);
 

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -38,10 +38,6 @@ namespace Content.Shared.Damage
         [IncludeDataField(customTypeSerializer: typeof(DamageSpecifierDictionarySerializer), readOnly: true)]
         public Dictionary<string, FixedPoint2> DamageDict { get; set; } = new();
 
-        [JsonIgnore]
-        [Obsolete("Use GetTotal()")]
-        public FixedPoint2 Total => GetTotal();
-
         /// <summary>
         ///     Returns a sum of the damage values.
         /// </summary>

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -516,12 +516,12 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             if (meleeUid == user)
             {
                 AdminLogger.Add(LogType.MeleeHit, LogImpact.Medium,
-                    $"{ToPrettyString(user):actor} melee attacked (light) {ToPrettyString(target.Value):subject} using their hands and dealt {damageResult.Total:damage} damage");
+                    $"{ToPrettyString(user):actor} melee attacked (light) {ToPrettyString(target.Value):subject} using their hands and dealt {damageResult.GetTotal():damage} damage");
             }
             else
             {
                 AdminLogger.Add(LogType.MeleeHit, LogImpact.Medium,
-                    $"{ToPrettyString(user):actor} melee attacked (light) {ToPrettyString(target.Value):subject} using {ToPrettyString(meleeUid):tool} and dealt {damageResult.Total:damage} damage");
+                    $"{ToPrettyString(user):actor} melee attacked (light) {ToPrettyString(target.Value):subject} using {ToPrettyString(meleeUid):tool} and dealt {damageResult.GetTotal():damage} damage");
             }
 
             PlayHitSound(target.Value, user, GetHighestDamageSound(modifiedDamage, _protoManager), hitEvent.HitSoundOverride, component.HitSound);
@@ -542,7 +542,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             }
         }
 
-        if (damageResult?.Total > FixedPoint2.Zero)
+        if (damageResult?.GetTotal() > FixedPoint2.Zero)
         {
             DoDamageEffect(targets, user, targetXform);
         }
@@ -670,7 +670,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 else
                 {
                     AdminLogger.Add(LogType.MeleeHit, LogImpact.Medium,
-                        $"{ToPrettyString(user):actor} melee attacked (heavy) {ToPrettyString(entity):subject} using {ToPrettyString(meleeUid):tool} and dealt {damageResult.Total:damage} damage");
+                        $"{ToPrettyString(user):actor} melee attacked (heavy) {ToPrettyString(entity):subject} using {ToPrettyString(meleeUid):tool} and dealt {damageResult.GetTotal():damage} damage");
                 }
             }
         }

--- a/Content.Tests/Shared/DamageTest.cs
+++ b/Content.Tests/Shared/DamageTest.cs
@@ -61,7 +61,7 @@ namespace Content.Tests.Shared
 
             // Check that it properly split up the groups into types
             FixedPoint2 damage;
-            Assert.That(damageSpec.Total, Is.EqualTo(FixedPoint2.New(8)));
+            Assert.That(damageSpec.GetTotal(), Is.EqualTo(FixedPoint2.New(8)));
             Assert.That(damageSpec.DamageDict.TryGetValue("Blunt", out damage));
             Assert.That(damage, Is.EqualTo(FixedPoint2.New(2)));
             Assert.That(damageSpec.DamageDict.TryGetValue("Piercing", out damage));
@@ -73,7 +73,7 @@ namespace Content.Tests.Shared
 
             // check that integer multiplication works
             damageSpec = damageSpec * 2;
-            Assert.That(damageSpec.Total, Is.EqualTo(FixedPoint2.New(16)));
+            Assert.That(damageSpec.GetTotal(), Is.EqualTo(FixedPoint2.New(16)));
             Assert.That(damageSpec.DamageDict.TryGetValue("Blunt", out damage));
             Assert.That(damage, Is.EqualTo(FixedPoint2.New(4)));
             Assert.That(damageSpec.DamageDict.TryGetValue("Piercing", out damage));
@@ -93,7 +93,7 @@ namespace Content.Tests.Shared
             Assert.That(damage, Is.EqualTo(FixedPoint2.New(4.4)));
             Assert.That(damageSpec.DamageDict.TryGetValue("Radiation", out damage));
             Assert.That(damage, Is.EqualTo(FixedPoint2.New(13.2)));
-            Assert.That(damageSpec.Total, Is.EqualTo(FixedPoint2.New(8.8 + 8.8 + 4.4 + 13.2)));
+            Assert.That(damageSpec.GetTotal(), Is.EqualTo(FixedPoint2.New(8.8 + 8.8 + 4.4 + 13.2)));
 
             // check that integer division works
             damageSpec = damageSpec / 2;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Updates all occurrences of obsolete `DamageSpecifier` `Total` to the recommended method `GetTotal()`.
Keeping PR small to avoid merge conflicts and long reviews.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Obsolete.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Following recommendation to change to `GetTotal()`.
_yes there is also a single change to a comment included, it just wasn't precise and it bothered me, okay?_

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

~~Question~~
~~Should I also remove the now-unused `Total` from `DamageSpecifier`?~~

~~I don't know what the conventions are for this. Do we keep it as a courtesy for downstream? Or just focus on our keeping codebase clean and remove it?~~

~~Docs don't specify. Please advise.~~