### PR TITLE
Remove random Cyrillic characters from locale files

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-thief.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-thief.ftl
@@ -6,7 +6,7 @@ thief-role-greeting-human =
     but that can't stop you from getting your fix by any means necessary.
 
 thief-role-greeting-animal =
-    You are a kleptomaniaс animal.
+    You are a kleptomaniac animal.
     Steal things that you like.
 
 thief-role-greeting-equipment =

--- a/Resources/Locale/en-US/reagents/meta/consumable/food/food.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/food/food.ftl
@@ -10,7 +10,7 @@ reagent-desc-vitamin = Found in healthy, complete meals.
 reagent-name-protein = protein
 reagent-desc-protein = Found in certain meals, good for bodily health.
 
-reagent-name-cocoapowder = сocoa powder
+reagent-name-cocoapowder = cocoa powder
 reagent-desc-cocoapowder = From the best varieties of cocoa beans
 
 reagent-name-butter = butter


### PR DESCRIPTION
## About the PR
While playing around with the game's data, I discovered 'cocoa powder' got sorted after all the other reagents. I poked around for a minute, and what do you know, that first letter isn't a c, it's actually the [Cyrillic lowercase letter с](https://en.wikipedia.org/wiki/Es_(Cyrillic))! I searched all .yml and .ftl files for more Cyrillic, and found exactly one other occurrence. This PR fixes both.

## Why / Balance
Correctness. For one, you currently can't find cocoa powder or anything that uses it in the guidebook by searching "cocoa powder". :D

## Technical details
.ftl

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
god I hope not