### PR TITLE
Mechanized treatment improvements

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -319,7 +319,7 @@
 
 # medical modules
 - type: entity
-  id: BorgModuleDiagnosis
+  id: BorgModuleDiagnosis # todo: reuse when med refractor is finished
   parent: [ BaseBorgModuleMedical, BaseProviderBorgModule ]
   name: diagnosis cyborg module
   components:
@@ -374,6 +374,7 @@
     - state: icon-chemist
   - type: ItemBorgModule
     items:
+    - HandheldHealthAnalyzerUnpowered
     - Beaker
     - Beaker
     - BorgDropper

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -135,10 +135,9 @@
     state: medical
   discipline: CivilianServices
   tier: 2
-  cost: 7500
+  cost: 5000
   recipeUnlocks:
   - BorgModuleAdvancedTreatment
-  - BorgModuleDiagnosis
   - BorgModuleDefibrillator
 
 - type: technology


### PR DESCRIPTION
## About the PR
I recently saw the new changes to the eng borg modules, thought the med borgs could get some love so here we are.

## Why / Balance
Medical borgs cannot use the new cool changes to the health analyzers and constant module switching feels clunky and annoying.
I also lowered the price of mechanized treatment to 5000 points so it matches robotic cleanliness.

## Media
New adv. treatment module

![image](https://github.com/space-wizards/space-station-14/assets/156087924/796622c2-e4f1-45e7-8546-c9a37388f4dc)

## Changelog
- removed diagnosis module from mechanized treatment research
- advanced treatment module now has a health scanner
- mechanized treatment now costs 5000 points instead of 7500
