### PR TITLE
Adds a miniscule item size for pills and cigarettes

### DIFF
--- a/Resources/Locale/en-US/items/components/item-component.ftl
+++ b/Resources/Locale/en-US/items/components/item-component.ftl
@@ -8,6 +8,7 @@ pick-up-verb-get-data-text-inventory = Put in hand
 
 item-component-on-examine-size = This is {INDEFINITE($size)} [bold]{$size}[/bold] item.
 
+item-component-size-Miniscule = miniscule
 item-component-size-Tiny = tiny
 item-component-size-Small = small
 item-component-size-Normal = medium

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -17,7 +17,7 @@
     slots: [ mask ]
     equippedPrefix: unlit
   - type: Item
-    size: Tiny
+    size: Miniscule
   - type: Construction
     graph: smokeableCigarette
     node: cigarette
@@ -42,7 +42,7 @@
     slots: [ mask ]
     equippedPrefix: unlit
   - type: Item
-    size: Tiny
+    size: Miniscule
   - type: Construction
     graph: smokeableCigarette
     node: cigarette

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -49,6 +49,7 @@
   - type: Storage
     grid:
     - 0,0,4,1
+    maxItemSize: Minisculewww
   - type: StorageFill
     contents:
     - id: Cigarette
@@ -117,6 +118,7 @@
   - type: Storage
     grid:
     - 0,0,4,1
+    maxItemSize: Miniscule
   - type: StorageFill
     contents:
     - id: CigaretteRandom

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -49,7 +49,7 @@
   - type: Storage
     grid:
     - 0,0,4,1
-    maxItemSize: Minisculewww
+    maxItemSize: Miniscule
   - type: StorageFill
     contents:
     - id: Cigarette

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -444,7 +444,7 @@
     sprite: Objects/Specific/Chemistry/pills.rsi
     state: pill
   - type: Item
-    size: Tiny
+    size: Miniscule
     sprite: Objects/Specific/Chemistry/pills.rsi
   - type: Pill
   - type: Food
@@ -505,4 +505,5 @@
     areaInsertRadius: 1
     storageInsertSound: /Audio/Effects/pill_insert.ogg
     storageRemoveSound: /Audio/Effects/pill_remove.ogg
+    maxItemSize: Miniscule
   - type: Dumpable

--- a/Resources/Prototypes/item_size.yml
+++ b/Resources/Prototypes/item_size.yml
@@ -1,3 +1,11 @@
+# Items that you hold between your fingers
+- type: itemSize
+  id: Miniscule
+  weight: 0
+  name: item-component-size-Miniscule
+  defaultShape:
+  - 0,0,0,0
+
 # Items that can be held completely in one's hand.
 - type: itemSize
   id: Tiny


### PR DESCRIPTION
## About the PR
Added an item size smaller than tiny for items such as pills and cigarettes.
Miniscule is still 1x1, but can fit in containers that can only hold miniscule items.

## Why / Balance
Storing 300u of chems with bottles in a pill canister is not cool, you could do the same with cigarette packs as well.

## Media
https://github.com/space-wizards/space-station-14/assets/140123969/7747ea04-fc31-4d73-b555-723d282866da
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Items can now be miniscule in size, they still take up the same space as tiny items when loosely thrown into your bag but can fit in more compact places.
- tweak: Pill canisters and cigarette packs can now only hold miniscule items.
- tweak: Pills and cigarettes are now miniscule in size.
