### PR TITLE
give anomaly borg module a signaller

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -417,6 +417,8 @@
     items:
     - AnomalyScanner
     - AnomalyLocatorUnpowered
+    - RemoteSignaller
+    - Multitool
 
 # service modules
 - type: entity


### PR DESCRIPTION
## About the PR
signaller and multitool

## Why / Balance
borgs doing anomaly cant activate the ape this lets them do that

also for keeping it maintained

## Technical details
no

## Media
![22:25:14](https://github.com/space-wizards/space-station-14/assets/39013340/82536c2a-6e26-429f-b8a3-66112d7a3c8d)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun