### PR TITLE
handcuff replacements are faster to escape from

### DIFF
--- a/Content.Shared/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Shared/Cuffs/Components/HandcuffComponent.cs
@@ -25,7 +25,7 @@ public sealed partial class HandcuffComponent : Component
     ///     The time it takes for a cuffed entity to uncuff itself.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float BreakoutTime = 30f;
+    public float BreakoutTime = 15f;
 
     /// <summary>
     ///     If an entity being cuffed is stunned, this amount of time is subtracted from the time it takes to add/remove their cuffs.

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -35,7 +35,7 @@
   parent: Handcuffs
   components:
   - type: Handcuff
-    breakoutTime: 15
+    breakoutTime: 3
     cuffedRSI: Objects/Misc/cablecuffs.rsi
     bodyIconState: body-overlay
     color: forestgreen
@@ -77,7 +77,7 @@
     size: Tiny
     storedRotation: 0
   - type: Handcuff
-    breakoutTime: 20  # halfway between improvised cablecuffs and metal ones
+    breakoutTime: 3
     cuffedRSI: Objects/Misc/cablecuffs.rsi  # cablecuffs will look fine
     bodyIconState: body-overlay
     breakOnRemove: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

- Makeshift cuffs and ties take 3 seconds to escape 
- Normal cuffs take 15 seconds to remove (The doafter before was so long it was pointless to attempt)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
- If you're actively holding the person this will never be an issue
- These cuffs can become temporary and replaced with proper cuffs when the detained is no longer an issue
- Prisoners can be left in their cells with cable cuffs still on as they won't take ages to remove
- makeshift cuffs are a direct upgrade to regular cuffs to the point where regulars are rarely used:
    - Take up half the space
    - easily replenished
    - do not require any extra attention to hold a prisoner as the doafter is so long
    
Summary: handcuff replacements are still a good temporary way to detain someone, but that person needs to be actively held and monitored so they cannot escape, while normal handcuffs still allow you reasonable time to do other things before attempting to stop the escape.

Team antagonists have a better chance at freeing handcuffed people if they push away the detainers. 
Allows cuffing to be strong while not extremely oppressive if the team is coherent.
Shouldn't change balancing for lone antagonists very much unless security leaves them alone for some reason or are interrupted by another antagonist.
(The detained can try to release themselves in a safe area)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
[I hate upload limits](https://youtu.be/GLyOS6xNJ9I)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:

- tweak: Handcuff and handcuff replacements are faster to escape. You can allow your teammates to uncuff themselves!


