### PR TITLE
Fix gun bolt crash

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -232,7 +232,10 @@ public abstract partial class SharedGunSystem
                 {
                     foreach (var (ent, _) in relayedArgs.Ammo)
                     {
-                        Del(ent!.Value);
+                        if (!IsClientSide(ent!.Value))
+                            continue;
+
+                        Del(ent.Value);
                     }
                 }
             }


### PR DESCRIPTION
Deleting non-predicted entities moment.

Resolves https://github.com/space-wizards/space-station-14/issues/23878

:cl:
- fix: Fix bolting guns causing exceptions.
