### PR TITLE
ambuzol beef

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -213,7 +213,7 @@
       amount: 1
     Ammonia:
       amount: 1
-    Blood:
+    ZombieBlood:
       amount: 2
   products:
     Ambuzol: 4
@@ -223,11 +223,10 @@
   reactants:
     Ambuzol:
       amount: 5
-    ZombieBlood:
-      amount: 15
+    Omnizine:
+      amount: 5
   products:
-    Blood: 15
-    AmbuzolPlus: 5
+    AmbuzolPlus: 10
 
 - type: reaction
   id: Synaptizine


### PR DESCRIPTION
make ambuzol require zombie blood
make ambuzol blood require omnizine

rn its metagaming to create this and admins are stepping in when people make it preemptively which is stupid so just make it require zombies first and problem solved

🆑 
- tweak: Ambuzol now requires zombie blood