### PR TITLE
shuttle console thrust limiter slider

### DIFF
--- a/Content.Client/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
+++ b/Content.Client/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
@@ -23,6 +23,7 @@ public sealed class ShuttleConsoleBoundUserInterface : BoundUserInterface
         _window.UndockPressed += OnUndockPressed;
         _window.StartAutodockPressed += OnAutodockPressed;
         _window.StopAutodockPressed += OnStopAutodockPressed;
+        _window.ThrustLimited += OnThrustLimited;
         _window.DestinationPressed += OnDestinationPressed;
         _window.OpenCentered();
         _window.OnClose += OnClose;
@@ -64,6 +65,11 @@ public sealed class ShuttleConsoleBoundUserInterface : BoundUserInterface
     private void OnUndockPressed(NetEntity obj)
     {
         SendMessage(new UndockRequestMessage() { DockEntity = obj });
+    }
+
+    private void OnThrustLimited(float val)
+    {
+        SendMessage(new ThrustLimitedMessage() { ThrustLimit = val });
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
@@ -22,6 +22,13 @@
                               Orientation="Vertical"/>
             </BoxContainer>
             <BoxContainer Orientation="Vertical">
+                <BoxContainer Orientation="Vertical">
+                    <Label Name="ThrustLimiterLabel"/>
+                    <Control MinSize="8 0"/>
+                    <Slider Name="ThrustLimiter" MinValue="0" MaxValue="1" HorizontalExpand="True"/>
+                </BoxContainer>
+            </BoxContainer>
+            <BoxContainer Orientation="Vertical">
                 <controls:StripeBack>
                     <Label Name="HyperspaceLabel" Text="{Loc 'shuttle-console-hyperspace-label'}" HorizontalAlignment="Center"/>
                 </controls:StripeBack>

--- a/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
@@ -14,5 +14,8 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         [DataField("zoom")]
         public Vector2 Zoom = new(1.5f, 1.5f);
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float ThrustLimit = 1f;
     }
 }

--- a/Content.Shared/Shuttles/BUIStates/ShuttleConsoleBoundInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/ShuttleConsoleBoundInterfaceState.cs
@@ -20,11 +20,14 @@ public sealed class ShuttleConsoleBoundInterfaceState : RadarConsoleBoundInterfa
 
     public List<(NetEntity Entity, string Destination, bool Enabled)> Destinations;
 
+    public float ThrustLimit;
+
     public ShuttleConsoleBoundInterfaceState(
         FTLState ftlState,
         TimeSpan ftlTime,
         List<(NetEntity Entity, string Destination, bool Enabled)> destinations,
         float maxRange,
+        float thrustLimit,
         NetCoordinates? coordinates,
         Angle? angle,
         List<DockingInterfaceState> docks) : base(maxRange, coordinates, angle, docks)
@@ -32,5 +35,6 @@ public sealed class ShuttleConsoleBoundInterfaceState : RadarConsoleBoundInterfa
         FTLState = ftlState;
         FTLTime = ftlTime;
         Destinations = destinations;
+        ThrustLimit = thrustLimit;
     }
 }

--- a/Content.Shared/Shuttles/Events/ThrustLimitedMessage.cs
+++ b/Content.Shared/Shuttles/Events/ThrustLimitedMessage.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Shuttles.Events;
+
+/// <summary>
+/// Raised when the client changes the shuttle console's thrust limit.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class ThrustLimitedMessage : BoundUserInterfaceMessage
+{
+    public float ThrustLimit;
+}

--- a/Resources/Locale/en-US/shuttles/console.ftl
+++ b/Resources/Locale/en-US/shuttles/console.ftl
@@ -28,6 +28,8 @@ shuttle-console-dock-label = Docking ports
 shuttle-console-docked = {$index} (Docked)
 shuttle-console-dock-button = Dock {$suffix}
 
+shuttle-console-thrust-limit-label = Thrust limiter: { TOSTRING($limit, "P0") }
+
 shuttle-console-hyperspace-label = FTL destinations
 shuttle-console-hyperspace-none = No destinations found
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
lets people limit a shuttle's thrust on a shuttle console for more precise movement
multiplies both thruster and gyro output by itself

additionally, fixes shuttle slowdown when people are watching the console but not actually piloting

## Why / Balance
QoL

## Technical details
it does TryComp every frame per pilot but it already does TryComp twice so i figured it's fine

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/57039557/4fe150c8-63ad-4ad9-b0c3-98125dcd260d)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Shuttle consoles now have thrust limiters, which allow you to perform more precise movements when needed.
- fix: Shuttles are no longer slowed down when people are on the console but not actually piloting.