### PR TITLE
Fix vox custom sprites

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -14,6 +14,8 @@
   - type:  HumanoidAppearance
     species: Vox
     #- type: VoxAccent # Not yet coded
+  - type: Inventory
+    speciesId: vox
   - type: Speech
     speechVerb: Vox
     speechSounds: Vox


### PR DESCRIPTION
## About the PR
Clothing with custom sprites for vox have been displaying the default sprites due to a component accident.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- fix: Clothes with alternate sprites for vox once again show the alternate sprites, instead of the defaults.
