### PR TITLE
Nerf the fridge explosion resistance

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -156,7 +156,7 @@
     stateDoorOpen: freezer_open
     stateDoorClosed: freezer_door
   - type: ExplosionResistance
-    damageCoefficient: 0.01
+    damageCoefficient: 0.50
   - type: AntiRottingContainer
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Nerfs the fridges explosion resistance. I keep seeing nuke ops. Even on salamander. Bringing over a fridge RIGHT next to the nuke. And the fridge just tanks it all. 

Right now you need 4 NUKES RIGHT NEXT TO THE FRIDGE before it even breaks. 

The fridge is being abused. Nuke ops should be trying to run away from the nuke before the explodes or die in glory. Not get in a fridge. Crew should be trying their best to escape.

At least take the fridge further away so that the damage does not effect them.

I don't care that's an Indiana jones reference. It is being abused

You can still survive a c4 right ontop of it and get minimal damage.



###### Btw unrelated this will be my 100th ever merged pr if it gets merged before anything else

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The fridge's explosion resistance has been nerfed significantly, It's no longer able to survive nukes at point blank range of the nuke.