### PR TITLE
Adds emote "Buzz" for moth

### DIFF
--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -264,6 +264,8 @@
   params:
     variation: 0.125
   sounds:
+    Buzz:
+      path: /Audio/Voice/Moth/moth_scream.ogg
     Scream:
       path: /Audio/Voice/Moth/moth_scream.ogg
     Laugh:

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -206,3 +206,18 @@
   chatMessages: ["emote-deathgasp"]
   chatTriggers:
   - deathgasp
+
+- type: emote
+  id: Buzz
+  category: Vocal
+  chatMessages: [buzz!]
+  chatTriggers:
+    - buzzing
+    - buzzing!
+    - buzzing.
+    - buzz
+    - buzz.
+    - buzz!
+    - buzzed
+    - buzzed.
+    - buzzed!

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -221,3 +221,6 @@
     - buzzed
     - buzzed.
     - buzzed!
+    - buzzes
+    - buzzes.
+    - buzzes!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Moths and mothroachs now can use "buzzing" like "scream" emoting (scream can still used)
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/48354940/3e57fd42-344a-4623-8f1a-373c807b1c85


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
- add: Added "buzzing" emote for Moths and Mothroach

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: Wertan
- add: Added "buzzing" emote for Moths and Mothroach
-->
