### PR TITLE
Server configurable late-join spawner priority for arrivals/cryostorage

### DIFF
--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -81,7 +81,10 @@ public sealed class ArrivalsSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<PlayerSpawningEvent>(OnPlayerSpawn, before: new[] { typeof(SpawnPointSystem), typeof(ContainerSpawnPointSystem) });
+        if (_cfgManager.GetCVar(CCVars.StationSpawningPrioritizeArrivals))
+            SubscribeLocalEvent<PlayerSpawningEvent>(OnPlayerSpawn, before: new[] { typeof(SpawnPointSystem), typeof(ContainerSpawnPointSystem) });
+        else
+            SubscribeLocalEvent<PlayerSpawningEvent>(OnPlayerSpawn, before: new[] { typeof(SpawnPointSystem) }, after: new[] { typeof(ContainerSpawnPointSystem) });
         SubscribeLocalEvent<StationArrivalsComponent, ComponentStartup>(OnArrivalsStartup);
 
         SubscribeLocalEvent<ArrivalsShuttleComponent, ComponentStartup>(OnShuttleStartup);

--- a/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Server.GameTicking;
-using Content.Server.Shuttles.Systems;
 using Content.Server.Spawners.Components;
 using Content.Server.Station.Systems;
 using Robust.Server.Containers;
@@ -18,7 +17,7 @@ public sealed class ContainerSpawnPointSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<PlayerSpawningEvent>(OnSpawnPlayer, before: new[] { typeof(SpawnPointSystem) }, after: new[] { typeof(ArrivalsSystem) });
+        SubscribeLocalEvent<PlayerSpawningEvent>(OnSpawnPlayer, before: new[] { typeof(SpawnPointSystem) });
     }
 
     private void OnSpawnPlayer(PlayerSpawningEvent args)

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -230,6 +230,12 @@ namespace Content.Shared.CCVar
             GameCryoSleepRejoining = CVarDef.Create("game.cryo_sleep_rejoining", false, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
+        /// Controls whether late-joiners spawn into arrivals or cryogenic storage, if both are enabled. Currently requires a server restart to take effect.
+        /// </summary>
+        public static readonly CVarDef<bool>
+            StationSpawningPrioritizeArrivals = CVarDef.Create("game.station_spawning_prioritize_arrivals", true, CVar.SERVER | CVar.REPLICATED);
+
+        /// <summary>
         ///     Whether a random position offset will be applied to the station on roundstart.
         /// </summary>
         public static readonly CVarDef<bool> StationOffset =


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Allows a server to configure the late-join spawn system priority between arrivals or cryostorage.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Requested in #24470.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

ArrivalsSystem and ContainerSpawnPointSystem no longer subscribe. Their priority is determined by StationSpawningSystem, so their callbacks were exposed and appropriately renamed.

PlayerSpawningEvent data is passed to them directly to avoid ugly parameter stuff, then sent off to the rest of the listeners as normal. It seemed appropriate, but let me know if it's not.

Other/future listeners of PlayerSpawningEvent can still take place between here and SpawnPointSystem.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
