### PR TITLE
Plushies can now have pAIs stuffed into them to make your companion even better!

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -38,6 +38,17 @@
       Cloth: 100
   - type: StaticPrice
     price: 5
+  - type: ItemSlots
+    slots:
+      item:
+        ejectSound:
+          collection: storageRustle
+        insertSound:
+          collection: storageRustle
+        #name: plushie-inserted-pai
+        whitelist:
+          components:
+          - PAI
 
 - type: entity
   parent: BasePlushie


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
I added a slot to plushies which can contain pAIs and only pAIs.

## Why / Balance
I thought it would be really neat.

## Media
![2024-02-15_21-43](https://github.com/space-wizards/space-station-14/assets/62638182/5c0d895c-0681-4180-b433-cc47b3de8e61)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Plushies now have some space inside where you can insert a pAI, for the ultimate companion.

