### PR TITLE
Make shotgun slug ammo not useless

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: BaseShellShotgun
   name: shell (.50)
   parent: BaseCartridge
@@ -47,8 +47,8 @@
         map: [ "enum.AmmoVisualLayers.Base" ]
   - type: CartridgeAmmo
     proto: PelletShotgunSlug
-    count: 4
-    spread: 5
+    count: 1
+    spread: 0
   - type: SpentAmmoVisuals
     state: "slug"
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: PelletShotgunSlug
   name: pellet (.50 slug)
   noSpawn: true
@@ -10,7 +10,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 8  # Should have the same or less damage than a regular pellet
+        Piercing: 8
+        Blunt: 20
 
 - type: entity
   id: PelletShotgunBeanbag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -10,8 +10,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 8
-        Blunt: 20
+        Piercing: 28
 
 - type: entity
   id: PelletShotgunBeanbag

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -742,7 +742,7 @@
         - CartridgePistol
         - CartridgeMagnum
         - ShellShotgun
-        - ShellShotgunSlug
+        - ShellShotgunSlug #shotgun slug
         - ShellShotgunFlare
         - ShellTranquilizer
         - CartridgeLightRifle

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -640,6 +640,7 @@
       - ForensicPad
       - RiotShield
       - ShellShotgun
+      - ShellShotunSlug
       - ShellShotgunFlare
       - ShellTranquilizer
       - MagazinePistol
@@ -741,6 +742,7 @@
         - CartridgePistol
         - CartridgeMagnum
         - ShellShotgun
+        - ShellShotgunSlug
         - ShellShotgunFlare
         - ShellTranquilizer
         - CartridgeLightRifle

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -640,7 +640,7 @@
       - ForensicPad
       - RiotShield
       - ShellShotgun
-      - ShellShotunSlug
+      - ShellShotgunSlug
       - ShellShotgunFlare
       - ShellTranquilizer
       - MagazinePistol
@@ -742,7 +742,7 @@
         - CartridgePistol
         - CartridgeMagnum
         - ShellShotgun
-        - ShellShotgunSlug #shotgun slug
+        - ShellShotgunSlug
         - ShellShotgunFlare
         - ShellTranquilizer
         - CartridgeLightRifle

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -192,6 +192,13 @@
     Steel: 20
 
 - type: latheRecipe
+  id: ShellShotgunSlug
+  result: ShellShotgunSlug
+  completetime: 2
+  materials:
+    Steel: 25
+
+- type: latheRecipe
   id: CartridgeMagnum
   result: CartridgeMagnum
   completetime: 2


### PR DESCRIPTION
## About the PR
Shotgun slugs now fire a single projectile that does 28 pierce with no spread.
Shotgun slugs are now able to be printed in secfabs and ammofabs for .25 steel (.05 more steel than pellet shells)

## Why / Balance
Shotgun slugs previously were literally just weaker versions of the pellet shell. It had 4 projectiles with spread that each did less damage individually than the pellet shell's individual projectiles did.

## Media
https://youtu.be/71k0lO-r_M8
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Shotgun slugs can now be printed in the security techfab.
- tweak: Shotgun slugs now fire a single strong projectile when fired.
