### PR TITLE
Touch up rotting examine text

### DIFF
--- a/Content.Server/Atmos/Rotting/RottingSystem.cs
+++ b/Content.Server/Atmos/Rotting/RottingSystem.cs
@@ -133,7 +133,8 @@ public sealed class RottingSystem : SharedRottingSystem
             return;
         }
 
-        var description = "perishable-" + stage;
+        var isMob = HasComp<MobStateComponent>(perishable);
+        var description = "perishable-" + stage + (!isMob ? "-nonmob" : string.Empty);
         args.PushMarkup(Loc.GetString(description, ("target", Identity.Entity(perishable, EntityManager))));
     }
 

--- a/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
+++ b/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Mobs.Components;
 
 namespace Content.Shared.Atmos.Rotting;
 
@@ -34,6 +35,10 @@ public abstract class SharedRottingSystem : EntitySystem
             >= 1 => "rotting-bloated",
             _ => "rotting-rotting"
         };
+
+        if (!HasComp<MobStateComponent>(uid))
+            description += "-nonmob";
+
         args.PushMarkup(Loc.GetString(description, ("target", Identity.Entity(uid, EntityManager))));
     }
 }

--- a/Resources/Locale/en-US/disease/miasma.ftl
+++ b/Resources/Locale/en-US/disease/miasma.ftl
@@ -1,7 +1,7 @@
 ammonia-smell = Something smells pungent!
-perishable-1 = [color=green]{ CAPITALIZE(SUBJECT($target)) } still {CONJUGATE-BASIC($target, "look", "looks")} fresh.[/color]
-perishable-2 = [color=orangered]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BASIC($target, "look", "looks")} somewhat fresh.[/color]
-perishable-3 = [color=red]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BASIC($target, "do not", "doesn't")} {CONJUGATE-BASIC($target, "look", "looks")} fresh anymore.[/color]
-rotting-rotting = [color=orange]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BE($target)} rotting![/color]
-rotting-bloated = [color=orangered]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BE($target)} bloated![/color]
-rotting-extremely-bloated = [color=red]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BE($target)} extremely bloated![/color]
+perishable-1 = [color=green]{ CAPITALIZE(POSS-ADJ($target)) } corpse still looks fresh.[/color]
+perishable-2 = [color=orangered]{ CAPITALIZE(POSS-ADJ($target)) } corpse looks somewhat fresh.[/color]
+perishable-3 = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } corpse doesn't look very fresh.[/color]
+rotting-rotting = [color=orange]{ CAPITALIZE(POSS-ADJ($target)) } corpse is rotting![/color]
+rotting-bloated = [color=orangered]{ CAPITALIZE(POSS-ADJ($target)) } corpse is bloated![/color]
+rotting-extremely-bloated = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } corpse is extremely bloated![/color]

--- a/Resources/Locale/en-US/disease/miasma.ftl
+++ b/Resources/Locale/en-US/disease/miasma.ftl
@@ -1,7 +1,21 @@
 ammonia-smell = Something smells pungent!
+
+## Perishable
+
 perishable-1 = [color=green]{ CAPITALIZE(POSS-ADJ($target)) } corpse still looks fresh.[/color]
 perishable-2 = [color=orangered]{ CAPITALIZE(POSS-ADJ($target)) } corpse looks somewhat fresh.[/color]
 perishable-3 = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } corpse doesn't look very fresh.[/color]
+
+perishable-1-nonmob = [color=green]{ CAPITALIZE(SUBJECT($target)) } still looks fresh.[/color]
+perishable-2-nonmob = [color=orangered]{ CAPITALIZE(SUBJECT($target)) } looks somewhat fresh.[/color]
+perishable-3-nonmob = [color=red]{ CAPITALIZE(SUBJECT($target)) } doesn't look very fresh.[/color]
+
+## Rotting
+
 rotting-rotting = [color=orange]{ CAPITALIZE(POSS-ADJ($target)) } corpse is rotting![/color]
 rotting-bloated = [color=orangered]{ CAPITALIZE(POSS-ADJ($target)) } corpse is bloated![/color]
 rotting-extremely-bloated = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } corpse is extremely bloated![/color]
+
+rotting-rotting-nonmob = [color=orange]{ CAPITALIZE(SUBJECT($target)) } is rotting![/color]
+rotting-bloated-nonmob = [color=orangered]{ CAPITALIZE(SUBJECT($target)) } is bloated![/color]
+rotting-extremely-bloated-nonmob = [color=red]{ CAPITALIZE(SUBJECT($target)) } is extremely bloated![/color]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

rewrote rotting/perishable examine text

breaks into mob/nonmob text because saying "its corpse looks fresh" is weird for meat but "it looks fresh" is weird for people

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

bothered me

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

n/a

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

mob

![image](https://github.com/space-wizards/space-station-14/assets/19853115/ff1f556b-ee65-40e0-99e5-cfaa2754bdf0)

nonmob

![image](https://github.com/space-wizards/space-station-14/assets/19853115/45fb8c2e-f641-449b-b97f-a6868c3c4616)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Rotting examine text doesn't have weird grammatical errors now