### PR TITLE
Machete buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -101,7 +101,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Slash: 15
+        Slash: 25
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item


### PR DESCRIPTION
## About the PR
Buff the machete gotten from syndicate weapons modules for borgs.

## Why / Balance
Machete is currently very weak and can be replaced with other free mods. It does 15 DPS slash. Shovels from the mining mod do 14 DPS blunt. The time to down unarmored targets is 7 seconds for both weapons and 9 seconds for general armored targets. The proposed change brings the machete to 25 slash damage, so it is no longer equal to the (free) mining mod. The time to down unarmored targets goes from 7 to 4 seconds, time to kill armored goes from 9 to 6. Seeing as how it essentially costs 13TC to be able to use the weapons mod and the fact that you are gambling on the borg being good at combat, this feels fair. This change also makes the machete viable, rather than the only purpose of the weapons mod being to get the advanced laser.

**Changelog**
:cl:
tweak: Buffed Machete

