### PR TITLE
Fully remove tile plating prying

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -40,11 +40,6 @@ namespace Content.Shared.Maps
 
         [DataField("canCrowbar")] public bool CanCrowbar { get; private set; }
 
-        /// <summary>
-        /// Whether this tile can be pried by an advanced prying tool if not pryable otherwise.
-        /// </summary>
-        [DataField("canAxe")] public bool CanAxe { get; private set; }
-
         [DataField("canWirecutter")] public bool CanWirecutter { get; private set; }
 
         /// <summary>

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -50,13 +50,7 @@ public sealed class TileSystem : EntitySystem
         var tileRef = _maps.GetTileRef(gridId, grid, indices);
         return PryTile(tileRef);
     }
-
-	public bool PryTile(TileRef tileRef)
-    {
-        return PryTile(tileRef, false);
-    }
-
-    public bool PryTile(TileRef tileRef, bool pryPlating)
+    public bool PryTile(TileRef tileRef)
     {
         var tile = tileRef.Tile;
 
@@ -65,7 +59,7 @@ public sealed class TileSystem : EntitySystem
 
         var tileDef = (ContentTileDefinition) _tileDefinitionManager[tile.TypeId];
 
-        if (!tileDef.CanCrowbar && !(pryPlating && tileDef.CanAxe))
+        if (!tileDef.CanCrowbar)
             return false;
 
         return DeconstructTile(tileRef);

--- a/Content.Shared/Tools/Components/TilePryingComponent.cs
+++ b/Content.Shared/Tools/Components/TilePryingComponent.cs
@@ -15,12 +15,6 @@ public sealed partial class TilePryingComponent : Component
     [DataField("qualityNeeded", customTypeSerializer:typeof(PrototypeIdSerializer<ToolQualityPrototype>)), AutoNetworkedField]
     public string QualityNeeded = "Prying";
 
-    /// <summary>
-    /// Whether this tool can pry tiles with CanAxe.
-    /// </summary>
-    [DataField("advanced"), AutoNetworkedField]
-    public bool Advanced = false;
-
     [DataField("delay"), AutoNetworkedField]
     public float Delay = 1f;
 }

--- a/Content.Shared/Tools/Systems/SharedToolSystem.TilePrying.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.TilePrying.cs
@@ -53,7 +53,7 @@ public abstract partial class SharedToolSystem
         }
 
         if (_netManager.IsServer)
-            _tiles.PryTile(tile, component.Advanced);
+            _tiles.PryTile(tile);
     }
 
     private bool TryPryTile(EntityUid toolEntity, EntityUid user, TilePryingComponent component, EntityCoordinates clickLocation)
@@ -72,7 +72,7 @@ public abstract partial class SharedToolSystem
 
         var tileDef = (ContentTileDefinition) _tileDefManager[tile.Tile.TypeId];
 
-        if (!tileDef.CanCrowbar && !(tileDef.CanAxe && component.Advanced))
+        if (!tileDef.CanCrowbar)
             return false;
 
         var ev = new TilePryingDoAfterEvent(GetNetCoordinates(coordinates));

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -38,7 +38,6 @@
     qualities:
       - Prying
   - type: TilePrying
-    advanced: true
   - type: Prying
   - type: UseDelay
     delay: 1

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1740,7 +1740,6 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: false
-  canAxe: false #You can't RCD these in SS13 apparently, so this is probably the next best thing
   footstepSounds:
     collection: FootstepHull
   itemDrop: FloorTileItemSteel #probably should not be normally obtainable, but the game shits itself and dies when you try to put null here
@@ -1753,7 +1752,6 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: false
-  canAxe: false
   footstepSounds:
     collection: FootstepHull
   itemDrop: FloorTileItemSteel
@@ -1766,7 +1764,6 @@
   baseTurf: Plating
   isSubfloor: false
   canCrowbar: false
-  canAxe: false
   footstepSounds:
     collection: FootstepHull
   itemDrop: FloorTileItemReinforced #same case as FloorHull

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -1,10 +1,9 @@
-﻿- type: tile
+- type: tile
   id: Plating
   name: tiles-plating
   sprite: /Textures/Tiles/plating.png
   baseTurf: Lattice
   isSubfloor: true
-  canAxe: true
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -21,7 +20,6 @@
   - 1.0
   baseTurf: Lattice
   isSubfloor: true
-  canAxe: true
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -33,7 +31,6 @@
   sprite: /Textures/Tiles/plating_burnt.png
   baseTurf: Lattice
   isSubfloor: true
-  canAxe: true
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -45,7 +42,6 @@
   sprite: /Textures/Tiles/Asteroid/asteroid_plating.png
   baseTurf: Lattice
   isSubfloor: true
-  canAxe: true
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -57,7 +53,6 @@
   sprite: /Textures/Tiles/snow_plating.png #Not in the snow planet RSI because it doesn't have any metadata. Should probably be moved to its own folder later.
   baseTurf: Lattice
   isSubfloor: true
-  canAxe: true
   footstepSounds:
     collection: FootstepPlating
   friction: 0.15 #a little less then actual snow


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This just cleans up what's now derelict code left by the removal of the fireaxe's ability to pry plating in #24388.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
flareguy said that this is never gonna be added to anything else
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I removed the fields from the component/ref and prototypes then I fixed up the if statements that used it.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
canAxe field was removed from tiles and Advanced was removed from the tile prying component.
TryPilePry no longer accepts a bool that was used for plate prying.
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun.