### PR TITLE
Cancel CanBuckle before popup for foldable items

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -4,7 +4,6 @@ using Content.Shared.Alert;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Database;
-using Content.Shared.Foldable;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
@@ -27,8 +26,6 @@ namespace Content.Shared.Buckle;
 
 public abstract partial class SharedBuckleSystem
 {
-    [Dependency] private readonly FoldableSystem _foldable = default!;
-
     private void InitializeBuckle()
     {
         SubscribeLocalEvent<BuckleComponent, ComponentStartup>(OnBuckleComponentStartup);
@@ -270,12 +267,6 @@ public abstract partial class SharedBuckleSystem
             {
                 return false;
             }
-        }
-
-        // If foldable, must be unfolded (rollerbeds)
-        if (HasComp<FoldableComponent>(strapUid) && _foldable.IsFolded(strapUid))
-        {
-            return false;
         }
 
         if (!HasComp<HandsComponent>(userUid))

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -4,6 +4,7 @@ using Content.Shared.Alert;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Database;
+using Content.Shared.Foldable;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
@@ -26,6 +27,8 @@ namespace Content.Shared.Buckle;
 
 public abstract partial class SharedBuckleSystem
 {
+    [Dependency] private readonly FoldableSystem _foldable = default!;
+
     private void InitializeBuckle()
     {
         SubscribeLocalEvent<BuckleComponent, ComponentStartup>(OnBuckleComponentStartup);
@@ -267,6 +270,12 @@ public abstract partial class SharedBuckleSystem
             {
                 return false;
             }
+        }
+
+        // If foldable, must be unfolded (rollerbeds)
+        if (HasComp<FoldableComponent>(strapUid) && _foldable.IsFolded(strapUid))
+        {
+            return false;
         }
 
         if (!HasComp<HandsComponent>(userUid))

--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Buckle;
+using Content.Shared.Buckle.Components;
 using Content.Shared.Storage.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
@@ -26,6 +27,8 @@ public sealed class FoldableSystem : EntitySystem
         SubscribeLocalEvent<FoldableComponent, ContainerGettingInsertedAttemptEvent>(OnInsertEvent);
         SubscribeLocalEvent<FoldableComponent, StoreMobInItemContainerAttemptEvent>(OnStoreThisAttempt);
         SubscribeLocalEvent<FoldableComponent, StorageOpenAttemptEvent>(OnFoldableOpenAttempt);
+
+        SubscribeLocalEvent<FoldableComponent, BuckleAttemptEvent>(OnBuckleAttempt);
     }
 
     private void OnGetState(EntityUid uid, FoldableComponent component, ref ComponentGetState args)
@@ -58,6 +61,12 @@ public sealed class FoldableSystem : EntitySystem
         args.Handled = true;
 
         if (comp.IsFolded)
+            args.Cancelled = true;
+    }
+
+    public void OnBuckleAttempt(EntityUid uid, FoldableComponent comp, ref BuckleAttemptEvent args)
+    {
+        if (args.Buckling && comp.IsFolded)
             args.Cancelled = true;
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This fixes the message "You can't buckle yourself there!" appearing when picking up folded rollerbeds.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![240121 rollerbedsbefore](https://github.com/space-wizards/space-station-14/assets/42424291/697269e7-1c0d-4703-9be2-68273dac2598)
![240121 rollerbedsafter](https://github.com/space-wizards/space-station-14/assets/42424291/c8272b92-a8f9-42e1-a6bc-1bd74f60a18f)
