### PR TITLE
Security barriers take 5 seconds to (un)lock

### DIFF
--- a/Content.Shared/Lock/LockComponent.cs
+++ b/Content.Shared/Lock/LockComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.DoAfter;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
@@ -50,6 +51,26 @@ public sealed partial class LockComponent : Component
     [DataField("breakOnEmag")]
     [AutoNetworkedField]
     public bool BreakOnEmag = true;
+
+    /// <summary>
+    /// Amount of do-after time needed to lock the entity.
+    /// </summary>
+    /// <remarks>
+    /// If set to zero, no do-after will be used.
+    /// </remarks>
+    [DataField]
+    [AutoNetworkedField]
+    public TimeSpan LockTime;
+
+    /// <summary>
+    /// Amount of do-after time needed to unlock the entity.
+    /// </summary>
+    /// <remarks>
+    /// If set to zero, no do-after will be used.
+    /// </remarks>
+    [DataField]
+    [AutoNetworkedField]
+    public TimeSpan UnlockTime;
 }
 
 /// <summary>
@@ -64,3 +85,31 @@ public record struct LockToggleAttemptEvent(EntityUid User, bool Silent = false,
 /// </summary>
 [ByRefEvent]
 public readonly record struct LockToggledEvent(bool Locked);
+
+/// <summary>
+/// Used to lock a lockable entity that has a lock time configured.
+/// </summary>
+/// <seealso cref="LockComponent"/>
+/// <seealso cref="LockSystem"/>
+[Serializable, NetSerializable]
+public sealed partial class LockDoAfter : DoAfterEvent
+{
+    public override DoAfterEvent Clone()
+    {
+        return this;
+    }
+}
+
+/// <summary>
+/// Used to unlock a lockable entity that has an unlock time configured.
+/// </summary>
+/// <seealso cref="LockComponent"/>
+/// <seealso cref="LockSystem"/>
+[Serializable, NetSerializable]
+public sealed partial class UnlockDoAfter : DoAfterEvent
+{
+    public override DoAfterEvent Clone()
+    {
+        return this;
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
@@ -45,6 +45,8 @@
   - type: Lock
     locked: false
     lockOnClick: true # toggle lock just by clicking on barrier
+    lockTime: 5
+    unlockTime: 5
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic


### PR DESCRIPTION
## About the PR
Security barriers take 5 seconds to (un)lock

## Why / Balance
People are using these as unhackable and hard-to-tailgate airlocks into sec. They should not be trivial for security officers to move through.

## Technical details
Made `LockComponent` have configurable lock times to implement this.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Security barriers need 5 seconds to lock and unlock.
