### PR TITLE
Fix end of round messages looping forever

### DIFF
--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -140,7 +140,7 @@ public sealed class BackgroundAudioSystem : EntitySystem
 
     private void PlayRestartSound(RoundRestartCleanupEvent ev)
     {
-        if (!_configManager.GetCVar(CCVars.LobbyMusicEnabled))
+        if (!_configManager.GetCVar(CCVars.RestartSoundsEnabled))
             return;
 
         var file = _gameTicker.RestartSound;

--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -25,6 +25,7 @@ public sealed class BackgroundAudioSystem : EntitySystem
     [Dependency] private readonly IStateManager _stateManager = default!;
 
     private readonly AudioParams _lobbyParams = new(-5f, 1, "Master", 0, 0, 0, true, 0f);
+    private readonly AudioParams _roundEndParams = new(-5f, 1, "Master", 0, 0, 0, false, 0f);
 
     public EntityUid? LobbyMusicStream;
     public EntityUid? LobbyRoundRestartAudioStream;
@@ -152,7 +153,7 @@ public sealed class BackgroundAudioSystem : EntitySystem
             file,
             Filter.Local(),
             false,
-            _lobbyParams.WithVolume(_lobbyParams.Volume + SharedAudioSystem.GainToVolume(_configManager.GetCVar(CCVars.LobbyMusicVolume)))
+            _roundEndParams.WithVolume(_roundEndParams.Volume + SharedAudioSystem.GainToVolume(_configManager.GetCVar(CCVars.LobbyMusicVolume)))
         )?.Entity;
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
closes #24910 

This makes it so end of round messages do not loop until the end of time.

Also round end messages now respect their actual setting instead of the lobby music one.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The end of round message used the same parameters as the ones for the end of round music which is set to loop indefinitely. This made the message loop forever.

Currently I just made params for the end of round message which are exactly identical to the music ones but with loop disabled. I believe both of these are supposed to have different parameters but at this time I have no idea what they are so I just disabled the looping.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: End of round messages no longer loop until the heat death of the universe.