### PR TITLE
fix flippo not igniting plasma

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -177,6 +177,10 @@
         - ReagentId: WeldingFuel
           Quantity: 12
         maxVol: 12 #uses less fuel than a welder, so this isnt as bad as it looks
+  - type: Welder
+    fuelConsumption: 0.01
+    fuelLitCost: 0.1
+    tankSafe: true
   - type: ToggleableLightVisuals
     spriteLayer: lighter_flame
     inhandVisuals:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Flippo doesn't ignite hazardous gases due to missing Welder component. 
This PR adds Welder component in exact same way as Lighter does. Flippo is parent of FlippoEngravedLighter, so it'll work there too. 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Being unable to epically throw flippo to plasma and see the world burn is such a waste and must be fixed.
Flippo already has a SolutionContainerManager with extended welding fuel capacity, so I'm pretty sure Welder component was meant to be there too.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl:
- fix: Flippo can burn plasma now!
