### PR TITLE
Allow more items to be recycled

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -270,6 +270,9 @@
     storedRotation: -90
   - type: IdentityBlocker
     coverage: MOUTH
+  - type: PhysicalComposition
+    materialComposition:
+      Plastic: 25
 
 - type: entity
   parent: ClothingMaskBase

--- a/Resources/Prototypes/Entities/Objects/Devices/geiger.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/geiger.yml
@@ -31,4 +31,7 @@
             Med: {state: geiger_on_med}
             High: {state: geiger_on_high}
             Extreme: {state: geiger_on_ext}
+    - type: PhysicalComposition
+      materialComposition:
+        Plastic: 100
 

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -54,6 +54,9 @@
         enabled:
           True: { state: fire_extinguisher_closed }
           False: { state: fire_extinguisher_open }
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 100
 
 - type: entity
   name: extinguisher spray

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -28,6 +28,9 @@
         maxVol: 100
   - type: UseDelay
     delay: 1
+  - type: PhysicalComposition
+    materialComposition:
+      Plastic: 50
   - type: Tag
     tags:
       - Mop
@@ -216,6 +219,9 @@
       coefficients:
         Blunt: 0.95
         Slash: 0.95
+  - type: PhysicalComposition
+    materialComposition:
+      Plastic: 50
   - type: Tag
     tags:
       - WetFloorSign

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -15,6 +15,9 @@
     size: Large
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     heldPrefix: firstaid
+  - type: PhysicalComposition
+    materialComposition:
+      Plastic: 150
   - type: Tag
     tags:
     - Medkit

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -158,6 +158,9 @@
     solution: beaker
   - type: StaticPrice
     price: 10
+  - type: PhysicalComposition
+    materialComposition:
+      Glass: 50
   - type: SolutionContainerVisuals
     maxFillLevels: 6
     fillBaseName: beaker
@@ -207,6 +210,9 @@
     fillBaseName: beakerlarge
     inHandsMaxFillLevels: 4
     inHandsFillBaseName: -fill-
+  - type: PhysicalComposition
+    materialComposition:
+      Glass: 100
   - type: StaticPrice
     price: 20
 

--- a/Resources/Prototypes/Entities/Objects/Tools/appraisal.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/appraisal.yml
@@ -17,6 +17,9 @@
     quickEquip: false
     slots:
     - Belt
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 250
   - type: Tag
     tags:
     - AppraisalTool

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -25,6 +25,9 @@
     price: 0
   - type: StackPrice
     price: 1
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 15
 
 - type: entity
   id: CableHVStack

--- a/Resources/Prototypes/Entities/Objects/Tools/gps.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gps.yml
@@ -12,6 +12,10 @@
   - type: Item
     sprite: Objects/Devices/gps.rsi
   - type: HandheldGPS
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 400
+      Glass: 150
   - type: Tag
     tags:
     - GPS

--- a/Resources/Prototypes/Entities/Objects/Tools/t-ray.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/t-ray.yml
@@ -19,5 +19,9 @@
         base:
           On: { state: tray-on }
           Off: { state: tray-off }
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 400
+      Glass: 150
   - type: StaticPrice
     price: 60

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -34,6 +34,9 @@
     node: bat
   - type: UseDelay
     delay: 1
+  - type: PhysicalComposition
+    materialComposition:
+      Wood: 250
   - type: Tag
     tags:
     - BaseballBat

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -79,6 +79,10 @@
     explosionType: Default
     intensitySlope: 1.5
     maxIntensity: 200
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 100
+      Plastic: 100
   - type: GuideHelp
     guides:
     - Security

--- a/Resources/Prototypes/Recipes/Lathes/janitorial.yml
+++ b/Resources/Prototypes/Recipes/Lathes/janitorial.yml
@@ -18,7 +18,7 @@
   result: Bucket
   completetime: 2
   materials:
-    Steel: 100
+    Plastic: 100
 
 - type: latheRecipe
   id: WetFloorSign

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -106,7 +106,7 @@
   result: ClothingMaskSterile
   completetime: 2
   materials:
-    Plastic: 100
+    Plastic: 50
 
 - type: latheRecipe
   id: DiseaseSwab


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Allow the following items to be recycled (NOTE: list is best-effort, please check the actual commit when reviewing):
- sterile mask (0.25 plastic sheet)
- fire extinguisher (1 steel sheets)
- all medkits (1.5 plastic sheets)
- LV/MV/HV cables (0.15 steel sheet)
- t-ray scanner (4 steel, 1.5 glass)
- mop, the basic one (0.5 plastic)
- large beaker (1 glass, 0.5 for small)
- geiger counter (1 plastic)
- appraisal tool (3 steel)
- stun baton (1 steel, 1 plastic)
- global positioning system (4 steel, 1.5 glass)
- baseball bat (2.5 wood)

Resolves issue #24372 
Does not address the issue where recyclable containers like the "survival box" will delete their contents.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
These prices are rough guesses. None exceed their crafting price (on the lathe), and some of the more expensive ones to make are roughly half their crafting price (medkits, t-ray scanner, large beaker, stun baton).

> It’s useful for cargo and salvage because they always have empty medkits and trash from salvage missions and disposals room with trash for recycling where’s have a lot plastic for station requests. Also it useful for all crew who don’t have resource for working on autolat they found or requested make in RnD they can recycle trash for materials for they needs like botanist have more option for recycling plastic for sterile swab or antag for making ammo in emag autolat.
\- gordod3 on issue #24372

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adding a PhysicalComposition component to an item allows it to be recycled and material-reclaimer'd.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- tweak: Many more items can now be recycled, including mops, medkits, and stun batons.
