### PR TITLE
Convert BasicStationEventScheduler to Use TimeSpans and DataFields

### DIFF
--- a/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
@@ -3,12 +3,28 @@
 [RegisterComponent, Access(typeof(BasicStationEventSchedulerSystem))]
 public sealed partial class BasicStationEventSchedulerComponent : Component
 {
-    public const float MinimumTimeUntilFirstEvent = 300;
+    /// <summary>
+    ///     The minimum amount of time that must past before the first event can trigger.
+    ///     This is in addition to the min and max times below.
+    /// </summary>
+    [DataField(), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan MinimumTimeUntilFirstEvent = TimeSpan.FromSeconds(300);
 
     /// <summary>
-    /// How long until the next check for an event runs
+    ///     The minimum amount of time that must past after the last event before the next event check will occur.
     /// </summary>
-    /// Default value is how long until first event is allowed
-    [ViewVariables(VVAccess.ReadWrite)]
-    public float TimeUntilNextEvent = MinimumTimeUntilFirstEvent;
+    [DataField(), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan MinimumTimeBetweenEvents = TimeSpan.FromSeconds(300);
+
+    /// <summary>
+    ///     The maximum amount of time that must past after the last event before the next event check will occur.
+    /// </summary>
+    [DataField(), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan MaximumTimeBetweenEvents = TimeSpan.FromSeconds(600);
+
+    /// <summary>
+    ///     The time at which the next event check will occur.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan NextEventTime = TimeSpan.Zero;
 }

--- a/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
@@ -1,30 +1,30 @@
 ﻿namespace Content.Server.StationEvents.Components;
 
-[RegisterComponent, Access(typeof(BasicStationEventSchedulerSystem))]
+[RegisterComponent, AutoGenerateComponentPause, Access(typeof(BasicStationEventSchedulerSystem))]
 public sealed partial class BasicStationEventSchedulerComponent : Component
 {
     /// <summary>
     ///     The minimum amount of time that must past before the first event can trigger.
     ///     This is in addition to the min and max times below.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan MinimumTimeUntilFirstEvent = TimeSpan.FromSeconds(300);
 
     /// <summary>
     ///     The minimum amount of time that must past after the last event before the next event check will occur.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan MinimumTimeBetweenEvents = TimeSpan.FromSeconds(300);
 
     /// <summary>
     ///     The maximum amount of time that must past after the last event before the next event check will occur.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan MaximumTimeBetweenEvents = TimeSpan.FromSeconds(600);
 
     /// <summary>
     ///     The time at which the next event check will occur.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoPausedField]
     public TimeSpan NextEventTime = TimeSpan.Zero;
 }

--- a/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
@@ -7,19 +7,19 @@ public sealed partial class BasicStationEventSchedulerComponent : Component
     ///     The minimum amount of time that must past before the first event can trigger.
     ///     This is in addition to the min and max times below.
     /// </summary>
-    [DataField(), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan MinimumTimeUntilFirstEvent = TimeSpan.FromSeconds(300);
 
     /// <summary>
     ///     The minimum amount of time that must past after the last event before the next event check will occur.
     /// </summary>
-    [DataField(), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan MinimumTimeBetweenEvents = TimeSpan.FromSeconds(300);
 
     /// <summary>
     ///     The maximum amount of time that must past after the last event before the next event check will occur.
     /// </summary>
-    [DataField(), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan MaximumTimeBetweenEvents = TimeSpan.FromSeconds(600);
 
     /// <summary>


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
I've edited the BasicStationEventScheduler gamerule to use TimeSpans, simply marking *when* the event will trigger and comparing it to the time instead of counting down, and to allow for modifying when events happen in the YAML rather than using hard coded values.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This was changed as we wish to alter the values downstream, and don't want to alter the hard coded ones.
It only affects game balance if the server in question wishes it to.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Instead of using hard coded numbers for randomizing when the next event will occur, the values are stored in the Component with a Datafield. Furthermore, the values are all stored as TimeSpans rather than floats, clarifying their usage (minutes, seconds, etc.). The next event's time is stored as an absolute time that it will trigger at, rather than as a countdown. It is than compared to the current time every update rather than the system counting it down (accumulator style)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
The floats used in BasicStationEventSchedulerSystem and its Component have been replaced with TimeSpans. Simply using TimeSpan.TotalSeconds will easily fix this if anything else is using them. 


No changelog required.
