### PR TITLE
Significantly nerf Deathnettles

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -174,20 +174,20 @@
   - type: MeleeWeapon
     damage:
       types:
-        Heat: 5.5
-        Caustic: 5.5
+        Heat: 8.5
+        Caustic: 8.5
   - type: SolutionContainerManager
     solutions:
       food:
         reagents:
         - ReagentId: SulfuricAcid
-          Quantity: 5
+          Quantity: 3
         - ReagentId: FluorosulfuricAcid
-          Quantity: 5
+          Quantity: 3
   - type: Produce
     seedId: deathNettle
   - type: MeleeChemicalInjector
-    transferAmount: 3
+    transferAmount: 2
     solution: food
   - type: Extractable
     grindableSolutionName: food

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -174,20 +174,20 @@
   - type: MeleeWeapon
     damage:
       types:
-        Heat: 4.5
-        Caustic: 4.5
+        Heat: 5.5
+        Caustic: 5.5
   - type: SolutionContainerManager
     solutions:
       food:
         reagents:
         - ReagentId: SulfuricAcid
-          Quantity: 9
+          Quantity: 5
         - ReagentId: FluorosulfuricAcid
-          Quantity: 9
+          Quantity: 5
   - type: Produce
     seedId: deathNettle
   - type: MeleeChemicalInjector
-    transferAmount: 2
+    transferAmount: 3
     solution: food
   - type: Extractable
     grindableSolutionName: food

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -174,22 +174,21 @@
   - type: MeleeWeapon
     damage:
       types:
-        Heat: 7.5
-        Caustic: 7.5
+        Heat: 4.5
+        Caustic: 4.5
   - type: SolutionContainerManager
     solutions:
       food:
         reagents:
         - ReagentId: SulfuricAcid
-          Quantity: 15
+          Quantity: 9
         - ReagentId: FluorosulfuricAcid
-          Quantity: 15
+          Quantity: 9
   - type: Produce
     seedId: deathNettle
   - type: MeleeChemicalInjector
-    transferAmount: 6
+    transferAmount: 2
     solution: food
-    pierceArmor: true # We do a little trolling
   - type: Extractable
     grindableSolutionName: food
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Deathnettles have had their ability to pierce armor be stripped and their damage values brought down alongside how much acid they can hold and how much it injects per hit

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Deathnettles have proved problematic for any who have had the unfortunate experience of facing them, botanists shouldn't have the power to kill nukies currently, not until they have the proper ways of getting rid of caustic damage and healing, there's also the issue of people trying to powergame nettles constantly. Botanists shouldn't just take down juggernauts and other antags like it's no issue, we have guns, we should be using them (A reminder I am aware of the desire to have nettles require gloves, this is a temporary patch until someone can code a proper system for that)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
--> :cl:
- tweak: Deathnettles are no longer able to bypass armor and don't do as much damage

