### PR TITLE
Updated disabler to have suitStorage tag under slots.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -427,6 +427,7 @@
       sprite: Objects/Weapons/Guns/Battery/disabler.rsi
       quickEquip: false
       slots:
+        - suitStorage
         - Belt
     - type: Gun
       fireRate: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Disablers now have the suitStorage tag so they can fit inside the suit storage slot.
Fixes #25202

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
As it currently stands pistols, which have the same shape and size as disablers, can be placed inside the suit storage slot while disablers cannot. This PR fixes this inconsistency.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added suitStorage to the disabler's slots property.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Disablers now fit inside the suit storage slot.
