### PR TITLE
Add prediction to Spill Container verb

### DIFF
--- a/Content.Client/Fluids/PuddleSystem.cs
+++ b/Content.Client/Fluids/PuddleSystem.cs
@@ -1,7 +1,9 @@
 using Content.Client.IconSmoothing;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.Fluids;
 using Content.Shared.Fluids.Components;
 using Robust.Client.GameObjects;
+using Robust.Shared.Map;
 
 namespace Content.Client.Fluids;
 
@@ -21,7 +23,7 @@ public sealed class PuddleSystem : SharedPuddleSystem
         if (args.Sprite == null)
             return;
 
-        float volume = 1f;
+        var volume = 1f;
 
         if (args.AppearanceData.TryGetValue(PuddleVisuals.CurrentVolume, out var volumeObj))
         {
@@ -64,4 +66,34 @@ public sealed class PuddleSystem : SharedPuddleSystem
             args.Sprite.Color *= baseColor;
         }
     }
+
+    #region Spill
+
+    // Maybe someday we'll have clientside prediction for entity spawning, but not today.
+    // Until then, these methods do nothing on the client.
+    public override bool TrySplashSpillAt(EntityUid uid, EntityCoordinates coordinates, Solution solution, out EntityUid puddleUid, bool sound = true, EntityUid? user = null)
+    {
+        puddleUid = EntityUid.Invalid;
+        return false;
+    }
+
+    public override bool TrySpillAt(EntityCoordinates coordinates, Solution solution, out EntityUid puddleUid, bool sound = true)
+    {
+        puddleUid = EntityUid.Invalid;
+        return false;
+    }
+
+    public override bool TrySpillAt(EntityUid uid, Solution solution, out EntityUid puddleUid, bool sound = true, TransformComponent? transformComponent = null)
+    {
+        puddleUid = EntityUid.Invalid;
+        return false;
+    }
+
+    public override bool TrySpillAt(TileRef tileRef, Solution solution, out EntityUid puddleUid, bool sound = true, bool tileReact = true)
+    {
+        puddleUid = EntityUid.Invalid;
+        return false;
+    }
+
+    #endregion Spill
 }

--- a/Content.Server/Fluids/Components/PreventSpillerComponent.cs
+++ b/Content.Server/Fluids/Components/PreventSpillerComponent.cs
@@ -1,7 +1,0 @@
-namespace Content.Server.Fluids.Components;
-
-[RegisterComponent]
-public sealed partial class PreventSpillerComponent : Component
-{
-
-}

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -1,5 +1,4 @@
 using Content.Server.Chemistry.Containers.EntitySystems;
-using Content.Server.Fluids.Components;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
@@ -8,7 +7,6 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Clothing.Components;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Database;
-using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
 using Content.Shared.IdentityManagement;
@@ -16,7 +14,6 @@ using Content.Shared.Inventory.Events;
 using Content.Shared.Popups;
 using Content.Shared.Spillable;
 using Content.Shared.Throwing;
-using Content.Shared.Verbs;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Player;
 
