### PR TITLE
Slimes can drink fourteenloko

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -162,16 +162,13 @@
     Poison:
       effects:
       - !type:HealthChange
-        damage:
-          types:
-            Poison: 1
-      - !type:HealthChange
         conditions:
         - !type:OrganType
           type: Slime
+          shouldHave: false
         damage:
           types:
-            Poison: -1
+            Poison: 1
 
 - type: reagent
   id: ShamblersJuice

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -165,6 +165,13 @@
         damage:
           types:
             Poison: 1
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Slime
+        damage:
+          types:
+            Poison: -1
 
 - type: reagent
   id: ShamblersJuice


### PR DESCRIPTION
## About the PR

Slimes can drink FourteenLoko not 1 time or even 2, but as much as they want. Their stomachs can process this obscure slurry without harming their bodies. 

## Why / Balance

Strange finding legal poison, that way they'll have at least one consumer in them. Interesting feature for the slime people.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl: Nimfar11

- tweak: Slimes can now drink FourteenLoko without harming their bodies.
