### PR TITLE
Dept. Head Dresser + Locker Fixup

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/dressers.yml
@@ -13,6 +13,7 @@
       - id: ClothingUniformJumpskirtCapFormalDress
       - id: ClothingHandsGlovesCaptain
       - id: ClothingNeckMantleCap
+      - id: ClothingOuterWinterCap
 
 - type: entity
   id: DresserChiefEngineerFilled
@@ -26,6 +27,7 @@
       - id: ClothingUniformJumpskirtChiefEngineerTurtle
       - id: ClothingNeckCloakCe
       - id: ClothingHeadHatBeretEngineering
+      - id: ClothingOuterWinterCE
 
 - type: entity
   id: DresserChiefMedicalOfficerFilled
@@ -38,6 +40,8 @@
       - id: ClothingCloakCmo
       - id: ClothingOuterCoatLabCmo
       - id: ClothingHeadHatBeretCmo
+      - id: ClothingEyesGlasses
+      - id: ClothingOuterWinterCMO
 
 - type: entity
   id: DresserHeadOfPersonnelFilled
@@ -50,6 +54,7 @@
       - id: ClothingNeckCloakHop
       - id: ClothingHeadHatHopcap
       - id: ClothingOuterWinterHoP
+      - id: ClothingEyesGlasses
 
 - type: entity
   id: DresserHeadOfSecurityFilled
@@ -66,7 +71,7 @@
       - id: ClothingUniformJumpsuitHoSAlt
       - id: ClothingUniformJumpskirtHosFormal
       - id: ClothingUniformJumpsuitHosFormal
-      - id: ClothingMaskNeckGaiter
+      - id: ClothingOuterWinterHoS
 
 - type: entity
   id: DresserQuarterMasterFilled
@@ -76,13 +81,13 @@
   - type: StorageFill
     contents:
       - id: ClothingNeckCloakQm
-      - id: ClothingHeadsetCargo
       - id: ClothingHeadHatBeretQM
       - id: ClothingUniformJumpsuitQMFormal
       - id: ClothingUniformJumpsuitQMTurtleneck
       - id: ClothingUniformJumpskirtQMTurtleneck
       - id: ClothingHandsGlovesColorBrown
       - id: ClothingNeckMantleQM
+      - id: ClothingOuterWinterQM
 
 - type: entity
   id: DresserResearchDirectorFilled
@@ -95,7 +100,8 @@
       - id: ClothingNeckCloakRd
       - id: ClothingHeadHatBeretRND
       - id: ClothingHandsGlovesColorPurple
-      - id: ClothingHeadsetAltScience
+      - id: ClothingEyesGlasses
+      - id: ClothingOuterWinterRD
 
 - type: entity
   id: DresserWardenFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -183,7 +183,6 @@
       - id: ClothingHeadsetAltMedical
       - id: ClothingCloakCmo
       - id: ClothingBackpackDuffelSurgeryFilled
-      - id: ClothingOuterCoatLabCmo
       - id: ClothingMaskSterile
       - id: ClothingHeadHatBeretCmo
       - id: ClothingOuterHardsuitMedical

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -222,13 +222,13 @@
       - id: ResearchComputerCircuitboard
       - id: ProtolatheMachineCircuitboard
       - id: CircuitImprinterMachineCircuitboard
-      - id: ClothingHeadsetMedicalScience
       - id: ClothingOuterHardsuitRd
       - id: HandTeleporter
       - id: DoorRemoteResearch
       - id: ClothingBeltUtilityFilled
       - id: RubberStampRd
       - id: BoxEncryptionKeyScience
+      - id: ClothingHeadsetAltScience
       - id: EncryptionKeyBinary
 
 - type: entity
@@ -241,12 +241,12 @@
       - id: ResearchComputerCircuitboard
       - id: ProtolatheMachineCircuitboard
       - id: CircuitImprinterMachineCircuitboard
-      - id: ClothingHeadsetMedicalScience
       - id: HandTeleporter
       - id: DoorRemoteResearch
       - id: ClothingBeltUtilityFilled
       - id: RubberStampRd
       - id: BoxEncryptionKeyScience
+      - id: ClothingHeadsetAltScience
       - id: EncryptionKeyBinary
 
 - type: entity
@@ -259,6 +259,7 @@
       - id: ClothingEyesHudSecurity
       - id: WeaponDisabler
       - id: ClothingOuterCoatHoSTrench
+      - id: ClothingMaskNeckGaiter
       - id: ClothingOuterHardsuitSecurityRed
       - id: ClothingMaskGasSwat
       - id: ClothingBeltSecurityFilled
@@ -285,6 +286,7 @@
       - id: ClothingEyesHudSecurity
       - id: WeaponDisabler
       - id: ClothingOuterCoatHoSTrench
+      - id: ClothingMaskNeckGaiter
       - id: ClothingBeltSecurityFilled
       - id: ClothingHeadsetAltSecurity
       - id: ClothingEyesGlassesSunglasses


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Ever notice that your employees as a head of a department get guaranteed access to winter coats, but you don't? Ever notice for some reason the RD has their over ear headset spawn in their dresser and not their locker, and the QM gets an extra cargo headset, not qm headset, in their dresser? Not to worry, this PR is here to fixup all that

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

A command headset for starts, should not be in an unprotected dresser, secondly the heads should have access to their winter coats incase it gets cold and or they want to look cool. I also saw the RD has free medical comms in their locker from the sci-med comms headset ( and they already get the extra channel of silicon! ) so I took that away from them too. I see no reason for the RD to get free med comms when the CMO gets no free research comms and also they shouldn't be double dipping comms anyways. Also the CMO spawns with their lab coat on, and has a spare in their dresser. If the map uses the hardsuit locker, that would spawn a third lab coat! Insanity!

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Added appropriate winter coats to the dressers of all the dept. heads
removed the spare cargo headset from the QM dresser
moved the over-ear headset from the RD dresser to the RD locker
removed the medical-science headset from the RD locker
added glasses to the HoP, CMO and RD dressers (nerds)
removed the CMO lab coat from the CMO locker

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Dept. Heads are now guaranteed to have their respective winter coats in their dressers
- tweak: Standardized the contents of Dept. Heads dressers and lockers

