### PR TITLE
Ectoplasm is grindable into Necrosol

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -140,9 +140,9 @@
           maxVol: 50
           reagents:
             - ReagentId: Ash
-              Quantity: 5
-            - ReagentId: SpaceLube
-              Quantity: 5
+              Quantity: 25
+            - ReagentId: Necrosol
+              Quantity: 25
     - type: GuideHelp
       guides:
       - MinorAntagonists


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Ectoplasm was basically useless. When you killed the revenant, no rewards. Sure maybe you can make a revenant plushie but i doubt you'd get a normal ghost plushie in the first place with how rare it is. Dragons give ichor and carps for carp fillets, loneops give syndicate gear, ninjas give a cool sword (sometimes). Considering necrosol is a "deathly" medicine and very hard to get, i feel like 25 units is fair considering revenants are considerably rare. Afterall, a competent botany can create a large amount of omnizine with ease.

**Changelog**

:cl: Ubaser
- tweak: Grinding ectoplasm now gives Necrosol.
