### PR TITLE
add 1hr overall playtime limit to TA

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -4,6 +4,8 @@
   description: job-description-technical-assistant
   playTimeTracker: JobTechnicalAssistant
   requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 3600 #1 hr
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 54000 #15 hrs


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Bad actors have easy access to tools that can end the round via several different means
Requires them to waste time to do so by playing the game normally.

Will not affect majority of players, one hour of playtime is one round of the game.
