### PR TITLE
Add LF option into gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,13 @@
 * text=auto
 
 ###############################################################################
+# Use LF line ending in code files
+###############################################################################
+*.cs   text eol=lf
+*.yml  text eol=lf
+*.json text eol=lf
+
+###############################################################################
 # Set default behavior for command prompt diff.
 #
 # This is need for earlier builds of msysgit that does not have it on by


### PR DESCRIPTION
## About the PR
Add an option to the gitattributes to replace the CRLF with the LF in the source files.

Closes #16248 

## Why / Balance
It is annoying to work with files that contain CRLF characters on Linux. It would be great if git would automatically replace these characters on every commit.

## Technical details
I can change every file with CRLF by myself, but it will make a lot of conflicts.

## Media
No CRLF, yay!
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Maybe it will cause more merge conflicts in the future, but I think it will be easy to solve.

**Changelog**
Players don't care.