### PR TITLE
Added verb action to Glue/Lube system

### DIFF
--- a/Content.Server/Glue/GlueSystem.cs
+++ b/Content.Server/Glue/GlueSystem.cs
@@ -35,7 +35,7 @@ public sealed class GlueSystem : SharedGlueSystem
     }
 
     // When glue bottle is used on item it will apply the glued and unremoveable components.
-    private void OnInteract(EntityUid uid, GlueComponent component, ref AfterInteractEvent args)
+    private void OnInteract(Entity<GlueComponent> entity, ref AfterInteractEvent args)
     {
         if (args.Handled)
             return;
@@ -43,20 +43,22 @@ public sealed class GlueSystem : SharedGlueSystem
         if (!args.CanReach || args.Target is not { Valid: true } target)
             return;
 
-        if (TryGlue(uid, component, target, args.User))
+        if (TryGlue(entity, entity, target, args.User))
             args.Handled = true;
     }
 
-    private void OnUtilityVerb(EntityUid uid, GlueComponent component, GetVerbsEvent<UtilityVerb> args)
+    private void OnUtilityVerb(Entity<GlueComponent> entity, ref GetVerbsEvent<UtilityVerb> args)
     {
         if (!args.CanInteract || !args.CanAccess || args.Target is not { Valid: true } target ||
-        _openable.IsClosed(uid))
+        _openable.IsClosed(entity))
             return;
+
+        var user = args.User;
 
         var verb = new UtilityVerb()
         {
-            Act = () => TryGlue(uid, component, args.Target, args.User),
-            IconEntity = GetNetEntity(uid),
+            Act = () => TryGlue(entity, entity, target, user),
+            IconEntity = GetNetEntity(entity),
             Text = Loc.GetString("glue-verb-text"),
             Message = Loc.GetString("glue-verb-message")
         };

--- a/Content.Server/Lube/LubeSystem.cs
+++ b/Content.Server/Lube/LubeSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Database;
+using Content.Shared.Glue;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
@@ -31,7 +32,7 @@ public sealed class LubeSystem : EntitySystem
         SubscribeLocalEvent<LubeComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
     }
 
-    private void OnInteract(EntityUid uid, LubeComponent component, ref AfterInteractEvent args)
+    private void OnInteract(Entity<LubeComponent> entity, ref AfterInteractEvent args)
     {
         if (args.Handled)
             return;
@@ -39,20 +40,22 @@ public sealed class LubeSystem : EntitySystem
         if (!args.CanReach || args.Target is not { Valid: true } target)
             return;
 
-        if (TryLube(uid, component, target, args.User))
+        if (TryLube(entity, entity, target, args.User))
             args.Handled = true;
     }
 
-    private void OnUtilityVerb(EntityUid uid, LubeComponent component, GetVerbsEvent<UtilityVerb> args)
+    private void OnUtilityVerb(Entity<LubeComponent> entity, ref GetVerbsEvent<UtilityVerb> args)
     {
         if (!args.CanInteract || !args.CanAccess || args.Target is not { Valid: true } target ||
-        _openable.IsClosed(uid))
+        _openable.IsClosed(entity))
             return;
+
+        var user = args.User;
 
         var verb = new UtilityVerb()
         {
-            Act = () => TryLube(uid, component, args.Target, args.User),
-            IconEntity = GetNetEntity(uid),
+            Act = () => TryLube(entity, entity, target, user),
+            IconEntity = GetNetEntity(entity),
             Text = Loc.GetString("lube-verb-text"),
             Message = Loc.GetString("lube-verb-message")
         };

--- a/Resources/Locale/en-US/glue/glue.ftl
+++ b/Resources/Locale/en-US/glue/glue.ftl
@@ -1,6 +1,6 @@
 glue-success = {THE($target)} has been covered in glue!
 glued-name-prefix = Glued {$target}
 glue-failure = Can't cover {THE($target)} in glue!
-glue-verb-text = Glue
+glue-verb-text = Apply Glue
 glue-verb-message = Glue an object
 

--- a/Resources/Locale/en-US/glue/glue.ftl
+++ b/Resources/Locale/en-US/glue/glue.ftl
@@ -1,3 +1,6 @@
 glue-success = {THE($target)} has been covered in glue!
 glued-name-prefix = Glued {$target}
 glue-failure = Can't cover {THE($target)} in glue!
+glue-verb-text = Glue
+glue-verb-message = Glue an object
+

--- a/Resources/Locale/en-US/lube/lube.ftl
+++ b/Resources/Locale/en-US/lube/lube.ftl
@@ -2,5 +2,5 @@ lube-success = {THE($target)} has been covered in lube!
 lubed-name-prefix = Lubed {$target}
 lube-failure = Can't cover {THE($target)} in lube!
 lube-slip = {THE($target)} slips out of your hands!
-lube-verb-text = Lube
+lube-verb-text = Apply Lube
 lube-verb-message = Lube an object

--- a/Resources/Locale/en-US/lube/lube.ftl
+++ b/Resources/Locale/en-US/lube/lube.ftl
@@ -2,3 +2,5 @@ lube-success = {THE($target)} has been covered in lube!
 lubed-name-prefix = Lubed {$target}
 lube-failure = Can't cover {THE($target)} in lube!
 lube-slip = {THE($target)} slips out of your hands!
+lube-verb-text = Lube
+lube-verb-message = Lube an object


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Added right-click Glue/Lube verbs (used by Space glue / lube tubes). This allows them to be used on containers and glasses.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Attempting to glue/lube a container like a bag makes the insert verb take priority. Same for trying to glue/lube something like a glass, which empties the reagent into the container. That keeps those objects from being glued/lubed, but with a right-click verb it is now possible.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Added a verb in each system using the Forensic Scanner verb implementation as a base. Had to move where the sound/pop-up message appears to avoid duplicating too much code. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://github.com/space-wizards/space-station-14/assets/83650252/7560e99b-5167-497a-9f7c-e9db391e06eb)![image](https://github.com/space-wizards/space-station-14/assets/83650252/749c950e-c091-4e35-9813-6fa95eb7fd54)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Space glue/lube tubes can now be used through the right-click menu.
