### PR TITLE
remove compact power tech

### DIFF
--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -41,20 +41,6 @@
   - FlatpackerMachineCircuitboard
 
 - type: technology
-  id: CompactPower
-  name: research-technology-compact-power
-  icon:
-    sprite: Structures/Power/Generation/wallmount_generator.rsi
-    state: panel
-  discipline: Industrial
-  tier: 1
-  cost: 7500
-  recipeUnlocks:
-  - WallmountSubstationElectronics
-  - WallmountGeneratorElectronics
-  - WallmountGeneratorAPUElectronics
-
-- type: technology
   id: IndustrialEngineering
   name: research-technology-industrial-engineering
   icon:


### PR DESCRIPTION
# About the PR
wallmount gens are meant to be used for escape pods. People just spam them for free infinite power at low cost.

No point in having them when we have more interesting PACMAN gens.

:cl:
- remove: Removed compact power tech.