### PR TITLE
Orbital Anomaly Cores

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
@@ -7,6 +7,7 @@
   components:
   - type: Sprite
     sprite: Structures/Specific/Anomalies/Cores/gravity_core.rsi
+    noRot: true
     layers:
     - state: core
     - state: pulse
@@ -25,6 +26,9 @@
       collection: RadiationPulse
   - type: UseDelay
     delay: 2
+  - type: Tag
+    tags:
+    - ForceableFollow
   - type: AnomalyCore
     timeToDecay: 600
     startPrice: 10000


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Allows players to force anomaly cores to orbit them.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Adds more flavor to anomaly cores, rather than just keeping them in storage for gorilla gauntlet use or a cargo bounty.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/91828755/31551a91-f85c-48bf-b0e7-53df5101bfcc

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: You can now make anomaly cores orbit you.
