### PR TITLE
Adds paramedic cap to the uniform printer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -959,6 +959,7 @@
       - ClothingHeadHatWarden
       - ClothingUniformJumpsuitWarden
       - ClothingUniformJumpskirtWarden
+      - ClothingHeadHatParamedicsoft
       # Winter outfits
       - ClothingOuterWinterCap
       - ClothingOuterWinterCE

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -1,5 +1,5 @@
 
-
+# Jumpsuits/skirts
 - type: latheRecipe
   id: ClothingUniformJumpsuitColorGrey # Tide
   result: ClothingUniformJumpsuitColorGrey
@@ -608,7 +608,7 @@
   completetime: 4
   materials:
     Cloth: 300
-
+# Command winter coats
 - type: latheRecipe
   id: ClothingOuterWinterCap
   result: ClothingOuterWinterCap
@@ -672,7 +672,7 @@
   materials:
     Cloth: 500
     Durathread: 400
-
+# Mantles
 - type: latheRecipe
   id: ClothingNeckMantleCap
   result: ClothingNeckMantleCap
@@ -728,8 +728,7 @@
   materials:
     Cloth: 200
     Durathread: 150
-
-
+# Winter coats
 - type: latheRecipe
   id: ClothingOuterWinterMusician
   result: ClothingOuterWinterMusician
@@ -905,7 +904,7 @@
   materials:
     Cloth: 500
     Durathread: 300
-
+# Hats
 - type: latheRecipe
   id: ClothingHeadHatCaptain
   result: ClothingHeadHatCaptain
@@ -1080,6 +1079,13 @@
   completetime: 2
   materials:
     Cloth: 100
+
+- type: latheRecipe
+  id: ClothingHeadHatParamedicsoft
+  result: ClothingHeadHatParamedicsoft
+  completetime: 1
+  materials:
+    Cloth: 100
 # Ties
 - type: latheRecipe
   id: ClothingNeckTieRed
@@ -1157,7 +1163,7 @@
   completetime: 2
   materials:
     Cloth: 200
-
+# Carpets
 - type: latheRecipe
   id: Carpet
   result: FloorCarpetItemRed


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added the paramedic cap to the uniform printer and cleaned up clothing.yml with extra comments to discern which category was what. Having "scarfs" and "ties" comments but nothing else was inconsistent.
If wanted I could add the paramedic's windbreaker too? It's the only thing missing.

## Why / Balance
Other clothes have accompanying hats/berets to match them in the printer, so why not paramed as well.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/155149356/c28fef09-15b7-411b-8128-3063ba8f294b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added the paramedic's cap to the uniform printer.
