### PR TITLE
Mantles in dressers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
@@ -12,6 +12,7 @@
       - id: ClothingUniformJumpsuitCapFormal
       - id: ClothingUniformJumpskirtCapFormalDress
       - id: ClothingHandsGlovesCaptain
+      - id: ClothingNeckMantleCap
 
 - type: entity
   id: DresserChiefEngineerFilled
@@ -20,6 +21,7 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingNeckMantleCE
       - id: ClothingUniformJumpsuitChiefEngineerTurtle
       - id: ClothingUniformJumpskirtChiefEngineerTurtle
       - id: ClothingNeckCloakCe
@@ -32,6 +34,7 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingNeckMantleCMO
       - id: ClothingCloakCmo
       - id: ClothingOuterCoatLabCmo
       - id: ClothingHeadHatBeretCmo
@@ -43,6 +46,7 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingNeckMantleHOP
       - id: ClothingNeckCloakHop
       - id: ClothingHeadHatHopcap
       - id: ClothingOuterWinterHoP
@@ -54,6 +58,7 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingNeckMantleHOS
       - id: ClothingHeadHatBeretHoS
       - id: ClothingHeadHatHoshat
       - id: ClothingNeckCloakHos
@@ -75,6 +80,7 @@
       - id: ClothingUniformJumpsuitQMTurtleneck
       - id: ClothingUniformJumpskirtQMTurtleneck
       - id: ClothingHandsGlovesColorBrown
+      - id: ClothingNeckMantleQM
 
 - type: entity
   id: DresserResearchDirectorFilled
@@ -83,6 +89,7 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingNeckMantleRD
       - id: ClothingNeckCloakRd
       - id: ClothingHeadHatBeretRND
       - id: ClothingHandsGlovesColorPurple

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -6,7 +6,6 @@
   - type: StorageFill
     contents:
       - id: BoxFolderQmClipboard
-      - id: ClothingNeckMantleQM
       - id: CargoRequestComputerCircuitboard
       - id: CargoShuttleComputerCircuitboard
       - id: CargoShuttleConsoleCircuitboard
@@ -27,7 +26,6 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterArmorCaptainCarapace
-      - id: ClothingNeckMantleCap
       - id: NukeDisk
       - id: PinpointerNuclear
       - id: CaptainIDCard
@@ -56,7 +54,6 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterArmorCaptainCarapace
-      - id: ClothingNeckMantleCap
       - id: NukeDisk
       - id: PinpointerNuclear
       - id: CaptainIDCard
@@ -83,7 +80,6 @@
   - type: StorageFill
     contents:
       - id: HoPIDCard
-      - id: ClothingNeckMantleHOP
       - id: ClothingHeadsetCommand
       - id: BoxPDA
       - id: BoxID
@@ -111,7 +107,6 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterHardsuitEngineeringWhite
-      - id: ClothingNeckMantleCE
       - id: ClothingMaskBreath
       - id: OxygenTankFilled
       - id: NitrogenTankFilled
@@ -138,7 +133,6 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesGlassesMeson
-      - id: ClothingNeckMantleCE
       - id: ClothingBeltChiefEngineerFilled
       - id: ClothingHandsGlovesColorYellow
       - id: CigarCase
@@ -159,7 +153,6 @@
   - type: StorageFill
     contents:
       - id: MedkitFilled
-      - id: ClothingNeckMantleCMO
       - id: ClothingHandsGlovesNitrile
       - id: ClothingEyesHudMedical
       - id: ClothingHeadsetAltMedical
@@ -184,7 +177,6 @@
   - type: StorageFill
     contents:
       - id: MedkitFilled
-      - id: ClothingNeckMantleCMO
       - id: ClothingHandsGlovesNitrile
       - id: ClothingEyesHudMedical
       - id: ClothingHeadsetAltMedical
@@ -204,7 +196,6 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingNeckMantleRD
       - id: ResearchComputerCircuitboard
       - id: ProtolatheMachineCircuitboard
       - id: CircuitImprinterMachineCircuitboard
@@ -223,7 +214,6 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingNeckMantleRD
       - id: ResearchComputerCircuitboard
       - id: ProtolatheMachineCircuitboard
       - id: CircuitImprinterMachineCircuitboard
