### PR TITLE
StrippableSystem doafter overhaul

### DIFF
--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -602,16 +602,14 @@ namespace Content.Server.Strip
 
             if (ev.Event.InventoryOrHand)
             {
-                if (ev.Event.InsertOrRemove &&
-                    !CanStripInsertInventory(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName, entity.Comp) ||
-                    !CanStripRemoveInventory(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName))
+                if (ev.Event.InsertOrRemove && !CanStripInsertInventory(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName, entity.Comp) ||
+                    !ev.Event.InsertOrRemove && !CanStripRemoveInventory(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName))
                         ev.Cancel();
             }
             else
             {
-                if (ev.Event.InsertOrRemove &&
-                    !CanStripInsertHand(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName, entity.Comp) ||
-                    !CanStripRemoveHand(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName))
+                if (ev.Event.InsertOrRemove && !CanStripInsertHand(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName, entity.Comp) ||
+                    !ev.Event.InsertOrRemove && !CanStripRemoveHand(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName))
                         ev.Cancel();
             }
         }

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -398,10 +398,8 @@ namespace Content.Server.Strip
             EntityUid held,
             string handName)
         {
-            if (!Resolve(user, ref user.Comp))
-                return false;
-
-            if (!Resolve(target, ref target.Comp))
+            if (!Resolve(user, ref user.Comp) ||
+                !Resolve(target, ref target.Comp))
                 return false;
 
             if (user.Comp.ActiveHand == null)

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -21,7 +21,6 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using System.Linq;
-using System.Diagnostics;
 
 namespace Content.Server.Strip
 {
@@ -595,20 +594,20 @@ namespace Content.Server.Strip
         {
             var args = ev.DoAfter.Args;
 
-            Debug.Assert(entity.Owner == args.User);
-            Debug.Assert(args.Target != null);
-            Debug.Assert(args.Used != null);
-            Debug.Assert(ev.Event.SlotOrHandName != null);
+            DebugTools.Assert(entity.Owner == args.User);
+            DebugTools.Assert(args.Target != null);
+            DebugTools.Assert(args.Used != null);
+            DebugTools.Assert(ev.Event.SlotOrHandName != null);
 
             if (ev.Event.InventoryOrHand)
             {
-                if (ev.Event.InsertOrRemove && !CanStripInsertInventory(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName, entity.Comp) ||
+                if ( ev.Event.InsertOrRemove && !CanStripInsertInventory(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName, entity.Comp) ||
                     !ev.Event.InsertOrRemove && !CanStripRemoveInventory(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName))
                         ev.Cancel();
             }
             else
             {
-                if (ev.Event.InsertOrRemove && !CanStripInsertHand(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName, entity.Comp) ||
+                if ( ev.Event.InsertOrRemove && !CanStripInsertHand(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName, entity.Comp) ||
                     !ev.Event.InsertOrRemove && !CanStripRemoveHand(args.User, args.Target.Value, args.Used.Value, ev.Event.SlotOrHandName))
                         ev.Cancel();
             }
@@ -619,10 +618,10 @@ namespace Content.Server.Strip
             if (ev.Cancelled)
                 return;
 
-            Debug.Assert(entity.Owner == ev.User);
-            Debug.Assert(ev.Target != null);
-            Debug.Assert(ev.Used != null);
-            Debug.Assert(ev.SlotOrHandName != null);
+            DebugTools.Assert(entity.Owner == ev.User);
+            DebugTools.Assert(ev.Target != null);
+            DebugTools.Assert(ev.Used != null);
+            DebugTools.Assert(ev.SlotOrHandName != null);
 
             if (ev.InventoryOrHand)
             {

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -95,7 +95,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
         if (component.StripDelay == null)
             return;
 
-        var (time, stealth) = _strippable.GetStripTimeModifiers(user, wearer, (float) component.StripDelay.Value.TotalSeconds);
+        var (time, stealth) = _strippable.GetStripTimeModifiers(user, wearer, component.StripDelay.Value);
 
         var args = new DoAfterArgs(EntityManager, user, time, new ToggleClothingDoAfterEvent(), item, wearer, item)
         {

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -20,7 +20,7 @@ public sealed partial class SlotDefinition
     [DataField("slotFlags")] public SlotFlags SlotFlags { get; private set; } = SlotFlags.PREVENTEQUIP;
     [DataField("showInWindow")] public bool ShowInWindow { get; private set; } = true;
     [DataField("slotGroup")] public string SlotGroup { get; private set; } = "Default";
-    [DataField("stripTime")] public float StripTime { get; private set; } = 4f;
+    [DataField("stripTime")] public TimeSpan StripTime { get; private set; } = TimeSpan.FromSeconds(4f);
 
     [DataField("uiWindowPos", required: true)]
     public Vector2i UIWindowPosition { get; private set; }

--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.DoAfter;
 using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
@@ -8,10 +9,10 @@ namespace Content.Shared.Strip.Components
     public sealed partial class StrippableComponent : Component
     {
         /// <summary>
-        /// The strip delay for hands.
+        ///     The strip delay for hands.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite), DataField("handDelay")]
-        public float HandStripDelay = 4f;
+        public TimeSpan HandStripDelay = TimeSpan.FromSeconds(4f);
     }
 
     [NetSerializable, Serializable]
@@ -21,63 +22,63 @@ namespace Content.Shared.Strip.Components
     }
 
     [NetSerializable, Serializable]
-    public sealed class StrippingSlotButtonPressed : BoundUserInterfaceMessage
+    public sealed class StrippingSlotButtonPressed(string slot, bool isHand) : BoundUserInterfaceMessage
     {
-        public readonly string Slot;
-
-        public readonly bool IsHand;
-
-        public StrippingSlotButtonPressed(string slot, bool isHand)
-        {
-            Slot = slot;
-            IsHand = isHand;
-        }
+        public readonly string Slot = slot;
+        public readonly bool IsHand = isHand;
     }
 
     [NetSerializable, Serializable]
-    public sealed class StrippingEnsnareButtonPressed : BoundUserInterfaceMessage
-    {
-        public StrippingEnsnareButtonPressed()
-        {
-        }
-    }
+    public sealed class StrippingEnsnareButtonPressed : BoundUserInterfaceMessage;
 
-    public abstract class BaseBeforeStripEvent : EntityEventArgs, IInventoryRelayEvent
+    [ByRefEvent]
+    public abstract class BaseBeforeStripEvent(TimeSpan initialTime, bool stealth = false) : EntityEventArgs, IInventoryRelayEvent
     {
-        public readonly float InitialTime;
-        public float Time => MathF.Max(InitialTime * Multiplier + Additive, 0f);
-        public float Additive = 0;
-        public float Multiplier = 1f;
-        public bool Stealth;
+        public readonly TimeSpan InitialTime = initialTime;
+        public TimeSpan Multiplier = TimeSpan.FromSeconds(1f);
+        public TimeSpan Additive = TimeSpan.Zero;
+        public bool Stealth = stealth;
+
+        public TimeSpan Time => TimeSpan.FromSeconds(MathF.Max(InitialTime.Seconds * Multiplier.Seconds + Additive.Seconds, 0f));
 
         public SlotFlags TargetSlots { get; } = SlotFlags.GLOVES;
+    }
 
-        public BaseBeforeStripEvent(float initialTime, bool stealth = false)
+    /// <summary>
+    ///     Used to modify strip times. Raised directed at the user.
+    /// </summary>
+    /// <remarks>
+    ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
+    /// </remarks>
+    [ByRefEvent]
+    public sealed class BeforeStripEvent(TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(initialTime, stealth);
+
+    /// <summary>
+    ///     Used to modify strip times. Raised directed at the target.
+    /// </summary>
+    /// <remarks>
+    ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
+    /// </remarks>
+    [ByRefEvent]
+    public sealed class BeforeGettingStrippedEvent(TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(initialTime, stealth);
+
+    /// <summary>
+    ///     Organizes the behavior of DoAfters for <see cref="StrippableSystem">.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed partial class StrippableDoAfterEvent : DoAfterEvent
+    {
+        public readonly bool InsertOrRemove;
+        public readonly bool InventoryOrHand;
+        public readonly string SlotOrHandName;
+
+        public StrippableDoAfterEvent(bool insertOrRemove, bool inventoryOrHand, string slotOrHandName)
         {
-            InitialTime = initialTime;
-            Stealth = stealth;
+            InsertOrRemove = insertOrRemove;
+            InventoryOrHand = inventoryOrHand;
+            SlotOrHandName = slotOrHandName;
         }
-    }
 
-    /// <summary>
-    /// Used to modify strip times. Raised directed at the user.
-    /// </summary>
-    /// <remarks>
-    /// This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
-    /// </remarks>
-    public sealed class BeforeStripEvent : BaseBeforeStripEvent
-    {
-        public BeforeStripEvent(float initialTime, bool stealth = false) : base(initialTime, stealth) { }
-    }
-
-    /// <summary>
-    /// Used to modify strip times. Raised directed at the target.
-    /// </summary>
-    /// <remarks>
-    /// This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
-    /// </remarks>
-    public sealed class BeforeGettingStrippedEvent : BaseBeforeStripEvent
-    {
-        public BeforeGettingStrippedEvent(float initialTime, bool stealth = false) : base(initialTime, stealth) { }
+        public override DoAfterEvent Clone() => this;
     }
 }

--- a/Content.Shared/Strip/Components/ThievingComponent.cs
+++ b/Content.Shared/Strip/Components/ThievingComponent.cs
@@ -11,7 +11,7 @@ public sealed partial class ThievingComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("stripTimeReduction")]
-    public float StripTimeReduction = 0.5f;
+    public TimeSpan StripTimeReduction = TimeSpan.FromSeconds(0.5f);
 
     /// <summary>
     /// Should it notify the user if they're stripping a pocket?

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -14,12 +14,12 @@ public abstract class SharedStrippableSystem : EntitySystem
         SubscribeLocalEvent<StrippableComponent, DragDropDraggedEvent>(OnDragDrop);
     }
 
-    public (float Time, bool Stealth) GetStripTimeModifiers(EntityUid user, EntityUid target, float initialTime)
+    public (TimeSpan Time, bool Stealth) GetStripTimeModifiers(EntityUid user, EntityUid target, TimeSpan initialTime)
     {
         var userEv = new BeforeStripEvent(initialTime);
-        RaiseLocalEvent(user, userEv);
+        RaiseLocalEvent(user, ref userEv);
         var ev = new BeforeGettingStrippedEvent(userEv.Time, userEv.Stealth);
-        RaiseLocalEvent(target, ev);
+        RaiseLocalEvent(target, ref ev);
         return (ev.Time, ev.Stealth);
     }
 

--- a/Content.Shared/Strip/ThievingSystem.cs
+++ b/Content.Shared/Strip/ThievingSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Inventory;
+using Content.Shared.Strip;
 using Content.Shared.Strip.Components;
 
 namespace Content.Shared.Strip;


### PR DESCRIPTION
## About the PR

Refactors Strippable DoAfter events to make them synchronous and organized.


## Technical details

### Strippable System & Component
- Synchronous DoAfters
- Made use of `TimeSpan`, `GetStripTimeModifiers()` and `ByRefEvent`
- Reorganized checks, removed some redundant ones
- Resolve pattern where useful
- Added more asserts
- Lots of cleanup

The DoAfters were grouped under one event to avoid copy-pasting eight separate cancel checks, asserts and function signatures.

Let me know if this is bad for performance and I'll roll them out instead.


## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


## Breaking changes

### TimeSpans
`ThievingComponent`, `InventoryTemplatePrototype` and `ToggleableClothingSystem` use `TimeSpan` in places where they intersect with `StrippableComponent`.


**Changelog**

N/A
