### PR TITLE
Fixed GluedComponent interactions with metamorphic glasses

### DIFF
--- a/Content.Server/Glue/GlueSystem.cs
+++ b/Content.Server/Glue/GlueSystem.cs
@@ -78,7 +78,7 @@ public sealed class GlueSystem : SharedGlueSystem
         base.Update(frameTime);
 
         var query = EntityQueryEnumerator<GluedComponent, UnremoveableComponent, MetaDataComponent>();
-        while (query.MoveNext(out var uid, out var glue, out _, out var meta))
+        while (query.MoveNext(out var uid, out var glue, out var _, out var meta))
         {
             if (_timing.CurTime < glue.Until)
                 continue;

--- a/Content.Server/Glue/GlueSystem.cs
+++ b/Content.Server/Glue/GlueSystem.cs
@@ -77,13 +77,16 @@ public sealed class GlueSystem : SharedGlueSystem
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<GluedComponent, UnremoveableComponent>();
-        while (query.MoveNext(out var uid, out var glue, out _))
+        var query = EntityQueryEnumerator<GluedComponent, MetaDataComponent, UnremoveableComponent>();
+        while (query.MoveNext(out var uid, out var glue, out var meta, out _))
         {
             if (_timing.CurTime < glue.Until)
                 continue;
 
-            _metaData.SetEntityName(uid, glue.BeforeGluedEntityName);
+            // Instead of string matching, just reconstruct the expected name and compare
+            if (meta.EntityName == Loc.GetString("glued-name-prefix", ("target", glue.BeforeGluedEntityName)))
+                _metaData.SetEntityName(uid, glue.BeforeGluedEntityName);
+
             RemComp<UnremoveableComponent>(uid);
             RemComp<GluedComponent>(uid);
         }

--- a/Content.Server/Glue/GlueSystem.cs
+++ b/Content.Server/Glue/GlueSystem.cs
@@ -77,8 +77,8 @@ public sealed class GlueSystem : SharedGlueSystem
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<GluedComponent, MetaDataComponent, UnremoveableComponent>();
-        while (query.MoveNext(out var uid, out var glue, out var meta, out _))
+        var query = EntityQueryEnumerator<GluedComponent, UnremoveableComponent, MetaDataComponent>();
+        while (query.MoveNext(out var uid, out var glue, out _, out var meta))
         {
             if (_timing.CurTime < glue.Until)
                 continue;


### PR DESCRIPTION
## About the PR

Glued metamorphic glasses no longer swap back to their metamorphized name after the glued effect wears off.


## Technical details

Reconstructs the expected name and checks if it matches.


## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

No cl, too smol
