### PR TITLE
Weld To Remove Rust On Reinforced Walls

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -564,7 +564,7 @@
     state: rgeneric
   - type: Construction
     graph: Girder
-    node: reinforcedWall
+    node: reinforcedWallRust
   - type: IconSmooth
     key: walls
     base: reinf_over

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -505,3 +505,11 @@
           steps:
             - tool: Welding
               doAfter: 5
+
+    - node: reinforcedWallRust
+      entity: WallReinforcedRust
+      edges:
+        - to: reinforcedWall
+          steps:
+            - tool: Welding
+              doAfter: 5


### PR DESCRIPTION
## About the PR
Adds a graph that'll allow you to remove rust from a reinforced wall with just a welder, akin to how you handle it with basic walls.

## Why / Balance
It was a royal pain in the ass to remove the rust from a reinforced wall before; having to deconstruct and reconstruct the whole thing.

## Media
https://github.com/space-wizards/space-station-14/assets/110078045/f455f2a8-e936-4239-9ce3-d51b70936483
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
:cl:
- fix: You can now remove the rust from reinforced walls with a welder.
