### PR TITLE
Dionae now bleed sap, and this can be used to make syrup.

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/reagents/meta/biological.ftl
@@ -8,7 +8,7 @@ reagent-name-slime = slime
 reagent-desc-slime = You thought this was gradient blood at first, but you were mistaken.
 
 reagent-name-sap = sap
-reagent-desc-sap = Sticky and sweet tree blood. Can be collected from a diona.
+reagent-desc-sap = Sticky, sweet tree blood.
 
 reagent-name-hemocyanin-blood = blue blood
 reagent-desc-hemocyanin-blood = Contains copper as opposed to iron which gives it a distinct blue color.

--- a/Resources/Locale/en-US/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/reagents/meta/biological.ftl
@@ -7,6 +7,9 @@ reagent-desc-insect-blood = Okay, this is really gross. It almost looks.. alive?
 reagent-name-slime = slime
 reagent-desc-slime = You thought this was gradient blood at first, but you were mistaken.
 
+reagent-name-sap = sap
+reagent-desc-sap = Sticky and sweet tree blood. Can be collected from a diona.
+
 reagent-name-hemocyanin-blood = blue blood
 reagent-desc-hemocyanin-blood = Contains copper as opposed to iron which gives it a distinct blue color.
 

--- a/Resources/Locale/en-US/reagents/meta/consumable/food/condiments.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/food/condiments.ftl
@@ -41,4 +41,4 @@ reagent-name-table-salt = table salt
 reagent-desc-table-salt = Commonly known as salt, Sodium Chloride is often used to season food or kill borers instantly.
 
 reagent-name-syrup = syrup
-reagent-desc-syrup = Delicious syrup made from tree sap, extremely sticky and sweet.
+reagent-desc-syrup = Delicious syrup made from tree sap, somehow stickier than glue.

--- a/Resources/Locale/en-US/reagents/meta/consumable/food/condiments.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/food/condiments.ftl
@@ -39,3 +39,6 @@ reagent-desc-soysauce = A salty soy-based flavoring.
 
 reagent-name-table-salt = table salt
 reagent-desc-table-salt = Commonly known as salt, Sodium Chloride is often used to season food or kill borers instantly.
+
+reagent-name-syrup = syrup
+reagent-desc-syrup = Delicious syrup made from tree sap, extremely sticky and sweet.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3129,7 +3129,7 @@
   - type: InventorySlots
   - type: Strippable
   - type: Bloodstream
-    bloodReagent: Water
+    bloodReagent: Sap
     bloodMaxVolume: 60
   - type: UserInterface
     interfaces:
@@ -3186,4 +3186,3 @@
   components:
   - type: ReplacementAccent
     accent: nymph
-    

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -24,14 +24,14 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#75b1f0"
+        color: "#cd7314"
   - type: Butcherable
     butcheringType: Spike
     spawned:
       - id: FoodMeatPlant
         amount: 5
   - type: Bloodstream
-    bloodReagent: Water
+    bloodReagent: Sap
   - type: Reactive
     groups:
       Flammable: [ Touch ]

--- a/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
@@ -175,12 +175,12 @@
   recognizable: true
   physicalDesc: reagent-physical-desc-sticky
   slippery: false
-  viscosity: 0.65
+  viscosity: 0.55 #Start using syrup to attach your remote recievers to your microwaves!
   tileReactions:
     - !type:SpillTileReaction
   metabolisms:
     Food:
-      # 40 diona blood for 1 unit of syrup... this stuff BETTER be worth it.
+      # 12 diona blood for 1 unit of syrup, this stuff better be worthwhile.
       effects:
       - !type:SatiateHunger
         factor: 6.0 #Stronger than cookedramen

--- a/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
@@ -164,3 +164,27 @@
       # eating salt on its own kinda sucks, kids
       - !type:SatiateThirst
         factor: -0.5
+
+- type: reagent
+  id: Syrup
+  name: reagent-name-syrup
+  group: Foods
+  desc: reagent-desc-syrup
+  flavor: sweet
+  color: "#fb7125"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-sticky
+  slippery: false
+  viscosity: 0.65
+  tileReactions:
+    - !type:SpillTileReaction
+  metabolisms:
+    Food:
+      # 40 diona blood for 1 unit of syrup... this stuff BETTER be worth it.
+      effects:
+      - !type:SatiateHunger
+        factor: 6.0 #Stronger than cookedramen
+  footstepSound:
+    collection: FootstepBlood
+    params:
+      volume: 6

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -92,7 +92,7 @@
   recognizable: true
   physicalDesc: reagent-physical-desc-sticky
   slippery: false
-  viscosity: 0.15
+  viscosity: 0.10
   tileReactions:
     - !type:SpillTileReaction
   metabolisms:
@@ -100,7 +100,7 @@
       # Sweet!
       effects:
       - !type:SatiateHunger
-        factor: 2
+        factor: 1
       - !type:SatiateThirst
         factor: 1
   footstepSound:

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -83,6 +83,32 @@
       volume: 6
 
 - type: reagent
+  id: Sap
+  name: reagent-name-sap
+  group: Biological
+  desc: reagent-desc-sap
+  flavor: sweet
+  color: "#cd7314"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-sticky
+  slippery: false
+  viscosity: 0.15
+  tileReactions:
+    - !type:SpillTileReaction
+  metabolisms:
+    Food:
+      # Sweet!
+      effects:
+      - !type:SatiateHunger
+        factor: 2
+      - !type:SatiateThirst
+        factor: 1
+  footstepSound:
+    collection: FootstepBlood
+    params:
+      volume: 6
+
+- type: reagent
   parent: Blood
   id: CopperBlood
   name: reagent-name-hemocyanin-blood

--- a/Resources/Prototypes/Recipes/Reactions/biological.yml
+++ b/Resources/Prototypes/Recipes/Reactions/biological.yml
@@ -25,6 +25,19 @@
     Water: 4
     Nitrogen: 1
 
+
+- type: reaction
+  id: SapBloodBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    Sap:
+      amount: 10
+  products:
+    Water: 9
+    Sugar: 1
+
 - type: reaction
   id: CopperBloodBreakdown
   source: true

--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -31,7 +31,7 @@
   - !type:CreateGas
     gas: WaterVapor
   products:
-    Syrup: 0.03 #40:1 ratio based on real syrup production
+    Syrup: 0.1 #12:1 sap to syruop
 
 # Holy - TODO: make it so only the chaplain can use the bible to start these reactions, not anyone with a bible
 

--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -26,12 +26,12 @@
   minTemp: 377
   reactants:
     Sap:
-      amount: 1.6
+      amount: 1.2
   effects:
   - !type:CreateGas
     gas: WaterVapor
   products:
-    Syrup: 0.04
+    Syrup: 0.03
 
 # Holy - TODO: make it so only the chaplain can use the bible to start these reactions, not anyone with a bible
 

--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -20,6 +20,19 @@
   products:
     EggCooked: 0.5
 
+- type: reaction
+  id: SapBoiling
+  impact: Low
+  minTemp: 377
+  reactants:
+    Sap:
+      amount: 4
+  effects:
+  - !type:CreateGas
+    gas: WaterVapor
+  products:
+    Syrup: 0.1 #based on real syrup production
+
 # Holy - TODO: make it so only the chaplain can use the bible to start these reactions, not anyone with a bible
 
 - type: reaction

--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -31,7 +31,7 @@
   - !type:CreateGas
     gas: WaterVapor
   products:
-    Syrup: 0.03
+    Syrup: 0.03 #40:1 ratio based on real syrup production
 
 # Holy - TODO: make it so only the chaplain can use the bible to start these reactions, not anyone with a bible
 

--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -26,12 +26,12 @@
   minTemp: 377
   reactants:
     Sap:
-      amount: 4
+      amount: 1.6
   effects:
   - !type:CreateGas
     gas: WaterVapor
   products:
-    Syrup: 0.1 #based on real syrup production
+    Syrup: 0.04
 
 # Holy - TODO: make it so only the chaplain can use the bible to start these reactions, not anyone with a bible
 


### PR DESCRIPTION
## About the PR
I switched the water in their blood for a new sap reagent, makes more sense for a tree.
This sap can be boiled to make syrup, a very sweet and helpful substance for feeding the crew or making sticky traps. Put it on pancakes, inject it into starving people, or toss it on the floor while running from sec.
People **_definitely_** won't make nymph sap factories in the freezer!
Sap can also be centrifuged into water and sugar for chemistry.

Syrup restores double the average amount of hunger and slows you by 55% when walking through it.

Sap restores below average hunger and thirst.
Boiling sap makes a cloud of water vapor and syrup at a 12:1 ratio of sap to syrup

## Why / Balance
Trees aren't full of water, they're full of sap. Which may be mostly water, but is still a different substance.
Also water is slippery and having slippery blood is annoying for enemies at best and gets you/your friends killed at worst.

## Media

https://github.com/space-wizards/space-station-14/assets/140123969/9fdabd88-a365-48d8-9f3e-0f07058641c1

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added sap
- add: Added syrup, it can be made by boiling sap.
- tweak: Dionae now bleed sap instead of water