### PR TITLE
Grindable ores

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -49,6 +49,14 @@
   - type: PhysicalComposition
     materialComposition:
       RawGold: 500
+  - type: Extractable
+    grindableSolutionName: goldore
+  - type: SolutionContainerManager
+    solutions:
+      goldore:
+        reagents:
+        - ReagentId: Gold
+          Quantity: 10
 
 - type: entity
   parent: GoldOre
@@ -72,6 +80,16 @@
   - type: PhysicalComposition
     materialComposition:
       RawIron: 500
+  - type: Extractable
+    grindableSolutionName: ironore
+  - type: SolutionContainerManager
+    solutions:
+      ironore:
+        reagents:
+        - ReagentId: Iron
+          Quantity: 9
+        - ReagentId: Carbon
+          Quantity: 1
 
 - type: entity
   id: SteelOre1
@@ -100,6 +118,14 @@
     energy: 0.6
     castShadows: false
     color: "#e592e7"
+  - type: Extractable
+    grindableSolutionName: plasmaore
+  - type: SolutionContainerManager
+    solutions:
+      plasmaore:
+        reagents:
+        - ReagentId: Plasma
+          Quantity: 10
 
 - type: entity
   parent: PlasmaOre
@@ -123,6 +149,14 @@
   - type: PhysicalComposition
     materialComposition:
       RawSilver: 500
+  - type: Extractable
+    grindableSolutionName: silverore
+  - type: SolutionContainerManager
+    solutions:
+      silverore:
+        reagents:
+        - ReagentId: Silver
+          Quantity: 10
 
 - type: entity
   parent: SilverOre
@@ -146,6 +180,14 @@
   - type: PhysicalComposition
     materialComposition:
       RawQuartz: 500
+  - type: Extractable
+    grindableSolutionName: quartzore
+  - type: SolutionContainerManager
+    solutions:
+      quartzaore:
+        reagents:
+        - ReagentId: Silicon
+          Quantity: 10
 
 - type: entity
   parent: SpaceQuartz
@@ -174,6 +216,17 @@
     energy: 0.8
     castShadows: false
     color: "#9be792"
+  - type: Extractable
+    grindableSolutionName: uraniumore
+  - type: SolutionContainerManager
+    solutions:
+      uraniumore:
+        reagents:
+        - ReagentId: Uranium
+          Quantity: 8
+        - ReagentId: Radium
+          Quantity: 2
+        canReact: false
 
 - type: entity
   parent: UraniumOre
@@ -202,6 +255,18 @@
     energy: 1
     castShadows: false
     color: "#eef066"
+  - type: Extractable
+    grindableSolutionName: bananiumore
+  - type: SolutionContainerManager
+    solutions:
+      bananiumore:
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 4
+        - ReagentId: Vitamin
+          Quantity: 2
+        - ReagentId: Honk
+          Quantity: 5
 
 - type: entity
   parent: BananiumOre


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

If the refined material can be processed, so should the ore material. For balance reasons, ore produces one fifth of the amount of resources compared to the sheet or ingot version. This PR allows chemists to obtain basic materials from ore even if the ore processor is somehow lost, and or cargo is out of money. Even if not, this is just a useful feature to exist since variety should be possible.

This PR also properly completes #11320.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/space-wizards/space-station-14/assets/134914314/b41125e4-282a-467b-9b1c-1d32882bbbff)

**Changelog**

:cl: Ubaser
- add: Ore is now grindable to obtain basic chemicals.
