### PR TITLE
Chemical implants for security and syndicate uplink

### DIFF
--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleBoundUserInterface.cs
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleBoundUserInterface.cs
@@ -40,6 +40,8 @@ public sealed class CriminalRecordsConsoleBoundUserInterface : BoundUserInterfac
         _window.OnDialogConfirmed += (_, reason) =>
             SendMessage(new CriminalRecordChangeStatus(SecurityStatus.Wanted, reason));
         _window.OnHistoryUpdated += UpdateHistory;
+        _window.OnChemicalInjectorActivate += () =>
+            SendMessage(new ActivateChemicalImplant());
         _window.OnHistoryClosed += () => _historyWindow?.Close();
         _window.OnClose += Close;
 

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
@@ -31,6 +31,7 @@
                 </BoxContainer>
                 <RichTextLabel Name="WantedReason" Visible="False"/>
                 <Button Name="HistoryButton" Text="{Loc 'criminal-records-console-crime-history'}"/>
+                <Button Name="ActivateImplantButton" Text="{Loc 'criminal-records-console-activate-implant'}"/>
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml.cs
@@ -1,3 +1,4 @@
+using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration;
@@ -34,6 +35,7 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
     public Action<CriminalRecord, bool, bool>? OnHistoryUpdated;
     public Action? OnHistoryClosed;
     public Action<SecurityStatus, string>? OnDialogConfirmed;
+    public Action? OnChemicalInjectorActivate;
 
     private uint _maxLength;
     private bool _isPopulating;
@@ -112,6 +114,11 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
             if (_selectedRecord is {} record)
                 OnHistoryUpdated?.Invoke(record, _access, true);
         };
+
+        ActivateImplantButton.OnPressed += _ =>
+        {
+            OnChemicalInjectorActivate?.Invoke();
+        };
     }
 
     public void UpdateState(CriminalRecordsConsoleState state)
@@ -159,6 +166,12 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
             PopulateRecordContainer(state.StationRecord, state.CriminalRecord);
             OnHistoryUpdated?.Invoke(state.CriminalRecord, _access, false);
             _selectedRecord = state.CriminalRecord;
