### PR TITLE
Add Flammable Touch Reaction for liquid tritium

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -87,6 +87,12 @@
   tileReactions:
   - !type:FlammableTileReaction
     temperatureMultiplier: 2.0
+  reactiveEffects:
+    Flammable:
+      methods: [ Touch ]
+      effects:
+      - !type:FlammableReaction
+        multiplier: 0.8
   metabolisms:
     Poison:
       effects:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Tritium currently does nothing when condensed besides adding a minor amount of radiation if ingested.  Current changes will allow liquid tritium to approach the hazards of gas tritium fires, and allows for more use of the underutilized condenser.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
iquid tritium doing nothing when added to a fire extinguisher is massively disappointing, this change would allow for an actual use for Tritium besides being used occasionally for hotter TEG temperatures or to make Frezon, and enables more cooperation between medbay/science and atmos in the occasion of a large threat.

Balance-wise, Tritium isn't super insignificant to make, and flamethrowers would need to have some ignition chem in addition to the tritium itself, which is fairly difficult for atmosians to acquire on their own. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Added a touch FlammableReaction to Tritium with a multiplier of .8
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
https://github.com/space-wizards/space-station-14/assets/12686577/cfb00535-5e72-4bc2-b6a9-bd08ad4ca945

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Liquid Tritium can now be used as a chem in flamethrowers
