### PR TITLE
add crew monitor as traitor steal objective

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -31,6 +31,11 @@
   - type: StationLimitedNetwork
   - type: StaticPrice
     price: 500
+  - type: Tag
+    tags:
+    - HighRiskItem
+  - type: StealTarget
+    stealGroup: HandheldCrewMonitor
 
 - type: entity
   id: HandheldCrewMonitorEmpty

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -12,6 +12,7 @@
   weights:
     CaptainIDStealObjective: 1
     CMOHyposprayStealObjective: 1
+    CMOCrewMonitorStealObjective: 1
     RDHardsuitStealObjective: 1
     NukeDiskStealObjective: 1
     MagbootsStealObjective: 1

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -8,6 +8,13 @@
     state: hypo
 
 - type: stealTargetGroup
+  id: HandheldCrewMonitor
+  name: handheld crew monitor
+  sprite:
+    sprite: Objects/Specific/Medical/handheldcrewmonitor.rsi
+    state: scanner
+
+- type: stealTargetGroup
   id: ClothingOuterHardsuitRd
   name: experimental research hardsuit
   sprite:

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -147,35 +147,58 @@
 ## cmo
 
 - type: entity
-  noSpawn: true
+  abstract: true
   parent: BaseTraitorStealObjective
-  id: CMOHyposprayStealObjective
+  id: BaseCMOStealObjective
   components:
   - type: NotJobRequirement
     job: ChiefMedicalOfficer
   - type: StealCondition
-    stealGroup: Hypospray
     owner: job-name-cmo
+
+- type: entity
+  noSpawn: true
+  parent: BaseCMOStealObjective
+  id: CMOHyposprayStealObjective
+  components:
+  - type: StealCondition
+    stealGroup: Hypospray
+
+- type: entity
+  noSpawn: true
+  parent: BaseCMOStealObjective
+  id: CMOCrewMonitorStealObjective
+  components:
+  - type: StealCondition
+    stealGroup: HandheldCrewMonitor
 
 ## rd
 
 - type: entity
-  noSpawn: true
+  abstract: true
   parent: BaseTraitorStealObjective
-  id: RDHardsuitStealObjective
+  id: BaseRDStealObjective
   components:
+  - type: NotJobRequirement
+    job: ResearchDirector
   - type: StealCondition
-    stealGroup: ClothingOuterHardsuitRd
     owner: job-name-rd
 
 - type: entity
   noSpawn: true
-  parent: BaseTraitorStealObjective
+  parent: BaseRDStealObjective
+  id: RDHardsuitStealObjective
+  components:
+  - type: StealCondition
+    stealGroup: ClothingOuterHardsuitRd
+
+- type: entity
+  noSpawn: true
+  parent: BaseRDStealObjective
   id: HandTeleporterStealObjective
   components:
   - type: StealCondition
     stealGroup: HandTeleporter
-    owner: job-name-rd
 
 ## hos
 


### PR DESCRIPTION
## About the PR
title

also clean up some copy paste in the objective yml

## Why / Balance
its a cmo exclusive now, so traitors try to make it non-exclusive :trollface:

## Technical details
no

## Media
![18:42:00](https://github.com/space-wizards/space-station-14/assets/39013340/c51efc95-1aea-4087-808e-b5f4dc712b4b)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Traitors can now be asked to steal the CMO's Handheld Crew Monitor.