### PR TITLE
Fix action container handling

### DIFF
--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -648,6 +648,13 @@ public abstract class SharedActionsSystem : EntitySystem
     /// </summary>
     protected virtual void ActionAdded(EntityUid performer, EntityUid actionId, ActionsComponent comp, BaseActionComponent action)
     {
+        if (TryComp<MindComponent>(performer, out var mindComp) &&
+            mindComp.OwnedEntity != null &&
+            HasComp<ActionsContainerComponent>(mindComp.OwnedEntity.Value))
+        {
+            GrantContainedAction(mindComp.OwnedEntity.Value, performer, actionId);
+        }
+
         // See client-side system for UI code.
     }
 


### PR DESCRIPTION
I don't even know if this is the best way to fix it but this at least fixes it.

Pros:
- ActionsSystem is in charge of action addition / removal during state handling instead of containers doing it Cons:
- If something removes an action from a container (atm this can happen if they get emptied for example) it may not update properly. In the future we could maybe add a new containertype for virtual entities or something.

I set the pvs budget to 5 and moved around and it appears fixed. Doesn't seem to cause any breaking changes.

I'd write a test but no idea how to repro the setup between client and server.

I'd also recommend checking it out locally and sanity-checking it for me.

Fixes https://github.com/space-wizards/space-station-14/issues/20483

:cl:
- fix: Fix actions disappearing.