### PR TITLE
Health analyzers and cryopods also show temperature in Kelvin

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -66,7 +66,7 @@ namespace Content.Client.HealthAnalyzer.UI
             );
 
             Temperature.Text = Loc.GetString("health-analyzer-window-entity-temperature-text",
-                ("temperature", float.IsNaN(msg.Temperature) ? "N/A" : $"{msg.Temperature - 273f:F1} °C")
+                ("temperature", float.IsNaN(msg.Temperature) ? "N/A" : $"{msg.Temperature - 273f:F1} °C ({msg.Temperature:F1} °K)")
             );
 
             BloodLevel.Text = Loc.GetString("health-analyzer-window-entity-blood-level-text",


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

![image](https://github.com/space-wizards/space-station-14/assets/42424291/f81ec561-be19-422f-8a6f-38242fb7cc15)


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

All of the guidebook entries use Kelvin. Helps new doctors work with cryogenic chems a bit smoother.


## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl: Krunk
- add: Health analysis interfaces now also display a subject's temperature in Kelvin.
