### PR TITLE
Remove tiered part crates from expeditions

### DIFF
--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -27,15 +27,6 @@
         - proto: CloningPodMachineCircuitboard
           cost: 2
         - proto: CognizineChemistryBottle
-        - proto: CratePartsT3
-          cost: 2
-          prob: 0.5
-        - proto: CratePartsT3T4
-          cost: 5
-          prob: 0.5
-        - proto: CratePartsT4
-          cost: 5
-          prob: 0.5
         - proto: CrateSalvageEquipment
           cost: 3
           prob: 0.5


### PR DESCRIPTION
Surprised this didn't get caught when tiered parts were removed.
:cl:
- remove: Tiered part crates will no longer appear on salvage expeditions.