### PR TITLE
Make the MRE wrapper count as trash

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -623,5 +623,6 @@
   - type: Tag
     tags:
     - ClothMade
+    - Trash
   - type: Sprite
     state: mre-wrapper


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The PR makes the MRE wrapper count as trash, letting it get picked up and inserted into the janitor's trash bag.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The standard ration for spessmen has been changed to nutribricks, which are contained in an MRE wrapper. This leads to lots
of wrappers getting left around the station. Janitors should be able to fit wrappers into their trash bag like most other similar items.


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added the Trash tag to the yml for the mre wrapper

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![2024-03-01-182415](https://github.com/space-wizards/space-station-14/assets/1129192/fb990c3e-1d35-4c4b-84a2-072d7477e3c6)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Nutribrick and MRE wrappers can now be put in trash bags
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
