### PR TITLE
Fix recycled containers deleting items inside them

### DIFF
--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Stacks;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.Map;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Timing;
 
@@ -111,20 +112,8 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
             component.NextSound = Timing.CurTime + component.SoundCooldown;
         }
 
-        if (TryComp<ContainerManagerComponent>(item, out var contManager)){
-            foreach (var cont in contManager.Containers.Values)
-            {
-                var containedEntites = cont.ContainedEntities.ToArray();
-
-                foreach (var entity in containedEntites)
-                {
-                    if (Terminating(entity))
-                        continue;
-
-                    Container.RemoveEntity(item, entity, force: true, destination: uid.ToCoordinates());
-                }
-            }
-        }
+        var reclaimedEvent = new GotReclaimedEvent(uid.ToCoordinates());
+        RaiseLocalEvent(item, ref reclaimedEvent);
 
         var duration = GetReclaimingDuration(uid, item, component);
         // if it's instant, don't bother with all the active comp stuff.
@@ -253,3 +242,6 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
         }
     }
 }
+
+[ByRefEvent]
+public record struct GotReclaimedEvent(EntityCoordinates Coordinates);

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -1,7 +1,8 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Audio;
 using Content.Shared.Body.Components;
+using Content.Shared.Coordinates;
 using Content.Shared.Database;
 using Content.Shared.Emag.Components;
 using Content.Shared.Emag.Systems;
@@ -108,6 +109,21 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
         {
             component.Stream = _audio.PlayPredicted(component.Sound, uid, user)?.Entity;
             component.NextSound = Timing.CurTime + component.SoundCooldown;
+        }
+
+        if (TryComp<ContainerManagerComponent>(item, out var contManager)){
+            foreach (var cont in contManager.Containers.Values)
+            {
+                var containedEntites = cont.ContainedEntities.ToArray();
+
+                foreach (var entity in containedEntites)
+                {
+                    if (Terminating(entity))
+                        continue;
+
+                    Container.RemoveEntity(item, entity, force: true, destination: uid.ToCoordinates());
+                }
+            }
         }
 
         var duration = GetReclaimingDuration(uid, item, component);

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -112,7 +112,7 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
             component.NextSound = Timing.CurTime + component.SoundCooldown;
         }
 
-        var reclaimedEvent = new GotReclaimedEvent(uid.ToCoordinates());
+        var reclaimedEvent = new GotReclaimedEvent(EntityManager.GetComponent<TransformComponent>(uid).Coordinates);
         RaiseLocalEvent(item, ref reclaimedEvent);
 
         var duration = GetReclaimingDuration(uid, item, component);

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -112,7 +112,7 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
             component.NextSound = Timing.CurTime + component.SoundCooldown;
         }
 
-        var reclaimedEvent = new GotReclaimedEvent(EntityManager.GetComponent<TransformComponent>(uid).Coordinates);
+        var reclaimedEvent = new GotReclaimedEvent(Transform(uid).Coordinates);
         RaiseLocalEvent(item, ref reclaimedEvent);
 
         var duration = GetReclaimingDuration(uid, item, component);
@@ -244,4 +244,4 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
 }
 
 [ByRefEvent]
-public record struct GotReclaimedEvent(EntityCoordinates Coordinates);
+public record struct GotReclaimedEvent(EntityCoordinates ReclaimerCoordinates);

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Coordinates;
 using Content.Shared.Destructible;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.Components;
@@ -11,6 +12,7 @@ using Content.Shared.Implants.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
 using Content.Shared.Lock;
+using Content.Shared.Materials;
 using Content.Shared.Placeable;
 using Content.Shared.Popups;
 using Content.Shared.Stacks;
@@ -95,6 +97,9 @@ public abstract class SharedStorageSystem : EntitySystem
         SubscribeAllEvent<StorageSetItemLocationEvent>(OnSetItemLocation);
         SubscribeAllEvent<StorageInsertItemIntoLocationEvent>(OnInsertItemIntoLocation);
         SubscribeAllEvent<StorageRemoveItemEvent>(OnRemoveItem);
+
+        SubscribeLocalEvent<StorageComponent, GotReclaimedEvent>(OnReclaimed);
+
         UpdatePrototypeCache();
     }
 
@@ -388,7 +393,12 @@ public abstract class SharedStorageSystem : EntitySystem
         args.Handled = true;
     }
 
-    private void OnDestroy(EntityUid uid, StorageComponent storageComp, DestructionEventArgs args)
+    private void OnReclaimed(EntityUid uid, StorageComponent storageComp, GotReclaimedEvent args)
+    {
+        _containerSystem.EmptyContainer(storageComp.Container, destination: args.Coordinates);
+    }
+
+        private void OnDestroy(EntityUid uid, StorageComponent storageComp, DestructionEventArgs args)
     {
         var coordinates = TransformSystem.GetMoverCoordinates(uid);
 

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -395,10 +395,10 @@ public abstract class SharedStorageSystem : EntitySystem
 
     private void OnReclaimed(EntityUid uid, StorageComponent storageComp, GotReclaimedEvent args)
     {
-        _containerSystem.EmptyContainer(storageComp.Container, destination: args.Coordinates);
+        _containerSystem.EmptyContainer(storageComp.Container, destination: args.ReclaimerCoordinates);
     }
 
-        private void OnDestroy(EntityUid uid, StorageComponent storageComp, DestructionEventArgs args)
+    private void OnDestroy(EntityUid uid, StorageComponent storageComp, DestructionEventArgs args)
     {
         var coordinates = TransformSystem.GetMoverCoordinates(uid);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Right now you can delete any item that fits in a survival box by placing it inside of one and then recycling the box in a Recycler/Material Reclaimer. This PR fixes this by dumping out any item inside containers.

- For Reclaimers,  any recyclable items inside the container get placed on top of the Reclaimer.
- For Recyclers, any recyclable items inside the container get recursively recycled as well.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

I doubt it's intended behavior to be able to effectively delete any item that fits in a box. Also ensures a recycled box provides the correct amount of material as its contents also get recycled.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

When trying to recycle, once all checks are passed it iterates through the object's containers if it has any and dumps out any items onto the machine doing the recycling.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/83650252/9e95b099-ab95-449d-b5a1-25b80afda8cd)
The result of recycling a survival box in a Recycler/Reclaimer.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Recyclers no longer delete items stored inside of recycled entities.
