### PR TITLE
Add option for admins to disable bwoink

### DIFF
--- a/Content.Client/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Client/Administration/Systems/BwoinkSystem.cs
@@ -19,11 +19,11 @@ namespace Content.Client.Administration.Systems
             OnBwoinkTextMessageRecieved?.Invoke(this, message);
         }
 
-        public void Send(NetUserId channelId, string text)
+        public void Send(NetUserId channelId, string text, bool playSound)
         {
             // Reuse the channel ID as the 'true sender'.
             // Server will ignore this and if someone makes it not ignore this (which is bad, allows impersonation!!!), that will help.
-            RaiseNetworkEvent(new BwoinkTextMessage(channelId, channelId, text));
+            RaiseNetworkEvent(new BwoinkTextMessage(channelId, channelId, text, playSound: playSound));
             SendInputTextUpdated(channelId, false);
         }
 

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -7,6 +7,8 @@
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="2">
                 <BoxContainer Access="Public" Name="BwoinkArea" VerticalExpand="True" />
                 <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
+                    <CheckBox Visible="True" Name="PlaySound" Access="Public" Text="{Loc 'admin-bwoink-play-sound'}" Pressed="True" />
+                    <Control HorizontalExpand="True" MinWidth="5" />
                     <Button Visible="True" Name="PopOut" Access="Public" Text="{Loc 'admin-logs-pop-out'}" StyleClasses="OpenBoth" HorizontalAlignment="Left" />
                     <Control HorizontalExpand="True" />
                     <Button Visible="False" Name="Bans" Text="{Loc 'admin-player-actions-bans'}" StyleClasses="OpenRight" />

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -407,18 +407,21 @@ namespace Content.Server.Administration.Systems
 
             if (senderAdmin is not null && senderAdmin.Flags == AdminFlags.Adminhelp) // Mentor. Not full admin. That's why it's colored differently.
             {
-                bwoinkText = $"[color=purple]{senderSession.Name}[/color]: {escapedText}";
+                bwoinkText = $"[color=purple]{senderSession.Name}[/color]";
             }
             else if (senderAdmin is not null && senderAdmin.HasFlag(AdminFlags.Adminhelp))
             {
-                bwoinkText = $"[color=red]{senderSession.Name}[/color]: {escapedText}";
+                bwoinkText = $"[color=red]{senderSession.Name}[/color]";
             }
             else
             {
-                bwoinkText = $"{senderSession.Name}: {escapedText}";
+                bwoinkText = $"{senderSession.Name}";
             }
 
-            var msg = new BwoinkTextMessage(message.UserId, senderSession.UserId, bwoinkText);
+            bwoinkText = (message.PlaySound ? "" : "(S) ") + bwoinkText + ": " + escapedText;
+
+            var playSound = senderAHelpAdmin && message.PlaySound;
+            var msg = new BwoinkTextMessage(message.UserId, senderSession.UserId, bwoinkText, playSound: playSound);
 
             LogBwoink(msg);
 
@@ -442,18 +445,20 @@ namespace Content.Server.Administration.Systems
                         // Doing the same thing as above, but with the override name. Theres probably a better way to do this.
                         if (senderAdmin is not null && senderAdmin.Flags == AdminFlags.Adminhelp) // Mentor. Not full admin. That's why it's colored differently.
                         {
-                            overrideMsgText = $"[color=purple]{_overrideClientName}[/color]: {escapedText}";
+                            overrideMsgText = $"[color=purple]{_overrideClientName}[/color]";
                         }
                         else if (senderAdmin is not null && senderAdmin.HasFlag(AdminFlags.Adminhelp))
                         {
-                            overrideMsgText = $"[color=red]{_overrideClientName}[/color]: {escapedText}";
+                            overrideMsgText = $"[color=red]{_overrideClientName}[/color]";
                         }
                         else
                         {
-                            overrideMsgText = $"{senderSession.Name}: {escapedText}"; // Not an admin, name is not overridden.
+                            overrideMsgText = $"{senderSession.Name}"; // Not an admin, name is not overridden.
                         }
 
-                        RaiseNetworkEvent(new BwoinkTextMessage(message.UserId, senderSession.UserId, overrideMsgText), session.Channel);
+                        overrideMsgText = (message.PlaySound ? "" : "(S) ") + overrideMsgText + ": " + escapedText;
+
+                        RaiseNetworkEvent(new BwoinkTextMessage(message.UserId, senderSession.UserId, overrideMsgText, playSound: playSound), session.Channel);
                     }
                     else
                         RaiseNetworkEvent(msg, session.Channel);

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -418,7 +418,7 @@ namespace Content.Server.Administration.Systems
                 bwoinkText = $"{senderSession.Name}";
             }
 
-            bwoinkText = (message.PlaySound ? "" : "(S) ") + bwoinkText + ": " + escapedText;
+            bwoinkText = $"{(message.PlaySound ? "" : "(S) ")}{bwoinkText}: {escapedText}";
 
             var playSound = senderAHelpAdmin && message.PlaySound;
             var msg = new BwoinkTextMessage(message.UserId, senderSession.UserId, bwoinkText, playSound: playSound);
@@ -456,7 +456,7 @@ namespace Content.Server.Administration.Systems
                             overrideMsgText = $"{senderSession.Name}"; // Not an admin, name is not overridden.
                         }
 
-                        overrideMsgText = (message.PlaySound ? "" : "(S) ") + overrideMsgText + ": " + escapedText;
+                        overrideMsgText = $"{(message.PlaySound ? "" : "(S) ")}{overrideMsgText}: {escapedText}";
 
                         RaiseNetworkEvent(new BwoinkTextMessage(message.UserId, senderSession.UserId, overrideMsgText, playSound: playSound), session.Channel);
                     }

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -72,7 +72,7 @@ namespace Content.Server.Administration.Systems
             _config.OnValueChanged(CVars.GameHostName, OnServerNameChanged, true);
             _config.OnValueChanged(CCVars.AdminAhelpOverrideClientName, OnOverrideChanged, true);
             _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("AHELP");
-            _maxAdditionalChars = GenerateAHelpMessage("", "", true, _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss"), _gameTicker.RunLevel).Length;
+            _maxAdditionalChars = GenerateAHelpMessage("", "", true, _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss"), _gameTicker.RunLevel, false).Length;
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
 
             SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameRunLevelChanged);
@@ -479,7 +479,7 @@ namespace Content.Server.Administration.Systems
                     str = str[..(DescriptionMax - _maxAdditionalChars - unameLength)];
                 }
                 var nonAfkAdmins = GetNonAfkAdmins();
-                _messageQueues[msg.UserId].Enqueue(GenerateAHelpMessage(senderSession.Name, str, !personalChannel, _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss"), _gameTicker.RunLevel, nonAfkAdmins.Count == 0));
+                _messageQueues[msg.UserId].Enqueue(GenerateAHelpMessage(senderSession.Name, str, !personalChannel, _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss"), _gameTicker.RunLevel, playSound, nonAfkAdmins.Count == 0));
             }
 
             if (admins.Count != 0 || sendsWebhook)
@@ -507,7 +507,7 @@ namespace Content.Server.Administration.Systems
                 .ToList();
         }
 
-        private static string GenerateAHelpMessage(string username, string message, bool admin, string roundTime, GameRunLevel roundState, bool noReceivers = false)
+        private static string GenerateAHelpMessage(string username, string message, bool admin, string roundTime, GameRunLevel roundState, bool playedSound, bool noReceivers = false)
         {
             var stringbuilder = new StringBuilder();
 
@@ -520,6 +520,8 @@ namespace Content.Server.Administration.Systems
 
             if(roundTime != string.Empty && roundState == GameRunLevel.InRound)
                 stringbuilder.Append($" **{roundTime}**");
+            if (!playedSound)
+                stringbuilder.Append(" **(S)**");
             stringbuilder.Append($" **{username}:** ");
             stringbuilder.Append(message);
             return stringbuilder.ToString();

--- a/Content.Shared/Administration/SharedBwoinkSystem.cs
+++ b/Content.Shared/Administration/SharedBwoinkSystem.cs
@@ -38,12 +38,15 @@ namespace Content.Shared.Administration
             public NetUserId TrueSender { get; }
             public string Text { get; }
 
-            public BwoinkTextMessage(NetUserId userId, NetUserId trueSender, string text, DateTime? sentAt = default)
+            public bool PlaySound { get; }
+
+            public BwoinkTextMessage(NetUserId userId, NetUserId trueSender, string text, DateTime? sentAt = default, bool playSound = true)
             {
                 SentAt = sentAt ?? DateTime.Now;
                 UserId = userId;
                 TrueSender = trueSender;
                 Text = text;
+                PlaySound = playSound;
             }
         }
     }

--- a/Resources/Locale/en-US/administration/bwoink.ftl
+++ b/Resources/Locale/en-US/administration/bwoink.ftl
@@ -10,3 +10,5 @@ bwoink-system-typing-indicator = {$players} {$count ->
 [one] is
 *[other] are
 } typing...
+
+admin-bwoink-play-sound = Bwoink?


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
In a vain attempt to get people to ahelp more, provide the possibility for admins to not play the bwoink sound if they don't want to scare the player. We also include an indicator if the message is silent.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Often times administrators want to thank users for providing an ahelp, or to politely remind them of something. This should ideally not play the very scary bwoink sound because most players associate it with "I just broke the rules". 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Add an additional field to the bwoink message that tells the client whether or not it should play a sound. We also need to add a few extra method parameters to make sure it is passed along correctly. Server-side, it only permits this field to be set if the admin is the one sending the bwoink message.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/57052305/127a78b7-ce50-4b37-b488-38cab4220715)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
The ahelp UI controller action and ahelp system Send method now have an additional parameter. They are not used outside of ahelp stuff so I doubt it is an issue. Simply pass true for this parameter to maintain the old behavior.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl: Aquif
ADMIN:
- add: Admins can now disable the bwoink sound if they don't want to scare players.


