### PR TITLE
Fix spawning glass shard for each glass sheet in stack

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -31,28 +31,37 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
             var getRandomVector = () => new Vector2(system.Random.NextFloat(-Offset, Offset), system.Random.NextFloat(-Offset, Offset));
 
-            foreach (var (entityId, minMax) in Spawn)
+            var executions = 1;
+            if (system.EntityManager.TryGetComponent<StackComponent>(owner, out var stack))
             {
-                var count = minMax.Min >= minMax.Max
-                    ? minMax.Min
-                    : system.Random.Next(minMax.Min, minMax.Max + 1);
+                executions = stack.Count;
+            }
 
-                if (count == 0) continue;
-
-                if (EntityPrototypeHelpers.HasComponent<StackComponent>(entityId, system.PrototypeManager, system.ComponentFactory))
+            for (var execution = 0; execution < executions; execution++)
+            {
+                foreach (var (entityId, minMax) in Spawn)
                 {
-                    var spawned = system.EntityManager.SpawnEntity(entityId, position.Offset(getRandomVector()));
-                    system.StackSystem.SetCount(spawned, count);
+                    var count = minMax.Min >= minMax.Max
+                        ? minMax.Min
+                        : system.Random.Next(minMax.Min, minMax.Max + 1);
 
-                    TransferForensics(spawned, system, owner);
-                }
-                else
-                {
-                    for (var i = 0; i < count; i++)
+                    if (count == 0) continue;
+
+                    if (EntityPrototypeHelpers.HasComponent<StackComponent>(entityId, system.PrototypeManager, system.ComponentFactory))
                     {
                         var spawned = system.EntityManager.SpawnEntity(entityId, position.Offset(getRandomVector()));
+                        system.StackSystem.SetCount(spawned, count);
 
                         TransferForensics(spawned, system, owner);
+                    }
+                    else
+                    {
+                        for (var i = 0; i < count; i++)
+                        {
+                            var spawned = system.EntityManager.SpawnEntity(entityId, position.Offset(getRandomVector()));
+
+                            TransferForensics(spawned, system, owner);
+                        }
                     }
                 }
             }

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -37,9 +37,9 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                 executions = stack.Count;
             }
 
-            for (var execution = 0; execution < executions; execution++)
+            foreach (var (entityId, minMax) in Spawn)
             {
-                foreach (var (entityId, minMax) in Spawn)
+                for (var execution = 0; execution < executions; execution++)
                 {
                     var count = minMax.Min >= minMax.Max
                         ? minMax.Min


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixed the issue of SpawnEntitiesBehavior not executing multiple times on entities with stack conponent.


## Why / Balance
Stackable entities loose their spawn entity behaviour when there are multiple of them in single stack, which causes in case of https://github.com/space-wizards/space-station-14/issues/25287 to punish players that have not known about it by deleting resources.

## Technical details
Now, `Execute` method loops its spawn code stack size times if the owner entity had `StackComponent`.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Now, `Execute` method loops its spawn code stack size times if the owner entity had `StackComponent`.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- fix: Damaging stacked glass sheets now gives appropriate amount of glass shards
