### PR TITLE
Add prediction to Openable

### DIFF
--- a/Content.Client/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Client/Nutrition/EntitySystems/OpenableSystem.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Nutrition.EntitySystems;
+
+namespace Content.Client.Nutrition.EntitySystems;
+
+public sealed class OpenableSystem : SharedOpenableSystem
+{
+}

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -130,21 +130,18 @@ public sealed class DrinkSystem : EntitySystem
 
     private void OnExamined(Entity<DrinkComponent> entity, ref ExaminedEvent args)
     {
-        var hasOpenable = TryComp<OpenableComponent>(entity, out var openable);
+        TryComp<OpenableComponent>(entity, out var openable);
         if (_openable.IsClosed(entity.Owner, null, openable) || !args.IsInDetailsRange || !entity.Comp.Examinable)
             return;
-
-        // put Empty / Xu after Opened, or start a new line
-        args.AddMarkup(hasOpenable ? " - " : "\n");
 
         var empty = IsEmpty(entity, entity.Comp);
         if (empty)
         {
-            args.AddMarkup(Loc.GetString("drink-component-on-examine-is-empty"));
+            args.PushMarkup(Loc.GetString("drink-component-on-examine-is-empty"));
             return;
         }
 
-        if (TryComp<ExaminableSolutionComponent>(entity, out var comp))
+        if (HasComp<ExaminableSolutionComponent>(entity))
         {
             //provide exact measurement for beakers
             args.PushText(Loc.GetString("drink-component-on-examine-exact-volume", ("amount", DrinkVolume(entity, entity.Comp))));
@@ -159,7 +156,7 @@ public sealed class DrinkSystem : EntitySystem
                 > 33 => HalfEmptyOrHalfFull(args),
                 _ => "drink-component-on-examine-is-mostly-empty",
             };
-            args.AddMarkup(Loc.GetString(remainingString));
+            args.PushMarkup(Loc.GetString(remainingString));
         }
     }
 

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -130,18 +130,21 @@ public sealed class DrinkSystem : EntitySystem
 
     private void OnExamined(Entity<DrinkComponent> entity, ref ExaminedEvent args)
     {
-        TryComp<OpenableComponent>(entity, out var openable);
+        var hasOpenable = TryComp<OpenableComponent>(entity, out var openable);
         if (_openable.IsClosed(entity.Owner, null, openable) || !args.IsInDetailsRange || !entity.Comp.Examinable)
             return;
+
+        // put Empty / Xu after Opened, or start a new line
+        args.AddMarkup(hasOpenable ? " - " : "\n");
 
         var empty = IsEmpty(entity, entity.Comp);
         if (empty)
         {
-            args.PushMarkup(Loc.GetString("drink-component-on-examine-is-empty"));
+            args.AddMarkup(Loc.GetString("drink-component-on-examine-is-empty"));
             return;
         }
 
-        if (HasComp<ExaminableSolutionComponent>(entity))
+        if (TryComp<ExaminableSolutionComponent>(entity, out var comp))
         {
             //provide exact measurement for beakers
             args.PushText(Loc.GetString("drink-component-on-examine-exact-volume", ("amount", DrinkVolume(entity, entity.Comp))));
@@ -156,7 +159,7 @@ public sealed class DrinkSystem : EntitySystem
                 > 33 => HalfEmptyOrHalfFull(args),
                 _ => "drink-component-on-examine-is-mostly-empty",
             };
-            args.PushMarkup(Loc.GetString(remainingString));
+            args.AddMarkup(Loc.GetString(remainingString));
         }
     }
 

--- a/Content.Server/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/OpenableSystem.cs
@@ -1,16 +1,6 @@
 using Content.Server.Chemistry.EntitySystems;
-using Content.Server.Fluids.EntitySystems;
 using Content.Shared.Nutrition.EntitySystems;
-using Content.Server.Nutrition.Components;
-using Content.Shared.Examine;
-using Content.Shared.Interaction;
-using Content.Shared.Interaction.Events;
 using Content.Shared.Nutrition.Components;
-using Content.Shared.Popups;
-using Content.Shared.Verbs;
-using Content.Shared.Weapons.Melee.Events;
-using Robust.Shared.Audio.Systems;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Nutrition.EntitySystems;
 
