### PR TITLE
Add Brigmedic Access & Accessories

### DIFF
--- a/Resources/Locale/en-US/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/prototypes/access/accesses.ftl
@@ -7,6 +7,7 @@ id-card-access-level-head-of-security = Head of Security
 id-card-access-level-security = Security
 id-card-access-level-armory = Armory
 id-card-access-level-brig = Brig
+id-card-access-level-brigmedic = Brigmedic
 id-card-access-level-detective = Detective
 
 id-card-access-level-chief-engineer = Chief Engineer

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -14,6 +14,7 @@
   - Detective
   - Armory
   - Brig
+  - Brigmedic
   - Lawyer
   - Engineering
   - Medical

--- a/Resources/Prototypes/Access/security.yml
+++ b/Resources/Prototypes/Access/security.yml
@@ -15,6 +15,10 @@
   name: id-card-access-level-brig
 
 - type: accessLevel
+  id: Brigmedic
+  name: id-card-access-level-brigmedic
+
+- type: accessLevel
   id: Detective
   name: id-card-access-level-detective
 
@@ -25,6 +29,7 @@
   - Security
   - Armory
   - Brig
+  - Brigmedic
   - Detective
   - Cryogenics
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -154,6 +154,21 @@
   - type: AccessReader
     access: [["Security"]]
 
+#Security hardsuit
+- type: entity
+  id: SuitStorageBrigmedic
+  parent: SuitStorageBase
+  suffix: Brigmedic
+  components:
+  - type: StorageFill
+    contents:
+        - id: NitrogenTankFilled
+        - id: OxygenTankFilled
+        - id: ClothingOuterHardsuitBrigmedic
+        - id: ClothingMaskBreath
+  - type: AccessReader
+    access: [["Brigmedic"]]
+
 #CE's hardsuit
 - type: entity
   id: SuitStorageCE

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -331,6 +331,16 @@
 
 - type: entity
   parent: AirlockSecurity
+  id: AirlockBrigmedicLocked
+  suffix: Brigmedic, Locked
+  components:
+  - type: AccessReader
+    access: [["Brigmedic"]]
+  - type: Wires
+    layoutId: AirlockSecurity
+
+- type: entity
+  parent: AirlockSecurity
   id: AirlockSecurityLawyerLocked
   suffix: Security/Lawyer, Locked
   components:
@@ -655,6 +665,14 @@
   components:
   - type: AccessReader
     access: [["Brig"]]
+
+- type: entity
+  parent: AirlockSecurityGlass
+  id: AirlockBrigmedicGlassLocked
+  suffix: Brigmedic, Locked
+  components:
+  - type: AccessReader
+    access: [["Brigmedic"]]
 
 - type: entity
   parent: AirlockSecurityGlass

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -321,7 +321,7 @@
     stateDoorOpen: armory_open
     stateDoorClosed: brigmedic_door
   - type: AccessReader
-    access: [["Medical"]]
+    access: [["Brigmedic"]]
 
 # Security Officer
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

![image](https://github.com/space-wizards/space-station-14/assets/52761126/d63d9ea1-95ca-4de2-ba35-abe25e52f27f)

Adds a Brigmedic access level, mainly for downstream use, as the existing Brigmedic assets lack parity with other roles (eg Detective).

To go with the access, also added regular, glass, and maintenance airlocks, plus a suit storage, and adds a hardsuitless locker.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added Brigmedic access and airlocks for downstreams.
