### PR TITLE
Remove tail wag emote text

### DIFF
--- a/Content.Server/Wagging/WaggingSystem.cs
+++ b/Content.Server/Wagging/WaggingSystem.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Server.Actions;
-using Content.Server.Chat.Systems;
 using Content.Server.Humanoid;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
@@ -16,7 +15,6 @@ namespace Content.Server.Wagging;
 public sealed class WaggingSystem : EntitySystem
 {
     [Dependency] private readonly ActionsSystem _actions = default!;
-    [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearance = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
@@ -101,9 +99,6 @@ public sealed class WaggingSystem : EntitySystem
             _humanoidAppearance.SetMarkingId(uid, MarkingCategories.Tail, idx, newMarkingId,
                 humanoid: humanoid);
         }
-
-        var emoteText = Loc.GetString(wagging.Wagging ? "wagging-emote-start" : "wagging-emote-stop", ("ent", uid));
-        _chat.TrySendInGameICMessage(uid, emoteText, InGameICChatType.Emote, ChatTransmitRange.Normal); // Ok while emotes dont have radial menu
 
         return true;
     }

--- a/Resources/Locale/en-US/actions/actions/wagging.ftl
+++ b/Resources/Locale/en-US/actions/actions/wagging.ftl
@@ -1,5 +1,2 @@
 action-name-toggle-wagging = Wagging Tail
 action-description-toggle-wagging = Start or stop wagging tail.
-
-wagging-emote-start = starts wagging {POSS-ADJ($ent)} tail.
-wagging-emote-stop = stops wagging {POSS-ADJ($ent)} tail.


### PR DESCRIPTION
## About the PR

Removes the emote text associated with starting and stopping the tail wag emote.

The action itself is unaffected.


## Why / Balance

#24091
https://discord.com/channels/310555209753690112/1204847785128501359


## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