@@ -242,7 +232,6 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesHudSecurity
-      - id: ClothingNeckMantleHOS
       - id: WeaponDisabler
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingOuterHardsuitSecurityRed
@@ -269,7 +258,6 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesHudSecurity
-      - id: ClothingNeckMantleHOS
       - id: WeaponDisabler
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingBeltSecurityFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -6,6 +6,7 @@
   - type: StorageFill
     contents:
       - id: BoxFolderQmClipboard
+      - id: ClothingNeckMantleQM
       - id: CargoRequestComputerCircuitboard
       - id: CargoShuttleComputerCircuitboard
       - id: CargoShuttleConsoleCircuitboard
@@ -26,6 +27,7 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterArmorCaptainCarapace
+      - id: ClothingNeckMantleCap
       - id: NukeDisk
       - id: PinpointerNuclear
       - id: CaptainIDCard
@@ -54,6 +56,7 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterArmorCaptainCarapace
+      - id: ClothingNeckMantleCap
       - id: NukeDisk
       - id: PinpointerNuclear
       - id: CaptainIDCard
@@ -80,6 +83,7 @@
   - type: StorageFill
     contents:
       - id: HoPIDCard
+      - id: ClothingNeckMantleHOP
       - id: ClothingHeadsetCommand
       - id: BoxPDA
       - id: BoxID
@@ -107,6 +111,7 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterHardsuitEngineeringWhite
+      - id: ClothingNeckMantleCE
       - id: ClothingMaskBreath
       - id: OxygenTankFilled
       - id: NitrogenTankFilled
@@ -133,6 +138,7 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesGlassesMeson
+      - id: ClothingNeckMantleCE
       - id: ClothingBeltChiefEngineerFilled
       - id: ClothingHandsGlovesColorYellow
       - id: CigarCase
@@ -153,6 +159,7 @@
   - type: StorageFill
     contents:
       - id: MedkitFilled
+      - id: ClothingNeckMantleCMO
       - id: ClothingHandsGlovesNitrile
       - id: ClothingEyesHudMedical
       - id: ClothingHeadsetAltMedical
@@ -177,6 +184,7 @@
   - type: StorageFill
     contents:
       - id: MedkitFilled
+      - id: ClothingNeckMantleCMO
       - id: ClothingHandsGlovesNitrile
       - id: ClothingEyesHudMedical
       - id: ClothingHeadsetAltMedical
@@ -196,6 +204,7 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingNeckMantleRD
       - id: ResearchComputerCircuitboard
       - id: ProtolatheMachineCircuitboard
       - id: CircuitImprinterMachineCircuitboard
@@ -214,6 +223,7 @@
   components:
   - type: StorageFill
     contents:
+      - id: ClothingNeckMantleRD
       - id: ResearchComputerCircuitboard
       - id: ProtolatheMachineCircuitboard
       - id: CircuitImprinterMachineCircuitboard
@@ -232,6 +242,7 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesHudSecurity
+      - id: ClothingNeckMantleHOS
       - id: WeaponDisabler
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingOuterHardsuitSecurityRed
@@ -258,6 +269,7 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesHudSecurity
+      - id: ClothingNeckMantleHOS
       - id: WeaponDisabler
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingBeltSecurityFilled

--- a/Resources/Prototypes/Entities/Structures/Furniture/dresser.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/dresser.yml
@@ -26,7 +26,7 @@
         acts: [ "Destruction" ]
   - type: Storage
     grid:
-    - 0,0,5,3
+    - 0,0,6,3
     maxItemSize: Normal
   - type: ContainerContainer
     containers:


### PR DESCRIPTION
Mantles in the dressers

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR adds mantles to the spawn contents of filled dressers of all the department heads! Simple as that, the size of dressers also were increased since the HoS has too much drip.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

I noticed when working on another PR, mantles do not natrually spawn within the dressers of the dept.
heads. Not only this I saw a thread from months ago about adding it to dressers but it seems it was enver
acted upon so I shall do so now.  Also sometimes a target for thieves? and it isn't a guaranteed spawn 
unless a mapper decided to place them?

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds the dept. head's respective mantles to their dressers so that they may naturally spawn and do not need to be manually added by mappers. The size of dressers was increased in order to store the new mantles.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

- tweak: Mantles are now guaranteed to appear on every station inside the respective dept. head's dresser.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
