### PR TITLE
Require plants to be harvestable before sampling

### DIFF
--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -262,13 +262,20 @@ public sealed class PlantHolderSystem : EntitySystem
                 return;
             }
 
+            component.Health -= (_random.Next(3, 5) * 10);
+
+            if (!component.Harvest)
+            {
+                _popup.PopupCursor(Loc.GetString("plant-holder-component-early-sample"), args.User);
+                return;
+            }
+
             component.Seed.Unique = false;
             var seed = _botany.SpawnSeedPacket(component.Seed, Transform(args.User).Coordinates, args.User);
             _randomHelper.RandomOffset(seed, 0.25f);
             var displayName = Loc.GetString(component.Seed.DisplayName);
             _popup.PopupCursor(Loc.GetString("plant-holder-component-take-sample-message",
                 ("seedName", displayName)), args.User);
-            component.Health -= (_random.Next(3, 5) * 10);
 
             if (component.Seed != null && component.Seed.CanScream)
             {

--- a/Resources/Locale/en-US/botany/components/plant-holder-component.ftl
+++ b/Resources/Locale/en-US/botany/components/plant-holder-component.ftl
@@ -32,3 +32,4 @@ plant-holder-component-light-improper-warning = The [color=yellow]improper light
 plant-holder-component-heat-improper-warning = The [color=orange]improper temperature level alert[/color] is blinking.
 plant-holder-component-pressure-improper-warning = The [color=lightblue]improper environment pressure alert[/color] is blinking.
 plant-holder-component-gas-missing-warning = The [color=cyan]improper gas environment alert[/color] is blinking.
+plant-holder-component-early-sample = It is not ready to sample, but you cut a bit of the plant anyway.


### PR DESCRIPTION
## About the PR
Clipping a plant now only produces seeds if a plant is harvestable. Suggested by @GreyMario in https://github.com/space-wizards/space-station-14/issues/24591#issuecomment-1912566099_.

## Why / Balance
In plant genetics (PR https://github.com/space-wizards/space-station-14/pull/11407), random mutations have a high probability of making a mutated plant seedless or non-viable (i.e. will die after a while). This was intended to make it more difficult to make a very strong plant. Instead, you were supposed to mutate a bunch of plants, and then cross-pollinate the ones with the traits you wanted to combine them. You could get a very potent plant if you were willing to put in the work.

However, it appears that players have been circumventing the intended gameplay loop by:

1. Planting a seed
2. Mutating it a lot, without caring if it becomes non-viable or seedless
3. Clipping the plant to get the seed
4. Repeat

This change:

- Makes a lot of sense because seeds come from fruits, and if a plant isn't ready to harvest it can't have seeds
- Brings very potent mutations back into balance, because plants need to be viable in order for you to clip their seeds
- Slows down seed spamming, because you have to wait until the first harvest before you can get seeds

For fun, clipping a seed early shows a message indicating that you knew the harvesting was premature, but you do it anyway and it applies the health change effect.