### PR TITLE
Strip Items From Things Before Biomassing Them

### DIFF
--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Humanoid;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Inventory;
 using Content.Shared.Jittering;
 using Content.Shared.Medical;
 using Content.Shared.Mind;
@@ -48,6 +49,7 @@ namespace Content.Server.Medical.BiomassReclaimer
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly MaterialStorageSystem _material = default!;
         [Dependency] private readonly SharedMindSystem _minds = default!;
+        [Dependency] private readonly InventorySystem _inventory = default!;
 
         public override void Update(float frameTime)
         {
@@ -226,6 +228,11 @@ namespace Content.Server.Medical.BiomassReclaimer
 
             component.CurrentExpectedYield = (int) Math.Max(0, physics.FixturesMass * component.YieldPerUnitMass);
             component.ProcessingTimer = physics.FixturesMass * component.ProcessingTimePerUnitMass;
+
+            if (_inventory.TryGetSlots(toProcess, out var slotDefinitions))
+                foreach (var slot in slotDefinitions)
+                    _inventory.TryUnequip(toProcess, slot.Name, true, true);
+
             QueueDel(toProcess);
         }
 


### PR DESCRIPTION
# Description

Removes any items a corpse may have on them before deleting the body.

# Why / Balance

Ported from Parkstation.
Being able to delete any item in a couple seconds as long as you have a corpse and reclaimer is not very good, and you may need something you've accidentally destroyed later (I have several times).

# Media

https://github.com/space-wizards/space-station-14/assets/77995199/f2de3a56-2dcd-4cbe-a9f3-31c3d6f2b074

# Changelog
:cl:
- tweak: Biomass reclaimers no longer act as a void to any unfortunate belongings a corpse may be wearing
