### PR TITLE
Adding embedding function to 23 melee weapons.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -81,6 +81,12 @@
         Slash: 8
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 6
 
 - type: entity
   name: shiv
@@ -107,6 +113,10 @@
     damage:
       types:
         Slash: 12
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 10
 
 - type: entity
   name: laser scalpel
@@ -218,6 +228,12 @@
     qualities:
       - Sawing
     speed: 1.5
+  - type: EmbeddableProjectile
+    sound: /Audio/Items/drill_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Brute: 12
 
 - type: entity
   name: advanced circular saw
@@ -237,6 +253,12 @@
         Brute: 15
     soundHit:
       path: /Audio/Items/drill_hit.ogg
+  - type: EmbeddableProjectile
+    sound: /Audio/Items/drill_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Brute: 12
   - type: Tool
     qualities:
       - Sawing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
@@ -21,6 +21,12 @@
     slots:
     - back
   - type: DisarmMalus
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 10
 
 - type: entity
   name: eldritch blade
@@ -45,6 +51,12 @@
     slots:
     - back
   - type: DisarmMalus
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 13
 
 - type: entity
   name: unholy halberd
@@ -81,5 +93,12 @@
     quickEquip: false
     slots:
     - back
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 8
+        Slash: 8
   - type: UseDelay
     delay: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -45,6 +45,13 @@
     stealGroup: FireAxe
   - type: IgniteOnMeleeHit
     fireStacks: -4
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types: # Don't put structural damage. When destroyed by a throw, the fire axe disappears
+        Blunt: 4
+        Slash: 8
 
 - type: entity
   id: FireAxeFlaming

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -25,6 +25,12 @@
       - Slicing
     useSound:
       path: /Audio/Items/Culinary/chop.ogg
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 8
 
 - type: entity
   name: kitchen knife
@@ -70,6 +76,10 @@
   - type: GuideHelp
     guides:
     - Chef
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 11
 
 - type: entity
   name: combat knife
@@ -90,8 +100,6 @@
     damage:
       types:
         Slash: 12
-  - type: EmbeddableProjectile
-    sound: /Audio/Weapons/star_hit.ogg
   - type: DamageOtherOnHit
     damage:
       types:
@@ -127,6 +135,10 @@
     damage:
       types:
         Slash: 15
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 12
   - type: Item
     sprite: Objects/Weapons/Melee/kukri_knife.rsi
 
@@ -152,6 +164,10 @@
     damage:
       types:
         Slash: 5.5
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 4
   - type: Item
     sprite: Objects/Weapons/Melee/shiv.rsi
   - type: DisarmMalus
@@ -171,6 +187,10 @@
     damage:
       types:
         Slash: 7 #each "tier" grants an additional 2 damage
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 6
   - type: Item
     sprite: Objects/Weapons/Melee/reinforced_shiv.rsi
   - type: Sprite
@@ -190,6 +210,10 @@
     damage:
       types:
         Slash: 9
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 7
   - type: Item
     sprite: Objects/Weapons/Melee/plasma_shiv.rsi
   - type: Sprite
@@ -210,6 +234,11 @@
       types:
         Slash: 7
         Radiation: 4
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 5
+        Radiation: 3
   - type: Item
     sprite: Objects/Weapons/Melee/uranium_shiv.rsi
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -11,6 +11,8 @@
     color: "#ffeead"
     enabled: false
     radius: 4
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
 
 - type: entity
   parent: BaseWeaponCrusher
@@ -49,6 +51,11 @@
       types:
         Blunt: 10
         Slash: 5
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 8
+        Slash: 4
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -81,6 +88,10 @@
     damage:
       types:
         Slash: 15
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 12
   - type: Tag
     tags:
     - Knife

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -23,6 +23,12 @@
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/captain_sabre.rsi
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 14
   - type: Tag
     tags:
     - CaptainSabre
@@ -51,6 +57,12 @@
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/katana.rsi
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 12
   - type: DisarmMalus
 
 - type: entity
@@ -67,6 +79,10 @@
     damage:
       types:
         Slash: 30
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 25
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/energykatana.rsi
@@ -77,13 +93,15 @@
     charges: 3
   - type: AutoRecharge
     rechargeDuration: 20
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg 
   - type: Clothing
     sprite: Objects/Weapons/Melee/energykatana.rsi
     slots:
     - Back
     - Belt
   - type: Reflect
-
+  
 - type: entity
   name: machete
   parent: BaseItem
@@ -102,8 +120,14 @@
     damage:
       types:
         Slash: 15
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 12
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/machete.rsi
@@ -125,10 +149,16 @@
     damage:
       types:
         Slash: 20
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 17
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item
     size: Normal
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
   - type: Clothing
     sprite: Objects/Weapons/Melee/claymore.rsi
     slots:
@@ -153,8 +183,14 @@
     damage:
       types:
         Slash: 16
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 13
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/cutlass.rsi


### PR DESCRIPTION
## About the PR
This PR added the ability to embedding 23 melee weapons.

All weapons that have been given the function will be listed below:

- swords (captain's sabre, katana, energy katana, machete, claymore, cutlass)
- crushers (all 3 weapons)
- knives (kitchen, butcher's cleaver)
- shiv (all 5 weapons)
- fireaxe
- cult weapons (all 3 weapons)
- scalpels (all 3 weapons)


## Why / Balance
Before this, only spears, combat knives and PEN could be stuck in. If we even have a pen stuck in, then why not give the same function to other bladed weapons?

Like a combat knife, each of the listed melee weapons deals ~85% damage when thrown


## Media
![image](https://github.com/space-wizards/space-station-14/assets/152051971/c0d60caa-192a-4904-aef3-18d6dffdec1c)
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
No CL
