### PR TITLE
Upgrade trash bag max item size to Normal

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -6,7 +6,7 @@
   components:
   - type: Item
     size: Large
-    shape: 
+    shape:
     - 0,0,2,2
   - type: Storage
     maxItemSize: Small
@@ -263,7 +263,7 @@
   - type: Storage
     grid:
     - 0,0,5,3
-    maxItemSize: Normal
+    maxItemSize: Large
     whitelist:
       tags:
         - TrashBag

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -223,6 +223,7 @@
         - Plunger
       components:
         - LightReplacer
+    maxItemSize: Large
   - type: ItemMapper
     mapLayers:
       bottle:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -9,7 +9,7 @@
       - state: icon-0
         map: ["enum.StorageFillLayers.Fill"]
   - type: Storage
-    maxItemSize: Small
+    maxItemSize: Normal
     grid:
     - 0,0,7,5
     quickInsert: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changes max item size for the trash bag to normal

## Why / Balance
Many items that are trash are normal size, like every brand name bottle of alcohol from the bartenders machine and being able to throw them away without shattering them would be nice QOL