### PR TITLE
Fix cryostorage removing minds of players who have entered ghost role

### DIFF
--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -301,6 +301,11 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
             if (Timing.CurTime < containedComp.GracePeriodEndTime)
                 continue;
 
+            if (containedComp.Cryostorage == null ||
+                !TryComp<CryostorageComponent>(containedComp.Cryostorage, out var cryo) ||
+                cryo.StoredPlayers.Contains(uid))
+                continue;
+
             Mind.TryGetMind(uid, out _, out var mindComp);
             var id = mindComp?.UserId ?? containedComp.UserId;
             HandleEnterCryostorage((uid, containedComp), id);

--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -197,7 +197,8 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
 
         if (!CryoSleepRejoiningEnabled || !comp.AllowReEnteringBody)
         {
-            if (userId != null && Mind.TryGetMind(userId.Value, out var mind))
+            if (userId != null && Mind.TryGetMind(userId.Value, out var mind) &&
+                HasComp<CryostorageContainedComponent>(mind.Value.Comp.CurrentEntity))
             {
                 _gameTicker.OnGhostAttempt(mind.Value, false);
             }
@@ -299,11 +300,6 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
                 continue;
 
             if (Timing.CurTime < containedComp.GracePeriodEndTime)
-                continue;
-
-            if (containedComp.Cryostorage == null ||
-                !TryComp<CryostorageComponent>(containedComp.Cryostorage, out var cryo) ||
-                cryo.StoredPlayers.Contains(uid))
                 continue;
 
             Mind.TryGetMind(uid, out _, out var mindComp);


### PR DESCRIPTION
## About the PR
Fixes a bug where cryo removes the mind from a new role if the player entered cryostorage, ghosted out and picked a ghost role before cryo finishes.

## Technical details
Right now it just checks if the player with the `CryostorageContainedComponent` is actually stored in the specified cryostorage. It could remove any mind contained in cryostorge, but I can't garantie that it won't cause more bugs.

## Media
I don't think there should be any media there. I can record the bug itself, but I think it is clear from the description.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: c4llv07e
- fix: Cryo won't remove you from the new body if you chose a new ghost role before cryo deleted your old body.