### PR TITLE
make thief gloves insulated

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
@@ -30,3 +30,7 @@
   - type: Thieving
     stripTimeReduction: 2
     stealthy: true
+  # insulated so engi thieves don't have to conveniently never touch electricity ever
+  - type: Insulated
+  - type: GloveHeatResistance
+    heatResistance: 1400


### PR DESCRIPTION
## About the PR
title

## Why / Balance
prevent engi thief metagame: oh wow you are wearing insuls but you wont hack any doors or cut any wires thats so quirky

thief should also have a reliable stealthy way to break into areas, emag is Not Subtle

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: The Thief's special gloves are now insulated.
