### PR TITLE
Adds additional clothing slots to aghost, and updates aghost bag contents

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
@@ -292,7 +292,6 @@
   components:
   - type: StorageFill
     contents:
-    - id: AdminPDA
     - id: GasAnalyzer
     - id: trayScanner
     - id: ForensicScanner

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
@@ -295,4 +295,8 @@
     - id: AdminPDA
     - id: GasAnalyzer
     - id: trayScanner
+    - id: ForensicScanner
+    - id: Omnitool
+    - id: WelderExperimental
+    - id: FoodPieBananaCream
   - type: Unremoveable

--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -9,6 +9,14 @@
       uiWindowPos: 2,1
       strippingWindowPos: 2,4
       displayName: ID
+    - name: id
+      slotTexture: id
+      slotFlags: IDCARD
+      slotGroup: SecondHotbar
+      stripTime: 6
+      uiWindowPos: 2,2
+      strippingWindowPos: 2,3
+      displayName: ID
 
     # For drip reasons.
     - name: head

--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -1,4 +1,4 @@
-﻿- type: inventoryTemplate
+- type: inventoryTemplate
   id: aghost
   slots:
     - name: back
@@ -15,5 +15,24 @@
       slotTexture: head
       slotFlags: HEAD
       uiWindowPos: 0,1
-      strippingWindowPos: 0,0
+      strippingWindowPos: 0,1
       displayName: Head
+    - name: mask
+      slotTexture: mask
+      slotFlags: MASK
+      uiWindowPos: 1,1
+      strippingWindowPos: 1,1
+      displayName: Mask
+    - name: neck
+      slotTexture: neck
+      slotFlags: NECK
+      uiWindowPos: 0,2
+      strippingWindowPos: 0,2
+      displayName: Neck
+    - name: eyes
+      slotTexture: glasses
+      slotFlags: EYES
+      stripTime: 3
+      uiWindowPos: 1,2
+      strippingWindowPos: 1,2
+      displayName: Eyes

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -326,6 +326,7 @@
   id: MobAghostGear
   equipment:
     back: ClothingBackpackSatchelHoldingAdmin
+    id: AdminPDA
 
 #Head Rev Gear
 - type: startingGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds
- Mask, Neck, Eyes, ID slot to aghost inventory proto
- adds Forensics scanner to aghost bag
- adds Omnitool to aghost bag
- adds Experimental welder to aghost bag
- adds a banana cream pie to aghost bag
- Takes the AdminPDA from the bag, and gives it it's own ID slot on the ghost.
<!-- What did you change in this PR? -->

## Why
Ever since we got a hat slot, admemes have tried their damndest to VV additional slots for style reasons, and have not been able to. So this is a mini-bulk update to give further options, along with adding a couple more common tools that are nice to have on hand.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
![image](https://github.com/space-wizards/space-station-14/assets/145869023/358cabb2-8c50-4f6b-b87e-5816b1e51122)
![image](https://github.com/space-wizards/space-station-14/assets/145869023/4e8a0701-62e4-4d98-b104-1768e390f5c5)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Sphiral
ADMIN:
- tweak: Aghosts can now smoke, wear glasses, and cloaks! Also, aghost bag contents now have some more commonly needed tools!