### PR TITLE
Adds purely atmospheric heat exchange to the gas thermomachine component

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
@@ -64,5 +64,11 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// </summary>
         [DataField, ViewVariables(VVAccess.ReadWrite)]
         public float EnergyLeakPercentage;
+
+        /// <summary>
+        /// If true, heat is exclusively exchanged with the local atmosphere instead of the inlet pipe air
+        /// </summary>
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public bool Atmospheric = false;
     }
 }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -55,17 +55,17 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnThermoMachineUpdated(EntityUid uid, GasThermoMachineComponent thermoMachine, ref AtmosDeviceUpdateEvent args)
         {
-            if (!(_power.IsPowered(uid) && TryComp<ApcPowerReceiverComponent>(uid, out var receiver))
-                || !TryComp<NodeContainerComponent>(uid, out var nodeContainer)
-                || !_nodeContainer.TryGetNode(nodeContainer, thermoMachine.InletName, out PipeNode? inlet))
-            {
+            if (!(_power.IsPowered(uid) && TryComp<ApcPowerReceiverComponent>(uid, out var receiver)))
                 return;
-            }
+
+            GetHeatExchangeGasMixture(uid, thermoMachine, out var heatExchangeGasMixture);
+            if (heatExchangeGasMixture == null)
+                return;
 
             float sign = Math.Sign(thermoMachine.Cp); // 1 if heater, -1 if freezer
             float targetTemp = thermoMachine.TargetTemperature;
             float highTemp = targetTemp + sign * thermoMachine.TemperatureTolerance;
-            float temp = inlet.Air.Temperature;
+            float temp = heatExchangeGasMixture.Temperature;
 
             if (sign * temp >= sign * highTemp) // upper bound
                 thermoMachine.HysteresisState = false; // turn off
@@ -74,8 +74,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             if (thermoMachine.HysteresisState)
                 targetTemp = highTemp; // when on, target upper hysteresis bound
-
-            if (!thermoMachine.HysteresisState) // Hysteresis is the same as "Should this be on?"
+            else // Hysteresis is the same as "Should this be on?"
             {
                 // Turn dynamic load back on when power has been adjusted to not cause lights to
                 // blink every time this heater comes on.
@@ -87,7 +86,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             float dQ = thermoMachine.HeatCapacity * thermoMachine.Cp * args.dt;
 
             // Clamps the heat transferred to not overshoot
-            float Cin = _atmosphereSystem.GetHeatCapacity(inlet.Air, true);
+            float Cin = _atmosphereSystem.GetHeatCapacity(heatExchangeGasMixture, true);
             float dT = targetTemp - temp;
             float dQLim = dT * Cin;
             float scale = 1f;
@@ -96,15 +95,43 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 scale = dQLim / dQ; // reduce power consumption
                 thermoMachine.HysteresisState = false; // turn off
             }
-            float dQActual = dQ * scale;
-            float dQLeak = dQActual * thermoMachine.EnergyLeakPercentage;
-            float dQPipe = dQActual - dQLeak;
-            _atmosphereSystem.AddHeat(inlet.Air, dQPipe);
 
-            if (_atmosphereSystem.GetContainingMixture(uid) is { } containingMixture)
-                _atmosphereSystem.AddHeat(containingMixture, dQLeak);
+            float dQActual = dQ * scale;
+            if (thermoMachine.Atmospheric)
+            {
+                _atmosphereSystem.AddHeat(heatExchangeGasMixture, dQActual);
+            }
+            else
+            {
+                float dQLeak = dQActual * thermoMachine.EnergyLeakPercentage;
+                float dQPipe = dQActual - dQLeak;
+                _atmosphereSystem.AddHeat(heatExchangeGasMixture, dQPipe);
+
+                if (dQLeak != 0f && _atmosphereSystem.GetContainingMixture(uid) is { } containingMixture)
+                    _atmosphereSystem.AddHeat(containingMixture, dQLeak);
+            }
 
             receiver.Load = thermoMachine.HeatCapacity;// * scale; // we're not ready for dynamic load yet, see note above
+        }
+
+        /// <summary>
+        /// Returns the gas mixture with which the thermomachine will exchange heat (the local atmosphere if atmospheric or the inlet pipe
+        /// air if not). Returns null if no gas mixture is found.
+        /// </summary>
+        private void GetHeatExchangeGasMixture(EntityUid uid, GasThermoMachineComponent thermoMachine, out GasMixture? heatExchangeGasMixture)
+        {
+            heatExchangeGasMixture = null;
+            if (thermoMachine.Atmospheric)
+            {
+                heatExchangeGasMixture = _atmosphereSystem.GetContainingMixture(uid);
+            }
+            else
+            {
+                if (!TryComp<NodeContainerComponent>(uid, out var nodeContainer)
+                    || !_nodeContainer.TryGetNode(nodeContainer, thermoMachine.InletName, out PipeNode? inlet))
+                    return;
+                heatExchangeGasMixture = inlet.Air;
+            }
         }
 
         private bool IsHeater(GasThermoMachineComponent comp)


### PR DESCRIPTION
To avoid code duplication (space heaters are coming next) and to keep PR atomics, i propose to add a way to make thermomachines purely atmospherics (in that they exchange heat exclusively with the local atmosphere (if any) instead of with a pipe node gas mixture).

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a `boolean` to the thermomachine component that makes it exclusively exchange heat with the local gas mixture instead of the node pipe air.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None, pipe node heat exchange is still working as intended.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

No cl needed
