### PR TITLE
buff gas leak event

### DIFF
--- a/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
@@ -13,6 +13,7 @@ public sealed partial class GasLeakRuleComponent : Component
         Gas.Plasma,
         Gas.Tritium,
         Gas.Frezon,
+        Gas.WaterVapor, // the fog
     };
 
     /// <summary>
@@ -33,14 +34,14 @@ public sealed partial class GasLeakRuleComponent : Component
     public bool FoundTile;
     public Gas LeakGas;
     public float MolesPerSecond;
-    public readonly int MinimumMolesPerSecond = 20;
+    public readonly int MinimumMolesPerSecond = 80;
 
     /// <summary>
     ///     Don't want to make it too fast to give people time to flee.
     /// </summary>
-    public int MaximumMolesPerSecond = 50;
+    public int MaximumMolesPerSecond = 200;
 
-    public int MinimumGas = 250;
-    public int MaximumGas = 1000;
+    public int MinimumGas = 1000;
+    public int MaximumGas = 4000;
     public float SparkChance = 0.05f;
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
makes the gas leak event 4x as strong, and also adds water vapor to the list of leakable gases

## Why / Balance
currently the gas leak event can be ignored essentially every time, this makes it less ignorable and an actual issue
why water vapour? the fog is coming

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
untested

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Gas leak events are now 4 times as strong, and may leak water vapor. The fog is coming.