### PR TITLE
Shuttle map IFF tweaks

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -345,7 +345,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
             // Rudimentary IFF for now, if IFF hiding on then we don't show on the map at all
             if (grid.Owner != _shuttleEntity &&
                 EntManager.TryGetComponent(grid, out iffComp) &&
-                (iffComp.Flags & (IFFFlags.Hide | IFFFlags.HideLabel)) != 0x0)
+                (iffComp.Flags & IFFFlags.Hide) != 0x0)
             {
                 continue;
             }
@@ -367,6 +367,9 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
             AddMapObject(existingEdges, existingVerts, mapObject);
 
             // Text
+            if (iffComp != null && (iffComp.Flags & IFFFlags.HideLabel) != 0x0)
+                continue;
+
             // Force drawing it at this point.
             var iffText = _shuttles.GetIFFLabel(grid, self: true, component: iffComp);
 

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
@@ -60,7 +60,7 @@ public abstract partial class SharedShuttleSystem
             return;
 
         component.Color = color;
-        Dirty(component);
+        Dirty(gridUid, component);
         UpdateIFFInterfaces(gridUid, component);
     }
 
@@ -73,7 +73,7 @@ public abstract partial class SharedShuttleSystem
             return;
 
         component.Flags |= flags;
-        Dirty(component);
+        Dirty(gridUid, component);
         UpdateIFFInterfaces(gridUid, component);
     }
 
@@ -87,7 +87,7 @@ public abstract partial class SharedShuttleSystem
             return;
 
         component.Flags &= ~flags;
-        Dirty(component);
+        Dirty(gridUid, component);
         UpdateIFFInterfaces(gridUid, component);
     }
 }

--- a/Content.Shared/Shuttles/UI/MapObjects/GridMapObject.cs
+++ b/Content.Shared/Shuttles/UI/MapObjects/GridMapObject.cs
@@ -3,5 +3,6 @@ namespace Content.Shared.Shuttles.UI.MapObjects;
 public record struct GridMapObject : IMapObject
 {
     public string Name { get; set; }
+    public bool HideButton { get; init; }
     public EntityUid Entity;
 }

--- a/Content.Shared/Shuttles/UI/MapObjects/IMapObject.cs
+++ b/Content.Shared/Shuttles/UI/MapObjects/IMapObject.cs
@@ -6,4 +6,9 @@ namespace Content.Shared.Shuttles.UI.MapObjects;
 public interface IMapObject
 {
     string Name { get; }
+
+    /// <summary>
+    /// Should we hide the button from being shown (AKA just draw it).
+    /// </summary>
+    bool HideButton { get; }
 }

--- a/Content.Shared/Shuttles/UI/MapObjects/ShuttleBeaconObject.cs
+++ b/Content.Shared/Shuttles/UI/MapObjects/ShuttleBeaconObject.cs
@@ -4,4 +4,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Shuttles.UI.MapObjects;
 
 [Serializable, NetSerializable]
-public readonly record struct ShuttleBeaconObject(NetEntity Entity, NetCoordinates Coordinates, string Name) : IMapObject;
+public readonly record struct ShuttleBeaconObject(NetEntity Entity, NetCoordinates Coordinates, string Name) : IMapObject
+{
+    public bool HideButton => false;
+}

--- a/Content.Shared/Shuttles/UI/MapObjects/ShuttleExclusionObject.cs
+++ b/Content.Shared/Shuttles/UI/MapObjects/ShuttleExclusionObject.cs
@@ -4,4 +4,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Shuttles.UI.MapObjects;
 
 [Serializable, NetSerializable]
-public record struct ShuttleExclusionObject(NetCoordinates Coordinates, float Range, string Name = "") : IMapObject;
+public record struct ShuttleExclusionObject(NetCoordinates Coordinates, float Range, string Name = "") : IMapObject
+{
+    public bool HideButton => false;
+}


### PR DESCRIPTION
- HideLabel just means it won't have its name / button drawn whereas Hide will block it completely.

![image](https://github.com/space-wizards/space-station-14/assets/31366439/d582dbe2-90a1-43e9-b3bf-ad97807f43f6)

:cl:
- tweak: Remove the buttons for generated debris from shuttle maps.
