### PR TITLE
Fix SSD indicator

### DIFF
--- a/Content.Client/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Client/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,4 +1,7 @@
 ﻿using Content.Shared.CCVar;
+using Content.Shared.Mind.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.NPC;
 using Content.Shared.SSDIndicator;
 using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
@@ -14,6 +17,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
 
     public override void Initialize()
     {
@@ -24,11 +28,15 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
     private void OnGetStatusIcon(EntityUid uid, SSDIndicatorComponent component, ref GetStatusIconsEvent args)
     {
-        if (!component.IsSSD ||
-            !_cfg.GetCVar(CCVars.ICShowSSDIndicator) ||
-            args.InContainer)
-            return;
-
-        args.StatusIcons.Add(_prototype.Index<StatusIconPrototype>(component.Icon));
+        if (component.IsSSD &&
+            _cfg.GetCVar(CCVars.ICShowSSDIndicator) &&
+            !args.InContainer &&
+            !_mobState.IsDead(uid) &&
+            !HasComp<ActiveNPCComponent>(uid) &&
+            TryComp<MindContainerComponent>(uid, out var mindContainer) &&
+            mindContainer.ShowExamineInfo)
+        {
+            args.StatusIcons.Add(_prototype.Index<StatusIconPrototype>(component.Icon));
+        }
     }
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class SSDIndicatorComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
-    public bool IsSSD = false;
+    public bool IsSSD = true;
 
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("icon", customTypeSerializer: typeof(PrototypeIdSerializer<StatusIconPrototype>))]

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,5 +1,4 @@
-﻿using Content.Shared.Mind.Components;
-using Content.Shared.NPC;
+﻿using Robust.Shared.Player;
 
 namespace Content.Shared.SSDIndicator;
 
@@ -10,30 +9,18 @@ public sealed class SSDIndicatorSystem : EntitySystem
 {
     public override void Initialize()
     {
-        SubscribeLocalEvent<SSDIndicatorComponent, ComponentInit>(OnInit);
-        SubscribeLocalEvent<SSDIndicatorComponent, MindAddedMessage>(OnMindAdded);
-        SubscribeLocalEvent<SSDIndicatorComponent, MindRemovedMessage>(OnMindRemoved);
+        SubscribeLocalEvent<SSDIndicatorComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<SSDIndicatorComponent, PlayerDetachedEvent>(OnPlayerDetached);
     }
 
-    private void OnInit(EntityUid uid, SSDIndicatorComponent component, ComponentInit args)
-    {
-        if (HasComp<ActiveNPCComponent>(uid))
-            return;
-
-        component.IsSSD = !HasComp<MindContainerComponent>(uid);
-    }
-
-    private void OnMindAdded(EntityUid uid, SSDIndicatorComponent component, MindAddedMessage args)
+    private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
     {
         component.IsSSD = false;
         Dirty(uid, component);
     }
 
-    private void OnMindRemoved(EntityUid uid, SSDIndicatorComponent component, MindRemovedMessage args)
+    private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
     {
-        if (HasComp<ActiveNPCComponent>(uid))
-            return;
-
         component.IsSSD = true;
         Dirty(uid, component);
     }


### PR DESCRIPTION
## About the PR

Fix [the SSD indicator](https://github.com/space-wizards/space-station-14/pull/19701) that currently only shows up on characters if the owning player explicitly used the `ghost` command.

## Why / Balance

To reduce confusion on what the green "Zz" indicator means and why it's so rare.

## Extra thoughts

Initially, I've wanted to add a yellow and purple "Zz" indicators and map it to characters being in SSD or catatonic. But it turned out that the MindComponent isn't being replicated client-side due to how PVS removes nested components.

## Technical details

- Changed mind add/remove event handlers to player attach/detach
- Moved the `HasComp<ActiveNPCComponent>` check to the client side
- Added `_mobState.IsDead(uid)` to avoid the "sleep" indicator from sticking with dead bodies
- Added `mindContainer.ShowExamineInfo` to avoid showing the indicator on things that prefer to hide their minds

## Media

<img width="300" alt="image" src="https://github.com/space-wizards/space-station-14/assets/1192090/44e76473-24b6-497b-a114-464ff31d68f4">

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
<!--
## Breaking changes

List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- fix: Fixed indicator near SSD players
