### PR TITLE
Bartender jugs are no longer treated like beakers.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -3,7 +3,7 @@
 # When adding new drinks also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\drinks_glass.yml
 - type: entity
   parent: BaseItem
-  id: DrinkBase
+  id: DrinkBaseNonChem
   abstract: true
   components:
   - type: SolutionContainerManager
@@ -23,8 +23,6 @@
         Blunt: 0
   - type: Spillable
     solution: drink
-  - type: FitsInDispenser
-    solution: drink
   - type: DrawableSolution
     solution: drink
   - type: RefillableSolution
@@ -35,6 +33,14 @@
     interfaces:
     - key: enum.TransferAmountUiKey.Key
       type: TransferAmountBoundUserInterface
+
+- type: entity
+  parent: DrinkBaseNonChem #extra step to allow for containers that cannot fit in dispensers
+  id: DrinkBase
+  abstract: true
+  components:
+  - type: FitsInDispenser
+    solution: drink
 
 - type: entity
   parent: DrinkBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -1,7 +1,7 @@
 # When adding new drinks also add to random spawner located in Resources\Prototypes\Entities\Markers\Spawners\Random\Food_Drinks\drinks_bottles.yml
 - type: entity
-  parent: DrinkBase
-  id: DrinkBottlePlasticBaseFull
+  parent: DrinkBaseNonChem
+  id: DrinkBottlePlasticBaseFullNonChem # Cannot be fitted into dispenser for items to be poured into it
   abstract: true
   components:
   - type: Tag
@@ -38,6 +38,14 @@
   - type: PhysicalComposition
     materialComposition:
       Plastic: 100
+
+- type: entity
+  parent: DrinkBottlePlasticBaseFullNonChem
+  id: DrinkBottlePlasticBaseFull
+  abstract: true
+  components:
+  - type: FitsInDispenser
+    solution: drink
 
 - type: entity
   parent: DrinkBottlePlasticBaseFull
@@ -711,7 +719,7 @@
 #boring jugs some more sprites are made
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkSugarJug
   name: sugar
   suffix: for drinks
@@ -727,7 +735,7 @@
   - type: Drink
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkLemonLimeJug
   name: lemon lime
   description: a dual citrus sensation.
@@ -744,7 +752,7 @@
     currentLabel: lemon-lime
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkMeadJug
   name: mead jug
   description: storing mead in a plastic jug should be a crime.
@@ -761,7 +769,7 @@
     currentLabel: mead
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkIceJug
   name: ice jug
   description: stubborn water. pretty cool.
@@ -778,7 +786,7 @@
     currentLabel: ice
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkCoffeeJug
   name: coffee jug
   description: wake up juice, of the heated kind.
@@ -795,7 +803,7 @@
     currentLabel: coffee
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkTeaJug
   name: tea jug
   description: the drink of choice for the Bri'ish and hipsters.
@@ -812,7 +820,7 @@
     currentLabel: tea
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkGreenTeaJug
   name: green tea jug
   description: its like tea... but green! great for settling the stomach.
@@ -844,7 +852,7 @@
   - type: Drink
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkDrGibbJug
   name: dr gibb. jug
   description: yeah I don't know either...
@@ -861,7 +869,7 @@
     currentLabel: dr gibb
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkRootBeerJug
   name: root beer jug
   description: this drink makes Australians giggle
@@ -878,7 +886,7 @@
     currentLabel: root beer
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkWaterMelonJuiceJug
   name: watermelon juice jug
   description: May include leftover seeds
@@ -895,7 +903,7 @@
     currentLabel: watermelon juice
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: DrinkEnergyDrinkJug
   name: red bool jug
   description: A jug of Red Bool, with enough caffine to kill a whole station.
@@ -912,7 +920,7 @@
     currentLabel: red bool
 
 - type: entity
-  parent: DrinkBottlePlasticBaseFull
+  parent: DrinkBottlePlasticBaseFullNonChem
   id: CustomDrinkJug
   name: beverage jug
   description: A jug for storing custom made drinks.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made it so that Bartender's jugs cannot be inserted into dispensers like beakers. 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
https://github.com/space-wizards/space-station-14/issues/24896

Stops Chemistry from easily having massive beakers, balancing production.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
DrinkBase and DrinkBottlePlasticBaseFull now have parents DrinkBaseNonChem and DrinkBottlePlasticBaseFullNonChem respectively. NonChem parents do not have the FitsInDispenser component
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
https://www.dropbox.com/scl/fi/gfpwpttuu15hruzgdixxk/Tea-jug-fix-Made-with-Clipchamp.mp4?rlkey=y0v5xi3efj1blcszsc15c9i1p&dl=0
## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Bartender Jugs can no longer be used as beakers for dispensers
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
