### PR TITLE
Fix ClimbSystem removing the climbing fixture when it still has contacts

### DIFF
--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
@@ -13,7 +12,6 @@ using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Movement.Events;
-using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;
@@ -353,7 +351,8 @@ public sealed partial class ClimbSystem : VirtualController
     {
         if (args.OurFixtureId != ClimbingFixtureName
             || !component.IsClimbing
-            || component.NextTransition != null)
+            || component.NextTransition != null
+            || args.OurFixture.Contacts.Count > 1)
         {
             return;
         }


### PR DESCRIPTION
## About the PR
See https://github.com/space-wizards/RobustToolbox/pull/4877

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
