### PR TITLE
allow happy honk to hold medium sized items

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -474,6 +474,7 @@
     sprite: Objects/Storage/Happyhonk/clown.rsi
     heldPrefix: box
   - type: Storage
+    maxItemSize: Normal
     grid:
     - 0,0,3,3
   - type: Tag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Allows happy honk to hold normal size items. webedit pr

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

I want to put bottles of space cola in my meals again

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Potato1234_x
- tweak: Happy Honk boxes can now hold normal sized items 
