### PR TITLE
Allow opening doors mid-deny animation, if you have the access

### DIFF
--- a/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
@@ -59,8 +59,7 @@ namespace Content.Server.DeviceLinking.Systems
             {
                 if (state == SignalState.High || state == SignalState.Momentary)
                 {
-                    if (door.State is DoorState.Closed or DoorState.Open)
-                        _doorSystem.TryToggleDoor(uid, door);
+                    _doorSystem.TryToggleDoor(uid, door);
                 }
             }
             else if (args.Port == component.InBolt)

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -136,13 +136,13 @@ public sealed class DoorSystem : SharedDoorSystem
         if (!door.BumpOpen)
             return;
 
-        if (door.State != DoorState.Closed)
+        if (door.State is not (DoorState.Closed or DoorState.Denying))
             return;
 
         var otherUid = args.OtherEntity;
 
         if (Tags.HasTag(otherUid, "DoorBumpOpener"))
-            TryOpen(uid, door, otherUid);
+            TryOpen(uid, door, otherUid, quiet: door.State == DoorState.Denying);
     }
     private void OnEmagged(EntityUid uid, DoorComponent door, ref GotEmaggedEvent args)
     {

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -212,9 +212,9 @@ public abstract class SharedDoorSystem : EntitySystem
         if (!Resolve(uid, ref door))
             return false;
 
-        if (door.State == DoorState.Closed)
+        if (door.State is DoorState.Closed or DoorState.Denying)
         {
-            return TryOpen(uid, door, user, predicted);
+            return TryOpen(uid, door, user, predicted, quiet: door.State == DoorState.Denying);
         }
         else if (door.State == DoorState.Open)
         {


### PR DESCRIPTION
## About the PR

the subject

## Why

It's rather annoying when you can't reliably interact with a door you have access to, requiring to wait until the clown who is banging on the door without the access to stop.

## Technical details

<details>

<summary>The clown's implementation</summary>

```diff
Index: Content.Server/My/ClickerSystem.cs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Content.Server/My/ClickerSystem.cs b/Content.Server/My/ClickerSystem.cs
new file mode 100644
--- /dev/null	(date 1707144928431)
+++ b/Content.Server/My/ClickerSystem.cs	(date 1707144928431)
@@ -0,0 +1,34 @@
+using Content.Shared.Doors.Components;
+using Content.Shared.Interaction;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server.My;
+
+public sealed class ClickerSystem : EntitySystem
+{
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<ClickerComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            var xform = Transform(uid);
+            var coordinates = xform.Coordinates;
+
+            if (!TryComp(xform.GridUid, out MapGridComponent? grid))
+                break;
+
+            var range = 3f;
+            var nearbyEntities = grid.GetCellsInSquareArea(coordinates, (int) Math.Ceiling(range / grid.TileSize));
+            foreach (var entity in nearbyEntities)
+            {
+                if (EntityManager.IsQueuedForDeletion(entity) || MetaData(entity).EntityLifeStage > EntityLifeStage.MapInitialized)
+                    continue;
+
+                if (!TryComp(entity, out DoorComponent? door))
+                    continue;
+
+                RaiseLocalEvent(entity, new ActivateInWorldEvent(uid, entity));
+            }
+        }
+    }
+}
Index: Content.Server/My/ClickerComponent.cs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Content.Server/My/ClickerComponent.cs b/Content.Server/My/ClickerComponent.cs
new file mode 100644
--- /dev/null	(date 1707145157591)
+++ b/Content.Server/My/ClickerComponent.cs	(date 1707145157591)
@@ -0,0 +1,6 @@
+namespace Content.Server.My;
+
+[RegisterComponent]
+public sealed partial class ClickerComponent : Component
+{
+}
```

</details>

## Media

Before:

https://github.com/space-wizards/space-station-14/assets/1192090/31170eb2-2217-4d85-a9cb-4c0be86dedda

After:

https://github.com/space-wizards/space-station-14/assets/1192090/6ba9afc4-103e-4c8e-8e61-31363c1698c1

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

<!--
## Breaking changes

List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
<!--
**Changelog**

Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
