### PR TITLE
Give clown overall and security playtime requirements

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -3,6 +3,10 @@
   name: job-name-clown
   description: job-description-clown
   playTimeTracker: JobClown
+  requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security #Just so you understand what you're doing when you slip an officer chasing someone.
+      time: 36000 # 10 hrs
   startingGear: ClownGear
   icon: "JobIconClown"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -6,7 +6,9 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security #Just so you understand what you're doing when you slip an officer chasing someone.
-      time: 36000 # 10 hrs
+      time: 36000 #10 hrs
+    - !type:OverallPlaytimeRequirement  #Clown is an art form and Saul Doogman with 2 hours playtime has insufficient experience to be funny.
+      time: 108000 #30 hrs
   startingGear: ClownGear
   icon: "JobIconClown"
   supervisors: job-supervisors-hop


### PR DESCRIPTION
## About the PR
Clown now requires 30 hours of overall playtime and 10 hours of security playtime.

## Why / Balance
Too many clowns just slip everyone non-stop and laugh all alone while the entire crew hates them. Most of the time they also cause problems to security and are in general a huge nuisance.
If you're the only one laughing you've failed as a clown, this pr's purpose is to give them some time on the receiving end of unfunny jokes.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
**Changelog**
:cl:
- tweak: Clown now requires security playtime to make them understand how much of a pain slipping everyone nonstop is.
