### PR TITLE
Allow IdentityBlocker partial coverage

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Actions;
+using Content.Shared.Actions;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
@@ -68,6 +68,6 @@ public sealed class MaskSystem : EntitySystem
         RaiseLocalEvent(uid, ref maskEv);
 
         var wearerEv = new WearerMaskToggledEvent(mask.IsToggled);
-        RaiseLocalEvent(uid, ref wearerEv);
+        RaiseLocalEvent(wearer, ref wearerEv);
     }
 }

--- a/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
+++ b/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
@@ -32,5 +32,5 @@ public sealed class SeeIdentityAttemptEvent : CancellableEntityEventArgs, IInven
     public SlotFlags TargetSlots => SlotFlags.MASK | SlotFlags.HEAD | SlotFlags.EYES;
 
     // cumulative coverage from each relayed slot
-    public IdentityBlockerCoverage Coverage = IdentityBlockerCoverage.NONE;
+    public IdentityBlockerCoverage TotalCoverage = IdentityBlockerCoverage.NONE;
 }

--- a/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
+++ b/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Inventory;
+using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.IdentityManagement.Components;
@@ -7,6 +7,20 @@ namespace Content.Shared.IdentityManagement.Components;
 public sealed partial class IdentityBlockerComponent : Component
 {
     public bool Enabled = true;
+
+    /// <summary>
+    /// What part of your face does this cover? Eyes, mouth, or full?
+    /// </summary>
+    [DataField]
+    public IdentityBlockerCoverage Coverage = IdentityBlockerCoverage.FULL;
+}
+
+public enum IdentityBlockerCoverage
+{
+    NONE  = 0,
+    MOUTH = 1 << 0,
+    EYES  = 1 << 1,
+    FULL  = MOUTH | EYES
 }
 
 /// <summary>
@@ -14,6 +28,9 @@ public sealed partial class IdentityBlockerComponent : Component
 /// </summary>
 public sealed class SeeIdentityAttemptEvent : CancellableEntityEventArgs, IInventoryRelayEvent
 {
-    // i.e. masks or helmets.
-    public SlotFlags TargetSlots => SlotFlags.MASK | SlotFlags.HEAD;
+    // i.e. masks, helmets, or glasses.
+    public SlotFlags TargetSlots => SlotFlags.MASK | SlotFlags.HEAD | SlotFlags.EYES;
+
+    // cumulative coverage from each relayed slot
+    public IdentityBlockerCoverage Coverage = IdentityBlockerCoverage.NONE;
 }

--- a/Content.Shared/IdentityManagement/SharedIdentitySystem.cs
+++ b/Content.Shared/IdentityManagement/SharedIdentitySystem.cs
@@ -23,7 +23,11 @@ public abstract class SharedIdentitySystem : EntitySystem
     private void OnSeeIdentity(EntityUid uid, IdentityBlockerComponent component, SeeIdentityAttemptEvent args)
     {
         if (component.Enabled)
-            args.Cancel();
+        {
+            args.Coverage |= component.Coverage;
+            if(args.Coverage == IdentityBlockerCoverage.FULL)
+                args.Cancel();
+        }
     }
 
     protected virtual void OnComponentInit(EntityUid uid, IdentityComponent component, ComponentInit args)

--- a/Content.Shared/IdentityManagement/SharedIdentitySystem.cs
+++ b/Content.Shared/IdentityManagement/SharedIdentitySystem.cs
@@ -24,8 +24,8 @@ public abstract class SharedIdentitySystem : EntitySystem
     {
         if (component.Enabled)
         {
-            args.Coverage |= component.Coverage;
-            if(args.Coverage == IdentityBlockerCoverage.FULL)
+            args.TotalCoverage |= component.Coverage;
+            if(args.TotalCoverage == IdentityBlockerCoverage.FULL)
                 args.Cancel();
         }
     }

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -122,6 +122,7 @@
     sprite: Clothing/Eyes/Glasses/outlawglasses.rsi
   - type: VisionCorrection
   - type: IdentityBlocker
+    coverage: EYES
 
 - type: entity
   parent: ClothingEyesBase
@@ -140,6 +141,8 @@
     tags:
     - HamsterWearable
     - WhitelistChameleon
+  - type: IdentityBlocker
+    coverage: EYES
 
 - type: entity
   parent: ClothingEyesBase
@@ -162,6 +165,8 @@
     guides:
     - Security
   - type: ShowSecurityIcons
+  - type: IdentityBlocker
+    coverage: EYES
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -262,6 +262,8 @@
   - type: IngestionBlocker
   - type: Item
     storedRotation: -90
+  - type: IdentityBlocker
+    coverage: MOUTH
 
 - type: entity
   parent: ClothingMaskBase
@@ -475,6 +477,7 @@
   - type: Clothing
     sprite: Clothing/Mask/neckgaiter.rsi
   - type: IdentityBlocker
+    coverage: MOUTH
   - type: Tag
     tags:
     - WhitelistChameleon


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

You can now hide your identity using a combination of items, like sunglasses + sterile mask, instead of needing something like a gas mask to cover everything at once.

Resolves #24390 

I didn't add a ton of partial eye/mouth coverage to existing items, since I wanted to avoid a scenario like secoffs being disguised due to their sunglasses + security gas mask. I started small and we can add some more if wanted after this PR. #24597 in particular will add face bandanas, which would introduce a supply of mouth coverage.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This allows different combinations of clothing to be worn to hide your identity. This makes logical sense, allows different style/drip while going incognito, and might shake up the standard gas mask disguise.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

I just added an enum for coverage, and the relay event adds up the coverage of each item. If it reaches full coverage, it blocks the identity, otherwise not.  Also, I saw there was a bug with WearerMaskToggledEvent since we weren't passing the right ID, so I fixed that.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/89101928/af4c96c6-1466-4ffa-a490-b12653f55474

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Some glasses and masks can be worn together to hide your identity.
