### PR TITLE
Travelling pointing arrows, brains can no longer point

### DIFF
--- a/Content.Client/Pointing/Components/PointingArrowComponent.cs
+++ b/Content.Client/Pointing/Components/PointingArrowComponent.cs
@@ -1,19 +1,12 @@
-using System.Numerics;
 using Content.Shared.Pointing.Components;
+using System.Numerics;
 
 namespace Content.Client.Pointing.Components;
 [RegisterComponent]
 public sealed partial class PointingArrowComponent : SharedPointingArrowComponent
 {
     /// <summary>
-    /// How long it takes to go from the bottom of the animation to the top.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("animationTime")]
-    public float AnimationTime = 0.5f;
-
-    /// <summary>
-    /// How far it goes in any direction.
+    /// How far the arrow moves up and down during the floating phase.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("offset")]

--- a/Content.Client/Pointing/PointingSystem.Visualizer.cs
+++ b/Content.Client/Pointing/PointingSystem.Visualizer.cs
@@ -1,0 +1,61 @@
+using Content.Client.Pointing.Components;
+using Content.Shared.Pointing;
+using Robust.Client.GameObjects;
+using Robust.Client.Animations;
+using Robust.Shared.Animations;
+using System.Numerics;
+
+namespace Content.Client.Pointing;
+
+public sealed partial class PointingSystem : SharedPointingSystem
+{
+    [Dependency] private readonly AnimationPlayerSystem _animationPlayer = default!;
+
+    public void InitializeVisualizer()
+    {
+        SubscribeLocalEvent<PointingArrowComponent, AnimationCompletedEvent>(OnAnimationCompleted);
+    }
+
+    private void OnAnimationCompleted(EntityUid uid, PointingArrowComponent component, AnimationCompletedEvent args)
+    {
+        if (args.Key == component.AnimationKey)
+            _animationPlayer.Stop(uid, component.AnimationKey);
+    }
+
+    private void BeginPointAnimation(EntityUid uid, Vector2 startPosition, Vector2 offset, string animationKey)
+    {
+        if (_animationPlayer.HasRunningAnimation(uid, animationKey))
+            return;
+
+        var animation = new Animation
+        {
+            Length = PointDuration,
+            AnimationTracks =
+            {
+                new AnimationTrackComponentProperty
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Offset),
+                    InterpolationMode = AnimationInterpolationMode.Cubic,
+                    KeyFrames =
+                    {
+                        // We pad here to prevent improper looping
+                        new AnimationTrackProperty.KeyFrame(startPosition, 0f),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeMove),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
+                    }
+                }
+            }
+        };
+
+        _animationPlayer.Play(uid, animation, animationKey);
+    }
+}

--- a/Content.Client/Pointing/PointingSystem.Visualizer.cs
+++ b/Content.Client/Pointing/PointingSystem.Visualizer.cs
@@ -39,10 +39,11 @@ public sealed partial class PointingSystem : SharedPointingSystem
                     InterpolationMode = AnimationInterpolationMode.Cubic,
                     KeyFrames =
                     {
-                        // We pad here to prevent improper looping
+                        // We pad here to prevent improper looping and tighten the overshoot, just a touch
                         new AnimationTrackProperty.KeyFrame(startPosition, 0f),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Lerp(startPosition, offset, 0.9f), PointKeyTimeMove),
                         new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeMove),
-                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
+                        new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeMove),
                         new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),
                         new AnimationTrackProperty.KeyFrame(Vector2.Zero, PointKeyTimeHover),
                         new AnimationTrackProperty.KeyFrame(offset, PointKeyTimeHover),

--- a/Content.Client/Pointing/PointingSystem.cs
+++ b/Content.Client/Pointing/PointingSystem.cs
@@ -1,6 +1,4 @@
 using Content.Client.Pointing.Components;
-using Content.Shared.Bed.Sleep;
-using Content.Shared.Mobs.Systems;
 using Content.Shared.Pointing;
 using Content.Shared.Verbs;
 using Robust.Client.GameObjects;
