### PR TITLE
 Remove the ability for command or any antag-safe role from being initial infected in zombie mode #25529 

### DIFF
--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -246,15 +246,23 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     /// </remarks>
     private void InfectInitialPlayers(ZombieRuleComponent component)
     {
-        //Get all players with initial infected enabled, and exclude those with the ZombieImmuneComponent
+        //Get all players with initial infected enabled, and exclude those with the ZombieImmuneComponent and roles with CanBeAntag = False
         var eligiblePlayers = _antagSelection.GetEligiblePlayers(
             _playerManager.Sessions
             ,component.PatientZeroPrototypeId,
             includeAllJobs: true,
             customExcludeCondition: player => HasComp<ZombieImmuneComponent>(player) || HasComp<InitialInfectedExemptComponent>(player) || !_jobs.CanBeAntag(player)
             );
-        //And get all players, excluding ZombieImmune - to fill any leftover initial infected slots
-        var allPlayers = _antagSelection.GetEligiblePlayers(_playerManager.Sessions, component.PatientZeroPrototypeId, acceptableAntags: Shared.Antag.AntagAcceptability.All, includeAllJobs: true, ignorePreferences: true, customExcludeCondition: HasComp<ZombieImmuneComponent>);
+
+        //And get all players, excluding ZombieImmune and roles with CanBeAntag = False - to fill any leftover initial infected slots
+        var allPlayers = _antagSelection.GetEligiblePlayers(
+            _playerManager.Sessions,
+            component.PatientZeroPrototypeId,
+            acceptableAntags: Shared.Antag.AntagAcceptability.All,
+            includeAllJobs: true,
+            ignorePreferences: true,
+            customExcludeCondition: player => HasComp<ZombieImmuneComponent>(player) || !_jobs.CanBeAntag(player) 
+            );
 
         //If there are no players to choose, abort
         if (allPlayers.Count == 0)

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -248,8 +248,8 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     {
         //Get all players with initial infected enabled, and exclude those with the ZombieImmuneComponent and roles with CanBeAntag = False
         var eligiblePlayers = _antagSelection.GetEligiblePlayers(
-            _playerManager.Sessions
-            ,component.PatientZeroPrototypeId,
+            _playerManager.Sessions,
+            component.PatientZeroPrototypeId,
             includeAllJobs: false,
             customExcludeCondition: player => HasComp<ZombieImmuneComponent>(player) || HasComp<InitialInfectedExemptComponent>(player) 
             );

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -22,7 +22,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using System.Globalization;
-using Content.Server.Roles.Jobs;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -42,7 +41,6 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly AntagSelectionSystem _antagSelection = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly JobSystem _jobs = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using System.Globalization;
+using Content.Server.Roles.Jobs;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -41,6 +42,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly AntagSelectionSystem _antagSelection = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly JobSystem _jobs = default!;
 
     public override void Initialize()
     {
@@ -245,7 +247,12 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     private void InfectInitialPlayers(ZombieRuleComponent component)
     {
         //Get all players with initial infected enabled, and exclude those with the ZombieImmuneComponent
-        var eligiblePlayers = _antagSelection.GetEligiblePlayers(_playerManager.Sessions, component.PatientZeroPrototypeId, includeAllJobs: true, customExcludeCondition: x => HasComp<ZombieImmuneComponent>(x) || HasComp<InitialInfectedExemptComponent>(x));
+        var eligiblePlayers = _antagSelection.GetEligiblePlayers(
+            _playerManager.Sessions
+            ,component.PatientZeroPrototypeId,
+            includeAllJobs: true,
+            customExcludeCondition: player => HasComp<ZombieImmuneComponent>(player) || HasComp<InitialInfectedExemptComponent>(player) || !_jobs.CanBeAntag(player)
+            );
         //And get all players, excluding ZombieImmune - to fill any leftover initial infected slots
         var allPlayers = _antagSelection.GetEligiblePlayers(_playerManager.Sessions, component.PatientZeroPrototypeId, acceptableAntags: Shared.Antag.AntagAcceptability.All, includeAllJobs: true, ignorePreferences: true, customExcludeCondition: HasComp<ZombieImmuneComponent>);
 

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -250,8 +250,8 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         var eligiblePlayers = _antagSelection.GetEligiblePlayers(
             _playerManager.Sessions
             ,component.PatientZeroPrototypeId,
-            includeAllJobs: true,
-            customExcludeCondition: player => HasComp<ZombieImmuneComponent>(player) || HasComp<InitialInfectedExemptComponent>(player) || !_jobs.CanBeAntag(player)
+            includeAllJobs: false,
+            customExcludeCondition: player => HasComp<ZombieImmuneComponent>(player) || HasComp<InitialInfectedExemptComponent>(player) 
             );
 
         //And get all players, excluding ZombieImmune and roles with CanBeAntag = False - to fill any leftover initial infected slots
@@ -259,9 +259,9 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
             _playerManager.Sessions,
             component.PatientZeroPrototypeId,
             acceptableAntags: Shared.Antag.AntagAcceptability.All,
-            includeAllJobs: true,
+            includeAllJobs: false ,
             ignorePreferences: true,
-            customExcludeCondition: player => HasComp<ZombieImmuneComponent>(player) || !_jobs.CanBeAntag(player) 
+            customExcludeCondition: HasComp<ZombieImmuneComponent> 
             );
 
         //If there are no players to choose, abort


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
https://github.com/ArchPigeon
>Remove the ability for any role that is marked as canBeAntag = False to be an initial infected zombie

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
https://github.com/ArchPigeon
> Initial Infected Captains and heads of security are very very stupid. Secoffs being zombies are similarly dumb. Zombie is the only role where Heads can be antags, sets a bad precedent, enables very short rounds where command or sec as antags have a massive advantage against the rest of the crew
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
https://github.com/ArchPigeon
> Check JobSystem.canBeAntag() and make sure it is false for any player before assigning them as a zombie initial infected
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- remove: Removed the ability for command or any antag-safe role to be initial infected in zombie mode
