### PR TITLE
Fix sloshing electricity & enable SpeechVerb masking

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Players;
 using Content.Shared.Radio;
+using Content.Shared.Speech;
 using Robust.Server.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -389,6 +390,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (message.Length == 0)
             return;
 
+        var speech = GetSpeechVerb(source, message);
+
         // get the entity's apparent name (if no override provided).
         string name;
         if (nameOverride != null)
@@ -400,10 +403,11 @@ public sealed partial class ChatSystem : SharedChatSystem
             var nameEv = new TransformSpeakerNameEvent(source, Name(source));
             RaiseLocalEvent(source, nameEv);
             name = nameEv.Name;
+            if (nameEv.SpeechVerb != null)
+                speech = nameEv.SpeechVerb;
         }
 
         name = FormattedMessage.EscapeText(name);
-        var speech = GetSpeechVerb(source, message);
         var wrappedMessage = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
             ("entityName", name),
             ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
@@ -873,10 +877,13 @@ public sealed class TransformSpeakerNameEvent : EntityEventArgs
     public EntityUid Sender;
     public string Name;
 
-    public TransformSpeakerNameEvent(EntityUid sender, string name)
+    public SpeechVerbPrototype? SpeechVerb;
+
+    public TransformSpeakerNameEvent(EntityUid sender, string name, SpeechVerbPrototype? speechVerb = null)
     {
         Sender = sender;
         Name = name;
+        SpeechVerb = speechVerb;
     }
 }
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -403,8 +403,9 @@ public sealed partial class ChatSystem : SharedChatSystem
             var nameEv = new TransformSpeakerNameEvent(source, Name(source));
             RaiseLocalEvent(source, nameEv);
             name = nameEv.Name;
-            if (nameEv.SpeechVerb != null)
-                speech = nameEv.SpeechVerb;
+            // Check for a speech verb override
+            if (nameEv.SpeechVerb != null && _prototypeManager.TryIndex<SpeechVerbPrototype>(nameEv.SpeechVerb, out var proto))
+                speech = proto;
         }
 
         name = FormattedMessage.EscapeText(name);
@@ -877,9 +878,10 @@ public sealed class TransformSpeakerNameEvent : EntityEventArgs
     public EntityUid Sender;
     public string Name;
 
-    public SpeechVerbPrototype? SpeechVerb;
+    [ValidatePrototypeId<SpeechVerbPrototype>]
+    public string? SpeechVerb;
 
