### PR TITLE
Give the HOS orders the nuclear codes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -275,7 +275,7 @@
       - id: JetpackSecurityFilled
       - id: BoxEncryptionKeySecurity
       - id: HoloprojectorSecurity
-      - id: BookSecretDocuments
+      - id: BookSecretDocumentsZipped
 
 - type: entity
   id: LockerHeadOfSecurityFilled
@@ -299,7 +299,7 @@
       - id: SecurityTechFabCircuitboard
       - id: BoxEncryptionKeySecurity
       - id: HoloprojectorSecurity
-      - id: BookSecretDocuments
+      - id: BookSecretDocumentsZipped
 
 - type: entity
   id: LockerFreezerVaultFilled

--- a/Resources/Prototypes/Entities/Objects/Misc/secret_documents.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/secret_documents.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   id: BookSecretDocuments
   name: "emergency security orders"
-  description: TOP SECRET. These documents specify the Emergency Orders that the HoS must carry out when ordered by Central Command.
+  description: TOP SECRET. These documents specify the Emergency Orders that the HoS must carry out when ordered by Central Command. They have been opened.
   components:
     - type: Sprite
       sprite: Objects/Misc/bureaucracy.rsi
@@ -14,3 +14,17 @@
         - HighRiskItem
     - type: StealTarget
       stealGroup: BookSecretDocuments
+
+- type: entity
+  parent: BookSecretDocuments
+  id: BookSecretDocumentsZipped
+  suffix: Filled
+  description: TOP SECRET. These documents specify the Emergency Orders that the HoS must carry out when ordered by Central Command.
+  components:
+    - type: SpawnItemsOnUse
+      items:
+        - id: BookSecretDocuments
+        - id: NukeCodePaperStation
+      sound:
+        path: /Audio/Items/jumpsuit_equip.ogg
+    


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The Head of Security's emergency orders can be unzipped for the station's nuclear codes
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There are two reasons why I think this would be a good addition.
1. During a nuclear operatives round, if the nukies have dat fukken disk but somehow forgot their codes/nuke, then they can hunt down the HOS and take the codes to the station's nuke from his dead body/locker as a last resort.
2. It'll make nuking the station a possibility outside of admemes, some examples for non-nukie-nuking would be like during zombies if the station is deemed "unrecoverable" the nuke could be used by the survivors as an RP alternative to calling the shuttle, or if a particularly ambitious traitor gets the "disk" and "orders" objectives they could decide to take it a step further by nuking the station. 
Keep in mind that literally everyone knows when and where the nuke is activated so unless **_everyone_** is on board with nuclear annihilation then it could be disarmed.
3. ~~It would allow the clown to arm the station's nuke like in the core design doc~~
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: The Head of Security's emergency orders can now be unzipped for the station's nuclear codes.