### PR TITLE
add DefaultActions system

### DIFF
--- a/Content.Shared/Actions/DefaultActionsComponent.cs
+++ b/Content.Shared/Actions/DefaultActionsComponent.cs
@@ -1,0 +1,33 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Actions;
+
+/// <summary>
+/// Grants a user a list of actions on mapinit.
+/// The action events must be handled by other systems.
+/// </summary>
+[RegisterComponent, Access(typeof(DefaultActionsSystem))]
+public sealed partial class DefaultActionsComponent : Component
+{
+    /// <summary>
+    /// Action id and entity to be added on mapinit.
+    /// </summary>
+    [DataField]
+    public List<ActionPair> Actions;
+}
+
+[DataDefinition]
+public sealed partial class ActionPair
+{
+    /// <summary>
+    /// Action entity prototype to be added.
+    /// </summary>
+    [DataField]
+    public EntProtoId Id;
+
+    /// <summary>
+    /// Action entity that has been added.
+    /// </summary>
+    [DataField]
+    public EntityUid? Entity;
+}

--- a/Content.Shared/Actions/DefaultActionsComponent.cs
+++ b/Content.Shared/Actions/DefaultActionsComponent.cs
@@ -12,8 +12,8 @@ public sealed partial class DefaultActionsComponent : Component
     /// <summary>
     /// Action id and entity to be added on mapinit.
     /// </summary>
-    [DataField]
-    public List<ActionPair> Actions;
+    [DataField(required: true)]
+    public List<ActionPair> Actions = new();
 }
 
 [DataDefinition]
@@ -22,8 +22,8 @@ public sealed partial class ActionPair
     /// <summary>
     /// Action entity prototype to be added.
     /// </summary>
-    [DataField]
-    public EntProtoId Id;
+    [DataField(required: true)]
+    public EntProtoId Id = string.Empty;
 
     /// <summary>
     /// Action entity that has been added.

--- a/Content.Shared/Actions/DefaultActionsSystem.cs
+++ b/Content.Shared/Actions/DefaultActionsSystem.cs
@@ -1,0 +1,27 @@
+namespace Content.Shared.Actions;
+
+/// <summary>
+/// Handles adding actions from <see cref="DefaultActionsComponent"/> on mapinit.
+/// </summary>
+public sealed class DefaultActionsSystem : EntitySystem
+{
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DefaultActionsComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(Entity<DefaultActionsComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp<ActionsComponent>(ent, out var actions))
+            return;
+
+        foreach (var pair in ent.Comp.Actions)
+        {
+            _actions.AddAction(performer: ent, ref pair.Entity, pair.Id, container: ent, actions);
+        }
+    }
+}


### PR DESCRIPTION
## About the PR
title
adds an action that is expected to always exist

should be used for specific entities and not things like scream or stating laws which would be for a component shared across multiple entities

## Why / Balance
- exterminator freedom action is why i made this
- maybe revenant/ling/xeno for the store action, or could be done better with a dedicated intrinsic store component
- probably aghost with all the consoles would be way nicer to have them in yml instead of demonic stuff, would also make adding manifest / whatever actions easy

## Technical details
basically the boilerplate but defined in yml instead of adding yet another XAction XActionEntity mapinit combo to your specific entity's specific component

ActionPair might be reusable for the rest of action api but thats for the future

usage is simple
```yml
- type: DefaultActions
  actions:
  - id: BoringAction
  - id: CoolAction
```

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun