### PR TITLE
Added Monitor Computer Boards to Observation Kit

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
@@ -44,4 +44,8 @@
           amount: 1
         - id: ClothingEyesGlassesHiddenSecurity
           amount: 1
+        - id: SurveillanceCameraMonitorCircuitboard
+          amount: 1
+        - id: CrewMonitoringComputerCircuitboard
+          amount: 1
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added a Surveillance Camera Monitor board and a Crew Monitoring Computer board to the Observation Kit.

## Why / Balance
With the removal of the syndicate crew monitor this bundle has lost a lot of its utility, adding these computer boards to the kit will allow an agent to set up a hidden monitoring station from which they can relay information to other agents.

## Technical details

## Media
I don't think this requires media but let me know if it does.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl:
- add: Surveillance Camera Monitor and Crew Monitoring Computer boards have been added to the Syndicate Observation Kit.
