### PR TITLE
Remove ability to start pulling while inside a container

### DIFF
--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -59,7 +59,7 @@ namespace Content.Shared.Pulling
                 return false;
             }
 
-            if (!_containerSystem.IsInSameOrNoContainer(puller, pulled))
+            if(_containerSystem.IsEntityInContainer(puller))
             {
                 return false;
             }

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -59,7 +59,7 @@ namespace Content.Shared.Pulling
                 return false;
             }
 
-            if(_containerSystem.IsEntityInContainer(puller))
+            if(_containerSystem.IsEntityInContainer(puller) || _containerSystem.IsEntityInContainer(pulled))
             {
                 return false;
             }


### PR DESCRIPTION
## About the PR
Prevents an exploit by which a player can cause pullable objects to become teleported to a known and configurable location by simply pulling them after performing a setup. This is done by removing the ability to initiate a pull while the player is inside of a container, which I couldn't really think of a legitimate purpose for.

## Why / Balance
Remove exploits add fun

## Media
- [X] This PR does not require an ingame showcase

**Changelog**
no cl no exploits