@@ -12,8 +10,6 @@ namespace Content.Client.Pointing;
 
 public sealed partial class PointingSystem : SharedPointingSystem
 {
-    [Dependency] private readonly MobStateSystem _mobState = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -35,18 +31,11 @@ public sealed partial class PointingSystem : SharedPointingSystem
         // I'm just adding this verb exclusively to clients so that the verb-loading pop-in on the verb menu isn't
         // as bad. Important for this verb seeing as its usually an option on just about any entity.
 
+        // this is a pointing arrow. no pointing here...
         if (HasComp<PointingArrowComponent>(args.Target))
-        {
-            // this is a pointing arrow. no pointing here...
-            return;
-        }
-
-        // Can the user point? Checking mob state directly instead of some action blocker, as many action blockers are blocked for
-        // ghosts and there is no obvious choice for pointing (unless ghosts CanEmote?).
-        if (_mobState.IsIncapacitated(args.User))
             return;
 
-        if (HasComp<SleepingComponent>(args.User))
+        if (!CanPoint(args.User))
             return;
 
         // We won't check in range or visibility, as this verb is currently only executable via the context menu,

--- a/Content.Server/Body/Systems/BrainSystem.cs
+++ b/Content.Server/Body/Systems/BrainSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Body.Components;
 using Content.Shared.Body.Events;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
+using Content.Shared.Pointing;
 
 namespace Content.Server.Body.Systems
 {
@@ -17,6 +18,7 @@ namespace Content.Server.Body.Systems
 
             SubscribeLocalEvent<BrainComponent, AddedToPartInBodyEvent>((uid, _, args) => HandleMind(args.Body, uid));
             SubscribeLocalEvent<BrainComponent, RemovedFromPartInBodyEvent>((uid, _, args) => HandleMind(uid, args.OldBody));
+            SubscribeLocalEvent<BrainComponent, PointAttemptEvent>(OnPointAttempt);
         }
 
         private void HandleMind(EntityUid newEntity, EntityUid oldEntity)
@@ -35,6 +37,11 @@ namespace Content.Server.Body.Systems
                 return;
 
             _mindSystem.TransferTo(mindId, newEntity, mind: mind);
+        }
+
+        private void OnPointAttempt(EntityUid uid, BrainComponent component, PointAttemptEvent args)
+        {
+            args.Cancel();
         }
     }
 }

--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Pointing.Components;
-using Content.Shared.Bed.Sleep;
 using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Eye;
@@ -10,7 +9,6 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
 using Content.Shared.Mind;
-using Content.Shared.Mobs.Systems;
 using Content.Shared.Pointing;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
@@ -35,7 +33,6 @@ namespace Content.Server.Pointing.EntitySystems
         [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly RotateToFaceSystem _rotateToFaceSystem = default!;
-        [Dependency] private readonly MobStateSystem _mobState = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly VisibilitySystem _visibilitySystem = default!;
         [Dependency] private readonly SharedMindSystem _minds = default!;
@@ -133,14 +130,7 @@ namespace Content.Server.Pointing.EntitySystems
                 return false;
             }
 
-            // Checking mob state directly instead of some action blocker, as many action blockers are blocked for
-            // ghosts and there is no obvious choice for pointing.
-            if (_mobState.IsIncapacitated(player))
-            {
-                return false;
-            }
-
-            if (HasComp<SleepingComponent>(player))
+            if (!CanPoint(player))
             {
                 return false;
             }

--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -17,6 +17,7 @@ using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
+using Robust.Shared.GameStates;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
@@ -49,6 +50,15 @@ namespace Content.Server.Pointing.EntitySystems
         private readonly Dictionary<ICommonSession, TimeSpan> _pointers = new();
 
         private const float PointingRange = 15f;
+
+        private void GetCompState(Entity<PointingArrowComponent> entity, ref ComponentGetState args)
+        {
+            args.State = new SharedPointingArrowComponentState
+            {
+                StartPosition = entity.Comp.StartPosition,
+                EndTime = entity.Comp.EndTime
+            };
+        }
 
         private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
         {
@@ -97,7 +107,7 @@ namespace Content.Server.Pointing.EntitySystems
             }
         }
 
