### PR TITLE
Fixes Electrocutions to use available power, not consumed power

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -258,7 +258,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             return false;
 
         var net = powerNet.NetworkNode;
-        var supp = net.LastCombinedSupply;
+        var supp = net.LastCombinedMaxSupply;
 
         if (supp <= 0f)
             return false;
@@ -295,7 +295,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
         {
             if (id != null &&
                 _nodeContainer.TryGetNode<Node>(nodeContainer, id, out var tryNode) &&
-                tryNode.NodeGroup is IBasePowerNet { NetworkNode: { LastCombinedSupply: > 0 } })
+                tryNode.NodeGroup is IBasePowerNet { NetworkNode: { LastCombinedMaxSupply: > 0 } })
             {
                 return tryNode;
             }


### PR DESCRIPTION
## About the PR
Electrocution damage now scales with available power supply.

## Why / Balance
Electrocution damage used to scale based on power being used: An HV wire with 10GW available but only 100w being used would electrocute you for 100w worth of damage. It now uses the 10GW instead.
This means that cutting any wire with more than 70kw of available power will electrocute you. 
For reference, a single unmodified substation or SMES provides 150kw, APCs 10kw.

## Technical details
Scale damage off LastCombinedMaxSupply instead of LastCombinedSupply.

## Media
⚡

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Cutting wires will now properly electrocute if enough power is available.
