### PR TITLE
Add anchorable flags

### DIFF
--- a/Content.Shared/Construction/Components/AnchorableComponent.cs
+++ b/Content.Shared/Construction/Components/AnchorableComponent.cs
@@ -1,16 +1,21 @@
 using Content.Shared.Construction.EntitySystems;
 using Content.Shared.Tools;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Construction.Components
 {
-    [RegisterComponent, Access(typeof(AnchorableSystem))]
+    [RegisterComponent, Access(typeof(AnchorableSystem)), NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class AnchorableComponent : Component
     {
-        [DataField("tool", customTypeSerializer: typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
-        public string Tool { get; private set; } = "Anchoring";
+        [DataField]
+        public ProtoId<ToolQualityPrototype> Tool { get; private set; } = "Anchoring";
 
-        [DataField("snap")]
+        [DataField, AutoNetworkedField]
+        public AnchorableFlags Flags = AnchorableFlags.Anchorable | AnchorableFlags.Unanchorable;
+
+        [DataField]
         [ViewVariables(VVAccess.ReadWrite)]
         public bool Snap { get; private set; } = true;
 
@@ -18,8 +23,16 @@ namespace Content.Shared.Construction.Components
         /// Base delay to use for anchoring.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("delay")]
+        [DataField]
         public float Delay = 1f;
+    }
+
+    [Flags]
+    public enum AnchorableFlags : byte
+    {
+        None = 0,
+        Anchorable = 1 << 0,
+        Unanchorable = 1 << 1,
     }
 
     public abstract class BaseAnchoredAttemptEvent : CancellableEntityEventArgs

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -69,6 +69,9 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (!Valid(uid, userUid, usingUid, false))
             return;
 
+        // Log unanchor attempt (server only)
+        _adminLogger.Add(LogType.Anchor, LogImpact.Low, $"{ToPrettyString(userUid):user} is trying to unanchor {ToPrettyString(uid):entity} from {transform.Coordinates:targetlocation}");
+
         _tool.UseTool(usingUid, userUid, uid, anchorable.Delay, usingTool.Qualities, new TryUnanchorCompletedEvent());
     }
 
@@ -181,16 +184,10 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (transform.Anchored)
         {
             TryUnAnchor(uid, userUid, usingUid, anchorable, transform, usingTool);
-
-            // Log unanchor attempt (server only)
-            _adminLogger.Add(LogType.Anchor, LogImpact.Low, $"{ToPrettyString(userUid):user} is trying to unanchor {ToPrettyString(uid):entity} from {transform.Coordinates:targetlocation}");
         }
         else
         {
             TryAnchor(uid, userUid, usingUid, anchorable, transform, pullable, usingTool);
-
-            // Log anchor attempt (server only)
-            _adminLogger.Add(LogType.Anchor, LogImpact.Low, $"{ToPrettyString(userUid):user} is trying to anchor {ToPrettyString(uid):entity} to {transform.Coordinates:targetlocation}");
         }
     }
 
@@ -215,6 +212,9 @@ public sealed partial class AnchorableSystem : EntitySystem
 
         if (!Valid(uid, userUid, usingUid, true, anchorable, usingTool))
             return;
+
+        // Log anchor attempt (server only)
+        _adminLogger.Add(LogType.Anchor, LogImpact.Low, $"{ToPrettyString(userUid):user} is trying to anchor {ToPrettyString(uid):entity} to {transform.Coordinates:targetlocation}");
 
         if (TryComp<PhysicsComponent>(uid, out var anchorBody) &&
             !TileFree(transform.Coordinates, anchorBody))
@@ -244,6 +244,12 @@ public sealed partial class AnchorableSystem : EntitySystem
             return false;
 
         if (!Resolve(usingUid, ref usingTool))
+            return false;
+
+        if (anchoring && (anchorable.Flags & AnchorableFlags.Anchorable) == 0x0)
+            return false;
+
+        if (!anchoring && (anchorable.Flags & AnchorableFlags.Unanchorable) == 0x0)
             return false;
 
         BaseAnchoredAttemptEvent attempt =

--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
@@ -6,6 +6,8 @@
   components:
   - type: InteractionOutline
   - type: Anchorable
+    flags:
+    - Anchorable
   - type: CollideOnAnchor
   - type: Physics
     canCollide: false

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -964,6 +964,9 @@
       state: request
     - map: ["computerLayerKeys"]
       state: tech_key
+  - type: Anchorable
+    flags:
+    - Anchorable
   - type: CargoPalletConsole
   - type: ActivatableUI
     key: enum.CargoPalletConsoleUiKey.Sale


### PR DESCRIPTION
Added it to cargo pallet and the ATS puter. Small steps. Also moved the log until the anchoring is actually confirmed to prevent dummy logs.

Left them as anchorable in case they somehow get unanchored (e.g. explosion) so they can still be placed down again.