### PR TITLE
make thief a subgamemode

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/SubGamemodesComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/SubGamemodesComponent.cs
@@ -1,0 +1,20 @@
+using Content.Server.GameTicking.Rules;
+using Content.Shared.Storage;
+
+namespace Content.Server.GameTicking.Rules.Components;
+
+/// <summary>
+/// When this gamerule is added it has a chance of adding other gamerules.
+/// Since it's done when added and not when started you can still use normal start logic.
+/// Used for starting subgamemodes in game presets.
+/// </summary>
+[RegisterComponent, Access(typeof(SubGamemodesSystem))]
+public sealed partial class SubGamemodesComponent : Component
+{
+    /// <summary>
+    /// Spawn entries for each gamerule prototype.
+    /// Use orGroups if you want to limit rules.
+    /// </summary>
+    [DataField(required: true)]
+    public List<EntitySpawnEntry> Rules = new();
+}

--- a/Content.Server/GameTicking/Rules/Components/ThiefRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ThiefRuleComponent.cs
@@ -29,12 +29,6 @@ public sealed partial class ThiefRuleComponent : Component
     [DataField]
     public bool PacifistThieves = true;
 
-    /// <summary>
-    /// A chance for this mode to be added to the game.
-    /// </summary>
-    [DataField]
-    public float RuleChance = 1f;
-
     [DataField]
     public ProtoId<AntagPrototype> ThiefPrototypeId = "Thief";
 

--- a/Content.Server/GameTicking/Rules/SubGamemodesSystem.cs
+++ b/Content.Server/GameTicking/Rules/SubGamemodesSystem.cs
@@ -1,0 +1,17 @@
+using Content.Server.GameTicking.Rules.Components;
+using Content.Shared.Storage;
+
+namespace Content.Server.GameTicking.Rules;
+
+public sealed class SubGamemodesSystem : GameRuleSystem<SubGamemodesComponent>
+{
+    protected override void Added(EntityUid uid, SubGamemodesComponent comp, GameRuleComponent rule, GameRuleAddedEvent args)
+    {
+        var picked = EntitySpawnCollection.GetSpawns(comp.Rules, RobustRandom);
+        foreach (var id in picked)
+        {
+            Log.Info($"Starting gamerule {id} as a subgamemode of {ToPrettyString(uid):rule}");
+            GameTicker.AddGameRule(id);
+        }
+    }
+}

