### PR TITLE
traitors are more sociable (not just among themselves anymore)

### DIFF
--- a/Content.Server/Objectives/Components/RandomHeadEvacuateComponent.cs
+++ b/Content.Server/Objectives/Components/RandomHeadEvacuateComponent.cs
@@ -1,0 +1,11 @@
+using Content.Server.Objectives.Systems;
+
+namespace Content.Server.Objectives.Components;
+
+/// <summary>
+/// Completion requires the target to fly to Central Command alive and free
+/// </summary>
+[RegisterComponent, Access(typeof(EvacuateHeadConditionSystem))]
+public sealed partial class RandomHeadEvacuateComponent : Component
+{
+}

--- a/Content.Server/Objectives/Systems/EvacuateHeadConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/EvacuateHeadConditionSystem.cs
@@ -1,0 +1,119 @@
+using Content.Server.Objectives.Components;
+using Content.Server.Shuttles.Systems;
+using Content.Shared.Mind;
+using Content.Server.GameTicking.Rules;
+using Content.Shared.Objectives.Components;
+using Content.Shared.Roles.Jobs;
+using Robust.Shared.Random;
+using Robust.Shared.Configuration;
+using System.Linq;
+using Content.Shared.Cuffs.Components;
+
+namespace Content.Server.Objectives.Systems
+{
+
+    public sealed class EvacuateHeadConditionSystem : EntitySystem
+    {
+        [Dependency] private readonly EmergencyShuttleSystem _emergencyShuttle = default!;
+        [Dependency] private readonly IConfigurationManager _config = default!;
+        [Dependency] private readonly IRobustRandom _random = default!;
+        [Dependency] private readonly SharedJobSystem _job = default!;
+        [Dependency] private readonly SharedMindSystem _mind = default!;
+        [Dependency] private readonly TargetObjectiveSystem _target = default!;
+        [Dependency] private readonly TraitorRuleSystem _traitorRule = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<RandomHeadEvacuateComponent, ObjectiveGetProgressEvent>(OnGetProgress);
+        }
+
+        private void OnGetProgress(EntityUid uid, RandomHeadEvacuateComponent comp, ref ObjectiveGetProgressEvent args)
+        {
+            if (!_target.GetTarget(uid, out var target))
+                return;
+
+            args.Progress = GetProgress(target.Value);
+        }
+
+        private void OnPersonAssigned(EntityUid uid, PickRandomPersonComponent comp, ref ObjectiveAssignedEvent args)
+        {
+            if (!TryComp<TargetObjectiveComponent>(uid, out var target))
+            {
+                args.Cancelled = true;
+                return;
+            }
+
+            // target already assigned
+            if (target.Target != null)
+                return;
+        
+            // no other humans
+            var allHumans = _mind.GetAliveHumansExcept(args.MindId);
+            if (allHumans.Count == 0)
+            {
+                args.Cancelled = true;
+                return;
+            }
+
+            _target.SetTarget(uid, _random.Pick(allHumans), target);
+        }
+
+        private void OnHeadAssigned(EntityUid uid, PickRandomHeadComponent comp, ObjectiveAssignedEvent args)
+        {
+            if (!TryComp<TargetObjectiveComponent>(uid, out var target))
+            {
+                args.Cancelled = true;
+                return;
+            }
+            // target already assigned
+            if (target.Target != null)
+                return;
+            // no other humans
+            var allHumans = _mind.GetAliveHumansExcept(args.MindId);
+            if (allHumans.Count == 0)
+            {
+                args.Cancelled = true;
+                return;
+            }
+            // new list
+            var allHeads = new List<EntityUid>();
+            foreach (var mind in allHumans)
+            {
+                if (_job.MindTryGetJob(mind, out _, out var prototype) && prototype.RequireAdminNotify)
+                    allHeads.Add(mind);
+            }
+            
+            if (allHeads.Count == 0)
+                return; // not the head=person because it causes errors
+
+            _target.SetTarget(uid, _random.Pick(allHeads), target);
+        }
+        
+        private float GetProgress(EntityUid mindId)
+        {
+            if (!TryComp<MindComponent>(mindId, out var mind))
+                return 0f;
+
+            // they will not evacuate if they are restrained
+            if (TryComp<CuffableComponent>(mind.OwnedEntity, out var cuffed) && cuffed.CuffedHandCount > 0)
+                return 0f;
+
+            // any emergency shuttle counts for this objective, but not pods.
+            if (mind.OwnedEntity != null && _emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value))
+                return 1f;
+
+            // evacuation went without purpose, loss
+            if (_emergencyShuttle.ShuttlesLeft)
+                return 0f;
+            
+            // dead is loss ...
+            if (_mind.IsCharacterDeadIc(mind))
+                return 0f;
+            else
+                return 0.5f;
+        }
+    }
+}
+

