### PR TITLE
Fix crew manifest department bugs

### DIFF
--- a/Content.Server/Access/Systems/AgentIDCardSystem.cs
+++ b/Content.Server/Access/Systems/AgentIDCardSystem.cs
@@ -7,6 +7,8 @@ using Content.Shared.Interaction;
 using Content.Shared.StatusIcon;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
+using Content.Shared.Roles;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Content.Server.Access.Systems
 {
@@ -98,6 +100,24 @@ namespace Content.Server.Access.Systems
             }
 
             _cardSystem.TryChangeJobIcon(uid, jobIcon, idCard);
+
+            if (TryFindJobProtoFromIcon(jobIcon, out var job))
+                _cardSystem.TryChangeJobDepartment(uid, job, idCard);
+        }
+
+        private bool TryFindJobProtoFromIcon(StatusIconPrototype jobIcon, [NotNullWhen(true)] out JobPrototype? job)
+        {
+            foreach (var jobPrototype in _prototypeManager.EnumeratePrototypes<JobPrototype>())
+            {
+                if(jobPrototype.Icon == jobIcon.ID)
+                {
+                    job = jobPrototype;
+                    return true;
+                }
+            }
+
+            job = null;
+            return false;
         }
     }
 }

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -131,6 +131,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
             && _prototype.TryIndex<StatusIconPrototype>(job.Icon, out var jobIcon))
         {
             _idCard.TryChangeJobIcon(targetId, jobIcon, player: player);
+            _idCard.TryChangeJobDepartment(targetId, job);
         }
 
         if (!newAccessList.TrueForAll(x => component.AccessLevels.Contains(x)))

--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -149,6 +149,7 @@ public sealed class IdCardSystem : SharedIdCardSystem
         if (!Resolve(uid, ref id))
             return false;
 
+        id.JobDepartments.Clear();
         foreach (var department in _prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
         {
             if (department.Roles.Contains(job.ID))


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This change updates the Agent ID's department when you change the icon, so you don't appear as 'Unknown' department on the crew monitor. (This doesn't provide any access, of course.)

I also noticed that updating a card's job with the ID card computer did not update the department, so a passenger promoted to Cargo Tech still appears in the Civilian department, instead of Cargo (on crew monitor), so I fixed that as well.

Fixes #24930 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Showing up as Unknown department can give away a traitor trying to use an Agent ID and might discourage its use.

Setting a new job with the ID card computer seems like it ought to update it to the correct department(s).

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The Agent ID system now fetches the JobPrototype associated to the JobIcon selected, and updates the card's department based on that.  Getting it from the job title seemed like a bad choice, due to localization, typos, etc. This solution does require enumerating through the JobPrototypes each time, so if we want to cache it, similar to how the ID card computer does it with a dropdown, let me know.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: The ID card console now correctly updates the ID's department when you update its job
- fix: The Agent ID will update its department depending on the selected icon
