### PR TITLE
Fix misprediction of emergency access

### DIFF
--- a/Content.Shared/Doors/Components/AirlockComponent.cs
+++ b/Content.Shared/Doors/Components/AirlockComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class AirlockComponent : Component
     public bool Safety = true;
 
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool EmergencyAccess = false;
 
     /// <summary>

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -126,6 +126,7 @@ public abstract class SharedAirlockSystem : EntitySystem
     public void ToggleEmergencyAccess(EntityUid uid, AirlockComponent component)
     {
         component.EmergencyAccess = !component.EmergencyAccess;
+        Dirty(uid, component); // This only runs on the server apparently so we need this.
         UpdateEmergencyLightStatus(uid, component);
     }
 


### PR DESCRIPTION
fixes #25800
fixes #25900

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The client now actually knows when an airlock is in emergency access.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The EmergencyAccess bool was not getting synced to the client. Made it AutoNetworked. Also dirtied the airlock component on the function that actually sets it since it's only called on the server when you use a remote and as such doesn't sync to the client otherwise.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun