### PR TITLE
Remove salvage flesh ghost roles

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/flesh.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/flesh.yml
@@ -252,10 +252,6 @@
         Slash: 6
   - type: ReplacementAccent
     accent: genericAggressive
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-salvage-flesh-name
-    description: ghost-role-information-salvage-flesh-description
   - type: SalvageMobRestrictions
 
 - type: entity


### PR DESCRIPTION
## About the PR
Aberrant flesh monsters on the meatball salvage wreck no longer have a chance to become a ghost role.

## Why / Balance
Seems it was missed due to being in a different folder from the rest of the salvage mobs, and it's been clogging up the ghost roles menu randomly for a good bit now.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