@@ -19,43 +9,11 @@ namespace Content.Server.Nutrition.EntitySystems;
 /// </summary>
 public sealed class OpenableSystem : SharedOpenableSystem
 {
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-    [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
-
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<OpenableComponent, ComponentInit>(OnInit);
-        SubscribeLocalEvent<OpenableComponent, UseInHandEvent>(OnUse);
-        SubscribeLocalEvent<OpenableComponent, ExaminedEvent>(OnExamined, after: new[] { typeof(PuddleSystem) });
         SubscribeLocalEvent<OpenableComponent, SolutionTransferAttemptEvent>(OnTransferAttempt);
-        SubscribeLocalEvent<OpenableComponent, MeleeHitEvent>(HandleIfClosed);
-        SubscribeLocalEvent<OpenableComponent, AfterInteractEvent>(HandleIfClosed);
-        SubscribeLocalEvent<OpenableComponent, GetVerbsEvent<Verb>>(AddOpenCloseVerbs);
-    }
-
-    private void OnInit(EntityUid uid, OpenableComponent comp, ComponentInit args)
-    {
-        UpdateAppearance(uid, comp);
-    }
-
-    private void OnUse(EntityUid uid, OpenableComponent comp, UseInHandEvent args)
-    {
-        if (args.Handled || !comp.OpenableByHand)
-            return;
-
-        args.Handled = TryOpen(uid, comp);
-    }
-
-    private void OnExamined(EntityUid uid, OpenableComponent comp, ExaminedEvent args)
-    {
-        if (!comp.Opened || !args.IsInDetailsRange)
-            return;
-
-        var text = Loc.GetString(comp.ExamineText);
-        args.PushMarkup(text);
     }
 
     private void OnTransferAttempt(EntityUid uid, OpenableComponent comp, SolutionTransferAttemptEvent args)
@@ -65,136 +23,5 @@ public sealed class OpenableSystem : SharedOpenableSystem
             // message says its just for drinks, shouldn't matter since you typically dont have a food that is openable and can be poured out
             args.Cancel(Loc.GetString("drink-component-try-use-drink-not-open", ("owner", uid)));
         }
-    }
-
-    private void HandleIfClosed(EntityUid uid, OpenableComponent comp, HandledEntityEventArgs args)
-    {
-        // prevent spilling/pouring/whatever drinks when closed
-        args.Handled = !comp.Opened;
-    }
-
-    private void AddOpenCloseVerbs(EntityUid uid, OpenableComponent comp, GetVerbsEvent<Verb> args)
-    {
-        if (args.Hands == null || !args.CanAccess || !args.CanInteract)
-            return;
-
-        Verb verb;
-        if (comp.Opened)
-        {
-            if (!comp.Closeable)
-                return;
-
-            verb = new()
-            {
-                Text = Loc.GetString(comp.CloseVerbText),
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/close.svg.192dpi.png")),
-                Act = () => TryClose(args.Target, comp)
-            };
-        }
-        else
-        {
-            verb = new()
-            {
-                Text = Loc.GetString(comp.OpenVerbText),
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/open.svg.192dpi.png")),
-                Act = () => TryOpen(args.Target, comp)
-            };
-        }
-        args.Verbs.Add(verb);
-    }
-
-    /// <summary>
-    /// Returns true if the entity either does not have OpenableComponent or it is opened.
-    /// Drinks that don't have OpenableComponent are automatically open, so it returns true.
-    /// </summary>
-    public bool IsOpen(EntityUid uid, OpenableComponent? comp = null)
-    {
-        if (!Resolve(uid, ref comp, false))
-            return true;
-
-        return comp.Opened;
-    }
-
-    /// <summary>
-    /// Returns true if the entity both has OpenableComponent and is not opened.
-    /// Drinks that don't have OpenableComponent are automatically open, so it returns false.
-    /// If user is not null a popup will be shown to them.
-    /// </summary>
-    public bool IsClosed(EntityUid uid, EntityUid? user = null, OpenableComponent? comp = null)
-    {
-        if (!Resolve(uid, ref comp, false))
-            return false;
-
-        if (comp.Opened)
-            return false;
-
-        if (user != null)
-            _popup.PopupEntity(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
-
-        return true;
-    }
-
-    /// <summary>
-    /// Update open visuals to the current value.
-    /// </summary>
-    public void UpdateAppearance(EntityUid uid, OpenableComponent? comp = null, AppearanceComponent? appearance = null)
-    {
-        if (!Resolve(uid, ref comp))
-            return;
-
-        _appearance.SetData(uid, OpenableVisuals.Opened, comp.Opened, appearance);
-    }
-
-    /// <summary>
-    /// Sets the opened field and updates open visuals.
-    /// </summary>
-    public void SetOpen(EntityUid uid, bool opened = true, OpenableComponent? comp = null)
-    {
-        if (!Resolve(uid, ref comp, false) || opened == comp.Opened)
-            return;
-
-        comp.Opened = opened;
-
-        if (opened)
-        {
-            var ev = new OpenableOpenedEvent();
-            RaiseLocalEvent(uid, ref ev);
-        }
-        else
-        {
-            var ev = new OpenableClosedEvent();
-            RaiseLocalEvent(uid, ref ev);
-        }
-
-        UpdateAppearance(uid, comp);
-    }
-
-    /// <summary>
-    /// If closed, opens it and plays the sound.
-    /// </summary>
-    /// <returns>Whether it got opened</returns>
-    public bool TryOpen(EntityUid uid, OpenableComponent? comp = null)
-    {
-        if (!Resolve(uid, ref comp, false) || comp.Opened)
-            return false;
-
-        SetOpen(uid, true, comp);
-        _audio.PlayPvs(comp.Sound, uid);
-        return true;
-    }
-
-    /// <summary>
-    /// If opened, closes it and plays the close sound, if one is defined.
-    /// </summary>
-    /// <returns>Whether it got closed</returns>
-    public bool TryClose(EntityUid uid, OpenableComponent? comp = null)
-    {
-        if (!Resolve(uid, ref comp, false) || !comp.Opened || !comp.Closeable)
-            return false;
-
-        SetOpen(uid, false, comp);
-        if (comp.CloseSound != null)
-            _audio.PlayPvs(comp.CloseSound, uid);
-        return true;
     }
 }