@@ -24,9 +21,6 @@ namespace Content.Server.Fluids.EntitySystems;
 
 public sealed partial class PuddleSystem
 {
-    [Dependency] private readonly OpenableSystem _openable = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
-
     protected override void InitializeSpillable()
     {
         base.InitializeSpillable();
@@ -34,7 +28,6 @@ public sealed partial class PuddleSystem
         SubscribeLocalEvent<SpillableComponent, LandEvent>(SpillOnLand);
         // Openable handles the event if it's closed
         SubscribeLocalEvent<SpillableComponent, MeleeHitEvent>(SplashOnMeleeHit, after: [typeof(OpenableSystem)]);
-        SubscribeLocalEvent<SpillableComponent, GetVerbsEvent<Verb>>(AddSpillVerb);
         SubscribeLocalEvent<SpillableComponent, GotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<SpillableComponent, SolutionContainerOverflowEvent>(OnOverflow);
         SubscribeLocalEvent<SpillableComponent, SpillDoAfterEvent>(OnDoAfter);
@@ -134,7 +127,7 @@ public sealed partial class PuddleSystem
         if (!_solutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var soln, out var solution))
             return;
 
-        if (_openable.IsClosed(entity.Owner))
+        if (Openable.IsClosed(entity.Owner))
             return;
 
         if (args.User != null)
@@ -153,7 +146,7 @@ public sealed partial class PuddleSystem
     private void OnAttemptPacifiedThrow(Entity<SpillableComponent> ent, ref AttemptPacifiedThrowEvent args)
     {
         // Don’t care about closed containers.
-        if (_openable.IsClosed(ent))
+        if (Openable.IsClosed(ent))
             return;
 
         // Don’t care about empty containers.
@@ -161,58 +154,6 @@ public sealed partial class PuddleSystem
             return;
 
         args.Cancel("pacified-cannot-throw-spill");
-    }
-
-    private void AddSpillVerb(Entity<SpillableComponent> entity, ref GetVerbsEvent<Verb> args)
-    {
-        if (!args.CanAccess || !args.CanInteract)
-            return;
-
-        if (!_solutionContainerSystem.TryGetSolution(args.Target, entity.Comp.SolutionName, out var soln, out var solution))
-            return;
-
-        if (_openable.IsClosed(args.Target))
-            return;
-
-        if (solution.Volume == FixedPoint2.Zero)
-            return;
-
-        if (_entityManager.HasComponent<PreventSpillerComponent>(args.User))
-            return;
-
-
-        Verb verb = new()
-        {
-            Text = Loc.GetString("spill-target-verb-get-data-text")
-        };
-
-        // TODO VERB ICONS spill icon? pouring out a glass/beaker?
-        if (entity.Comp.SpillDelay == null)
-        {
-            var target = args.Target;
-            verb.Act = () =>
-            {
-                var puddleSolution = _solutionContainerSystem.SplitSolution(soln.Value, solution.Volume);
-                TrySpillAt(Transform(target).Coordinates, puddleSolution, out _);
-            };
-        }
-        else
-        {
-            var user = args.User;
-            verb.Act = () =>
-            {
-                _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, user, entity.Comp.SpillDelay ?? 0, new SpillDoAfterEvent(), entity.Owner, target: entity.Owner)
-                {
-                    BreakOnTargetMove = true,
-                    BreakOnUserMove = true,
-                    BreakOnDamage = true,
-                    NeedHand = true,
-                });
-            };
-        }
-        verb.Impact = LogImpact.Medium; // dangerous reagent reaction are logged separately.
-        verb.DoContactInteraction = true;
-        args.Verbs.Add(verb);
     }
 
     private void OnDoAfter(Entity<SpillableComponent> entity, ref SpillDoAfterEvent args)

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -46,7 +46,6 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ITileDefinitionManager _tileDefMan = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
-    [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly ReactiveSystem _reactive = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
@@ -551,11 +550,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
     #region Spill
 
-    /// <summary>
-    ///     First splashes reagent on reactive entities near the spilling entity, then spills the rest regularly to a
-    ///     puddle. This is intended for 'destructive' spills, like when entities are destroyed or thrown.
-    /// </summary>
-    public bool TrySplashSpillAt(EntityUid uid,
+    public override bool TrySplashSpillAt(EntityUid uid,
         EntityCoordinates coordinates,
         Solution solution,
         out EntityUid puddleUid,
@@ -600,11 +595,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         return TrySpillAt(coordinates, solution, out puddleUid, sound);
     }
 
-    /// <summary>
-    ///     Spills solution at the specified coordinates.
-    /// Will add to an existing puddle if present or create a new one if not.
-    /// </summary>
-    public bool TrySpillAt(EntityCoordinates coordinates, Solution solution, out EntityUid puddleUid, bool sound = true)
+    public override bool TrySpillAt(EntityCoordinates coordinates, Solution solution, out EntityUid puddleUid, bool sound = true)
     {
         if (solution.Volume == 0)
         {
@@ -621,10 +612,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         return TrySpillAt(mapGrid.GetTileRef(coordinates), solution, out puddleUid, sound);
     }
 
-    /// <summary>
-    /// <see cref="TrySpillAt(Robust.Shared.Map.EntityCoordinates,Content.Shared.Chemistry.Components.Solution,out Robust.Shared.GameObjects.EntityUid,bool)"/>
-    /// </summary>
-    public bool TrySpillAt(EntityUid uid, Solution solution, out EntityUid puddleUid, bool sound = true,
+    public override bool TrySpillAt(EntityUid uid, Solution solution, out EntityUid puddleUid, bool sound = true,
         TransformComponent? transformComponent = null)
     {
         if (!Resolve(uid, ref transformComponent, false))
@@ -636,10 +624,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         return TrySpillAt(transformComponent.Coordinates, solution, out puddleUid, sound: sound);
     }
 
-    /// <summary>
-    /// <see cref="TrySpillAt(Robust.Shared.Map.EntityCoordinates,Content.Shared.Chemistry.Components.Solution,out Robust.Shared.GameObjects.EntityUid,bool)"/>
-    /// </summary>
-    public bool TrySpillAt(TileRef tileRef, Solution solution, out EntityUid puddleUid, bool sound = true,
+    public override bool TrySpillAt(TileRef tileRef, Solution solution, out EntityUid puddleUid, bool sound = true,
         bool tileReact = true)
     {
         if (solution.Volume <= 0)

--- a/Content.Shared/Fluids/Components/PreventSpillerComponent.cs
+++ b/Content.Shared/Fluids/Components/PreventSpillerComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Fluids.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PreventSpillerComponent : Component
+{
+
+}

--- a/Content.Shared/Fluids/SharedPuddleSystem.Spillable.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Spillable.cs
@@ -1,14 +1,24 @@
+using Content.Shared.Database;
+using Content.Shared.DoAfter;
 using Content.Shared.Examine;
+using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Spillable;
+using Content.Shared.Verbs;
 using Content.Shared.Weapons.Melee;
 
 namespace Content.Shared.Fluids;
 
 public abstract partial class SharedPuddleSystem
 {
+    [Dependency] protected readonly SharedOpenableSystem Openable = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
     protected virtual void InitializeSpillable()
     {
         SubscribeLocalEvent<SpillableComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<SpillableComponent, GetVerbsEvent<Verb>>(AddSpillVerb);
     }
 
     private void OnExamined(Entity<SpillableComponent> entity, ref ExaminedEvent args)
@@ -20,5 +30,57 @@ public abstract partial class SharedPuddleSystem
             if (HasComp<MeleeWeaponComponent>(entity))
                 args.PushMarkup(Loc.GetString("spill-examine-spillable-weapon"));
         }
+    }
+
+    private void AddSpillVerb(Entity<SpillableComponent> entity, ref GetVerbsEvent<Verb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (!_solutionContainerSystem.TryGetSolution(args.Target, entity.Comp.SolutionName, out var soln, out var solution))
+            return;
+
+        if (Openable.IsClosed(args.Target))
+            return;
+
+        if (solution.Volume == FixedPoint2.Zero)
+            return;
+
+        if (_entityManager.HasComponent<PreventSpillerComponent>(args.User))
+            return;
+
+
+        Verb verb = new()
+        {
+            Text = Loc.GetString("spill-target-verb-get-data-text")
+        };
+
+        // TODO VERB ICONS spill icon? pouring out a glass/beaker?
+        if (entity.Comp.SpillDelay == null)
+        {
+            var target = args.Target;
+            verb.Act = () =>
+            {
+                var puddleSolution = _solutionContainerSystem.SplitSolution(soln.Value, solution.Volume);
+                TrySpillAt(Transform(target).Coordinates, puddleSolution, out _);
+            };
+        }
+        else
+        {
+            var user = args.User;
+            verb.Act = () =>
+            {
+                _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, user, entity.Comp.SpillDelay ?? 0, new SpillDoAfterEvent(), entity.Owner, target: entity.Owner)
+                {
+                    BreakOnTargetMove = true,
+                    BreakOnUserMove = true,
+                    BreakOnDamage = true,
+                    NeedHand = true,
+                });
+            };
+        }
+        verb.Impact = LogImpact.Medium; // dangerous reagent reaction are logged separately.
+        verb.DoContactInteraction = true;
+        args.Verbs.Add(verb);
     }
 }

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -1,12 +1,14 @@
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
+using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.StepTrigger.Components;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Fluids;
@@ -15,6 +17,7 @@ public abstract partial class SharedPuddleSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
 
     /// <summary>
     /// The lowest threshold to be considered for puddle sprite states as well as slipperiness of a puddle.
@@ -106,4 +109,37 @@ public abstract partial class SharedPuddleSystem : EntitySystem
                 args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-no"));
         }
     }
