### PR TITLE
Make metabolism of multiple groups sane (finite blood exploit!)

### DIFF
--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -70,13 +70,14 @@
           types:
             Poison: 0.1
     Medicine:
+      metabolismRate: 0.1
       effects:
       - !type:ModifyBloodLevel
         condition:
         - !type:OrganType
           type: Arachnid
           shouldHave: true
-        amount: 0.4
+        amount: 0.8
 
 - type: reagent
   id: Fluorine
@@ -161,13 +162,14 @@
           types:
             Poison: 0.1
     Medicine:
+      metabolismRate: 0.1
       effects:
       - !type:ModifyBloodLevel
         condition:
         - !type:OrganType
           type: Arachnid
           shouldHave: false
-        amount: 0.4
+        amount: 0.8
 
 - type: reagent
   id: Lithium


### PR DESCRIPTION
## About the PR
This PR tries to fix the situation mentioned in the "Why / Balance" section by:
 - Making all reagents with multiple metabolism groups have explicitly the same rate on all of them (wasn't the case only for iron and copper). This makes the behavior same, but deliberate.
 - Introducing a concrete behavior for multi group reagents. An average is taken across all the applicable group rates and that is used as the actual rate. Since all multi group rates have been adjusted to be the same, the average is the same as each individual rate. At the same time, if an entity would metabolize only one group, the average would be equal to the rate of that group. Caution should be still taken if someone wants to add multi rate reagent on overlapping groups. This behavior has been primarily chosen to maximize backwards compatibility.
 - Reverting the effective potency to the 8u/u figure from PR [14814](https://github.com/space-wizards/space-station-14/pull/14814) . This is double the recent PR [25678](https://github.com/space-wizards/space-station-14/pull/25678), but 1/5 the PR [20863](https://github.com/space-wizards/space-station-14/pull/20863) making it a lesser nerf.

## Why / Balance
I've been surprised to learn about the way copper/iron metabolism has been adjusted in a [recent PR](https://github.com/space-wizards/space-station-14/pull/25678) . Here is the story as I understand it now (I make a bunch of assumptions which might be wrong and mean no disrespect to the authors):
- PR [14814](https://github.com/space-wizards/space-station-14/pull/14814) Increased the blood regenerating quality of Iron. The [commit message](https://github.com/space-wizards/space-station-14/pull/14814/commits/0580107b78f473fab041c75c452b880b0d78ffef) (I'd like to praise the author for using them) incorrectly states that it buffs the blood increase "2->4u per 1u". This is no doubt because of the way reagent potency is specified in the prototypes. At this time, the [default metablization rate](https://github.com/QuietlyWhisper/space-station-14/blob/2de7122310445167efc9832b24d50344d4d75fb0/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs#L163) applicable to iron was 0.5u/s (the same default as today). The effects of reagents specified in the prototype are applied per second and not per unit. This means that the effect per unit is double the number specified in the prototype (at default metabolization rate) and the change introduced in this commit is a change from 2u per second to 4u per second (4u/u to 8u/u).
- PR [20863](https://github.com/space-wizards/space-station-14/pull/20863) has introduced the concept of blue blood and copper/iron toxicity. This is done by introducing the poison metabolism group with a different metabolization rate of 0.1u/s, while the medicine group kept the default 0.5u/s. This was probably made in an attempt to slow down the toxic effect of the reagent if introduced in the wrong species, but keep the medicinal rate in the correct species. The code doesn't handle this properly, because there is no obvious way to choose between the two in metabolizers that accept both. Instead, it uses the same rate in both cases and happens to choose the poison rate, because the group comes last in the list of groups (undoubtedly arbitrary decision). This of course bumps the potency from 8u/u to 40u/u.
- PR [25678](https://github.com/space-wizards/space-station-14/pull/25678) attempts to revert the issue by decreasing the poison metabolization rate by a factor of 10 from 40u/u to 4u/u. This is arbitrary, as the glitch increased the potency only by a factor of 5. From the wording of the PR, I believe the author doesn't necessarily insist the figure of 4u/u is balanced, just that the 40u/u one isn't and attempts to revert to previous state. It also doesn't fix any of the underlying issues. For example, the chemistry guidebook entry still mentions the incorrect rates.

I assume the [14814](https://github.com/space-wizards/space-station-14/pull/14814) actually made the balance changes based on gameplay testing, and those weren't changed until the introduction of the bug, so I assume this is the balanced value we are trying to get back to. It's also worth mentioning that the current rate is the one deemed insufficient by [14814](https://github.com/space-wizards/space-station-14/pull/14814), although there may have been significant changes to the bleeding mechanics since.

The proposed state of blood regenerating reagents is as follows:
 - 1u iron/copper replenishes 8u of blood over 10 seconds. It is easy to obtain by a chemist and with notable exceptions is difficult to obtain by others. It is more difficult to use as one has to take care not to poison the recipient.
 - 1u saline replenishes 12u of blood over 2 seconds. It is generally easy to obtain.
 - 1u protein replenishes 2u of blood over 2 seconds. It is generally easy to obtain. It has other minor medicinal effects.
 - 1u ichor replenishes 6u blood over 2 seconds. It is generally very difficult to obtain. It has other major medicinal effects.
 
This PR tries to fix the situation without introducing any opinions on the gameplay balance.

## Technical details
It's all technical details.

## Media

![CuFe](https://github.com/space-wizards/space-station-14/assets/68151557/e5d53e5b-435b-4289-ba1f-fdb924bbb6bb)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Hopefully this fixes everything it breaks.

## Final notes
Some notable observations can be made about this incident:
 - Iron replenishes water in diona species. Quirky!
 - The fact that prototypes and chemistry guide specify the effect in terms of seconds metabolized instead of units metabolized is incredibly confusing for both developers and players. This is often exacerbated by the fact that damage effects are sometimes specified/displayed as a sum across a damage group, leading new players to greatly misjudge dosage potency.


**Changelog**
:cl:
- tweak: Iron and copper now heal 8u of blood per unit.
- fix: Iron and copper now show accurate metabolization rates.