### PR TITLE
Contraband Storage Crate

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -285,9 +285,10 @@
 
 - type: entity
   parent: CrateBaseSecure
+  suffix: Armory, Secure
   id: CrateContrabandStorageSecure
   name: contraband storage crate
-  description: A crate for storing contraband confiscated from suspects or prisoners.
+  description: An armory access locked crate for storing contraband confiscated from suspects or prisoners.
   components:
   - type: Icon
     sprite: Structures/Storage/Crates/sec_gear.rsi

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -285,6 +285,19 @@
 
 - type: entity
   parent: CrateBaseSecure
+  id: CrateContrabandStorageSecure
+  name: contraband storage crate
+  description: A crate for storing contraband permanently removed from suspects or prisoners.
+  components:
+  - type: Icon
+    sprite: Structures/Storage/Crates/sec_gear.rsi
+  - type: Sprite
+    sprite: Structures/Storage/Crates/sec_gear.rsi
+  - type: AccessReader
+    access: [["Armory"]]
+
+- type: entity
+  parent: CrateBaseSecure
   id: CrateCommandSecure
   name: command crate
   components:

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -290,8 +290,6 @@
   name: contraband storage crate
   description: An armory access locked crate for storing contraband confiscated from suspects or prisoners.
   components:
-  - type: Icon
-    sprite: Structures/Storage/Crates/sec_gear.rsi
   - type: Sprite
     sprite: Structures/Storage/Crates/sec_gear.rsi
   - type: AccessReader

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -287,7 +287,7 @@
   parent: CrateBaseSecure
   id: CrateContrabandStorageSecure
   name: contraband storage crate
-  description: A crate for storing contraband permanently removed from suspects or prisoners.
+  description: A crate for storing contraband confiscated from suspects or prisoners.
   components:
   - type: Icon
     sprite: Structures/Storage/Crates/sec_gear.rsi


### PR DESCRIPTION
## About the PR
Adds a Contraband Storage Crate for the armory. This can be used by mappers to provide better and more suitable storage then an empty rack.

## Why / Balance
Dumping items that were confiscated from the syndicate on the ground or in exposed racks felt wrong and unfitting for more stations. This provides an armory locked crate to fill that purpose.

## Media
![Content Client_JYZIEQmEgm](https://github.com/space-wizards/space-station-14/assets/91865152/e458cda6-791c-4145-92c3-ae052482813a)

**Changelog**

No CL, not really player facing.
