### PR TITLE
Carrots now properly contain Oculine

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -378,12 +378,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 9
+        maxVol: 12
         reagents:
         - ReagentId: JuiceCarrot
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Oculine
+          Qauntity: 3
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/carrot.rsi
   - type: Produce
@@ -393,6 +395,8 @@
       reagents:
       - ReagentId: JuiceCarrot
         Quantity: 10
+      - ReagentId: Oculine
+        Qauntity: 2
 
 - type: entity
   name: cabbage

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -385,7 +385,7 @@
         - ReagentId: Vitamin
           Quantity: 4
         - ReagentId: Oculine
-          Qauntity: 3
+          Quantity: 3
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/carrot.rsi
   - type: Produce
@@ -396,7 +396,7 @@
       - ReagentId: JuiceCarrot
         Quantity: 10
       - ReagentId: Oculine
-        Qauntity: 2
+        Quantity: 2
 
 - type: entity
   name: cabbage

--- a/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
@@ -41,7 +41,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Oculine
-        amount: 0.15
+        amount: 0.5
       - !type:AdjustReagent
         reagent: Nutriment
         amount: 0.5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Eating carrots directly now heal your eyes and you can juice them for raw oculine at a slightly lower rate than eating them raw. Also, carrot juice now injects 0.5u of oculine as this is part of the missing 1u from grinding them.

Solves ##24227.

**Changelog**

:cl: Ubaser
- fix: Carrots now properly contain Oculine, and you can Juice them to obtain the raw chemical.
