### PR TITLE
Spacelube slide

### DIFF
--- a/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
@@ -17,14 +17,19 @@ namespace Content.Server.Chemistry.TileReactions
     [DataDefinition]
     public sealed partial class SpillTileReaction : ITileReaction
     {
-        [DataField("launchForwardsMultiplier")] private float _launchForwardsMultiplier = 1;
-        [DataField("requiredSlipSpeed")] private float _requiredSlipSpeed = 6;
-        [DataField("paralyzeTime")] private float _paralyzeTime = 1;
-        [DataField("superSlippery")] private bool _superSlippery;
+        [DataField] private float _launchForwardsMultiplier = 1;
+        [DataField] private float _requiredSlipSpeed = 6;
+        [DataField] private float _paralyzeTime = 1;
+
+        /// <summary>
+        /// <see cref="SlipperyComponent.SuperSlippery"/>
+        /// </summary>
+        [DataField] private bool _superSlippery;
 
         public FixedPoint2 TileReact(TileRef tile, ReagentPrototype reagent, FixedPoint2 reactVolume)
         {
-            if (reactVolume < 5) return FixedPoint2.Zero;
+            if (reactVolume < 5)
+                return FixedPoint2.Zero;
 
             var entityManager = IoCManager.Resolve<IEntityManager>();
 
@@ -35,7 +40,7 @@ namespace Content.Server.Chemistry.TileReactions
                 slippery.LaunchForwardsMultiplier = _launchForwardsMultiplier;
                 slippery.ParalyzeTime = _paralyzeTime;
                 slippery.SuperSlippery = _superSlippery;
-                entityManager.Dirty(slippery);
+                entityManager.Dirty(puddleUid, slippery);
 
                 var step = entityManager.EnsureComponent<StepTriggerComponent>(puddleUid);
                 entityManager.EntitySysManager.GetEntitySystem<StepTriggerSystem>().SetRequiredTriggerSpeed(puddleUid, _requiredSlipSpeed, step);

--- a/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
@@ -17,14 +17,14 @@ namespace Content.Server.Chemistry.TileReactions
     [DataDefinition]
     public sealed partial class SpillTileReaction : ITileReaction
     {
-        [DataField] private float _launchForwardsMultiplier = 1;
-        [DataField] private float _requiredSlipSpeed = 6;
-        [DataField] private float _paralyzeTime = 1;
+        [DataField("launchForwardsMultiplier")] private float _launchForwardsMultiplier = 1;
+        [DataField("requiredSlipSpeed")] private float _requiredSlipSpeed = 6;
+        [DataField("paralyzeTime")] private float _paralyzeTime = 1;
 
         /// <summary>
         /// <see cref="SlipperyComponent.SuperSlippery"/>
         /// </summary>
-        [DataField] private bool _superSlippery;
+        [DataField("superSlippery")] private bool _superSlippery;
 
         public FixedPoint2 TileReact(TileRef tile, ReagentPrototype reagent, FixedPoint2 reactVolume)
         {

--- a/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
@@ -20,6 +20,7 @@ namespace Content.Server.Chemistry.TileReactions
         [DataField("launchForwardsMultiplier")] private float _launchForwardsMultiplier = 1;
         [DataField("requiredSlipSpeed")] private float _requiredSlipSpeed = 6;
         [DataField("paralyzeTime")] private float _paralyzeTime = 1;
+        [DataField("superSlippery")] private bool _superSlippery;
 
         public FixedPoint2 TileReact(TileRef tile, ReagentPrototype reagent, FixedPoint2 reactVolume)
         {
@@ -33,6 +34,7 @@ namespace Content.Server.Chemistry.TileReactions
                 var slippery = entityManager.EnsureComponent<SlipperyComponent>(puddleUid);
                 slippery.LaunchForwardsMultiplier = _launchForwardsMultiplier;
                 slippery.ParalyzeTime = _paralyzeTime;
+                slippery.SuperSlippery = _superSlippery;
                 entityManager.Dirty(slippery);
 
                 var step = entityManager.EnsureComponent<StepTriggerComponent>(puddleUid);

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -293,7 +293,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     {
         // Reactive entities have a chance to get a touch reaction from slipping on a puddle
         // (i.e. it is implied they fell face first onto it or something)
-        if (!HasComp<ReactiveComponent>(args.Slipped))
+        if (!HasComp<ReactiveComponent>(args.Slipped) || HasComp<SlidingComponent>(args.Slipped))
             return;
 
         // Eventually probably have some system of 'body coverage' to tweak the probability but for now just 0.5

--- a/Content.Shared/Slippery/SlidingComponent.cs
+++ b/Content.Shared/Slippery/SlidingComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Slippery;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class SlidingComponent : Component
+{
+    /// <summary>
+    ///     A list of SuperSlippery entities the entity with this component is colliding with.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<EntityUid> CollidingEntities = new ();
+
+    /// <summary>
+    ///     The friction modifier that will be applied to any friction calculations.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float FrictionModifier;
+}

--- a/Content.Shared/Slippery/SlidingComponent.cs
+++ b/Content.Shared/Slippery/SlidingComponent.cs
@@ -2,6 +2,9 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.Slippery;
 
+/// <summary>
+/// Applies continuous movement to the attached entity when colliding with super slipper entities.
+/// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SlidingComponent : Component
 {

--- a/Content.Shared/Slippery/SlidingSystem.cs
+++ b/Content.Shared/Slippery/SlidingSystem.cs
@@ -1,0 +1,60 @@
+using Content.Shared.Movement.Events;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+using Robust.Shared.Physics.Events;
+
+namespace Content.Shared.Slippery;
+
+public sealed class SlidingSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SlidingComponent, TileFrictionEvent>(OnSlideAttempt);
+        SubscribeLocalEvent<SlidingComponent, StoodEvent>(OnStand);
+        SubscribeLocalEvent<SlidingComponent, StartCollideEvent>(OnStartCollide);
+        SubscribeLocalEvent<SlidingComponent, EndCollideEvent>(OnEndCollide);
+    }
+
+    /// <summary>
+    ///     Modify the friction by the frictionModifier stored on the component.
+    /// </summary>
+    private void OnSlideAttempt(EntityUid uid, SlidingComponent component, ref TileFrictionEvent args)
+    {
+        args.Modifier = component.FrictionModifier;
+    }
+
+    /// <summary>
+    ///     Remove the component when the entity stands up again.
+    /// </summary>
+    private void OnStand(EntityUid uid, SlidingComponent component, ref StoodEvent args)
+    {
+        RemComp<SlidingComponent>(uid);
+    }
+
+    /// <summary>
+    ///     Sets friction to 0 if colliding with a SuperSlippery Entity.
+    /// </summary>
+    private void OnStartCollide(EntityUid uid, SlidingComponent component, ref StartCollideEvent args)
+    {
+        if (!TryComp<SlipperyComponent>(args.OtherEntity, out var slippery) || !slippery.SuperSlippery)
+            return;
+
+        component.CollidingEntities.Add(args.OtherEntity);
+        component.FrictionModifier = 0;
+    }
+
+    /// <summary>
+    ///     Set friction to normal when ending collision with a SuperSlippery entity.
+    /// </summary>
+    private void OnEndCollide(EntityUid uid, SlidingComponent component, ref EndCollideEvent args)
+    {
+        if (TryComp<SlipperyComponent>(args.OtherEntity, out var slippery) && slippery.SuperSlippery)
+            component.CollidingEntities.Remove(args.OtherEntity);
+
+        if (component.CollidingEntities.Count == 0)
+            component.FrictionModifier = SharedStunSystem.KnockDownModifier;
+    }
+
+}

--- a/Content.Shared/Slippery/SlidingSystem.cs
+++ b/Content.Shared/Slippery/SlidingSystem.cs
@@ -43,6 +43,7 @@ public sealed class SlidingSystem : EntitySystem
 
         component.CollidingEntities.Add(args.OtherEntity);
         component.FrictionModifier = 0;
+        Dirty(uid, component);
     }
 
     /// <summary>
@@ -50,11 +51,13 @@ public sealed class SlidingSystem : EntitySystem
     /// </summary>
     private void OnEndCollide(EntityUid uid, SlidingComponent component, ref EndCollideEvent args)
     {
-        if (TryComp<SlipperyComponent>(args.OtherEntity, out var slippery) && slippery.SuperSlippery)
-            component.CollidingEntities.Remove(args.OtherEntity);
+        if (!component.CollidingEntities.Remove(args.OtherEntity))
+            return;
 
         if (component.CollidingEntities.Count == 0)
             component.FrictionModifier = SharedStunSystem.KnockDownModifier;
+
+        Dirty(uid, component);
     }
 
 }

--- a/Content.Shared/Slippery/SlipperyComponent.cs
+++ b/Content.Shared/Slippery/SlipperyComponent.cs
@@ -23,7 +23,6 @@ namespace Content.Shared.Slippery
         /// <summary>
         /// How many seconds the mob will be paralyzed for.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
         [DataField, AutoNetworkedField]
         [Access(Other = AccessPermissions.ReadWrite)]
         public float ParalyzeTime = 3f;
@@ -31,9 +30,16 @@ namespace Content.Shared.Slippery
         /// <summary>
         /// The entity's speed will be multiplied by this to slip it forwards.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
         [DataField, AutoNetworkedField]
         [Access(Other = AccessPermissions.ReadWrite)]
         public float LaunchForwardsMultiplier = 1f;
+
+        /// <summary>
+        /// If this is true, any slipping entity loses it's friction until
+        /// it's not colliding with any SuperSlippery entities anymore.
+        /// </summary>
+        [DataField, AutoNetworkedField]
+        [Access(Other = AccessPermissions.ReadWrite)]
+        public bool SuperSlippery;
     }
 }

--- a/Content.Shared/Slippery/SlipperyComponent.cs
+++ b/Content.Shared/Slippery/SlipperyComponent.cs
@@ -35,7 +35,7 @@ namespace Content.Shared.Slippery
         public float LaunchForwardsMultiplier = 1f;
 
         /// <summary>
-        /// If this is true, any slipping entity loses it's friction until
+        /// If this is true, any slipping entity loses its friction until
         /// it's not colliding with any SuperSlippery entities anymore.
         /// </summary>
         [DataField, AutoNetworkedField]

--- a/Content.Shared/Slippery/SlipperySystem.cs
+++ b/Content.Shared/Slippery/SlipperySystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.StatusEffect;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Stunnable;
 using JetBrains.Annotations;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics.Components;
@@ -60,7 +59,7 @@ public sealed class SlipperySystem : EntitySystem
 
     private void TrySlip(EntityUid uid, SlipperyComponent component, EntityUid other)
     {
-        if (HasComp<KnockedDownComponent>(other))
+        if (HasComp<KnockedDownComponent>(other) && !component.SuperSlippery)
             return;
 
         var attemptEv = new SlipAttemptEvent();
@@ -71,8 +70,13 @@ public sealed class SlipperySystem : EntitySystem
         var ev = new SlipEvent(other);
         RaiseLocalEvent(uid, ref ev);
 
-        if (TryComp(other, out PhysicsComponent? physics))
+        if (TryComp(other, out PhysicsComponent? physics) && !HasComp<SlidingComponent>(other))
+        {
             _physics.SetLinearVelocity(other, physics.LinearVelocity * component.LaunchForwardsMultiplier, body: physics);
+
+            if (component.SuperSlippery)
+                EnsureComp<SlidingComponent>(other);
+        }
 
         var playSound = !_statusEffects.HasStatusEffect(other, "KnockedDown");
 

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -110,6 +110,7 @@
       paralyzeTime: 3
       launchForwardsMultiplier: 2
       requiredSlipSpeed: 1
+      superSlippery: true
 
 - type: reagent
   id: SpaceGlue


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When you slip on space lube you now lose all friction and will keep sliding until you reach the end of the puddle.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Large puddles of lube  are annoying to traverse, you can only move maybe 1 tile before you fall down again. Now you just fall down once and slide to the other side.
Now that entities keep sliding until they reach the end of the puddle, you can make lube traps that slide people into ~~dangerous~~ fun situations.


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Puddles can now be SuperSlippery, if an entity slips on a SuperSlippery puddle, they will get the SlidingComponent. While an entity has the SlidingComponent, any friction event calculations will be multiplied by 0(no friction). When an entity with the SlidingComponent stops coliding with a SuperSlippery puddle, the friction multiplier will be set to the one that entities normally get when knocked down. When the entity stands up again, the entity loses the SlidingComponent.
SlidingComponent prevents further velocity increases from other slips.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
The stutter at 19 seconds was a mispredict that should be fixed now.

https://github.com/space-wizards/space-station-14/assets/137322659/b705c26f-81fa-49e7-8989-5993204fa524


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- tweak: When slipping on lube you now keep sliding until you reach a tile without lube.
