### PR TITLE
Disable voting for Sandbox mode

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -79,7 +79,7 @@
     - sandbox
   name: sandbox-title
   description: sandbox-description
-  showInVote: true
+  showInVote: false # Not suitable for use without admin intervention, since entity spamming can quickly crash a server
   maxPlayers: 5
   rules:
     - Sandbox


### PR DESCRIPTION
## About the PR
Disable voting for Sandbox mode. Players can vote for sandbox on a public server, and then entity spam to quickly lag a server or run it out of memory.

## Why / Balance
Requested by WizDen game admins. Admins can still force the game mode, and other servers are welcome to make sandbox votable as they see fit.

This is certainly sub-optimal, since it's nice to be able to "test things" on an empty server. However, recent abuse of this has led to lagging/unresponsive public servers.

This can also certainly be reverted once there are mitigations, such as:

- Limiting the global number of entities
- Limiting entity spawn rate, either directly through the entity spawn menu or through entities that when spawned, spawn other entities (such as a few special markers)