### PR TITLE
Set nav map icon textures to use bilinear filtering

### DIFF
--- a/Resources/Textures/Interface/NavMap/beveled_circle.png.yml
+++ b/Resources/Textures/Interface/NavMap/beveled_circle.png.yml
@@ -1,0 +1,2 @@
+﻿sample:
+  filter: true

--- a/Resources/Textures/Interface/NavMap/beveled_hexagon.png.yml
+++ b/Resources/Textures/Interface/NavMap/beveled_hexagon.png.yml
@@ -1,0 +1,2 @@
+﻿sample:
+  filter: true

--- a/Resources/Textures/Interface/NavMap/beveled_square.png.yml
+++ b/Resources/Textures/Interface/NavMap/beveled_square.png.yml
@@ -1,0 +1,2 @@
+﻿sample:
+  filter: true

--- a/Resources/Textures/Interface/NavMap/beveled_triangle.png.yml
+++ b/Resources/Textures/Interface/NavMap/beveled_triangle.png.yml
@@ -1,0 +1,2 @@
+﻿sample:
+  filter: true


### PR DESCRIPTION
This just makes them look slightly better when zoomed.
