### PR TITLE
Fix candy bowls

### DIFF
--- a/Content.Shared/Storage/EntitySystems/BinSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/BinSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Item;
 using Content.Shared.Storage.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
@@ -32,7 +33,7 @@ public sealed class BinSystem : EntitySystem
         SubscribeLocalEvent<BinComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<BinComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<BinComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
-        SubscribeLocalEvent<BinComponent, InteractHandEvent>(OnInteractHand);
+        SubscribeLocalEvent<BinComponent, InteractHandEvent>(OnInteractHand, before: new[] { typeof(SharedItemSystem) });
         SubscribeLocalEvent<BinComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
         SubscribeLocalEvent<BinComponent, GetVerbsEvent<AlternativeVerb>>(OnAltInteractHand);
         SubscribeLocalEvent<BinComponent, ExaminedEvent>(OnExamined);

--- a/Content.Shared/Storage/EntitySystems/BinSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/BinSystem.cs
@@ -8,9 +8,7 @@ using Content.Shared.Item;
 using Content.Shared.Storage.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
-using Robust.Shared.Map;
 using Robust.Shared.Network;
-using Robust.Shared.Timing;
 
 namespace Content.Shared.Storage.EntitySystems;
 
@@ -19,7 +17,6 @@ namespace Content.Shared.Storage.EntitySystems;
 /// </summary>
 public sealed class BinSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly ISharedAdminLogManager _admin = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
@@ -74,7 +71,7 @@ public sealed class BinSystem : EntitySystem
 
     private void OnInteractHand(EntityUid uid, BinComponent component, InteractHandEvent args)
     {
-        if (args.Handled || !_timing.IsFirstTimePredicted)
+        if (args.Handled)
             return;
 
         EntityUid? toGrab = component.Items.LastOrDefault();
@@ -110,9 +107,6 @@ public sealed class BinSystem : EntitySystem
     private void InsertIntoBin(EntityUid user, EntityUid target, EntityUid itemInHand, BinComponent component, bool handled, bool canReach)
     {
         if (handled || !canReach)
-            return;
-
-        if (!_timing.IsFirstTimePredicted)
             return;
 
         if (!TryInsertIntoBin(target, itemInHand, component))

--- a/Resources/Prototypes/Entities/Objects/Misc/candy_bowl.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/candy_bowl.yml
@@ -55,9 +55,11 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.10,-0.10,0.10,0.10"
-        density: 3
+        density: 20
         mask:
-          - TabletopMachineMask
+        - TabletopMachineMask
+        restitution: 0.3
+        friction: 0.2
   - type: InteractionOutline
   - type: ItemMapper
     sprite: Objects/Misc/candy_bowl.rsi


### PR DESCRIPTION
## About the PR

Candy bowls are bins, but also items, which conflict during the OnInteractHand event.


## Technical details

Removed `IsFirstTimePredicted` to fix a mispredict on pickup. I assume the appearance flickering is due to ItemMapper because it happens for stuff like crayon boxes too.

Also tweaked wonky physics by replacing with settings from BaseItem.


## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl: Krunk
- fix: Candy bowls function properly again!
