### PR TITLE
Add prediction for puddle and spillable examines

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/SpillBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpillBehavior.cs
@@ -1,6 +1,6 @@
 using Content.Server.Chemistry.Containers.EntitySystems;
-using Content.Server.Fluids.Components;
 using Content.Server.Fluids.EntitySystems;
+using Content.Shared.Fluids.Components;
 using JetBrains.Annotations;
 
 namespace Content.Server.Destructible.Thresholds.Behaviors

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
@@ -1,6 +1,4 @@
-using Content.Server.Fluids.Components;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
 
@@ -9,11 +7,6 @@ namespace Content.Server.Fluids.EntitySystems;
 public sealed partial class PuddleSystem
 {
     private static readonly TimeSpan EvaporationCooldown = TimeSpan.FromSeconds(1);
-
-    [ValidatePrototypeId<ReagentPrototype>]
-    private const string Water = "Water";
-
-    public static string[] EvaporationReagents = new[] { Water };
 
     private void OnEvaporationMapInit(Entity<EvaporationComponent> entity, ref MapInitEvent args)
     {
@@ -63,10 +56,5 @@ public sealed partial class PuddleSystem
                 QueueDel(uid);
             }
         }
-    }
-
-    public bool CanFullyEvaporate(Solution solution)
-    {
-        return solution.GetTotalPrototypeQuantity(EvaporationReagents) == solution.Volume;
     }
 }

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -9,15 +9,14 @@ using Content.Shared.Clothing.Components;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
-using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
+using Content.Shared.Fluids.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Popups;
 using Content.Shared.Spillable;
 using Content.Shared.Throwing;
 using Content.Shared.Verbs;
-using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Player;
 
@@ -28,28 +27,18 @@ public sealed partial class PuddleSystem
     [Dependency] private readonly OpenableSystem _openable = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
 
-    private void InitializeSpillable()
+    protected override void InitializeSpillable()
     {
-        SubscribeLocalEvent<SpillableComponent, ExaminedEvent>(OnExamined);
+        base.InitializeSpillable();
+
         SubscribeLocalEvent<SpillableComponent, LandEvent>(SpillOnLand);
-        // openable handles the event if its closed
-        SubscribeLocalEvent<SpillableComponent, MeleeHitEvent>(SplashOnMeleeHit, after: new[] { typeof(OpenableSystem) });
+        // Openable handles the event if it's closed
+        SubscribeLocalEvent<SpillableComponent, MeleeHitEvent>(SplashOnMeleeHit, after: [typeof(OpenableSystem)]);
         SubscribeLocalEvent<SpillableComponent, GetVerbsEvent<Verb>>(AddSpillVerb);
         SubscribeLocalEvent<SpillableComponent, GotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<SpillableComponent, SolutionContainerOverflowEvent>(OnOverflow);
         SubscribeLocalEvent<SpillableComponent, SpillDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<SpillableComponent, AttemptPacifiedThrowEvent>(OnAttemptPacifiedThrow);
-    }
-
-    private void OnExamined(Entity<SpillableComponent> entity, ref ExaminedEvent args)
-    {
-        using (args.PushGroup(nameof(SpillableComponent)))
-        {
-            args.PushMarkup(Loc.GetString("spill-examine-is-spillable"));
-
-            if (HasComp<MeleeWeaponComponent>(entity))
-                args.PushMarkup(Loc.GetString("spill-examine-spillable-weapon"));
-        }
     }
 
     private void OnOverflow(Entity<SpillableComponent> entity, ref SolutionContainerOverflowEvent args)

--- a/Content.Shared/Fluids/Components/EvaporationComponent.cs
+++ b/Content.Shared/Fluids/Components/EvaporationComponent.cs
@@ -1,19 +1,20 @@
-﻿using Content.Server.Fluids.EntitySystems;
-using Content.Shared.FixedPoint;
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
-namespace Content.Server.Fluids.Components;
+namespace Content.Shared.Fluids.Components;
 
 /// <summary>
 /// Added to puddles that contain water so it may evaporate over time.
 /// </summary>
