### PR TITLE
Made Sec Hud Show Borg Job Icons + Made Borgs Unimplantable

### DIFF
--- a/Content.Client/Overlays/ShowSecurityIconsSystem.cs
+++ b/Content.Client/Overlays/ShowSecurityIconsSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Mindshield.Components;
 using Content.Shared.Overlays;
 using Content.Shared.PDA;
 using Content.Shared.Security.Components;
+using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
 using Robust.Shared.Prototypes;
@@ -62,6 +63,11 @@ public sealed class ShowSecurityIconsSystem : EquipmentHudSystem<ShowSecurityIco
                     break;
                 }
             }
+        }
+
+        if (TryComp<BorgChassisComponent>(uid, out var borgComp) && !HasComp<ShowSyndicateIconsComponent>(uid))
+        {
+            jobIconToGet = borgComp.BorgJobIcon;
         }
 
         if (_prototypeMan.TryIndex<StatusIconPrototype>(jobIconToGet, out var jobIcon))

--- a/Content.Shared/Silicons/Borgs/Components/BorgChassisComponent.cs
+++ b/Content.Shared/Silicons/Borgs/Components/BorgChassisComponent.cs
@@ -1,6 +1,8 @@
 ﻿using Content.Shared.Whitelist;
+using Content.Shared.StatusIcon;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Silicons.Borgs.Components;
@@ -75,6 +77,9 @@ public sealed partial class BorgChassisComponent : Component
 
     [DataField("noMindState")]
     public string NoMindState = string.Empty;
+
+    [DataField("borgJobIcon"), ViewVariables(VVAccess.ReadWrite)]
+    public ProtoId<StatusIconPrototype> BorgJobIcon = "JobIconBorg";
     #endregion
 }
 

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -205,6 +205,7 @@
     - ShoesRequiredStepTriggerImmune
     - DoorBumpOpener
     - CanPilot
+    - Unimplantable
   - type: Emoting
   - type: GuideHelp
     guides:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR makes it so that people wearing sec huds will see the borg job icon beside borgs instead of the unknown job icon. This only works with station borgs and not syndicate borgs. Syndicate borgs will show up as unknown to people wearing sec huds. Also I found through testing that borgs didn't have the Unimplantable tag, so this PR also fixes that.
Closes #25211
(I had to remake this PR because I broke the original branch when merging).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It felt strange that we had the borg job icon available but borgs would always show up as unknown when using the sec hud so I wanted to fix that. Unfortunately, this change clashes with the current ruling for borgs where if somebody has a job icon displayed then it means they're a crew member. This change makes borgs also see borg job icons for other borgs (because they use the same system sec huds use for showing job icons). I'm making this PR now in the state it's currently in because I could not for the life of me figure out how to code it so that if you are playing as a borg you do not see job icons over other borgs. Also couldn't figure out how to make syndicate borgs show the borg job icon if you're playing as a nuke op. I'm willing to implement this functionality if somebody can show me how (or leave the PR as is and we redefine borg rules, whichever is easier).

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
In ShowSecurityIconsSystem.cs inside the DecideSecurityIcon function, it will now check if the entity has the BorgChassisComponent and does not have the ShowSyndicateIconsComponent. If true, it will grab a new BorgJobIcon field added to BorgChassisComponent which holds the JobIconBorg status and set jobIconToGet to this value.
Added Unimplantable to the tags of BaseBorgChassis.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
PoV of a crew member wearing sec hud:
![image](https://github.com/space-wizards/space-station-14/assets/16091937/56fb45ad-73dc-4e68-8880-e4fc484fe93e)
PoV of a station borg:
![image](https://github.com/space-wizards/space-station-14/assets/16091937/2b7b0e99-cc41-4c7b-b750-e5eece69a086)
PoV of a nuclear operative:
![image](https://github.com/space-wizards/space-station-14/assets/16091937/b1323aa8-b5ff-4ddd-b534-17b7d819dc76)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Job icons for borgs can now be seen while wearing sechud.
- fix: Borgs can no longer be implanted.
