### PR TITLE
Grammar fix

### DIFF
--- a/Resources/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml
@@ -50,7 +50,7 @@
     <GuideEntityEmbed Entity="MobDragon" Caption=""/>
   </Box>
 
-  A Space Dragon is a giant dragon that creates space carp rifts and eat the crew.
+  A Space Dragon is a giant dragon that creates space carp rifts and eats the crew.
 
   ## Abilities
 


### PR DESCRIPTION
## About the PR
Grammar.

## Why / Balance
"a giant dragon that [...] eat the crew."

## Technical details
no

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no
