### PR TITLE
Add boundary check to chat sanitizer

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Content.Shared.CCVar;
@@ -94,7 +95,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
 
         foreach (var (smiley, replacement) in SmileyToEmote)
         {
-            if (input.EndsWith(smiley, true, CultureInfo.InvariantCulture) && (input.EndsWith(" "+smiley, true, CultureInfo.InvariantCulture) || input.Equals(smiley, CultureInfo.InvariantCultureIgnoreCase)))
+            if (input.EndsWith(smiley, true, CultureInfo.InvariantCulture) && (input.EndsWith(" "+smiley, true, CultureInfo.InvariantCulture) || input.Equals(smiley, StringComparison.InvariantCultureIgnoreCase)))
             {
                 sanitized = input.Remove(input.Length - smiley.Length).TrimEnd();
                 emote = Loc.GetString(replacement, ("ent", speaker));

--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -63,8 +63,6 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { "lmao.", "chatsan-laughs" },
         { "lol", "chatsan-laughs" },
         { "lol.", "chatsan-laughs" },
-        { "lel", "chatsan-laughs" },
-        { "lel.", "chatsan-laughs" },
         { "kek", "chatsan-laughs" },
         { "kek.", "chatsan-laughs" },
         { "rofl", "chatsan-laughs" },

--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -63,6 +63,8 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { "lmao.", "chatsan-laughs" },
         { "lol", "chatsan-laughs" },
         { "lol.", "chatsan-laughs" },
+        { "lel", "chatsan-laughs" },
+        { "lel.", "chatsan-laughs" },
         { "kek", "chatsan-laughs" },
         { "kek.", "chatsan-laughs" },
         { "rofl", "chatsan-laughs" },
@@ -92,7 +94,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
 
         foreach (var (smiley, replacement) in SmileyToEmote)
         {
-            if (input.EndsWith(smiley, true, CultureInfo.InvariantCulture))
+            if (input.EndsWith(smiley, true, CultureInfo.InvariantCulture) && (input.EndsWith(" "+smiley, true, CultureInfo.InvariantCulture) || input.Equals(smiley, CultureInfo.InvariantCultureIgnoreCase)))
             {
                 sanitized = input.Remove(input.Length - smiley.Length).TrimEnd();
                 emote = Loc.GetString(replacement, ("ent", speaker));


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds a check for a space or full equality to smiley checking.

## Why / Balance
I suspect there have been many cases of people ending a sentence in "parallel" or "1:3" and emoting where they didn't intend.

## Technical details
Until regex happens, we add another check for a space before the smiley. It may also be the case that there is no possible way a space can fit (i.e. string beginning), so also check for equality.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/21104932/45956be6-0480-4064-a776-ed66d67c349e)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl: router
- fix: Quick-emoting in chat messages now check for word boundaries, finally allowing players to say "parallel".
