### PR TITLE
Fixed Fire Extinguisher safety range

### DIFF
--- a/Content.Server/Extinguisher/FireExtinguisherSystem.cs
+++ b/Content.Server/Extinguisher/FireExtinguisherSystem.cs
@@ -93,7 +93,7 @@ public sealed class FireExtinguisherSystem : EntitySystem
 
     private void OnGetInteractionVerbs(Entity<FireExtinguisherComponent> entity, ref GetVerbsEvent<InteractionVerb> args)
     {
-        if (!args.CanInteract)
+        if (!args.CanAccess || !args.CanInteract)
             return;
 
         var user = args.User;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The Fire Extinguishers safety was able to be toggled from any range. Now you have to be within range to toggle it!

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Beck Thompson
- fix: The Fire Extinguishers safety can now only be toggled when in range.

