### PR TITLE
adds cybersun pen to Syndicate PDA's

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -727,6 +727,11 @@
   - type: Pda
     id: SyndicateIDCard
     state: pda-syndi
+    penSlot:
+      startingItem: CyberPen
+      whitelist:
+        tags:
+        - Write
   - type: PdaBorderColor
     borderColor: "#891417"
   - type: Icon
@@ -1015,6 +1020,11 @@
   - type: Pda
     id: SyndicateIDCard
     state: pda-syndi-agent
+    penSlot:
+      startingItem: CyberPen
+      whitelist:
+        tags:
+        - Write
   - type: PdaBorderColor
     borderColor: "#891417"
   - type: Icon


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
*Syndicate* PDA's now start with Cybersun Pens, instead of boring old Nanotrasen-issued pens.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Makes more sense. Gives Syndie Spawns a back-up melee weapon.

## Media

- [X] This PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Syndicate PDA's now start with the Cybersun Pen.