+
+            state.CriminalRecord.Implants.TryGetValue(state.StationRecord.Name, out var implant);
+
+            ActivateImplantButton.Disabled = implant == null || !_access;
+
+            ActivateImplantButton.StyleClasses.Add(StyleBase.ButtonCaution);
         }
         else
         {
@@ -190,6 +203,7 @@ public sealed partial class CriminalRecordsConsoleWindow : FancyWindow
         PersonDna.Text = Loc.GetString("general-station-record-console-record-dna", ("dna", stationRecord.DNA ?? na));
 
         StatusOptionButton.SelectId((int) criminalRecord.Status);
+
         if (criminalRecord.Reason is {} reason)
         {
             var message = FormattedMessage.FromMarkup(Loc.GetString("criminal-records-console-wanted-reason"));

--- a/Content.Server/Implants/ChemicalImplantSystem.cs
+++ b/Content.Server/Implants/ChemicalImplantSystem.cs
@@ -1,0 +1,46 @@
+using Content.Server.Station.Systems;
+using Content.Server.StationRecords.Systems;
+using Content.Shared.CriminalRecords;
+using Content.Shared.Implants.Components;
+using Content.Shared.StationRecords;
+using Content.Shared.Tag;
+
+namespace Content.Server.Implants;
+
+public sealed class ChemicalImplantSystem : EntitySystem
+{
+    [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
+
+    [ValidatePrototypeId<TagPrototype>]
+    public const string ChemicalImplantTag = "ChemicalImplant";
+
+    /// <summary>
+    /// Links the implant to the targets criminal record after injection is completed.
+    /// </summary>
+    public void LinkImplant(EntityUid implant, EntityUid implanted, SubdermalImplantComponent component)
+    {
+        if (!_tag.HasTag(implant, ChemicalImplantTag))
+            return;
+
+        if (component.ImplantedEntity is not { } ent)
+            return;
+
+        var name = Name(implanted);
+        var xform = Transform(ent);
+        var station = _station.GetStationInMap(xform.MapID);
+
+        if (station == null || _stationRecords.GetRecordByName(station.Value, name) is not { } id)
+            return;
+
+        if (_stationRecords.TryGetRecord<CriminalRecord>(new StationRecordKey(id, station.Value),
+                out var record))
+        {
+            var implants = new HashSet<NetEntity> { GetNetEntity(implant) };
+
+            if(!record.Implants.TryAdd(name, implants))
+                record.Implants[name].Add(GetNetEntity(implant));
+        }
+    }
+}

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -3,9 +3,6 @@ using Content.Server.Mind;
 using Content.Server.Popups;
 using Content.Server.Roles;
 using Content.Shared.Database;
-using Content.Shared.Implants;
-using Content.Shared.Implants.Components;
-using Content.Shared.Mindshield.Components;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Tag;
 
@@ -19,29 +16,10 @@ public sealed class MindShieldSystem : EntitySystem
     [Dependency] private readonly IAdminLogManager _adminLogManager = default!;
     [Dependency] private readonly RoleSystem _roleSystem = default!;
     [Dependency] private readonly MindSystem _mindSystem = default!;
-    [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
 
     [ValidatePrototypeId<TagPrototype>]
     public const string MindShieldTag = "MindShield";
-
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<SubdermalImplantComponent, ImplantImplantedEvent>(ImplantCheck);
-    }
-
-    /// <summary>
-    /// Checks if the implant was a mindshield or not
-    /// </summary>
-    public void ImplantCheck(EntityUid uid, SubdermalImplantComponent comp, ref ImplantImplantedEvent ev)
-    {
-        if (_tag.HasTag(ev.Implant, MindShieldTag) && ev.Implanted != null)
-        {
-            EnsureComp<MindShieldComponent>(ev.Implanted.Value);
-            MindShieldRemovalCheck(ev.Implanted.Value, ev.Implant);
-        }
-    }
 
     /// <summary>
     /// Checks if the implanted person was a Rev or Head Rev and remove role or destroy mindshield respectively.

--- a/Content.Shared/CriminalRecords/CriminalRecord.cs
+++ b/Content.Shared/CriminalRecords/CriminalRecord.cs
@@ -29,6 +29,12 @@ public sealed record CriminalRecord
     /// </summary>
     [DataField]
     public List<CrimeHistory> History = new();
+
+    /// <summary>
+    /// A dictionary that keeps track of the implants people with a criminal record have.
+    /// </summary>
+    [DataField]
+    public Dictionary<string, HashSet<NetEntity>> Implants = new();
 }
 
 /// <summary>

--- a/Content.Shared/CriminalRecords/CriminalRecordsUi.cs
+++ b/Content.Shared/CriminalRecords/CriminalRecordsUi.cs
@@ -100,3 +100,14 @@ public sealed class CriminalRecordDeleteHistory : BoundUserInterfaceMessage
         Index = index;
     }
 }
+
+/// <summary>
+/// Used to activate a criminal's chemical implant.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class ActivateChemicalImplant : BoundUserInterfaceMessage
+{
+    public ActivateChemicalImplant()
+    {
+    }
+}

--- a/Content.Shared/Explosion/Components/OnTrigger/InjectOnTrigger.cs
+++ b/Content.Shared/Explosion/Components/OnTrigger/InjectOnTrigger.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.Explosion.Components.OnTrigger;
+
+[RegisterComponent]
+public sealed partial class InjectOnTriggerComponent : Component
+{
+}

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -16,7 +16,7 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
-    [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] protected readonly TagSystem Tag = default!;
 
     public const string BaseStorageId = "storagebase";
 
@@ -42,11 +42,11 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
         }
 
         //replace micro bomb with macro bomb
