### PR TITLE
Repairable shuttles

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -39,6 +39,9 @@
         behaviors:
           - !type:DoActsBehavior
             acts: ["Destruction"]
+          - !type:PlaySoundBehavior
+            sound:
+              path: /Audio/Effects/metalbreak.ogg
     - type: StaticPrice
       price: 300
   placement:
@@ -49,9 +52,21 @@
   name: thruster
   parent: [ BaseThruster, ConstructibleMachine ]
   components:
-  - type: Thruster
   - type: Machine
     board: ThrusterMachineCircuitboard
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+        - !type:PlaySoundBehavior
+          sound:
+            path: /Audio/Effects/metalbreak.ogg
+        - !type:ChangeConstructionNodeBehavior
+          node: machineFrame
   - type: Sprite
     sprite: Structures/Shuttles/thruster.rsi
     layers:
@@ -142,6 +157,19 @@
     color: "#4246b3"
   - type: Machine
     board: GyroscopeMachineCircuitboard
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+        - !type:PlaySoundBehavior
+          sound:
+            path: /Audio/Effects/metalbreak.ogg
+        - !type:ChangeConstructionNodeBehavior
+          node: machineFrame
   - type: UpgradePowerDraw
     powerDrawMultiplier: 0.75
     scaling: Exponential

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -58,6 +58,11 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 300
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
         damage: 100
       behaviors:
         - !type:DoActsBehavior
@@ -159,6 +164,11 @@
     board: GyroscopeMachineCircuitboard
   - type: Destructible
     thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 100

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -59,6 +59,7 @@
     - trigger:
         !type:DamageTrigger
         damage: 300
+      behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]
     - trigger:
@@ -167,6 +168,7 @@
     - trigger:
         !type:DamageTrigger
         damage: 300
+      behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]
     - trigger:


### PR DESCRIPTION
## About the PR
Now if a shuttle's gyroscope or thrusters break down, they can still be repaired.

## Why / Balance
fixing the shuttles is necessary

## Media

https://github.com/space-wizards/space-station-14/assets/96445749/a5df4da2-85b5-45ec-9ef1-f5cb1c0f9b59

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added the ability to repair thrusters and gyroscopes on the shuttle.
