### PR TITLE
Change crew monitoring console to use GPS coordinates as opposed to c…

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
@@ -1,6 +1,7 @@
 using Content.Client.Pinpointer.UI;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.GameObjects;
 
 namespace Content.Client.Medical.CrewMonitoring;
 
@@ -63,7 +64,9 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
             if (!LocalizedNames.TryGetValue(netEntity, out var name))
                 name = "Unknown";
 
-            var message = name + "\nLocation: [x = " + MathF.Round(blip.Coordinates.X) + ", y = " + MathF.Round(blip.Coordinates.Y) + "]";
+            // Text location of the blip will display GPS coordinates for the purpose of being able to find a person via GPS
+            // Previously it displayed coordinates relative to the center of the station, which had no use.
+            var message = name + "\nLocation: [x = " + MathF.Round(blip.MapCoordinates.X) + ", y = " + MathF.Round(blip.MapCoordinates.Y) + "]";
 
             _trackedEntityLabel.Text = message;
             _trackedEntityPanel.Visible = true;

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -27,6 +27,7 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
     private readonly IEntityManager _entManager;
     private readonly IPrototypeManager _prototypeManager;
     private readonly SpriteSystem _spriteSystem;
+    private readonly SharedTransformSystem _transformSystem;
 
     private NetEntity? _trackedEntity;
     private bool _tryToScrollToListFocus;
@@ -39,6 +40,8 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
         _entManager = IoCManager.Resolve<IEntityManager>();
         _prototypeManager = IoCManager.Resolve<IPrototypeManager>();
         _spriteSystem = _entManager.System<SpriteSystem>();
+        _transformSystem = _entManager.System<SharedTransformSystem>();
+
 
         _blipTexture = _spriteSystem.Frame0(new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/NavMap/beveled_circle.png")));
 
@@ -149,7 +152,7 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
         // Show monitor on nav map
         if (monitorCoords != null && _blipTexture != null)
         {
-            NavMap.TrackedEntities[_entManager.GetNetEntity(monitor)] = new NavMapBlip(monitorCoords.Value, _blipTexture, Color.Cyan, true, false);
+            NavMap.TrackedEntities[_entManager.GetNetEntity(monitor)] = new NavMapBlip(monitorCoords.Value, monitorCoords.Value.ToMap(_entManager, _transformSystem), _blipTexture, Color.Cyan, true, false);
         }
     }
 
@@ -289,6 +292,7 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
                 NavMap.TrackedEntities.TryAdd(sensor.SuitSensorUid,
                     new NavMapBlip
                     (coordinates.Value,
+                    coordinates.Value.ToMap(_entManager, _transformSystem),
                     _blipTexture,
                     (_trackedEntity == null || sensor.SuitSensorUid == _trackedEntity) ? Color.LimeGreen : Color.LimeGreen * Color.DimGray,
                     sensor.SuitSensorUid == _trackedEntity));
@@ -355,6 +359,7 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
             {
                 data = new NavMapBlip
                     (data.Coordinates,
+                    data.Coordinates.ToMap(_entManager, _transformSystem),
                     data.Texture,
                     (currTrackedEntity == null || castSensor.SuitSensorUid == currTrackedEntity) ? Color.LimeGreen : Color.LimeGreen * Color.DimGray,
                     castSensor.SuitSensorUid == currTrackedEntity);

--- a/Content.Client/Pinpointer/UI/NavMapControl.cs
+++ b/Content.Client/Pinpointer/UI/NavMapControl.cs
@@ -642,14 +642,16 @@ public partial class NavMapControl : MapGridControl
 public struct NavMapBlip
 {
     public EntityCoordinates Coordinates;
+    public MapCoordinates MapCoordinates;
     public Texture Texture;
     public Color Color;
     public bool Blinks;
     public bool Selectable;
 
-    public NavMapBlip(EntityCoordinates coordinates, Texture texture, Color color, bool blinks, bool selectable = true)
+    public NavMapBlip(EntityCoordinates coordinates, MapCoordinates mapCoordinates, Texture texture, Color color, bool blinks, bool selectable = true)
     {
         Coordinates = coordinates;
+        MapCoordinates = mapCoordinates;
         Texture = texture;
         Color = color;
         Blinks = blinks;

--- a/Content.Client/Power/PowerMonitoringWindow.xaml.cs
+++ b/Content.Client/Power/PowerMonitoringWindow.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class PowerMonitoringWindow : FancyWindow
     private readonly IEntityManager _entManager;
     private readonly SpriteSystem _spriteSystem;
     private readonly IGameTiming _gameTiming;
+    private readonly SharedTransformSystem _transformSystem;
 
     private const float BlinkFrequency = 1f;
 
@@ -39,6 +40,7 @@ public sealed partial class PowerMonitoringWindow : FancyWindow
         RobustXamlLoader.Load(this);
         _entManager = IoCManager.Resolve<IEntityManager>();
         _gameTiming = IoCManager.Resolve<IGameTiming>();
+        _transformSystem = _entManager.System<SharedTransformSystem>();
 
         _spriteSystem = _entManager.System<SpriteSystem>();
         _owner = owner;
@@ -166,7 +168,7 @@ public sealed partial class PowerMonitoringWindow : FancyWindow
         if (monitorCoords != null && mon != null)
         {
             var texture = _spriteSystem.Frame0(new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/NavMap/beveled_circle.png")));
-            var blip = new NavMapBlip(monitorCoords.Value, texture, Color.Cyan, true, false);
+            var blip = new NavMapBlip(monitorCoords.Value, monitorCoords.Value.ToMap(_entManager, _transformSystem), texture, Color.Cyan, true, false);
             NavMap.TrackedEntities[mon.Value] = blip;
         }
 
@@ -233,7 +235,7 @@ public sealed partial class PowerMonitoringWindow : FancyWindow
         if (_focusEntity != null && usedEntity != _focusEntity && !entitiesOfInterest.Contains(usedEntity.Value))
             modulator = Color.DimGray;
 
-        var blip = new NavMapBlip(coords, _spriteSystem.Frame0(texture), color * modulator, blink);
+        var blip = new NavMapBlip(coords, coords.ToMap(_entManager, _transformSystem), _spriteSystem.Frame0(texture), color * modulator, blink);
         NavMap.TrackedEntities[netEntity] = blip;
     }
 


### PR DESCRIPTION
…enter of station coordinates.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The crew monitoring console will now display the GPS (map) coordinates of people you focus on as opposed to the coordinates relative to the center of the station.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There is nothing else in the game that uses coordinates relative to the center of the station. On the other hand, there are some major things that use GPS (map) coordinates (tracking implants, THE NUCLEAR BOMB LOCATION) for example. There clearly is a preference for GPS (map) coordinates. This change brings the crew monitor computer into line with this preference and also works in tandem with #25096 to allow paramedics to locate people based on GPS coordinates with the removal of the crew monitor.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I added a new field to NavMapBlip called MapCoordinates that uses the MapCoordinate class and added it to the constructor. I added support for MapCoordinates wherever there was usage of the NavMapBlip (3 for the crew monitor, 2 for the power monitor). I didn't change how the NavMapBlip displays itself on the map, I only altered the text that states the location of the blip.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/58439124/a6809016-de67-489f-aa3a-dd3c6512fcb3

I've attached a video displaying how the Crew Monitor Console now correctly displays your coordinates using map coordinates (ex: -38, 101) as opposed to from station center coordinates (ex: 0, 5).

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
No breaking changes that I am aware of.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
Tweak: The crew monitor console now uses the same coordinate system a GPS does. Good luck navigating!

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
