### PR TITLE
Fixes silver bars being whole stacks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -59,7 +59,7 @@
         reagents:
         - ReagentId: Gold
           Quantity: 10
-          
+
 - type: entity
   parent: IngotGold
   id: IngotGold1
@@ -113,3 +113,5 @@
   components:
   - type: Sprite
     state: silver
+  - type: Stack
+    count: 1


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Single bars of silver were actually whole stacks. This line must have been deleted on accident at some point.

## Technical details
n/a

## Media
n/a

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a
