### PR TITLE
Fix microwave bug when power interruption can make ingredients unusable

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -106,7 +106,7 @@ namespace Content.Server.Kitchen.EntitySystems
 
         private void OnActiveMicrowaveInsert(Entity<ActiveMicrowaveComponent> ent, ref EntInsertedIntoContainerMessage args)
         {
-            AddComp<ActivelyMicrowavedComponent>(args.Entity);
+            EnsureComp<ActivelyMicrowavedComponent>(args.Entity);
         }
 
         private void OnActiveMicrowaveRemove(Entity<ActiveMicrowaveComponent> ent, ref EntRemovedFromContainerMessage args)
@@ -428,7 +428,7 @@ namespace Content.Server.Kitchen.EntitySystems
                     QueueDel(item);
                 }
 
-                AddComp<ActivelyMicrowavedComponent>(item);
+                EnsureComp<ActivelyMicrowavedComponent>(item);
 
                 var metaData = MetaData(item); //this simply begs for cooking refactor
                 if (metaData.EntityPrototype == null)
@@ -464,7 +464,7 @@ namespace Content.Server.Kitchen.EntitySystems
                 CanSatisfyRecipe(component, r, solidsDict, reagentDict)).FirstOrDefault(r => r.Item2 > 0);
 
             _audio.PlayPvs(component.StartCookingSound, uid);
-            var activeComp = AddComp<ActiveMicrowaveComponent>(uid); //microwave is now cooking
+            var activeComp = EnsureComp<ActiveMicrowaveComponent>(uid); //microwave is now cooking
             activeComp.CookTimeRemaining = component.CurrentCookTimerTime * component.CookTimeMultiplier;
             activeComp.TotalTime = component.CurrentCookTimerTime; //this doesn't scale so that we can have the "actual" time
             activeComp.PortionedRecipe = portionedRecipe;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

### The issue

When the MicrowaveSystem starts cooking, it applies the ActivelyMicrowaved component to each ingredient. If then the microwave loses power halfway-through, it'd require to start microwaving over, which in turn would attempt to add the same ActivelyMicrowaved component, resulting in an exception, essentially wasting the ingredients as they would never be able to used in microwaiving again.

```
System.InvalidOperationException: Component reference type ActivelyMicrowaved already occupied by Content.Server.Kitchen.Components.ActivelyMicrowavedComponent
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, ComponentRegistration reg, Boolean overwrite, Boolean skipInit, MetaDataComponent metadata) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 295
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, Boolean overwrite, Boolean skipInit, MetaDataComponent metadata) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 272
   at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid, T component, Boolean overwrite, MetaDataComponent metadata) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 250
   at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 188
   at Content.Server.Kitchen.EntitySystems.MicrowaveSystem.Wzhzhzh(EntityUid uid, MicrowaveComponent component, Nullable`1 user) in /space-station-14/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs:line 431
   at Content.Server.Kitchen.EntitySystems.MicrowaveSystem.<Initialize>b__15_0(EntityUid u, MicrowaveComponent c, MicrowaveStartCookMessage m) in /space-station-14/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs:line 75
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEventCore(EntityUid uid, Unit& unitRef, Type type, Boolean broadcast) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 217
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent(EntityUid uid, Object args, Boolean broadcast) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 186
   at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent(EntityUid uid, Object args, Boolean broadcast) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystem.cs:line 154
   at Robust.Shared.GameObjects.SharedUserInterfaceSystem.OnMessageReceived(BaseBoundUIWrapMessage msg, EntitySessionEventArgs args) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs:line 89
   at Robust.Shared.GameObjects.EventBusExt.HandlerWrapper`1.Invoke(EntitySessionMessage`1 msg) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EventBusExt.cs:line 46
   at Robust.Shared.GameObjects.EntityEventBus.ProcessSingleEventCore(EventSource source, Unit& unitRef, EventData subs) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs:line 335
   at Robust.Server.GameObjects.ServerEntityManager.DispatchEntityNetworkMessage(MsgEntity message) in /space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 212
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 150
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 702
   at Robust.Shared.Timing.GameLoop.Run() in /space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 569
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /space-station-14/RobustToolbox/Robust.Server/Program.cs:line 76
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /space-station-14/RobustToolbox/Robust.Server/Program.cs:line 44
   at Robust.Server.ContentStart.Start(String[] args) in /space-station-14/RobustToolbox/Robust.Server/ContentStart.cs:line 10
   at Content.Server.Program.Main(String[] args) in /space-station-14/Content.Server/Program.cs:line 9
Unhandled exception. System.InvalidOperationException: Component reference type ActivelyMicrowaved already occupied by Content.Server.Kitchen.Components.ActivelyMicrowavedComponent
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, ComponentRegistration reg, Boolean overwrite, Boolean skipInit, MetaDataComponent metadata) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 295
   at Robust.Shared.GameObjects.EntityManager.AddComponentInternal[T](EntityUid uid, T component, Boolean overwrite, Boolean skipInit, MetaDataComponent metadata) in /space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 272
```

### The solution

Change `AddComp` calls with `EnsureComp` to avoid the exception.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
To fix an annoing bug.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
n/a

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
<!--
## Breaking changes

List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
<!--
**Changelog**

Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Fixed a microwave issue where a power outage could render ingredients unusable.

