### PR TITLE
Restore MonoOverlay

### DIFF
--- a/Resources/Prototypes/Decals/Overlays/grayscale.yml
+++ b/Resources/Prototypes/Decals/Overlays/grayscale.yml
@@ -207,6 +207,14 @@
     state: threequartertile_overlay_270
 
 - type: decal
+  id: MonoOverlay
+  tags: ["station", "overlay"]
+  defaultCustomColor: true
+  sprite:
+    sprite: Decals/Overlays/greyscale.rsi
+    state: mono
+
+- type: decal
   id: CheckerNESW
   tags: ["station", "overlay"]
   defaultCustomColor: true


### PR DESCRIPTION
https://github.com/space-wizards/space-station-14/pull/24949 nuked it.

:cl:
- fix: Fix decal error spam in console due to a missing overlay.