### PR TITLE
SS14-12462 Nerf food and drink vending machines

### DIFF
--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Popups;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
+using Robust.Shared.Random;
 
 namespace Content.Shared.VendingMachines;
 
@@ -17,6 +18,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
+    [Dependency] protected readonly IRobustRandom Randomizer = default!;
 
     public override void Initialize()
     {
@@ -27,11 +29,11 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
 
     protected virtual void OnComponentInit(EntityUid uid, VendingMachineComponent component, ComponentInit args)
     {
-        RestockInventoryFromPrototype(uid, component);
+        RestockInventoryFromPrototype(uid, component, component.InitialStockQuality);
     }
 
     public void RestockInventoryFromPrototype(EntityUid uid,
-        VendingMachineComponent? component = null)
+        VendingMachineComponent? component = null, float restockQuality = 1f)
     {
         if (!Resolve(uid, ref component))
         {
@@ -41,9 +43,9 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
         if (!PrototypeManager.TryIndex(component.PackPrototypeId, out VendingMachineInventoryPrototype? packPrototype))
             return;
 
-        AddInventoryFromPrototype(uid, packPrototype.StartingInventory, InventoryType.Regular, component);
-        AddInventoryFromPrototype(uid, packPrototype.EmaggedInventory, InventoryType.Emagged, component);
-        AddInventoryFromPrototype(uid, packPrototype.ContrabandInventory, InventoryType.Contraband, component);
+        AddInventoryFromPrototype(uid, packPrototype.StartingInventory, InventoryType.Regular, component, restockQuality);
+        AddInventoryFromPrototype(uid, packPrototype.EmaggedInventory, InventoryType.Emagged, component, restockQuality);
+        AddInventoryFromPrototype(uid, packPrototype.ContrabandInventory, InventoryType.Contraband, component, restockQuality);
     }
 
     /// <summary>
@@ -80,7 +82,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
 
     private void AddInventoryFromPrototype(EntityUid uid, Dictionary<string, uint>? entries,
         InventoryType type,
-        VendingMachineComponent? component = null)
+        VendingMachineComponent? component = null, float restockQuality = 1.0f)
     {
         if (!Resolve(uid, ref component) || entries == null)
         {
@@ -107,6 +109,15 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
         {
             if (PrototypeManager.HasIndex<EntityPrototype>(id))
             {
+                var restock = amount;
+                var chanceOfMissingStock = 1 - restockQuality;
+
+                var result = Randomizer.NextFloat(0, 1);
+                if (result < chanceOfMissingStock)
+                {
+                    restock = (uint) Math.Floor(amount * result / chanceOfMissingStock);
+                }
+
                 if (inventory.TryGetValue(id, out var entry))
                     // Prevent a machine's stock from going over three times
                     // the prototype's normal amount. This is an arbitrary
@@ -114,9 +125,9 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
                     // restocking a machine who doesn't want to force vend out
                     // all the items just to restock one empty slot without
                     // losing the rest of the restock.
-                    entry.Amount = Math.Min(entry.Amount + amount, 3 * amount);
+                    entry.Amount = Math.Min(entry.Amount + amount, 3 * restock);
                 else
-                    inventory.Add(id, new VendingMachineInventoryEntry(type, id, amount));
+                    inventory.Add(id, new VendingMachineInventoryEntry(type, id, restock));
             }
         }
     }

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -123,7 +123,11 @@ namespace Content.Shared.VendingMachines
         public float DenyAccumulator = 0f;
         public float DispenseOnHitAccumulator = 0f;
 
-        [DataField("initialStockQuality")]
+        /// <summary>
+        /// The quality of the stock in the vending machine on spawn.
+        /// Represents the percentage chance (0.0f = 0%, 1.0f = 100%) each set of items in the machine is fully-stocked.
+        /// If not fully stocked, the stock will have a random value between 0 (inclusive) and max stock (exclusive).
+        /// </summary>
         public float InitialStockQuality = 1.0f;
 
         /// <summary>

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -128,6 +128,7 @@ namespace Content.Shared.VendingMachines
         /// Represents the percentage chance (0.0f = 0%, 1.0f = 100%) each set of items in the machine is fully-stocked.
         /// If not fully stocked, the stock will have a random value between 0 (inclusive) and max stock (exclusive).
         /// </summary>
+        [DataField]
         public float InitialStockQuality = 1.0f;
 
         /// <summary>

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -123,6 +123,9 @@ namespace Content.Shared.VendingMachines
         public float DenyAccumulator = 0f;
         public float DispenseOnHitAccumulator = 0f;
 
+        [DataField("initialStockQuality")]
+        public float InitialStockQuality = 1.0f;
+
         /// <summary>
         ///     While disabled by EMP it randomly ejects items
         /// </summary>

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -359,6 +359,7 @@
     screenState: screen
     ejectDelay: 5
     soundVend: /Audio/Machines/machine_vend_hot_drink.ogg
+    initialStockQuality: 0.33
   - type: Advertise
     pack: HotDrinksMachineAds
   - type: Speech
@@ -396,6 +397,7 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     ejectDelay: 1.9
+    initialStockQuality: 0.33
   - type: Advertise
     pack: RobustSoftdrinksAds
   - type: Speech
@@ -539,6 +541,7 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     ejectDelay: 1.9
+    initialStockQuality: 0.33
   - type: Advertise
     pack: RobustSoftdrinksAds
   - type: Speech
@@ -573,6 +576,7 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     ejectDelay: 1.9
+    initialStockQuality: 0.33
   - type: Advertise
     pack: RobustSoftdrinksAds
   - type: Speech
@@ -607,6 +611,7 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     ejectDelay: 1.9
+    initialStockQuality: 0.33
   - type: Advertise
     pack: RobustSoftdrinksAds
   - type: Speech
@@ -697,6 +702,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    initialStockQuality: 0.33
   - type: Advertise
     pack: DiscountDansAds
   - type: Speech
@@ -902,6 +908,7 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+    initialStockQuality: 0.33
   - type: Advertise
     pack: GetmoreChocolateCorpAds
   - type: Speech
@@ -1045,6 +1052,7 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+    initialStockQuality: 0.33
   - type: Advertise
     pack: BodaAds
   - type: Speech
@@ -1236,6 +1244,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    initialStockQuality: 0.33
   - type: Advertise
     pack: ChangAds
   - type: Speech
@@ -1258,7 +1267,7 @@
   parent: VendingMachine
   id: VendingMachineSalvage
   name: Salvage Vendor
-  description: A dwarves best friend!
+  description: A dwarf's best friend!
   components:
   - type: VendingMachine
     pack: SalvageEquipmentInventory
@@ -1299,6 +1308,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    initialStockQuality: 0.33
   - type: Advertise
     pack: DonutAds
   - type: Speech
@@ -1911,6 +1921,7 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     soundVend: /Audio/Items/bikehorn.ogg
+    initialStockQuality: 1.0 # Nobody knows how Honk does it, but their vending machines always seem well-stocked...
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/happyhonk.rsi
     layers:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Reduces the amount of food in all food and vending machines EXCEPT the Honk meal one by about half.

## Why / Balance
Vending machines provide too much food (and drink) at the moment to the crew, robbing the chef/bartender of a reason to exist, and robbing the janitor of a reason to want to refill vending machines early in the round.

## Technical details
This PR adds a new "initialStockQuality" field to vending machines and sets it at 0.33 for almost all food and drink vendors. The intent at the moment is to drop food and drink vending machine stocks by somewhere around a half - two thirds of the time, about two-thirds of the stock of a given item will be missing.

This number can be tuned to discourage people relying on vending machines and make round start a bit more variable when hunting noms.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/732532/29139d1a-98e4-4b64-9670-cd2ef284d1b1


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Food and drink stocks in vending machines has been reduced to encourage people to use the kitchen and bar.
