### PR TITLE
Fix notice board storage fill visuals

### DIFF
--- a/Content.Server/Storage/EntitySystems/StorageFillVisualizerSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageFillVisualizerSystem.cs
@@ -47,7 +47,7 @@ public sealed class StorageFillVisualizerSystem : EntitySystem
         if (!_appearance.TryGetData<int>(uid, StorageVisuals.Capacity, out var capacity, appearance))
             return;
 
-        var level = ContentHelpers.RoundToEqualLevels(used, capacity, component.MaxFillLevels);
+        var level = ContentHelpers.RoundToLevels(used, capacity, component.MaxFillLevels);
         _appearance.SetData(uid, StorageFillVisuals.FillLevel, level, appearance);
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixes #24489 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Storage fill visuals rounding down to zero makes it look like there is nothing in them when there isn't quite enough to round up to the first level. This change makes sure it is at least level 1 if there is anything at all in there.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

ContentHelpers.RoundToLevels only rounds to level 0 if actual is also 0, so it makes sure that level 1 is selected with anything in the storage.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no cl