### PR TITLE
1% chance of dropping AllAtOnce gamepreset secret

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,7 +2,8 @@
   id: Secret
   weights:
     Nukeops: 0.20
-    Traitor: 0.60
+    Traitor: 0.59
     Zombie: 0.05
     Survival: 0.10
     Revolutionary: 0.05
+    AllAtOnce: 0.01 # We do a little bit of trolling

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -6,4 +6,4 @@
     Zombie: 0.05
     Survival: 0.10
     Revolutionary: 0.05
-    AllAtOnce: 0.01 # We do a little bit of trolling
+    AllAtOnce: 0.01 # We do a little trolling


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Agents drop 1% less often, but there is now a 1% chance for all at once
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Someday, one shift out of 100, absolute madness will occur.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
n/a
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
🆑
- tweak: All at once gamepreset can drop in secret with a 1% chance
- tweak: Chance to drop Traitors in Secret is now 59% instead of 60%