### PR TITLE
Removes all big O2 tanks from non-emergency & fire lockers + removes counterpart N2 tanks

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -13,9 +13,6 @@
       - id: EmergencyOxygenTankFilled
       - id: EmergencyOxygenTankFilled
         prob: 0.5
-      - id: EmergencyNitrogenTankFilled
-      - id: EmergencyNitrogenTankFilled
-        prob: 0.5
       - id: FoodTinMRE
       - id: FoodTinMRE
         prob: 0.5

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -6,8 +6,6 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterHardsuitSpatio
-      - id: OxygenTankFilled
-      - id: NitrogenTankFilled
       - id: ClothingShoesBootsMag
       - id: ClothingMaskGasExplorer
       - id: ClothingBeltUtilityFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -82,8 +82,6 @@
     contents:
       - id: ClothingOuterHardsuitAtmos
       - id: ClothingMaskGasAtmos
-      - id: OxygenTankFilled
-      - id: NitrogenTankFilled
       - id: ClothingOuterSuitAtmosFire
       - id: ClothingHeadHelmetAtmosFire
       - id: GasAnalyzer
@@ -120,8 +118,6 @@
       - id: ClothingOuterHardsuitEngineering
       - id: ClothingHandsGlovesColorYellow
       - id: ClothingMaskGas
-      - id: OxygenTankFilled
-      - id: NitrogenTankFilled
       - id: ClothingShoesBootsMag
       - id: RCD
       - id: RCDAmmo

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -133,8 +133,6 @@
     contents:
       - id: ClothingOuterHardsuitEngineeringWhite
       - id: ClothingMaskBreath
-      - id: OxygenTankFilled
-      - id: NitrogenTankFilled
       - id: ClothingEyesGlassesMeson
       - id: ClothingBeltChiefEngineerFilled
       - id: ClothingShoesBootsMagAdv

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -28,12 +28,6 @@
       - id: OxygenTankFilled
         prob: 0.20
         orGroup: EmergencyTankOrRegularTank
-      - id: EmergencyNitrogenTankFilled
-        prob: 0.80
-        orGroup: EmergencyNitrogenOrRegularNitrogen
-      - id: NitrogenTankFilled
-        prob: 0.20
-        orGroup: EmergencyNitrogenOrRegularNitrogen
       - id: ToolboxEmergencyFilled
         prob: 0.4
       - id: MedkitOxygenFilled
@@ -58,12 +52,6 @@
       - id: OxygenTankFilled
         prob: 0.20
         orGroup: EmergencyTankOrRegularTank
-      - id: NitrogenTankFilled
-        prob: 0.80
-        orGroup: EmergencyNitrogenOrRegularNitrogen
-      - id: EmergencyNitrogenTankFilled
-        prob: 0.20
-        orGroup: EmergencyNitrogenOrRegularNitrogen  
       - id: ToolboxEmergencyFilled
         prob: 0.4
       - id: MedkitOxygenFilled
@@ -84,7 +72,6 @@
         - id: ClothingHeadHelmetFire
         - id: ClothingMaskGas
         - id: OxygenTankFilled
-        - id: NitrogenTankFilled
         - id: FireExtinguisher
           prob: 0.25
 - type: entity
@@ -98,7 +85,6 @@
         - id: ClothingHeadHelmetFire
         - id: ClothingMaskGas
         - id: OxygenTankFilled
-        - id: NitrogenTankFilled
         - id: FireExtinguisher
           prob: 0.25
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -7,7 +7,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitEVA
         - id: ClothingHeadHelmetEVA
@@ -21,7 +20,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitEVA
         - id: ClothingHeadHelmetEVALarge
@@ -35,7 +33,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterSuitEmergency
         - id: ClothingMaskBreath
@@ -47,8 +44,7 @@
   suffix: Prisoner EVA
   components:
   - type: StorageFill
-    contents:
-        - id: NitrogenTankFilled
+    contents:   
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitEVAPrisoner
         - id: ClothingHeadHelmetEVALarge
@@ -62,7 +58,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitSyndicate
         - id: ClothingHeadHelmetSyndicate
@@ -76,7 +71,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitPirateEVA
         - id: ClothingMaskGas
@@ -103,7 +97,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitBasic
         - id: ClothingMaskBreath
@@ -116,7 +109,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingShoesBootsMag
         - id: ClothingOuterHardsuitEngineering
@@ -132,7 +124,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitAtmos
         - id: ClothingMaskBreath
@@ -147,7 +138,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitSecurity
         - id: ClothingMaskBreath
@@ -162,7 +152,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: JetpackVoidFilled
         - id: ClothingShoesBootsMagAdv
@@ -179,7 +168,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitMedical
         - id: ClothingMaskBreathMedical
@@ -194,7 +182,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitRd
         - id: ClothingMaskBreath
@@ -209,7 +196,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: JetpackSecurityFilled
         - id: ClothingOuterHardsuitSecurityRed
@@ -225,7 +211,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitWarden
         - id: ClothingMaskBreath
@@ -240,7 +225,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitCap
         - id: ClothingMaskGasCaptain
@@ -255,7 +239,6 @@
   components:
   - type: StorageFill
     contents:
-      - id: NitrogenTankFilled
       - id: OxygenTankFilled
       - id: ClothingShoesBootsMag
       - id: ClothingOuterHardsuitSpatio
@@ -271,7 +254,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitSyndie
         - id: ClothingShoesBootsMagSyndie
@@ -285,7 +267,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitPirateCap
         - id: ClothingMaskGas
@@ -298,7 +279,6 @@
   components:
   - type: StorageFill
     contents:
-        - id: NitrogenTankFilled
         - id: OxygenTankFilled
         - id: ClothingOuterHardsuitWizard
         - id: ClothingMaskBreath


### PR DESCRIPTION
## About the PR
- Removes big O2 tanks from all lockers, they're still in suit storages and tank dispensers.
- Removes any N2 tanks where they existed as a counterpart to O2 tanks (save for tank dispensers.)

There's a pretty good chance I missed a few fills, so tell me if I did.

## Why / Balance
The way it is currently is fairly bloaty; tank dispensers are already mapped in their appropriate areas (EVA, eng, salv, etc,) so the duplicate O2 tanks in lockers ends up being pretty redundant.

Even more redundant, though, and the more controversial part of this PR, are the N2 tanks. There is no reason to duplicate these in every single instance oxygen exists; it makes the N2 breathing trait of slimes basically completely pointless and effectively just serves as bloat for the sake of it. If slimes are going to have the same internals availability as all other species, then they should just be made to breathe O2.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Downstream mappers might need to map tank dispensers into places that need them, provided they were effectively redundant before. This shouldn't be an issue upstream, though, apparently they are already mapped here.

**Changelog**
:cl:
- tweak: Big O2 tanks and N2 tanks no longer spawn in any departmental locker. Use tank dispensers to get them instead.
- remove: Removed all instances where N2 tanks spawned as counterparts to O2 tanks. This includes things like lockers, suit storages, and the emergency toolbox.
