### PR TITLE
Add popup message for activating trigger with hand

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.OnUse.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.OnUse.cs
@@ -171,6 +171,8 @@ public sealed partial class TriggerSystem
         if (args.Handled || HasComp<AutomatedTimerComponent>(uid) || component.UseVerbInstead)
             return;
 
+        _popupSystem.PopupEntity(Loc.GetString("trigger-activated", ("device", uid)), args.User, args.User);
+
         HandleTimerTrigger(
             uid,
             args.User,

--- a/Resources/Locale/en-US/weapons/grenades/timer-trigger.ftl
+++ b/Resources/Locale/en-US/weapons/grenades/timer-trigger.ftl
@@ -12,3 +12,5 @@ verb-start-detonation = Start detonation
 verb-toggle-start-on-stick = Toggle auto-activation
 popup-start-on-stick-off = The device will no longer activate automatically when planted
 popup-start-on-stick-on = The device will now activate automatically when planted
+
+trigger-activated = You activate {THE($device)}.


### PR DESCRIPTION
## About the PR
Add a popup message for activating things with `OnUseTimerTriggerComponent` in your hand.

## Why / Balance
Things with `OnUseTimerTriggerComponent` can be activated in your hand. Usually this causes a thing to blow up a little bit later. Some of the things that you would like for it to blow up don't provide any feedback, e.g. flashes or beeps. So, you could activate it, think you're lagging out or the thing didn't work, and then blow yourself up.

This tries to mitigate this by sending a private popup message to the user.