### PR TITLE
PlayerListControl fixes.

### DIFF
--- a/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml.cs
+++ b/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml.cs
@@ -29,6 +29,8 @@ namespace Content.Client.Administration.UI.CustomControls
         private IEntityManager _entManager;
         private IUserInterfaceManager _uiManager;
 
+        private PlayerInfo? _selectedPlayer;
+
         public PlayerListControl()
         {
             _entManager = IoCManager.Resolve<IEntityManager>();
@@ -54,6 +56,7 @@ namespace Content.Client.Administration.UI.CustomControls
                 return;
 
             OnSelectionChanged?.Invoke(selectedPlayer);
+            _selectedPlayer = selectedPlayer;
 
             // update label text. Only required if there is some override (e.g. unread bwoink count).
             if (OverrideText != null && args.Button.Children.FirstOrDefault()?.Children?.FirstOrDefault() is Label label)
@@ -95,6 +98,8 @@ namespace Content.Client.Administration.UI.CustomControls
                 _sortedPlayerList.Sort((a, b) => Comparison(a, b));
 
             PlayerListContainer.PopulateList(_sortedPlayerList.Select(info => new PlayerListData(info)).ToList());
+            if (_selectedPlayer != null)
+                PlayerListContainer.Select(new PlayerListData(_selectedPlayer));
         }
 
         public void PopulateList(IReadOnlyList<PlayerInfo>? players = null)
@@ -102,6 +107,9 @@ namespace Content.Client.Administration.UI.CustomControls
             players ??= _adminSystem.PlayerList;
 
             _playerList = players.ToList();
+            if (_selectedPlayer != null && !_playerList.Contains(_selectedPlayer))
+                _selectedPlayer = null;
+
             FilterList();
         }
 

--- a/Content.Client/UserInterface/Controls/ListContainer.cs
+++ b/Content.Client/UserInterface/Controls/ListContainer.cs
@@ -18,7 +18,7 @@ public sealed class ListContainer : Control
     public bool Group
     {
         get => _buttonGroup != null;
-        set => _buttonGroup = value ? new ButtonGroup(isNoneSetAllowed: true) : null;
+        set => _buttonGroup = value ? new ButtonGroup() : null;
     }
     public bool Toggle { get; set; }
     public Action<ListData, ListContainerButton>? GenerateItem;

--- a/Content.Client/UserInterface/Controls/ListContainer.cs
+++ b/Content.Client/UserInterface/Controls/ListContainer.cs
@@ -18,7 +18,7 @@ public sealed class ListContainer : Control
     public bool Group
     {
         get => _buttonGroup != null;
-        set => _buttonGroup = value ? new ButtonGroup() : null;
+        set => _buttonGroup = value ? new ButtonGroup(isNoneSetAllowed: true) : null;
     }
     public bool Toggle { get; set; }
     public Action<ListData, ListContainerButton>? GenerateItem;

--- a/Content.Shared/Administration/PlayerInfo.cs
+++ b/Content.Shared/Administration/PlayerInfo.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Administration
 {
     [Serializable, NetSerializable]
-    public record PlayerInfo(
+    public sealed record PlayerInfo(
         string Username,
         string CharacterName,
         string IdentityName,
@@ -20,5 +20,15 @@ namespace Content.Shared.Administration
 
         public string PlaytimeString => _playtimeString ??=
             OverallPlaytime?.ToString("%d':'hh':'mm") ?? Loc.GetString("generic-unknown-title");
+
+        public bool Equals(PlayerInfo? other)
+        {
+            return other?.SessionId == SessionId;
+        }
+
+        public override int GetHashCode()
+        {
+            return SessionId.GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
Fix a button being selected by default always, which then can't be selected properly for real. This affected multiple admin UIs.

This broke due to upstream RT changes but ButtonGroup was always kinda busted so whatever. Uses the new IsNoneSetAllowed to implement everything properly.

Also make sure the selected player STAYS selected when filtering the list and stuff.

Also this PlayerInfo record has been changed to only do equality on the User ID because otherwise it'd need to compare each field individually which would be weird.

Requires https://github.com/space-wizards/RobustToolbox/commit/4677296934def6d9e41fda3698ce81baf3793b5c

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
ADMIN:
- fix: Fixed selection behavior for player lists such as the ban panel or ahelp window.