### PR TITLE
Fix reagent dispenser item slot ID

### DIFF
--- a/Content.IntegrationTests/Tests/Chemistry/DispenserTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/DispenserTest.cs
@@ -25,7 +25,7 @@ public sealed class DispenserTest : InteractionTest
         await Interact();
 
         // Eject beaker via BUI.
-        var ev = new ItemSlotButtonPressedEvent(ReagentDispenserComponent.BeakerSlotId);
+        var ev = new ItemSlotButtonPressedEvent(SharedReagentDispenser.OutputSlotName);
         await SendBui(ReagentDispenserUiKey.Key, ev);
 
         // Beaker is back in the player's hands

--- a/Content.Server/Chemistry/Components/ReagentDispenserComponent.cs
+++ b/Content.Server/Chemistry/Components/ReagentDispenserComponent.cs
@@ -39,11 +39,6 @@ namespace Content.Server.Chemistry.Components
         [DataField]
         public EntityWhitelist? StorageWhitelist;
 
-        /// <summary>
-        /// Slot for container to dispense into.
-        /// </summary>
-        public static string BeakerSlotId = "beakerSlot";
-
         [DataField]
         public ItemSlot BeakerSlot = new();
 

--- a/Content.Server/Chemistry/Components/ReagentDispenserComponent.cs
+++ b/Content.Server/Chemistry/Components/ReagentDispenserComponent.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Chemistry.Components
         /// <summary>
         /// Slot for container to dispense into.
         /// </summary>
-        public static string BeakerSlotId = "ReagentDispenser-beakerSlot";
+        public static string BeakerSlotId = "beakerSlot";
 
         [DataField]
         public ItemSlot BeakerSlot = new();

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -202,7 +202,7 @@ namespace Content.Server.Chemistry.EntitySystems
                 _itemSlotsSystem.AddItemSlot(uid, component.StorageSlotIds[i], component.StorageSlots[i]);
             }
 
-            _itemSlotsSystem.AddItemSlot(uid, ReagentDispenserComponent.BeakerSlotId, component.BeakerSlot);
+            _itemSlotsSystem.AddItemSlot(uid, SharedReagentDispenser.OutputSlotName, component.BeakerSlot);
         }
     }
 }

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -5,10 +5,11 @@ namespace Content.Shared.Chemistry
 {
     /// <summary>
     /// This class holds constants that are shared between client and server.
+    /// TODO: Kill this. The comp now stores the slot ID.
     /// </summary>
     public sealed class SharedReagentDispenser
     {
-        public const string OutputSlotName = "ReagentDispenser-beakerSlot";
+        public const string OutputSlotName = "beakerSlot";
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -5,7 +5,6 @@ namespace Content.Shared.Chemistry
 {
     /// <summary>
     /// This class holds constants that are shared between client and server.
-    /// TODO: Kill this. The comp now stores the slot ID.
     /// </summary>
     public sealed class SharedReagentDispenser
     {

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -68,7 +68,7 @@
     containers:
       machine_board: !type:Container
       machine_parts: !type:Container
-      ReagentDispenser-beakerSlot: !type:ContainerSlot
+      beakerSlot: !type:ContainerSlot
   - type: StaticPrice
     price: 1000
   - type: Wires


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Change the slot ID back to what it was to keep old map saves with an item in the slot loading correctly.

This also fixes the "You can't put this in the dispenser!" message not appearing when inserting an item without `FitsInDispenserComponent` because the whitelisted slot name wasn't changed.