### PR TITLE
Fix decal error spam

### DIFF
--- a/Content.Client/Decals/Overlays/DecalOverlay.cs
+++ b/Content.Client/Decals/Overlays/DecalOverlay.cs
@@ -59,8 +59,14 @@ namespace Content.Client.Decals.Overlays
             {
                 foreach (var decal in decals.Values)
                 {
-                    if (!_cachedTextures.TryGetValue(decal.Id, out var cache) && _prototypeManager.TryIndex<DecalPrototype>(decal.Id, out var decalProto))
+                    if (!_cachedTextures.TryGetValue(decal.Id, out var cache))
                     {
+                        // Nothing to cache someone messed up
+                        if (!_prototypeManager.TryIndex<DecalPrototype>(decal.Id, out var decalProto))
+                        {
+                            continue;
+                        }
+
                         cache = (_sprites.Frame0(decalProto.Sprite), decalProto.SnapCardinals);
                         _cachedTextures[decal.Id] = cache;
                     }


### PR DESCRIPTION
The out variable can be null if the decal ID doesn't exist so this just avoids that scenario.