### PR TITLE
Re-organise main menu screen

### DIFF
--- a/Content.Client/MainMenu/UI/MainMenuControl.xaml
+++ b/Content.Client/MainMenu/UI/MainMenuControl.xaml
@@ -2,44 +2,46 @@
          xmlns:pllax="clr-namespace:Content.Client.Parallax"
          xmlns:clog="clr-namespace:Content.Client.Changelog">
     <pllax:ParallaxControl />
-    <LayoutContainer>
-        <BoxContainer Name="VBox"
-                      Orientation="Vertical"
-                      StyleIdentifier="mainMenuVBox">
-            <TextureRect Name="Logo"
-                         Stretch="KeepCentered" />
-            <BoxContainer Orientation="Horizontal"
-                          SeparationOverride="4">
-                <Label Text="{Loc 'main-menu-username-label'}" />
-                <LineEdit Name="UsernameBox"
-                          Access="Public"
-                          PlaceHolder="{Loc 'main-menu-username-text'}"
-                          HorizontalExpand="True" />
-            </BoxContainer>
+    <BoxContainer Name="VBox"
+                  Orientation="Vertical"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  HorizontalExpand="True"
+                  VerticalExpand="True"
+                  StyleIdentifier="mainMenuVBox"
+                  SeparationOverride="3">
+        <TextureRect Name="Logo"
+                     Stretch="KeepCentered"/>
+        <GridContainer Columns="2">
+            <Label Text="{Loc 'main-menu-username-label'}" />
+            <LineEdit Name="UsernameBox"
+                      Access="Public"
+                      PlaceHolder="{Loc 'main-menu-username-text'}"
+                      HorizontalExpand="True" />
+            <Label Text="{Loc 'main-menu-address-label'}"/>
             <LineEdit Name="AddressBox"
                       Access="Public"
                       Text="localhost"
                       PlaceHolder="server address:port"
                       HorizontalExpand="True" />
-            <Button Name="DirectConnectButton"
-                    Access="Public"
-                    Text="{Loc 'main-menu-direct-connect-button'}"
-                    TextAlign="Center"
-                    StyleIdentifier="mainMenu" />
-            <Control MinSize="0 2" />
-            <Button Name="OptionsButton"
-                    Access="Public"
-                    Text="{Loc 'main-menu-options-button'}"
-                    TextAlign="Center"
-                    StyleIdentifier="mainMenu" />
-            <Button Name="QuitButton"
-                    Access="Public"
-                    Text="{Loc 'main-menu-quit-button'}"
-                    TextAlign="Center"
-                    StyleIdentifier="mainMenu" />
-            <clog:ChangelogButton
-                Name="ChangelogButton"
-                Access="Public"/>
-        </BoxContainer>
-    </LayoutContainer>
+        </GridContainer>
+        <Button Name="DirectConnectButton"
+                Access="Public"
+                Text="{Loc 'main-menu-direct-connect-button'}"
+                TextAlign="Center"
+                StyleIdentifier="mainMenu"/>
+        <Button Name="OptionsButton"
+                Access="Public"
+                Text="{Loc 'main-menu-options-button'}"
+                TextAlign="Center"
+                StyleIdentifier="mainMenu"/>
+        <Button Name="QuitButton"
+                Access="Public"
+                Text="{Loc 'main-menu-quit-button'}"
+                TextAlign="Center"
+                StyleIdentifier="mainMenu"/>
+        <clog:ChangelogButton
+            Name="ChangelogButton"
+            Access="Public"/>
+    </BoxContainer>
 </Control>

--- a/Resources/Locale/en-US/main-menu/main-menu.ftl
+++ b/Resources/Locale/en-US/main-menu/main-menu.ftl
@@ -2,9 +2,10 @@ main-menu-invalid-username-with-reason = Invalid username:
                                          {$invalidReason}
 main-menu-invalid-username = Invalid username
 main-menu-failed-to-connect = Failed to connect:
-                              {$reason} 
+                              {$reason}
 main-menu-username-label = Username:
 main-menu-username-text = Username
+main-menu-address-label = Server Address:
 main-menu-join-public-server-button = Join Public Server
 main-menu-join-public-server-button-tooltip = Cannot connect to public server with a debug build.
 main-menu-direct-connect-button = Direct Connect


### PR DESCRIPTION
- The dummy control of 2px size between direct connect and options has annoyed me for almost 5 years.
- Why is it in the top-right.
- Why is the server address not labelled.

![image](https://github.com/space-wizards/space-station-14/assets/31366439/e3b97bb2-0ba4-4cd7-9072-c9fa9b9f1615)
