### PR TITLE
prevent opening debug menus without perms

### DIFF
--- a/Content.Client/UserInterface/Systems/Sandbox/SandboxUIController.cs
+++ b/Content.Client/UserInterface/Systems/Sandbox/SandboxUIController.cs
@@ -30,6 +30,7 @@ public sealed class SandboxUIController : UIController, IOnStateChanged<Gameplay
     [Dependency] private readonly IEyeManager _eye = default!;
     [Dependency] private readonly IInputManager _input = default!;
     [Dependency] private readonly ILightManager _light = default!;
+    [Dependency] private readonly IClientAdminManager _admin = default!;
 
     [UISystemDependency] private readonly DebugPhysicsSystem _debugPhysics = default!;
     [UISystemDependency] private readonly MarkerSystem _marker = default!;
@@ -53,13 +54,28 @@ public sealed class SandboxUIController : UIController, IOnStateChanged<Gameplay
         CheckSandboxVisibility();
 
         _input.SetInputCommand(ContentKeyFunctions.OpenEntitySpawnWindow,
-            InputCmdHandler.FromDelegate(_ => EntitySpawningController.ToggleWindow()));
+            InputCmdHandler.FromDelegate(_ =>
+            {
+                if (!_admin.CanAdminPlace())
+                    return;
+                EntitySpawningController.ToggleWindow();
+            }));
         _input.SetInputCommand(ContentKeyFunctions.OpenSandboxWindow,
             InputCmdHandler.FromDelegate(_ => ToggleWindow()));
         _input.SetInputCommand(ContentKeyFunctions.OpenTileSpawnWindow,
-            InputCmdHandler.FromDelegate(_ => TileSpawningController.ToggleWindow()));
+            InputCmdHandler.FromDelegate(_ =>
+            {
+                if (!_admin.CanAdminPlace())
+                    return;
+                TileSpawningController.ToggleWindow();
+            }));
         _input.SetInputCommand(ContentKeyFunctions.OpenDecalSpawnWindow,
-            InputCmdHandler.FromDelegate(_ => DecalPlacerController.ToggleWindow()));
+            InputCmdHandler.FromDelegate(_ =>
+            {
+                if (!_admin.CanAdminPlace())
+                    return;
+                DecalPlacerController.ToggleWindow();
+            }));
 
         CommandBinds.Builder
             .Bind(ContentKeyFunctions.EditorCopyObject, new PointerInputCmdHandler(Copy))


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
affects tile menu, entity spawn menu, and decal placer.

all 3 of these require the Spawn admin perms in order to use. however, any player can open them up. This isn't inherently bad but it lets players poke through a lot of debug prototypes and assets which isn't really wanted. It's also potentially confusing to be able to open a 'hidden' menu that they are otherwise unable to interact with.

this simply does a rudimentary check for the Spawn permission before allowing opening the windows via keybind.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun