### PR TITLE
fixed the specific if statement called when plant age is under 0

### DIFF
--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -621,6 +621,7 @@ public sealed class PlantHolderSystem : EntitySystem
             RemovePlant(uid, component);
             component.ForceUpdate = true;
             Update(uid, component);
+            return;
         }
 
         CheckHealth(uid, component);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The plant holder module was programmed to destroy its plant and call an update if the Age was below 0 (eg. with cryo).
However, after executing the called update, it proceeded to continue executing the original Update call, potentially leading to null pointer exceptions if/when the seed is referenced in later code.
So I added a return at the end.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bugfix
This caused some issues when I was testing the effects on cryo in the dev environment.


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->