### PR TITLE
Remove the Mothroach Crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -218,12 +218,3 @@
   category: Livestock
   group: market
 
-- type: cargoProduct
-  id: LivestockMothroach
-  icon:
-    sprite: Mobs/Animals/mothroach.rsi
-    state: mothroach
-  product: CrateNPCMothroach
-  cost: 5000
-  category: Livestock
-  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/npc.yml
@@ -254,13 +254,3 @@
     contents:
       - id: MobKangaroo
 
-- type: entity
-  id: CrateNPCMothroach
-  parent: CrateLivestock
-  name: crate of mothroaches
-  description: A crate containing four mothroaches.
-  components:
-  - type: StorageFill
-    contents:
-      - id: MobMothroach
-        amount: 4


### PR DESCRIPTION
it was my code, i dont want it in the game

Just really pissed with the community rn, dont want my code in this game

[X] Fills
[X] Crate removal


<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Mothroach crates are now unorderable.

## Why / Balance
I dont want anything to do with the community right now

## Technical details
No code

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: Avalon
- remove: You can no longer order Mothroach crates from Cargo.


