### PR TITLE
predict egg cracking + refactor

### DIFF
--- a/Content.Shared/Chemistry/Components/SolutionSpikerComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionSpikerComponent.cs
@@ -2,7 +2,7 @@ using Content.Shared.Chemistry.EntitySystems;
 
 namespace Content.Shared.Chemistry.Components;
 
-[RegisterComponent, Access(typeof(SolutionSpikerSystem))]
+[RegisterComponent, NetworkedComponent, Access(typeof(SolutionSpikerSystem))]
 public sealed partial class SolutionSpikerComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Chemistry/Components/SolutionSpikerComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionSpikerComponent.cs
@@ -1,30 +1,32 @@
-namespace Content.Server.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
 
-[RegisterComponent]
+namespace Content.Shared.Chemistry.Components;
+
+[RegisterComponent, Access(typeof(SolutionSpikerSystem))]
 public sealed partial class SolutionSpikerComponent : Component
 {
     /// <summary>
     ///     The source solution to take the reagents from in order
     ///     to spike the other solution container.
     /// </summary>
-    [DataField]
-    public string SourceSolution { get; private set; } = string.Empty;
+    [DataField(required: true)]
+    public string SourceSolution = string.Empty;
 
     /// <summary>
     ///     If spiking with this entity should ignore empty containers or not.
     /// </summary>
     [DataField]
-    public bool IgnoreEmpty { get; private set; }
+    public bool IgnoreEmpty;
 
     /// <summary>
     ///     What should pop up when spiking with this entity.
     /// </summary>
     [DataField]
-    public LocId Popup { get; private set; } = "spike-solution-generic";
+    public LocId Popup = "spike-solution-generic";
 
     /// <summary>
     ///     What should pop up when spiking fails because the container was empty.
     /// </summary>
     [DataField]
-    public LocId PopupEmpty { get; private set; } = "spike-solution-empty-generic";
+    public LocId PopupEmpty = "spike-solution-empty-generic";
 }

--- a/Content.Shared/Chemistry/Components/SolutionSpikerComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionSpikerComponent.cs
@@ -19,6 +19,13 @@ public sealed partial class SolutionSpikerComponent : Component
     public bool IgnoreEmpty;
 
     /// <summary>
+    /// If true, the entity is deleted after spiking.
+    /// This is almost certainly what you want.
+    /// </summary>
+    [DataField]
+    public bool Delete = true;
+
+    /// <summary>
     ///     What should pop up when spiking with this entity.
     /// </summary>
     [DataField]

--- a/Content.Shared/Chemistry/Components/SolutionSpikerComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionSpikerComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Chemistry.EntitySystems;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Chemistry.Components;
 

--- a/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
@@ -1,12 +1,9 @@
-using Content.Server.Chemistry.Components;
-using Content.Server.Chemistry.Containers.EntitySystems;
-using Content.Server.Explosion.EntitySystems;
-using Content.Server.Popups;
+using Content.Shared.Popups;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Interaction;
 
-namespace Content.Server.Chemistry.EntitySystems;
+namespace Content.Shared.Chemistry.EntitySystems;
 
 /// <summary>
 ///     Entity system used to handle when solution containers are 'spiked'
@@ -17,11 +14,10 @@ namespace Content.Server.Chemistry.EntitySystems;
 ///     Examples of spikable entity interactions include pills being dropped into glasses,
 ///     eggs being cracked into bowls, and so on.
 /// </summary>
-public sealed class SolutionSpikableSystem : EntitySystem
+public sealed class SolutionSpikerSystem : EntitySystem
 {
-    [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
-    [Dependency] private readonly TriggerSystem _triggerSystem = default!;
-    [Dependency] private readonly PopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
 
     public override void Initialize()
     {
@@ -47,23 +43,23 @@ public sealed class SolutionSpikableSystem : EntitySystem
     {
         if (!Resolve(source, ref spikableSource, ref managerSource, false)
             || !Resolve(target, ref spikableTarget, ref managerTarget, false)
-            || !_solutionContainerSystem.TryGetRefillableSolution((target, spikableTarget, managerTarget), out var targetSoln, out var targetSolution)
-            || !_solutionContainerSystem.TryGetSolution((source, managerSource), spikableSource.SourceSolution, out _, out var sourceSolution))
+            || !_solution.TryGetRefillableSolution((target, spikableTarget, managerTarget), out var targetSoln, out var targetSolution)
+            || !_solution.TryGetSolution((source, managerSource), spikableSource.SourceSolution, out _, out var sourceSolution))
         {
             return;
         }
 
         if (targetSolution.Volume == 0 && !spikableSource.IgnoreEmpty)
         {
-            _popupSystem.PopupEntity(Loc.GetString(spikableSource.PopupEmpty, ("spiked-entity", target), ("spike-entity", source)), user, user);
+            _popup.PopupClient(Loc.GetString(spikableSource.PopupEmpty, ("spiked-entity", target), ("spike-entity", source)), user, user);
             return;
         }
 
-        if (!_solutionContainerSystem.ForceAddSolution(targetSoln.Value, sourceSolution))
+        if (!_solution.ForceAddSolution(targetSoln.Value, sourceSolution))
             return;
 
-        _popupSystem.PopupEntity(Loc.GetString(spikableSource.Popup, ("spiked-entity", target), ("spike-entity", source)), user, user);
+        _popup.PopupClient(Loc.GetString(spikableSource.Popup, ("spiked-entity", target), ("spike-entity", source)), user, user);
         sourceSolution.RemoveAllSolution();
-        _triggerSystem.Trigger(source, user);
+        QueueDel(source);
     }
 }

--- a/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
@@ -60,6 +60,7 @@ public sealed class SolutionSpikerSystem : EntitySystem
 
         _popup.PopupClient(Loc.GetString(spikableSource.Popup, ("spiked-entity", target), ("spike-entity", source)), user, user);
         sourceSolution.RemoveAllSolution();
-        QueueDel(source);
+        if (spikableSource.Delete)
+            QueueDel(source);
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -30,7 +30,6 @@
     sourceSolution: food
     ignoreEmpty: true
     popup: spike-solution-egg
-  - type: DeleteOnTrigger
   # egg fragile
   - type: DamageOnHighSpeedImpact
     minimumSpeed: 0.1

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -118,7 +118,6 @@
   - type: SolutionSpiker
     sourceSolution: food
     ignoreEmpty: true
-  - type: DeleteOnTrigger
   - type: Extractable
     grindableSolutionName: food
 

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -454,7 +454,6 @@
         maxVol: 20
   - type: SolutionSpiker
     sourceSolution: food
-  - type: DeleteOnTrigger
   - type: Extractable
     grindableSolutionName: food
   - type: StaticPrice


### PR DESCRIPTION
## About the PR
title

## Why / Balance
stop botanists cracking eggs into eachother and picking up the bucket because of lack of prediction during egg ops

## Technical details
previously it used trigger system for no reason when *everything* used DeleteOnTrigger.
now it just deletes it by default. 
making a spikable c4 is extremely sus, but if you want it to at least not be deleted, set `delete: false` in `SolutionSpiker`

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
SolutionSpikerComponent is now in shared.
SolutionSpikerSystem renamed for consistency and is now in shared.

**Changelog**
egg egg egg egg egg