### PR TITLE
Hotfix: Set round end information for replays back to null on round start instead of round end

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Replays.cs
+++ b/Content.Server/GameTicking/GameTicker.Replays.cs
@@ -128,9 +128,6 @@ public sealed partial class GameTicker
         metadata["roundEndPlayers"] = _serialman.WriteValue(_replayRoundPlayerInfo);
         metadata["roundEndText"] = new ValueDataNode(_replayRoundText);
         metadata["server_id"] = new ValueDataNode(_configurationManager.GetCVar(CCVars.ServerId));
-        // These should be set to null to prepare them for the next round.
-        _replayRoundPlayerInfo = null;
-        _replayRoundText = null;
     }
 
     private ResPath GetAutoReplayPath()

--- a/Content.Server/GameTicking/GameTicker.Replays.cs
+++ b/Content.Server/GameTicking/GameTicker.Replays.cs
@@ -48,6 +48,10 @@ public sealed partial class GameTicker
             var tempDir = _cfg.GetCVar(CCVars.ReplayAutoRecordTempDir);
             ResPath? moveToPath = null;
 
+            // Set the round end player and text back to null to prevent it from writing the previous round's data.
+            _replayRoundPlayerInfo = null;
+            _replayRoundText = null;
+
             if (!string.IsNullOrEmpty(tempDir))
             {
                 var baseReplayPath = new ResPath(_cfg.GetCVar(CVars.ReplayDirectory)).ToRootedPath();


### PR DESCRIPTION
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

![image](https://github.com/space-wizards/space-station-14/assets/34938708/0373fee7-809f-4fe7-bea1-78d0a9ef3812)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase