### PR TITLE
Adjusts wallmount arcs and partially fix nanomed issues

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1337,7 +1337,7 @@
     snapCardinals: false
   - type: Rotatable
   - type: WallMount
-    arc: 90
+    arc: 175
   - type: Transform
     noRot: false
 

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1324,12 +1324,18 @@
   parent: VendingMachine
   name: vending machine
   abstract: true
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wallmount
   components:
+  - type: Fixtures
   - type: Sprite
     drawdepth: WallMountedItems
     snapCardinals: false
+  - type: Rotatable
   - type: WallMount
-    arc: 180
+    arc: 90
   - type: Transform
     noRot: false
 

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1329,6 +1329,8 @@
     snap:
     - Wallmount
   components:
+  - type: Physics
+    canCollide: false
   - type: Fixtures
   - type: Sprite
     drawdepth: WallMountedItems

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -116,7 +116,7 @@
   - type: ResistLocker
   - type: Weldable
   - type: WallMount
-    arc: 90
+    arc: 175
   - type: StaticPrice
     price: 50
   - type: Transform

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -116,7 +116,7 @@
   - type: ResistLocker
   - type: Weldable
   - type: WallMount
-    arc: 180
+    arc: 90
   - type: StaticPrice
     price: 50
   - type: Transform

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/defib_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/defib_cabinet.yml
@@ -4,7 +4,7 @@
   description: A small wall mounted cabinet designed to hold a defibrillator.
   components:
     - type: WallMount
-      arc: 90
+      arc: 175
     - type: Transform
       anchored: true
     - type: Clickable

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -189,7 +189,7 @@
   parent: SignalSwitch
   components:
   - type: WallMount
-    arc: 180
+    arc: 90
   - type: Construction
     graph: SignalSwitchDirectionalGraph
     node: SignalSwitchDirectionalNode
@@ -201,7 +201,7 @@
   parent: SignalButton
   components:
   - type: WallMount
-    arc: 180
+    arc: 90
   - type: Construction
     graph: SignalButtonDirectionalGraph
     node: SignalButtonDirectionalNode
@@ -213,7 +213,7 @@
   parent: ApcNetSwitch
   components:
   - type: WallMount
-    arc: 180
+    arc: 90
   - type: Construction
     graph: LightSwitchDirectionalGraph
     node: LightSwitchDirectionalNode

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -189,7 +189,7 @@
   parent: SignalSwitch
   components:
   - type: WallMount
-    arc: 90
+    arc: 175
   - type: Construction
     graph: SignalSwitchDirectionalGraph
     node: SignalSwitchDirectionalNode
@@ -201,7 +201,7 @@
   parent: SignalButton
   components:
   - type: WallMount
-    arc: 90
+    arc: 175
   - type: Construction
     graph: SignalButtonDirectionalGraph
     node: SignalButtonDirectionalNode
@@ -213,7 +213,7 @@
   parent: ApcNetSwitch
   components:
   - type: WallMount
-    arc: 90
+    arc: 175
   - type: Construction
     graph: LightSwitchDirectionalGraph
     node: LightSwitchDirectionalNode

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
@@ -8,7 +8,7 @@
     - Wallmount
   components:
   - type: WallMount
-    arc: 180
+    arc: 90
   - type: Sprite
     sprite: Structures/Storage/tanks.rsi
     state: cleanerdispenser

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/walldispenser.yml
@@ -8,7 +8,7 @@
     - Wallmount
   components:
   - type: WallMount
-    arc: 90
+    arc: 175
   - type: Sprite
     sprite: Structures/Storage/tanks.rsi
     state: cleanerdispenser


### PR DESCRIPTION
## About the PR
- Adjust the arc on wallmounted dispensers, vending machines, wall lockers, and switches from 180->175 degrees
- Fixes [#21516](https://github.com/space-wizards/space-station-14/issues/21516) where you could only access nanomed vendors from certain sides despite mapped orientation.

## Why / Balance
When it is set to 180 it creates unintended issues where players can access mallmounted items when they shouldn't be able to. 
Before
![image](https://github.com/space-wizards/space-station-14/assets/107660393/cfa5076a-2371-4a35-9918-39b3e110dcf1)
After
![image](https://github.com/space-wizards/space-station-14/assets/107660393/23c39f38-e8b7-4c87-b80c-e24111f74e89)
![image](https://github.com/space-wizards/space-station-14/assets/107660393/653e5554-234f-4b98-8a3f-30362bedd05d)
![image](https://github.com/space-wizards/space-station-14/assets/107660393/0b06ad39-5678-42ed-a869-ef99f9af1079)
![image](https://github.com/space-wizards/space-station-14/assets/107660393/fd17a9b9-4d1a-4181-9e56-7984bcde2ffb)

## Technical details
Note: This still doesn't fix the issues where dispensed items from vending machines are dispensed on the wall and always forced north if there is no additional wall to the north.
https://github.com/space-wizards/space-station-14/assets/107660393/d6a82d89-f8c2-400e-8cbf-0ae411b5ca1e

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- tweak: Tweaked wallmounted objects can not be interacted with through thindows or windoors.
- fix: Fixed NanoMed vendor not being accessible from all directions. 
