### PR TITLE
Revert "Require plants to be harvestable before sampling"

### DIFF
--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -262,20 +262,13 @@ public sealed class PlantHolderSystem : EntitySystem
                 return;
             }
 
-            component.Health -= (_random.Next(3, 5) * 10);
-
-            if (!component.Harvest)
-            {
-                _popup.PopupCursor(Loc.GetString("plant-holder-component-early-sample"), args.User);
-                return;
-            }
-
             component.Seed.Unique = false;
             var seed = _botany.SpawnSeedPacket(component.Seed, Transform(args.User).Coordinates, args.User);
             _randomHelper.RandomOffset(seed, 0.25f);
             var displayName = Loc.GetString(component.Seed.DisplayName);
             _popup.PopupCursor(Loc.GetString("plant-holder-component-take-sample-message",
                 ("seedName", displayName)), args.User);
+            component.Health -= (_random.Next(3, 5) * 10);
 
             if (component.Seed != null && component.Seed.CanScream)
             {

--- a/Resources/Locale/en-US/botany/components/plant-holder-component.ftl
+++ b/Resources/Locale/en-US/botany/components/plant-holder-component.ftl
@@ -32,4 +32,3 @@ plant-holder-component-light-improper-warning = The [color=yellow]improper light
 plant-holder-component-heat-improper-warning = The [color=orange]improper temperature level alert[/color] is blinking.
 plant-holder-component-pressure-improper-warning = The [color=lightblue]improper environment pressure alert[/color] is blinking.
 plant-holder-component-gas-missing-warning = The [color=cyan]improper gas environment alert[/color] is blinking.
-plant-holder-component-early-sample = It is not ready to sample, but you cut a bit of the plant anyway.


### PR DESCRIPTION
Reverts space-wizards/space-station-14#24851

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Reverts space-wizards/space-station-14#24851

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Simply put, the change just quite heavily detracts from the overall botany workflow and experience to avoid specific issues with the mutation system.
People both in the original PR and the [Discord discussion](https://discord.com/channels/310555209753690112/1207815132672037035) have expressed concerns about it, so I think it would merit at least further discussion.

I would expect just reverting the change without doing anything else would be considered to increase botany "power level", which seems undesirable, but I would say other means of balancing out its issues merit consideration instead of such relatively drastic changes to the flow of just doing the basics of the job.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