-        public bool TryPoint(ICommonSession? session, EntityCoordinates coords, EntityUid pointed)
+        public bool TryPoint(ICommonSession? session, EntityCoordinates coordsPointed, EntityUid pointed)
         {
             if (session?.AttachedEntity is not { } player)
             {
@@ -105,9 +115,9 @@ namespace Content.Server.Pointing.EntitySystems
                 return false;
             }
 
-            if (!coords.IsValid(EntityManager))
+            if (!coordsPointed.IsValid(EntityManager))
             {
-                Log.Warning($"Player {ToPrettyString(player)} attempted to point at invalid coordinates: {coords}");
+                Log.Warning($"Player {ToPrettyString(player)} attempted to point at invalid coordinates: {coordsPointed}");
                 return false;
             }
 
@@ -135,21 +145,25 @@ namespace Content.Server.Pointing.EntitySystems
                 return false;
             }
 
-            if (!InRange(player, coords))
+            if (!InRange(player, coordsPointed))
             {
                 _popup.PopupEntity(Loc.GetString("pointing-system-try-point-cannot-reach"), player, player);
                 return false;
             }
 
+            var mapCoordsPointed = coordsPointed.ToMap(EntityManager);
+            _rotateToFaceSystem.TryFaceCoordinates(player, mapCoordsPointed.Position);
 
-            var mapCoords = coords.ToMap(EntityManager);
-            _rotateToFaceSystem.TryFaceCoordinates(player, mapCoords.Position);
-
-            var arrow = EntityManager.SpawnEntity("PointingArrow", coords);
+            var arrow = EntityManager.SpawnEntity("PointingArrow", coordsPointed);
 
             if (TryComp<PointingArrowComponent>(arrow, out var pointing))
             {
-                pointing.EndTime = _gameTiming.CurTime + TimeSpan.FromSeconds(4);
+                if (TryComp(player, out TransformComponent? xformPlayer))
+                    pointing.StartPosition = EntityCoordinates.FromMap(arrow, xformPlayer.Coordinates.ToMap(EntityManager)).Position;
+
+                pointing.EndTime = _gameTiming.CurTime + PointDuration;
+
+                Dirty(arrow, pointing);
             }
 
             if (EntityQuery<PointingArrowAngeringComponent>().FirstOrDefault() != null)
@@ -215,10 +229,10 @@ namespace Content.Server.Pointing.EntitySystems
                 TileRef? tileRef = null;
                 string? position = null;
 
-                if (_mapManager.TryFindGridAt(mapCoords, out var gridUid, out var grid))
+                if (_mapManager.TryFindGridAt(mapCoordsPointed, out var gridUid, out var grid))
                 {
-                    position = $"EntId={gridUid} {grid.WorldToTile(mapCoords.Position)}";
-                    tileRef = grid.GetTileRef(grid.WorldToTile(mapCoords.Position));
+                    position = $"EntId={gridUid} {grid.WorldToTile(mapCoordsPointed.Position)}";
+                    tileRef = grid.GetTileRef(grid.WorldToTile(mapCoordsPointed.Position));
                 }
 
                 var tileDef = _tileDefinitionManager[tileRef?.Tile.TypeId ?? 0];
@@ -228,7 +242,7 @@ namespace Content.Server.Pointing.EntitySystems
 
                 viewerMessage = Loc.GetString("pointing-system-other-point-at-tile", ("otherName", playerName), ("tileName", name));
 
-                _adminLogger.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(player):user} pointed at {name} {(position == null ? mapCoords : position)}");
+                _adminLogger.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(player):user} pointed at {name} {(position == null ? mapCoordsPointed : position)}");
             }
 
             _pointers[session] = _gameTiming.CurTime;
@@ -241,6 +255,8 @@ namespace Content.Server.Pointing.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
+
+            SubscribeLocalEvent<PointingArrowComponent, ComponentGetState>(GetCompState);
 
             SubscribeNetworkEvent<PointingAttemptEvent>(OnPointAttempt);
 
@@ -255,8 +271,8 @@ namespace Content.Server.Pointing.EntitySystems
         {
             var target = GetEntity(ev.Target);
 
-            if (TryComp(target, out TransformComponent? xform))
-                TryPoint(args.SenderSession, xform.Coordinates, target);
+            if (TryComp(target, out TransformComponent? xformTarget))
+                TryPoint(args.SenderSession, xformTarget.Coordinates, target);
             else
                 Log.Warning($"User {args.SenderSession} attempted to point at a non-existent entity uid: {ev.Target}");
         }

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Pointing;
 using Content.Shared.PowerCell;
 using Content.Shared.PowerCell.Components;
 using Content.Shared.Roles;
