### PR TITLE
New uplink item - Secret Storage Crate.

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -151,8 +151,8 @@ uplink-syndicate-weapon-module-desc = This module will give a cyborg advanced la
 uplink-singularity-beacon-name = Singularity Beacon
 uplink-singularity-beacon-desc = A device that attracts singularities. Has to be anchored and powered. Causes singularities to grow when consumed.
 
-uplink-syndicate-weapon-module-name = secret storage crate
-uplink-syndicate-weapon-module-desc = A crate with an invisibility function. Designed for secret storage of your belongings.
+uplink-syndicate-crate-secret-storage = secret storage crate
+uplink-syndicate-crate-secret-storage-desc = A crate with an invisibility function. Designed for secret storage of your belongings.
 
 # Implants
 uplink-storage-implanter-name = Storage Implanter

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -151,6 +151,9 @@ uplink-syndicate-weapon-module-desc = This module will give a cyborg advanced la
 uplink-singularity-beacon-name = Singularity Beacon
 uplink-singularity-beacon-desc = A device that attracts singularities. Has to be anchored and powered. Causes singularities to grow when consumed.
 
+uplink-syndicate-weapon-module-name = secret storage crate
+uplink-syndicate-weapon-module-desc = A crate with an invisibility function. Designed for secret storage of your belongings.
+
 # Implants
 uplink-storage-implanter-name = Storage Implanter
 uplink-storage-implanter-desc = Hide goodies inside of yourself with new bluespace technology!

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -11,7 +11,7 @@
   id: CrateSecretStorage
   parent: CrateSyndicate
   name: secret storage crate
-  description: A box full of riddles...
+  description: A crate full of riddles...
   components:
     - type: Stealth
       hadOutline: true

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -8,6 +8,18 @@
       totalPrice: 50
 
 - type: entity
+  id: CrateSecretStorage
+  parent: CrateSyndicate
+  name: secret storage crate
+  description: A box full of riddles...
+  components:
+    - type: Stealth
+      hadOutline: true
+    - type: StealthOnMove
+      passiveVisibilityRate: -0.10
+      movementVisibilityRate: 0.10
+      
+- type: entity
   id: CrateSyndicateSuperSurplusBundle
   parent: CrateSyndicate
   name: Syndicate super surplus crate

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -599,7 +599,7 @@
   description: uplink-syndicate-crate-secret-storage-desc
   productEntity: CrateSecretStorage
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - UplinkUtility
 # Implants

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -592,6 +592,16 @@
     Telecrystal: 5
   categories:
     - UplinkUtility
+  
+- type: listing
+  id: UplinkCrateSecretStorage
+  name: uplink-syndicate-crate-secret-storage
+  description: uplink-syndicate-crate-secret-storage-desc
+  productEntity: CrateSecretStorage
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkUtility
 # Implants
 
 - type: listing


### PR DESCRIPTION
## About the PR
This PR adds a stealth box-like crate to the uplink in the Utilities category.

## Why / Balance
This innovation in the game will perfectly allow traitors to conveniently hide their things in an invisible crate (or hide in case of danger) for 2 TC. However, it will not replace the stealth box; 
UPDATE: The syndicate's symbols attract too many eyes, and the crate does not allow entities to pass through

## Technical details
PR takes the syndicate crate as a base and adds two stealth-related components to it.

## Media

https://github.com/space-wizards/space-station-14/assets/152051971/1fcc6eca-6b27-4410-80ab-be648272e830

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

### P.S

I am sorry for my English

**Changelog**

- tweak: Price change (from 4 to 2 TC)
