### PR TITLE
survival nutribricks, lizzers can eat nutribricks, moffs can eat the leftovers

### DIFF
--- a/Resources/Prototypes/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/Body/Organs/reptilian.yml
@@ -7,6 +7,7 @@
     specialDigestible:
       tags:
       - Fruit
+      - ReptilianFood
       - Meat
       - Pill
       - Crayon

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -10,7 +10,7 @@
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
       - id: Flare
-      - id: FoodTinMRE
+      - id: FoodSnackNutribrick
       - id: DrinkWaterBottleFull
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -383,6 +383,9 @@
       - nutribrick
   - type: Item
     size: Small
+  - type: Tag
+    tags:
+      - ReptilianFood
   - type: Sprite
     state: nutribrick-open
   - type: Food
@@ -608,5 +611,17 @@
   name: MRE wrapper
   description: A general purpose wrapper for a variety of military food goods.
   components:
+  - type: Food
+    requiresSpecialDigestion: true
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 30
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 40
+  - type: Tag
+    tags:
+    - ClothMade
   - type: Sprite
     state: mre-wrapper

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -261,16 +261,16 @@
 
 - type: Tag
   id: CarpetOrange
-  
+
 - type: Tag
   id: CarpetPurple
 
 - type: Tag
   id: CarpetPink
-  
+
 - type: Tag
   id: CarpetRed
-  
+
 - type: Tag
   id: CarpetWhite
 
@@ -991,6 +991,9 @@
 
 - type: Tag
   id: ReinforcedGlassShard
+
+- type: Tag
+  id: ReptilianFood
 
 - type: Tag
   id: RifleStock


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Nutribricks now spawn in the survival kit in place of tinned meat.
Lizards can now eat nutribricks
Moths can now eat nutribrick wrappers

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Every species now has something they can eat from their survival kit.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added a new tag, `ReptilianFood`, which, as the name implies, is a specific tag to allow lizards to eat a specific item.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Aexxie
- tweak: Nutribricks spawn in Survival Kits in place of Tinned Meat.
- fix: Lizards can now eat Nutribricks.
- add: Moths can eat Nutribrick wrappers.