--- a/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
@@ -39,10 +39,6 @@ public sealed class ThiefRuleSystem : GameRuleSystem<ThiefRuleComponent>
         var query = QueryActiveRules();
         while (query.MoveNext(out _, out var comp, out _))
         {
-            //Chance to not launch the game rule
-            if (!_random.Prob(comp.RuleChance))
-                continue;
-
             //Get all players eligible for this role, allow selecting existing antags
             //TO DO: When voxes specifies are added, increase their chance of becoming a thief by 4 times >:)
             var eligiblePlayers = _antagSelection.GetEligiblePlayers(ev.Players, comp.ThiefPrototypeId, acceptableAntags: AntagAcceptability.All, allowNonHumanoids: true);

--- a/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
@@ -37,7 +37,7 @@ public sealed class ThiefRuleSystem : GameRuleSystem<ThiefRuleComponent>
     private void OnPlayersSpawned(RulePlayerJobsAssignedEvent ev)
     {
         var query = QueryActiveRules();
-        while (query.MoveNext(out _, out var comp, out _))
+        while (query.MoveNext(out var uid, out _, out var comp, out var gameRule))
         {
             //Get all players eligible for this role, allow selecting existing antags
             //TO DO: When voxes specifies are added, increase their chance of becoming a thief by 4 times >:)
@@ -45,7 +45,11 @@ public sealed class ThiefRuleSystem : GameRuleSystem<ThiefRuleComponent>
 
             //Abort if there are none
             if (eligiblePlayers.Count == 0)
+            {
+                Log.Warning($"No eligible thieves found, ending game rule {ToPrettyString(uid):rule}");
+                GameTicker.EndGameRule(uid, gameRule);
                 continue;
+            }
 
             //Calculate number of thieves to choose
             var thiefCount = _random.Next(1, comp.MaxAllowThief + 1);

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -28,13 +28,12 @@
     - CarpRiftsObjective
     - DragonSurviveObjective
 
-# need for admin panel antag create (because the rule doesn't have a roundstart entity like TraitorRule)
 - type: entity
-  id: Thief
-  parent: BaseGameRule
   noSpawn: true
+  parent: BaseGameRule
+  id: Thief
   components:
-  - type: ThiefRule 
+  - type: ThiefRule
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -86,6 +86,8 @@
   parent: BaseSubGamemodesRule
   noSpawn: true
   components:
+  - type: GameRule
+    minPlayers: 1
   - type: TraitorRule
 
 - type: entity

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -5,11 +5,10 @@
   components:
   - type: GameRule
 
-# a rule that has common subgamemode rules, roundstart is fairly normal so there is time for them to play out
 - type: entity
-  abstract: true
+  noSpawn: true
   parent: BaseGameRule
-  id: BaseSubGamemodesRule
+  id: SubGamemodesRule
   components:
   - type: SubGamemodes
     rules:
@@ -66,7 +65,7 @@
 
 - type: entity
   id: Nukeops
-  parent: BaseSubGamemodesRule
+  parent: BaseGameRule
   noSpawn: true
   components:
   - type: GameRule
@@ -83,14 +82,14 @@
 
 - type: entity
   id: Traitor
-  parent: BaseSubGamemodesRule
+  parent: BaseGameRule
   noSpawn: true
   components:
   - type: TraitorRule
 
 - type: entity
   id: Revolutionary
-  parent: BaseSubGamemodesRule
+  parent: BaseGameRule
   noSpawn: true
   components:
   - type: RevolutionaryRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -86,8 +86,6 @@
   parent: BaseSubGamemodesRule
   noSpawn: true
   components:
-  - type: GameRule
-    minPlayers: 1
   - type: TraitorRule
 
 - type: entity

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -5,6 +5,17 @@
   components:
   - type: GameRule
 
+# a rule that has common subgamemode rules, roundstart is fairly normal so there is time for them to play out
+- type: entity
+  abstract: true
+  parent: BaseGameRule
+  id: BaseSubGamemodesRule
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: Thief
+      prob: 0.5
+
 - type: entity
   id: DeathMatch31
   parent: BaseGameRule
@@ -55,15 +66,13 @@
 
 - type: entity
   id: Nukeops
-  parent: BaseGameRule
+  parent: BaseSubGamemodesRule
   noSpawn: true
   components:
   - type: GameRule
     minPlayers: 20
   - type: NukeopsRule
     faction: Syndicate
-  - type: ThiefRule #the thieves come as an extension of another gamemode
-    ruleChance: 0.5
 
 - type: entity
   id: Pirates
@@ -74,21 +83,17 @@
 
 - type: entity
   id: Traitor
-  parent: BaseGameRule
+  parent: BaseSubGamemodesRule
   noSpawn: true
   components:
   - type: TraitorRule
-  - type: ThiefRule #the thieves come as an extension of another gamemode
-    ruleChance: 0.5
 
 - type: entity
   id: Revolutionary
-  parent: BaseGameRule
+  parent: BaseSubGamemodesRule
   noSpawn: true
   components:
   - type: RevolutionaryRule
-  - type: ThiefRule #the thieves come as an extension of another gamemode
-    ruleChance: 0.5
 
 - type: entity
   id: Sandbox

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -93,6 +93,7 @@
   showInVote: false
   rules:
     - Traitor
+    - SubGamemodes
     - BasicStationEventScheduler
     - BasicRoundstartVariation
 
@@ -118,6 +119,7 @@
   showInVote: false
   rules:
     - Nukeops
+    - SubGamemodes
     - BasicStationEventScheduler
     - BasicRoundstartVariation
 
@@ -132,6 +134,7 @@
   showInVote: false
   rules:
     - Revolutionary
+    - SubGamemodes
     - BasicStationEventScheduler
     - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -93,7 +93,7 @@
   showInVote: false
   rules:
     - Traitor
-    - SubGamemodes
+    - SubGamemodesRule
     - BasicStationEventScheduler
     - BasicRoundstartVariation
 
@@ -119,7 +119,7 @@
   showInVote: false
   rules:
     - Nukeops
-    - SubGamemodes
+    - SubGamemodesRule
     - BasicStationEventScheduler
     - BasicRoundstartVariation
 
@@ -134,7 +134,7 @@
   showInVote: false
   rules:
     - Revolutionary
-    - SubGamemodes
+    - SubGamemodesRule
     - BasicStationEventScheduler
     - BasicRoundstartVariation
 


### PR DESCRIPTION
## About the PR
thing ripped out of turf war so it can be merged now

## Why / Balance
adding rule components for 1 gamemode onto another gamemode is evil

## Technical details
see other pr

## Media
the smite still works
![01:56:00](https://github.com/space-wizards/space-station-14/assets/39013340/7f51e3f8-06b4-43ac-a004-22eef3df61c2)

adding game rule is real
![02:01:09](https://github.com/space-wizards/space-station-14/assets/39013340/48d37e45-dd83-4e38-8849-45c2d3171ec2)

roundstart random thief rule works, on traitor preset
![02:14:16](https://github.com/space-wizards/space-station-14/assets/39013340/ddd52096-92ae-4ddb-b4b1-a968b02b1649)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
`ruleChance` removed from `ThiefRule`, which is no longer added to random gamemodes' rules. use the `SubGamemodes` component instead.

**Changelog**
no cl no fun