### PR TITLE
allow building atmos devices on lattice or thindow tiles

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -475,7 +475,6 @@
   - sprite: Structures/Piping/Atmospherics/vent.rsi
     state: vent_off
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -497,7 +496,6 @@
   - sprite: Structures/Piping/Atmospherics/vent.rsi
     state: vent_off
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -519,7 +517,6 @@
   - sprite: Structures/Piping/Atmospherics/scrubber.rsi
     state: scrub_off
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -541,7 +538,6 @@
   - sprite: Structures/Piping/Atmospherics/outletinjector.rsi
     state: injector
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 # ATMOS BINARY
@@ -564,7 +560,6 @@
   - sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpPressure
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -586,7 +581,6 @@
   - sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpVolume
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -608,7 +602,6 @@
   - sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpPassiveGate
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -630,7 +623,6 @@
   - sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpManualValve
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -652,7 +644,6 @@
   - sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpSignalValve
   conditions:
-  - !type:TileNotBlocked {}
   - !type:NoUnstackableInTile
 
 - type: construction
@@ -674,7 +665,6 @@
   - sprite: Structures/Piping/Atmospherics/gascanisterport.rsi
     state: gasCanisterPort
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -695,8 +685,6 @@
     state: pipeStraight
   - sprite: Structures/Piping/Atmospherics/vent.rsi
     state: vent_off
-  conditions:
-    - !type:TileNotBlocked {}
 
 - type: construction
   id: HeatExchanger
@@ -711,8 +699,6 @@
   icon:
     sprite: Structures/Piping/Atmospherics/heatexchanger.rsi
     state: heStraight
-  conditions:
-    - !type:TileNotBlocked {}
 
 # ATMOS TRINARY
 - type: construction
@@ -730,7 +716,6 @@
     state: gasFilter
   mirror: GasFilterFlipped
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -749,7 +734,6 @@
     state: gasFilterF
   mirror: GasFilter
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -767,7 +751,6 @@
     state: gasMixer
   mirror: GasMixerFlipped
   conditions:
-    - !type:TileNotBlocked {}
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -786,7 +769,6 @@
     state: gasMixerF
   mirror: GasMixer
   conditions:
-    - !type:TileNotBlocked
     - !type:NoUnstackableInTile
 
 - type: construction
@@ -803,7 +785,6 @@
     sprite: Structures/Piping/Atmospherics/pneumaticvalve.rsi
     state: off
   conditions:
-    - !type:TileNotBlocked
     - !type:NoUnstackableInTile
 
 # INTERCOM


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
loosens placement restrictions on all atmos devices, allowing players to build them on lattice and below thindows without having a headache
note that this is partially a fix, as you're supposed to be able to build radiators on lattice to make use of all their functionality

## Why / Balance
currently building atmos devices behaves weirdly:
1) radiators have differing functionality on plating and on lattice, but you can't build them on lattice and have to hope the game registers the plating under them as atmos-less (it sometimes just does not so you can't use the radiator as a space-radiator)
2) you can build an atmos device and then build a thindow on top of it, but not build a thindow and then an atmos device below it, which is often frustrating and needlessly annoying
3) you can build pipes but not atmos devices on lattice

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
not tested, trust
should behave like pipe building

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Atmos devices can now be built behind directional windows and on lattice.