### PR TITLE
Moves muted to shared

### DIFF
--- a/Content.Server/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Server/Abilities/Mime/MimePowersSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Physics;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
+using MutedComponent = Content.Shared.Speech.Muting.MutedComponent;
 
 namespace Content.Server.Abilities.Mime
 {

--- a/Content.Server/Mobs/CritMobActionsSystem.cs
+++ b/Content.Server/Mobs/CritMobActionsSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Robust.Server.Console;
 using Robust.Shared.Player;
+using MutedComponent = Content.Shared.Speech.Muting.MutedComponent;
 
 namespace Content.Server.Mobs;
 

--- a/Content.Server/Mobs/DeathgaspSystem.cs
+++ b/Content.Server/Mobs/DeathgaspSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.Speech.Muting;
 using Content.Shared.Mobs;
 using Robust.Shared.Prototypes;
+using MutedComponent = Content.Shared.Speech.Muting.MutedComponent;
 
 namespace Content.Server.Mobs;
 

--- a/Content.Server/Puppet/VentriloquistPuppetSystem.cs
+++ b/Content.Server/Puppet/VentriloquistPuppetSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Puppet;
 using Content.Server.Speech.Muting;
 using Content.Shared.CombatMode;
 using Content.Shared.Hands;
+using MutedComponent = Content.Shared.Speech.Muting.MutedComponent;
 
 namespace Content.Server.Puppet
 {

--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -15,12 +15,12 @@ namespace Content.Server.Speech.Muting
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<MutedComponent, SpeakAttemptEvent>(OnSpeakAttempt);
-            SubscribeLocalEvent<MutedComponent, EmoteEvent>(OnEmote, before: new[] { typeof(VocalSystem) });
-            SubscribeLocalEvent<MutedComponent, ScreamActionEvent>(OnScreamAction, before: new[] { typeof(VocalSystem) });
+            SubscribeLocalEvent<Shared.Speech.Muting.MutedComponent, SpeakAttemptEvent>(OnSpeakAttempt);
+            SubscribeLocalEvent<Shared.Speech.Muting.MutedComponent, EmoteEvent>(OnEmote, before: new[] { typeof(VocalSystem) });
+            SubscribeLocalEvent<Shared.Speech.Muting.MutedComponent, ScreamActionEvent>(OnScreamAction, before: new[] { typeof(VocalSystem) });
         }
 
-        private void OnEmote(EntityUid uid, MutedComponent component, ref EmoteEvent args)
+        private void OnEmote(EntityUid uid, Shared.Speech.Muting.MutedComponent component, ref EmoteEvent args)
         {
             if (args.Handled)
                 return;
@@ -30,7 +30,7 @@ namespace Content.Server.Speech.Muting
                 args.Handled = true;
         }
 
-        private void OnScreamAction(EntityUid uid, MutedComponent component, ScreamActionEvent args)
+        private void OnScreamAction(EntityUid uid, Shared.Speech.Muting.MutedComponent component, ScreamActionEvent args)
         {
             if (args.Handled)
                 return;
@@ -44,7 +44,7 @@ namespace Content.Server.Speech.Muting
         }
 
 
-        private void OnSpeakAttempt(EntityUid uid, MutedComponent component, SpeakAttemptEvent args)
+        private void OnSpeakAttempt(EntityUid uid, Shared.Speech.Muting.MutedComponent component, SpeakAttemptEvent args)
         {
             // TODO something better than this.
 

--- a/Content.Shared/Speech/Muting/MutedComponent.cs
+++ b/Content.Shared/Speech/Muting/MutedComponent.cs
@@ -1,6 +1,8 @@
-namespace Content.Server.Speech.Muting
+namespace Content.Shared.Speech.Muting
 {
     [RegisterComponent]
     public sealed partial class MutedComponent : Component
-    {}
+    {
+
+    }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Muted comp is moved from server to shared.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Needed to check if muted for Magic refactor, which will be in shared.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase