### PR TITLE
Do not log missing components in OpenableSystem

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/OpenableSystem.cs
@@ -118,7 +118,7 @@ public sealed class OpenableSystem : EntitySystem
     /// </summary>
     public void SetOpen(EntityUid uid, bool opened = true, OpenableComponent? comp = null)
     {
-        if (!Resolve(uid, ref comp) || opened == comp.Opened)
+        if (!Resolve(uid, ref comp, false) || opened == comp.Opened)
             return;
 
         comp.Opened = opened;
@@ -132,7 +132,7 @@ public sealed class OpenableSystem : EntitySystem
     /// <returns>Whether it got opened</returns>
     public bool TryOpen(EntityUid uid, OpenableComponent? comp = null)
     {
-        if (!Resolve(uid, ref comp) || comp.Opened)
+        if (!Resolve(uid, ref comp, false) || comp.Opened)
             return false;
 
         SetOpen(uid, true, comp);


### PR DESCRIPTION
## About the PR
Pass `logMissing = false` in more of the `Resolve()` calls in `OpenableSystem`.

## Why / Balance
`OpenableSystem`'s API is designed to return reasonable values even if the entity it is being called on is missing the `OpenableComponent`. This avoids the caller from needing to do ugly `Resolve`/`TryComp`'s before using the methods provided by the system.

Expand this convention to `SetOpen()` and `TryOpen()` to avoid unnecessary log spam.