### PR TITLE
Textiles bundle name tweak.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -23,7 +23,7 @@
 - type: entity
   id: CrateMaterialTextiles
   parent: CrateGenericSteel
-  name: textiles crate
+  name: textiles crate (cloth and durathread)
   description: 60 pieces of cloth and 30 pieces of durathread.
   components:
   - type: StorageFill


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds "(cloth and durathread)" to the name of the textiles bundle.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Makes it easier to find for people who don't know the precise name of the bundle.
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
