### PR TITLE
Small Artifact Fixes

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -47,6 +47,8 @@
     components:
     - Item # it doesnt necessarily have to be restricted from structures, but i think it'll be better that way
   permanentComponents:
+  - type: Item
+    size: Huge
   - type: ContainerContainer
     containers:
       storagebase: !type:Container

--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -147,6 +147,12 @@
   permanentComponents:
   - type: PowerSupplier
     supplyRate: 20000
+  - type: NodeContainer
+    examinable: true
+    nodes:
+      output_hv:
+        !type:CableDeviceNode
+        nodeGroupID: HVPower
 
 - type: artifactEffect
   id: EffectBigIron


### PR DESCRIPTION
## About the PR
Simple artifact change to allow the "20kw Power Producer" artifact node to work properly, and a small change to the storage artifact.

## Why / Balance
It felt very weird that the 20kw artifact could supply the power, but not actually output it in anyway (Likely an oversight by the designer). Also it gives more visual feedback to what the artifact reaction actually did.
![image](https://github.com/space-wizards/space-station-14/assets/127038462/0ffb1a4b-0bd9-45f9-bd4c-a783cf155630)

Also made Storage Artifacts Visually make sense when inspecting them as they cannot fit in any storage regardless of what the size says. This just makes it more apparent to players.
Original:
![image](https://github.com/space-wizards/space-station-14/assets/127038462/0b39ca30-8abd-4f0b-a57e-c22efb69a2fd)

New:
![temp](https://github.com/space-wizards/space-station-14/assets/127038462/2d69035a-57c4-4f7d-b39f-c7b9ac40e26c)

**Changelog**
No CL
