### PR TITLE
Decrease the chemical cost of regen mesh and sutures and move them to their own file

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1695,40 +1695,6 @@
     LeavesCannabis: 1
 
 - type: microwaveMealRecipe
-  id: RecipeAloeCream
-  name: aloe cream recipe
-  result: AloeCream
-  time: 10
-  solids:
-    FoodAloe: 1
-
-- type: microwaveMealRecipe
-  id: RecipeMedicatedSuture
-  name: medicated suture recipe
-  result: MedicatedSuture
-  time: 10
-  solids:
-    FoodPoppy: 1
-    Brutepack: 1
-    MaterialCloth1: 1
-  reagents:
-    TranexamicAcid: 50
-    Cryptobiolin: 50
-
-- type: microwaveMealRecipe
-  id: RecipeRegenerativeMesh
-  name: regenerative mesh recipe
-  result: RegenerativeMesh
-  time: 10
-  solids:
-    FoodAloe: 1
-    Ointment: 1
-    MaterialCloth1: 1
-  reagents:
-    Sigynate: 50
-    Dermaline: 50
-
-- type: microwaveMealRecipe
   id: RecipeTrashBakedBananaPeel
   name: baked banana peel recipe
   result: TrashBakedBananaPeel

--- a/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
@@ -16,8 +16,8 @@
     Brutepack: 1
     MaterialCloth1: 1
   reagents:
-    TranexamicAcid: 10
-    Cryptobiolin: 10
+    TranexamicAcid: 20
+    Cryptobiolin: 20
 
 - type: microwaveMealRecipe
   id: RecipeRegenerativeMesh
@@ -29,5 +29,5 @@
     Ointment: 1
     MaterialCloth1: 1
   reagents:
-    Sigynate: 10
-    Dermaline: 10
+    Sigynate: 20
+    Dermaline: 20

--- a/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
@@ -1,0 +1,33 @@
+- type: microwaveMealRecipe
+  id: RecipeAloeCream
+  name: aloe cream recipe
+  result: AloeCream
+  time: 10
+  solids:
+    FoodAloe: 1
+
+- type: microwaveMealRecipe
+  id: RecipeMedicatedSuture
+  name: medicated suture recipe
+  result: MedicatedSuture
+  time: 10
+  solids:
+    FoodPoppy: 1
+    Brutepack: 1
+    MaterialCloth1: 1
+  reagents:
+    TranexamicAcid: 10
+    Cryptobiolin: 10
+
+- type: microwaveMealRecipe
+  id: RecipeRegenerativeMesh
+  name: regenerative mesh recipe
+  result: RegenerativeMesh
+  time: 10
+  solids:
+    FoodAloe: 1
+    Ointment: 1
+    MaterialCloth1: 1
+  reagents:
+    Sigynate: 10
+    Dermaline: 10


### PR DESCRIPTION
## About the PR
Moves medical recipes that are done in the microwave (Aloe cream, regenerative mesh, and medicated sutures) to their own file in the microwave recipes folder.
Decreases the cost of regen mesh and medicated sutures from 50u of each chem to 20u of each chem.
20u Tranexamic acid + 20u Cryptobiolin = suture
20u Dermaline + 20u Sigynate = mesh

## Why / Balance
After limited chems was added the amount of medicines needed to make sutures remained in the state it was in when chems were infinite, this is a bit too costly so I've decreased it.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Advanced topical meds now cost significantly less chemicals