--- a/Content.Server/Objectives/Systems/EvacuateHeadConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/EvacuateHeadConditionSystem.cs
@@ -40,12 +40,20 @@ namespace Content.Server.Objectives.Systems
 
         private void OnPersonAssigned(EntityUid uid, PickRandomPersonComponent comp, ref ObjectiveAssignedEvent args)
         {
-            _killPersonConditionSystem.OnPersonAssigned(uid, comp, ref args);
+            //I'm not sure
+            var targetComponent = new TargetObjectiveComponent();
+
+            var targetUid = _random.Pick(_killPersonConditionSystem.killPersonTargets);
+            _target.SetTarget(uid, targetUid, targetComponent);
         }
 
         private void OnHeadAssigned(EntityUid uid, PickRandomHeadComponent comp, ref ObjectiveAssignedEvent args)
         {
-            _killPersonConditionSystem.OnHeadAssigned(uid, comp, ref args);
+            //I'm not sure
+            var targetComponent = new TargetObjectiveComponent();
+            
+            var targetUid = _random.Pick(_killPersonConditionSystem.killHeadTargets);
+            _target.SetTarget(uid, targetUid, targetComponent);
         }
         
         private float GetProgress(EntityUid mindId)

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -21,6 +21,10 @@ public sealed class KillPersonConditionSystem : EntitySystem
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly TargetObjectiveSystem _target = default!;
 
+    //the list for "addicted"
+    public List<EntityUid> killPersonTargets = new List<EntityUid>();
+    public List<EntityUid> killHeadTargets = new List<EntityUid>();
+    
     public override void Initialize()
     {
         base.Initialize();
@@ -60,8 +64,11 @@ public sealed class KillPersonConditionSystem : EntitySystem
             args.Cancelled = true;
             return;
         }
+        
+        var targetUid = _random.Pick(allHumans);
+        _target.SetTarget(uid, targetUid, target);
 
-        _target.SetTarget(uid, _random.Pick(allHumans), target);
+        killPersonTargets.Add(targetUid);
     }
 
     public void OnHeadAssigned(EntityUid uid, PickRandomHeadComponent comp, ref ObjectiveAssignedEvent args)
@@ -96,7 +103,10 @@ public sealed class KillPersonConditionSystem : EntitySystem
         if (allHeads.Count == 0)
             allHeads = allHumans; // fallback to non-head target
 
-        _target.SetTarget(uid, _random.Pick(allHeads), target);
+        var targetUid = _random.Pick(allHeads);
+        _target.SetTarget(uid, targetUid, target);
+
+        killHeadTargets.Add(targetUid);
     }
 
     private float GetProgress(EntityUid target, bool requireDead)

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -40,7 +40,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
         args.Progress = GetProgress(target.Value, comp.RequireDead);
     }
 
-    private void OnPersonAssigned(EntityUid uid, PickRandomPersonComponent comp, ref ObjectiveAssignedEvent args)
+    public void OnPersonAssigned(EntityUid uid, PickRandomPersonComponent comp, ref ObjectiveAssignedEvent args)
     {
         // invalid objective prototype
         if (!TryComp<TargetObjectiveComponent>(uid, out var target))
@@ -64,7 +64,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
         _target.SetTarget(uid, _random.Pick(allHumans), target);
     }
 
