### PR TITLE
Crop harvest int cast fix

### DIFF
--- a/Content.Server/Botany/Systems/BotanySystem.Produce.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Produce.cs
@@ -17,10 +17,7 @@ public sealed partial class BotanySystem
         {
             var amount = FixedPoint2.New(quantity.Min);
             if (quantity.PotencyDivisor > 0 && seed.Potency > 0)
-            {
                 amount += FixedPoint2.New(seed.Potency / quantity.PotencyDivisor);
-                amount += quantity.Min;
-            }
             amount = FixedPoint2.New(MathHelper.Clamp(amount.Float(), quantity.Min, quantity.Max));
             solutionContainer.MaxVolume += amount;
             solutionContainer.AddReagent(chem, amount);

--- a/Content.Server/Botany/Systems/BotanySystem.Produce.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Produce.cs
@@ -17,8 +17,11 @@ public sealed partial class BotanySystem
         {
             var amount = FixedPoint2.New(quantity.Min);
             if (quantity.PotencyDivisor > 0 && seed.Potency > 0)
+            {
                 amount += FixedPoint2.New(seed.Potency / quantity.PotencyDivisor);
-            amount = FixedPoint2.New((int) MathHelper.Clamp(amount.Float(), quantity.Min, quantity.Max));
+                amount += quantity.Min;
+            }
+            amount = FixedPoint2.New(MathHelper.Clamp(amount.Float(), quantity.Min, quantity.Max));
             solutionContainer.MaxVolume += amount;
             solutionContainer.AddReagent(chem, amount);
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Deleted an int cast on line 21 of BotanySystemProduce.cs.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This was done to align with the algorithm described in comments starting at line 57 of SeedPrototype.cs. People were getting shorted their chemical change! (decimals)
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
MathHelper.Clamp() returns a float in this instance, but there was an (int) cast applied, which dropped any decimals. I deleted the (int) cast.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:
![harvestbefore](https://github.com/space-wizards/space-station-14/assets/159584039/8bab0e03-120a-4fcc-abdc-42e0984a8725)
After:
![harvestafter](https://github.com/space-wizards/space-station-14/assets/159584039/a7ac0a8b-7ed9-45d9-9fb2-4819c8d8d3be)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
I am fairly new to this project, so there may have been a critical reason why the chemicals were only integers, but I do not know what that would be. I believe amount is a FixedPoint2, so there should be no weird float shenanigans?
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Crops are now harvested with decimal amounts of nutriment, vitamin, etc.
