### PR TITLE
Remove obsolete suffix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -6,7 +6,6 @@
   id: AsteroidRock
   parent: BaseStructure
   name: asteroid rock
-  suffix: Low Ore Yield
   description: A rocky asteroid.
   components:
   - type: PlacementReplacement
@@ -191,7 +190,7 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_asteroid_west
         - state: rock_silver
-        
+
 - type: entity
   id: AsteroidRockSilverCrab
   parent: AsteroidRockSilver
@@ -223,7 +222,7 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_asteroid_west
         - state: rock_tin
-        
+
 - type: entity
   id: AsteroidRockTinCrab
   parent: AsteroidRockTin


### PR DESCRIPTION
## About the PR
Ore loot pool was removed from the base asteroid rock. There was still a lingering suffix labeling it as containing ore. Removed it.

## Why / Balance
Inaccurate 

## Technical details
n/a
## Media
n/a
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a
