### PR TITLE
removes syndie pAI from thief stuff

### DIFF
--- a/Resources/Locale/en-US/thief/backpack.ftl
+++ b/Resources/Locale/en-US/thief/backpack.ftl
@@ -38,7 +38,7 @@ thief-backpack-category-chemistry-description =
 thief-backpack-category-syndie-name = syndie kit
 thief-backpack-category-syndie-description =
     A set of items from a syndicate agent you've robbed
-    in the past. Includes an Agent ID card, Emag, a syndicate pAI,
+    in the past. Includes an Agent ID card, Emag,
     and some strange red crystals.
 
 thief-backpack-category-sleeper-name = sleepwalker's kit

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -57,7 +57,6 @@
   content:
   - AgentIDCard
   - Emag
-  - SyndicatePersonalAI
   - ClothingHeadHatSyndieMAA
   - CigPackSyndicate
   - Telecrystal10 #The thief cannot use them, but it may induce communication with traitors


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
removes syndie pAI from thief toolboxes
## Why / Balance
having access to syndie radio can lead to metagaming of nukies (hearing nukie chatter and like a good thief telling it to captain in exchange for your objectives)
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- remove: Thieves no longer have the skill to steal pAIs from cybersun employees, and thus have lost their stash of Syndie pAIs.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
