### PR TITLE
Zombie Diona Fixes

### DIFF
--- a/Content.Server/Species/Systems/NymphSystem.cs
+++ b/Content.Server/Species/Systems/NymphSystem.cs
@@ -1,6 +1,8 @@
 using Content.Server.Mind;
 using Content.Shared.Species.Components;
 using Content.Shared.Body.Events;
+using Content.Shared.Zombies;
+using Content.Server.Zombies;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -11,6 +13,7 @@ public sealed partial class NymphSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _protoManager= default!;
     [Dependency] private readonly MindSystem _mindSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly ZombieSystem _zombie = default!;
 
     public override void Initialize()
     {
@@ -30,12 +33,18 @@ public sealed partial class NymphSystem : EntitySystem
         if (!_protoManager.TryIndex<EntityPrototype>(comp.EntityPrototype, out var entityProto))
             return;
 
+        // Get the organs' position & spawn a nymph there
         var coords = Transform(uid).Coordinates;
         var nymph = EntityManager.SpawnAtPosition(entityProto.ID, coords);
 
+        if (HasComp<ZombieComponent>(args.OldBody)) // Zombify the new nymph if old one is a zombie
+            _zombie.ZombifyEntity(nymph);
+
+        // Move the mind if there is one and it's supposed to be transferred
         if (comp.TransferMind == true && _mindSystem.TryGetMind(args.OldBody, out var mindId, out var mind))
             _mindSystem.TransferTo(mindId, nymph, mind: mind);
 
+        // Delete the old organ
         QueueDel(uid);
     }
 }

--- a/Content.Shared/Species/Systems/ReformSystem.cs
+++ b/Content.Shared/Species/Systems/ReformSystem.cs
@@ -4,12 +4,11 @@ using Content.Shared.DoAfter;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;
 using Content.Shared.Mind;
-using Content.Shared.Humanoid;
+using Content.Shared.Zombies;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
-using Robust.Shared.Serialization.Manager;
 
 namespace Content.Shared.Species;
 
@@ -23,8 +22,6 @@ public sealed partial class ReformSystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stunSystem = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly SharedMindSystem _mindSystem = default!;
-    [Dependency] private readonly MetaDataSystem _metaData = default!;
-    [Dependency] private readonly ISerializationManager _serializationManager = default!;
 
     public override void Initialize()
     {
@@ -35,6 +32,8 @@ public sealed partial class ReformSystem : EntitySystem
 
         SubscribeLocalEvent<ReformComponent, ReformEvent>(OnReform);
         SubscribeLocalEvent<ReformComponent, ReformDoAfterEvent>(OnDoAfter);
+
+        SubscribeLocalEvent<ReformComponent, EntityZombifiedEvent>(OnZombified);
     }
 
     private void OnMapInit(EntityUid uid, ReformComponent comp, MapInitEvent args)
@@ -95,10 +94,15 @@ public sealed partial class ReformSystem : EntitySystem
 
         // This transfers the mind to the new entity
         if (_mindSystem.TryGetMind(uid, out var mindId, out var mind))
-                _mindSystem.TransferTo(mindId, child, mind: mind);
+            _mindSystem.TransferTo(mindId, child, mind: mind);
 
         // Delete the old entity
         QueueDel(uid);
+    }
+
+    private void OnZombified(EntityUid uid, ReformComponent comp, ref EntityZombifiedEvent args)
+    {
+        _actionsSystem.RemoveAction(uid, comp.ActionEntity); // Zombies can't reform
     }
 
     public sealed partial class ReformEvent : InstantActionEvent { } 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Zombie Diona now split into zombie nymphs. Zombie nymphs can no longer reform. Also added some comments and removed some unused dependencies so I hopefully don't have to touch this system again for awhile. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Diona curing themselves is funny but not good. This solves that issue while still not completely ruining their gimmick, also making sense game-wise (no nymph would want to reform with a zombie).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl: Lank
- fix: Diona can no longer split or reform to cure themselves of a zombie infection. 