-[RegisterComponent, Access(typeof(PuddleSystem))]
+[NetworkedComponent]
+[RegisterComponent, Access(typeof(SharedPuddleSystem))]
 public sealed partial class EvaporationComponent : Component
 {
     /// <summary>
     /// The next time we remove the EvaporationSystem reagent amount from this entity.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("nextTick", customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [ViewVariables(VVAccess.ReadWrite), DataField("nextTick", customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan NextTick = TimeSpan.Zero;
 
     /// <summary>

--- a/Content.Shared/Fluids/Components/PuddleComponent.cs
+++ b/Content.Shared/Fluids/Components/PuddleComponent.cs
@@ -11,10 +11,10 @@ namespace Content.Shared.Fluids.Components
     [RegisterComponent, NetworkedComponent, Access(typeof(SharedPuddleSystem))]
     public sealed partial class PuddleComponent : Component
     {
-        [DataField("spillSound")]
+        [DataField]
         public SoundSpecifier SpillSound = new SoundPathSpecifier("/Audio/Effects/Fluids/splat.ogg");
 
-        [DataField("overflowVolume")]
+        [DataField]
         public FixedPoint2 OverflowVolume = FixedPoint2.New(20);
 
         [DataField("solution")] public string SolutionName = "puddle";

--- a/Content.Shared/Fluids/Components/SpillableComponent.cs
+++ b/Content.Shared/Fluids/Components/SpillableComponent.cs
@@ -1,6 +1,6 @@
 using Content.Shared.FixedPoint;
 
-namespace Content.Server.Fluids.Components;
+namespace Content.Shared.Fluids.Components;
 
 [RegisterComponent]
 public sealed partial class SpillableComponent : Component
@@ -12,15 +12,15 @@ public sealed partial class SpillableComponent : Component
     ///     Should this item be spilled when worn as clothing?
     ///     Doesn't count for pockets or hands.
     /// </summary>
-    [DataField("spillWorn")]
+    [DataField]
     public bool SpillWorn = true;
 
-    [DataField("spillDelay")]
+    [DataField]
     public float? SpillDelay;
 
     /// <summary>
     ///     At most how much reagent can be splashed on someone at once?
     /// </summary>
-    [DataField("maxMeleeSpillAmount")]
+    [DataField]
     public FixedPoint2 MaxMeleeSpillAmount = FixedPoint2.New(20);
 }

--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Reagent;
+
+namespace Content.Shared.Fluids;
+
+public abstract partial class SharedPuddleSystem
+{
+    [ValidatePrototypeId<ReagentPrototype>]
+    private const string Water = "Water";
+
+    public static readonly string[] EvaporationReagents = [Water];
+
+    public bool CanFullyEvaporate(Solution solution)
+    {
+        return solution.GetTotalPrototypeQuantity(EvaporationReagents) == solution.Volume;
+    }
+}

--- a/Content.Shared/Fluids/SharedPuddleSystem.Spillable.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Spillable.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Examine;
+using Content.Shared.Fluids.Components;
+using Content.Shared.Weapons.Melee;
+
+namespace Content.Shared.Fluids;
+
+public abstract partial class SharedPuddleSystem
+{
+    protected virtual void InitializeSpillable()
+    {
+        SubscribeLocalEvent<SpillableComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<SpillableComponent> entity, ref ExaminedEvent args)
+    {
+        using (args.PushGroup(nameof(SpillableComponent)))
+        {
+            args.PushMarkup(Loc.GetString("spill-examine-is-spillable"));
+
+            if (HasComp<MeleeWeaponComponent>(entity))
+                args.PushMarkup(Loc.GetString("spill-examine-spillable-weapon"));
+        }
+    }
+}

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -2,13 +2,16 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.DragDrop;
+using Content.Shared.Examine;
+using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
 using Content.Shared.Movement.Events;
+using Content.Shared.StepTrigger.Components;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Fluids;
 
-public abstract class SharedPuddleSystem : EntitySystem
+public abstract partial class SharedPuddleSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
@@ -28,6 +31,9 @@ public abstract class SharedPuddleSystem : EntitySystem
         SubscribeLocalEvent<DrainableSolutionComponent, CanDropTargetEvent>(OnDrainCanDropTarget);
         SubscribeLocalEvent<RefillableSolutionComponent, CanDropDraggedEvent>(OnRefillableCanDropDragged);
         SubscribeLocalEvent<PuddleComponent, GetFootstepSoundEvent>(OnGetFootstepSound);
+        SubscribeLocalEvent<PuddleComponent, ExaminedEvent>(HandlePuddleExamined);
+
+        InitializeSpillable();
     }
 
     private void OnRefillableCanDrag(Entity<RefillableSolutionComponent> entity, ref CanDragEvent args)
@@ -73,6 +79,31 @@ public abstract class SharedPuddleSystem : EntitySystem
             && _prototypeManager.TryIndex(reagentId.Value.Prototype, out ReagentPrototype? proto))
         {
             args.Sound = proto.FootstepSound;
+        }
+    }
+
+    private void HandlePuddleExamined(Entity<PuddleComponent> entity, ref ExaminedEvent args)
+    {
+        using (args.PushGroup(nameof(PuddleComponent)))
+        {
+            if (TryComp<StepTriggerComponent>(entity, out var slippery) && slippery.Active)
+            {
+                args.PushMarkup(Loc.GetString("puddle-component-examine-is-slippery-text"));
+            }
+
+            if (HasComp<EvaporationComponent>(entity) &&
+                _solutionContainerSystem.ResolveSolution(entity.Owner, entity.Comp.SolutionName,
+                    ref entity.Comp.Solution, out var solution))
+            {
+                if (CanFullyEvaporate(solution))
+                    args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating"));
+                else if (solution.GetTotalPrototypeQuantity(EvaporationReagents) > FixedPoint2.Zero)
+                    args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-partial"));
+                else
+                    args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-no"));
+            }
+            else
+                args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-no"));
         }
     }
 }

--- a/Resources/Locale/en-US/fluids/components/puddle-component.ftl
+++ b/Resources/Locale/en-US/fluids/components/puddle-component.ftl
@@ -1,4 +1,4 @@
-puddle-component-examine-is-slipper-text = It looks [color=#169C9C]slippery[/color].
+puddle-component-examine-is-slippery-text = It looks [color=#169C9C]slippery[/color].
 puddle-component-examine-evaporating = It is [color=#5E7C16]evaporating[/color].
 puddle-component-examine-evaporating-partial = It is [color=#FED83D]partially evaporating[/color].
 puddle-component-examine-evaporating-no = It is [color=#B02E26]not evaporating[/color].


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added client-side prediction to the popup when examining puddles, and for the "This container looks spillable" and "You could splash this onto someone with a melee attack" portions of the popup when examining containers.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Prediction is nice - you no longer have to wait a second for the server to send the text, so examining things is faster and easier.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Moved some portions of PuddleSystem to Shared, as well as a few components.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
More of PuddleSystem and some components are in Shared now, so some using directives may need adjustment.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.