### PR TITLE
Fix stun baton EMP state

### DIFF
--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -99,11 +99,10 @@ namespace Content.Server.Stunnable.Systems
 
         private void OnChargeChanged(Entity<StunbatonComponent> entity, ref ChargeChangedEvent args)
         {
-            if (_itemToggle.IsActivated(entity.Owner) &&
-                TryComp<BatteryComponent>(entity.Owner, out var battery) &&
+            if (TryComp<BatteryComponent>(entity.Owner, out var battery) &&
                 battery.CurrentCharge < entity.Comp.EnergyPerUse)
             {
-                _itemToggle.Toggle(entity.Owner, predicted: false);
+                _itemToggle.TryDeactivate(entity.Owner, predicted: false);
             }
         }
     }

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -30,6 +30,7 @@ namespace Content.Server.Stunnable.Systems
             SubscribeLocalEvent<StunbatonComponent, StaminaDamageOnHitAttemptEvent>(OnStaminaHitAttempt);
             SubscribeLocalEvent<StunbatonComponent, ItemToggleActivateAttemptEvent>(TryTurnOn);
             SubscribeLocalEvent<StunbatonComponent, ItemToggledEvent>(ToggleDone);
+            SubscribeLocalEvent<StunbatonComponent, ChargeChangedEvent>(OnChargeChanged);
         }
 
         private void OnStaminaHitAttempt(Entity<StunbatonComponent> entity, ref StaminaDamageOnHitAttemptEvent args)
@@ -38,12 +39,6 @@ namespace Content.Server.Stunnable.Systems
             !TryComp<BatteryComponent>(entity.Owner, out var battery) || !_battery.TryUseCharge(entity.Owner, entity.Comp.EnergyPerUse, battery))
             {
                 args.Cancelled = true;
-                return;
-            }
-
-            if (battery.CurrentCharge < entity.Comp.EnergyPerUse)
-            {
-                _itemToggle.Toggle(entity.Owner, predicted: false);
             }
         }
 
@@ -100,6 +95,16 @@ namespace Content.Server.Stunnable.Systems
                 Used = used,
                 User = user
             });
+        }
+
+        private void OnChargeChanged(Entity<StunbatonComponent> entity, ref ChargeChangedEvent args)
+        {
+            if (_itemToggle.IsActivated(entity.Owner) &&
+                TryComp<BatteryComponent>(entity.Owner, out var battery) &&
+                battery.CurrentCharge < entity.Comp.EnergyPerUse)
+            {
+                _itemToggle.Toggle(entity.Owner, predicted: false);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

 Stun batons now toggle off after being drained by an EMP.

Fixes #24486 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Just subscribed to ChargeChangedEvent and moved the toggle off logic there.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Stun batons now toggle off after being drained by an EMP.
