### PR TITLE
Fixed incorrect path to the uranium spear image in the construction menu

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/weapons.yml
+++ b/Resources/Prototypes/Recipes/Construction/weapons.yml
@@ -39,7 +39,7 @@
   targetNode: spear
   category: construction-category-weapons
   description: A crude uranium spear for when you need to put holes in somebody.
-  icon: { sprite: Objects/Weapons/Melee/plasma_spear.rsi, state: spear }
+  icon: { sprite: Objects/Weapons/Melee/uranium_spear.rsi, state: spear }
   objectType: Item
 
 - type: construction


### PR DESCRIPTION
Fixed incorrect path to the uranium spear image in the construction menu

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixed incorrect path to the uranium spear image in the construction menu

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- fix: Fixed incorrect path to the uranium spear image in the construction menu
![Screenshot_14](https://github.com/space-wizards/space-station-14/assets/140359015/05f61800-d657-4038-8180-4d969cef86a7)

