### PR TITLE
Paper is now bad food

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -61,6 +61,7 @@
     solution: food
     delay: 7
     forceFeedDelay: 7
+  - type: BadFood
   - type: SolutionContainerManager
     solutions:
       food:


### PR DESCRIPTION
## About the PR
Adds BadFood component to the paper to stop NPC critters and all other animals from eating it.

## Why / Balance
Mouse eat my drawing :(

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
there is no cl, only Zuul.