### PR TITLE
Remove sunglasses from ClothesMate.

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -73,7 +73,6 @@
     ClothingHeadRastaHat: 2
     ClothingBeltStorageWaistbag: 3
     ClothingEyesGlasses: 6
-    ClothingEyesGlassesSunglasses: 2
     ClothingHandsGlovesColorBlack: 4
     ClothingHandsGlovesColorGray: 4
     ClothingHandsGlovesColorBrown: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->


## About the PR
<!-- What did you change in this PR? -->
Removing sunglasses from ClothesMate.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
A feedback from discord server: https://discord.com/channels/310555209753690112/1206896736920936489

As told in discussion, sunglasses got into ClothesMate due of early metagaming from security against head revolutionaires, so there first iteration were like... fake.

So story in short: one of contributors added same sunglasses, with same sprite, with same name, but diffrent description and functionality, one of them is sunglasses with flash immunity, and another doesnt got it.

And after two weeks, one of head devs saw that theres is two same item, that have a lot of similarities in sprite and name, but not in description and functions, so them after terminated fake sunglasses from game. And returned normal sunglasses to barthender and musician... and into clothesmate.

Main reason that they stayed in clothesmate is because to defend head revs from metagaming from security. These main reason is no longer active part of a game, and went into refractoring/else.

Due of discussion that having security items in a public places, and giving a lot of people(that might be evil) flash immunity is very wrong in balance purpose.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:
![image-63](https://github.com/Holinka4ever/space-station-14/assets/138782168/ca2a436d-fa89-42ae-9217-68499e81b714)
After
![image-56](https://github.com/Holinka4ever/space-station-14/assets/138782168/e3a31607-b420-4a66-bf67-ea255e6a7360)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- remove: Sunglasses were removed from ClothesMate