### PR TITLE
Removing the embedding function of pens.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -261,15 +261,6 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 25
-  - type: EmbeddableProjectile
-    offset: 0.3,0.0
-    removalTime: 0.0
-  - type: ThrowingAngle
-    angle: 315
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Piercing: 3
 
 #TODO: I want the luxury pen to write a cool font like Merriweather in the future.
 
@@ -300,10 +291,6 @@
     state: overpriced_pen
   - type: MeleeWeapon
     wideAnimationRotation: -45
-    damage:
-      types:
-        Piercing: 15
-  - type: DamageOtherOnHit
     damage:
       types:
         Piercing: 15


### PR DESCRIPTION
## Why / Balance
Based on my previous PR, and a discussion on Discord about embedding objects into a wall, it simply does not make sense for a pen to be inserted into a METAL wall. I don't think the pen is designed for that at all. We make too many meme changes.

**Changelog**
No CL.
