### PR TITLE
Fix iron/copper being overtuned (infinite blood exploit!)

### DIFF
--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -76,7 +76,7 @@
         - !type:OrganType
           type: Arachnid
           shouldHave: true
-        amount: 4
+        amount: 0.4
 
 - type: reagent
   id: Fluorine

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -167,7 +167,7 @@
         - !type:OrganType
           type: Arachnid
           shouldHave: false
-        amount: 4
+        amount: 0.4
 
 - type: reagent
   id: Lithium


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Reverts copper and iron's blood restoration from 1u = 40u to 1u = 4u

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This was unintentionally buffed when spiders were changed to no longer use iron as a blood restoring reagent. Because metabolism rate was reduced, more ticks of metabolism happen, and each time it does, the effect is applied. This can result in a player essentially having infinite blood as long as they kept iron in their system.

Note: This does nerf these reagents unfortunately. Saline is a much better chem to use now though at least!

Another way this can be resolved is increasing the metabolism rate, if that is preferred instead. It should keep the general balance the same.

**Changelog**

:cl: Whisper
- fix: Iron and copper no longer grant infinite blood!
