### PR TITLE
Botany no longer gets meta weapons

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -16,7 +16,7 @@
     swingLeft: true
     damage:
       types:
-        Slash: 10
+        Slash: 6
   - type: Item
     sprite: Objects/Tools/Hydroponics/hoe.rsi
 
@@ -83,8 +83,8 @@
     swingLeft: true
     damage:
       types:
-        Slash: 10
-        Piercing: 5
+        Slash: 8
+        Piercing: 2
   - type: Item
     sprite: Objects/Tools/Hydroponics/hatchet.rsi
 
@@ -104,8 +104,8 @@
     wideAnimationRotation: 45
     damage:
       types:
-        Blunt: 10
-        Piercing: 5 # I guess you can stab it into them?
+        Blunt: 8
+        Piercing: 2 # I guess you can stab it into them?
   - type: Item
     sprite: Objects/Tools/Hydroponics/spade.rsi
   - type: Shovel


### PR DESCRIPTION
## About the PR
Hatchets/spades have been reduced to 10 damage a hit.
The hoe has been reduced to 6 damage a hit.

## Why / Balance
Botany hatchet meta is dead.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- tweak: Botany's hatchet, spade, and hoe have received a damage decrease to 10, 10, and 6 damage respectively.
