### PR TITLE
Fixes glowsticks being unable to be inserted into trashbags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   name: green glowstick
   parent: BaseItem
   id: GlowstickBase
@@ -60,6 +60,9 @@
           maxDuration: 10 # 300.0
           startValue: 5.0
           endValue: 1.5
+    - type: Tag
+      tags:
+      - Trash
 
 - type: entity
   name: red glowstick


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added the trash tag to glowsticks so janitors can clean them up. This has the side effect of unused glowsticks now being able to be trashed but I dont think it matters too much.
Side note, I did not touch the type entity, not sure why it shows as diff.
Edit: Solves #25843

## Why / Balance
"Cant insert" is annoying, especially after a pizza party.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun
