### PR TITLE
Cigarettes now do very minor cellular damage

### DIFF
--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -201,6 +201,14 @@
   plantMetabolism:
   - !type:PlantAdjustHealth
     amount: -5
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        probability: 0.02
+        damage:
+          types:
+            Cellular: 2 #smoking gives you cancer.
 
 # TODO: Replace these nonstandardized effects with generic brain damage
 - type: reagent


### PR DESCRIPTION

## About the PR
Nicotine, which is the only reagent present in ALL cigarettes, now has a 2% chance to deal 2 cellular damage per .5u
This averages to about 14.4 damage per hour, so a 2 hour shift would bring you up to 28.8 damage, and a 7 hour shift would crit you.

## Why / Balance
Smoking kills, and this game does not sufficiently reflect that as of now.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/140123969/6962fd6a-3df2-428d-9510-1e9579a90638)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Smoking now causes mild lung cancer in the form of cellular damage.
