### PR TITLE
Clarify stripping logs

### DIFF
--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -238,7 +238,15 @@ namespace Content.Server.Strip
                 _popup.PopupEntity(message, target, target, PopupType.Large);
             }
 
-            _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):user} is trying to place the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s {slot} slot");
+            if (ev.Stealth)
+            {
+                _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):actor} is trying to stealthily place the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s {slot} slot");
+            }
+            else
+            {
+
+                _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):actor} is trying to place the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s {slot} slot");
+            }
 
             var result = await _doAfter.WaitDoAfter(doAfterArgs);
             if (result != DoAfterStatus.Finished)
@@ -250,7 +258,7 @@ namespace Content.Server.Strip
             {
                 _inventorySystem.TryEquip(user, target, held, slot);
 
-                _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):user} has placed the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s {slot} slot");
+                _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has placed the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s {slot} slot");
             }
         }
 
@@ -305,14 +313,21 @@ namespace Content.Server.Strip
                 DuplicateCondition = DuplicateConditions.SameTool
             };
 
-            _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):user} is trying to place the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s hands");
+            if (ev.Stealth)
+            {
+                _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):actor} is trying to stealthily place the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s hands");
+            }
+            else
+            {
+                _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):actor} is trying to place the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s hands");
+            }
 
             var result = await _doAfter.WaitDoAfter(doAfterArgs);
             if (result != DoAfterStatus.Finished) return;
 
             _handsSystem.TryDrop(user, checkActionBlocker: false, handsComp: userHands);
             _handsSystem.TryPickup(target, held, handName, checkActionBlocker: false, animateUser: !ev.Stealth, animate: !ev.Stealth, handsComp: hands);
-            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):user} has placed the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s hands");
+            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has placed the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s hands");
             // hand update will trigger strippable update
         }
 
@@ -381,7 +396,15 @@ namespace Content.Server.Strip
                 }
             }
 
-            _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):user} is trying to strip the item {ToPrettyString(item):item} from {ToPrettyString(target):target}");
+            if (ev.Stealth)
+            {
+                _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):actor} is trying to stealthily strip the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s {slot} slot");
+            }
+            else
+            {
+
+                _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):actor} is trying to strip the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s {slot} slot");
+            }
 
             var result = await _doAfter.WaitDoAfter(doAfterArgs);
             if (result != DoAfterStatus.Finished)
@@ -394,7 +417,7 @@ namespace Content.Server.Strip
             RaiseLocalEvent(item, new DroppedEvent(user), true);
 
             _handsSystem.PickupOrDrop(user, item, animateUser: !ev.Stealth, animate: !ev.Stealth);
-            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):user} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}");
+            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s {slot} slot");
 
         }
 
@@ -453,8 +476,17 @@ namespace Content.Server.Strip
                     strippable.Owner);
             }
 
-            _adminLogger.Add(LogType.Stripping, LogImpact.Low,
-                $"{ToPrettyString(user):user} is trying to strip the item {ToPrettyString(item):item} from {ToPrettyString(target):target}");
+            if (ev.Stealth)
+            {
+                _adminLogger.Add(LogType.Stripping, LogImpact.Low,
+                    $"{ToPrettyString(user):actor} is trying to stealthily strip the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands");
+            }
+            else
+            {
+
+                _adminLogger.Add(LogType.Stripping, LogImpact.Low,
+                    $"{ToPrettyString(user):actor} is trying to strip the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands");
+            }
 
             var result = await _doAfter.WaitDoAfter(doAfterArgs);
             if (result != DoAfterStatus.Finished)
@@ -464,7 +496,7 @@ namespace Content.Server.Strip
             _handsSystem.PickupOrDrop(user, item, animateUser: !ev.Stealth, animate: !ev.Stealth, handsComp: userHands);
             // hand update will trigger strippable update
             _adminLogger.Add(LogType.Stripping, LogImpact.Medium,
-                $"{ToPrettyString(user):user} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}");
+                $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands");
         }
     }
 }

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -244,7 +244,6 @@ namespace Content.Server.Strip
             }
             else
             {
-
                 _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):actor} is trying to place the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s {slot} slot");
             }
 
@@ -402,7 +401,6 @@ namespace Content.Server.Strip
             }
             else
             {
-
                 _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):actor} is trying to strip the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s {slot} slot");
             }
 
@@ -483,7 +481,6 @@ namespace Content.Server.Strip
             }
             else
             {
-
                 _adminLogger.Add(LogType.Stripping, LogImpact.Low,
                     $"{ToPrettyString(user):actor} is trying to strip the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands");
             }


### PR DESCRIPTION
Closes #12383

It should be noted that stripping was already logged, this pr just does some extra stuff too.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This Pr makes it clear from which slot an item is being stripped from/to where it wasn't logged already, and also makes it clear whether this was done stealthily such as with the thieving gloves where no doafter or message is shown to others.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I edited the log messages.

Also changed :user to :actor at the request of CE.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun