### PR TITLE
EMP disables suit sensors

### DIFF
--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -72,4 +72,10 @@ public sealed partial class SuitSensorComponent : Component
     /// </summary>
     [DataField("server")]
     public string? ConnectedServer = null;
+
+    /// <summary>
+    /// The previous mode of the suit. This is used to restore the state when an EMP effect ends.
+    /// </summary>
+    [ViewVariables]
+    public SuitSensorMode PreviousMode = SuitSensorMode.SensorOff;
 }

--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -72,10 +72,4 @@ public sealed partial class SuitSensorComponent : Component
     /// </summary>
     [DataField("server")]
     public string? ConnectedServer = null;
-
-    /// <summary>
-    /// The previous mode of the suit. This is used to restore the state when an EMP effect ends.
-    /// </summary>
-    [ViewVariables]
-    public SuitSensorMode PreviousMode = SuitSensorMode.SensorOff;
 }

--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -76,6 +76,13 @@ public sealed partial class SuitSensorComponent : Component
     /// <summary>
     /// The previous mode of the suit. This is used to restore the state when an EMP effect ends.
     /// </summary>
-    [ViewVariables]
+    [DataField, ViewVariables]
     public SuitSensorMode PreviousMode = SuitSensorMode.SensorOff;
+
+    /// <summary>
+    ///  The previous locked status of the controls.  This is used to restore the state when an EMP effect ends.
+    ///  This keeps prisoner jumpsuits/internal implants from becoming unlocked after an EMP.
+    /// </summary>
+    [DataField, ViewVariables]
+    public bool PreviousControlsLocked = false;
 }

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -2,11 +2,13 @@ using Content.Server.Access.Systems;
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Components;
 using Content.Server.DeviceNetwork.Systems;
+using Content.Server.Emp;
 using Content.Server.GameTicking;
 using Content.Server.Medical.CrewMonitoring;
 using Content.Server.Popups;
 using Content.Server.Station.Systems;
 using Content.Shared.Damage;
+using Content.Shared.Emp;
 using Content.Shared.Examine;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Medical.SuitSensor;
@@ -44,6 +46,8 @@ public sealed class SuitSensorSystem : EntitySystem
         SubscribeLocalEvent<SuitSensorComponent, GetVerbsEvent<Verb>>(OnVerb);
         SubscribeLocalEvent<SuitSensorComponent, EntGotInsertedIntoContainerMessage>(OnInsert);
         SubscribeLocalEvent<SuitSensorComponent, EntGotRemovedFromContainerMessage>(OnRemove);
+        SubscribeLocalEvent<SuitSensorComponent, EmpPulseEvent>(OnEmpPulse);
+        SubscribeLocalEvent<SuitSensorComponent, EmpDisabledRemoved>(OnEmpFinished);
     }
 
     private void OnUnpaused(EntityUid uid, SuitSensorComponent component, ref EntityUnpausedEvent args)
@@ -214,6 +218,10 @@ public sealed class SuitSensorSystem : EntitySystem
         if (!args.CanAccess || !args.CanInteract || args.Hands == null)
             return;
 
+        // use this instead of overwriting ControlsLocked on tracking implants/prisoner suits
+        if (HasComp<EmpDisabledComponent>(uid))
+            return;
+
         args.Verbs.UnionWith(new[]
         {
             CreateVerb(uid, component, args.User, SuitSensorMode.SensorOff),
@@ -237,6 +245,18 @@ public sealed class SuitSensorSystem : EntitySystem
             return;
 
         component.User = null;
+    }
+
+    private void OnEmpPulse(EntityUid uid, SuitSensorComponent component, ref EmpPulseEvent args)
+    {
+        args.Affected = true;
+        args.Disabled = true;
+        SetSensor(uid, SuitSensorMode.SensorOff, null, component);
+    }
+
+    private void OnEmpFinished(EntityUid uid, SuitSensorComponent component, ref EmpDisabledRemoved args)
+    {
+        SetSensor(uid, component.PreviousMode, null, component);
     }
 
     private Verb CreateVerb(EntityUid uid, SuitSensorComponent component, EntityUid userUid, SuitSensorMode mode)
@@ -281,6 +301,7 @@ public sealed class SuitSensorSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
+        component.PreviousMode = component.Mode;
         component.Mode = mode;
 
         if (userUid != null)

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -47,6 +47,7 @@ public sealed class SuitSensorSystem : EntitySystem
         SubscribeLocalEvent<SuitSensorComponent, EntGotInsertedIntoContainerMessage>(OnInsert);
         SubscribeLocalEvent<SuitSensorComponent, EntGotRemovedFromContainerMessage>(OnRemove);
         SubscribeLocalEvent<SuitSensorComponent, EmpPulseEvent>(OnEmpPulse);
+        SubscribeLocalEvent<SuitSensorComponent, EmpDisabledRemoved>(OnEmpFinished);
     }
 
     private void OnUnpaused(EntityUid uid, SuitSensorComponent component, ref EntityUnpausedEvent args)
@@ -204,9 +205,6 @@ public sealed class SuitSensorSystem : EntitySystem
                 return;
         }
 
-        if (HasComp<EmpDisabledComponent>(uid))
-            msg = "suit-sensor-examine-off";
-
         args.PushMarkup(Loc.GetString(msg));
     }
 
@@ -218,6 +216,10 @@ public sealed class SuitSensorSystem : EntitySystem
 
         // standard interaction checks
         if (!args.CanAccess || !args.CanInteract || args.Hands == null)
+            return;
+
+        // use this instead of overwriting ControlsLocked on tracking implants/prisoner suits
+        if (HasComp<EmpDisabledComponent>(uid))
             return;
 
         args.Verbs.UnionWith(new[]
@@ -249,6 +251,12 @@ public sealed class SuitSensorSystem : EntitySystem
     {
         args.Affected = true;
         args.Disabled = true;
+        SetSensor(uid, SuitSensorMode.SensorOff, null, component);
+    }
+
+    private void OnEmpFinished(EntityUid uid, SuitSensorComponent component, ref EmpDisabledRemoved args)
+    {
+        SetSensor(uid, component.PreviousMode, null, component);
     }
 
     private Verb CreateVerb(EntityUid uid, SuitSensorComponent component, EntityUid userUid, SuitSensorMode mode)
@@ -293,6 +301,7 @@ public sealed class SuitSensorSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
+        component.PreviousMode = component.Mode;
         component.Mode = mode;
 
         if (userUid != null)
@@ -308,7 +317,7 @@ public sealed class SuitSensorSystem : EntitySystem
             return null;
 
         // check if sensor is enabled and worn by user
-        if (sensor.Mode == SuitSensorMode.SensorOff || sensor.User == null || transform.GridUid == null || HasComp<EmpDisabledComponent>(uid))
+        if (sensor.Mode == SuitSensorMode.SensorOff || sensor.User == null || transform.GridUid == null)
             return null;
 
         // try to get mobs id from ID slot


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Jumpsuits hit by an EMP now are set to disabled for the duration of the effect. When the effect ends, they return to normal.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

If things like headsets get disabled by EMPs, it makes sense for suit sensors to be disrupted too.

This would allow for some interesting play, like disabling a victim's suit sensors before killing them to reduce suspicion, or help a fellow traitor with a tracking implant escape.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/89101928/546f990f-5df8-446d-b98b-f1fc47e07f4c

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: EMPs temporarily disable suit sensors