### PR TITLE
Anomaly bug fix

### DIFF
--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -426,7 +426,7 @@ public partial record struct AnomalySpawnSettings()
     /// <summary>
     /// should entities block spawning?
     /// </summary>
-    public bool CanSpawnOnEntities { get; set; } = true;
+    public bool CanSpawnOnEntities { get; set; } = false;
 
     /// <summary>
     /// The minimum number of entities that spawn per pulse


### PR DESCRIPTION
## About the PR
Anomalies can no longer spawn entities in walls or other objects

## Why / Balance
because trees in the wall are bad.

**Changelog**
:cl:
- fix: Anomalies can no longer spawn entities in walls or other objects.
