### PR TITLE
Nerf Beanbags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: PelletShotgunSlug
   name: pellet (.50 slug)
   noSpawn: true
@@ -26,7 +26,7 @@
       types:
         Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 55 # 2 hits to stun
+    damage: 40 # 3 hits to stun
 
 - type: entity
   id: PelletShotgun


### PR DESCRIPTION
## About the PR
Shotgun beanbag rounds now deal 40 stamina damage instead of 55, meaning they take 3 hits to stun someone instead of 2.

## Why / Balance
Me when roundstart near-instant stun with zero reloads which is available to a **_service job_**
Any somewhat skilled double barrel shotgun user can still stun someone in around 2 seconds using a bandolier or ammo box (or even faster, just pulling the shell out of your bag with a keybind) but now the bartender can't just run up to an antag and stun them without giving said antag a single chance to react.

Security's beanbag stuns are still a thing, but it's more forgiving since a Kammerer only holds 4 shots and dodging two of them means you won't be stunned. It's also fine that security gets beanbags because they already have rubber bullets and disablers.

## Media
https://github.com/space-wizards/space-station-14/assets/140123969/b4f439c7-203d-4b1f-83cc-ece871f54b53
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Shotgun beanbag rounds now deal 40 stamina damage and stun in 3 hits.

