### PR TITLE
Allow t-ray to penetrate carpets and puddles

### DIFF
--- a/Content.Client/SubFloor/SubFloorHideSystem.cs
+++ b/Content.Client/SubFloor/SubFloorHideSystem.cs
@@ -67,12 +67,13 @@ public sealed class SubFloorHideSystem : SharedSubFloorHideSystem
         // allows a t-ray to show wires/pipes above carpets/puddles
         if (scannerRevealed)
         {
-            component.OriginalDrawDepth = args.Sprite.DrawDepth;
+            component.OriginalDrawDepth ??= args.Sprite.DrawDepth;
             args.Sprite.DrawDepth = (int) Shared.DrawDepth.DrawDepth.FloorObjects + 1;
         }
-        else
+        else if (component.OriginalDrawDepth.HasValue)
         {
-            args.Sprite.DrawDepth = component.OriginalDrawDepth;
+            args.Sprite.DrawDepth = component.OriginalDrawDepth.Value;
+            component.OriginalDrawDepth = null;
         }
     }
 

--- a/Content.Client/SubFloor/SubFloorHideSystem.cs
+++ b/Content.Client/SubFloor/SubFloorHideSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.DrawDepth;
 using Content.Shared.SubFloor;
 using Robust.Client.GameObjects;
 
@@ -62,6 +63,17 @@ public sealed class SubFloorHideSystem : SharedSubFloorHideSystem
         }
 
         args.Sprite.Visible = hasVisibleLayer || revealed;
+
+        // allows a t-ray to show wires/pipes above carpets/puddles
+        if (scannerRevealed)
+        {
+            component.OriginalDrawDepth = args.Sprite.DrawDepth;
+            args.Sprite.DrawDepth = (int) Shared.DrawDepth.DrawDepth.FloorObjects + 1;
+        }
+        else
+        {
+            args.Sprite.DrawDepth = component.OriginalDrawDepth;
+        }
     }
 
     private void UpdateAll()

--- a/Content.Shared/SubFloor/SubFloorHideComponent.cs
+++ b/Content.Shared/SubFloor/SubFloorHideComponent.cs
@@ -51,6 +51,6 @@ namespace Content.Shared.SubFloor
         /// e.g. when a t-ray revealed cable is drawn above a carpet.
         /// </summary>
         [DataField]
-        public int OriginalDrawDepth;
+        public int? OriginalDrawDepth;
     }
 }

--- a/Content.Shared/SubFloor/SubFloorHideComponent.cs
+++ b/Content.Shared/SubFloor/SubFloorHideComponent.cs
@@ -45,5 +45,12 @@ namespace Content.Shared.SubFloor
         /// </summary>
         [DataField("visibleLayers")]
         public HashSet<Enum> VisibleLayers = new() { SubfloorLayers.FirstLayer };
+
+        /// <summary>
+        /// This is used for storing the original draw depth of a t-ray revealed entity.
+        /// e.g. when a t-ray revealed cable is drawn above a carpet.
+        /// </summary>
+        [DataField]
+        public int OriginalDrawDepth;
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

T-ray scanners can now penetrate carpets and puddles.

Closes #22970
Closes #24378

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Large carpets and puddles can make it difficult to follow cables/pipes when you're trying to find a cut cable or missing pipe.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The draw depth of the subfloor entities is raised when revealing and then reset upon hiding.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/89101928/93ce6d0e-f168-4ba1-acca-ee045104bed1

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: t-ray scanners can now penetrate carpets and puddles
