### PR TITLE
Fix death acidifier item deletion

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -283,6 +283,15 @@ public partial class SharedBodySystem
         SoundSpecifier? gibSoundOverride = null
         )
     {
+        if (deleteItems)
+        {
+            var items = _inventory.GetHandOrInventoryEntities(bodyId);
+            foreach (var item in items)
+            {
+                QueueDel(item);
+            }
+        }
+
         var gibs = new HashSet<EntityUid>();
 
         if (!Resolve(bodyId, ref body, false))


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
resolves #25213 
Death acidifiers now again delete everything the person that died was wearing.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It's what it's supposed to do.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
GibBody now again makes use of the deleteItem parameter.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- fix: Death acidifiers will now again delete everything the person injected with was wearing when triggered.

