### PR TITLE
Keep reagent dispenser inventory ordered

### DIFF
--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -58,6 +58,8 @@ namespace Content.Client.Chemistry.UI
                 return;
 
             ChemicalList.Children.Clear();
+            //Sort inventory by reagentLabel
+            inventory.Sort((x, y) => x.Value.Key.CompareTo(y.Value.Key));
 
             foreach (KeyValuePair<string, KeyValuePair<string, string>> entry in inventory)
             {

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -97,31 +97,21 @@ namespace Content.Server.Chemistry.EntitySystems
                 var storageSlotId = ReagentDispenserComponent.BaseStorageSlotId + i;
                 var storedContainer = _itemSlotsSystem.GetItemOrNull(reagentDispenser.Owner, storageSlotId);
 
-                // Add volume remaining label and prepare solution contents string
-                FixedPoint2 quantity = 0f;
-                string solContents = "";
-                if (storedContainer != null && _solutionContainerSystem.TryGetDrainableSolution(storedContainer.Value, out _, out var sol))
-                {
-                    quantity = sol.Volume;
-                    solContents = string.Join("-", sol.Contents.Select(x =>
-                        {
-                            return (_prototypeManager.TryIndex(x.Reagent.Prototype, out ReagentPrototype? p) ? p.LocalizedName
-                            : Loc.GetString("reagent-dispenser-window-reagent-name-not-found-text"));
-                        })
-                    );
-                }
-
-                // Set label from manually-applied label, the solution contents or metadata if unavailable
+                // Set label from manually-applied label, or metadata if unavailable
                 string reagentLabel;
                 if (TryComp<LabelComponent>(storedContainer, out var label) && !string.IsNullOrEmpty(label.CurrentLabel))
                     reagentLabel = label.CurrentLabel;
-                else if (solContents != "")
-                    reagentLabel = solContents;
                 else if (storedContainer != null)
                     reagentLabel = Name(storedContainer.Value);
                 else
                     continue;
 
+                // Add volume remaining label
+                FixedPoint2 quantity = 0f;
+                if (storedContainer != null && _solutionContainerSystem.TryGetDrainableSolution(storedContainer.Value, out _, out var sol))
+                {
+                    quantity = sol.Volume;
+                }
                 var storedAmount = Loc.GetString("reagent-dispenser-window-quantity-label-text", ("quantity", quantity));
 
                 inventory.Add(new KeyValuePair<string, KeyValuePair<string, string>>(storageSlotId, new KeyValuePair<string, string>(reagentLabel, storedAmount)));

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -97,26 +97,38 @@ namespace Content.Server.Chemistry.EntitySystems
                 var storageSlotId = ReagentDispenserComponent.BaseStorageSlotId + i;
                 var storedContainer = _itemSlotsSystem.GetItemOrNull(reagentDispenser.Owner, storageSlotId);
 
-                // Set label from manually-applied label, or metadata if unavailable
+                // Add volume remaining label and prepare solution contents string
+                FixedPoint2 quantity = 0f;
+                string solContents = "";
+                if (storedContainer != null && _solutionContainerSystem.TryGetDrainableSolution(storedContainer.Value, out _, out var sol))
+                {
+                    quantity = sol.Volume;
+                    solContents = string.Join("-", sol.Contents.Select(x =>
+                        {
+                            return (_prototypeManager.TryIndex(x.Reagent.Prototype, out ReagentPrototype? p) ? p.LocalizedName
+                            : Loc.GetString("reagent-dispenser-window-reagent-name-not-found-text"));
+                        })
+                    );
+                }
+
+                // Set label from manually-applied label, the solution contents or metadata if unavailable
                 string reagentLabel;
                 if (TryComp<LabelComponent>(storedContainer, out var label) && !string.IsNullOrEmpty(label.CurrentLabel))
                     reagentLabel = label.CurrentLabel;
+                else if (solContents != "")
+                    reagentLabel = solContents;
                 else if (storedContainer != null)
                     reagentLabel = Name(storedContainer.Value);
                 else
                     continue;
 
-                // Add volume remaining label
-                FixedPoint2 quantity = 0f;
-                if (storedContainer != null && _solutionContainerSystem.TryGetDrainableSolution(storedContainer.Value, out _, out var sol))
-                {
-                    quantity = sol.Volume;
-                }
                 var storedAmount = Loc.GetString("reagent-dispenser-window-quantity-label-text", ("quantity", quantity));
 
                 inventory.Add(new KeyValuePair<string, KeyValuePair<string, string>>(storageSlotId, new KeyValuePair<string, string>(reagentLabel, storedAmount)));
             }
 
+            //Sort inventory by reagentLabel
+            inventory.Sort((x, y) => x.Value.Key.CompareTo(y.Value.Key));
             return inventory;
         }
 

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -127,8 +127,6 @@ namespace Content.Server.Chemistry.EntitySystems
                 inventory.Add(new KeyValuePair<string, KeyValuePair<string, string>>(storageSlotId, new KeyValuePair<string, string>(reagentLabel, storedAmount)));
             }
 
-            //Sort inventory by reagentLabel
-            inventory.Sort((x, y) => x.Value.Key.CompareTo(y.Value.Key));
             return inventory;
         }
 


### PR DESCRIPTION
## About the PR
This will keep the dispensable reagents buttons sorted in lexicographical order.
~Additionally, if a jug doesn't have a label, we'll try to use the reagents it contains to make the button label.~

## Why / Balance
Purely QoL.

## Technical details
N/A

## Media

https://github.com/space-wizards/space-station-14/assets/262623/da99dc00-df38-496d-aea2-d9be14d91f5a

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
