### PR TITLE
Security Belts for Cadets

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -31,6 +31,7 @@
     outerClothing: ClothingOuterArmorBasic
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity
+    belt: ClothingBeltSecurityFilled
     pocket1: WeaponPistolMk58Nonlethal
     pocket2: BookSecurity
   innerClothingSkirt: ClothingUniformJumpskirtColorRed


### PR DESCRIPTION
## About the PR
Gives cadets a filled security belt on spawn, that's it.

## Why / Balance
They're trusted with lethal firearms, don't see why they can't be trusted with a stun weapon.
Some players may not know where to get new gear, could may result in them thinking the pistol is their only tool for the job (could explain a lot of the cadet shootings).
Without any proper stun/riot gear on start it makes them fairly easy targets for groups on spawn.

Only reason I can see not to do this is the chance of them easily losing it due to AFKing or accidently dropping it, but once again, they're already trusted with a firearm.

## Media
- [X] This PR does not require an ingame showcase.

**Changelog**
Minor enough that I don't think it's needed.