### PR TITLE
buff cargo hydroponics crate

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
@@ -52,10 +52,14 @@
       - id: PlantBGoneSpray
       - id: WeedSpray
       - id: PestSpray
+      - id: HydroponicsToolClippers
       - id: HydroponicsToolScythe
+      - id: HydroponicsToolSpade
       - id: HydroponicsToolHatchet
       - id: ClothingOuterApronBotanist
       - id: ClothingHandsGlovesLeather
+      - id: EZNutrientChemistryBottle
+        amount: 2
 
 - type: entity
   id: CrateHydroponicsSeeds


### PR DESCRIPTION
## About the PR
adds:
- clippers
- spade
- 2 bottles of ez nutrient

to hydroponics crate order

## Why / Balance
right now the crate only has 2 useful things, plant b gone and the hoe. with these you can actually use it to kickstart a farm. the ez nutrient is much more efficiently made by buying chemical crates rather than $500 for 60u

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun