### PR TITLE
Clipping a harvestable plant yields undamaged seeds

### DIFF
--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -159,7 +159,6 @@ public sealed class PlantHolderSystem : EntitySystem
                 if (!_botany.TryGetSeed(seeds, out var seed))
                     return;
 
-                float? seedHealth = seeds.HealthOverride;
                 var name = Loc.GetString(seed.Name);
                 var noun = Loc.GetString(seed.Noun);
                 _popup.PopupCursor(Loc.GetString("plant-holder-component-plant-success-message",
@@ -169,9 +168,9 @@ public sealed class PlantHolderSystem : EntitySystem
                 component.Seed = seed;
                 component.Dead = false;
                 component.Age = 1;
-                if (seedHealth is float realSeedHealth)
+                if (seeds.HealthOverride != null)
                 {
-                    component.Health = realSeedHealth;
+                    component.Health = seeds.HealthOverride.Value;
                 }
                 else
                 {
@@ -287,15 +286,19 @@ public sealed class PlantHolderSystem : EntitySystem
                 return;
             }
 
-            component.Health -= (_random.Next(3, 5) * 10); //Clippers remove part of a plant, damaging it
+            component.Health -= (_random.Next(3, 5) * 10);
 
-            float? nullHealthOverride = null;
-            if (!component.Harvest)  //If plant is not harvestable, sets nullHealthOverride to null. Makes it so clipping a harvestable plant does not yield damaged seeds.
+            float? healthOverride;
+            if (component.Harvest)
             {
-                nullHealthOverride = component.Health;
+                healthOverride = null;
+            }
+            else
+            {
+                healthOverride = component.Health;
             }
             component.Seed.Unique = false;
-            var seed = _botany.SpawnSeedPacket(component.Seed, Transform(args.User).Coordinates, args.User, nullHealthOverride);
+            var seed = _botany.SpawnSeedPacket(component.Seed, Transform(args.User).Coordinates, args.User, healthOverride);
             _randomHelper.RandomOffset(seed, 0.25f);
             var displayName = Loc.GetString(component.Seed.DisplayName);
             _popup.PopupCursor(Loc.GetString("plant-holder-component-take-sample-message",

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -287,9 +287,15 @@ public sealed class PlantHolderSystem : EntitySystem
                 return;
             }
 
-            component.Health -= (_random.Next(3, 5) * 10);
+            component.Health -= (_random.Next(3, 5) * 10); //Clippers remove part of a plant, damaging it
+
+            float? nullHealthOverride = null;
+            if (!component.Harvest)  //If plant is not harvestable, sets nullHealthOverride to null. Makes it so clipping a harvestable plant does not yield damaged seeds.
+            {
+                nullHealthOverride = component.Health;
+            }
             component.Seed.Unique = false;
-            var seed = _botany.SpawnSeedPacket(component.Seed, Transform(args.User).Coordinates, args.User, component.Health);
+            var seed = _botany.SpawnSeedPacket(component.Seed, Transform(args.User).Coordinates, args.User, nullHealthOverride);
             _randomHelper.RandomOffset(seed, 0.25f);
             var displayName = Loc.GetString(component.Seed.DisplayName);
             _popup.PopupCursor(Loc.GetString("plant-holder-component-take-sample-message",


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
When you clip a harvestable plant, the seeds will be at full health instead of being damaged.

## Why / Balance
Mostly a bandaid patch to make Botany slightly more tolerable (specifically, less of a waiting game) while a rework/refactor is figured out. Clipping a plant in any condition currently causes it and its clippings to be damaged, and this is quite bothersome.
The plant you harvest from is still damaged. Don't be overzealous!

## Technical details
~~Added a new variable, nullHealthOverride, that the clipper's SpawnSeedPacket checks instead of component.Health. It's null if the plant is harvestable, causing healthOverride to get null and not override the seed's health.
(Please inform me if this is hacky- it feels like it, but I'm new to C# and largely coding as a whole, and would love to learn more effective means.)~~ declares healthOverride in the plant holder system and uses it in the function as opposed to component.Health, setting it to null if the plant is harvestable and thus causing the resulting plant's health to be drawn from endurance

## Media
https://github.com/space-wizards/space-station-14/assets/160211017/3fd78d6d-705f-4ac6-8ba4-11e5f43a6483

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None to my knowledge. This is my first time interacting with the code directly, but it is an extremely simple change.

**Changelog**
:cl:
- add: Clipping harvestable plants now yields undamaged seeds.