### PR TITLE
Add guidebook page for the RTG

### DIFF
--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -13,6 +13,7 @@ guide-entry-portable-generator = Portable Generators
 guide-entry-ame = Antimatter Engine (AME)
 guide-entry-singularity = Singularity
 guide-entry-teg = Thermo-electric Generator (TEG)
+guide-entry-rtg = RTG
 guide-entry-controls = Controls
 guide-entry-radio = Radio
 guide-entry-jobs = Jobs

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -247,6 +247,10 @@
     range: 5
     sound:
       path: /Audio/Ambience/Objects/buzzing.ogg
+  - type: GuideHelp
+    guides:
+    - RTG
+    - Power
   - type: Destructible
     thresholds:
       - trigger:

--- a/Resources/Prototypes/Guidebook/engineering.yml
+++ b/Resources/Prototypes/Guidebook/engineering.yml
@@ -65,6 +65,7 @@
   - AME
   - Singularity
   - TEG
+  - RTG
 
 - type: guideEntry
   id: AME
@@ -80,6 +81,11 @@
   id: TEG
   name: guide-entry-teg
   text: "/ServerInfo/Guidebook/Engineering/TEG.xml"
+
+- type: guideEntry
+  id: RTG
+  name: guide-entry-rtg
+  text: "/ServerInfo/Guidebook/Engineering/RTG.xml"
 
 - type: guideEntry
   id: PortableGenerator

--- a/Resources/ServerInfo/Guidebook/Engineering/RTG.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/RTG.xml
@@ -1,0 +1,17 @@
+<Document>
+# Radioisotope Thermoelectric Generator (RTG)
+
+<Box>
+  <GuideEntityEmbed Entity="GeneratorRTG" Caption="RTG" />
+  <GuideEntityEmbed Entity="GeneratorRTGDamaged" Caption="Damaged RTG" />
+</Box>
+
+Making power using a Radioisotope Thermoelectric Generator (RTG) is similar to making power using solar.
+RTGs only provide 10 kW of power, but they provide it for free and for the entire round.
+Basically, if you connect an RTG to your power grid, it'll give you free power.
+
+Sometimes, RTGs are damaged.
+Damaged RTGs behave just like regular ones, but they're radioactive.
+That means they're more dangerous, but on the bright side, you can put radiation collectors next to them to turn that radiation into more power.
+
+</Document>


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
I added a guidebook page for the Radioisotope Thermoelectric Generator (RTG) and added a link to the page to the Examine text of RTGs.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The RTG is a power source that players may encounter in the game. It would be helpful for them to have information about it when they do.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This is just a simple change to the guidebook adding a new page to the engineering section.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

The new guidebook page:
![rtg_guidebook_page](https://github.com/space-wizards/space-station-14/assets/67563877/08016577-7780-4bcf-985a-9e65a13cd0cf)

The help text of the RTG now:
![rtg_help_text_screenshot](https://github.com/space-wizards/space-station-14/assets/67563877/1159cc4e-d705-49d1-8e66-ac399a8dd7da)


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
This pull request introduces no breaking changes.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: The guidebook now contains a page for the Radioisotope Thermoelectric Generator (RTG).