### PR TITLE
Add a container display to dispenser UI

### DIFF
--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -32,19 +32,22 @@
                     StyleClasses="OpenLeft"/>
         </BoxContainer>
         <Control MinSize="0 10"/>
-        <ScrollContainer HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True" MinSize="0 160">
-            <PanelContainer VerticalExpand="True"
-                            SizeFlagsStretchRatio="6"
-                            MinSize="0 150">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1b1b1e" />
-                </PanelContainer.PanelOverride>
-                <BoxContainer Name="ContainerInfo"
-                              Orientation="Vertical"
-                              HorizontalExpand="True">
-                    <Label Text="{Loc 'reagent-dispenser-window-no-container-loaded-text'}"/>
-                </BoxContainer>
-            </PanelContainer>
-        </ScrollContainer>
+        <BoxContainer Orientation="Horizontal">
+            <SpriteView Name="View" Scale="4 4" MinSize="150 150"/>
+            <ScrollContainer HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True" MinSize="0 160">
+                <PanelContainer VerticalExpand="True"
+                                SizeFlagsStretchRatio="6"
+                                MinSize="0 150">
+                    <PanelContainer.PanelOverride>
+                        <gfx:StyleBoxFlat BackgroundColor="#1b1b1e" />
+                    </PanelContainer.PanelOverride>
+                    <BoxContainer Name="ContainerInfo"
+                                Orientation="Vertical"
+                                HorizontalExpand="True">
+                        <Label Text="{Loc 'reagent-dispenser-window-no-container-loaded-text'}"/>
+                    </BoxContainer>
+                </PanelContainer>
+            </ScrollContainer>
+        </BoxContainer>
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Client.Stylesheets;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Reagent;
@@ -52,7 +51,7 @@ namespace Content.Client.Chemistry.UI
         /// Update the button grid of reagents which can be dispensed.
         /// </summary>
         /// <param name="inventory">Reagents which can be dispensed by this dispenser</param>
-        public void UpdateReagentsList(List<KeyValuePair<string, KeyValuePair<string,string>>> inventory)
+        public void UpdateReagentsList(List<KeyValuePair<string, KeyValuePair<string, string>>> inventory)
         {
             if (ChemicalList == null)
                 return;
@@ -85,6 +84,11 @@ namespace Content.Client.Chemistry.UI
             var castState = (ReagentDispenserBoundUserInterfaceState) state;
             UpdateContainerInfo(castState);
             UpdateReagentsList(castState.Inventory);
+
+            if (castState.OutputContainerEntity is { } containerEntity)
+                View.SetEntity(containerEntity);
+            else
+                View.SetEntity(null);
 
             // Disable the Clear & Eject button if no beaker
             ClearButton.Disabled = castState.OutputContainer is null;
@@ -134,7 +138,7 @@ namespace Content.Client.Chemistry.UI
 
             if (state.OutputContainer is null)
             {
-                ContainerInfo.Children.Add(new Label {Text = Loc.GetString("reagent-dispenser-window-no-container-loaded-text") });
+                ContainerInfo.Children.Add(new Label { Text = Loc.GetString("reagent-dispenser-window-no-container-loaded-text") });
                 return;
             }
 
@@ -159,11 +163,11 @@ namespace Content.Client.Chemistry.UI
                     ? p.LocalizedName
                     : Loc.GetString("reagent-dispenser-window-reagent-name-not-found-text");
 
-                var nameLabel = new Label {Text = $"{localizedName}: "};
+                var nameLabel = new Label { Text = $"{localizedName}: " };
                 var quantityLabel = new Label
                 {
                     Text = Loc.GetString("reagent-dispenser-window-quantity-label-text", ("quantity", quantity)),
-                    StyleClasses = {StyleNano.StyleClassLabelSecondaryColor},
+                    StyleClasses = { StyleNano.StyleClassLabelSecondaryColor },
                 };
 
                 ContainerInfo.Children.Add(new BoxContainer

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -18,6 +18,7 @@ namespace Content.Client.Chemistry.UI
     public sealed partial class ReagentDispenserWindow : DefaultWindow
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
         public event Action<BaseButton.ButtonEventArgs, DispenseReagentButton>? OnDispenseReagentButtonPressed;
         public event Action<GUIMouseHoverEventArgs, DispenseReagentButton>? OnDispenseReagentButtonMouseEntered;
         public event Action<GUIMouseHoverEventArgs, DispenseReagentButton>? OnDispenseReagentButtonMouseExited;
@@ -85,7 +86,8 @@ namespace Content.Client.Chemistry.UI
             UpdateContainerInfo(castState);
             UpdateReagentsList(castState.Inventory);
 
-            View.SetEntity(castState.OutputContainerEntity);
+            _entityManager.TryGetEntity(castState.OutputContainerEntity, out var outputContainerEnt);
+            View.SetEntity(outputContainerEnt);
 
             // Disable the Clear & Eject button if no beaker
             ClearButton.Disabled = castState.OutputContainer is null;

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -85,10 +85,7 @@ namespace Content.Client.Chemistry.UI
             UpdateContainerInfo(castState);
             UpdateReagentsList(castState.Inventory);
 
-            if (castState.OutputContainerEntity is { } containerEntity)
-                View.SetEntity(containerEntity);
-            else
-                View.SetEntity(null);
+            View.SetEntity(castState.OutputContainerEntity);
 
             // Disable the Clear & Eject button if no beaker
             ClearButton.Disabled = castState.OutputContainer is null;

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -68,7 +68,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
             var inventory = GetInventory(reagentDispenser);
 
-            var state = new ReagentDispenserBoundUserInterfaceState(outputContainerInfo, inventory, reagentDispenser.Comp.DispenseAmount);
+            var state = new ReagentDispenserBoundUserInterfaceState(outputContainerInfo, GetNetEntity(outputContainer), inventory, reagentDispenser.Comp.DispenseAmount);
             _userInterfaceSystem.TrySetUiState(reagentDispenser, ReagentDispenserUiKey.Key, state);
         }
 

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -56,6 +56,8 @@ namespace Content.Shared.Chemistry
     public sealed class ReagentDispenserBoundUserInterfaceState : BoundUserInterfaceState
     {
         public readonly ContainerInfo? OutputContainer;
+
+        public readonly NetEntity? OutputContainerEntity;
         /// <summary>
         /// A list of the reagents which this dispenser can dispense.
         /// </summary>
@@ -63,9 +65,10 @@ namespace Content.Shared.Chemistry
 
         public readonly ReagentDispenserDispenseAmount SelectedDispenseAmount;
 
-        public ReagentDispenserBoundUserInterfaceState(ContainerInfo? outputContainer, List<KeyValuePair<string, KeyValuePair<string, string>>> inventory, ReagentDispenserDispenseAmount selectedDispenseAmount)
+        public ReagentDispenserBoundUserInterfaceState(ContainerInfo? outputContainer, NetEntity? outputContainerEntity, List<KeyValuePair<string, KeyValuePair<string, string>>> inventory, ReagentDispenserDispenseAmount selectedDispenseAmount)
         {
             OutputContainer = outputContainer;
+            OutputContainerEntity = outputContainerEntity;
             Inventory = inventory;
             SelectedDispenseAmount = selectedDispenseAmount;
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added a sprite viewer to the reagent dispenser UI window that shows the current appearance of the container inserted into the machine.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It's fun and more intuitive to see the container fill up than just reading the numbers going up on the UI. This is especially fun for mixing drinks in metamorphic glasses, since you get visual feedback when making the right mix.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a SpriteView control to ReagentDispenserWindow. ReagentDispenserSystem is modified to pass the NetEntity ID of the output container from the server to the client UI.

This is the first time I've messed with UI stuff, so let me know what's wrong so I can fix it.

I cleaned up a few compiler warnings in the files I touched too, mostly formatting issues.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Chem dispenser:

https://github.com/space-wizards/space-station-14/assets/85356/6e13bdd2-1522-4529-b341-6f79d84ceb95

Booze/Soda dispenser (in combination with #25319):

https://github.com/space-wizards/space-station-14/assets/85356/b601cf0d-a604-40c6-93ba-3bd402480237


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added a live preview display to reagent dispensers.