### PR TITLE
Fix placement mode on chairs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -4,7 +4,7 @@
   abstract: true
   description: You sit in this. Either by will or force.
   placement:
-    mode: SnapgridCenter
+    mode: PlaceFree
   components:
   - type: Clickable
   - type: InteractionOutline
@@ -65,6 +65,8 @@
   id: ChairBase
   abstract: true
   parent: UnanchoredChairBase
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Physics
     bodyType: Static
@@ -87,6 +89,8 @@
   id: StoolBase
   parent: OfficeChairBase
   abstract: true
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Physics
     bodyType: Static
@@ -116,7 +120,7 @@
 - type: entity
   name: stool
   id: Stool
-  parent: ChairBase
+  parent: UnanchoredChairBase
   description: Apply butt.
   components:
   - type: Sprite
@@ -241,7 +245,7 @@
 
 - type: entity
   id: ChairMeat
-  parent: ChairBase
+  parent: UnanchoredChairBase
   name: meat chair
   description: Uncomfortably sweaty.
   components:
@@ -285,7 +289,7 @@
   name: web chair
   id: ChairWeb
   description: For true web developers.
-  parent: ChairBase
+  parent: UnanchoredChairBase
   components:
   - type: Sprite
     sprite: Structures/Web/chair.rsi
@@ -347,8 +351,6 @@
   parent: ChairFolding
   id: ChairFoldingSpawnFolded
   suffix: folded
-  placement:
-    mode: PlaceFree
   components:
   - type: Foldable
     folded: true
@@ -364,4 +366,3 @@
   - type: Construction
     graph: Seat
     node: chairSteelBench
-


### PR DESCRIPTION
## About the PR
Placement mode on chairs was donked up a little bit recently. This returns the ability to free place certain(unanchored) chairs while mapping.

## Why / Balance
More dynamic mapping 

## Technical details
n/a

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a