-    public TransformSpeakerNameEvent(EntityUid sender, string name, SpeechVerbPrototype? speechVerb = null)
+    public TransformSpeakerNameEvent(EntityUid sender, string name, string? speechVerb = null)
     {
         Sender = sender;
         Name = name;

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -877,8 +877,6 @@ public sealed class TransformSpeakerNameEvent : EntityEventArgs
 {
     public EntityUid Sender;
     public string Name;
-
-    [ValidatePrototypeId<SpeechVerbPrototype>]
     public string? SpeechVerb;
 
     public TransformSpeakerNameEvent(EntityUid sender, string name, string? speechVerb = null)

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -79,7 +79,10 @@ public sealed class RadioSystem : EntitySystem
 
         name = FormattedMessage.EscapeText(name);
 
-        var speech = _chat.GetSpeechVerb(messageSource, message);
+        var speech = mask != null && mask.Enabled && mask.SpeechVerb != null
+            ? mask.SpeechVerb
+            : _chat.GetSpeechVerb(messageSource, message);
+
         var content = escapeMarkup
             ? FormattedMessage.EscapeText(message)
             : message;

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
+using Content.Shared.Speech;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -79,9 +80,16 @@ public sealed class RadioSystem : EntitySystem
 
         name = FormattedMessage.EscapeText(name);
 
-        var speech = mask != null && mask.Enabled && mask.SpeechVerb != null
-            ? mask.SpeechVerb
-            : _chat.GetSpeechVerb(messageSource, message);
+        SpeechVerbPrototype speech;
+        if (mask != null
+            && mask.Enabled
+            && mask.SpeechVerb != null
+            && _prototype.TryIndex<SpeechVerbPrototype>(mask.SpeechVerb, out var proto))
+        {
+            speech = proto;
+        }
+        else
+            speech = _chat.GetSpeechVerb(messageSource, message);
 
         var content = escapeMarkup
             ? FormattedMessage.EscapeText(message)

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -83,7 +83,7 @@ public sealed class RadioSystem : EntitySystem
         SpeechVerbPrototype speech;
         if (mask != null
             && mask.Enabled
-            && mask.EnableSpeechVerbModification
+            && mask.SpeechVerb != null
             && _prototype.TryIndex<SpeechVerbPrototype>(mask.SpeechVerb, out var proto))
         {
             speech = proto;

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -83,7 +83,7 @@ public sealed class RadioSystem : EntitySystem
         SpeechVerbPrototype speech;
         if (mask != null
             && mask.Enabled
-            && mask.SpeechVerb != null
+            && mask.EnableSpeechVerbModification
             && _prototype.TryIndex<SpeechVerbPrototype>(mask.SpeechVerb, out var proto))
         {
             speech = proto;

--- a/Content.Server/Speech/Components/ListenWireAction.cs
+++ b/Content.Server/Speech/Components/ListenWireAction.cs
@@ -1,13 +1,9 @@
-using System.Text;
-
 using Content.Server.Speech.Components;
 using Content.Server.Chat.Systems;
-using Content.Server.Speech.EntitySystems;
 using Content.Server.VoiceMask;
 using Content.Server.Wires;
 using Content.Shared.Speech;
 using Content.Shared.Wires;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Speech;
 
@@ -15,17 +11,17 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
 {
     private WiresSystem _wires = default!;
     private ChatSystem _chat = default!;
-    private IPrototypeManager _prototypeManager = default!;
 
     /// <summary>
     /// Length of the gibberish string sent when pulsing the wire
     /// </summary>
-    private int _noiseLength = 16;
+    private const int NoiseLength = 16;
 
     /// <summary>
     /// Identifier of the SpeechVerbPrototype to use when pulsing the wire
     /// </summary>
-    private string _speechVerb = "Electricity";
+    [ValidatePrototypeId<SpeechVerbPrototype>]
+    private const string SpeechVerb = "Electricity";
     public override Color Color { get; set; } = Color.Green;
     public override string Name { get; set; } = "wire-name-listen";
 
@@ -41,7 +37,6 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
 
         _wires = EntityManager.System<WiresSystem>();
         _chat = EntityManager.System<ChatSystem>();
-        _prototypeManager = IoCManager.Resolve<IPrototypeManager>();
     }
     public override StatusLightState? GetLightState(Wire wire)
     {
@@ -83,7 +78,7 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         // Save the user's existing voicemask if they have one
         var oldEnabled = true;
         var oldVoiceName = Loc.GetString("wire-listen-pulse-error-name");
-        SpeechVerbPrototype? oldSpeechVerb = null;
+        string? oldSpeechVerb = null;
         if (EntityManager.TryGetComponent<VoiceMaskComponent>(user, out var oldMask))
         {
             oldEnabled = oldMask.Enabled;
@@ -95,10 +90,10 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         var mask = EntityManager.EnsureComponent<VoiceMaskComponent>(user);
         mask.Enabled = true;
         mask.VoiceName = Loc.GetString("wire-listen-pulse-identifier");
-        mask.SpeechVerb = _prototypeManager.Index<SpeechVerbPrototype>(_speechVerb);
+        mask.SpeechVerb = SpeechVerb;
 
         var chars = Loc.GetString("wire-listen-pulse-characters").ToCharArray();
-        var noiseMsg = _chat.BuildGibberishString(chars, _noiseLength);
+        var noiseMsg = _chat.BuildGibberishString(chars, NoiseLength);
 
         var attemptEv = new ListenAttemptEvent(wire.Owner);
         EntityManager.EventBus.RaiseLocalEvent(wire.Owner, attemptEv);

--- a/Content.Server/Speech/Components/ListenWireAction.cs
+++ b/Content.Server/Speech/Components/ListenWireAction.cs
@@ -78,14 +78,12 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         // Save the user's existing voicemask if they have one
         var oldEnabled = true;
         var oldVoiceName = Loc.GetString("wire-listen-pulse-error-name");
-        var oldSpeechVerb = "";
-        var oldSpeechVerbEnabled = false;
+        string? oldSpeechVerb = null;
         if (EntityManager.TryGetComponent<VoiceMaskComponent>(user, out var oldMask))
         {
             oldEnabled = oldMask.Enabled;
             oldVoiceName = oldMask.VoiceName;
             oldSpeechVerb = oldMask.SpeechVerb;
-            oldSpeechVerbEnabled = oldMask.EnableSpeechVerbModification;
         }
 
         // Give the user a temporary voicemask component
@@ -93,7 +91,6 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         mask.Enabled = true;
         mask.VoiceName = Loc.GetString("wire-listen-pulse-identifier");
         mask.SpeechVerb = SpeechVerb;
-        mask.EnableSpeechVerbModification = true;
 
         var chars = Loc.GetString("wire-listen-pulse-characters").ToCharArray();
         var noiseMsg = _chat.BuildGibberishString(chars, NoiseLength);
@@ -114,7 +111,6 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
             mask.Enabled = oldEnabled;
             mask.VoiceName = oldVoiceName;
             mask.SpeechVerb = oldSpeechVerb;
-            mask.EnableSpeechVerbModification = oldSpeechVerbEnabled;
         }
 
         base.Pulse(user, wire);

--- a/Content.Server/Speech/Components/ListenWireAction.cs
+++ b/Content.Server/Speech/Components/ListenWireAction.cs
@@ -78,12 +78,14 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         // Save the user's existing voicemask if they have one
         var oldEnabled = true;
         var oldVoiceName = Loc.GetString("wire-listen-pulse-error-name");
-        string? oldSpeechVerb = null;
+        var oldSpeechVerb = "";
+        var oldSpeechVerbEnabled = false;
         if (EntityManager.TryGetComponent<VoiceMaskComponent>(user, out var oldMask))
         {
             oldEnabled = oldMask.Enabled;
             oldVoiceName = oldMask.VoiceName;
             oldSpeechVerb = oldMask.SpeechVerb;
+            oldSpeechVerbEnabled = oldMask.EnableSpeechVerbModification;
         }
 
         // Give the user a temporary voicemask component
@@ -91,6 +93,7 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         mask.Enabled = true;
         mask.VoiceName = Loc.GetString("wire-listen-pulse-identifier");
         mask.SpeechVerb = SpeechVerb;
+        mask.EnableSpeechVerbModification = true;
 
         var chars = Loc.GetString("wire-listen-pulse-characters").ToCharArray();
         var noiseMsg = _chat.BuildGibberishString(chars, NoiseLength);
@@ -111,6 +114,7 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
             mask.Enabled = oldEnabled;
             mask.VoiceName = oldVoiceName;
             mask.SpeechVerb = oldSpeechVerb;
+            mask.EnableSpeechVerbModification = oldSpeechVerbEnabled;
         }
 
         base.Pulse(user, wire);

--- a/Content.Server/Speech/Components/ListenWireAction.cs
+++ b/Content.Server/Speech/Components/ListenWireAction.cs
@@ -7,6 +7,7 @@ using Content.Server.VoiceMask;
 using Content.Server.Wires;
 using Content.Shared.Speech;
 using Content.Shared.Wires;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Speech;
 
@@ -14,11 +15,17 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
 {
     private WiresSystem _wires = default!;
     private ChatSystem _chat = default!;
+    private IPrototypeManager _prototypeManager = default!;
 
     /// <summary>
     /// Length of the gibberish string sent when pulsing the wire
     /// </summary>
     private int _noiseLength = 16;
+
+    /// <summary>
+    /// Identifier of the SpeechVerbPrototype to use when pulsing the wire
+    /// </summary>
+    private string _speechVerb = "Electricity";
     public override Color Color { get; set; } = Color.Green;
     public override string Name { get; set; } = "wire-name-listen";
 
@@ -34,6 +41,7 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
 
         _wires = EntityManager.System<WiresSystem>();
         _chat = EntityManager.System<ChatSystem>();
+        _prototypeManager = IoCManager.Resolve<IPrototypeManager>();
     }
     public override StatusLightState? GetLightState(Wire wire)
     {
@@ -85,6 +93,7 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         var mask = EntityManager.EnsureComponent<VoiceMaskComponent>(user);
         mask.Enabled = true;
         mask.VoiceName = Loc.GetString("wire-listen-pulse-identifier");
+        mask.SpeechVerb = _prototypeManager.Index<SpeechVerbPrototype>(_speechVerb);
 
         var chars = Loc.GetString("wire-listen-pulse-characters").ToCharArray();
         var noiseMsg = _chat.BuildGibberishString(chars, _noiseLength);

--- a/Content.Server/Speech/Components/ListenWireAction.cs
+++ b/Content.Server/Speech/Components/ListenWireAction.cs
@@ -83,10 +83,12 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         // Save the user's existing voicemask if they have one
         var oldEnabled = true;
         var oldVoiceName = Loc.GetString("wire-listen-pulse-error-name");
+        SpeechVerbPrototype? oldSpeechVerb = null;
         if (EntityManager.TryGetComponent<VoiceMaskComponent>(user, out var oldMask))
         {
             oldEnabled = oldMask.Enabled;
             oldVoiceName = oldMask.VoiceName;
+            oldSpeechVerb = oldMask.SpeechVerb;
         }
 
         // Give the user a temporary voicemask component
@@ -113,6 +115,7 @@ public sealed partial class ListenWireAction : BaseToggleWireAction
         {
             mask.Enabled = oldEnabled;
             mask.VoiceName = oldVoiceName;
+            mask.SpeechVerb = oldSpeechVerb;
         }
 
         base.Pulse(user, wire);

--- a/Content.Server/VoiceMask/VoiceMaskComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskComponent.cs
@@ -9,5 +9,8 @@ public sealed partial class VoiceMaskComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite)] public string VoiceName = "Unknown";
 
+    /// <summary>
+    /// If not null, overrides the speech verb used when this entity speaks.
+    /// </summary>
     [ViewVariables(VVAccess.ReadWrite)] public SpeechVerbPrototype? SpeechVerb;
 }

--- a/Content.Server/VoiceMask/VoiceMaskComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskComponent.cs
@@ -1,21 +1,23 @@
 using Content.Shared.Speech;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.VoiceMask;
 
 [RegisterComponent]
 public sealed partial class VoiceMaskComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite)] public bool Enabled = true;