+
+    #region Spill
+
+    /// <summary>
+    ///     First splashes reagent on reactive entities near the spilling entity, then spills the rest regularly to a
+    ///     puddle. This is intended for 'destructive' spills, like when entities are destroyed or thrown.
+    /// </summary>
+    public abstract bool TrySplashSpillAt(EntityUid uid,
+        EntityCoordinates coordinates,
+        Solution solution,
+        out EntityUid puddleUid,
+        bool sound = true,
+        EntityUid? user = null);
+
+    /// <summary>
+    ///     Spills solution at the specified coordinates.
+    /// Will add to an existing puddle if present or create a new one if not.
+    /// </summary>
+    public abstract bool TrySpillAt(EntityCoordinates coordinates, Solution solution, out EntityUid puddleUid, bool sound = true);
+
+    /// <summary>
+    /// <see cref="TrySpillAt(EntityCoordinates, Solution, out EntityUid, bool)"/>
+    /// </summary>
+    public abstract bool TrySpillAt(EntityUid uid, Solution solution, out EntityUid puddleUid, bool sound = true,
+        TransformComponent? transformComponent = null);
+
+    /// <summary>
+    /// <see cref="TrySpillAt(EntityCoordinates, Solution, out EntityUid, bool)"/>
+    /// </summary>
+    public abstract bool TrySpillAt(TileRef tileRef, Solution solution, out EntityUid puddleUid, bool sound = true,
+        bool tileReact = true);
+
+    #endregion Spill
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The verbs menu entry for Spill Container is now added in Shared, so it will show up when generating the verbs menu client-side, without having to wait for the server to send it.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Waiting for all the verbs to show up in the menu is annoying, and it's a real pain when the menu jumps around after getting more verbs from the server. This is one less verb that will do that.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
All of the TrySpillAt and TrySplashAt methods in Server's PuddleSystem were made into overrides of new abstract versions in SharedPuddleSystem, and Client was given dummy implementations that always fail. Proper prediction for those methods would require spawning client-side entities, then replacing them with the server-side entities when the update arrives, which would be a great system to have but not something happening right now. Having the ability to call these methods (and do nothing client-side) from Shared is helpful though - in this case for the spill DoAfter, but I've run into other instances where I want to have it.
PreventSpillerComponent was moved to Shared.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
PreventSpillerComponent was moved to Shared, which will affect any using directives that reference it.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nope