### PR TITLE
Anomalies can't appear near gas miners, arrival docks and cryosleep unit

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -1003,6 +1003,8 @@
   components:
     - type: PriorityDock
       tag: DockArrivals
+    - type: AntiAnomalyZone
+      zoneRadius: 10
 
 - type: entity
   parent: AirlockGlassShuttle

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -31,6 +31,8 @@
     - type: GasMiner
       maxExternalPressure: 300
       spawnAmount: 200
+    - type: AntiAnomalyZone
+      zoneRadius: 5
 
 - type: entity
   name: O2 gas miner

--- a/Resources/Prototypes/Entities/Structures/cryopod.yml
+++ b/Resources/Prototypes/Entities/Structures/cryopod.yml
@@ -42,6 +42,8 @@
         base:
           True: { state: sleeper_1 }
           False: { state: sleeper_0 }
+  - type: AntiAnomalyZone
+    zoneRadius: 15
 
 # This one handles all spawns, latejoin and roundstart.
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/cryopod.yml
+++ b/Resources/Prototypes/Entities/Structures/cryopod.yml
@@ -42,8 +42,6 @@
         base:
           True: { state: sleeper_1 }
           False: { state: sleeper_0 }
-  - type: AntiAnomalyZone
-    zoneRadius: 15
 
 # This one handles all spawns, latejoin and roundstart.
 - type: entity
@@ -58,8 +56,10 @@
 - type: entity
   parent: CryogenicSleepUnit
   id: CryogenicSleepUnitSpawnerLateJoin
-  suffix: Spawner, LateJoin
+  suffix: Spawner, LateJoin, Anti-Anomaly
   components:
     - type: ContainerSpawnPoint
       containerId: storage
       spawnType: LateJoin
+    - type: AntiAnomalyZone
+      zoneRadius: 15


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Title

## Why / Balance
These three points are extremely important things for the round, so I would protect them from anomalies. And it's better to do this automatically for all maps at once than to manually zone on mapping.

**Changelog**
no cl! 
NO CL! 
**NO CL!**
