### PR TITLE
Don't double-dip survival intensity scaling

### DIFF
--- a/Content.Server/StationEvents/Events/AnomalySpawnRule.cs
+++ b/Content.Server/StationEvents/Events/AnomalySpawnRule.cs
@@ -33,7 +33,7 @@ public sealed class AnomalySpawnRule : StationEventSystem<AnomalySpawnRuleCompon
         if (grid is null)
             return;
 
-        var amountToSpawn = Math.Max(1, (int) MathF.Round(GetSeverityModifier() / 2));
+        var amountToSpawn = 1;
         for (var i = 0; i < amountToSpawn; i++)
         {
             _anomaly.SpawnOnRandomGridLocation(grid.Value, component.AnomalySpawnerPrototype);

--- a/Content.Server/StationEvents/Events/BluespaceArtifactRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceArtifactRule.cs
@@ -19,7 +19,7 @@ public sealed class BluespaceArtifactRule : StationEventSystem<BluespaceArtifact
     {
         base.Started(uid, component, gameRule, args);
 
-        var amountToSpawn = Math.Max(1, (int) MathF.Round(GetSeverityModifier() / 1.5f));
+        var amountToSpawn = 1;
         for (var i = 0; i < amountToSpawn; i++)
         {
             if (!TryFindRandomTile(out _, out _, out _, out var coords))

--- a/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
@@ -25,11 +25,9 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
         if (jobList.Count == 0)
             return;
 
-        var mod = GetSeverityModifier();
-
         // Low chance to completely change up the late-join landscape by closing all positions except infinite slots.
         // Lower chance than the /tg/ equivalent of this event.
-        if (RobustRandom.Prob(Math.Min(0.25f * MathF.Sqrt(mod), 1.0f)))
+        if (RobustRandom.Prob(0.25f))
         {
             var chosenJob = RobustRandom.PickAndTake(jobList);
             _stationJobs.MakeJobUnlimited(chosenStation.Value, chosenJob); // INFINITE chaos.
@@ -42,8 +40,8 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
         }
         else
         {
-            var lower = (int) (jobList.Count * Math.Min(1.0f, 0.20 * mod));
-            var upper = (int) (jobList.Count * Math.Min(1.0f, 0.30 * mod));
+            var lower = (int) (jobList.Count * 0.20);
+            var upper = (int) (jobList.Count * 0.30);
             // Changing every role is maybe a bit too chaotic so instead change 20-30% of them.
             var num = RobustRandom.Next(lower, upper);
             for (var i = 0; i < num; i++)

--- a/Content.Server/StationEvents/Events/GasLeakRule.cs
+++ b/Content.Server/StationEvents/Events/GasLeakRule.cs
@@ -19,8 +19,6 @@ namespace Content.Server.StationEvents.Events
             if (!TryComp<StationEventComponent>(uid, out var stationEvent))
                 return;
 
-            var mod = MathF.Sqrt(GetSeverityModifier());
-
             // Essentially we'll pick out a target amount of gas to leak, then a rate to leak it at, then work out the duration from there.
             if (TryFindRandomTile(out component.TargetTile, out var target, out component.TargetGrid, out component.TargetCoords))
             {
@@ -29,7 +27,7 @@ namespace Content.Server.StationEvents.Events
 
                 component.LeakGas = RobustRandom.Pick(component.LeakableGases);
                 // Was 50-50 on using normal distribution.
-                var totalGas = RobustRandom.Next(component.MinimumGas, component.MaximumGas) * mod;
+                var totalGas = RobustRandom.Next(component.MinimumGas, component.MaximumGas);
                 var startAfter = stationEvent.StartDelay;
                 component.MolesPerSecond = RobustRandom.Next(component.MinimumMolesPerSecond, component.MaximumMolesPerSecond);
 

--- a/Content.Server/StationEvents/Events/MeteorSwarmRule.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmRule.cs
@@ -17,8 +17,7 @@ namespace Content.Server.StationEvents.Events
         {
             base.Started(uid, component, gameRule, args);
 
-            var mod = Math.Sqrt(GetSeverityModifier());
-            component.WaveCounter = (int) (RobustRandom.Next(component.MinimumWaves, component.MaximumWaves) * mod);
+            component.WaveCounter = RobustRandom.Next(component.MinimumWaves, component.MaximumWaves);
         }
 
         protected override void ActiveTick(EntityUid uid, MeteorSwarmRuleComponent component, GameRuleComponent gameRule, float frameTime)
@@ -29,8 +28,6 @@ namespace Content.Server.StationEvents.Events
                 return;
             }
 
-            var mod = GetSeverityModifier();
-
             component.Cooldown -= frameTime;
 
             if (component.Cooldown > 0f)
@@ -38,7 +35,7 @@ namespace Content.Server.StationEvents.Events
 
             component.WaveCounter--;
 
-            component.Cooldown += (component.MaximumCooldown - component.MinimumCooldown) * RobustRandom.NextFloat() / mod + component.MinimumCooldown;
+            component.Cooldown += (component.MaximumCooldown - component.MinimumCooldown) * RobustRandom.NextFloat() + component.MinimumCooldown;
 
             Box2? playableArea = null;
             var mapId = GameTicker.DefaultMap;

--- a/Content.Server/StationEvents/Events/RandomSentienceRule.cs
+++ b/Content.Server/StationEvents/Events/RandomSentienceRule.cs
@@ -11,7 +11,6 @@ public sealed class RandomSentienceRule : StationEventSystem<RandomSentienceRule
     {
         HashSet<EntityUid> stationsToNotify = new();
 
-        var mod = GetSeverityModifier();
         var targetList = new List<Entity<SentienceTargetComponent>>();
         var query = EntityQueryEnumerator<SentienceTargetComponent>();
         while (query.MoveNext(out var targetUid, out var target))
@@ -21,7 +20,7 @@ public sealed class RandomSentienceRule : StationEventSystem<RandomSentienceRule
 
         RobustRandom.Shuffle(targetList);
 
-        var toMakeSentient = (int) (RobustRandom.Next(2, 5) * Math.Sqrt(mod));
+        var toMakeSentient = RobustRandom.Next(2, 5);
         var groups = new HashSet<string>();
 
         foreach (var target in targetList)

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -134,25 +134,5 @@ public abstract partial class StationEventSystem<T> : GameRuleSystem<T> where T 
         GameTicker.EndGameRule(uid, component);
     }
 
-    public float GetSeverityModifier()
-    {
-        var ev = new GetSeverityModifierEvent();
-        RaiseLocalEvent(ev);
-        return ev.Modifier;
-    }
-
     #endregion
-}
-
-/// <summary>
-///     Raised broadcast to determine what the severity modifier should be for an event, some positive number that can be multiplied with various things.
-///     Handled by usually other game rules (like the ramping scheduler).
-///     Most events should try and make use of this if possible.
-/// </summary>
-public sealed class GetSeverityModifierEvent : EntityEventArgs
-{
-    /// <summary>
-    ///     Should be multiplied/added to rather than set, for commutativity.
-    /// </summary>
-    public float Modifier = 1.0f;
 }

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -28,9 +28,6 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
             .Where(x => !x.Abstract)
             .Select(x => x.ID).ToList();
 
-        // TODO: This is gross, but not much can be done until event refactor, which needs Dynamic.
-        var mod = (float) Math.Sqrt(GetSeverityModifier());
-
         foreach (var (_, transform) in EntityManager.EntityQuery<GasVentPumpComponent, TransformComponent>())
         {
             if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station != chosenStation)
@@ -40,14 +37,14 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
 
             var solution = new Solution();
 
-            if (!RobustRandom.Prob(Math.Min(0.33f * mod, 1.0f)))
+            if (!RobustRandom.Prob(0.33f))
                 continue;
 
-            var pickAny = RobustRandom.Prob(Math.Min(0.05f * mod, 1.0f));
+            var pickAny = RobustRandom.Prob(0.05f);
             var reagent = RobustRandom.Pick(pickAny ? allReagents : component.SafeishVentChemicals);
 
             var weak = component.WeakReagents.Contains(reagent);
-            var quantity = (weak ? component.WeakReagentQuantity : component.ReagentQuantity) * mod;
+            var quantity = weak ? component.WeakReagentQuantity : component.ReagentQuantity;
             solution.AddReagent(reagent, quantity);
 
             var foamEnt = Spawn("Foam", transform.Coordinates);

--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -25,13 +25,6 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
         return component.MaxChaos / component.EndTime * roundTime + component.StartingChaos;
     }
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<GetSeverityModifierEvent>(OnGetSeverityModifier);
-    }
-
     protected override void Started(EntityUid uid, RampingStationEventSchedulerComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, component, gameRule, args);
@@ -70,19 +63,6 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
 
             PickNextEventTime(uid, scheduler);
             _event.RunRandomEvent();
-        }
-    }
-
-    private void OnGetSeverityModifier(GetSeverityModifierEvent ev)
-    {
-        var query = EntityQueryEnumerator<RampingStationEventSchedulerComponent, GameRuleComponent>();
-        while (query.MoveNext(out var uid, out var scheduler, out var gameRule))
-        {
-            if (!GameTicker.IsGameRuleActive(uid, gameRule))
-                return;
-
-            ev.Modifier *= GetChaosModifier(uid, scheduler);
-            Logger.Info($"Ramping set modifier to {ev.Modifier}");
         }
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

don't scale intensity of events, survival already scales quantity of events

survival is like ~half rewritten in a branch im working on but pulling this out since we readded it to secret in the interim

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

was tuned nonsensically and made certain things like ventclog really really stupid
