### PR TITLE
fix water gun and spray nozzle collision

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -754,14 +754,16 @@
         maxVol: 50
   - type: Fixtures
     fixtures:
-      fix1:
+      projectile:
         shape:
           !type:PhysShapeAabb
           bounds: "-0.10,-0.30,0.10,0.15"
         hard: false
         mask:
-        - FullTileMask
-        - Opaque
+        - Impassable
+        - BulletImpassable
+  - type: CanPenetrate
+    penetrationLayer: MobLayer
   - type: Vapor
     active: true
   - type: Appearance


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Water gun and spray nozzle projectiles now properly collide with things they should collide with, instead of being able to fly through closed airlocks/firelocks. 
They now collide with anything a bullet collides with, with the exception of them being able to penetrate based on the solution used. For example sulfuric acid will penetrate mobs and deal it's damage to all of them, but phlogiston will stop at the first entity hit and light them on fire(this is the same behavior as before this PR).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Water gun and spray nozzle projectiles are shooting through closed glass airlocks/firelocks(maybe more stuff), I assumed this is a bug.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I gave the projectile the CanPenetrate component and set it's PenetrationLayer to the MobLayer

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- fix: Water gun and spray nozzle projectiles don't phase through closed airlocks/firelocks anymore.

