### PR TITLE
Weight based AreaInsert and Dumpable delay, a janitor qol tweak

### DIFF
--- a/Content.Shared/Storage/Components/DumpableComponent.cs
+++ b/Content.Shared/Storage/Components/DumpableComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.DoAfter;
+using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
@@ -24,7 +25,7 @@ public sealed partial class DumpableComponent : Component
     /// How long each item adds to the doafter.
     /// </summary>
     [DataField("delayPerItem"), AutoNetworkedField]
-    public TimeSpan DelayPerItem = TimeSpan.FromSeconds(0.2);
+    public TimeSpan DelayPerItem = TimeSpan.FromSeconds(SharedStorageSystem.AreaInsertDelayPerItem);
 
     /// <summary>
     /// The multiplier modifier

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -54,6 +54,8 @@ public abstract class SharedStorageSystem : EntitySystem
     [ValidatePrototypeId<ItemSizePrototype>]
     public const string DefaultStorageMaxItemSize = "Normal";
 
+    public const float AreaInsertDelayPerItem = 0.075f;
+
     private ItemSizePrototype _defaultStorageMaxItemSize = default!;
 
     public bool CheckingCanInsert;
@@ -258,11 +260,14 @@ public abstract class SharedStorageSystem : EntitySystem
         if (storageComp.AreaInsert && (args.Target == null || !HasComp<ItemComponent>(args.Target.Value)))
         {
             var validStorables = new List<EntityUid>();
+            var delay = 0f;
 
             foreach (var entity in _entityLookupSystem.GetEntitiesInRange(args.ClickLocation, storageComp.AreaInsertRadius, LookupFlags.Dynamic | LookupFlags.Sundries))
             {
                 if (entity == args.User
-                    || !_itemQuery.HasComponent(entity)
+                    // || !_itemQuery.HasComponent(entity)
+                    || !TryComp<ItemComponent>(entity, out var itemComp) // Need comp to get item size to get weight
+                    || !_prototype.TryIndex(itemComp.Size, out var itemSize)
                     || !CanInsert(uid, entity, out _, storageComp)
                     || !_interactionSystem.InRangeUnobstructed(args.User, entity))
                 {
@@ -270,12 +275,13 @@ public abstract class SharedStorageSystem : EntitySystem
                 }
 
                 validStorables.Add(entity);
+                delay += itemSize.Weight * AreaInsertDelayPerItem;
             }
 
             //If there's only one then let's be generous
             if (validStorables.Count > 1)
             {
-                var doAfterArgs = new DoAfterArgs(EntityManager, args.User, 0.2f * validStorables.Count, new AreaPickupDoAfterEvent(GetNetEntityList(validStorables)), uid, target: uid)
+                var doAfterArgs = new DoAfterArgs(EntityManager, args.User, delay, new AreaPickupDoAfterEvent(GetNetEntityList(validStorables)), uid, target: uid)
                 {
                     BreakOnDamage = true,
                     BreakOnUserMove = true,

--- a/Content.Shared/Storage/StorageComponent.cs
+++ b/Content.Shared/Storage/StorageComponent.cs
@@ -47,13 +47,13 @@ namespace Content.Shared.Storage
 
         // TODO: Make area insert its own component.
         [DataField]
-        public bool QuickInsert; // Can insert storables by "attacking" them with the storage entity
+        public bool QuickInsert; // Can insert storables by clicking them with the storage entity
 
         [DataField]
         public bool ClickInsert = true; // Can insert stuff by clicking the storage entity with it
 
         [DataField]
-        public bool AreaInsert;  // "Attacking" with the storage entity causes it to insert all nearby storables after a delay
+        public bool AreaInsert; // Clicking with the storage entity causes it to insert all nearby storables after a delay
 
         [DataField]
         public int AreaInsertRadius = 1;


### PR DESCRIPTION
## About the PR

The delay for dumping and area inserting items into containers now scales with total item weight.


## Why / Balance

Currently, a trash bag full of small items takes ~6 seconds to area insert. A bag full of tiny items takes a whopping 12 and is twice as long when dumping. (24 seconds!) This PR flattens these times and retunes the average to be roughly 5s for all weights in both situations.

Overall, this is a QoL tweak for Janitor players when picking up large piles of ejected cartridges, typically found after firefights.


## Technical details

`StorageComponent` and `DumpableComponent` now sum up the weights of all the items instead of simply counting them. The TimePerItem was turned into a constant and was reduced slightly to retune the average.

`DumpableComponent` reads the same constant to set it's default value. Prototypes with explicitly set TimePerItem fields are unaffected.


## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl: Krunk
- tweak: Picking up and dumping trash is less arduous for tiny, plentiful items, such as bullets.
