### PR TITLE
Fix cyborgs spawning with wheelchairbound trait

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -55,6 +55,9 @@
   id: WheelchairBound
   name: trait-wheelchair-bound-name
   description: trait-wheelchair-bound-desc
+  blacklist:
+    components:
+      - BorgChassis
   components:
     - type: BuckleOnMapInit
       prototype: VehicleWheelchair

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -48,6 +48,9 @@
   id: Muted
   name: trait-muted-name
   description: trait-muted-desc
+  blacklist:
+    components:
+      - BorgChassis
   components:
     - type: Muted
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This blacklists cyborgs from spawning with the Wheelchair Bound or Muted trait.

Fixes #20428 
Fixes #24434 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Borgs cannot be buckled into wheelchairs, so they are unable to move if they spawn with this trait.
I went ahead and blacklisted Muted as well, as borgs need to be able to state their laws.

I'm not sure if we'd want to disable other traits for cyborgs as well, but these were the most obvious.
Also, I'd imagine a lot of this will change when the medical refactor is done.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Cyborgs can no longer spawn with the Wheelchair Bound or Muted trait
