### PR TITLE
let sensors be used on exped

### DIFF
--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringConsoleComponent.cs
@@ -9,11 +9,15 @@ public sealed partial class CrewMonitoringConsoleComponent : Component
     /// <summary>
     ///     List of all currently connected sensors to this console.
     /// </summary>
+    /// <remarks>
+    /// Not saved since server will sync it after loading.
+    /// </remarks>
+    [ViewVariables]
     public Dictionary<string, SuitSensorStatus> ConnectedSensors = new();
 
     /// <summary>
     ///     After what time sensor consider to be lost.
     /// </summary>
-    [DataField("sensorTimeout"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float SensorTimeout = 10f;
 }

--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerComponent.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerComponent.cs
@@ -7,28 +7,27 @@ namespace Content.Server.Medical.CrewMonitoring;
 [Access(typeof(CrewMonitoringServerSystem))]
 public sealed partial class CrewMonitoringServerComponent : Component
 {
-
     /// <summary>
     ///     List of all currently connected sensors to this server.
     /// </summary>
-    public readonly Dictionary<string, SuitSensorStatus> SensorStatus = new();
+    [DataField]
+    public Dictionary<string, SuitSensorStatus> SensorStatus = new();
 
     /// <summary>
     ///     After what time sensor consider to be lost.
     /// </summary>
-    [DataField("sensorTimeout"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float SensorTimeout = 10f;
 
     /// <summary>
     ///     Whether the server can become the currently active server. The server being unavailable usually means that it isn't powered
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public bool Available = true;
-
 
     /// <summary>
     ///     Whether the server is the currently active server for the station it's on
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public bool Active = true;
 }

--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -60,12 +60,6 @@ public sealed partial class SuitSensorComponent : Component
     public TimeSpan NextUpdate = TimeSpan.Zero;
 
     /// <summary>
-    ///     The station this suit sensor belongs to. If it's null the suit didn't spawn on a station and the sensor doesn't work.
-    /// </summary>
-    [DataField("station")]
-    public EntityUid? StationId = null;
-
-    /// <summary>
     ///     The server the suit sensor sends it state to.
     ///     The suit sensor will try connecting to a new server when no server is connected.
     ///     It does this by calling the servers entity system for performance reasons.

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -5,7 +5,6 @@ using Content.Server.DeviceNetwork.Systems;
 using Content.Server.GameTicking;
 using Content.Server.Medical.CrewMonitoring;
 using Content.Server.Popups;
-using Content.Server.Station.Systems;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Inventory.Events;
@@ -30,12 +29,10 @@ public sealed class SuitSensorSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly StationSystem _stationSystem = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawn);
         SubscribeLocalEvent<SuitSensorComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<SuitSensorComponent, EntityUnpausedEvent>(OnUnpaused);
         SubscribeLocalEvent<SuitSensorComponent, GotEquippedEvent>(OnEquipped);
@@ -56,18 +53,15 @@ public sealed class SuitSensorSystem : EntitySystem
         base.Update(frameTime);
 
         var curTime = _gameTiming.CurTime;
-        var sensors = EntityManager.EntityQueryEnumerator<SuitSensorComponent, DeviceNetworkComponent>();
+        var sensors = EntityQueryEnumerator<SuitSensorComponent, DeviceNetworkComponent, TransformComponent>();
 
-        while (sensors.MoveNext(out var uid, out var sensor, out var device))
+        while (sensors.MoveNext(out var uid, out var sensor, out var device, out var xform))
         {
             if (device.TransmitFrequency is null)
                 continue;
 
             // check if sensor is ready to update
             if (curTime < sensor.NextUpdate)
-                continue;
-
-            if (!CheckSensorAssignedStation(uid, sensor))
                 continue;
 
             // TODO: This would cause imprecision at different tick rates.
@@ -81,7 +75,7 @@ public sealed class SuitSensorSystem : EntitySystem
             //Retrieve active server address if the sensor isn't connected to a server
             if (sensor.ConnectedServer == null)
             {
-                if (!_monitoringServerSystem.TryGetActiveServerAddress(sensor.StationId!.Value, out var address))
+                if (!_monitoringServerSystem.TryGetActiveServerAddress(xform.MapID, out var address))
                     continue;
 
                 sensor.ConnectedServer = address;
@@ -101,51 +95,8 @@ public sealed class SuitSensorSystem : EntitySystem
         }
     }
 
-    /// <summary>
-    /// Checks whether the sensor is assigned to a station or not
-    /// and tries to assign an unassigned sensor to a station if it's currently on a grid
-    /// </summary>
-    /// <returns>True if the sensor is assigned to a station or assigning it was successful. False otherwise.</returns>
-    private bool CheckSensorAssignedStation(EntityUid uid, SuitSensorComponent sensor)
-    {
-        if (!sensor.StationId.HasValue && Transform(uid).GridUid == null)
-            return false;
-
-        sensor.StationId = _stationSystem.GetOwningStation(uid);
-        return sensor.StationId.HasValue;
-    }
-
-    private void OnPlayerSpawn(PlayerSpawnCompleteEvent ev)
-    {
-        // If the player spawns in arrivals then the grid underneath them may not be appropriate.
-        // in which case we'll just use the station spawn code told us they are attached to and set all of their
-        // sensors.
-        var sensorQuery = GetEntityQuery<SuitSensorComponent>();
-        var xformQuery = GetEntityQuery<TransformComponent>();
-        RecursiveSensor(ev.Mob, ev.Station, sensorQuery, xformQuery);
-    }
-
-    private void RecursiveSensor(EntityUid uid, EntityUid stationUid, EntityQuery<SuitSensorComponent> sensorQuery, EntityQuery<TransformComponent> xformQuery)
-    {
-        var xform = xformQuery.GetComponent(uid);
-        var enumerator = xform.ChildEnumerator;
-
-        while (enumerator.MoveNext(out var child))
-        {
-            if (sensorQuery.TryGetComponent(child, out var sensor))
-            {
-                sensor.StationId = stationUid;
-            }
-
-            RecursiveSensor(child, stationUid, sensorQuery, xformQuery);
-        }
-    }
-
     private void OnMapInit(EntityUid uid, SuitSensorComponent component, MapInitEvent args)
     {
-        // Fallback
-        component.StationId ??= _stationSystem.GetOwningStation(uid);
-
         // generate random mode
         if (component.RandomMode)
         {

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -49,7 +49,6 @@
     transmitFrequencyId: SuitSensor
   - type: WirelessNetworkConnection
     range: 1200
-  - type: StationLimitedNetwork
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -29,7 +29,6 @@
       autoConnect: false
     - type: WirelessNetworkConnection
       range: 500
-    - type: StationLimitedNetwork
     - type: ApcPowerReceiver
       powerLoad: 200
       priority: Low


### PR DESCRIPTION
## About the PR
removes the buggy station requirement and instead sensors just require that the server be on the same map

will help salvage if they set up crew monitoring, and also make them probably not disappear when going onto wrecks

draft so it can be made to prioritise syncing with a server on the same grid rather than whatever the query returns first

## Why / Balance
fixes #24877

## Technical details
where it checked for owning station which commonly stopped returning the actual station it instead checks the mapid

## Media
skeletony on the exped
![22:35:43](https://github.com/space-wizards/space-station-14/assets/39013340/eeb376bc-03cd-4900-8ca0-abebfde7f857)

camera man can see where he is on crew monitor!!!
![22:35:18](https://github.com/space-wizards/space-station-14/assets/39013340/b30c28e0-242d-4c2f-8e6e-e46a33d5b8c2)

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
yes

**Changelog**
:cl:
- fix: Fixed crew monitoring not working off-station.
