### PR TITLE
Obsolete `Logger` cleanup for `EntitySystem`s

### DIFF
--- a/Content.Client/Alerts/ClientAlertsSystem.cs
+++ b/Content.Client/Alerts/ClientAlertsSystem.cs
@@ -33,7 +33,7 @@ public sealed class ClientAlertsSystem : AlertsSystem
 
         AlertOrder = _prototypeManager.EnumeratePrototypes<AlertOrderPrototype>().FirstOrDefault();
         if (AlertOrder == null)
-            Log.Error("alert", "no alertOrder prototype found, alerts will be in random order");
+            Log.Error("No alertOrder prototype found, alerts will be in random order");
     }
 
     public IReadOnlyDictionary<AlertKey, AlertState>? ActiveAlerts

--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -271,7 +271,7 @@ public sealed class ClientClothingSystem : ClothingSystem
         {
             if (!revealedLayers.Add(key))
             {
-                Logger.Warning($"Duplicate key for clothing visuals: {key}. Are multiple components attempting to modify the same layer? Equipment: {ToPrettyString(equipment)}");
+                Log.Warning($"Duplicate key for clothing visuals: {key}. Are multiple components attempting to modify the same layer? Equipment: {ToPrettyString(equipment)}");
                 continue;
             }
 

--- a/Content.Client/IconSmoothing/IconSmoothSystem.cs
+++ b/Content.Client/IconSmoothing/IconSmoothSystem.cs
@@ -231,7 +231,7 @@ namespace Content.Client.IconSmoothing
 
             if (!spriteQuery.TryGetComponent(uid, out var sprite))
             {
-                Logger.Error($"Encountered a icon-smoothing entity without a sprite: {ToPrettyString(uid)}");
+                Log.Error($"Encountered a icon-smoothing entity without a sprite: {ToPrettyString(uid)}");
                 RemCompDeferred(uid, smooth);
                 return;
             }
@@ -242,7 +242,7 @@ namespace Content.Client.IconSmoothing
             {
                 if (!_mapManager.TryGetGrid(xform.GridUid, out grid))
                 {
-                    Logger.Error($"Failed to calculate IconSmoothComponent sprite in {uid} because grid {xform.GridUid} was missing.");
+                    Log.Error($"Failed to calculate IconSmoothComponent sprite in {uid} because grid {xform.GridUid} was missing.");
                     return;
                 }
             }

--- a/Content.Client/Info/InfoSystem.cs
+++ b/Content.Client/Info/InfoSystem.cs
@@ -12,13 +12,13 @@ public sealed class InfoSystem : EntitySystem
     {
         base.Initialize();
         SubscribeNetworkEvent<RulesMessage>(OnRulesReceived);
-        Logger.DebugS("info", "Requested server info.");
+        Log.Debug("Requested server info.");
         RaiseNetworkEvent(new RequestRulesMessage());
     }
 
     private void OnRulesReceived(RulesMessage message, EntitySessionEventArgs eventArgs)
     {
-        Logger.DebugS("info", "Received server rules.");
+        Log.Debug("Received server rules.");
         Rules = message;
         _rules.UpdateRules();
     }

--- a/Content.Client/Light/RgbLightControllerSystem.cs
+++ b/Content.Client/Light/RgbLightControllerSystem.cs
@@ -146,7 +146,7 @@ namespace Content.Client.Light
                 else
                 {
                     // admeme fuck-ups or bad yaml?
-                    Logger.Warning($"RGB light attempted to use invalid sprite index {index} on entity {ToPrettyString(uid)}");
+                    Log.Warning($"RGB light attempted to use invalid sprite index {index} on entity {ToPrettyString(uid)}");
                     rgb.Layers.Remove(index);
                 }
             }

--- a/Content.Client/Sprite/RandomSpriteSystem.cs
+++ b/Content.Client/Sprite/RandomSpriteSystem.cs
@@ -51,7 +51,7 @@ public sealed class RandomSpriteSystem : SharedRandomSpriteSystem
             {
                 if (layer.Key is not { } strKey || !int.TryParse(strKey, out index))
                 {
-                    Logger.Error($"Invalid key `{layer.Key}` for entity with random sprite {ToPrettyString(uid)}");
+                    Log.Error($"Invalid key `{layer.Key}` for entity with random sprite {ToPrettyString(uid)}");
                     continue;
                 }
             }

--- a/Content.Server/Atmos/EntitySystems/AutomaticAtmosSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AutomaticAtmosSystem.cs
@@ -39,7 +39,7 @@ public sealed class AutomaticAtmosSystem : EntitySystem
         if (physics.Mass / ShuttleSystem.TileMassMultiplier >= 7.0f)
         {
             AddComp<GridAtmosphereComponent>(ev.Entity);
-            Logger.InfoS("atmos", $"Giving grid {ev.Entity} GridAtmosphereComponent.");
+            Log.Info($"Giving grid {ev.Entity} GridAtmosphereComponent.");
         }
         // It's not super important to remove it should the grid become too small again.
         // If explosions ever gain the ability to outright shatter grids, do rethink this.

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
@@ -167,7 +167,7 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
                 }
                 else
                 {
-                    Logger.Warning("atmos", $"{ToPrettyString(uid)} received GasFilterSelectGasMessage with an invalid ID: {args.ID}");
+                    Log.Warning($"{ToPrettyString(uid)} received GasFilterSelectGasMessage with an invalid ID: {args.ID}");
                 }
             }
             else

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -156,7 +156,7 @@ public sealed partial class ExplosionSystem
 #endif
         }
 
-        Logger.InfoS("Explosion", $"Processed {TilesPerTick - tilesRemaining} tiles in {Stopwatch.Elapsed.TotalMilliseconds}ms");
+        Log.Info($"Processed {TilesPerTick - tilesRemaining} tiles in {Stopwatch.Elapsed.TotalMilliseconds}ms");
 
         // we have finished processing our tiles. Is there still an ongoing explosion?
         if (_activeExplosion != null)

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
@@ -37,7 +37,7 @@ public sealed partial class ExplosionSystem : EntitySystem
 
         if (!_explosionTypes.TryGetValue(typeID, out var typeIndex))
         {
-            Logger.Error("Attempted to spawn explosion using a prototype that was not defined during initialization. Explosion prototype hot-reload is not currently supported.");
+            Log.Error("Attempted to spawn explosion using a prototype that was not defined during initialization. Explosion prototype hot-reload is not currently supported.");
             return null;
         }
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -290,7 +290,7 @@ public sealed partial class ExplosionSystem : EntitySystem
 
         if (!_prototypeManager.TryIndex<ExplosionPrototype>(typeId, out var type))
         {
-            Logger.Error($"Attempted to spawn unknown explosion prototype: {type}");
+            Log.Error($"Attempted to spawn unknown explosion prototype: {type}");
             return;
         }
 

--- a/Content.Server/Explosion/EntitySystems/SmokeOnTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/SmokeOnTriggerSystem.cs
@@ -37,7 +37,7 @@ public sealed class SmokeOnTriggerSystem : SharedSmokeOnTriggerSystem
         var ent = Spawn(comp.SmokePrototype, coords.SnapToGrid());
         if (!TryComp<SmokeComponent>(ent, out var smoke))
         {
-            Logger.Error($"Smoke prototype {comp.SmokePrototype} was missing SmokeComponent");
+            Log.Error($"Smoke prototype {comp.SmokePrototype} was missing SmokeComponent");
             Del(ent);
             return;
         }

--- a/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
@@ -186,7 +186,7 @@ public sealed partial class HumanoidAppearanceSystem : SharedHumanoidAppearanceS
 
         if (speciesPrototype == null)
         {
-            Logger.Error("Tried to get age representation of species that couldn't be indexed: " + species);
+            Log.Error("Tried to get age representation of species that couldn't be indexed: " + species);
             return Loc.GetString("identity-age-young");
         }
 

