### PR TITLE
Adds navmap beacon for escape pods

### DIFF
--- a/Resources/Locale/en-US/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/navmap-beacons/station-beacons.ftl
@@ -71,3 +71,4 @@ station-beacon-theater = Theater
 station-beacon-tools = Tools
 station-beacon-disposals = Disposals
 station-beacon-cryosleep = Cryosleep
+station-beacon-escape-pod = Escape Pod

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -624,3 +624,10 @@
   - type: NavMapBeacon
     text: station-beacon-cryosleep
 
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconEscapePod
+  suffix: Escape Pod
+  components:
+  - type: NavMapBeacon
+    text: station-beacon-escape-pod


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Seems like a useful thing for players to be able to find on the map.

## Technical details
n/a

## Media
n/a

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a