### PR TITLE
Space damage now causes heat along with blunt

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -238,7 +238,7 @@
     damage:
       types:
         Blunt: 0.50 #per second, scales with pressure and other constants.
-        Burn: 0.1
+        Heat: 0.1
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
     allowedStates:
     - Alive

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -237,7 +237,8 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.55 #per second, scales with pressure and other constants.
+        Blunt: 0.50 #per second, scales with pressure and other constants.
+        Burn: 0.1
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
     allowedStates:
     - Alive

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -37,7 +37,8 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 0.60 #per second, scales with pressure and other constants. Slighty more than humans.
+        Blunt: 0.50 #per second, scales with pressure and other constants.
+        Burn: 0.2 # 0.1 more than humans, i feel like low pressure would make slime boil more than blunt stretch them so i decided on this instead.
   - type: Reactive
     groups:
       Flammable: [ Touch ]

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -38,7 +38,7 @@
     damage:
       types:
         Blunt: 0.50 #per second, scales with pressure and other constants.
-        Burn: 0.2 # 0.1 more than humans, i feel like low pressure would make slime boil more than blunt stretch them so i decided on this instead.
+        Heat: 0.2 # 0.1 more than humans, i feel like low pressure would make slime boil more than blunt stretch them so i decided on this instead.
   - type: Reactive
     groups:
       Flammable: [ Touch ]


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

Space burns your skin from the ionizing radiation and intense light. Also, your blood boils. Radiation would be too difficult to implement and generally not a good idea, so i decided to just do burn. The reason why it's under barotrauma instead of general space damage is because even if you're not in space your blood still boils from lack of pressure (aka barotrauma)

Makes space a tiny teensy little bit more dangerous by 0.5 damage increase per second along with making treatment more complex considering there is another added damage type.

![image](https://github.com/space-wizards/space-station-14/assets/134914314/3a8b25c7-306c-4157-9da0-2ed334fbc3bb)

**Changelog**

:cl: Ubaser
- tweak: Unpressurized areas now deal heat damage along with blunt.