### PR TITLE
Remove battery from crew observation kit, fix description

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -184,7 +184,7 @@ uplink-micro-bomb-implanter-desc = Explode on death or manual activation with th
 
 # Bundles
 uplink-observation-kit-name = Observation Kit
-uplink-observation-kit-desc = Includes syndicate crew monitor, high power cell and security hud disguised as sunglasses.
+uplink-observation-kit-desc = Includes surveillance camera monitor board and security hud disguised as sunglasses.
 
 uplink-emp-kit-name = Electrical Disruptor Kit
 uplink-emp-kit-desc = The ultimate reversal on energy-based weaponry: Disables disablers, stuns stunbatons, discharges laser guns! Contains 3 EMP grenades and an EMP implanter. Note: Does not disrupt actual firearms.

--- a/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
@@ -40,8 +40,6 @@
   components:
     - type: StorageFill
       contents:
-        - id: PowerCellHigh
-          amount: 1
         - id: ClothingEyesGlassesHiddenSecurity
           amount: 1
         - id: SurveillanceCameraMonitorCircuitboard


### PR DESCRIPTION
## About the PR
Removes the battery from the Crew Observation Kit, as it was added to be placed inside the portable crew monitor.
Fixes the description to describe the contents accurately.

## Why / Balance
Not useful thingy.