### PR TITLE
Add Secret Extended and Secret Greenshift

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -40,6 +40,24 @@
     - Secret
 
 - type: gamePreset
+  id: SecretExtended
+  alias:
+    - secretextended
+  name: secret-title
+  showInVote: false
+  description: secret-description
+  rules:
+    - BasicStationEventScheduler
+
+- type: gamePreset
+  id: SecretGreenshift
+  alias:
+  - secretgreenshift
+  name: secret-title
+  showInVote: false #4boring4vote
+  description: secret-description
+
+- type: gamePreset
   id: Sandbox
   alias:
     - sandbox

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -40,21 +40,21 @@
     - Secret
 
 - type: gamePreset
-  id: SecretExtended
+  id: SecretExtended #For Admin Use: Runs Extended but shows "Secret" in lobby.
   alias:
     - secretextended
   name: secret-title
-  showInVote: false
+  showInVote: false #Admin Use
   description: secret-description
   rules:
     - BasicStationEventScheduler
 
 - type: gamePreset
-  id: SecretGreenshift
+  id: SecretGreenshift #For Admin Use: Runs Greenshift but shows "Secret" in lobby.
   alias:
   - secretgreenshift
   name: secret-title
-  showInVote: false #4boring4vote
+  showInVote: false #Admin Use
   description: secret-description
 
 - type: gamePreset


### PR DESCRIPTION
Added Secret Extended and Secret Greenshift for admin use as to not alert the dorks of extended.

Proof I didn't break the game:
![image](https://github.com/space-wizards/space-station-14/assets/7548248/b41e7b2f-f4ed-4f29-8a96-70a449debcbb)
![image](https://github.com/space-wizards/space-station-14/assets/7548248/a71de422-538b-4f14-9988-88bdc1a340d9)

