### PR TITLE
Guaranteed Big Tanks in Emergency Closets

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -22,18 +22,8 @@
     contents:
       - id: ClothingOuterSuitEmergency
       - id: ClothingMaskBreath
-      - id: EmergencyOxygenTankFilled
-        prob: 0.80
-        orGroup: EmergencyTankOrRegularTank
       - id: OxygenTankFilled
-        prob: 0.20
-        orGroup: EmergencyTankOrRegularTank
-      - id: EmergencyNitrogenTankFilled
-        prob: 0.80
-        orGroup: EmergencyNitrogenOrRegularNitrogen
       - id: NitrogenTankFilled
-        prob: 0.20
-        orGroup: EmergencyNitrogenOrRegularNitrogen
       - id: ToolboxEmergencyFilled
         prob: 0.4
       - id: MedkitOxygenFilled
@@ -52,18 +42,8 @@
     contents:
       - id: ClothingOuterSuitEmergency
       - id: ClothingMaskBreath
-      - id: EmergencyOxygenTankFilled
-        prob: 0.80
-        orGroup: EmergencyTankOrRegularTank
       - id: OxygenTankFilled
-        prob: 0.20
-        orGroup: EmergencyTankOrRegularTank
       - id: NitrogenTankFilled
-        prob: 0.80
-        orGroup: EmergencyNitrogenOrRegularNitrogen
-      - id: EmergencyNitrogenTankFilled
-        prob: 0.20
-        orGroup: EmergencyNitrogenOrRegularNitrogen  
       - id: ToolboxEmergencyFilled
         prob: 0.4
       - id: MedkitOxygenFilled


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Got rid of the random chance to have small oxygen/nitrogen tanks in emergency closets and guaranteed the big ones.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It feels like emergency supplies shouldn't really be random, and the fire closets already had guaranteed large tanks with no problems so far.

I view the smaller emergency oxygen tanks that people start with as just a stopgap you can use until you make it to an emergency closet.

It's kind of a disappointment when you only end up finding another small tank when there's a tesloose or a singuloose going on. It doesn't really make sense for the huge emergency locker to have a tiny oxygen tank...

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
yml change to emergency closets

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Guaranteed larger oxygen and nitrogen tanks in emergency closets.