### PR TITLE
Make metamorphic glasses use last solution's empty sprite

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -212,8 +212,6 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
 
         if (solution.GetPrimaryReagentId() is { } reagent)
             AppearanceSystem.SetData(uid, SolutionContainerVisuals.BaseOverride, reagent.ToString(), appearanceComponent);
-        else
-            AppearanceSystem.SetData(uid, SolutionContainerVisuals.BaseOverride, string.Empty, appearanceComponent);
     }
 
 
@@ -281,8 +279,6 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
 
         if (solution.GetPrimaryReagentId() is { } reagent)
             AppearanceSystem.SetData(uid, SolutionContainerVisuals.BaseOverride, reagent.ToString(), appearanceComponent);
-        else
-            AppearanceSystem.SetData(uid, SolutionContainerVisuals.BaseOverride, string.Empty, appearanceComponent);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
A simple tweak to the behavior of metamorphic glasses, intended to compliment the sprites added by #25319.
When you completely empty a metamorphic glass, instead of reverting to the default empty glass sprite, it will look like an empty version of the glass for the drink it previously contained. It will still revert its label and description to the metamorphic glass; it is only the sprite that keeps the old appearance. Putting a new solution into the glass will of course update the appearance to reflect the new contents.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There are nice empty sprites for all the drinks now, but they never get displayed due to the glass reverting to the default when empty. This keeps the bar looking interesting after people finish their drinks, by having a variety of empty glasses sitting around.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This just stops the solution ID from being blanked when the glass is emptied.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/85356/eb7c59d7-b45e-4e5e-9b4e-07216c53f8df

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
