### PR TITLE
Fix: Holosigns can be stored again

### DIFF
--- a/Content.Server/Holosign/HolosignSystem.cs
+++ b/Content.Server/Holosign/HolosignSystem.cs
@@ -44,7 +44,7 @@ public sealed class HolosignSystem : EntitySystem
 
         if (args.Handled
             || !args.CanReach // prevent placing out of range
-            || TryComp<StorageComponent>(args.Target, out var storageComp) // if it's a storage component like a bag, we ignore usage so it can be stored
+            || HasComp<StorageComponent>(args.Target) // if it's a storage component like a bag, we ignore usage so it can be stored
             || !_powerCell.TryUseCharge(uid, component.ChargeUse) // if no battery or no charge, doesn't work
             )
             return;

--- a/Content.Server/Holosign/HolosignSystem.cs
+++ b/Content.Server/Holosign/HolosignSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Coordinates.Helpers;
 using Content.Server.Power.Components;
 using Content.Server.PowerCell;
 using Content.Shared.Interaction;
+using Content.Shared.Storage;
 
 namespace Content.Server.Holosign;
 
@@ -43,6 +44,7 @@ public sealed class HolosignSystem : EntitySystem
 
         if (args.Handled
             || !args.CanReach // prevent placing out of range
+            || TryComp<StorageComponent>(args.Target, out var storageComp) // if it's a storage component like a bag, we ignore usage so it can be stored
             || !_powerCell.TryUseCharge(uid, component.ChargeUse) // if no battery or no charge, doesn't work
             )
             return;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I added a check for StorageComponents to the Holosign so that it can be placed in bags and coats again. Currently, attempting to use holosigns on your bag or coat will just use the holosign without placing the holosign in your bag.


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Previously the only way that Holosigns worked was an in-hand usage (Z). My PR to make it use the ranged interact system broke the storage of holosigns.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Originally Holosigns only had an in-hand use and didn't deal with the interaction system at all.
My migration to the interact system failed to account for anything it might interact with (who could have guessed it would be important). I was only checking if the click was in range and if the holosign had a battery.

So, now I'm checking whether the item interacted with is a StorageComponent. If it is, the holosign doesn't activate and args.handled remains false so that the holosign can be stored into the component.


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


https://github.com/space-wizards/space-station-14/assets/58439124/a0e440cf-2327-423d-8056-f742ebded2c7



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
NO CL BECAUSE IT'S JUST ME BEING DUMB