### PR TITLE
make decoys buckleable

### DIFF
--- a/Resources/Prototypes/Body/Prototypes/decoy.yml
+++ b/Resources/Prototypes/Body/Prototypes/decoy.yml
@@ -1,0 +1,8 @@
+﻿- type: body
+  id: Decoy
+  name: decoy
+  root: root
+  # fake part
+  slots:
+    root:
+      part: null

--- a/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
@@ -40,6 +40,9 @@
     folded: true
   - type: PowerCellSlot
     cellSlotId: cell_slot
+  - type: Body
+    prototype: Decoy
+  - type: Buckle # pour one out for a syndie homie
   - type: ItemSlots
     slots:
       cell_slot:


### PR DESCRIPTION
## About the PR
title

## Why / Balance
pour one out for a syndie homie, now for the whole squad

## Technical details
fake body <ins>/!\\</ins>

## Media
![07:42:48](https://github.com/space-wizards/space-station-14/assets/39013340/5a331e7f-d92c-44dc-8b29-f0e340114747)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Decoy balloons can now sit on chairs.
