### PR TITLE
Tiny anomaly cores

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
@@ -19,7 +19,7 @@
           True: { visible: true }
           False: { visible: false }
   - type: Item
-    size: Normal
+    size: Tiny
   - type: EmitSoundOnUse #placeholder for future unical mechanic
     sound:
       collection: RadiationPulse


### PR DESCRIPTION
## About the PR
Anomaly cores now occupy 1x1 inventory grid instead of 2x2

## Why / Balance
its small

**Changelog**
boring cl