### PR TITLE
Buff the AME until somebody fixes engineering

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -181,7 +181,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Fuel is squared so more fuel vastly increases power and efficiency
         // We divide by the number of cores so a larger AME is less efficient at the same fuel settings
         // this results in all AMEs having the same efficiency at the same fuel-per-core setting
-        return 20000f * fuel * fuel / cores;
+        return 2000000f * fuel * fuel / cores;
     }
 
     public int GetTotalStability()


### PR DESCRIPTION
All the engineering numbers are complete unusable garbage and it's apparently completely impossible to properly set up power on some maps.

This is a band-aid fix (and apology to all engineering players) until somebody fixes this shit properly.

:cl:
- fix: The AME can now single-handedly power the entire station until one of our cool coders gets their shit together and fixes engineering.
