### PR TITLE
Med hud for medical cyborgs and med module merge

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -210,6 +210,12 @@
     - Binary
     - Common
     - Science
+  - type: ShowHealthBars
+    damageContainers:
+    - Biological
+  - type: ShowHealthIcons
+    damageContainers:
+    - Biological
   - type: ActiveRadio
     channels:
     - Medical
@@ -319,6 +325,12 @@
           - BorgModuleSyndicate
       hasMindState: synd_medical_e
       noMindState: synd_medical
+    - type: ShowHealthBars
+      damageContainers:
+      - Biological
+    - type: ShowHealthIcons
+      damageContainers:
+      - Biological
     - type: Construction
       node: syndicatemedical
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -374,6 +374,7 @@
     - state: icon-chemist
   - type: ItemBorgModule
     items:
+    - HandheldHealthAnalyzerUnpowered
     - Beaker
     - Beaker
     - BorgDropper

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -138,7 +138,6 @@
   cost: 7500
   recipeUnlocks:
   - BorgModuleAdvancedTreatment
-  - BorgModuleDiagnosis
   - BorgModuleDefibrillator
 
 - type: technology


### PR DESCRIPTION

## About the PR
<!-- What did you change in this PR? -->
I recently saw the new changes to the eng borg modules, thought the med borgs could get some love so here we are.
## Why / Balance
The medical cyborg med modules are a bit of a mess, defib, analysis and treatment are separate modules, I've merged adv. treatment and analysis together because constantly switching between modules feels clunky and annoying.


## Media
med hud in action
![image](https://github.com/space-wizards/space-station-14/assets/156087924/7377fb36-bcdc-4771-afbd-c1129c0409a5)
new advanced medical module
![image](https://github.com/space-wizards/space-station-14/assets/156087924/6775d0fc-316f-4c13-9080-870fec5dd46d)

**Changelog**
Medical cyborgs and their syndicate counterparts now have a medhud
The advanced treatment module has a health analyzer
The analysis module is removed from mechanical treatment research
