### PR TITLE
Make some damage sources not cancel do afters

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -402,7 +402,7 @@ namespace Content.Server.Atmos.EntitySystems
                     if (TryComp(uid, out TemperatureComponent? temp))
                         _temperatureSystem.ChangeHeat(uid, 12500 * damageScale, false, temp);
 
-                    _damageableSystem.TryChangeDamage(uid, flammable.Damage * damageScale);
+                    _damageableSystem.TryChangeDamage(uid, flammable.Damage * damageScale, interruptsDoAfters: false);
 
                     AdjustFireStacks(uid, flammable.FirestackFade * (flammable.Resisting ? 10f : 1f), flammable);
                 }

--- a/Content.Server/Chemistry/ReagentEffects/HealthChange.cs
+++ b/Content.Server/Chemistry/ReagentEffects/HealthChange.cs
@@ -115,7 +115,11 @@ namespace Content.Server.Chemistry.ReagentEffects
             var scale = ScaleByQuantity ? args.Quantity : FixedPoint2.New(1);
             scale *= args.Scale;
 
-            args.EntityManager.System<DamageableSystem>().TryChangeDamage(args.SolutionEntity, Damage * scale, IgnoreResistances);
+            args.EntityManager.System<DamageableSystem>().TryChangeDamage(
+                args.SolutionEntity,
+                Damage * scale,
+                IgnoreResistances,
+                interruptsDoAfters: false);
         }
     }
 }

--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -262,7 +262,11 @@ namespace Content.Server.Guardian
             if (args.DamageDelta == null || component.Host == null || component.DamageShare > 0)
                 return;
 
-            _damageSystem.TryChangeDamage(component.Host, args.DamageDelta * component.DamageShare, origin: args.Origin);
+            _damageSystem.TryChangeDamage(
+                component.Host,
+                args.DamageDelta * component.DamageShare,
+                origin: args.Origin,
+                interruptsDoAfters: false);
             _popupSystem.PopupEntity(Loc.GetString("guardian-entity-taking-damage"), component.Host.Value, component.Host.Value);
 
         }


### PR DESCRIPTION
- poison chemicals (HealthChange effect)
- being on fire
- guardians transferring damage to owner
