### PR TITLE
Fix grid inventory pick/drop rotation

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -233,6 +233,8 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
 
         if (args.Function == ContentKeyFunctions.MoveStoredItem)
         {
+            DraggingRotation = control.Location.Rotation;
+
             _menuDragHelper.MouseDown(control);
             _menuDragHelper.Update(0f);
 


### PR DESCRIPTION
## About the PR
Fixes an issue with grid inventory UI causing items to rotate when picking them out.


## Technical details
The internal 'dragging rotation' is also used for pick and drop interactions. It wasn't being read during OnPiecePressed.

Directly emptying one storage container to another is one such situation, because the context menu is used, which triggers a rotation.


## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl: Krunk
- fix: Fixed grid inventory occasionally messing with your item rotation.
