### PR TITLE
Update Tmax to computationally sound limit

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -52,7 +52,7 @@ namespace Content.Shared.Atmos
         ///     calculations and so cap it here. The physical interpretation is that at this temperature, any
         ///     gas that you would have transforms into plasma.
         /// </summary>
-        public const float Tmax = 200e3f;
+        public const float Tmax = 262144; // 1/64 of max safe integer, any values above will result in a ~0.03K epsilon
 
         /// <summary>
         ///     Liters in a cell.


### PR DESCRIPTION
## About the PR
Makes the Atmospherics.Tmax slightly higher, from 200kK to 262kK due to how floats work.

## Why / Balance
Might as well go the full forte with defining the [domain of calculation](https://github.com/space-wizards/space-station-14/pull/22882). This is the largest number that an epsilon of 1/64 = 0.015625K can exist, and any larger epsilon will probably be unacceptable at SS14's tickrates. ***In hindsight, I think this should be made a `CCVar`,*** however, I'm not currently capable of doing that due to physical GPU-ending reasons (fuck you nvidia)

## Technical details
https://float.exposed/0x48800000 (fiddle with `Raw Hexadecimal Integer Value`)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
no cl no fun (it's literally a constant change)