### PR TITLE
Adding a simple Wooden Closet

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
@@ -193,3 +193,21 @@
         bluespaceEffectOnTeleportSource: true
         destroyAfterUses: 2
         destroyType: DeleteComponent
+
+# Wooden closet
+- type: entity
+  id: CabinetCloset
+  parent: ClosetSteelBase
+  name: wooden closet
+  description: That's a fine wood.
+  components:
+  - type: Appearance
+  - type: EntityStorageVisuals
+    stateBaseClosed: cabinet
+    stateDoorOpen: cabinet_open
+    stateDoorClosed: cabinet_door  
+  - type: EntityStorage
+    closeSound:
+      path: /Audio/Effects/woodenclosetclose.ogg
+    openSound:
+      path: /Audio/Effects/woodenclosetopen.ogg

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
@@ -198,7 +198,7 @@
 - type: entity
   id: CabinetCloset
   parent: ClosetSteelBase
-  name: wooden closet
+  name: wardrobe
   description: That's a fine wood.
   components:
   - type: Appearance


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Basically just added wooden cabinet without lock on it

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It will really look cool as a part of interior and even cooler without those locks on it

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/92464780/5f234688-7c4f-402c-b668-c8ec2b9d8b5f)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase



**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Wooden closet without lock (Wardrobe)
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
