### PR TITLE
Fix examine text bug for Openable Drinkables

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -130,21 +130,18 @@ public sealed class DrinkSystem : EntitySystem
 
     private void OnExamined(Entity<DrinkComponent> entity, ref ExaminedEvent args)
     {
-        var hasOpenable = TryComp<OpenableComponent>(entity, out var openable);
+        TryComp<OpenableComponent>(entity, out var openable);
         if (_openable.IsClosed(entity.Owner, null, openable) || !args.IsInDetailsRange || !entity.Comp.Examinable)
             return;
-
-        // put Empty / Xu after Opened, or start a new line
-        args.AddMarkup(hasOpenable ? " - " : "\n");
 
         var empty = IsEmpty(entity, entity.Comp);
         if (empty)
         {
-            args.AddMarkup(Loc.GetString("drink-component-on-examine-is-empty"));
+            args.PushMarkup(Loc.GetString("drink-component-on-examine-is-empty"));
             return;
         }
 
-        if (TryComp<ExaminableSolutionComponent>(entity, out var comp))
+        if (HasComp<ExaminableSolutionComponent>(entity))
         {
             //provide exact measurement for beakers
             args.PushText(Loc.GetString("drink-component-on-examine-exact-volume", ("amount", DrinkVolume(entity, entity.Comp))));
@@ -159,7 +156,7 @@ public sealed class DrinkSystem : EntitySystem
                 > 33 => HalfEmptyOrHalfFull(args),
                 _ => "drink-component-on-examine-is-mostly-empty",
             };
-            args.AddMarkup(Loc.GetString(remainingString));
+            args.PushMarkup(Loc.GetString(remainingString));
         }
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When examining an item that can be opened and contains an examinable solution, the Opened/Closed state and fullness estimation are now shown on separate lines.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The previous implementation tried to display both on the same line, which is nice for compactness, but has formatting problems.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The old implementation attempts to do part of the text in Openable and part of it in Drinkable. Specifically, Drinkable attempts to append the text added by Openable, but winds up being sorted first, so the text it's meant to append is put at the start of the line. It would be possible to change the order around using priorities, but it's pretty messy to have one system's formatting rely so heavily on another.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:
<img width="484" alt="before" src="https://github.com/space-wizards/space-station-14/assets/85356/a2a82d59-513e-455c-a23a-b4090cd3f1e9">
After:
<img width="484" alt="after" src="https://github.com/space-wizards/space-station-14/assets/85356/dc288fcc-0326-47a1-ba7d-4e9a4286b8bd">


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
