### PR TITLE
Added a research and construction path to the base R&D point generator.

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -63,6 +63,7 @@ research-technology-advanced-anomaly-research = Advanced Anomaly Research
 research-technology-rped = Rapid Part Exchange
 research-technology-super-parts = Super Parts
 research-technology-deterrence = Deterrence Technologies
+research-technology-point-generation = Point Generation
 
 research-technology-janitorial-equipment = Janitorial Equipment
 research-technology-laundry-tech = Laundry Tech

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1356,5 +1356,5 @@
     tagRequirements:
         AnomalyCore:
           Amount: 1
-          DefaultPrototype: AnomalyCore
+          DefaultPrototype: AnomalyCoreGravityInert
           ExamineName: Anomaly Core

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1338,4 +1338,23 @@
     materialRequirements:
       Steel: 5
       CableHV: 2
-      
+
+- type: entity
+  id: BaseResearchAndDevelopmentPointSourceCircuitboard
+  parent: BaseMachineCircuitboard
+  name: R&D point source board
+  description: A machine printed circuit board for an R&D point generator.
+  components:
+  - type: Sprite
+    state: science
+  - type: MachineBoard
+    prototype: BaseResearchAndDevelopmentPointSource
+    requirements:
+     Capacitor: 4
+    materialRequirements:
+      Uranium: 10
+    tagRequirements:
+        AnomalyCore:
+          Amount: 1
+          DefaultPrototype: AnomalyCore
+          ExamineName: Anomaly Core

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -447,6 +447,7 @@
       - ArtifactAnalyzerMachineCircuitboard
       - TraversalDistorterMachineCircuitboard
       - ArtifactCrusherMachineCircuitboard
+      - BaseResearchAndDevelopmentPointSourceCircuitboard
       - BoozeDispenserMachineCircuitboard
       - SodaDispenserMachineCircuitboard
       - TelecomServerCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -416,6 +416,7 @@
       - StasisBedMachineCircuitboard
       - OreProcessorIndustrialMachineCircuitboard
       - CargoTelepadMachineCircuitboard
+      - SalvageMagnetMachineCircuitboard
       - RipleyCentralElectronics
       - RipleyPeripheralsElectronics
       - HonkerCentralElectronics

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -416,7 +416,6 @@
       - StasisBedMachineCircuitboard
       - OreProcessorIndustrialMachineCircuitboard
       - CargoTelepadMachineCircuitboard
-      - SalvageMagnetMachineCircuitboard
       - RipleyCentralElectronics
       - RipleyPeripheralsElectronics
       - HonkerCentralElectronics

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -63,9 +63,9 @@
 
 - type: entity
   id: BaseResearchAndDevelopmentPointSource
-  parent: BaseMachinePowered
+  parent: [ BaseMachinePowered, ConstructibleMachine ]
   name: "base R&D point source"
-  # We should make this abstract once there are actual point sources.
+  description: A safe container for an anomaly core, which feeds research directly into the R&D server.
   components:
   - type: Sprite
     sprite: Structures/Machines/rndpointsource.rsi
@@ -78,6 +78,8 @@
   - type: ResearchPointSource
     pointspersecond: 25
     active: true
+  - type: Machine
+    board: BaseResearchAndDevelopmentPointSourceCircuitboard
   - type: PointLight
     radius: 1.5
     energy: 1.6

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
@@ -5,6 +5,9 @@
   name: anomaly core
   description: The core of a destroyed incomprehensible object.
   components:
+  - type: Tag
+    tags: 
+    - AnomalyCore
   - type: Sprite
     sprite: Structures/Specific/Anomalies/Cores/gravity_core.rsi
     layers:

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -956,3 +956,13 @@
      Steel: 100
      Glass: 900
      Gold: 100
+
+- type: latheRecipe
+  id: BaseResearchAndDevelopmentPointSourceCircuitboard
+  result: BaseResearchAndDevelopmentPointSourceCircuitboard
+  category: Circuitry
+  completetime: 6
+  materials:
+     Steel: 100
+     Glass: 900
+     Gold: 100

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -860,6 +860,16 @@
     Gold: 100
 
 - type: latheRecipe
+  id: SalvageMagnetMachineCircuitboard
+  result: SalvageMagnetMachineCircuitboard
+  category: Circuitry
+  completetime: 4
+  materials:
+    Steel: 100
+    Glass: 900
+    Silver: 100
+
+- type: latheRecipe
   id: SodaDispenserMachineCircuitboard
   result: SodaDispenserMachineCircuitboard
   category: Circuitry

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -860,16 +860,6 @@
     Gold: 100
 
 - type: latheRecipe
-  id: SalvageMagnetMachineCircuitboard
-  result: SalvageMagnetMachineCircuitboard
-  category: Circuitry
-  completetime: 4
-  materials:
-    Steel: 100
-    Glass: 900
-    Silver: 100
-
-- type: latheRecipe
   id: SodaDispenserMachineCircuitboard
   result: SodaDispenserMachineCircuitboard
   category: Circuitry

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -185,6 +185,7 @@
   cost: 15000
   recipeUnlocks:
   - CargoTelepadMachineCircuitboard
+  - SalvageMagnetMachineCircuitboard
 
 - type: technology
   id: QuantumFiberWeaving

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -185,7 +185,6 @@
   cost: 15000
   recipeUnlocks:
   - CargoTelepadMachineCircuitboard
-  - SalvageMagnetMachineCircuitboard
 
 - type: technology
   id: QuantumFiberWeaving

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -164,3 +164,15 @@
   cost: 10000
   recipeUnlocks:
   - DeviceQuantumSpinInverter
+
+- type: technology
+  id: PointGeneration
+  name: research-technology-point-generation
+  icon:
+    sprite: Structures/Machines/rndpointsource.rsi
+    state: rndpointsource-icon
+  discipline: Experimental
+  tier: 3
+  cost: 10000
+  recipeUnlocks:
+  - BaseResearchAndDevelopmentPointSourceCircuitboard

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -14,6 +14,9 @@
   id: Ambrosia
 
 - type: Tag
+  id: AnomalyCore
+  
+- type: Tag
   id: AppraisalTool
 
 - type: Tag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added an experimental tier 3 technology that would allow science to create safe point generators.

## Why / Balance
Each focus that science has access to should, hopefully, help the specific department(s) that the focus is based on. And the experimental focus tree does do that, mitigating the safety risks of having anomalies active across the station. However, their tier 3 technology hardly helps their work or keep the station safe. While fun to use, the tier 3 techs for experimental are practically just toys. This tech is made to give science an absolutely safe way to research, while keeping the generation over time effect that would allow them to focus on utilizing their toys rather than babysitting anomalies or artifacts. The recipe requiring an anomaly core ensures that science will still have to put in some kind of risk for the reward of long-term safety.

## Media
![1](https://github.com/space-wizards/space-station-14/assets/88403244/8aac7bad-2883-4e95-a79a-1d0fc39aecaf)
![2](https://github.com/space-wizards/space-station-14/assets/88403244/e1b85adc-6313-4c2c-a9bd-e0a339853d3f)
![3](https://github.com/space-wizards/space-station-14/assets/88403244/99a97a16-06a9-4fc5-8847-e011fd62b9de)



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Science now has a new tier 3 experimental technology, allowing them to safely research anomaly cores. 