### PR TITLE
Make radiation collector a power supplier

### DIFF
--- a/Content.Server/Singularity/Components/RadiationCollectorComponent.cs
+++ b/Content.Server/Singularity/Components/RadiationCollectorComponent.cs
@@ -11,11 +11,21 @@ namespace Content.Server.Singularity.Components;
 public sealed partial class RadiationCollectorComponent : Component
 {
     /// <summary>
-    ///     How much joules will collector generate for each rad.
+    ///     Power output (in Watts) per unit of radiation collected.
     /// </summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
     public float ChargeModifier = 30000f;
+
+    /// <summary>
+    ///     Number of power ticks that the power supply can remain active for. This is needed since
+    ///     power and radiation don't update at the same tickrate, and since radiation does not provide
+    ///     an update when radiation is removed. When this goes to zero, zero out the power supplier
+    ///     to model the radiation source going away.
+    /// </summary>
+    [DataField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int PowerTicksLeft = 0;
 
     /// <summary>
     ///     Is the machine enabled.

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -62,21 +62,11 @@
       - reactantPrototype: Plasma
         powerGenerationEfficiency: 1
         reactantBreakdownRate: 0.0001
-    # Note that this doesn't matter too much (see next comment)
-    # However it does act as a cap on power receivable via the collector.
-  - type: Battery
-    maxCharge: 100000
-    startingCharge: 0
-  - type: BatteryDischarger
-    # This is JUST a default. It has to be dynamically adjusted to ensure that the battery doesn't discharge "too fast" & run out immediately, while still scaling by input power.
-    activeSupplyRate: 100000
   - type: RadiationReceiver
+  - type: PowerSupplier
   - type: Anchorable
   - type: Rotatable
   - type: Pullable
-  - type: PowerNetworkBattery
-    maxSupply: 1000000000
-    supplyRampTolerance: 1000000000
   - type: GuideHelp
     guides: [ Singularity, Power ]
   - type: ContainerContainer


### PR DESCRIPTION
## About the PR
This PR changes radiation collectors from batteries to ordinary power suppliers. Based on code from Mining Station 14.

## Why / Balance
@PJB3005 [was complaining](https://discord.com/channels/310555209753690112/770682801607278632/1202565488459382845) that the power coming from radiation collectors looks like this:

![image](https://github.com/space-wizards/space-station-14/assets/3229565/9bc805ff-6274-47bb-b48f-d2deb83ac8cd)

This changes the radiation collector so that it behaves like an ordinary power supplier with relatively smooth output levels:

![image](https://github.com/space-wizards/space-station-14/assets/3229565/d227e5f5-6012-4b1e-bd68-2229d742d92e)

This has the advantage of appearing relatively consistent in the power monitoring console instead of fluctuating wildly. This also makes the singulo a more stable power supply.

Note that this still fluctuates a bit, and if you play this game it is evident why (the singularity itself is growing and shrinking).

This also makes radiation collectors behave more intuitively like solar panels, where you have to collect and use the power that is being produced now, instead of e.g. accumulating it in a battery.

## Technical details
- Replace the battery-related components with a simple power supplier component.
- On radiation, set `MaxSupply`
- Add a holdover time to each radiation supplier component that turns off the supply after a certain amount of time without radiation, since the radiation system does not provide any "radiation is gone" events
- The radiation to power conversion ratio remains unchanged, since previously it was energy/rad * 1 rad/sec, which through unit analysis becomes energy/sec = power (Watts)

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
N/A