### PR TITLE
Adds a mask slot and moves adminPDA to new ID slot for aghost

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
@@ -292,7 +292,6 @@
   components:
   - type: StorageFill
     contents:
-    - id: AdminPDA
     - id: GasAnalyzer
     - id: trayScanner
   - type: Unremoveable

--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -1,4 +1,4 @@
-﻿- type: inventoryTemplate
+- type: inventoryTemplate
   id: aghost
   slots:
     - name: back
@@ -9,11 +9,25 @@
       uiWindowPos: 2,1
       strippingWindowPos: 2,4
       displayName: ID
+    - name: id
+      slotTexture: id
+      slotFlags: IDCARD
+      slotGroup: SecondHotbar
+      stripTime: 6
+      uiWindowPos: 2,2
+      strippingWindowPos: 2,3
+      displayName: ID
 
     # For drip reasons.
     - name: head
       slotTexture: head
       slotFlags: HEAD
-      uiWindowPos: 0,1
+      uiWindowPos: 0,2
       strippingWindowPos: 0,0
       displayName: Head
+    - name: mask
+      slotTexture: mask
+      slotFlags: MASK
+      uiWindowPos: 0,1
+      strippingWindowPos: 1,1
+      displayName: Mask

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -326,6 +326,7 @@
   id: MobAghostGear
   equipment:
     back: ClothingBackpackSatchelHoldingAdmin
+    id: AdminPDA
 
 #Head Rev Gear
 - type: startingGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- adds mask slot to aghost
- removes Admin PDA from aghost backpack, and puts it in a newly added ID slot for aghost
<!-- What did you change in this PR? -->

## Why / Balance
Multiple admins have wished for a mask slot since the hat slot update, and having the PDA outside the backpack, readily available, is much nicer and more efficient for admins.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
![image](https://github.com/space-wizards/space-station-14/assets/145869023/83f22e33-6a81-4a0f-8909-e49a3a17dbd7)
![image](https://github.com/space-wizards/space-station-14/assets/145869023/67adf84b-9cc1-4271-8eae-f9dbbe72909b)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
*Should* be none. As the concerns expressed with the previous closed aghost PR, nothing extra is added into the backpack, and there should be no problems in relation to the concern of mapping. We already have a hat slot, so a mask slot shouldn't break anything.

**Changelog**
:cl: Sphiral
ADMIN:
- tweak: Took the AdminPDA from the backpack and gave it it's own slot on aghosts! Also aghosts can smoke/wear masks now!
