### PR TITLE
Fix reagents obtained from grinding iron ore.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -87,9 +87,7 @@
       ironore:
         reagents:
         - ReagentId: Iron
-          Quantity: 9
-        - ReagentId: Carbon
-          Quantity: 1
+          Quantity: 10
 
 - type: entity
   id: SteelOre1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

The reason why steel sheets give carbon is because coal is used in the recipe to create them.. and the raw iron ore does not contain iron. I changed it so that raw iron ore only gives iron as a reagent. The reason why its 10u not 9u is because of the standardisation of all ores giving 10u total.  