--- a/Content.Shared/Nutrition/Components/OpenableComponent.cs
+++ b/Content.Shared/Nutrition/Components/OpenableComponent.cs
@@ -1,27 +1,29 @@
-using Content.Server.Nutrition.EntitySystems;
+using Content.Shared.Nutrition.EntitySystems;
 using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
 
-namespace Content.Server.Nutrition.Components;
+namespace Content.Shared.Nutrition.Components;
 
 /// <summary>
 /// A drink or food that can be opened.
 /// Starts closed, open it with Z or E.
 /// </summary>
-[RegisterComponent, Access(typeof(OpenableSystem))]
+[NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, Access(typeof(SharedOpenableSystem))]
 public sealed partial class OpenableComponent : Component
 {
     /// <summary>
     /// Whether this drink or food is opened or not.
     /// Drinks can only be drunk or poured from/into when open, and food can only be eaten when open.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool Opened;
 
     /// <summary>
     /// If this is false you cant press Z to open it.
     /// Requires an OpenBehavior damage threshold or other logic to open.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool OpenableByHand = true;
 
     /// <summary>
@@ -61,7 +63,7 @@ public sealed partial class OpenableComponent : Component
     /// <summary>
     /// Can this item be closed again after opening?
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool Closeable;
 
     /// <summary>

--- a/Content.Shared/Nutrition/EntitySystems/SharedOpenableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedOpenableSystem.cs
@@ -1,7 +1,189 @@
+using Content.Shared.Examine;
+using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Utility;
+
 namespace Content.Shared.Nutrition.EntitySystems;
 
+/// <summary>
+/// Provides API for openable food and drinks, handles opening on use and preventing transfer when closed.
+/// </summary>
 public abstract partial class SharedOpenableSystem : EntitySystem
 {
+    [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
+    [Dependency] protected readonly SharedAudioSystem Audio = default!;
+    [Dependency] protected readonly SharedPopupSystem Popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<OpenableComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<OpenableComponent, UseInHandEvent>(OnUse);
+        SubscribeLocalEvent<OpenableComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<OpenableComponent, MeleeHitEvent>(HandleIfClosed);
+        SubscribeLocalEvent<OpenableComponent, AfterInteractEvent>(HandleIfClosed);
+        SubscribeLocalEvent<OpenableComponent, GetVerbsEvent<Verb>>(AddOpenCloseVerbs);
+    }
+
+    private void OnInit(EntityUid uid, OpenableComponent comp, ComponentInit args)
+    {
+        UpdateAppearance(uid, comp);
+    }
+
+    private void OnUse(EntityUid uid, OpenableComponent comp, UseInHandEvent args)
+    {
+        if (args.Handled || !comp.OpenableByHand)
+            return;
+
+        args.Handled = TryOpen(uid, comp, args.User);
+    }
+
+    private void OnExamined(EntityUid uid, OpenableComponent comp, ExaminedEvent args)
+    {
+        if (!comp.Opened || !args.IsInDetailsRange)
+            return;
+
+        var text = Loc.GetString(comp.ExamineText);
+        args.PushMarkup(text);
+    }
+
+    private void HandleIfClosed(EntityUid uid, OpenableComponent comp, HandledEntityEventArgs args)
+    {
+        // prevent spilling/pouring/whatever drinks when closed
+        args.Handled = !comp.Opened;
+    }
+
+    private void AddOpenCloseVerbs(EntityUid uid, OpenableComponent comp, GetVerbsEvent<Verb> args)
+    {
+        if (args.Hands == null || !args.CanAccess || !args.CanInteract)
+            return;
+
+        Verb verb;
+        if (comp.Opened)
+        {
+            if (!comp.Closeable)
+                return;
+
+            verb = new()
+            {
+                Text = Loc.GetString(comp.CloseVerbText),
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/close.svg.192dpi.png")),
+                Act = () => TryClose(args.Target, comp, args.User)
+            };
+        }
+        else
+        {
+            verb = new()
+            {
+                Text = Loc.GetString(comp.OpenVerbText),
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/open.svg.192dpi.png")),
+                Act = () => TryOpen(args.Target, comp, args.User)
+            };
+        }
+        args.Verbs.Add(verb);
+    }
+
+    /// <summary>
+    /// Returns true if the entity either does not have OpenableComponent or it is opened.
+    /// Drinks that don't have OpenableComponent are automatically open, so it returns true.
+    /// </summary>
+    public bool IsOpen(EntityUid uid, OpenableComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp, false))
+            return true;
+
+        return comp.Opened;
+    }
+
+    /// <summary>
+    /// Returns true if the entity both has OpenableComponent and is not opened.
+    /// Drinks that don't have OpenableComponent are automatically open, so it returns false.
+    /// If user is not null a popup will be shown to them.
+    /// </summary>
+    public bool IsClosed(EntityUid uid, EntityUid? user = null, OpenableComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp, false))
+            return false;
+
+        if (comp.Opened)
+            return false;
+
+        if (user != null)
+            Popup.PopupEntity(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Update open visuals to the current value.
+    /// </summary>
+    public void UpdateAppearance(EntityUid uid, OpenableComponent? comp = null, AppearanceComponent? appearance = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return;
+
+        Appearance.SetData(uid, OpenableVisuals.Opened, comp.Opened, appearance);
+    }
+
+    /// <summary>
+    /// Sets the opened field and updates open visuals.
+    /// </summary>
+    public void SetOpen(EntityUid uid, bool opened = true, OpenableComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp, false) || opened == comp.Opened)
+            return;
+
+        comp.Opened = opened;
+        Dirty(uid, comp);
+
+        if (opened)
+        {
+            var ev = new OpenableOpenedEvent();
+            RaiseLocalEvent(uid, ref ev);
+        }
+        else
+        {
+            var ev = new OpenableClosedEvent();
+            RaiseLocalEvent(uid, ref ev);
+        }
+
+        UpdateAppearance(uid, comp);
+    }
+
+    /// <summary>
+    /// If closed, opens it and plays the sound.
+    /// </summary>
+    /// <returns>Whether it got opened</returns>
+    public bool TryOpen(EntityUid uid, OpenableComponent? comp = null, EntityUid? user = null)
+    {
+        if (!Resolve(uid, ref comp, false) || comp.Opened)
+            return false;
+
+        SetOpen(uid, true, comp);
+        Audio.PlayPredicted(comp.Sound, uid, user);
+        return true;
+    }
+
+    /// <summary>
+    /// If opened, closes it and plays the close sound, if one is defined.
+    /// </summary>
+    /// <returns>Whether it got closed</returns>
+    public bool TryClose(EntityUid uid, OpenableComponent? comp = null, EntityUid? user = null)
+    {
+        if (!Resolve(uid, ref comp, false) || !comp.Opened || !comp.Closeable)
+            return false;
+
+        SetOpen(uid, false, comp);
+        if (comp.CloseSound != null)
+            Audio.PlayPredicted(comp.CloseSound, uid, user);
+        return true;
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Implements prediction for Openables. This means that the Opened/Closed part of the examine description and the Open/Close verb menu actions will show up immediately instead of needing to wait for the server to send an update. It also means that opening and closing bottles and cans will be slightly more responsive.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There's really no reason not to have this predicted. It feels better this way.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Moved OpenableComponent and almost all of OpenableSystem to Shared. Only the subscription and handler for SolutionTransferAttemptEvent remain in Server, since solution code is still stuck on the server for now.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
Most interactions with OpenableSystem should now use SharedOpenableSystem. OpenableComponent is now in the Shared namespace.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
