### PR TITLE
Green alert shuttle time change

### DIFF
--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -5,7 +5,7 @@
     green:
       announcement: alert-level-green-announcement
       color: Green
-      shuttleTime: 1200
+      shuttleTime: 600
     blue:
       announcement: alert-level-blue-announcement
       sound: /Audio/Misc/bluealert.ogg


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Set shuttle arrive time on green code to 10 minutes.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Green alert shuttle time is set to 20 mins, while blue, red etc. set to 10. I can see why this is a good thing, but everyone just sets alert to blue to call the shuttle. So instead of people setting alert level to blue every time they want to call a shuttle, why not just make it 10 minutes to green as well.
I'm not sure if this is a correct way of addressing the issue of _blue→call evac→green_, but I don't have any better idea for now.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
N/A
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Evacuation shuttle arrives 10 minutes on green alert now.
