### PR TITLE
Prevent willful deconversion of Revolutionaries

### DIFF
--- a/Content.Server/Implants/ImplanterSystem.cs
+++ b/Content.Server/Implants/ImplanterSystem.cs
@@ -48,10 +48,17 @@ public sealed partial class ImplanterSystem : SharedImplanterSystem
                 if (implant == null)
                     return;
 
-                // show popup to the user saying implant failed
-                var name = Identity.Name(target, EntityManager, args.User);
-                var msg = Loc.GetString("implanter-component-implant-failed", ("implant", implant), ("target", name));
-                _popup.PopupEntity(msg, target, args.User);
+                // optionally, show popup to explain why the implant failed
+                var ev = new PopupAfterFailedImplantEvent(args.User, target, implant.Value);
+                RaiseLocalEvent(target, ev);
+                if (!ev.Handled)
+                {
+                    // show generic popup saying the implant failed
+                    var name = Identity.Name(target, EntityManager, args.User);
+                    var msg = Loc.GetString("implanter-component-implant-failed", ("implant", implant), ("target", name));
+                    _popup.PopupEntity(msg, target, args.User);
+                }
+
                 // prevent further interaction since popup was shown
                 args.Handled = true;
                 return;

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -225,3 +225,18 @@ public sealed class AddImplantAttemptEvent : CancellableEntityEventArgs
         Implanter = implanter;
     }
 }
+
+public sealed class PopupAfterFailedImplantEvent : CancellableEntityEventArgs
+{
+    public readonly EntityUid User;
+    public readonly EntityUid Target;
+    public readonly EntityUid Implant;
+    public bool Handled = false;
+
+    public PopupAfterFailedImplantEvent(EntityUid user, EntityUid target, EntityUid implant)
+    {
+        User = user;
+        Target = target;
+        Implant = implant;
+    }
+}

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -1,8 +1,10 @@
 using Content.Shared.IdentityManagement;
+using Content.Shared.Implants;
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Popups;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Stunnable;
+using Content.Shared.Tag;
 
 namespace Content.Shared.Revolutionary;
 
@@ -10,11 +12,48 @@ public sealed class SharedRevolutionarySystem : EntitySystem
 {
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedStunSystem _sharedStun = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
+
+    [ValidatePrototypeId<TagPrototype>]
+    public const string MindShieldTag = "MindShield";
 
     public override void Initialize()
     {
         base.Initialize();
+        SubscribeLocalEvent<RevolutionaryComponent, AddImplantAttemptEvent>(PreventSelfDeconvert);
+        SubscribeLocalEvent<RevolutionaryComponent, PopupAfterFailedImplantEvent>(InformTargetWasSelf);
         SubscribeLocalEvent<MindShieldComponent, MapInitEvent>(MindShieldImplanted);
+    }
+
+    /// <summary>
+    /// Prevents Revs from attempting to implant themselves with a mindshield.
+    /// </summary>
+    public void PreventSelfDeconvert(EntityUid uid, RevolutionaryComponent comp, ref AddImplantAttemptEvent ev)
+    {
+        if (IsMindshieldTargetSelf(ev.User, ev.Target, ev.Implant))
+        {
+            ev.Cancel();
+        }
+    }
+
+    /// <summary>
+    /// Informs the Rev why the implant failed.
+    /// </summary>
+    public void InformTargetWasSelf(EntityUid uid, RevolutionaryComponent comp, ref PopupAfterFailedImplantEvent ev)
+    {
+        if (IsMindshieldTargetSelf(ev.User, ev.Target, ev.Implant))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("rev-fail-self-mindshield"), ev.User);
+            ev.Handled = true;
+        }
+    }
+
+    /// <summary>
+    /// Checks if a Rev is attempting to implant themselves with a mindshield.
+    /// </summary>
+    public bool IsMindshieldTargetSelf(EntityUid user, EntityUid target, EntityUid implant)
+    {
+        return _tag.HasTag(implant, MindShieldTag) && HasComp<RevolutionaryComponent>(user) && !HasComp<HeadRevolutionaryComponent>(user) && user == target;
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -31,6 +31,8 @@ rev-role-greeting =
 
 rev-briefing = Help your head revolutionaries kill every head to take over the station.
 
+rev-fail-self-mindshield = You cannot bring yourself to betray the revolution!
+
 ## General
 
 rev-title = Revolutionaries


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Prevents converted Revolutionaries from using mind-shield implants to deconvert themselves.

Head Revolutionaries are unaffected and may still choose to break the implant on themselves.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Issue #20064 aims to convert rules to mechanics. Willful deconversion seems like a unanimously ahelpable event as Revolutionaries have no in-character reason to justify betraying the revolution.

This change does not prevent players from choosing to forgo Revolutionary responsibilities, it simply prevents them from giving themselves a free pass to do so. It also prevents such people from giving themselves a justification to act against the Revolution should they encounter it's members again, later.

Even if one argued a Rev could set up some disaster and then convert themselves on purpose to avoid heat, deconversion does not trigger NLR. A character would remember all of their actions and would know how to thwart whatever plans were set in motion, or at least warn others.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

SharedRevolutionarySystem responds to AddImplantAttemptEvent to determine if the implant should fail.

PopupAfterFailedImplantEvent was added to allow a system to override what message is displayed to a user when an implant fails. SharedRevolutionarySystem uses it to display the message, "You cannot bring yourself to betray the revolution!"

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![Content Client_T4neFAHrpD](https://github.com/space-wizards/space-station-14/assets/42424291/20b16d6a-c1a7-42d9-87ab-3bb4e7496456)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Krunk
- tweak: Converted Revolutionaries can no longer willfully de-convert themselves with a mind-shield.
