### PR TITLE
sterile swab dispenser instead of box

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
@@ -89,27 +89,6 @@
       - state: nitrile
 
 - type: entity
-  name: sterile swab box
-  parent: BoxCardboard
-  id: BoxMouthSwab
-  components:
-  - type: Storage
-    grid:
-    - 0,0,4,3
-  - type: StorageFill
-    contents:
-      - id: DiseaseSwab
-        amount: 10
-  - type: Sprite
-    layers:
-      - state: box
-      - state: swab
-  - type: GuideHelp
-    guides:
-  # - Virology (when it's back)
-    - Botany
-
-- type: entity
   name: body bag box
   parent: BoxCardboard
   id: BoxBodyBag

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
@@ -20,6 +20,27 @@
     - Botany
 
 - type: entity
+  parent: BaseAmmoProvider # trust
+  id: BoxMouthSwab
+  name: sterile swab dispenser
+  description: Dispenses 30 sterile swabs, extremely useful for botany.
+  components:
+  - type: Sprite
+    layers:
+    - state: boxwide
+    - state: swab
+  - type: BallisticAmmoProvider
+    whitelist:
+      components:
+      - BotanySwab
+    proto: DiseaseSwab
+    capacity: 30
+  - type: GuideHelp
+    guides:
+  # - Virology (when it's back)
+    - Botany
+
+- type: entity
   parent: BaseItem
   id: Vaccine
   name: vaccine

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
@@ -20,7 +20,7 @@
     - Botany
 
 - type: entity
-  parent: BaseAmmoProvider # trust
+  parent: BaseAmmoProvider # this is for cycling swabs out and not spawning 30 entities, trust
   id: BoxMouthSwab
   name: sterile swab dispenser
   description: Dispenses 30 sterile swabs, extremely useful for botany.


### PR DESCRIPTION
## About the PR
replaces swab box with a swab dispenser, like a shotgun shell dispenser but for swabs

## Why / Balance
swab box was bad:
- le entity spam
- after storage rework it got nerfed hard from 30 to 10 swabs
- its a pain in the ass to use now that you have to open a nested storage, or just put it all in your bag because thats easier
- its a tardis (3x3 with 4x5 storage)

## Technical details
no

## Media
trust
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Sterile Swabs now come in dispensers making them easier to use.
