### PR TITLE
Revert "Fix ItemSlots prediction"

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -274,7 +274,7 @@ namespace Content.Shared.Containers.ItemSlots
             if (ev.Cancelled)
                 return false;
 
-            return _containers.CanInsert(usedUid, slot.ContainerSlot);
+            return _containers.CanInsert(usedUid, slot.ContainerSlot, assumeEmpty: true);
         }
 
         /// <summary>


### PR DESCRIPTION
Reverts space-wizards/space-station-14#25552

This change broke quick swapping for things like magazines in guns and ID cards in PDAs.