### PR TITLE
Monkeys can wear all types of masks, not just breath/gas masks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -13,7 +13,6 @@
   - type: IdentityBlocker
   - type: Tag
     tags:
-    - MonkeyWearable
     - HamsterWearable
     - WhitelistChameleon
     - HidesNose

--- a/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
@@ -20,12 +20,6 @@
     uiWindowPos: 0,1
     strippingWindowPos: 1,1
     displayName: Mask
-    whitelist:
-      tags:
-        - MonkeyWearable
-        - PetWearable
-      components:
-        - Smokable
   - name: jumpsuit
     slotTexture: uniform
     slotFlags: INNERCLOTHING


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
title

## Why / Balance
was weird how they could wear only a select few of masks

## Technical details
removed mask whitelist in monkey inventory plate

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/f307cc52-bb69-45e0-95c0-c39ee2b8cb02)
![image](https://github.com/space-wizards/space-station-14/assets/45323883/9d26212b-968a-42dc-a8b5-0a507b41003e)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
nope

**Changelog**
no
