### PR TITLE
Fix exception when opening agent ID chameleon menu

### DIFF
--- a/Content.Client/Clothing/UI/ChameleonMenu.xaml.cs
+++ b/Content.Client/Clothing/UI/ChameleonMenu.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Numerics;
 using Content.Client.Clothing.Systems;
 using Content.Client.Stylesheets;
@@ -69,9 +69,14 @@ public sealed partial class ChameleonMenu : DefaultWindow
                 Group = group,
                 StyleClasses = {StyleBase.ButtonSquare},
                 ToggleMode = true,
-                Pressed = _selectedId == id,
                 ToolTip = proto.Name
             };
+
+            if (_selectedId == id)
+            {
+                button.Pressed = true;
+            }
+
             button.OnPressed += _ => OnIdSelected?.Invoke(id);
             Grid.AddChild(button);
 


### PR DESCRIPTION
Fixes #25219

Setting a grouped button's `Pressed` to `false` throws this exception: https://github.com/space-wizards/RobustToolbox/blob/4a06acda325d4ae8d882b00baf38ee8a4a77fcae/Robust.Client/UserInterface/Controls/BaseButton.cs#L104

This PR makes it only set it to `true` when the chameleon menu button matches the item's current appearance.

This is a regression caused by 89c27416d07f35105842227e3383bf7e9c103ad1. Most likely this engine PR:
https://github.com/space-wizards/RobustToolbox/pull/4841

It's possible that the actual bug is in engine, but this is at least a bandaid fix.