### PR TITLE
PA now require CE access to change settings

### DIFF
--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -188,6 +188,6 @@ public sealed partial class ParticleAcceleratorControlBoxComponent : Component
     [ViewVariables]
     public bool CanBeEnabled = true;
 
-    [DataField("accessDeniedSound")]
+    [DataField]
     public SoundSpecifier AccessDeniedSound = new SoundPathSpecifier("/Audio/Machines/custom_deny.ogg");
 }

--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.ParticleAccelerator.Wires;
 using Content.Shared.Singularity.Components;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Audio;
 
 namespace Content.Server.ParticleAccelerator.Components;
 
@@ -186,4 +187,7 @@ public sealed partial class ParticleAcceleratorControlBoxComponent : Component
     /// </summary>
     [ViewVariables]
     public bool CanBeEnabled = true;
+
+    [DataField("accessDeniedSound")]
+    public SoundSpecifier AccessDeniedSound = new SoundPathSpecifier("/Audio/Machines/custom_deny.ogg");
 }

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -18,11 +18,11 @@ namespace Content.Server.ParticleAccelerator.EntitySystems;
 
 public sealed partial class ParticleAcceleratorSystem
 {
+    [Dependency] private readonly AccessReaderSystem _accessReader = default!;
     [Dependency] private readonly IAdminManager _adminManager = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly AccessReaderSystem _accessReader = default!;
 
     private void InitializeControlBoxSystem()
     {

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Timing;
 using Robust.Shared.Player;
+using FastAccessors;
 
 namespace Content.Server.ParticleAccelerator.EntitySystems;
 
@@ -82,7 +83,7 @@ public sealed partial class ParticleAcceleratorSystem
             return;
         if (!(user?.AttachedEntity is { } player))
             return;
-        if (!CheckAccess(uid, player, comp))
+        if (!CheckAccess((uid, comp), player))
             return;
 
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(user.AttachedEntity.Value):player} has turned {ToPrettyString(uid)} on");
@@ -105,7 +106,7 @@ public sealed partial class ParticleAcceleratorSystem
             return;
         if (!(user?.AttachedEntity is { } player))
             return;
-        if (!CheckAccess(uid, player, comp))
+        if (!CheckAccess((uid, comp), player))
             return;
 
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(user.AttachedEntity.Value):player} has turned {ToPrettyString(uid)} off");
@@ -156,7 +157,7 @@ public sealed partial class ParticleAcceleratorSystem
             return;
         if (!(user?.AttachedEntity is { } player))
             return;
-        if (!CheckAccess(uid, player, comp))
+        if (!CheckAccess((uid, comp), player))
             return;
 
         strength = (ParticleAcceleratorPowerState) MathHelper.Clamp(
@@ -407,13 +408,13 @@ public sealed partial class ParticleAcceleratorSystem
 
         UpdateUI(uid, comp);
     }
-    private bool CheckAccess(EntityUid uid, EntityUid user, ParticleAcceleratorControlBoxComponent comp)
+    private bool CheckAccess(Entity<ParticleAcceleratorControlBoxComponent> ent, EntityUid user)
     {
-        if (_accessReader.IsAllowed(user, uid))
+        if (_accessReader.IsAllowed(user, ent))
             return true;
 
-        _popup.PopupEntity(Loc.GetString("particle-accelerator-control-box-access-denied"), uid, user);
-        _audio.PlayPvs(comp.AccessDeniedSound, uid);
+        _popup.PopupEntity(Loc.GetString("particle-accelerator-control-box-access-denied"), ent, user);
+        _audio.PlayPvs(ent.Comp.AccessDeniedSound, ent);
 
         return false;
     }

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -20,8 +20,8 @@ public sealed partial class ParticleAcceleratorSystem
 {
     [Dependency] private readonly AccessReaderSystem _accessReader = default!;
     [Dependency] private readonly IAdminManager _adminManager = default!;
-    [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     private void InitializeControlBoxSystem()

--- a/Resources/Locale/en-US/particle-accelerator/components/particle-accelerator-control-box-component.ftl
+++ b/Resources/Locale/en-US/particle-accelerator/components/particle-accelerator-control-box-component.ftl
@@ -1,1 +1,2 @@
 particle-accelerator-control-box-component-wires-update-limiter-on-pulse = The control box makes a whirring noise.
+particle-accelerator-control-box-access-denied = Access denied.

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -15,6 +15,8 @@
   - type: ActivatableUI
     key: enum.ParticleAcceleratorControlBoxUiKey.Key
   - type: ActivatableUIRequiresPower
+  - type: AccessReader
+    access: [["ChiefEngineer"]]
   - type: UserInterface
     interfaces:
     - key: enum.ParticleAcceleratorControlBoxUiKey.Key

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -92,6 +92,7 @@
   - !type:ParticleAcceleratorLimiterWireAction
   - !type:ParticleAcceleratorPowerWireAction
   - !type:ParticleAcceleratorStrengthWireAction
+  - !type:AccessWireAction
 
 - type: wireLayout
   id: Docking


### PR DESCRIPTION
## About the PR
Particle Accelerator now requires Chief Engineer access in order to work. (doesn't affect "Scan Parts").

## Why / Balance
Particle Accelerator is responsible for very dangerous parts of the station like tesla and singularity. Unqualified station personal might tinker with it, which might lead to eventual doom of the station. Having responsible access of CE to it should not allow such events to happen! At least if someone will not acquire CE id card or use EMAG on PA computer.

ps: What I'm trying to solve here, is limit the ability of unexperienced engineers to launch tesla/singularity and basically cause a round end for many people that have nothing to do with it on the station. It's fun for some, but it's also very disrupting for others. CE access would allow new player to get early guidance on launching such systems without causing immediate disaster. It's also seem to be a generally good practice of CE inspecting a sing/tesla setup before launch. There is still plenty room in the game where tesla/singularity can get loose don't worry, let's just focus on limiting factor of some engineer doing stuff wrong because he didn't know what is right.

## Technical details
Added access check on PA computer. If check failed, there would be a popup and sound effect.


## Media

https://github.com/space-wizards/space-station-14/assets/23162722/7ae94127-d21a-4c1a-a9cb-3abf66d706ac

PS: if just so happens your CE is dead, added a access wire for you to cut! 

https://github.com/space-wizards/space-station-14/assets/23162722/1a087f16-7eda-4254-b549-1b025bf4cb00

- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No public API changed.

**Changelog**
- add: PA control computer now requires Chief Engineer access to change it's settings
