### PR TITLE
Added filtered chat search 

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -449,18 +449,18 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (originalMessage == message)
         {
             if (name != Name(source))
-                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {ToPrettyString(source):user} as {name}: {originalMessage}.");
+                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {ToPrettyString(source):user} as {name}, content( {originalMessage}. )");
             else
-                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {ToPrettyString(source):user}: {originalMessage}.");
+                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {ToPrettyString(source):user}, content( {originalMessage}. )");
         }
         else
         {
             if (name != Name(source))
                 _adminLogger.Add(LogType.Chat, LogImpact.Low,
-                    $"Say from {ToPrettyString(source):user} as {name}, original: {originalMessage}, transformed: {message}.");
+                    $"Say from {ToPrettyString(source):user} as {name}, content( original: {originalMessage}, transformed: {message}. )");
             else
                 _adminLogger.Add(LogType.Chat, LogImpact.Low,
-                    $"Say from {ToPrettyString(source):user}, original: {originalMessage}, transformed: {message}.");
+                    $"Say from {ToPrettyString(source):user}, content( original: {originalMessage}, transformed: {message}. )");
         }
     }
 


### PR DESCRIPTION
## About the PR
resolves #24972, adds the ability to explicitly search chat content while avoiding false positive logs, as opposed to the current system where if the search text matches any part of the string it will display the corresponding log. See the linked issue for more details. You can now do this by deselecting all the other log types and only selecting the chat log. 

## Why / Balance
Requested change from one of the admins.

## Technical details
Uses a regex search to filter out any false positive matches in the string, only showing chat logs that contain the required content.

## Media
With more than one selected log type, including the chat log.
<img width="711" alt="Screen Shot 2024-02-06 at 11 07 52 AM" src="https://github.com/space-wizards/space-station-14/assets/73014819/4f3aff5d-3ebb-44b4-9d46-b5659ac6119d">

Chat only selected log.
<img width="698" alt="Screen Shot 2024-02-06 at 11 08 22 AM" src="https://github.com/space-wizards/space-station-14/assets/73014819/991c8e2b-7073-4699-9b58-00439b7ea1b8">

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
- add: Adds the ability for admins to explicitly search chat content by only selecting the chat log type. Resolves the issue of the log search bar unnecessarily returning unwanted logs. 
