### PR TITLE
flare ghetto chem chemicals

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -71,3 +71,25 @@
         maxDuration: 15.0
         startValue: 10.0
         endValue: 1.0
+  - type: Extractable
+    grindableSolutionName: flare
+  - type: SolutionContainerManager
+    solutions:
+      flare:
+        maxVol: 20
+        reagents:
+        # flare casing
+        - ReagentId: Iron
+          Quantity: 10
+        # red phosphorus = red flare trust
+        - ReagentId: Phosphorus
+          Quantity: 3
+        - ReagentId: Carbon
+          Quantity: 1
+        - ReagentId: Oxygen
+          Quantity: 2
+        # fuel or something
+        - ReagentId: Charcoal
+          Quantity: 2
+        - ReagentId: Sulfur
+          Quantity: 2


### PR DESCRIPTION
## About the PR
give flares some chemicals when ground or reclaimed

## Why / Balance
easy source of phosphorus and stuff for ghetto chem, everyone has a flare

## Technical details
no

## Media
dark beige drink
![18:41:00](https://github.com/space-wizards/space-station-14/assets/39013340/664501f0-f30d-4a2d-8eb8-55be24c3b49f)

it go in grinder
only using the bottom sprite is existing thing :trollface:
![18:39:43](https://github.com/space-wizards/space-station-14/assets/39013340/1afc4090-4efb-41c8-ba95-e332edd31648)

juice
![18:40:53](https://github.com/space-wizards/space-station-14/assets/39013340/4726cf27-c7ec-48c3-b29e-6716f76c1163)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun