### PR TITLE
small botany fix

### DIFF
--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -766,6 +766,7 @@ public sealed class PlantHolderSystem : EntitySystem
         component.Seed = null;
         component.Dead = false;
         component.Age = 0;
+        component.LastProduce = 0;
         component.Sampled = false;
         component.Harvest = false;
         component.ImproperLight = false;


### PR DESCRIPTION
## About the PR
fixed plants being removed not resetting LastProduce

## Why / Balance
if you were doing non-reharvestable plants it would basically double the production time since:
1. the plant would first wait until age > production
2. the plant would then wait until age - LastProduce > production

after a plant is harvested LastProduce would be the old age, production, which is how its doubled

now that LastProduce gets reset the second part is basically ignored since it seems intended for reharvestable plants, leaving production time actually be production.

## Technical details
LastProduce = 0 real

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun