### PR TITLE
Fix disposals bins not automatically flushing after an object is inserted

### DIFF
--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -198,7 +198,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         if (args.Handled || args.Cancelled || args.Args.Target == null || args.Args.Used == null)
             return;
 
-        AfterInsert(uid, component, args.Args.Target.Value, args.Args.User);
+        AfterInsert(uid, component, args.Args.Target.Value, args.Args.User, doInsert: true);
 
         args.Handled = true;
     }
@@ -512,7 +512,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
 
         if (delay <= 0 || userId == null)
         {
-            AfterInsert(unitId, unit, toInsertId, userId);
+            AfterInsert(unitId, unit, toInsertId, userId, doInsert: true);
             return true;
         }
 
@@ -796,11 +796,11 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         Dirty(component);
     }
 
-    public void AfterInsert(EntityUid uid, SharedDisposalUnitComponent component, EntityUid inserted, EntityUid? user = null)
+    public void AfterInsert(EntityUid uid, SharedDisposalUnitComponent component, EntityUid inserted, EntityUid? user = null, bool doInsert = false)
     {
         _audioSystem.PlayPvs(component.InsertSound, uid);
 
-        if (!_containerSystem.Insert(inserted, component.Container))
+        if (doInsert && !_containerSystem.Insert(inserted, component.Container))
             return;
 
         if (user != inserted && user != null)


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
Bug.

## Technical details
Because of Spaghetti Code:tm:, AfterInsert() in DisposalUnitSystem still handles insertion itself. Except in all cases except drag/drop insert, the object is already inserted so this check fails and the remaining logic doesn't happen anymore. Fixed now.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- fix: Fixed disposals bins not automatically flushing after an item was inserted.