### PR TITLE
Fix sliding bug

### DIFF
--- a/Content.Shared/Slippery/SlidingSystem.cs
+++ b/Content.Shared/Slippery/SlidingSystem.cs
@@ -59,5 +59,4 @@ public sealed class SlidingSystem : EntitySystem
 
         Dirty(uid, component);
     }
-
 }

--- a/Content.Shared/Slippery/SlipperySystem.cs
+++ b/Content.Shared/Slippery/SlipperySystem.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Slippery;
 
@@ -78,6 +79,7 @@ public sealed class SlipperySystem : EntitySystem
             {
                 var sliding = EnsureComp<SlidingComponent>(other);
                 sliding.CollidingEntities.Add(uid);
+                DebugTools.AssertNotEqual(sliding.CollidingEntities, 0);
             }
         }
 

--- a/Content.Shared/Slippery/SlipperySystem.cs
+++ b/Content.Shared/Slippery/SlipperySystem.cs
@@ -79,7 +79,7 @@ public sealed class SlipperySystem : EntitySystem
             {
                 var sliding = EnsureComp<SlidingComponent>(other);
                 sliding.CollidingEntities.Add(uid);
-                DebugTools.AssertNotEqual(sliding.CollidingEntities, 0);
+                DebugTools.AssertNotEqual(sliding.CollidingEntities.Count, 0);
             }
         }
 

--- a/Content.Shared/Slippery/SlipperySystem.cs
+++ b/Content.Shared/Slippery/SlipperySystem.cs
@@ -79,7 +79,7 @@ public sealed class SlipperySystem : EntitySystem
             {
                 var sliding = EnsureComp<SlidingComponent>(other);
                 sliding.CollidingEntities.Add(uid);
-                DebugTools.AssertNotEqual(sliding.CollidingEntities.Count, 0);
+                DebugTools.Assert(_physics.GetContactingEntities(other, physics).Contains(uid));
             }
         }
 

--- a/Content.Shared/Slippery/SlipperySystem.cs
+++ b/Content.Shared/Slippery/SlipperySystem.cs
@@ -75,7 +75,10 @@ public sealed class SlipperySystem : EntitySystem
             _physics.SetLinearVelocity(other, physics.LinearVelocity * component.LaunchForwardsMultiplier, body: physics);
 
             if (component.SuperSlippery)
-                EnsureComp<SlidingComponent>(other);
+            {
+                var sliding = EnsureComp<SlidingComponent>(other);
+                sliding.CollidingEntities.Add(uid);
+            }
         }
 
         var playSound = !_statusEffects.HasStatusEffect(other, "KnockedDown");


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
If you slip on a single tile sized puddle of lube(specifically a single tile) you lose friction untill you stand up again. This PR fixes that.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Single tile of lube shouldn't launch you across the hallway.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
First puddle slipped on was not added to the list of entities on SlidingComponent, so friction was never set to the correct value upon ending collision with the first SuperSlippery entity, only ones following after it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
Haven't seen anyone mention this bug yet so no cl needed I guess.

:cl: Dygon
- fix: Single tile sized puddles of space lube won't let you slide extremely far anymore.
