### PR TITLE
Fixes indestructible mop buckets

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -173,7 +173,7 @@
     guides:
     - Janitorial
   - type: Damageable
-    damageModifierSet: Wood
+    damageContainer: Inorganic
   - type: Destructible
     thresholds:
     - trigger:
@@ -182,14 +182,7 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: WoodDestroy
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          MaterialWoodPlank:
-            min: 1
-            max: 3
+
 
 - type: entity
   name: mop bucket

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -183,7 +183,6 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
 
-
 - type: entity
   name: mop bucket
   id: MopBucketFull

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -172,6 +172,24 @@
   - type: GuideHelp
     guides:
     - Janitorial
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 70
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroy
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWoodPlank:
+            min: 1
+            max: 3
 
 - type: entity
   name: mop bucket


### PR DESCRIPTION
## About the PR
fixes #24992, mop buckets are now destructible
## Why / Balance
immersion I guess? Idk.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: fixes mop buckets being indestructible.
