### PR TITLE
Add cli command to show the round end summary & add search box to crew manifest

### DIFF
--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -163,20 +163,21 @@ namespace Content.Client.GameTicking.Managers
     }
 
     [UsedImplicitly, AnyCommand]
-    public sealed class ChangelogCommand : IConsoleCommand
+    public sealed class RoundSummaryCommand : IConsoleCommand
     {
-        public string Command => "roundendsummary";
-        public string Description => "Opens the round end summary window";
-        public string Help => $"Usage: {Command}";
+        [Dependency] private readonly IEntitySystemManager _entitySystem = default!;
+
+        public string Command => "roundsummary";
+        public string Description => Loc.GetString("round-summary-command-description");
+        public string Help => Loc.GetString("round-summary-command-help-text", ("command", Command));
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            var entitySystem = IoCManager.Resolve<IEntitySystemManager>();
-            var clientGameTicker = entitySystem.GetEntitySystem<ClientGameTicker>();
-            var window = clientGameTicker.RoundEndSummaryWindow;
+            var gameTicker = _entitySystem.GetEntitySystem<ClientGameTicker>();
+            var window = gameTicker.RoundEndSummaryWindow;
             if (window == null)
             {
-                shell.WriteLine(Loc.GetString("round-end-summary-command-no-window"));
+                shell.WriteLine(Loc.GetString("round-summary-command-no-window"));
                 return;
             }
 

--- a/Resources/Locale/en-US/round-end/round-end-summary-command.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-summary-command.ftl
@@ -1,0 +1,3 @@
+round-summary-command-description = Opens the round end summary window.
+round-summary-command-help-text = Usage: {$command}
+round-summary-command-no-window = Round end summary is currently unavailable

--- a/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
@@ -1,6 +1,7 @@
 round-end-summary-window-title = Round End Summary
 round-end-summary-window-round-end-summary-tab-title = Round Information
 round-end-summary-window-player-manifest-tab-title = Player Manifest
+round-end-summary-window-player-manifest-search = Search
 round-end-summary-window-round-id-label = Round [color=white]#{$roundId}[/color] has ended.
 round-end-summary-window-gamemode-name-label = The game mode was [color=white]{$gamemode}[/color].
 round-end-summary-window-duration-label = It lasted for [color=yellow]{$hours} hours, {$minutes} minutes, and {$seconds} seconds.

--- a/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
@@ -7,4 +7,3 @@ round-end-summary-window-gamemode-name-label = The game mode was [color=white]{$
 round-end-summary-window-duration-label = It lasted for [color=yellow]{$hours} hours, {$minutes} minutes, and {$seconds} seconds.
 round-end-summary-window-player-info-if-observer-text = [color=gray]{$playerOOCName}[/color] was [color=lightblue]{$playerICName}[/color], an observer.
 round-end-summary-window-player-info-if-not-observer-text = [color=gray]{$playerOOCName}[/color] was [color={$icNameColor}]{$playerICName}[/color] playing role of [color=orange]{$playerRole}[/color].
-round-end-summary-command-no-window = Round end summary is currently unavailable

--- a/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
@@ -6,3 +6,4 @@ round-end-summary-window-gamemode-name-label = The game mode was [color=white]{$
 round-end-summary-window-duration-label = It lasted for [color=yellow]{$hours} hours, {$minutes} minutes, and {$seconds} seconds.
 round-end-summary-window-player-info-if-observer-text = [color=gray]{$playerOOCName}[/color] was [color=lightblue]{$playerICName}[/color], an observer.
 round-end-summary-window-player-info-if-not-observer-text = [color=gray]{$playerOOCName}[/color] was [color={$icNameColor}]{$playerICName}[/color] playing role of [color=orange]{$playerRole}[/color].
+round-end-summary-command-no-window = Round end summary is currently unavailable


### PR DESCRIPTION
## About the PR

- Add a console command to show the round end summary window.
- Add a search box to filter the manifest tab.

It will work if you've seen the round end summary and closed it, it will not work if you joined after the round end.

It may require the engine changes to fix SpriteView rendering in the lobby
- https://github.com/space-wizards/RobustToolbox/pull/4886

## Why / Balance

Dunno, I've heard people keep closing the summary just to realize shortly that they'd like to check something.

## Media

https://github.com/space-wizards/space-station-14/assets/1192090/7a5203e7-7c2c-4e02-9ac3-e7a84f8a1886

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
<!--
## Breaking changes

List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
<!--
**Changelog**

Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
