### PR TITLE
Dions are now firmly rooted to the ground

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -97,6 +97,7 @@
   - type: BodyEmotes
     soundsId: DionaBodyEmotes
   - type: IgnoreKudzu
+  - type: NoSlip
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
## About the PR
NoSlip for Dionas

## Why / Balance
the Dions are a very sad species right now. And they can't wear boots. So let their roots hold firmly to the earth at all times!

**Changelog**
:cl:
- add: Dionas can't slip anymore
