### PR TITLE
Wrap objective briefing text

### DIFF
--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -149,7 +149,10 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
         if (briefing != null)
         {
             var briefingControl = new ObjectiveBriefingControl();
-            briefingControl.Label.Text = briefing;
+            var text = new FormattedMessage();
+            text.PushColor(Color.Yellow);
+            text.AddText(briefing);
+            briefingControl.Label.SetMessage(text);
             _window.Objectives.AddChild(briefingControl);
         }
 

--- a/Content.Client/UserInterface/Systems/Objectives/Controls/ObjectiveBriefingControl.xaml
+++ b/Content.Client/UserInterface/Systems/Objectives/Controls/ObjectiveBriefingControl.xaml
@@ -2,5 +2,5 @@
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Systems.Objectives.Controls"
     Orientation="Horizontal">
-    <Label Name="Label" Access="Public" Modulate="#FFFF00"/>
+    <RichTextLabel Name="Label" Access="Public" SetWidth="325" HorizontalAlignment="Left"/>
 </controls:ObjectiveBriefingControl>


### PR DESCRIPTION
## About the PR
Wrap the objective briefing so that it doesn't march off the end of the page.

| Before                                                                                                          | After                                                                                                           |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://github.com/space-wizards/space-station-14/assets/3229565/a24c7fa9-446c-47b6-a8bf-07bd0a8dfe19) | ![image](https://github.com/space-wizards/space-station-14/assets/3229565/1674d572-963b-4a84-9fbc-d8c41ad2202c) |

## Why / Balance
It didn't look good, and people have been manually wrapping text (poorly).

## Technical details
Replace the `Label` with a `RichTextLabel` with a set width and formatted message.