### PR TITLE
Lathe-able Welding Masks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -12,7 +12,7 @@
   - type: EyeProtection
   - type: PhysicalComposition
     materialComposition:
-      Steel: 500
+      Steel: 200
       Glass: 100
   - type: StaticPrice
     price: 50

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -161,6 +161,7 @@
       - BorgChargerCircuitboard
       - WeaponCapacitorRechargerCircuitboard
       - HandheldStationMap
+      - ClothingHeadHatWelding
   - type: EmagLatheRecipes
     emagStaticRecipes:
        - CartridgePistol

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -178,3 +178,11 @@
   materials:
     Steel: 300
     Plastic: 100
+
+- type: latheRecipe
+  id: ClothingHeadHatWelding
+  result: ClothingHeadHatWelding
+  completetime: 2
+  materials:
+    Steel: 300
+    Glass: 200

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -184,5 +184,5 @@
   result: ClothingHeadHatWelding
   completetime: 2
   materials:
-    Steel: 300
+    Steel: 400
     Glass: 200


### PR DESCRIPTION
## About the PR
Making this on the behalf of someone who mentioned it's surprisingly difficult to get your hands on a welding mask.
This allows you to construct one in an Autolathe with four steel and two glass.

(Had to change the composition of the mask from 5 steel to 2 as to avoid cargo abuse with the hyper lathe + material reclaimer.)

## Why / Balance
Welding masks actually do show up for non-engineers a lot less than you'd think; the main way of getting them being praying to god they're mapped in a maints room.
This is the most direct approach to fixing that, also providing a renewable source of them.

## Media
- [X] This PR does not require an ingame showcase.

**Changelog**
:cl:
- add: Welding masks can now be made in the Autolathe.
