### PR TITLE
Fix brig timer labels to displaying correctly.

### DIFF
--- a/Content.Server/DeviceLinking/Systems/SignalTimerSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignalTimerSystem.cs
@@ -186,7 +186,7 @@ public sealed class SignalTimerSystem : EntitySystem
         if (appearance != null)
         {
             _appearanceSystem.SetData(uid, TextScreenVisuals.TargetTime, timer.TriggerTime, appearance);
-            _appearanceSystem.SetData(uid, TextScreenVisuals.ScreenText, "", appearance);
+            _appearanceSystem.SetData(uid, TextScreenVisuals.ScreenText, string.Empty, appearance);
         }
 
         _signalSystem.InvokePort(uid, component.StartPort);

--- a/Content.Server/DeviceLinking/Systems/SignalTimerSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignalTimerSystem.cs
@@ -68,7 +68,7 @@ public sealed class SignalTimerSystem : EntitySystem
 
         if (TryComp<AppearanceComponent>(uid, out var appearance))
         {
-            _appearanceSystem.SetData(uid, TextScreenVisuals.ScreenText, new[] { signalTimer.Label }, appearance);
+            _appearanceSystem.SetData(uid, TextScreenVisuals.ScreenText, signalTimer.Label, appearance);
         }
 
         _audio.PlayPvs(signalTimer.DoneSound, uid);
@@ -142,7 +142,7 @@ public sealed class SignalTimerSystem : EntitySystem
         component.Label = args.Text[..Math.Min(5, args.Text.Length)];
 
         if (!HasComp<ActiveSignalTimerComponent>(uid))
-            _appearanceSystem.SetData(uid, TextScreenVisuals.ScreenText, new string?[] { component.Label });
+            _appearanceSystem.SetData(uid, TextScreenVisuals.ScreenText, component.Label);
     }
 
     /// <summary>
@@ -186,7 +186,7 @@ public sealed class SignalTimerSystem : EntitySystem
         if (appearance != null)
         {
             _appearanceSystem.SetData(uid, TextScreenVisuals.TargetTime, timer.TriggerTime, appearance);
-            _appearanceSystem.SetData(uid, TextScreenVisuals.ScreenText, new string?[] { }, appearance);
+            _appearanceSystem.SetData(uid, TextScreenVisuals.ScreenText, "", appearance);
         }
 
         _signalSystem.InvokePort(uid, component.StartPort);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Only partially resolves #25024 since stopping the timer is still not functional. 

This PR fixes brig timers displaying labels improperly.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Talking to the original PR author of #19471 it seems they hadn't fully applied a refactor. This led to C.C.TextScreenSystem which handles displaying the timer expecting a string from the label key while the C.S.SignalTimerSystem set the key to the type of string?[].

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Brig timers display their label properly again.