### PR TITLE
Adds atmospherics access to the fire fighting door remote. Feels like…

### DIFF
--- a/Resources/Prototypes/Access/engineering.yml
+++ b/Resources/Prototypes/Access/engineering.yml
@@ -21,3 +21,4 @@
   id: FireFight
   tags:
     - Engineering
+    - Atmospherics


### PR DESCRIPTION
… an oversight for the atmos door remote to not have atmos access.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added atmospherics access to the fire fighting door remote.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Because it feels like an oversight for the door remote that only atmos has access to, to not have access to atmos. Every other door remote is essentially made to mimic the holder's starting access, so it feels fitting for the atmos door remote to have atmos access. Plus, having additional access to distro or freezers is helpful during "firefighting" efforts by non-atmos and adds another target for antags to try and steal.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I added the Atmospherics tag to the engineering.yml access file for the firefighting door remote.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
No breaking changes.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The firefighting door remote now has access to atmos doors.