### PR TITLE
Added display for amount of hits left in stun batons/stun prods.

### DIFF
--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -48,6 +48,12 @@ namespace Content.Server.Stunnable.Systems
             ? Loc.GetString("comp-stunbaton-examined-on")
             : Loc.GetString("comp-stunbaton-examined-off");
             args.PushMarkup(onMsg);
+
+            if (TryComp<BatteryComponent>(entity.Owner, out var battery))
+            {
+                var count = (int) (battery.CurrentCharge / entity.Comp.EnergyPerUse);
+                args.PushMarkup(Loc.GetString("melee-battery-examine", ("color", "yellow"), ("count", count)));
+            }
         }
 
         private void ToggleDone(Entity<StunbatonComponent> entity, ref ItemToggledEvent args)

--- a/Resources/Locale/en-US/weapons/melee/melee.ftl
+++ b/Resources/Locale/en-US/weapons/melee/melee.ftl
@@ -1,3 +1,7 @@
 melee-inject-failed-hardsuit = Your {$weapon} cannot inject through hardsuits!
 
 melee-balloon-pop = {CAPITALIZE(THE($balloon))} popped!
+
+
+#BatteryComponent
+melee-battery-examine = It has enough charge for [color={$color}]{$count}[/color] hits.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I added text to the examine description of stun batons and stun prods that lets you know how many hits you have left before it runs out of battery.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
You had no way to know how many hits was left in your stun baton and sometimes ran out in the middle of an arrest. Now you know exactly how many hits you have left, which allows you to determine when you need to charge or not.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I added a locale string for the battery examine which is just the gun battery examine quote but changing it from "shots" to hits. 

The BatterySystem doesn't have a method that lets you figure out how many "charges" something has left unlike the PowerCellSystem's UsesRemaining method. So instead I calculated the count of hits left in the StunBatonSystem file. I'm not exactly sure what the BatterySystem is mainly intended for, so I didn't try to implement a UsesRemaining method in it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/58439124/d890a9b7-281b-4436-bfa2-9a97803b6bba



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None that I'm aware of.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Stun batons and stun prods now display their hits remaining.