### PR TITLE
Makes the e-sword light plasma fires, as intended.

### DIFF
--- a/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
+++ b/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.Atmos.EntitySystems;
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Temperature;
 using Robust.Server.GameObjects;
 
@@ -17,11 +18,18 @@ public sealed class IgnitionSourceSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<IgnitionSourceComponent, IsHotEvent>(OnIsHot);
+
+        SubscribeLocalEvent<ItemToggleHotComponent, ItemToggledEvent>(OnItemToggle);
     }
 
     private void OnIsHot(Entity<IgnitionSourceComponent> ent, ref IsHotEvent args)
     {
         SetIgnited((ent.Owner, ent.Comp), args.IsHot);
+    }
+    private void OnItemToggle(Entity<ItemToggleHotComponent> ent, ref ItemToggledEvent args)
+    {
+        if (TryComp<IgnitionSourceComponent>(ent, out var comp))
+            SetIgnited((ent.Owner, comp), args.Activated);
     }
 
     /// <summary>

--- a/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
+++ b/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
@@ -18,7 +18,6 @@ public sealed class IgnitionSourceSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<IgnitionSourceComponent, IsHotEvent>(OnIsHot);
-
         SubscribeLocalEvent<ItemToggleHotComponent, ItemToggledEvent>(OnItemToggle);
     }
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -78,6 +78,8 @@
     malus: 0
   - type: Reflect
     enabled: false
+  - type: IgnitionSource
+    temperature: 700
 
 - type: entity
   name: pen


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Made e-swords act as an ignition source

## Why / Balance
I saw a funny med nukie running around in plasma gas with an e-sword not on fire and thought "they should be on fire"

## Technical details
Added an event to IgnitionSourceSystem to properly work with the "ItemToggleHotComponent". Previously it only worked with the "IsHotEvent".

Added the IgnitionSource component to the energy sword.

## Media

https://github.com/space-wizards/space-station-14/assets/83733158/614456ff-38b6-4dbf-93ce-aa9472647a4b






- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None



**Changelog**
:cl: 
-tweak: E-sword now lights plasma fires

