### PR TITLE
Fix improper prediction on unpryable doors

### DIFF
--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -28,8 +28,6 @@ public sealed class DoorSystem : SharedDoorSystem
     {
         base.Initialize();
 
-
-        SubscribeLocalEvent<DoorComponent, BeforePryEvent>(OnBeforeDoorPry);
         SubscribeLocalEvent<DoorComponent, WeldableAttemptEvent>(OnWeldAttempt);
         SubscribeLocalEvent<DoorComponent, WeldableChangedEvent>(OnWeldChanged);
         SubscribeLocalEvent<DoorComponent, GotEmaggedEvent>(OnEmagged);
@@ -123,12 +121,6 @@ public sealed class DoorSystem : SharedDoorSystem
             SetState(uid, DoorState.Welded, component);
         else if (component.State == DoorState.Welded)
             SetState(uid, DoorState.Closed, component);
-    }
-
-    private void OnBeforeDoorPry(EntityUid id, DoorComponent door, ref BeforePryEvent args)
-    {
-        if (door.State == DoorState.Welded || !door.CanPry)
-            args.Cancelled = true;
     }
     #endregion
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -60,6 +60,7 @@ public abstract class SharedDoorSystem : EntitySystem
 
         SubscribeLocalEvent<DoorComponent, StartCollideEvent>(HandleCollide);
         SubscribeLocalEvent<DoorComponent, PreventCollideEvent>(PreventCollision);
+        SubscribeLocalEvent<DoorComponent, BeforePryEvent>(OnBeforePry);
         SubscribeLocalEvent<DoorComponent, GetPryTimeModifierEvent>(OnPryTimeModifier);
 
     }
@@ -173,6 +174,12 @@ public abstract class SharedDoorSystem : EntitySystem
     private void OnPryTimeModifier(EntityUid uid, DoorComponent door, ref GetPryTimeModifierEvent args)
     {
         args.BaseTime = door.PryTime;
+    }
+
+    private void OnBeforePry(EntityUid uid, DoorComponent door, ref BeforePryEvent args)
+    {
+        if (door.State == DoorState.Welded || !door.CanPry)
+            args.Cancelled = true;
     }
 
     /// <summary>
@@ -460,7 +467,7 @@ public abstract class SharedDoorSystem : EntitySystem
             //If the colliding entity is a slippable item ignore it by the airlock
             if (otherPhysics.CollisionLayer == (int)CollisionGroup.SlipLayer && otherPhysics.CollisionMask == (int)CollisionGroup.ItemMask)
                 continue;
-            
+
             //For when doors need to close over conveyor belts
             if (otherPhysics.CollisionLayer == (int) CollisionGroup.ConveyorMask)
                 continue;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Things like blast doors would get improperly predicted and start a doafter on the client when it shouldn't since blast doors should be unpryable. I did not test it but the same would probably happen to welded doors which were checked on the same place. The server would then cancel the doafter causing the doafter bar to briefly appear before disappearing.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I moved the check from server to shared. I have no idea why it wasn't before, probably because it remained from how prying was handled before prying got turned into its own component and system.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun.