### PR TITLE
Rebalances electrocution damage to a log scale

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -63,9 +63,9 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
     private const string DamageType = "Shock";
 
     // Multiply and shift the log scale for shock damage.
-    private const float ElectrifiedScalePerWatt = 2.8f;
-    private const float ElectrifiedShiftDamage = -30.6f;
-
+    private const float ElectrifiedScaleLogCoefficent = 1.35f;
+    private const float ElectrifiedShiftDamage = 1.67f;
+    private const float ElectrifiedDamageSupplyCoefficent = 0.00001f;
     private const float RecursiveDamageMultiplier = 0.75f;
     private const float RecursiveTimeMultiplier = 0.8f;
 
@@ -265,7 +265,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             return false;
 
         // Initial damage scales off of the available supply on the principle that the victim has shorted the entire powernet through their body.
-        var damageScale = ElectrifiedShiftDamage + MathF.Log(supp) * ElectrifiedScalePerWatt;
+        var damageScale = ElectrifiedShiftDamage + MathF.Log(supp * ElectrifiedDamageSupplyCoefficent) * ElectrifiedScaleLogCoefficent;
         if (damageScale <= 0f)
             return false;
 
@@ -278,7 +278,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
                     entity,
                     uid,
                     node,
-                    (int) (electrified.ShockDamage * damageScale * MathF.Pow(RecursiveDamageMultiplier, depth)),
+                    (int) MathF.Ceiling(electrified.ShockDamage * damageScale * MathF.Pow(RecursiveDamageMultiplier, depth)),
                     TimeSpan.FromSeconds(electrified.ShockTime * MathF.Min(1f + MathF.Log2(1f + damageScale), 3f) * MathF.Pow(RecursiveTimeMultiplier, depth)),
                     true,
                     electrified.SiemensCoefficient);

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -62,8 +62,9 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
     [ValidatePrototypeId<DamageTypePrototype>]
     private const string DamageType = "Shock";
 
-    // Yes, this is absurdly small for a reason.
-    private const float ElectrifiedScalePerWatt = 1E-6f;
+    // Multiply and shift the log scale for shock damage.
+    private const float ElectrifiedScalePerWatt = 2.8f;
+    private const float ElectrifiedShiftDamage = -30.6f;
 
     private const float RecursiveDamageMultiplier = 0.75f;
     private const float RecursiveTimeMultiplier = 0.8f;
@@ -264,7 +265,9 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             return false;
 
         // Initial damage scales off of the available supply on the principle that the victim has shorted the entire powernet through their body.
-        var damageScale = supp * ElectrifiedScalePerWatt;
+        var damageScale = ElectrifiedShiftDamage + MathF.Log(supp) * ElectrifiedScalePerWatt;
+        if (damageScale <= 0f)
+            return false;
 
         {
             var lastRet = true;


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Electrocution damage now follows a logarithmic curve. This table shows the values for reference:

| Available Supply  | Damage | Comment |
| ------------- | ------------- | ------------- |
| <=29kw| 0hp | A standard APC is 10kw |
| 30kw | 1hp | A PACMAN generator |
| 50kw | 12hp | A SUPERPACMAN generator |
| 150kw | 34hp | A single SMES or a Substation |
| 600kw | 62hp | 4 SMESes in parallel |
| 1MW | 74hp | ~7 SMESes, or 1 Tesla Coil |
| 2MW | 88hp | ~13 SMESes, or 2 Tesla Coils |
| 4MW | 100hp | ~27 SMESes, or 4 Tesla Coils |
| 10MW | 119hp | ~67 SMESes, or 10 Tesla coils |
| 40MW | 147hp | Just for reference. Logs are fun. |
| 565MW | 200hp | Moth on a lamp. |
| 1.21GW | 216hp | Back to 1955 with you. |

## Why / Balance
Electrified grilles and messing with wires without insulated gloves will now cause damage consistently as of #24554. With the current numbers, this may cause people to be fried for thousands of damage by touching the wrong grille, which is a bit much.

For reference, 4MW would previously cause 80-100 shock before this change. With a MW pulse from some generators, you could get thousands of damage. This mainly peters that part out. See #20880 for other values.

Blue is old curve, Red is new curve.
![image](https://github.com/space-wizards/space-station-14/assets/3650235/2b72d12e-beb3-4e3e-9d92-faf74ae4ea21)

## Technical details
Changed maff. Maff good?

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Rebalanced electrocution damage to ramp up slower with power levels.
