### PR TITLE
One Rat King per MouseMigration event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -200,7 +200,7 @@
       prob: 0.02
     specialEntries:
     - id: SpawnPointGhostRatKing
-      prob: 0.005
+      prob: 0 # single guaranteed spawn only
 
 - type: entity
   id: CockroachMigration


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Exactly one Rat King ghost role will be spawned per MouseMigration event.

Fixes #25218 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

SpecialEntries for VentCrittersRule were added in #17833. I'm not sure if the intention was to allow multiple Rat Kings. If that's the case, maybe we just need to decrease the probability to keep it from happening as often.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Since SpecialEntries are guaranteed to spawn at least once, then we can set the probability of later spawns to zero if we want exactly one entity spawned.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Only one rat king will spawn per Mouse Migration event