--- a/Content.Server/Info/InfoSystem.cs
+++ b/Content.Server/Info/InfoSystem.cs
@@ -17,7 +17,7 @@ public sealed class InfoSystem : EntitySystem
 
     private void OnRequestRules(RequestRulesMessage message, EntitySessionEventArgs eventArgs)
     {
-        Log.Debug("info", "Client requested rules.");
+        Log.Debug("Client requested rules.");
         var title = Loc.GetString(_cfg.GetCVar(CCVars.RulesHeader));
         var path = _cfg.GetCVar(CCVars.RulesFile);
         var rules = "Server could not read its rules.";
@@ -27,7 +27,7 @@ public sealed class InfoSystem : EntitySystem
         }
         catch (Exception)
         {
-            Log.Debug("info", "Could not read server rules file.");
+            Log.Debug("Could not read server rules file.");
         }
         var response = new RulesMessage(title, rules);
         RaiseNetworkEvent(response, eventArgs.SenderSession.Channel);

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.Emitter.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.Emitter.cs
@@ -16,7 +16,7 @@ public sealed partial class ParticleAcceleratorSystem
         var xformQuery = GetEntityQuery<TransformComponent>();
         if (!xformQuery.TryGetComponent(uid, out var xform))
         {
-            Logger.Error("ParticleAccelerator attempted to emit a particle without (having) a transform from which to base its initial position and orientation.");
+            Log.Error("ParticleAccelerator attempted to emit a particle without (having) a transform from which to base its initial position and orientation.");
             return;
         }
 

--- a/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
@@ -73,7 +73,7 @@ namespace Content.Server.Spawners.EntitySystems
 
             if (component.Prototypes.Count == 0)
             {
-                Logger.Warning($"Prototype list in ConditionalSpawnComponent is empty! Entity: {ToPrettyString(uid)}");
+                Log.Warning($"Prototype list in ConditionalSpawnComponent is empty! Entity: {ToPrettyString(uid)}");
                 return;
             }
 
@@ -94,7 +94,7 @@ namespace Content.Server.Spawners.EntitySystems
 
             if (component.Prototypes.Count == 0)
             {
-                Logger.Warning($"Prototype list in RandomSpawnerComponent is empty! Entity: {ToPrettyString(uid)}");
+                Log.Warning($"Prototype list in RandomSpawnerComponent is empty! Entity: {ToPrettyString(uid)}");
                 return;
             }
 

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -323,8 +323,7 @@ public sealed partial class StationJobsSystem
 
             jobs.ExtendedAccess = count <= thresh;
 
-            Logger.DebugS(
-                "station", "Station {Station} on extended access: {ExtendedAccess}",
+            Log.Debug("Station {Station} on extended access: {ExtendedAccess}",
                 Name(station), jobs.ExtendedAccess);
         }
     }

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -456,7 +456,7 @@ public sealed class StationSystem : EntitySystem
 
         if (xform.GridUid == EntityUid.Invalid)
         {
-            Log.Debug("A");
+            Log.Debug("Unable to get owning station - GridUid invalid.");
             return null;
         }
 

