### PR TITLE
Add 5 hours of hop playtime requirement to captain

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -16,6 +16,9 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 54000 # 15 hours
+    - !type:RoleTimeRequirement
+      role: JobHeadOfPersonnel
+      time: 18000 # 5 Hours
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Captain needs five hours of HoP playtime to unlock.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Captains sometimes do not know the basics of the HoP's duties, or how to use the ID card computer. This will prevent that. To be more specific, it's the captains duty to know the ins and outs of every department, and the HoP is an integral command role to the station.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Add five hours to the role playtime requirements for the role of Head of Personnel in the captain's prototype.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl: YuNii
- tweak: Added five hours of HoP playtime to the Captain's unlock requirements.


