### PR TITLE
Prevents FloorOcclusion from breaking rendering

### DIFF
--- a/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
+++ b/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
@@ -45,7 +45,7 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
     {
         var shader = _proto.Index<ShaderPrototype>("HorizontalCut").Instance();
 
-        if (sprite.PostShader is not null && !sprite.PostShader.Equals(shader))
+        if (sprite.PostShader is not null && sprite.PostShader != shader)
             return;
 
         if (enabled)

--- a/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
+++ b/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
@@ -43,9 +43,14 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
 
     private void SetShader(SpriteComponent sprite, bool enabled)
     {
+        var shader = _proto.Index<ShaderPrototype>("HorizontalCut").Instance();
+
+        if (sprite.PostShader is not null && !sprite.PostShader.Equals(shader))
+            return;
+
         if (enabled)
         {
-            sprite.PostShader = _proto.Index<ShaderPrototype>("HorizontalCut").Instance();
+            sprite.PostShader = shader;
         }
         else
         {


### PR DESCRIPTION
## About the PR

This PR adds a condition so that FloorOcclusionSystem does not overwrite existing PostShaders.

## Why / Balance

Because if a Mutable PostShader already exists, the FloorOcclusionSystem will simply replace it with its own, which is Immutable, which creates conflict with other systems and breaks the game's rendering and UI, to the point that all clients are immediately left with a black screen and the FPS drops to 0, eventually resulting in a crash. There is an in-game situation where this bug is replicable and I will not address it publicly in this PR because it is potentially game breaking, if you want you can chat with me via DM on discord (my name is the same).

## Technical details

Adds an extra condition so that the FloorOcclusionSystem does not replace the PostShader of other systems. Honestly this is a workaround, this system should be redone in the engine, but I don't have the knowledge to do so.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
The FloorOcclusionSystem should no longer work if there is already another PostShader in sprite.

**Changelog**

:cl:
- fix: Prevents rendering from crashing in certain scenarios
