### PR TITLE
Update log probe UI for better looking

### DIFF
--- a/Content.Client/CartridgeLoader/Cartridges/LogProbeUiEntry.xaml
+++ b/Content.Client/CartridgeLoader/Cartridges/LogProbeUiEntry.xaml
@@ -4,16 +4,16 @@
               Orientation="Vertical">
     <BoxContainer Orientation="Horizontal">
         <Label Name="NumberLabel"
-               Align="Center"
-               SetWidth="60"
+               Align="Right"
+               SetWidth="26"
                ClipText="True"/>
         <Label Name="TimeLabel"
                Align="Center"
-               SetWidth="280"
+               SetWidth="100"
                ClipText="True"/>
         <Label Name="AccessorLabel"
-               Align="Center"
-               SetWidth="110"
+               Align="Left"
+               SetWidth="390"
                ClipText="True"/>
     </BoxContainer>
     <customControls:HSeparator Margin="0 5 0 5"/>

--- a/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml
+++ b/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml
@@ -9,10 +9,10 @@
                               BorderColor="#5a5a5a"
                               BorderThickness="0 0 0 1"/>
         </PanelContainer.PanelOverride>
-        <BoxContainer Orientation="Horizontal" Align="Center" Margin="8">
-            <Label HorizontalExpand="True" Text="{Loc 'log-probe-label-number'}"/>
-            <Label HorizontalExpand="True" Text="{Loc 'log-probe-label-time'}"/>
-            <Label HorizontalExpand="True" Text="{Loc 'log-probe-label-accessor'}"/>
+        <BoxContainer Orientation="Horizontal" Margin="4 8">
+            <Label Align="Right" SetWidth="26" ClipText="True" Text="{Loc 'log-probe-label-number'}"/>
+            <Label Align="Center" SetWidth="100" ClipText="True" Text="{Loc 'log-probe-label-time'}"/>
+            <Label Align="Left" SetWidth="390" ClipText="True" Text="{Loc 'log-probe-label-accessor'}"/>
         </BoxContainer>
     </PanelContainer>
     <ScrollContainer VerticalExpand="True" HScrollEnabled="True">

--- a/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
+++ b/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
@@ -18,4 +18,4 @@ log-probe-program-name = LogProbe
 log-probe-scan = Downloaded logs from {$device}!
 log-probe-label-time = Time
 log-probe-label-accessor = Accessed by
-log-probe-label-number = Number
+log-probe-label-number = #


### PR DESCRIPTION
## About the PR

Tune around the sizing of the log probe UI to fit more data and generally look better.

## Why

> the logprobe changes are quite nice
> 
> — @EmoGarbage404, https://github.com/space-wizards/space-station-14/pull/24868#pullrequestreview-1861554077

## Media

Before:
<img src="https://github.com/space-wizards/space-station-14/assets/1192090/545c26cb-27ae-4c45-9a14-9c1d1ffd01c7" width="400">

After:
<img src="https://github.com/space-wizards/space-station-14/assets/1192090/4cc81d08-72b7-4a7f-9884-4d8c0b6a075c" width="400">

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
<!--
## Breaking changes

List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
<!--
**Changelog**

Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
