### PR TITLE
Fix slipping through fences

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
@@ -163,7 +163,8 @@
         mask:
         - FullTileMask
         layer:
-        - TableLayer
+        - HighImpassable
+        - MidImpassable
   - type: InteractionPopup
     interactSuccessString: fence-rattle-success
     messagePerceivedByOthers: fence-rattle-success
@@ -230,7 +231,8 @@
         mask:
         - TableMask
         layer:
-        - TableLayer
+        - HighImpassable
+        - MidImpassable
   - type: InteractionPopup
     interactSuccessString: fence-rattle-success
     messagePerceivedByOthers: fence-rattle-success
@@ -266,7 +268,8 @@
         mask:
         - TableMask
         layer:
-        - TableLayer
+        - HighImpassable
+        - MidImpassable
   - type: InteractionPopup
     interactSuccessString: fence-rattle-success
     messagePerceivedByOthers: fence-rattle-success
@@ -301,7 +304,8 @@
         mask:
         - TableMask
         layer:
-        - TableLayer
+        - HighImpassable
+        - MidImpassable
   - type: InteractionOutline
   - type: Door
     openSpriteState: door_opened

--- a/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
@@ -163,8 +163,8 @@
         mask:
         - FullTileMask
         layer:
-        - HighImpassable
         - MidImpassable
+        - LowImpassable
   - type: InteractionPopup
     interactSuccessString: fence-rattle-success
     messagePerceivedByOthers: fence-rattle-success
@@ -231,8 +231,8 @@
         mask:
         - TableMask
         layer:
-        - HighImpassable
         - MidImpassable
+        - LowImpassable
   - type: InteractionPopup
     interactSuccessString: fence-rattle-success
     messagePerceivedByOthers: fence-rattle-success
@@ -268,8 +268,8 @@
         mask:
         - TableMask
         layer:
-        - HighImpassable
         - MidImpassable
+        - LowImpassable
   - type: InteractionPopup
     interactSuccessString: fence-rattle-success
     messagePerceivedByOthers: fence-rattle-success
@@ -304,8 +304,8 @@
         mask:
         - TableMask
         layer:
-        - HighImpassable
         - MidImpassable
+        - LowImpassable
   - type: InteractionOutline
   - type: Door
     openSpriteState: door_opened


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
resolves #24837 
You can't slip through chain link fences anymore, but in exchange flying mobs can't pass them anymore either.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
We don't turn into a terminator the moment we fall down.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
CollisionLayer changed from TableLayer to HighImpassable and MidImpassable.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- fix: You can't slip through chain link fences anymore.