### PR TITLE
Fix RUN_THIS.py so it would be cross-platform and it would be possible to use it from cmd on Windows

### DIFF
--- a/RUN_THIS.py
+++ b/RUN_THIS.py
@@ -5,14 +5,9 @@ from __future__ import print_function
 import sys
 import subprocess
 
-IS_WINDOWS = sys.platform in ("win32", "cygwin")
-
 version = sys.version_info
 if version.major < 3 or (version.major == 3 and version.minor < 5):
     print("ERROR: You need at least Python 3.5 to build SS14.")
     sys.exit(1)
 
-if IS_WINDOWS:
-    subprocess.run(["py", "-3", "git_helper.py"], cwd="BuildChecker")
-else:
-    subprocess.run(["python3", "git_helper.py"], cwd="BuildChecker")
+subprocess.run([sys.executable, "git_helper.py"], cwd="BuildChecker")


### PR DESCRIPTION
## About the PR
I'm not sure why it was decided to do this weird setup with `py -3` on Windows cygwin when there's `sys.executable` which contains the full absolute path to the current python3 that executes the current script.

## Technical details
Everything works correctly:
```
Hooks need updating.
Copying hook post-checkout
Copying hook post-merge
$ git submodule update --init --recursive
Submodule 'RobustToolbox' (https://github.com/space-wizards/RobustToolbox.git) registered for path 'RobustToolbox'
Cloning into 'C:/Workspace/SpaceStation14/space-station-14/RobustToolbox'...
Submodule path 'RobustToolbox': checked out '2b6381c332793b6207db2d865234674f36824bbe'
Submodule 'Lidgren.Network' (https://github.com/space-wizards/lidgren-network-gen3.git) registered for path 'RobustToolbox/Lidgren.Network/Lidgren.Network'
Submodule 'NetSerializer' (https://github.com/space-wizards/netserializer) registered for path 'RobustToolbox/NetSerializer'
Submodule 'Robust.LoaderApi' (https://github.com/space-wizards/Robust.LoaderApi.git) registered for path 'RobustToolbox/Robust.LoaderApi'
Submodule 'XamlX' (https://github.com/space-wizards/XamlX) registered for path 'RobustToolbox/XamlX'
Submodule 'cefglue' (https://github.com/space-wizards/cefglue.git) registered for path 'RobustToolbox/cefglue'
Cloning into 'C:/Workspace/SpaceStation14/space-station-14/RobustToolbox/Lidgren.Network/Lidgren.Network'...
Cloning into 'C:/Workspace/SpaceStation14/space-station-14/RobustToolbox/NetSerializer'...
Cloning into 'C:/Workspace/SpaceStation14/space-station-14/RobustToolbox/Robust.LoaderApi'...
Cloning into 'C:/Workspace/SpaceStation14/space-station-14/RobustToolbox/XamlX'...
Cloning into 'C:/Workspace/SpaceStation14/space-station-14/RobustToolbox/cefglue'...
Submodule path 'RobustToolbox/Lidgren.Network/Lidgren.Network': checked out '45f89ca2639ec05d4700691a1160fccd79cb4c86'
Submodule path 'RobustToolbox/NetSerializer': checked out '7f51deaecab8498a8953f7fb3e551b9892c5dff4'
Submodule path 'RobustToolbox/Robust.LoaderApi': checked out '99a2f4b88077629f69fb66f74f50e88dbe43e0e8'
Submodule path 'RobustToolbox/XamlX': checked out 'dca5a5f8c2759b940a87449584724ec71aa0dd19'
Submodule path 'RobustToolbox/cefglue': checked out 'e265d67a21d0e526178f72326bd45f36d85ad6ca'
```