### PR TITLE
Reduce eshield hp

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -439,7 +439,7 @@
               acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
-            damage: 150
+            damage: 100
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Reduces the hp of energy shields from 150 to 100

## Why / Balance
Energy shields already provide 95% immunity to a significant portion of security's tools to fight against nukies. Being practically immune to disablers and laser weaponry is already an incredible benefit. The shields don't need to tank an entire 30 round magazine as well. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Reduced energy shield's hp from 150 to 100.