+    [DataField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public bool Enabled = true;
 
-    [ViewVariables(VVAccess.ReadWrite)] public string VoiceName = "Unknown";
+    [DataField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public string VoiceName = "Unknown";
 
     /// <summary>
     /// If EnableSpeechVerbModification is true, overrides the speech verb used when this entity speaks.
     /// </summary>
+    [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
-    [ValidatePrototypeId<SpeechVerbPrototype>]
-    public string SpeechVerb = "Default";
-
-    [ViewVariables(VVAccess.ReadWrite)]
-    public bool EnableSpeechVerbModification = false;
+    public ProtoId<SpeechVerbPrototype>? SpeechVerb;
 }

--- a/Content.Server/VoiceMask/VoiceMaskComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskComponent.cs
@@ -10,9 +10,12 @@ public sealed partial class VoiceMaskComponent : Component
     [ViewVariables(VVAccess.ReadWrite)] public string VoiceName = "Unknown";
 
     /// <summary>
-    /// If not null, overrides the speech verb used when this entity speaks.
+    /// If EnableSpeechVerbModification is true, overrides the speech verb used when this entity speaks.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [ValidatePrototypeId<SpeechVerbPrototype>]
-    public string? SpeechVerb;
+    public string SpeechVerb = "Default";
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    public bool EnableSpeechVerbModification = false;
 }

--- a/Content.Server/VoiceMask/VoiceMaskComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskComponent.cs
@@ -12,5 +12,7 @@ public sealed partial class VoiceMaskComponent : Component
     /// <summary>
     /// If not null, overrides the speech verb used when this entity speaks.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)] public SpeechVerbPrototype? SpeechVerb;
+    [ViewVariables(VVAccess.ReadWrite)]
+    [ValidatePrototypeId<SpeechVerbPrototype>]
+    public string? SpeechVerb;
 }

