### PR TITLE
add troll conducting gloves to uplink

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -310,6 +310,9 @@ uplink-decoy-disk-desc = A piece of plastic with a lenticular printing, made to 
 uplink-cigarettes-name = Syndicate Smokes Packet
 uplink-cigarettes-desc = Elite cigarettes for elite agents. Infused with medicine for when you need to do more than calm your nerves.
 
+uplink-clothing-conducting-gloves-name = Conducting Gloves
+uplink-clothing-conducting-gloves-desc = Looks exactly like insulated gloves, but shocks you far worse than if you had nothing at all! Best given as a gift to passengers you really don't like.
+
 uplink-snack-box-name = Syndicate Snack Box
 uplink-snack-box-desc = A box of delicious snacks and drinks to eat alone or with your team. Includes 1 toy you didn't want.
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1317,6 +1317,16 @@
   - UplinkMisc
 
 - type: listing
+  id: UplinkClothingConductingGloves
+  name: uplink-clothing-conducting-gloves-name
+  description: uplink-clothing-conducting-gloves-desc
+  productEntity: ClothingHandsGlovesConducting
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkMisc
+
+- type: listing
   id: UplinkSnackBox
   name: uplink-snack-box-name
   description: uplink-snack-box-desc

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -191,3 +191,11 @@
       - 1.5
       - 1.5
       - 1.5
+
+- type: entity
+  parent: ClothingHandsGlovesColorYellow
+  id: ClothingHandsGlovesConducting
+  suffix: Conducting
+  components:
+  - type: Insulated
+    coefficient: 5 # zap em good


### PR DESCRIPTION
## About the PR
they look like insuls but are 5x worse than bare hands

cutting a wire on a door will do 75 shock damage
cutting an smes wire on dev will almost instakill

## Why / Balance
funny item for engis to give to tiders asking for gloves
put them in maints closets to troll powergamers
etc

could be mapped too with a random spawner :trollface:

## Technical details
no

## Media
![145048](https://github.com/space-wizards/space-station-14/assets/39013340/28f06131-86fa-4112-88e5-0a3764fea4fc)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Added Conducting Gloves to the uplink, they make shocks much worse rather than stop them.