### PR TITLE
Nuke Music start adjusted for duration

### DIFF
--- a/Content.Server/Audio/ServerGlobalSoundSystem.cs
+++ b/Content.Server/Audio/ServerGlobalSoundSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Server.Station.Systems;
 using Content.Shared.Audio;
 using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
 using Robust.Shared.Console;
 using Robust.Shared.Player;
 
@@ -10,6 +11,7 @@ public sealed class ServerGlobalSoundSystem : SharedGlobalSoundSystem
 {
     [Dependency] private readonly IConsoleHost _conHost = default!;
     [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
 
     public override void Shutdown()
     {
@@ -50,9 +52,13 @@ public sealed class ServerGlobalSoundSystem : SharedGlobalSoundSystem
 
     public void DispatchStationEventMusic(EntityUid source, SoundSpecifier sound, StationEventMusicType type)
     {
+        DispatchStationEventMusic(source, _audio.GetSound(sound), type);
+    }
+
+    public void DispatchStationEventMusic(EntityUid source, string sound, StationEventMusicType type)
+    {
         var audio = AudioParams.Default.WithVolume(-8);
-        var soundFile = sound.GetSound();
-        var msg = new StationEventMusicEvent(soundFile, type, audio);
+        var msg = new StationEventMusicEvent(sound, type, audio);
 
         var filter = GetStationAndPvs(source);
         RaiseNetworkEvent(msg, filter);

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -46,7 +46,8 @@ public sealed class NukeSystem : EntitySystem
     /// <summary>
     ///     Used to calculate when the nuke song should start playing for maximum kino with the nuke sfx
     /// </summary>
-    private const float NukeSongLength = 60f + 51.6f;
+    private float _nukeSongLength;
+    private string _selectedNukeSong = String.Empty;
 
     /// <summary>
     ///     Time to leave between the nuke song and the nuke alarm playing.
@@ -292,9 +293,9 @@ public sealed class NukeSystem : EntitySystem
 
         // Start playing the nuke event song so that it ends a couple seconds before the alert sound
         // should play
-        if (nuke.RemainingTime <= NukeSongLength + nuke.AlertSoundTime + NukeSongBuffer && !nuke.PlayedNukeSong)
+        if (nuke.RemainingTime <= _nukeSongLength + nuke.AlertSoundTime + NukeSongBuffer && !nuke.PlayedNukeSong && !string.IsNullOrEmpty(_selectedNukeSong))
         {
-            _sound.DispatchStationEventMusic(uid, nuke.ArmMusic, StationEventMusicType.Nuke);
+            _sound.DispatchStationEventMusic(uid, _selectedNukeSong, StationEventMusicType.Nuke);
             nuke.PlayedNukeSong = true;
         }
 
@@ -457,6 +458,9 @@ public sealed class NukeSystem : EntitySystem
         var y = (int) pos.Y;
         var posText = $"({x}, {y})";
 
+        // We are collapsing the randomness here, otherwise we would get separate random song picks for checking duration and when actually playing the song afterwards
+        _selectedNukeSong = _audio.GetSound(component.ArmMusic);
+
         // warn a crew
         var announcement = Loc.GetString("nuke-component-announcement-armed",
             ("time", (int) component.RemainingTime), ("position", posText));
@@ -464,6 +468,7 @@ public sealed class NukeSystem : EntitySystem
         _chatSystem.DispatchStationAnnouncement(stationUid ?? uid, announcement, sender, false, null, Color.Red);
 
         _sound.PlayGlobalOnStation(uid, _audio.GetSound(component.ArmSound));
+        _nukeSongLength = (float) _audio.GetAudioLength(_selectedNukeSong).TotalSeconds;
 
         // turn on the spinny light
         _pointLight.SetEnabled(uid, true);


### PR DESCRIPTION
## About the PR

Nuke Music now begins playing at the appropriate time  to end just-on-target regardless of the duration of the music (as long as it's less than 290 seconds)

fixes  #25775

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

