### PR TITLE
Service and External Cadet Access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -18,6 +18,8 @@
   - Security
   - Brig
   - Maintenance
+  - Service
+  - External
   - Cryogenics
   special:
   - !type:AddImplantSpecial


### PR DESCRIPTION
## About the PR
Gives security cadets service, and more importantly external access.

## Why / Balance
Mainly to just make it consistent with a security officer's access.
Imagine giving out hardsuits to officer in a time of need only to realize the capable cadet you just handed it to can't go outside without someone's help.

## Media
- [X] This PR does not require an ingame showcase.

**Changelog**
Should be minor enough not to warrant one.