### PR TITLE
9x rate on non-wide scrubbers

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
@@ -20,7 +20,7 @@
                     </BoxContainer>
                 </BoxContainer>
                 <BoxContainer>
-                    <CheckBox Name="CWideNet" Text="{Loc 'air-alarm-ui-scrubber-wide-net-label'}" />
+                    <CheckBox Name="CWideNet" Text="{Loc 'air-alarm-ui-scrubber-wide-net-label'}" ToolTip="{Loc 'air-alarm-ui-scrubber-wide-net-tooltip'}" />
                 </BoxContainer>
                 <BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
                     <Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-widget-copy'}" ToolTip="{Loc 'air-alarm-ui-widget-copy-tooltip'}" />

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -71,10 +71,13 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             var position = _transformSystem.GetGridTilePositionOrDefault((uid,xform));
             var environment = _atmosphereSystem.GetTileMixture(xform.GridUid, xform.MapUid, position, true);
 
-            Scrub(timeDelta, scrubber, environment, outlet);
-
             if (!scrubber.WideNet)
+            {
+                Scrub(timeDelta * 9, scrubber, environment, outlet); // We're scrubbing 1 tile instead of 9 so scrub 9 times faster
                 return;
+            }
+
+            Scrub(timeDelta, scrubber, environment, outlet);
 
             // Scrub adjacent tiles too.
             foreach (var adjacent in _atmosphereSystem.GetAdjacentTileMixtures(xform.GridUid.Value, position, false, true))

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -57,6 +57,7 @@ air-alarm-ui-vent-internal-bound-label = Internal bound
 air-alarm-ui-scrubber-pump-direction-label = Direction
 air-alarm-ui-scrubber-volume-rate-label = Rate (L)
 air-alarm-ui-scrubber-wide-net-label = WideNet
+air-alarm-ui-scrubber-wide-net-tooltip = Scrubs in a 3x3 area centered on itself. If disabled, scrubbing rate is redirected to own tile.
 
 ### Thresholds
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
makes scrubbers without widenet scrub 9 times faster to compensate for affecting only 1 tile instead of 9, keeping the total scrubbing rate the same
also adds a tooltip to widenet explaining what it does

## Why / Balance
makes non-widenet scrubbers not just entirely inferior to widenet scrubbers
there's currently no reason to ever set a scrubber to non-widenet, so this makes widenet being on or off actually matter and not just always be "remember to enable widenet"
with this change a scrubber set to non-widenet will keep the tile it's on clean, but a scrubber with widenet will actually scrub more gas overall as you can only scrub so much gas from only one tile
this is also an indirect buff to burnchambers as their scrubbers are often on edges and waste a lot of their widenet coverage

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/57039557/0bf7cc20-1543-44ad-888c-ea45cc2d7ac5)
scrubbing rate tested, works
viableness test results in comment: https://github.com/space-wizards/space-station-14/pull/25385#issuecomment-1953877505

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Scrubbers not set to WideNet are now 9 times faster, and WideNet now has a tooltip.
