### PR TITLE
Added winddown to space drugs effect

### DIFF
--- a/Content.Client/Drugs/DrugOverlaySystem.cs
+++ b/Content.Client/Drugs/DrugOverlaySystem.cs
@@ -38,6 +38,7 @@ public sealed class DrugOverlaySystem : EntitySystem
     private void OnPlayerDetached(EntityUid uid, SeeingRainbowsComponent component, LocalPlayerDetachedEvent args)
     {
         _overlay.Intoxication = 0;
+        _overlay.TimeTicker = 0;
         _overlayMan.RemoveOverlay(_overlay);
     }
 
@@ -52,6 +53,7 @@ public sealed class DrugOverlaySystem : EntitySystem
         if (_player.LocalEntity == uid)
         {
             _overlay.Intoxication = 0;
+            _overlay.TimeTicker = 0;
             _overlayMan.RemoveOverlay(_overlay);
         }
     }

--- a/Content.Client/Drugs/RainbowOverlay.cs
+++ b/Content.Client/Drugs/RainbowOverlay.cs
@@ -20,6 +20,7 @@ public sealed class RainbowOverlay : Overlay
     private readonly ShaderInstance _rainbowShader;
 
     public float Intoxication = 0.0f;
+    public float TimeTicker = 0.0f;
 
     private const float VisualThreshold = 10.0f;
     private const float PowerDivisor = 250.0f;
@@ -48,7 +49,17 @@ public sealed class RainbowOverlay : Overlay
             return;
 
         var timeLeft = (float) (time.Value.Item2 - time.Value.Item1).TotalSeconds;
-        Intoxication += (timeLeft - Intoxication) * args.DeltaSeconds / 16f;
+
+        TimeTicker += args.DeltaSeconds;
+
+        if (timeLeft - TimeTicker > timeLeft / 16f)
+        {
+            Intoxication += (timeLeft - Intoxication) * args.DeltaSeconds / 16f;
+        }
+        else
+        {
+            Intoxication -= Intoxication/(timeLeft - TimeTicker) * args.DeltaSeconds;
+        }
     }
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

The space drugs shader effect now gradually loses intensity as it's nearing its end.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Makes for a smoother transition than going from 100% to 0% instantly.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/62557990/1dd19974-1066-4f76-a270-6844f35af042


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase