### PR TITLE
Fix welder status always being "not lit"

### DIFF
--- a/Content.Client/Tools/UI/WelderStatusControl.cs
+++ b/Content.Client/Tools/UI/WelderStatusControl.cs
@@ -17,11 +17,11 @@ public sealed class WelderStatusControl : Control
     private readonly ItemToggleComponent? _toggleComponent;
     private readonly RichTextLabel _label;
 
-    public WelderStatusControl(WelderComponent parent, EntityUid? uid = null)
+    public WelderStatusControl(Entity<WelderComponent> parent)
     {
         _parent = parent;
         _entMan = IoCManager.Resolve<IEntityManager>();
-        if (_entMan.TryGetComponent<ItemToggleComponent>(uid, out var itemToggle))
+        if (_entMan.TryGetComponent<ItemToggleComponent>(parent.Owner, out var itemToggle))
             _toggleComponent = itemToggle;
         _label = new RichTextLabel { StyleClasses = { StyleNano.StyleClassItemStatus } };
         AddChild(_label);

--- a/Content.Client/Tools/UI/WelderStatusControl.cs
+++ b/Content.Client/Tools/UI/WelderStatusControl.cs
@@ -21,7 +21,7 @@ public sealed class WelderStatusControl : Control
     {
         _parent = parent;
         _entMan = IoCManager.Resolve<IEntityManager>();
-        if (_entMan.TryGetComponent<ItemToggleComponent>(parent.Owner, out var itemToggle))
+        if (_entMan.TryGetComponent<ItemToggleComponent>(parent, out var itemToggle))
             _toggleComponent = itemToggle;
         _label = new RichTextLabel { StyleClasses = { StyleNano.StyleClassItemStatus } };
         AddChild(_label);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The status description for welders always displays "not lit", regardless of the welder's actual status. This fixes that.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug fix.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The uid being passed to TryGetComponent to get the ItemToggleComponent was null. The constructor for WelderStatusControl has been modified to properly pass in the uid.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Welders properly display their lit status again.