### PR TITLE
Curadrobe Additions

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/curadrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/curadrobe.yml
@@ -1,10 +1,11 @@
 - type: vendingMachineInventory
   id: CuraDrobeInventory
   startingInventory:
-    BooksBag: 1
+    BooksBag: 2
     HandLabeler: 2
     ClothingEyesGlasses: 2
     ClothingEyesGlassesJamjar: 2
+    ClothingNeckScarfStripedGreen: 2
     ClothingUniformJumpsuitCurator: 3
     ClothingUniformJumpskirtCurator: 3
     ClothingUniformJumpsuitLibrarian: 3


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added an additional book bag and two green scarves to the Curadrobe.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There are generally two librarians and some stations don't have a book bag mapped for them. I don't know of any other way to get a book bag without the vendor... The fun vending machine has like five book bags for some reason, but that's not mapped on every station.

Green scarves face a similar issue where it is sometimes not mapped at all. It's nice not having to walk all the way to the winterdrobe for my scarf.... Librarian main by the way.


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no CL!