### PR TITLE
Shot glass max volume decrease

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
@@ -41,7 +41,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 7
+        maxVol: 5
   - type: SolutionTransfer
     transferAmount: 10
     minTransferAmount: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changes the maximum volume of shot glasses from 7u to 5u

## Why / Balance
It bugged me the way shot glasses took two sips when normal shots take one sip in real life

## Media
![Shot](https://github.com/space-wizards/space-station-14/assets/159507482/8e10e9f6-1c7c-4b79-abc5-4bae57561256)
![Content Client_r6uzd9W46o](https://github.com/space-wizards/space-station-14/assets/159507482/87db1029-4500-43ea-bf55-0d7d8e32c2bd)



**Changelog**

:cl: Lawdog
- tweak: Changed the max volume of shot glasses from 7u to 5u to better represent drinking shots in real life