-        if (_container.TryGetContainer(component.ImplantedEntity.Value, ImplanterComponent.ImplantSlotId, out var implantContainer) && _tag.HasTag(uid, "MacroBomb"))
+        if (_container.TryGetContainer(component.ImplantedEntity.Value, ImplanterComponent.ImplantSlotId, out var implantContainer) && Tag.HasTag(uid, "MacroBomb"))
         {
             foreach (var implant in implantContainer.ContainedEntities)
             {
-                if (_tag.HasTag(implant, "MicroBomb"))
+                if (Tag.HasTag(implant, "MicroBomb"))
                 {
                     _container.Remove(implant, implantContainer);
                     QueueDel(implant);

--- a/Resources/Locale/en-US/criminal-records/criminal-records.ftl
+++ b/Resources/Locale/en-US/criminal-records/criminal-records.ftl
@@ -32,6 +32,7 @@ criminal-records-console-detained = {$name} has been detained by {$officer}.
 criminal-records-console-released = {$name} has been released by {$officer}.
 criminal-records-console-not-wanted = {$name} is no longer wanted.
 criminal-records-console-unknown-officer = <unknown officer>
+criminal-records-console-implants-activated = {$name}'s implants have been activated by {$officer}.
 
 ## Filters
 
@@ -43,3 +44,6 @@ criminal-records-dna-filter = DNA
 ## Arrest auto history lines
 criminal-records-console-auto-history = ARRESTED: {$reason}
 criminal-records-console-unspecified-reason = <unspecified reason>
+
+## Implants
+criminal-records-console-activate-implant = Activate Implants

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -182,6 +182,9 @@ uplink-death-acidifier-implant-desc = Completely melts the user and their equipm
 uplink-micro-bomb-implanter-name = Micro Bomb Implanter
 uplink-micro-bomb-implanter-desc = Explode on death or manual activation with this implant. Destroys the body with all equipment.
 
+uplink-emergency-implanter-name = Emergency Implanter
+uplink-emergency-implanter-desc = Injects healing chemicals into the bloodstream when the user's health reaches critical levels.
+
 # Bundles
 uplink-observation-kit-name = Observation Kit
 uplink-observation-kit-desc = Includes surveillance camera monitor board and security hud disguised as sunglasses.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -57,3 +57,13 @@
   cost: 5200
   category: Armory
   group: market
+
+- type: cargoProduct
+  id: ChemicalImplants
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateChemicalImplants
+  cost: 2000
+  category: Armory
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -36,6 +36,19 @@
         amount: 5
 
 - type: entity
+  id: CrateChemicalImplants
+  parent: CrateWeaponSecure
+  name: chemical implants
+  description: Contains 2 lethal and 2 nonlethal chemical implants. These can be activated from any criminal record console to remotely disable previously released prisoners.
+  components:
+  - type: StorageFill
+    contents:
+    - id: LethalChemicalImplanter
+      amount: 2
+    - id: NonLethalChemicalImplanter
+      amount: 2
+
+- type: entity
   parent: CrateWeaponSecure
   id: CrateTrainingBombs
   name: training bombs

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -525,7 +525,7 @@
   description: uplink-binary-translator-key-desc
   icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: rd_label }
   productEntity: EncryptionKeyBinary
-  cost: 
+  cost:
     Telecrystal: 1
 
   categories:
@@ -729,6 +729,21 @@
       blacklist:
         components:
           - SurplusBundle
+
+- type: listing
+  id: UplinkEmergencyChemicalImplanter
+  name: uplink-emergency-implanter-name
+  description: uplink-emergency-implanter-desc
+  productEntity: EmergencyChemicalImplanter
+  cost:
+    Telecrystal: 5
+  categories:
+  - UplinkImplants
+  conditions:
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
 
 # Bundles
 

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -159,7 +159,7 @@
 - type: entity
   id: LethalChemicalImplanter
   name: lethal chemical implanter
-  parent: BaseImplantOnlyImplanterSyndi
+  parent: BaseImplantOnlyImplanter
   components:
   - type: Implanter
     implant: LethalChemicalImplant
@@ -167,7 +167,7 @@
 - type: entity
   id: NonLethalChemicalImplanter
   name: nonlethal chemical implanter
-  parent: BaseImplantOnlyImplanterSyndi
+  parent: BaseImplantOnlyImplanter
   components:
   - type: Implanter
     implant: NonLethalChemicalImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -156,6 +156,22 @@
     - type: Implanter
       implant: TrackingImplant
 
+- type: entity
+  id: LethalChemicalImplanter
+  name: lethal chemical implanter
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+  - type: Implanter
+    implant: LethalChemicalImplant
+
+- type: entity
+  id: NonLethalChemicalImplanter
+  name: nonlethal chemical implanter
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+  - type: Implanter
+    implant: NonLethalChemicalImplant
+
 #Traitor implanters
 
 - type: entity
@@ -205,6 +221,14 @@
   components:
     - type: Implanter
       implant: DnaScramblerImplant
+
+- type: entity
+  id: EmergencyChemicalImplanter
+  name: emergency chemical implanter
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+  - type: Implanter
+    implant: EmergencyChemicalImplant
 
 #Nuclear Operative/Special implanters
 

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -120,7 +120,7 @@
   parent: BaseChemicalImplant
   id: LethalChemicalImplant
   name: lethal chemical implant
-  description: This implant can be remotely triggered to inject the target with a lethal dose of poison.
+  description: This implant can be remotely triggered from a criminal record console to inject the target with a lethal dose of poison.
   noSpawn: true
   components:
   - type: SolutionContainerManager
@@ -142,7 +142,7 @@
   parent: BaseChemicalImplant
   id: NonLethalChemicalImplant
   name: nonlethal chemical implant
-  description: This implant can be remotely triggered to inject the target with a sleeping agent.
+  description: This implant can be remotely triggered from a criminal record console to inject the target with a sleeping agent.
   noSpawn: true
   components:
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -10,6 +10,19 @@
     - SubdermalImplant
     - HideContextMenu
 
+- type: entity
+  parent: BaseSubdermalImplant
+  id: BaseChemicalImplant
+  components:
+  - type: SubdermalImplant
+    whitelist:
+      components:
+      - Bloodstream # the target needs a bloodstream to inject the chemicals into
+  - type: InjectOnTrigger
+  - type: EmitSoundOnTrigger
+    sound:
+      path: "/Audio/Items/hypospray.ogg"
+
 #Fun implants
 
 - type: entity
@@ -103,6 +116,48 @@
     - type: Rattle
       radioChannel: "Security"
 
+- type: entity
+  parent: BaseChemicalImplant
+  id: LethalChemicalImplant
+  name: lethal chemical implant
+  description: This implant can be remotely triggered to inject the target with a lethal dose of poison.
+  noSpawn: true
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      implant:
+        maxVol: 50
+        reagents:
+        - ReagentId: Lexorin
+          Quantity: 25
+        - ReagentId: Nocturine
+          Quantity: 25
+  - type: Tag
+    tags:
+    - SubdermalImplant
+    - HideContextMenu
+    - ChemicalImplant
+
+- type: entity
+  parent: BaseChemicalImplant
+  id: NonLethalChemicalImplant
+  name: nonlethal chemical implant
+  description: This implant can be remotely triggered to inject the target with a sleeping agent.
+  noSpawn: true
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      implant:
+        maxVol: 50
+        reagents:
+        - ReagentId: Nocturine
+          Quantity: 50 #170 seconds of forced sleep
+  - type: Tag
+    tags:
+    - SubdermalImplant
+    - HideContextMenu
+    - ChemicalImplant
+
 #Traitor implants
 
 - type: entity
@@ -177,7 +232,7 @@
       range: 1.75
       energyConsumption: 50000
       disableDuration: 10
-      
+
 - type: entity
   parent: BaseSubdermalImplant
   id: ScramImplant
@@ -203,6 +258,26 @@
       whitelist:
         components:
         - HumanoidAppearance # syndies cant turn hamlet into a human
+
+- type: entity
+  parent: BaseChemicalImplant
+  id: EmergencyChemicalImplant
+  name: emergency chemical implant
+  description: This implant automatically injects a dose of healing chemicals when the user goes into a critical state.
+  noSpawn: true
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      implant:
+        maxVol: 50
+        reagents:
+        - ReagentId: Omnizine
+          Quantity: 30
+        - ReagentId: DexalinPlus
+          Quantity: 20
+  - type: TriggerOnMobstateChange
+    mobState:
+    - Critical
 
 #Nuclear Operative/Special Exclusive implants
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -312,6 +312,9 @@
   id: ChemDispensable # container that can go into the chem dispenser
 
 - type: Tag
+  id: ChemicalImplant
+
+- type: Tag
   id: Cigarette
 
 - type: Tag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds two new implants for security: the lethal chemical implant and the nonlethal chemical implant.
Adds one new implant for the traitor/nukie uplink: the emergency chemical implant.

The emergency chemical implant injects the user with 30u of omnizine and 20u of dexalin plus when the they go into crit, after which it is deleted.

The security chemical implants contain either 25u of lexorin and 25u of nocturine for the lethal version, or 50u of nocturine(170 seconds of sleep) for the nonlethal version.
The security chemical implants can only be remotely activated through a criminal record console, this requires security access.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The emergency implant allows traitors and nukies to get out of crit if they fall into it while not in reach of the enemy. It can't be activated manually, so it's not just an easy way to get some healing mid-battle.

The security chemical implants give security more variety in their punishment levels, this will allow security to release known criminals with a chemical implant instead of just putting them in perma. If the person that got released gets caught causing trouble again they can be remotely incapacitated or killed.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
When a chemical implant is successfully injected into an entity, their criminal record will be updated with this new implant. If the "activate implants" button on the criminal record console is pressed all the chemical implants in their body will be triggered instantly. When triggered, the implant will transfer it's solution to the bloodstream of the entity it's implanted in, after that it gets deleted.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/137322659/6d680960-b8df-4c54-8f52-b5c5a549ac49


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- add: Security can now get lethal and nonlethal chemical implanters from cargo, these implants can be remotely triggered from a criminal record console.
- add: The syndicate uplink now has an emergency implanter available for purchase, this implant will inject healing chemicals when the user goes into crit.