### PR TITLE
Lowers Syndicate Reinforcement TC Cost

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -425,7 +425,7 @@
   productEntity: ReinforcementRadioSyndicate
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
   cost:
-    Telecrystal: 16
+    Telecrystal: 14
   categories:
   - UplinkUtility
   conditions:
@@ -441,7 +441,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
   cost:
-    Telecrystal: 16
+    Telecrystal: 15
   categories:
   - UplinkUtility
   conditions:


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Syndicate Reinforcement Cost has been lowered to 14 TC
Nuclear Operatives' Reinforcements have been lowered to 15 TC
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
https://discord.com/channels/310555209753690112/311537926376783886/1199068205398892616

At the moment, this is just a waste of your TC even if you band together the TC of 2 people. It just isn't worth the price.
Also, the person who becomes your reinforcement has no guarantee to be even competent, let alone robust and they come in the most obvious gear available, which isn't good and they're not on the manifest so are prone to be perma-ed after the first encounter.
Not only do you get nothing worth while, you bank all your TC on this person being worthwhile and cannot afford anything of any value afterwards.

(For Nuclear Operatives, the cost is only slightly lowered to stop Nukies amassing a 10 man squad or smth)
## Media

- [X] This PR does not require an ingame showcase

**Changelog**
:cl: DangerRevolution
- tweak: Changed Syndicate Reinforcement Cost to 14 TC
- tweak: Changed Nuclear Operative Reinforcement Cost to 15 TC