### PR TITLE
Fix PlayerListControl re-raising selection changed when repopulated.

### DIFF
--- a/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml.cs
+++ b/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml.cs
@@ -52,6 +52,9 @@ namespace Content.Client.Administration.UI.CustomControls
             if (args == null || data is not PlayerListData {Info: var selectedPlayer})
                 return;
 
+            if (selectedPlayer == _selectedPlayer)
+                return;
+
             if (args.Event.Function != EngineKeyFunctions.UIClick)
                 return;
 


### PR DESCRIPTION
## About the PR
This caused the ahelp window to unfocus the message box after sending something.

## Technical details
Now we just skip duplicate "item pressed" events from the ListContainer.

This caused the ahelp window to unfocus the message box after sending something. Flow is something like this: you send ahelp -> bwoink window refreshes player list due to new bwoink -> repopulated player list -> sent selection change -> repopulates right pane -> line edit gets unfocused.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
