### PR TITLE
Open some windows non-centered to avoid covering the player

### DIFF
--- a/Content.Client/Atmos/UI/GasAnalyzerBoundUserInterface.cs
+++ b/Content.Client/Atmos/UI/GasAnalyzerBoundUserInterface.cs
@@ -18,7 +18,7 @@ namespace Content.Client.Atmos.UI
 
             _window = new GasAnalyzerWindow();
             _window.OnClose += OnClose;
-            _window.OpenCentered();
+            _window.OpenCenteredLeft();
         }
 
         protected override void ReceiveMessage(BoundUserInterfaceMessage message)

--- a/Content.Client/Crayon/UI/CrayonBoundUserInterface.cs
+++ b/Content.Client/Crayon/UI/CrayonBoundUserInterface.cs
@@ -24,7 +24,7 @@ namespace Content.Client.Crayon.UI
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
             var crayonDecals = prototypeManager.EnumeratePrototypes<DecalPrototype>().Where(x => x.Tags.Contains("crayon"));
             _menu.Populate(crayonDecals);
-            _menu.OpenCentered();
+            _menu.OpenCenteredLeft();
         }
 
         protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/Lathe/UI/LatheBoundUserInterface.cs
+++ b/Content.Client/Lathe/UI/LatheBoundUserInterface.cs
@@ -31,7 +31,7 @@ namespace Content.Client.Lathe.UI
                 SendMessage(new LatheQueueRecipeMessage(recipe, amount));
             };
 
-            _menu.OpenCentered();
+            _menu.OpenCenteredRight();
         }
 
         protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -37,7 +37,7 @@ namespace Content.Client.RoundEnd
 
             Contents.AddChild(roundEndTabs);
 
-            OpenCentered();
+            OpenCenteredRight();
             MoveToFront();
         }
 

--- a/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
+++ b/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
@@ -36,7 +36,7 @@ namespace Content.Client.VendingMachines
 
             _menu.Populate(_cachedInventory, out _cachedFilteredIndex);
 
-            _menu.OpenCentered();
+            _menu.OpenCenteredLeft();
         }
 
         protected override void UpdateState(BoundUserInterfaceState state)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

title

i didnt initially notice this much as a problem while playing since i use oldchat but for people that use nuchat its slightly more annoying esp with stuff like vendors since the game is centered

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

general idea among the ones i changed here is that you're likely to want them open while also being able to look at what you're interacting with / look at your character

rationale for each:
- gas analyzer/crayon : you're likely going to be walking around with the UI for these open, so open them offcenter to make that easier
- lathe/vendor : you might be interacting with this window multiple times, and they spawn items, so you're gonna want to interact with the items they spawn
- round end: this can show up while you're actively moving around and people will kneejerk close it so they can see their player rather than focusing on it

lathe opens to the right because it still blocked character on oldchat when opened left on default UI scale (what I use)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

n/a

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

![Content Client_2024-01-31_02-38-46](https://github.com/space-wizards/space-station-14/assets/19853115/14126fbe-103c-4740-ac30-688457bcf546)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Crayon/lathe/vendor/round end/gas analyzer windows now open closer to the sides of the screen