--- a/Content.Server/VoiceMask/VoiceMaskComponent.cs
+++ b/Content.Server/VoiceMask/VoiceMaskComponent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Speech;
+
 namespace Content.Server.VoiceMask;
 
 [RegisterComponent]
@@ -6,4 +8,6 @@ public sealed partial class VoiceMaskComponent : Component
     [ViewVariables(VVAccess.ReadWrite)] public bool Enabled = true;
 
     [ViewVariables(VVAccess.ReadWrite)] public string VoiceName = "Unknown";
+
+    [ViewVariables(VVAccess.ReadWrite)] public SpeechVerbPrototype? SpeechVerb;
 }

--- a/Content.Server/VoiceMask/VoiceMaskSystem.cs
+++ b/Content.Server/VoiceMask/VoiceMaskSystem.cs
@@ -66,7 +66,7 @@ public sealed partial class VoiceMaskSystem : EntitySystem
                 */
 
             args.Name = component.VoiceName;
-            if (component.EnableSpeechVerbModification)
+            if (component.SpeechVerb != null)
                 args.SpeechVerb = component.SpeechVerb;
         }
     }

--- a/Content.Server/VoiceMask/VoiceMaskSystem.cs
+++ b/Content.Server/VoiceMask/VoiceMaskSystem.cs
@@ -66,6 +66,7 @@ public sealed partial class VoiceMaskSystem : EntitySystem
                 */
 
             args.Name = component.VoiceName;