-    private void OnHeadAssigned(EntityUid uid, PickRandomHeadComponent comp, ref ObjectiveAssignedEvent args)
+    public void OnHeadAssigned(EntityUid uid, PickRandomHeadComponent comp, ref ObjectiveAssignedEvent args)
     {
         // invalid prototype
         if (!TryComp<TargetObjectiveComponent>(uid, out var target))

--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -1,12 +1,4 @@
 ﻿Entries:
-- author: DrMelon
-  changes:
-  - message: Fixed the Tesla Ball moving too fast by being pushed with explosions.
-      Now it moves as-designed.
-    type: Fix
-  id: 5513
-  time: '2024-01-02T18:09:06.0000000+00:00'
-  url: https://api.github.com/repos/space-wizards/space-station-14/pulls/23377
 - author: tday
   changes:
   - message: The admin log will now include attempts to draw from mobs with a syringe.
@@ -3852,3 +3844,10 @@
   id: 6012
   time: '2024-02-23T13:19:52.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/25496
+- author: Erisfiregamer1
+  changes:
+  - message: Fixed a typo when forcefeeding someone.
+    type: Fix
+  id: 6013
+  time: '2024-02-24T01:45:02.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/25512

--- a/Resources/Locale/en-US/objectives/conditions/personal-evac.ftl
+++ b/Resources/Locale/en-US/objectives/conditions/personal-evac.ftl
@@ -1,0 +1,2 @@
+objective-condition-head-evac-title = Make sure {$targetName}, {CAPITALIZE($job)}, flies off to centcom alive and free. {$targetName} has the information we need
+objective-condition-person-evac-title = Ensure {$targetName}, {CAPITALIZE($job)}, arrives at centcom alive and available. {$targetName} is required for the following agency actions

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -40,6 +40,7 @@
   weights:
     RandomTraitorAliveObjective: 1
     RandomTraitorProgressObjective: 1
+    RandomHeadEvacuateObjective: 1
 
 #Thief groups
 - type: weightedRandom

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -132,6 +132,42 @@
 
 - type: entity
   noSpawn: true
+  parent: [BaseTraitorSocialObjective, BaseKeepAliveObjective]
+  id: RandomPersonEvacuateObjective
+  description: Identify yourself at your own risk. We need them alive and not imprisoned on centcom.
+  components:
+  - type: Objective
+    difficulty: 1.5
+    icon:
+      sprite: Structures/Furniture/chairs.rsi
+      state: shuttle
+  - type: TargetObjective
+    title: objective-condition-person-evac-title
+  - type: PickRandomPerson
+  - type: ObjectiveLimit
+    limit: 2 #enough.
+  - type: RandomHeadEvacuate
+
+- type: entity
+  noSpawn: true
+  parent: [BaseTraitorSocialObjective, BaseKeepAliveObjective]
+  id: RandomHeadEvacuateObjective
+  description: Identify yourself at your own risk. We need them alive and not imprisoned on centcom.
+  components:
+  - type: Objective
+    difficulty: 2.5
+    icon:
+      sprite: Structures/Furniture/chairs.rsi
+      state: shuttle
+    # one's enough, he's not a blue shield.
+    unique: true
+  - type: TargetObjective
+    title: objective-condition-head-evac-title
+  - type: RandomHeadEvacuate
+  - type: PickRandomHead
+
+- type: entity
+  noSpawn: true
   parent: [BaseTraitorSocialObjective, BaseHelpProgressObjective]
   id: RandomTraitorProgressObjective
   description: Identify yourself at your own risk. We just need them to succeed.

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -134,7 +134,7 @@
   noSpawn: true
   parent: [BaseTraitorSocialObjective, BaseKeepAliveObjective]
   id: RandomPersonEvacuateObjective
-  description: Identify yourself at your own risk. We need them alive and not imprisoned on centcom.
+  description: Be extremely careful. We're sure someone's been sent in for the kill. We need them alive and not imprisoned on centcom. Trust someone at your own risk. 
   components:
   - type: Objective
     difficulty: 1.5
@@ -152,7 +152,7 @@
   noSpawn: true
   parent: [BaseTraitorSocialObjective, BaseKeepAliveObjective]
   id: RandomHeadEvacuateObjective
-  description: Identify yourself at your own risk. We need them alive and not imprisoned on centcom.
+  description: Be extremely careful. We're sure someone's been sent in for the kill. We need them alive and not imprisoned on centcom. Trust someone at your own risk. 
   components:
   - type: Objective
     difficulty: 2.5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The traitors have 2 new objectives, they can now be required to have a head or an ordinary humanoid fly off to CentCom alive and free

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
At this point, the traitors don't look like what I'd like to see them look like. They're regular villains with black morals who only help each other (unless they got opposite goals). That's not cool, antagonists should make the round interesting. For everyone. 
My objectives will cause conflict among the traitors. They'll have to talk to each other more carefully and go to the point of killing much less often. Killing for highrisk isn't cool. 
The man has a target on the CMO hypospray? haha, he'll kill it of course since that's the most encouraged way to go. By killing you get the items and your coveted highrisk. Now that very CMO (probably) needs to be rescued by another agent, which will cause a business conversation or massacre between the two of you. It's more interesting, imho
Also, my objectives can cause fun, like "Steal the senior engineer's magnetic boots and make sure he flies off to CentCom".
From time to time, the traitors will have to save the scientist from himself, because he is very important to his employers.

More gray morality for agents is cool.  

Maybe I should engage in some petty trolling so the agent doesn't know if he needs to rescue a coworker or a regular person.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I'm not quite sure about `GetProgress`, at least it worked correctly during the test
I'm not sure about line 149 of `Resources/Prototypes/Objectives/traitor.yml`, I didn't have the intelligence to figure out if I'm right or not
now two lists are declared in the `KillPersonConditionSystem` class:`killPersonTargets` and `killHeadTargets`. My system is tied to them
I didn't understand where I should get the `TargetObjectiveComponent` from, so I made getting it so silly. Please, if this is creating a problem, help me solve it
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![изображение](https://github.com/space-wizards/space-station-14/assets/93311212/47f5cc6b-1ce3-4155-97c7-a374e67a34a5)
(objectives are issued through the console, they can't be in that order in the game)
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Traitors may be tasked with evacuating a head or regular humanoid.
