### PR TITLE
Make super bite burger easier to craft

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -292,7 +292,7 @@
   solids:
     FoodBreadBun: 1
     FoodMeat: 2
-    FoodCheeseSlice: 3
+    FoodCheeseSlice: 2
     FoodTomato: 2
     FoodEgg: 2
 

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -291,9 +291,9 @@
     TableSalt: 5
   solids:
     FoodBreadBun: 1
-    FoodMeat: 3
+    FoodMeat: 2
     FoodCheeseSlice: 3
-    FoodTomato: 3
+    FoodTomato: 2
     FoodEgg: 2
 
 - type: microwaveMealRecipe


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Resolves #24034 by making the burger a bit easier to craft, but still the ingredient with the most items needed to make in the game.