### PR TITLE
Disabled quick equip on buckets

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -21,6 +21,7 @@
     sprite: Objects/Tools/bucket.rsi
     slots:
     - HEAD
+    quickEquip: false
   - type: SolutionContainerManager
     solutions:
       bucket:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Client doesn't have a drink event, so quick equipping a bucket forces it onto your head and spills the contents.

This also happens when spam-clicking soap into a bucket.

Here is a band-aid fix to both of these until I figure out what the correct solution is.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Annoying to spill your bucket by accidentally equipping it.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Related things...
https://github.com/space-wizards/space-station-14/pull/24334#issuecomment-1907132876
https://github.com/space-wizards/space-station-14/issues/13803

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Krunk
- fix: To prevent accidental spills, buckets can no longer be quick-equipped.
