### PR TITLE
grille is flimsy

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -52,12 +52,9 @@
   id: PerforatedMetallic
   coefficients:
     Blunt: 2
-    Slash: 0.6
     Piercing: 0.2
-    Shock: 1.2
+    Shock: 0.6
   flatReductions:
-    Blunt: 5
-    Heat: 5
     Piercing: 10
 
 # for fragile electronics like consoles or shuttle engines.


### PR DESCRIPTION
## About the PR
grille is no longer harder to destroy than reinforced window

i think it slipped through in the structural damage rework and it became op

## Why / Balance
It is a flimsy framework of iron rods.

still hard to shoot but bashing cutting and melting it are easy again
it was weak to shock damage for some reason so now it isnt (???????)

fixes #24879

## Technical details
no

## Media
rouny
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Grilles are no longer incredibly strong.
