### PR TITLE
fix: ambient music fade in (#25874)

### DIFF
--- a/Content.Client/Audio/ContentAudioSystem.cs
+++ b/Content.Client/Audio/ContentAudioSystem.cs
@@ -107,7 +107,7 @@ public sealed partial class ContentAudioSystem : SharedContentAudioSystem
 
         _fadingOut.Remove(stream.Value);
         var curVolume = component.Volume;
-        var change = (curVolume - MinVolume) / duration;
+        var change = (MinVolume - curVolume) / duration;
         _fadingIn.Add(stream.Value, (change, component.Volume));
         component.Volume = MinVolume;
     }
@@ -151,8 +151,8 @@ public sealed partial class ContentAudioSystem : SharedContentAudioSystem
                 continue;
             }
 
-            var volume = component.Volume + change * frameTime;
-            volume = MathF.Max(target, volume);
+            var volume = component.Volume - change * frameTime;
+            volume = MathF.Min(target, volume);
             _audio.SetVolume(stream, volume, component);
 
             if (component.Volume.Equals(target))


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Ambient music  volume now set to ambient music volume slider.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Space ambience tracks being super loud #25874.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
FadeIn and UpdateFades now get correct values instead of blasting music on maximum volume.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
Before:
https://github.com/space-wizards/space-station-14/assets/82627200/8a2ab0c5-d3ae-4cb5-85d8-97703ecdb52a
After:
https://github.com/space-wizards/space-station-14/assets/82627200/2b364261-b267-4bad-ab3e-10d389df6eb4