### PR TITLE
Fix issue where round could reset all job priorities to high

### DIFF
--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -523,7 +523,12 @@ namespace Content.Client.Preferences.UI
             _jobCategories.Clear();
             var firstCategory = true;
 
-            foreach (var department in _prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
+            var departments = _prototypeManager.EnumeratePrototypes<DepartmentPrototype>()
+                .OrderByDescending(department => department.Weight)
+                .ThenBy(department => Loc.GetString($"department-{department.ID}"))
+                .ToList();
+
+            foreach (var department in departments)
             {
                 var departmentName = Loc.GetString($"department-{department.ID}");
 

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -567,8 +567,11 @@ namespace Content.Client.Preferences.UI
                     _jobList.AddChild(category);
                 }
 
-                var jobs = department.Roles.Select(o => _prototypeManager.Index<JobPrototype>(o)).Where(o => o.SetPreference).ToList();
-                jobs.Sort((x, y) => -string.Compare(x.LocalizedName, y.LocalizedName, StringComparison.CurrentCultureIgnoreCase));
+                var jobs = department.Roles.Select(jobId => _prototypeManager.Index<JobPrototype>(jobId))
+                    .Where(job => job.SetPreference)
+                    .OrderByDescending(job => job.Weight)
+                    .ThenBy(job => job.LocalizedName)
+                    .ToList();
 
                 foreach (var job in jobs)
                 {

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -605,6 +605,11 @@ namespace Content.Client.Preferences.UI
 
                 }
             }
+
+            if (Profile is not null)
+            {
+                UpdateJobPriorities();
+            }
         }
 
         private void OnFlavorTextChange(string content)

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -30,4 +30,10 @@ public sealed partial class DepartmentPrototype : IPrototype
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool Primary = true;
+
+    /// <summary>
+    /// Departments with a higher weight sorted before other departments in UI.
+    /// </summary>
+    [DataField("weight")]
+    public int Weight { get; private set; } = 0;
 }

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -11,6 +11,7 @@
   id: Civilian
   description: department-Civilian-description
   color: "#9FED58"
+  weight: -10
   roles:
   - Bartender
   - Borg
@@ -44,6 +45,7 @@
   - ResearchDirector
   - Quartermaster
   primary: false
+  weight: 100
 
 - type: department
   id: Engineering
@@ -71,6 +73,7 @@
   id: Security
   description: department-Security-description
   color: "#DE3A3A"
+  weight: 20
   roles:
   - HeadOfSecurity
   - SecurityCadet
@@ -91,6 +94,7 @@
   id: Specific
   description: department-Specific-description
   color: "#9FED58"
+  weight: 10
   roles:
   - Boxer
   - Reporter


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
### The issue

When a round ends, JobRequirementsManager triggers Update action, causing HumanoidProfileEditor to reload its UI controls.

https://github.com/space-wizards/space-station-14/blob/efdc6f8d4c5dc8c593b6403c6592f0ddc6212266/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs#L381-L382

The `UpdateRoleRequirements` method, however, lacks any logic to populate the refreshed UI controls based on the player's profile preferences, leaving all the job preference options in the default "high" position.

### The solution

I added a call to the `UpdateJobPriorities` method when a profile is available.

Also, I noticed that departments aren't sorted in any particular order, as well as jobs are sorted in a weird descending alphabetical order. I decided to fix that as well.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
To fix a bug and introduce a more consistent ordering to the job preferences screen.

## Media

![image](https://github.com/space-wizards/space-station-14/assets/1192090/b26df09c-6165-4b61-9714-8f64578d6592)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
<!--
## Breaking changes

List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
<!--
**Changelog**

Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