+            args.SpeechVerb = component.SpeechVerb;
         }
     }
 

--- a/Content.Server/VoiceMask/VoiceMaskSystem.cs
+++ b/Content.Server/VoiceMask/VoiceMaskSystem.cs
@@ -66,7 +66,8 @@ public sealed partial class VoiceMaskSystem : EntitySystem
                 */
 
             args.Name = component.VoiceName;
-            args.SpeechVerb = component.SpeechVerb;
+            if (component.EnableSpeechVerbModification)
+                args.SpeechVerb = component.SpeechVerb;
         }
     }
 

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -113,3 +113,7 @@ chat-speech-verb-ghost-1 = complains
 chat-speech-verb-ghost-2 = breathes
 chat-speech-verb-ghost-3 = hums
 chat-speech-verb-ghost-4 = mutters
+
+chat-speech-verb-electricity-1 = crackles
+chat-speech-verb-electricity-2 = buzzes
+chat-speech-verb-electricity-3 = screeches

--- a/Resources/Prototypes/Voice/speech_verbs.yml
+++ b/Resources/Prototypes/Voice/speech_verbs.yml
@@ -121,3 +121,10 @@
   - chat-speech-verb-ghost-3
   - chat-speech-verb-ghost-4
   - chat-speech-verb-mumble
+
+- type: speechVerb
+  id: Electricity
+  speechVerbStrings:
+  - chat-speech-verb-electricity-1
+  - chat-speech-verb-electricity-2
+  - chat-speech-verb-electricity-3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Pulsing the mic wire on an intercom will now use an appropriate verb for the chatlog message. Electricity can crackle, buzz, and screech.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
![electric_slosh](https://github.com/space-wizards/space-station-14/assets/85356/5c6ad51b-3f1d-44cf-8f48-c07dd8c7cb1c)
Previously, the message used the speech verb set of the person pulsing the wire. This looked silly in many cases.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
VoiceMaskComponent now has a nullable SpeechVerb property. If not null, it will override the speech verbs used by the entity.

I hooked this up for the special case of radio messages* and the general use of speaking too, for completeness. Note that I didn't let the user modify this on wearable voicemasks since that could affect game balance (is catching people using the wrong speech verbs for the character they're disguised as intended gameplay?).

This also has potential for admin shenanigans - give a player a voicemask component and set the SpeechVerb to Canine and they'll bark woof and howl all their chat messages.

*Why is this a special case anyway? It probably should use TransformSpeakerNameEvent like normal speech.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