--- a/Content.Server/Store/Systems/StoreSystem.Listings.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Listings.cs
@@ -43,7 +43,7 @@ public sealed partial class StoreSystem
     {
         if (!_proto.TryIndex<ListingPrototype>(listingId, out var proto))
         {
-            Logger.Error("Attempted to add invalid listing.");
+            Log.Error("Attempted to add invalid listing.");
             return false;
         }
         return TryAddListing(component, proto);

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -210,7 +210,7 @@ namespace Content.Server.Strip
 
             if (!_inventorySystem.TryGetSlot(target, slot, out var slotDef))
             {
-                Logger.Error($"{ToPrettyString(user)} attempted to place an item in a non-existent inventory slot ({slot}) on {ToPrettyString(target)}");
+                Log.Error($"{ToPrettyString(user)} attempted to place an item in a non-existent inventory slot ({slot}) on {ToPrettyString(target)}");
                 return;
             }
 
@@ -347,7 +347,7 @@ namespace Content.Server.Strip
 
             if (!_inventorySystem.TryGetSlot(target, slot, out var slotDef))
             {
-                Logger.Error($"{ToPrettyString(user)} attempted to take an item from a non-existent inventory slot ({slot}) on {ToPrettyString(target)}");
+                Log.Error($"{ToPrettyString(user)} attempted to take an item from a non-existent inventory slot ({slot}) on {ToPrettyString(target)}");
                 return;
             }
 

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -27,7 +27,7 @@ public sealed class TraitSystem : EntitySystem
         {
             if (!_prototypeManager.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
             {
-                Logger.Warning($"No trait found with ID {traitId}!");
+                Log.Warning($"No trait found with ID {traitId}!");
                 return;
             }
 

--- a/Content.Server/Worldgen/Systems/Biomes/BiomeSelectionSystem.cs
+++ b/Content.Server/Worldgen/Systems/Biomes/BiomeSelectionSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.Worldgen.Components;
 using Content.Server.Worldgen.Prototypes;
 using Robust.Shared.Prototypes;
@@ -35,7 +35,7 @@ public sealed class BiomeSelectionSystem : BaseWorldSystem
             return;
         }
 
-        Logger.Error($"Biome selection ran out of biomes to select? See biomes list: {component.Biomes}");
+        Log.Error($"Biome selection ran out of biomes to select? See biomes list: {component.Biomes}");
     }
 
     private void OnBiomeSelectionStartup(EntityUid uid, BiomeSelectionComponent component, ComponentStartup args)

--- a/Content.Server/Worldgen/Systems/WorldgenConfigSystem.cs
+++ b/Content.Server/Worldgen/Systems/WorldgenConfigSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Administration;
+using Content.Server.Administration;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Events;
 using Content.Server.Worldgen.Components;
@@ -74,7 +74,7 @@ public sealed class WorldgenConfigSystem : EntitySystem
             return;
 
         var target = _map.GetMapEntityId(_gameTicker.DefaultMap);
-        Logger.Debug($"Trying to configure {_gameTicker.DefaultMap}, aka {ToPrettyString(target)} aka {target}");
+        Log.Debug($"Trying to configure {_gameTicker.DefaultMap}, aka {ToPrettyString(target)} aka {target}");
         var cfg = _proto.Index<WorldgenConfigPrototype>(_worldgenConfig);
 
         cfg.Apply(target, _ser, EntityManager); // Apply the config to the map.

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -157,7 +157,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
 
         if (doAfter.Delay <= TimeSpan.Zero)
         {
-            Logger.Warning("Awaited instant DoAfters are not supported fully supported");
+            Log.Warning("Awaited instant DoAfters are not supported fully supported");
             return DoAfterStatus.Finished;
         }
 

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -171,7 +171,7 @@ namespace Content.Shared.Interaction
         {
             if (!ValidateClientInput(session, coords, uid, out var userEntity))
             {
-                Logger.InfoS("system.interaction", $"TryPullObject input validation failed");
+                Log.Info($"TryPullObject input validation failed");
                 return true;
             }
 
@@ -203,7 +203,7 @@ namespace Content.Shared.Interaction
             // client sanitization
             if (!TryComp(item, out TransformComponent? itemXform) || !ValidateClientInput(args.SenderSession, itemXform.Coordinates, item, out var user))
             {
-                Logger.InfoS("system.interaction", $"Inventory interaction validation failed.  Session={args.SenderSession}");
+                Log.Info($"Inventory interaction validation failed.  Session={args.SenderSession}");
                 return;
             }
 
@@ -225,7 +225,7 @@ namespace Content.Shared.Interaction
             // client sanitization
             if (!ValidateClientInput(session, coords, uid, out var user))
             {
-                Logger.InfoS("system.interaction", $"Alt-use input validation failed");
+                Log.Info($"Alt-use input validation failed");
                 return true;
             }
 
@@ -239,7 +239,7 @@ namespace Content.Shared.Interaction
             // client sanitization
             if (!ValidateClientInput(session, coords, uid, out var userEntity))
             {
-                Logger.InfoS("system.interaction", $"Use input validation failed");
+                Log.Info($"Use input validation failed");
                 return true;
             }
 
@@ -547,7 +547,7 @@ namespace Content.Shared.Interaction
 
             if (length > MaxRaycastRange)
             {
-                Logger.Warning("InRangeUnobstructed check performed over extreme range. Limiting CollisionRay size.");
+                Log.Warning("InRangeUnobstructed check performed over extreme range. Limiting CollisionRay size.");
                 length = MaxRaycastRange;
             }
 
@@ -921,7 +921,7 @@ namespace Content.Shared.Interaction
         {
             if (!ValidateClientInput(session, coords, uid, out var user))
             {
-                Logger.InfoS("system.interaction", $"ActivateItemInWorld input validation failed");
+                Log.Info($"ActivateItemInWorld input validation failed");
                 return false;
             }
 
@@ -1100,14 +1100,13 @@ namespace Content.Shared.Interaction
 
             if (!coords.IsValid(EntityManager))
             {
-                Logger.InfoS("system.interaction", $"Invalid Coordinates: client={session}, coords={coords}");
+                Log.Info($"Invalid Coordinates: client={session}, coords={coords}");
                 return false;
             }
 
             if (IsClientSide(uid))
             {
-                Logger.WarningS("system.interaction",
-                    $"Client sent interaction with client-side entity. Session={session}, Uid={uid}");
+                Log.Warning($"Client sent interaction with client-side entity. Session={session}, Uid={uid}");
                 return false;
             }
 
@@ -1115,15 +1114,13 @@ namespace Content.Shared.Interaction
 
             if (userEntity == null || !userEntity.Value.Valid)
             {
-                Logger.WarningS("system.interaction",
-                    $"Client sent interaction with no attached entity. Session={session}");
+                Log.Warning($"Client sent interaction with no attached entity. Session={session}");
                 return false;
             }
 
             if (!Exists(userEntity))
             {
-                Logger.WarningS("system.interaction",
-                    $"Client attempted interaction with a non-existent attached entity. Session={session},  entity={userEntity}");
+                Log.Warning($"Client attempted interaction with a non-existent attached entity. Session={session},  entity={userEntity}");
                 return false;
             }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed almost all[^1] obsolete `Logger` calls in Content's `EntitySystem`s to use `Log` instead. `Log` automatically selects the system-specific `Sawmill`, so this isn't just a refactor - it makes logs slightly more accurate (puts them in appropriate sawmill/context rather than the root sawmill).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Using `Logger` directly for logging is marked obsolete. Assumed this is a desired change.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This changes some log contexts, but generally in a desirable way:
- For most, it put logs in `system.appropriate` `Sawmill` rather than root.
- For some that were forced into another `Sawmill` it changes it to a more specific one, i.e. from `atmos` it becomes `system.gas_filter` or `system.automatic_atmos` and  `system.station` into `system.station_jobs`.
- For the rest it remains unchanged

**I assumed that all of the above was desirable because this seems to be the standard convention** - I imagine that was the idea behind the `Log` in all `EntitySystem`s coupled with `[Obsolete] Logger` methods - **but if my assumptions are incorrect and/or there are exceptions, please let me know and I will adjust.**

[^1]: There is only one `EntitySystem` that I didn't update - `ExamineSystemShared`. That is because the `Logger` is in a `static` method and refactoring that away causes a lot of cascading changes. May do it as a separate PR to avoid overly diluting this one.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
Log output changes. `EntitySystem` logs now go to the expected `Sawmill` for the system rather than hardcoded/root one.
Any log analyzers anticipating these logs' context must be updated.