### PR TITLE
Disabled quick equip on paper cups

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -337,4 +337,5 @@
   - type: Clothing
     slots:
     - HEAD
+    quickEquip: false
     sprite: Clothing/Head/Hats/party_water_cup.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
papercups cant be quick equipped

## Why / Balance
Annoying to spill your paper cup by accidentally equipping it.

## Technical details
3

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- fix: To prevent accidental spills, paper cups can no longer be quick-equipped.
