### PR TITLE
Hoods and some chaplain's hats now hides hair

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -347,6 +347,9 @@
     sprite: Clothing/Head/Hats/plaguedoctor.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/plaguedoctor.rsi
+  - type: Tag
+    tags:
+    - HidesHair
 
 - type: entity
   parent: ClothingHeadBase
@@ -484,6 +487,9 @@
     sprite: Clothing/Head/Hats/witch.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/witch.rsi
+  - type: Tag
+    tags:
+    - HidesHair
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -94,6 +94,7 @@
     sprite: Clothing/Head/Hoods/chaplain.rsi
   - type: Tag
     tags:
+    - HidesHair
     - HamsterWearable
     - WhitelistChameleon
 
@@ -107,6 +108,10 @@
     sprite: Clothing/Head/Hoods/cult.rsi
   - type: Clothing
     sprite: Clothing/Head/Hoods/cult.rsi
+  - type: Tag
+    tags:
+    - HidesHair
+  
 
 - type: entity
   parent: ClothingHeadBase
@@ -120,6 +125,7 @@
     sprite: Clothing/Head/Hoods/nun.rsi
   - type: Tag
     tags:
+    - HidesHair
     - HamsterWearable
     - WhitelistChameleon
 
@@ -153,6 +159,9 @@
     sprite: Clothing/Head/Hoods/goliathcloak.rsi
   - type: Clothing
     sprite: Clothing/Head/Hoods/goliathcloak.rsi
+  - type: Tag
+    tags:
+    - HidesHair
 
 - type: entity
   parent: ClothingHeadBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Hoods, plague hat, and witch hat now have tag "Hides Hair"

## Why / Balance
Really?
Well... because it is supposed to do so?


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: All hoods have tag "Hides Hair"
- tweak: Plague Doctor's hat and Witch hat (with red hair) have tag "Hides Hair"
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
