### PR TITLE
Prototype component remover

### DIFF
--- a/Content.Shared/Prototypes/Components/ComponentRemoverComponent.cs
+++ b/Content.Shared/Prototypes/Components/ComponentRemoverComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Prototypes.Components;
+
+/// <summary>
+/// Component to specify other components to remove in response to a variety of events.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ComponentRemoverComponent : Component
+{
+    /// <summary>
+    /// Perform the remove in response to OnMapInit.
+    /// </summary>
+    [DataField("doOnMapInit")]
+    public bool DoOnMapInit = false;
+
+    /// <summary>
+    /// Components to remove.
+    /// </summary>
+    [DataField("components", required: true)]
+    public ComponentRegistry Components = new();
+}

--- a/Content.Shared/Prototypes/Systems/SharedComponentRemoverSystem.cs
+++ b/Content.Shared/Prototypes/Systems/SharedComponentRemoverSystem.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Prototypes.Components;
+
+namespace Content.Shared.Prototypes.Systems;
+
+public sealed class SharedComponentRemoverSystem : EntitySystem
+{
+    [Dependency] private readonly IComponentFactory _componentFactory = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ComponentRemoverComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, ComponentRemoverComponent comp, MapInitEvent ev)
+    {
+        if (!comp.DoOnMapInit)
+            return;
+
+        foreach (var entry in comp.Components)
+            if (_componentFactory.TryGetRegistration(entry.Key, out var registration))
+                RemComp(uid, registration.Type);
+    }
+}


### PR DESCRIPTION
## About the PR

Adds a new system to remove other components in response to an event.
Currently a draft to help workshop additional features or concerns.


## Why / Balance

I was adding RemComp lines to prevent the Exterminator antagonist from getting hungry or thirsty when Sloth suggested the pattern was common enough to be turned into a component.


## Technical details

Example:

Instead of...

```
private void OnMapInit(EntityUid uid, SomeComponent comp, MapInitEvent ev)
{
    RemComp<HungerComponent>(uid);
    RemComp<ThirstComponent>(uid);
}
```

...you can do...

```
- type: entity
  abstract: true
  id: MobTerminatorBase
  components:
  - type: ZombieImmune # yeah no
  - type: FlashImmunity # no brain to brainwash, eyes are robotic
  - type: ComponentRemover
    doOnMapInit: true
    components:
    - type: Hunger
    - type: Thirst
```

Currently only supports MapInitEvent. -> Could this be made generic? 🤔
If not, please suggest other events this pattern is commonly found in.

Fails silently for any listed component that doesn't exist. -> Is this desired?


## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
