### PR TITLE
Fix inconsistency in onions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -987,7 +987,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 14
+        maxVol: 18
         reagents:
         - ReagentId: Nutriment
           Quantity: 10
@@ -1000,7 +1000,7 @@
   - type: Produce
     seedId: onionred
   - type: SliceableFood
-    count: 4
+    count: 5
     slice: FoodOnionRedSlice
 
 - type: entity
@@ -1073,7 +1073,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 3
+        maxVol: 5
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
@@ -1096,7 +1096,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 3
+        maxVol: 5
         reagents:
         - ReagentId: Nutriment
           Quantity: 2


### PR DESCRIPTION
## About the PR
Fixes some inconsistencies with onions
- Red onions had `maxVol: 14` but 18 total reagents: Changed to `maxVol: 18`
- Red onions made 4 slices white onions had 5: Changed red to 5
- Both red and white onion slices had `maxVol: 3` but 5 total reagents: Changed to `maxVol: 5`

## Why / Balance
Consistency

## Technical details
n/a

## Media
n/a
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a