@@ -67,6 +68,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
         SubscribeLocalEvent<BorgChassisComponent, GetCharactedDeadIcEvent>(OnGetDeadIC);
 
         SubscribeLocalEvent<BorgBrainComponent, MindAddedMessage>(OnBrainMindAdded);
+        SubscribeLocalEvent<BorgBrainComponent, PointAttemptEvent>(OnPointAttempt);
 
         InitializeModules();
         InitializeMMI();
@@ -240,6 +242,12 @@ public sealed partial class BorgSystem : SharedBorgSystem
         }
 
         _mind.TransferTo(mindId, containerEnt, mind: mind);
+    }
+
+    private void OnPointAttempt(EntityUid uid, BorgBrainComponent component, PointAttemptEvent args)
+    {
+        if (!HasComp<BorgChassisComponent>(uid))
+            args.Cancel();
     }
 
     private void UpdateBatteryAlert(EntityUid uid, PowerCellSlotComponent? slotComponent = null)

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -68,7 +68,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
         SubscribeLocalEvent<BorgChassisComponent, GetCharactedDeadIcEvent>(OnGetDeadIC);
 
         SubscribeLocalEvent<BorgBrainComponent, MindAddedMessage>(OnBrainMindAdded);
-        SubscribeLocalEvent<BorgBrainComponent, PointAttemptEvent>(OnPointAttempt);
+        SubscribeLocalEvent<BorgBrainComponent, PointAttemptEvent>(OnBrainPointAttempt);
 
         InitializeModules();
         InitializeMMI();
@@ -244,10 +244,9 @@ public sealed partial class BorgSystem : SharedBorgSystem
         _mind.TransferTo(mindId, containerEnt, mind: mind);
     }
 
-    private void OnPointAttempt(EntityUid uid, BorgBrainComponent component, PointAttemptEvent args)
+    private void OnBrainPointAttempt(EntityUid uid, BorgBrainComponent component, PointAttemptEvent args)
     {
-        if (!HasComp<BorgChassisComponent>(uid))
-            args.Cancel();
+        args.Cancel();
     }
 
     private void UpdateBatteryAlert(EntityUid uid, PowerCellSlotComponent? slotComponent = null)

--- a/Content.Shared/Bed/Sleep/SharedSleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SharedSleepingSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Actions;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Pointing;
 using Content.Shared.Speech;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
@@ -25,6 +26,7 @@ namespace Content.Server.Bed.Sleep
             SubscribeLocalEvent<SleepingComponent, ComponentShutdown>(OnShutdown);
             SubscribeLocalEvent<SleepingComponent, SpeakAttemptEvent>(OnSpeakAttempt);
             SubscribeLocalEvent<SleepingComponent, CanSeeAttemptEvent>(OnSeeAttempt);
+            SubscribeLocalEvent<SleepingComponent, PointAttemptEvent>(OnPointAttempt);
             SubscribeLocalEvent<SleepingComponent, EntityUnpausedEvent>(OnSleepUnpaused);
         }
 
@@ -69,6 +71,11 @@ namespace Content.Server.Bed.Sleep
         {
             if (component.LifeStage <= ComponentLifeStage.Running)
                 args.Cancel();
+        }
+
+        private void OnPointAttempt(EntityUid uid, SleepingComponent component, PointAttemptEvent args)
+        {
+            args.Cancel();
         }
     }
 }

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -9,6 +9,7 @@ using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Events;
+using Content.Shared.Pointing;
 using Content.Shared.Pulling.Events;
 using Content.Shared.Speech;
 using Content.Shared.Standing;
@@ -38,6 +39,7 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, StartPullAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, UpdateCanMoveEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, StandAttemptEvent>(CheckAct);
+        SubscribeLocalEvent<MobStateComponent, PointAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, TryingToSleepEvent>(OnSleepAttempt);
         SubscribeLocalEvent<MobStateComponent, CombatModeShouldHandInteractEvent>(OnCombatModeShouldHandInteract);
         SubscribeLocalEvent<MobStateComponent, AttemptPacifiedAttackEvent>(OnAttemptPacifiedAttack);

