### PR TITLE
Make EscapeInventorySystem respect Unremovable (fix glued hamster deletion)

### DIFF
--- a/Content.Server/Glue/GlueSystem.cs
+++ b/Content.Server/Glue/GlueSystem.cs
@@ -99,7 +99,8 @@ public sealed class GlueSystem : SharedGlueSystem
 
     private void OnHandPickUp(Entity<GluedComponent> entity, ref GotEquippedHandEvent args)
     {
-        EnsureComp<UnremoveableComponent>(entity);
+        var comp = EnsureComp<UnremoveableComponent>(entity);
+        comp.DeleteOnDrop = false;
         entity.Comp.Until = _timing.CurTime + entity.Comp.Duration;
     }
 }

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -41,6 +41,15 @@ public sealed class EscapeInventorySystem : EntitySystem
         if (!_containerSystem.TryGetContainingContainer(uid, out var container) || !_actionBlockerSystem.CanInteract(uid, container.Owner))
             return;
 
+        // Make sure there's nothing stopped the removal (like being glued)
+        var removeAttemptEv = new ContainerGettingRemovedAttemptEvent(container, uid);
+        RaiseLocalEvent(uid, removeAttemptEv);
+        if (removeAttemptEv.Cancelled)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-failed-resisting"), uid, uid);
+            return;
+        }
+
         // Contested
         if (_handsSystem.IsHolding(container.Owner, uid, out var inHand))
         {
@@ -53,7 +62,10 @@ public sealed class EscapeInventorySystem : EntitySystem
                 contestResults = 1;
 
             if (contestResults >= MaximumMassDisadvantage)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-failed-resisting"), uid, uid);
                 return;
+            }
 
             AttemptEscape(uid, container.Owner, component, contestResults);
             return;
@@ -80,7 +92,6 @@ public sealed class EscapeInventorySystem : EntitySystem
         if (!_doAfterSystem.TryStartDoAfter(doAfterEventArgs, out component.DoAfter))
             return;
 
-        Dirty(user, component);
         _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-start-resisting"), user, user);
         _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-start-resisting-target"), container, container);
     }
@@ -88,7 +99,6 @@ public sealed class EscapeInventorySystem : EntitySystem
     private void OnEscape(EntityUid uid, CanEscapeInventoryComponent component, EscapeInventoryEvent args)
     {
         component.DoAfter = null;
-        Dirty(uid, component);
 
         if (args.Handled || args.Cancelled)
             return;

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -42,9 +42,7 @@ public sealed class EscapeInventorySystem : EntitySystem
             return;
 
         // Make sure there's nothing stopped the removal (like being glued)
-        var removeAttemptEv = new ContainerGettingRemovedAttemptEvent(container, uid);
-        RaiseLocalEvent(uid, removeAttemptEv);
-        if (removeAttemptEv.Cancelled)
+        if (!_containerSystem.CanRemove(uid, container))
         {
             _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-failed-resisting"), uid, uid);
             return;

--- a/Resources/Locale/en-US/resist/components/escape-inventory-component.ftl
+++ b/Resources/Locale/en-US/resist/components/escape-inventory-component.ftl
@@ -1,2 +1,3 @@
 escape-inventory-component-start-resisting = You start struggling to escape!
 escape-inventory-component-start-resisting-target = Something is struggling to get out of your inventory!
+escape-inventory-component-failed-resisting = Can't escape!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This makes EscapeInventorySystem behave properly if there's a reason why the escapee can't be removed. In practice, this prevents small mobs from escaping when they're glued to their captor's hands (until the glue wears off). The player attempting to escape will see a popup telling them that they can't escape. As a bonus, this message is also displayed when being unable to escape due to mass advantage.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Currently, glued small mobs that escape are simply deleted from the world, due to the logic of Unremovable, which gets added to glued objects.
This bug was reported here: https://discord.com/channels/310555209753690112/1199451935481286806
This PR also makes the easy fix of preventing all glued objects that are (somehow) dropped from being deleted by setting DeleteOnDrop to false for glued objects, but I think it makes sense to block the escape attempt too, and this also makes the system compatible with potential future things that should block escapes.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
EscapeInventorySystem now calls SharedContainerSystem.CanRemove before attempting the escape, and aborts if it fails.

I also removed two calls to Dirty that were causing debug assert failures for being used on unnetworked components.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/85356/9b7971b2-eb52-43ad-8c74-81396da8148d

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Glued mobs can no longer struggle free from their captor's hands.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
