### PR TITLE
chat color change

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     private readonly bool _adminLoocEnabled = true;
 
     [ValidatePrototypeId<ColorPalettePrototype>]
-    private const string _chatNamePalette = "Material";
+    private const string ChatNamePalette = "ChatNames";
     private string[] _chatNameColors = default!;
 
     public override void Initialize()
@@ -84,7 +84,7 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameChange);
 
-        var nameColors = _prototypeManager.Index<ColorPalettePrototype>(_chatNamePalette).Colors.Values.ToArray();
+        var nameColors = _prototypeManager.Index<ColorPalettePrototype>(ChatNamePalette).Colors.Values.ToArray();
         _chatNameColors = new string[nameColors.Length];
         for (var i = 0; i < nameColors.Length; i++)
         {

--- a/Resources/Prototypes/Palettes/text.yml
+++ b/Resources/Prototypes/Palettes/text.yml
@@ -33,3 +33,20 @@
     amber-darken-2: "#cc8000"
     amber-accent-2: "#7c6200"
     amber-accent-4: "#996700"
+
+- type: palette
+  id: ChatNames
+  name: Chat Names
+  colors:
+    ploink: "#da8bc9"
+    ourple: "#b18bda"
+    us-navy: "#96a4eb"
+    yet-another-blue: "#8cb7e8"
+    cyan: "#8bc9da"
+    fake-color: "#8bdaba"
+    green: "#8bda8e"
+    you-wish-you-were-green: "#a9da8b"
+    piss: "#ceda8b"
+    orange: "#dabc8b"
+    the-orange-she-tells-you-not-to-worry-about: "#daa58b"
+    red: "#da8b8b"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
swaps the text colors for a basic palette that i cooked up.
is essentially just fixed saturation / lightness with a variable hue.

a few of the colors look similar but they all read pretty well overall.

made in 15 minutes.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/1888afad-fac7-4be6-b342-43c43c54d3a0)
![image](https://github.com/space-wizards/space-station-14/assets/98561806/e67fb2ee-6740-4ee4-9604-a3fe99837687)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Changed the colors used for chat names.
