### PR TITLE
Fix entity menu grouping and sorting

### DIFF
--- a/Content.Client/ContextMenu/UI/EntityMenuPresenterGrouping.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuPresenterGrouping.cs
@@ -18,7 +18,7 @@ namespace Content.Client.ContextMenu.UI
         {
             if (GroupingContextMenuType == 0)
             {
-                var newEntities = entities.GroupBy(e => Identity.Name(e, _entityManager) + (_entityManager.GetComponent<MetaDataComponent>(e).EntityPrototype?.ID ?? string.Empty)).ToList();
+                var newEntities = entities.GroupBy(e => Identity.Name(e, _entityManager)).ToList();
                 return newEntities.Select(grp => grp.ToList()).ToList();
             }
             else

--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -7,6 +7,7 @@ using Content.Client.Verbs;
 using Content.Client.Verbs.UI;
 using Content.Shared.CCVar;
 using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Input;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -91,7 +92,10 @@ namespace Content.Client.ContextMenu.UI
 
             var entitySpriteStates = GroupEntities(entities);
             var orderedStates = entitySpriteStates.ToList();
-            orderedStates.Sort((x, y) => string.CompareOrdinal(_entityManager.GetComponent<MetaDataComponent>(x.First()).EntityPrototype?.Name, _entityManager.GetComponent<MetaDataComponent>(y.First()).EntityPrototype?.Name));
+            orderedStates.Sort((x, y) => string.Compare(
+                Identity.Name(x.First(), _entityManager),
+                Identity.Name(y.First(), _entityManager),
+                StringComparison.CurrentCulture));
             Elements.Clear();
             AddToUI(orderedStates);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

### The issue

If you have ever tried to pick a medicine solution with a syringe off a smart fridge that stores a dozen of jugs, you'd notice something strange — the entity menu groups jugs inconsistently, excluding some jugs from grouping. Also, the order of the menu may seem a bit off, as if it doesn't respect the applied labels.

![image](https://github.com/space-wizards/space-station-14/assets/1192090/1917bce8-a93e-47ea-9848-de7e85162bdb)

![image](https://github.com/space-wizards/space-station-14/assets/1192090/751787d0-112e-4c47-8cd6-e10408b2c332)

### The solution

I removed the invisible to the end player prototype IDs from participating in the entity menu grouping. This way, it groups things by the entity's translated name and the applied label, if any. Which seems to provide a more consistent result.

I also changed the sorting logic a bit, to have it use labels as well.

![image](https://github.com/space-wizards/space-station-14/assets/1192090/5aab3593-9ec1-4fff-8fd2-f7535b66ab9c)

There is a small issue though, it now groups together certain things that have the same name, but I believe it shouldn't cause any trouble.

![image](https://github.com/space-wizards/space-station-14/assets/1192090/9411f1f6-88e2-40a3-a100-9c92fdbe27ed)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Having things ordered and grouped differently in a smart fridge each round kinda sucks.


## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

<!--
## Breaking changes

List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Jugs with the same labels are now correctly grouped and sorted in the context menu.

