### PR TITLE
RobustHarvest data fields now static and not public.

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/RobustHarvest.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/RobustHarvest.cs
@@ -11,14 +11,11 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
     [DataDefinition]
     public sealed partial class RobustHarvest : ReagentEffect
     {
-        [DataField]
-        public int PotencyLimit = 50;
+        [DataField] static int PotencyLimit = 50;
 
-        [DataField]
-        public int PotencyIncrease = 3;
+        [DataField] static int PotencyIncrease = 3;
 
-        [DataField]
-        public int PotencySeedlessThreshold = 30;
+        [DataField] static int PotencySeedlessThreshold = 30;
 
         public override void Effect(ReagentEffectArgs args)
         {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed the data fields in RobustHarvest.cs to be static and not public.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
RobustHarvest is a specific chemical with specific limits that should not be modifiable in play.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
It is no longer possible to set a custom `PotencyLimit`, `PotencyIncrease`, or `PotencySeedlessThreshold` for robust harvest outside of the class itself. If your game uses custom values for robust harvest, make sure they are changed in the `RobustHarvest` class in RobustHarvest.cs.