### PR TITLE
slight botany clipping rework

### DIFF
--- a/Content.Server/Botany/Components/PlantHolderComponent.cs
+++ b/Content.Server/Botany/Components/PlantHolderComponent.cs
@@ -56,9 +56,6 @@ public sealed partial class PlantHolderComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("harvest")]
     public bool Harvest;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("sampled")]
-    public bool Sampled;
-
     [ViewVariables(VVAccess.ReadWrite), DataField("yieldMod")]
     public int YieldMod = 1;
 

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -250,12 +250,6 @@ public sealed class PlantHolderSystem : EntitySystem
                 return;
             }
 
-            if (component.Sampled)
-            {
-                _popup.PopupCursor(Loc.GetString("plant-holder-component-already-sampled-message"), args.User);
-                return;
-            }
-
             if (component.Dead)
             {
                 _popup.PopupCursor(Loc.GetString("plant-holder-component-dead-plant-message"), args.User);
@@ -268,15 +262,12 @@ public sealed class PlantHolderSystem : EntitySystem
             var displayName = Loc.GetString(component.Seed.DisplayName);
             _popup.PopupCursor(Loc.GetString("plant-holder-component-take-sample-message",
                 ("seedName", displayName)), args.User);
-            component.Health -= (_random.Next(3, 5) * 10);
+            component.Health -= _random.Next(30, 50);
 
             if (component.Seed != null && component.Seed.CanScream)
             {
                 _audio.PlayPvs(component.Seed.ScreamSound, uid, AudioParams.Default.WithVolume(-2));
             }
-
-            if (_random.Prob(0.3f))
-                component.Sampled = true;
 
             // Just in case.
             CheckLevelSanity(uid, component);
@@ -766,7 +757,6 @@ public sealed class PlantHolderSystem : EntitySystem
         component.Seed = null;
         component.Dead = false;
         component.Age = 0;
-        component.Sampled = false;
         component.Harvest = false;
         component.ImproperLight = false;
         component.ImproperPressure = false;

--- a/Resources/Locale/en-US/botany/components/plant-holder-component.ftl
+++ b/Resources/Locale/en-US/botany/components/plant-holder-component.ftl
@@ -12,7 +12,6 @@ plant-holder-component-empty-message = {$owner} is empty!
 plant-holder-component-spray-message = You spray {$owner}.
 plant-holder-component-transfer-message = You transfer {$amount}u to {$owner}.
 plant-holder-component-nothing-to-sample-message = There is nothing to take a sample of!
-plant-holder-component-already-sampled-message = This plant has already been sampled.
 plant-holder-component-dead-plant-message = This plant is dead.
 plant-holder-component-take-sample-message = You take a sample from the {$seedName}.
 plant-holder-component-compost-message = You compost {$usingItem} into {$owner}.


### PR DESCRIPTION
## About the PR
removed rng Sampled and instead its fully health dependent

## Why / Balance
1. how it was before you could be unlucky and only get 1 seed or get 6, leading to botanists turning into machines to get a lot of seeds with shift+e/b because of rng kicking in early
2. since you cant get trolled by Sampled anymore you also dont need to make a giant stock of seeds before mutating, you can just spread them out as normal and then clip after mutating knowing that you will be able to get a seed. this was why youd need a giant stock in the first place so now its just a thing you do if the plant is healthy enough or you actually need more seeds

Sampled bool just served to annoy botanists and didnt prevent anything

sampling a plant to death usually gives 3-6 seeds (bungo) things that have more health will give more as you would expect

## Technical details
removed Sampled entirely

also changed a 30/40/50 damage to be 30-50 to be a little less predictable

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
removed the `Sampled` field

**Changelog**
:cl:
- tweak: Clipping plants is now purely based on health instead of a hidden random variable.
