### PR TITLE
Disables the random sentience event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -239,17 +239,19 @@
     maxDuration: 120
   - type: PowerGridCheckRule
 
-- type: entity
-  id: RandomSentience
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 10
-    duration: 1
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-  - type: RandomSentienceRule
+#Disabled due to being hilariously lame.
+#
+#- type: entity
+#  id: RandomSentience
+#  parent: BaseGameRule
+#  noSpawn: true
+#  components:
+#  - type: StationEvent
+#    weight: 10
+#    duration: 1
+#    startAudio:
+#      path: /Audio/Announcements/attention.ogg
+#  - type: RandomSentienceRule
 
 - type: entity
   parent: BaseGameRule


### PR DESCRIPTION
## About the PR
Disables the RandomSentience event. This only comments out the yaml responsible for the event, and does not remove any associated code.

## Why / Balance
This event only really ends up accomplishing two things the vast majority of the time: clogging up the ghost role menu, and removing a possible spawn chance for another event to spawn.
These roles are not fun to play as or to roleplay as, and are very rarely taken as a result. I would be willing to bet that very few people want to sit around all round to play as an immobile hydroponics tray that most people won't even realize is sentient.

The event *is* inherintly kind of funny, but that's all it really has going for it. You'll probably get significantly more engaging roleplay by playing as a pAI.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- remove: Removed the random sentience event.
