### PR TITLE
Fix missing [NetSerializable] in SimplePredictReconcileTest

### DIFF
--- a/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
@@ -10,6 +10,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 namespace Content.IntegrationTests.Tests.Networking
@@ -420,6 +421,7 @@ namespace Content.IntegrationTests.Tests.Networking
             }
         }
 
+        [Serializable, NetSerializable]
         public sealed class SetFooMessage : EntityEventArgs
         {
             public SetFooMessage(NetEntity uid, bool newFoo)


### PR DESCRIPTION
This didn't cause any issues because NetSerializer wasn't used in integration tests... until https://github.com/space-wizards/RobustToolbox/pull/4838.
