### PR TITLE
Fix magic mirror sends a lot of messages on color change.

### DIFF
--- a/Content.Client/Humanoid/SingleMarkingPicker.xaml
+++ b/Content.Client/Humanoid/SingleMarkingPicker.xaml
@@ -19,7 +19,7 @@
 
         <!-- Color sliders -->
         <ScrollContainer MinHeight="200" HorizontalExpand="True">
-            <BoxContainer Name="ColorSelectorContainer" HorizontalExpand="True" />
+            <BoxContainer Name="ColorSelectorContainer" HorizontalExpand="False" Orientation="Vertical"/>
         </ScrollContainer>
     </BoxContainer>
 </BoxContainer>

--- a/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/SingleMarkingPicker.xaml.cs
@@ -231,10 +231,23 @@ public sealed partial class SingleMarkingPicker : BoxContainer
             selector.OnColorChanged += color =>
             {
                 marking.SetColor(colorIndex, color);
+            };
+
+            var button = new Button
+            {
+                Name = $"SelectColorButton",
+                Text = Loc.GetString("marking-color-choose"),
+                ToggleMode = false,
+                HorizontalExpand = true,
+            };
+
+            button.OnPressed += args =>
+            {
                 OnColorChanged!((_slot, marking));
             };
 
             ColorSelectorContainer.AddChild(selector);
+            ColorSelectorContainer.AddChild(button);
         }
     }
 

--- a/Resources/Locale/en-US/preferences/ui/markings-picker.ftl
+++ b/Resources/Locale/en-US/preferences/ui/markings-picker.ftl
@@ -10,6 +10,7 @@ marking-used = {$marking-name}
 marking-used-forced = {$marking-name} (Forced)
 marking-slot-add = Add
 marking-slot-remove = Remove
+marking-color-choose = Choose color
 
 # Categories
 


### PR DESCRIPTION
## About the PR
Add a button to the marking picker UI that will raise the `OnColorChanged` action and remove it from the slider.

I would also like to change this, but it a bit unrelated to the PR. It will fix фд error that occurs every time someone uses mirror. Should I add it?
```diff
-        _doAfterSystem.Cancel(component.DoAfter);
+        if (_doAfterSystem.GetStatus(component.DoAfter) != DoAfterStatus.Invalid)
+            _doAfterSystem.Cancel(component.DoAfter);
```

## Why / Balance
Because magic mirror starts changing the hair color every time the slider changes, which causes a lot of network messages and doafter pop-ups to appear.
Because magic mirror starts changing the hair color every time the slider changes, which makes a lot of network messages and doafter popups.

## Technical details
`SingleMarkingPicker` is only used by magic mirror and character creation screen, so it shouldn't break anything.

## Media

![image](https://github.com/space-wizards/space-station-14/assets/38111072/7e30ef70-9f64-484d-9b47-e07765b4b6e4)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Too little to announce.
