### PR TITLE
Epinephrine buff

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -312,9 +312,8 @@
       effects:
       - !type:HealthChange
         conditions:
-          # they gotta be in crit first
-        - !type:MobStateCondition
-          mobstate: Critical
+        - !type:TotalDamage
+          min: 90
         - !type:ReagentThreshold
           min: 0
           max: 20
@@ -323,8 +322,8 @@
             Asphyxiation: -3
             Poison: -0.5
           groups:
-            Brute: -0.5
-            Burn: -0.5
+            Brute: -0.1
+            Burn: -0.1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -351,6 +350,12 @@
           min: 1
         reagent: Histamine
         amount: 4
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:TotalDamage
+          min: 90
+        key: PressureImmunity
+        component: PressureImmunity
       - !type:GenericStatusEffect
         key: Stun
         time: 0.75

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -322,8 +322,8 @@
             Asphyxiation: -3
             Poison: -0.5
           groups:
-            Brute: -0.1
-            Burn: -0.1
+            Brute: -1
+            Burn: -1
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed the working condition of the chem from being in a critical state to having more than 90 damage.
Added pressure immunity while above 90 damage.
Doubled the brute and burn healing from 0.5/u to 1/u(heals only above 90 damage)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There is basically no reason currently to make epinephrine, because it's outclassed by other chemicals that are way easier to make.
This change will give it a niche of allowing you to stay at 90 damage, even in spaced areas, as long as no additional damage of any kind is dealt.

Emergency pens contain 12u of epinephrine, which before this PR healed 6 brute and 6 burn as long as the mob was crit, now one emergency pen heals 12 brute and 12 burn as long as the person is above 90 damage.
One emergency pen will allow someone to walk in a spaced area for 24 seconds(only above 90 damage), but they will be extremely slowed down because of the damage slowdown. So it's not just a reintroduction of the spacepen, which allowed people to pass spaced areas with minimal harm and no slowdown if used before entering the spaced area.
Epinephrine making people pressure immune above 90 damage also makes it so someone in a hardsuit has a bit more time to reach an unspaced area when trying to save someone without a hardsuit.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: Dygon
- tweak: Epinephrine now heals while above 90 damage, has it's brute and burn healing doubled, and makes people above 90 damage pressure immune.