### PR TITLE
Adjusts the chat name color palette to be properly high-contrast

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     private readonly bool _adminLoocEnabled = true;
 
     [ValidatePrototypeId<ColorPalettePrototype>]
-    private const string _chatNamePalette = "Daltonic";
+    private const string _chatNamePalette = "ChatNames";
     private string[] _chatNameColors = default!;
 
     public override void Initialize()

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     private readonly bool _adminLoocEnabled = true;
 
     [ValidatePrototypeId<ColorPalettePrototype>]
-    private const string _chatNamePalette = "Material";
+    private const string _chatNamePalette = "Daltonic";
     private string[] _chatNameColors = default!;
 
     public override void Initialize()

--- a/Resources/Prototypes/Palettes/text.yml
+++ b/Resources/Prototypes/Palettes/text.yml
@@ -35,11 +35,14 @@
     amber-accent-4: "#996700"
 
 - type: palette
-  id: Daltonic
-  name: Daltonic
+  id: ChatNames
+  name: ChatNames
   colors:
-    fuchsia: "#f44c77"
-    violet: "#993fe8"
-    chatreuse: "#d6eb63"
-    cyan: "#26a3f0"
-    orange: "#f5964e"
+    daltonicfuchsia: "#f44c77"
+    daltonicviolet: "#993fe8"
+    daltonicchatreuse: "#d6eb63"
+    daltoniccyan: "#26a3f0"
+    daltonicorange: "#f5964e"
+    green: "#5ef05a"
+    lightblue: "#85e6da"
+    gold: "#e6b940"

--- a/Resources/Prototypes/Palettes/text.yml
+++ b/Resources/Prototypes/Palettes/text.yml
@@ -38,7 +38,7 @@
   id: Daltonic
   name: Daltonic
   colors:
-    fuchsia: "#f5489c"
+    fuchsia: "#f44c77"
     violet: "#993fe8"
     chatreuse: "#d6eb63"
     cyan: "#26a3f0"

--- a/Resources/Prototypes/Palettes/text.yml
+++ b/Resources/Prototypes/Palettes/text.yml
@@ -38,8 +38,8 @@
   id: Daltonic
   name: Daltonic
   colors:
-    fuchsia: "#fe0095"
-    violet: "#a800ff"
-    chatreuse: "#e1ff00"
-    cyan: "#00c0ff"
-    orange: "#ff9d51"
+    fuchsia: "#f5489c"
+    violet: "#993fe8"
+    chatreuse: "#d6eb63"
+    cyan: "#26a3f0"
+    orange: "#f5964e"

--- a/Resources/Prototypes/Palettes/text.yml
+++ b/Resources/Prototypes/Palettes/text.yml
@@ -33,3 +33,13 @@
     amber-darken-2: "#cc8000"
     amber-accent-2: "#7c6200"
     amber-accent-4: "#996700"
+
+- type: palette
+  id: Daltonic
+  name: Daltonic
+  colors:
+    fuchsia: "#fe0095"
+    violet: "#a800ff"
+    chatreuse: "#e1ff00"
+    cyan: "#00c0ff"
+    orange: "#ff9d51"


### PR DESCRIPTION
## About the PR / Why
The colors in #24478 are particularly problematic for pretty much everyone due to the low contrast with the chat background, even *with* #24555.

So this PR replaces the bootleg Material Design palette with a far more distinct 8-color palette that we golfed and whipped up on the spot. This palette is designed to be reasonably high contrast (though proper text outlines would be ideal on top of this, as high-noise backgrounds can still cause readability issues with these). Additionally, the first 5 colors of the palette, the Daltonic colors, are chosen specifically for colorblind compatibility.

For the sake of maintaining parity with the material palette (which contains 8 unique colors excluding the different-luminosity variants), three extra colors are bolted on.

## Technical details
N/A

## Media

![dotnet_uJQ50zYIvx](https://github.com/space-wizards/space-station-14/assets/6356337/cdc842d4-6a00-4e18-aa7f-69dd9dfda82d)


![dotnet_TlQtHbmko0](https://github.com/space-wizards/space-station-14/assets/6356337/9030862e-a8bd-4458-853e-1a988f773132)


<details>
<summary> Old daltonic palette </summary>

### Normal Vision
![dotnet_vgxkjB2Ttq](https://github.com/space-wizards/space-station-14/assets/6356337/0786d5cf-c16f-4aa5-ac86-7090b9ada7fc)

### Protanopia
![firefox_hjybeVCp5S](https://github.com/space-wizards/space-station-14/assets/6356337/49c5a44a-7451-4321-a32f-4c074a069921)

### Deuteranopia
![firefox_uWTPdJr3b0](https://github.com/space-wizards/space-station-14/assets/6356337/2492fe62-681c-4e64-9aba-b5d78c5150c5)

### Tritanopia
![firefox_IKxAUnPRzu](https://github.com/space-wizards/space-station-14/assets/6356337/ef047cf7-5000-4b52-a5f0-8373c1bbda5e)

### Blue cone monochromacy
![firefox_BTBGB2JcRQ](https://github.com/space-wizards/space-station-14/assets/6356337/6bcd9bd5-60cc-4656-ba91-73ca6e73dc59)

</details>

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- tweak: The color palette of chat names has been adjusted for better contrast and moderate colorblind compatibility (a few colors are problematic for colorblind folks like ourself, but the variety does help)
