### PR TITLE
Removes fireaxe plating prying

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -38,7 +38,6 @@
     qualities:
       - Prying
   - type: TilePrying
-    advanced: true
   - type: Prying
   - type: UseDelay
     delay: 1


### PR DESCRIPTION
## About the PR
Removes ``advanced: true`` from the fire axe's TilePrying component, making fireaxes no longer able to pry plating.
This doesn't touch any of the actual code related to prying plating since I don't know C#, someone else will have to clean it up afterwards. For players, though, this should have the exact same result anyways.

## Why / Balance
This feature is hilariously overpowered and abusable, it lets you space rooms for literally free with no time or resource investment & is constantly abused in nuke ops to make wherever they're standing instantly uninhabitable. There's a reason the RCD takes charges to deconstruct floors.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- remove: Fireaxes can no longer pry plating tiles.
