### PR TITLE
Fix shield absorbing asphyxiation damage

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -47,13 +47,23 @@ public sealed partial class BlockingSystem
             if (args.Damage.GetTotal() <= 0)
                 return;
 
+            // A shield should only block damage it can itself absorb. To determine that we need the Damageable component on it.
+            if (!TryComp<DamageableComponent>(component.BlockingItem, out var dmgComp))
+                return;
+
             var blockFraction = blocking.IsBlocking ? blocking.ActiveBlockFraction : blocking.PassiveBlockFraction;
             blockFraction = Math.Clamp(blockFraction, 0, 1);
             _damageable.TryChangeDamage(component.BlockingItem, blockFraction * args.OriginalDamage);
 
-            args.Damage *= (1 - blockFraction);
+            var modify = new DamageModifierSet();
+            foreach (var (key, _) in dmgComp.Damage.DamageDict)
+            {
+                modify.Coefficients.TryAdd(key, 1 - blockFraction);
+            }
 
-            if (blocking.IsBlocking)
+            args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, modify);
+
+            if (blocking.IsBlocking && !args.Damage.Equals(args.OriginalDamage))
             {
                 _audio.PlayPvs(blocking.BlockSound, uid);
             }

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -56,7 +56,7 @@ public sealed partial class BlockingSystem
             _damageable.TryChangeDamage(component.BlockingItem, blockFraction * args.OriginalDamage);
 
             var modify = new DamageModifierSet();
-            foreach (var (key, _) in dmgComp.Damage.DamageDict)
+            foreach (var key in dmgComp.Damage.DamageDict.Keys)
             {
                 modify.Coefficients.TryAdd(key, 1 - blockFraction);
             }


### PR DESCRIPTION
fixes #25966

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The shield will now only reduce damage itself can absorb.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
A shield should probably not oxygenate your blood supply.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Instead of just multiplying the damage of the user, we now create a damagemodiferset with all the damages that the shield can take. For that we use the shield's damageable component. This does mean that shields that cannot take damage will no longer absorb damage.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Shields will no longer absorb asphyxiation damage, or any other damage they themselves can't take.