### PR TITLE
Fix ItemSlots prediction

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -274,7 +274,7 @@ namespace Content.Shared.Containers.ItemSlots
             if (ev.Cancelled)
                 return false;
 
-            return _containers.CanInsert(usedUid, slot.ContainerSlot, assumeEmpty: true);
+            return _containers.CanInsert(usedUid, slot.ContainerSlot);
         }
 
         /// <summary>


### PR DESCRIPTION
IDK what this arg is for but seems okay with guns. Without it it always thinks the insertion can work.