### PR TITLE
Changed door remote to trigger based on vision occlusion rather than …

### DIFF
--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -10,6 +10,7 @@ using Content.Server.Doors.Systems;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Database;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Examine;
 using static Content.Server.Remotes.DoorRemoteComponent;
 
 namespace Content.Server.Remotes
@@ -65,10 +66,9 @@ namespace Content.Server.Remotes
             if (args.Handled
                 || args.Target == null
                 || !TryComp<DoorComponent>(args.Target, out var doorComp) // If it isn't a door we don't use it
-                // The remote can be used anywhere the user can see the door.
-                // This doesn't work that well, but I don't know of an alternative
-                || !_interactionSystem.InRangeUnobstructed(args.User, args.Target.Value,
-                    SharedInteractionSystem.MaxRaycastRange, CollisionGroup.Opaque))
+                // Only able to control doors if they are within your vision and within your max range.
+                // Not affected by mobs or machines anymore.
+                || !ExamineSystemShared.InRangeUnOccluded(args.User, args.Target.Value, SharedInteractionSystem.MaxRaycastRange, null))
             {
                 return;
             }


### PR DESCRIPTION
…opaque collision targeting check. Ian's butt will no longer absorb your 5G signals.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I changed the check for door remotes to be based on vision rather than collision checking opaque objects. Opaque objects included mobs and machines, which didn't make sense in terms of blocking door remote usage.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
In nukie situations when most people use the door remote to try and bolt doors, there are many people in the way. Most people feel like their door remote is broken in this situation, in reality it's just because the door remote was collision checking against the people.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The code originally used InRangeUnobstructed which sends out a raycast and checks for collision. We can't use InRangeObstructed to only check for walls and airlocks because there is no collision mask that only includes these two objects. The two options were choosing between walls and mobs and walls and windows, both were not ideal.

Instead I relied on InRangeUnoccluded from the examine system, which bases interaction based on your vision rather than any kind of object collision. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Video attachment of me testing out the door remote (no collision with mobs, doesn't work when out of view, works only in range)
https://cdn.discordapp.com/attachments/560845886263918612/1205794076784332820/2024-02-10_00-34-14.mp4?ex=65d9aa3e&is=65c7353e&hm=cea091e768c68b1e743691c9fbf733c4d0b2e13170b2a664b08a8cf7dfc8ac5d&

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
There are no breaking changes.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Fix: All door remotes 5G signals are no longer absorbed by mobs, machines, or Ian's cute butt.
