### PR TITLE
Prevent clients from setting their species to whatever they want

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -375,7 +375,7 @@ namespace Content.Shared.Preferences
         {
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
 
-            if (!prototypeManager.TryIndex<SpeciesPrototype>(Species, out var speciesPrototype))
+            if (!prototypeManager.TryIndex<SpeciesPrototype>(Species, out var speciesPrototype) || speciesPrototype.RoundStart == false)
             {
                 Species = SharedHumanoidAppearanceSystem.DefaultSpecies;
                 speciesPrototype = prototypeManager.Index<SpeciesPrototype>(Species);


### PR DESCRIPTION
## About the PR
Changes a single line that should've been there since the start. This doesn't mess up anything else (from what I tested), but does prevent players from spawning with species they shouldn't

## Why / Balance
Roundstart terminator cringe

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media

https://github.com/space-wizards/space-station-14/assets/49997488/4091a268-2d21-4573-a00f-b68b11fae7ad

Selecting is impossible

![Content Client_51TyCjcJzx](https://github.com/space-wizards/space-station-14/assets/49997488/b3ad6af5-e7e1-480e-9883-c25102fc8e01)
![rider64_Fog8RXvCgO](https://github.com/space-wizards/space-station-14/assets/49997488/408bfdb4-f997-43e8-8519-f913c2f1988f)
Even directly editing the database doesn't work

![image](https://github.com/space-wizards/space-station-14/assets/49997488/b2d045b8-5879-47b9-91c6-ab494b793d84)
Spawned terminator (both admin and event) still work fine, so do closet skeletons, and gingerbreads

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Is there even anything that uses this check outside of being sent from the client?

**Changelog**
No cl no fun
