### PR TITLE
SS14 Secret gamemode weight change (attempt 2)

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,8 +1,8 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.20
+    Nukeops: 0.17
     Traitor: 0.60
-    Zombie: 0.05
+    Zombie: 0.00
     Survival: 0.10
-    Revolutionary: 0.05
+    Revolutionary: 0.13

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,8 +1,8 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.17
-    Traitor: 0.60
+    Nukeops: 0.25
+    Traitor: 0.50
     Zombie: 0.00
     Survival: 0.10
-    Revolutionary: 0.13
+    Revolutionary: 0.15

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,8 +1,8 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.25
-    Traitor: 0.50
+    Nukeops: 0.20
+    Traitor: 0.55
     Zombie: 0.00
     Survival: 0.10
     Revolutionary: 0.15


### PR DESCRIPTION
Updates secret game weights



## About the PR
 - Increased revs chance
 - Slightly decreased nukie chance
 - Decreased zombie chance to zero

## Why / Balance
 - Revs increased because 5% is too low for a game mode that is most of the time immediately ruined by unrobust head revs who do not know what they're doing and immediately publicly flash. Additionally around the time it was originally removed actual strategies were beginning to develop and the game mode was becoming better. Additionally, the (majority of the) people YEARN to have revs back.
 - Zombies were removed because survival is just better zombies. (we essencially had 15% zombies)
 - Nukie chance slightly decreased to allow rev slight increase

https://discord.com/channels/310555209753690112/1214521833790111775/1214521833790111775 for discussion and voting results