### PR TITLE
Nukeops start with softsuits but gain an additional +8TC

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1283,6 +1283,26 @@
     Telecrystal: 10
   categories:
   - UplinkArmor
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
+
+- type: listing
+  id: UplinkHardsuitSyndieEliteNukeops
+  name: uplink-hardsuit-syndieelite-name
+  description: uplink-hardsuit-syndieelite-desc
+  productEntity: ClothingOuterHardsuitSyndieElite
+  cost:
+    Telecrystal: 14
+  categories:
+  - UplinkArmor
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
 
 - type: listing
   id: UplinkClothingOuterHardsuitJuggernaut
@@ -1293,7 +1313,26 @@
     Telecrystal: 12
   categories:
   - UplinkArmor
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
 
+- type: listing
+  id: UplinkClothingOuterHardsuitJuggernautNukeops
+  name: uplink-clothing-outer-hardsuit-juggernaut-name
+  description: uplink-clothing-outer-hardsuit-juggernaut-desc
+  productEntity: ClothingOuterHardsuitJuggernaut
+  cost:
+    Telecrystal: 16
+  categories:
+  - UplinkArmor
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
 # Misc
 
 - type: listing

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -95,8 +95,21 @@
 #this uplink MUST be used for nukeops, as it has the tag for filtering the listing.
 - type: entity
   parent: BaseUplinkRadio
+  id: BaseUplinkRadio48TC
+  suffix: 48 TC, NukeOps
+  components:
+  - type: Store
+    preset: StorePresetUplink
+    balance:
+      Telecrystal: 48
+  - type: Tag
+    tags:
+    - NukeOpsUplink
+
+- type: entity
+  parent: BaseUplinkRadio
   id: BaseUplinkRadio40TC
-  suffix: 40 TC, NukeOps
+  suffix: 40 TC, NukeOps, Medic/Commander
   components:
   - type: Store
     preset: StorePresetUplink
@@ -105,6 +118,7 @@
   - type: Tag
     tags:
     - NukeOpsUplink
+
 
 - type: entity
   parent: BaseUplinkRadio

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -90,7 +90,7 @@
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
     shoes: ClothingShoesBootsCombatFilled
-    pocket1: BaseUplinkRadio40TC
+    pocket1: BaseUplinkRadio48TC
     id: SyndiPDA
   innerClothingSkirt: ClothingUniformJumpsuitOperative
   satchel: ClothingBackpackDuffelSyndicateOperative
@@ -106,11 +106,11 @@
     eyes: ClothingEyesHudSyndicate
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
-    outerClothing: ClothingOuterHardsuitSyndie
+    outerClothing: ClothingOuterHardsuitSyndicate # this is the softsuit. the id names for these suck, a bloodred is ClothingOuterHardsuitSyndie
     shoes: ClothingShoesBootsCombatFilled
     id: SyndiPDA
     pocket1: DoubleEmergencyOxygenTankFilled
-    pocket2: BaseUplinkRadio40TC
+    pocket2: BaseUplinkRadio48TC
     belt: ClothingBeltMilitaryWebbing
   innerClothingSkirt: ClothingUniformJumpskirtOperative
   satchel: ClothingBackpackDuffelSyndicateOperative

--- a/Resources/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml
@@ -30,7 +30,7 @@
   Taking on a whole station in a fight is a difficult job, luckily you are well prepared for the job. Every operative has an [color=#a4885c]Uplink[/color]. It comes with 40 [color=#a4885c]Telecrystals[/color], which you can use to purchase gear. What you get depends on the strategy picked by your commander or voted for by the team. Only your commander and agent will have passenger access, but no external airlock access. This means you will need something to hack or blast your way onto the station.  In general you should need some weapons, something to breach doors, and utility/healing.
 
   <Box>
-    <GuideEntityEmbed Entity="BaseUplinkRadio40TC" Caption="The Uplink"/>
+    <GuideEntityEmbed Entity="BaseUplinkRadio48TC" Caption="The Uplink"/>
   </Box>
 
   ## Getting to the Station

--- a/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
@@ -8,7 +8,7 @@
 
   ## Uplink
   <Box>
-    <GuideEntityEmbed Entity="BaseUplinkRadio40TC" Caption="Uplink"/>
+    <GuideEntityEmbed Entity="BaseUplinkRadio48TC" Caption="Uplink"/>
   </Box>
   - The [color=#a4885c]Uplink[/color] is the most important tool as a Traitor, as it can purchase tools and weapons with [color=#a4885c]telecrystals[/color](TC).
   <Box>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
1. Nuclear Operatives start with syndicate softsuits (EVA) now, they used to start with hardsuits
2. Nuclear Operatives' uplinks start with 48 TC as opposed to 40 TC
3. The Medic and Commander are excluded from this, they start with their own hardsuits and 40 TC.
4. Nukeops now have separate listings for the elite and juggernaut suit with higher prices, from 10>14 and 12>16 TC
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
1. Webvest ops bitch!!!!!!!!!!!!!!!!

2. This should facilitate more sidegrade-related builds, we probably need more hardsuit sidegrades but I'd postpone that until suit barriers are added.

3. Make purchasing suit sidegrades less of a pain to deal with. As it stands you basically need to buy a reinforcement if you buy a jugsuit or an elite suit so you can give them your old hardsuit, which kind of railroads you into having reinforcements even if you don't want them.

3.1. As an (un)fortunate side effect, this kind of promotes balanced team hardsuit composition with medic/commander being railroaded into their original suits because of how elite/juggernaut suit are priced with operatives in mind.

3.2. As another side effect, nukies get sidegrades for cheaper, this should be fine considering they're not objective buffs and come off as situational.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I've tested this on a local but the way I've added another nukie uplink makes me wonder if it actually works, testing says yes but uhhhhhhhhhhhhh
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: BurninDreamer
- tweak: Nuclear Operatives start with 48 TC, the Medic and Commander still start with 40 TC.
- tweak: Nuclear Operatives no longer start with hardsuits, they start with syndicate EVAs instead, the Medic and Commander retain their hardsuits.
