### PR TITLE
Prevent client crash when right-clicking empty action bar slot

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -514,7 +514,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (actionId == null)
         {
             button.ClearData();
-            if (_container?.TryGetButtonIndex(button, out position) ?? false)
+            if ((_container?.TryGetButtonIndex(button, out position) ?? false) && position < _actions.Count)
             {
                 _actions.RemoveAt(position);
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes a crash (#22350) when right-clicking an empty slot in the action bar