### PR TITLE
Reintroduce starvation damage with a cap.

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -102,6 +102,12 @@ public sealed partial class HungerComponent : Component
     public DamageSpecifier? StarvationDamage;
 
     /// <summary>
+    /// The maximum quantity of damage that can be taken per-type.
+    /// </summary>
+    [DataField("starvationDamageCap")]
+    public DamageSpecifier? StarvationDamageCap;
+
+    /// <summary>
     /// The time when the hunger will update next.
     /// </summary>
     [DataField("nextUpdateTime", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -11,6 +11,14 @@
   - type: HumanoidAppearance
     species: Arachnid
   - type: Hunger
+    starvationDamage:
+      types:
+        Cold: 0.5
+        Bloodloss: 0.5
+    starvationDamageCap:
+      types:
+        Cold: 30.0
+        Bloodloss: 30.0
   - type: Thirst
   - type: Sericulture
     action: ActionSericulture

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -8,6 +8,12 @@
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger
+    starvationDamage:
+      types:
+        Bloodloss: 0.5
+    starvationDamageCap:
+      types:
+        Bloodloss: 60.0
     baseDecayRate: 0.0083
   - type: Thirst
     baseDecayRate: 0.0083

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -6,6 +6,14 @@
   abstract: true
   components:
   - type: Hunger
+    starvationDamage:
+      types:
+        Cold: 0.5
+        Bloodloss: 0.5
+    starvationDamageCap:
+      types:
+        Cold: 30.0
+        Bloodloss: 30.0
   - type: Thirst
   - type: Icon
     sprite: Mobs/Species/Slime/parts.rsi # It was like this beforehand, no idea why.

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -6,6 +6,14 @@
   abstract: true
   components:
   - type: Hunger
+    starvationDamage:
+      types:
+        Cold: 0.5
+        Bloodloss: 0.5
+    starvationDamageCap:
+      types:
+        Cold: 30.0
+        Bloodloss: 30.0
   - type: Icon # It will not have an icon in the adminspawn menu without this. Body parts seem fine for whatever reason.
     sprite: Mobs/Species/Human/parts.rsi
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -8,6 +8,14 @@
   - type: HumanoidAppearance
     species: Moth
   - type: Hunger
+    starvationDamage:
+      types:
+        Cold: 0.5
+        Bloodloss: 0.5
+    starvationDamageCap:
+      types:
+        Cold: 30.0
+        Bloodloss: 30.0
   - type: Thirst
   - type: Icon
     sprite: Mobs/Species/Moth/parts.rsi

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -8,6 +8,14 @@
   - type: HumanoidAppearance
     species: Reptilian
   - type: Hunger
+    starvationDamage:
+      types:
+        Cold: 0.5
+        Bloodloss: 0.5
+    starvationDamageCap:
+      types:
+        Cold: 30.0
+        Bloodloss: 30.0
   - type: Puller
     needsHands: false
   - type: Thirst

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -5,6 +5,12 @@
   abstract: true
   components:
   - type: Hunger
+    starvationDamage:
+      types:
+        Bloodloss: 0.5
+    starvationDamageCap:
+      types:
+        Bloodloss: 60.0
   - type: Thirst
   - type: Icon
     sprite: Mobs/Species/Slime/parts.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Re-add starvation damage, but with a capped value. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Many players just ignore eating with the removal of starvation damage. Starvation damage will force players to start eating because it will be far more noticeable. This re-adds it, while not murdering SSD players.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Add a new field to the Hunger component that contains maximum values for damage. Then, only apply damage if the current damage is less than the cap. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. -->
:cl: aquif
- tweak: Re-add starvation damage. Starvation damage now has a cap that cannot be exceeded.
