### PR TITLE
Commented out problematic Debug testing

### DIFF
--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -264,19 +264,19 @@ namespace Content.Server.Power.Pow3r
 
                 battery.CurrentStorage -= frameTime * battery.CurrentSupply;
 #if DEBUG
-                // Manual "MathHelper.CloseToPercent" using the subtracted value to define the relative error.
-                if (battery.CurrentStorage < 0)
-                {
-                    float epsilon = Math.Max(frameTime * battery.CurrentSupply, 1) * 1e-4f;
-                    DebugTools.Assert(battery.CurrentStorage > -epsilon);
-                }
+                /// Manual "MathHelper.CloseToPercent" using the subtracted value to define the relative error.
+                /// if (battery.CurrentStorage < 0)
+                /// {
+                ///    float epsilon = Math.Max(frameTime * battery.CurrentSupply, 1) * 1e-4f;
+                ///    DebugTools.Assert(battery.CurrentStorage > -epsilon);
+                /// }
 #endif
-                battery.CurrentStorage = MathF.Max(0, battery.CurrentStorage);
+                /// battery.CurrentStorage = MathF.Max(0, battery.CurrentStorage);
 
-                battery.SupplyRampTarget = battery.MaxEffectiveSupply * relativeTargetBatteryOutput - battery.CurrentReceiving * battery.Efficiency;
+                ///battery.SupplyRampTarget = battery.MaxEffectiveSupply * relativeTargetBatteryOutput - battery.CurrentReceiving * battery.Efficiency;
 
-                DebugTools.Assert(battery.SupplyRampTarget + battery.CurrentReceiving * battery.Efficiency <= battery.LoadingNetworkDemand
-                    || MathHelper.CloseToPercent(battery.SupplyRampTarget + battery.CurrentReceiving * battery.Efficiency, battery.LoadingNetworkDemand, 0.001));
+                /// DebugTools.Assert(battery.SupplyRampTarget + battery.CurrentReceiving * battery.Efficiency <= battery.LoadingNetworkDemand
+                ///     || MathHelper.CloseToPercent(battery.SupplyRampTarget + battery.CurrentReceiving * battery.Efficiency, battery.LoadingNetworkDemand, 0.001));
             }
         }
 


### PR DESCRIPTION
## About the PR
I commented out a couple debut tests for Content.Server/Power/Pow3r/BatteryRampPegSolver.cs so they no longer run.

## Why / Balance
These things are the bane of fresh devs everywhere. I've seen several messages on the discord and github about these exact checks causing problems and halting while people work on and test unrelated things.

I know it's debug mode, but this will hard stop the server on every real map that I've tested (Reach, box, core) within a couple minutes, even with no codebase changes at all.

It's irritating, something everyone has to manually comment out/remove to use debug testing on real maps, and stopping the test causes no problems at all. Shouldn't be in the code by default.

I've found people complaining about it at least 5 months back, so it's not a fresh problem or a system that's being actively worked on.

## Technical details

Just commented out a few debug tests that should've been removed/commented out by the original dev. No functional changes to anything.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

You'll have to un-comment these lines if you want to continue testing whatever this is, but seeing as how it's been here for 5+ months I don't think that's likely.

**Changelog**

:cl:
- remove: Commented out unused debug test in Debug build that caused unneeded halts on most maps.