--- a/Content.Shared/Pointing/Components/SharedPointingArrowComponent.cs
+++ b/Content.Shared/Pointing/Components/SharedPointingArrowComponent.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameStates;
+using System.Numerics;
 
 namespace Content.Shared.Pointing.Components;
 
@@ -6,8 +7,16 @@ namespace Content.Shared.Pointing.Components;
 public abstract partial class SharedPointingArrowComponent : Component
 {
     /// <summary>
+    /// The position of the sender when the point began.
+    /// </summary>
+    [DataField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public Vector2 StartPosition;
+
+    /// <summary>
     /// When the pointing arrow ends
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("endTime")]
+    [DataField]
+    [ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan EndTime;
 }

--- a/Content.Shared/Pointing/SharedPointingSystem.cs
+++ b/Content.Shared/Pointing/SharedPointingSystem.cs
@@ -1,17 +1,18 @@
 using Robust.Shared.Serialization;
+using System.Numerics;
 
 namespace Content.Shared.Pointing;
 
 public abstract class SharedPointingSystem : EntitySystem
 {
-    [Serializable, NetSerializable]
-    protected sealed class PointingArrowComponentState : ComponentState
-    {
-        public TimeSpan EndTime;
+    protected readonly TimeSpan PointDuration = TimeSpan.FromSeconds(4);
+    protected readonly float PointKeyTimeMove = 0.15f;
+    protected readonly float PointKeyTimeHover = 0.5f;
 
-        public PointingArrowComponentState(TimeSpan endTime)
-        {
-            EndTime = endTime;
-        }
+    [Serializable, NetSerializable]
+    public sealed class SharedPointingArrowComponentState : ComponentState
+    {
+        public Vector2 StartPosition { get; init; }
+        public TimeSpan EndTime { get; init; }
     }
 }

--- a/Content.Shared/Pointing/SharedPointingSystem.cs
+++ b/Content.Shared/Pointing/SharedPointingSystem.cs
@@ -15,4 +15,22 @@ public abstract class SharedPointingSystem : EntitySystem
         public Vector2 StartPosition { get; init; }
         public TimeSpan EndTime { get; init; }
     }
+
+    public bool CanPoint(EntityUid uid)
+    {
+        var ev = new PointAttemptEvent(uid);
+        RaiseLocalEvent(uid, ev, true);
+
+        return !ev.Cancelled;
+    }
+}
+
+public sealed class PointAttemptEvent : CancellableEntityEventArgs
+{
+    public PointAttemptEvent(EntityUid uid)
+    {
+        Uid = uid;
+    }
+
+    public EntityUid Uid { get; }
 }

--- a/Content.Shared/Pointing/SharedPointingSystem.cs
+++ b/Content.Shared/Pointing/SharedPointingSystem.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Pointing;
 public abstract class SharedPointingSystem : EntitySystem
 {
     protected readonly TimeSpan PointDuration = TimeSpan.FromSeconds(4);
-    protected readonly float PointKeyTimeMove = 0.15f;
+    protected readonly float PointKeyTimeMove = 0.1f;
     protected readonly float PointKeyTimeHover = 0.5f;
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
## About the PR

Makes pointing arrows travel from the pointer to the target and animates them smoothly.

Fixes brain pointing using a new attempt event.


## Why / Balance

This makes it much easier to tell who is pointing and at what.



## Technical details

On the client side, `PointingSystem` no longer reuses the visualizer for gravity. The verb-check has been converted to a new attempt event under `SharedPointingSystem`.

On the server side, entity coordinates local to the arrow are sent during `TryPoint()`.

In Shared, AnimationTime was moved out of the component to a readonly variable.


## Media

Initial:
![vlc_sHpIgBDSHV](https://github.com/space-wizards/space-station-14/assets/42424291/36a371de-83d1-4797-90d1-2f954260327a)

Reduced overshoot, a bit punchier:
![vlc_RuGfs733rl](https://github.com/space-wizards/space-station-14/assets/42424291/5284a3f4-c5b9-4b85-86cd-f11d3f7e8837)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl: Krunk
- add: Pointing arrows now begin at the player and smoothly animate to their target.
