### PR TITLE
Fix nymphs being deleted immediatly after spawning

### DIFF
--- a/Content.Server/Species/Systems/NymphSystem.cs
+++ b/Content.Server/Species/Systems/NymphSystem.cs
@@ -1,15 +1,15 @@
+using Content.Server.Mind;
 using Content.Shared.Species.Components;
 using Content.Shared.Body.Events;
-using Content.Shared.Mind;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
-namespace Content.Shared.Species.Systems;
+namespace Content.Server.Species.Systems;
 
 public sealed partial class NymphSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _protoManager= default!;
-    [Dependency] private readonly SharedMindSystem _mindSystem = default!;
+    [Dependency] private readonly MindSystem _mindSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
@@ -36,6 +36,6 @@ public sealed partial class NymphSystem : EntitySystem
         if (comp.TransferMind == true && _mindSystem.TryGetMind(args.OldBody, out var mindId, out var mind))
             _mindSystem.TransferTo(mindId, nymph, mind: mind);
 
-        EntityManager.QueueDeleteEntity(uid);
+        QueueDel(uid);
     }
 }

--- a/Content.Shared/Species/Systems/NymphSystem.cs
+++ b/Content.Shared/Species/Systems/NymphSystem.cs
@@ -4,11 +4,11 @@ using Content.Shared.Mind;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
-namespace Content.Shared.Species;
+namespace Content.Shared.Species.Systems;
 
 public sealed partial class NymphSystem : EntitySystem
 {
-    [Dependency] protected readonly IPrototypeManager _protoManager = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager= default!;
     [Dependency] private readonly SharedMindSystem _mindSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
@@ -31,7 +31,7 @@ public sealed partial class NymphSystem : EntitySystem
             return;
 
         var coords = Transform(uid).Coordinates;
-        var nymph = EntityManager.SpawnEntity(entityProto.ID, coords);
+        var nymph = EntityManager.SpawnAtPosition(entityProto.ID, coords);
 
         if (comp.TransferMind == true && _mindSystem.TryGetMind(args.OldBody, out var mindId, out var mind))
             _mindSystem.TransferTo(mindId, nymph, mind: mind);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
resolves #25334 
Nymphs were parented to the diona entity so when the diona body got deleted at the end of the gibbing step they would get deleted too. Nymphs are now parented to the grid/map after spawning.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Nymph spawning now uses SpawnAtPosition instead of SpawnEntity.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Dygon
- fix: Diona nymphs aren't deleted immediately after spawning anymore.
