### PR TITLE
Fix weird rotation when strapped to a bed

### DIFF
--- a/Content.Shared/Buckle/Components/StrapComponent.cs
+++ b/Content.Shared/Buckle/Components/StrapComponent.cs
@@ -66,11 +66,11 @@ public sealed partial class StrapComponent : Component
     public Vector2 BuckleOffset = Vector2.Zero;
 
     /// <summary>
-    /// The angle in degrees to rotate the player by when they get strapped
+    /// The angle to rotate the player by when they get strapped
     /// </summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
-    public int Rotation;
+    public Angle Rotation;
 
     /// <summary>
     /// The size of the strap which is compared against when buckling entities

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -357,7 +357,7 @@ public abstract partial class SharedBuckleSystem
         if (TryComp<AppearanceComponent>(buckleUid, out var appearance))
             Appearance.SetData(buckleUid, BuckleVisuals.Buckled, true, appearance);
 
-        _rotationVisuals.SetHorizontalAngle(buckleUid, Angle.FromDegrees(strapComp.Rotation));
+        _rotationVisuals.SetHorizontalAngle(buckleUid, strapComp.Rotation);
 
         ReAttach(buckleUid, strapUid, buckleComp, strapComp);
         SetBuckledTo(buckleUid, strapUid, strapComp, buckleComp);

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -357,7 +357,7 @@ public abstract partial class SharedBuckleSystem
         if (TryComp<AppearanceComponent>(buckleUid, out var appearance))
             Appearance.SetData(buckleUid, BuckleVisuals.Buckled, true, appearance);
 
-        _rotationVisuals.SetHorizontalAngle(buckleUid,  strapComp.Rotation);
+        _rotationVisuals.SetHorizontalAngle(buckleUid, Angle.FromDegrees(strapComp.Rotation));
 
         ReAttach(buckleUid, strapUid, buckleComp, strapComp);
         SetBuckledTo(buckleUid, strapUid, strapComp, buckleComp);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Stops people being placed at a funny rotation when strapped to a bed.
Fixes #24563

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug fix.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
StrapComponent specifies an angle as an int in _degrees_, and RotationVisualizerSystem takes an Angle in _radians_. Now StrapComponent uses Angle too.

I know this will get stomped by the eventual buckle/vehicle refactor, but at least it'll be fixed for now.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
<img width="252" alt="Lying in bed like a normal mothperson" src="https://github.com/space-wizards/space-station-14/assets/85356/0b507d9d-da23-426c-8b8f-ef7e94f1ec54">

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed weird rotation while strapped to a bed.