### PR TITLE
Revert "Cigarettes now do very minor cellular damage"

### DIFF
--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -201,14 +201,6 @@
   plantMetabolism:
   - !type:PlantAdjustHealth
     amount: -5
-  metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        probability: 0.02
-        damage:
-          types:
-            Cellular: 2 #smoking gives you cancer.
 
 # TODO: Replace these nonstandardized effects with generic brain damage
 - type: reagent


### PR DESCRIPTION
Reverts space-wizards/space-station-14#24546

I don't really get why this PR was implemented so I'll go over what i think is dumb about it.

Dealing a fairly permanent damage type, even if it's in minor amounts, when smoking is a massive nerf to an item that doesn't actually provide any upsides. Knowing that it's going to hurt you is going to discourage players from doing it, straight up. I think this is bad for a couple of reason.

Cigarettes have a few interesting interactions. Primarily, they're trash. Cigarettes and cigars leave garbage on the floor that provides janitors something to clean up. This kind of naturally produced trash is just generally nice to have. Things that create garbage are good because it gives cleaning a purpose. Reducing the amount of trash players are naturally producing is going to hurt the reduce of cleaning janitors are able to do, which gives them less stuff to do.

Additionally, cigarettes can be heat sources. This is pretty niche, but it's always a silly interaction when someone smoking accidentally lights a plasma fire. In the future, things like burning ashes from cigarettes should absolutely be capable of starting minor fires. There's a lot of subtle atmospheric reactions you could do with it.

Lastly, cigarettes are just good flavor. Smoking is Cool:tm: and it can be a statement about your character. It primarily exists as a super mild RP thing so I don't see a really good reason to punish players for doing it, especially when it doesn't even provide meaningful upsides.

Small additional note: the PR isn't even implemented correctly? The act of smoking and inhaling doesn't do cellular damage, the metabolism of nicotine does. This is effectively the same but it also means the damage isn't even consistent across all types of cigarettes (since some don't contain nicotine iirc) and you can also just use nicotine as a super mild cellular poison. It just doesn't seem very well thought out.

:cl:
- remove: Cigarettes no longer deal cellular damage when smoked. 