### PR TITLE
Make radio jammer block suit sensors

### DIFF
--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -88,6 +88,8 @@ public sealed partial class SuitSensorComponent : Component
     public bool PreviousControlsLocked = false;
 }
 
-public sealed class SuitSensorsSendAttemptEvent : CancellableEntityEventArgs
+[ByRefEvent]
+public record struct SuitSensorsSendAttemptEvent
 {
+    public bool Cancelled;
 };

--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -88,9 +88,6 @@ public sealed partial class SuitSensorComponent : Component
     public bool PreviousControlsLocked = false;
 }
 
-[ByRefEvent]
-public record struct SuitSensorsSendAttemptEvent(EntityUid Source)
+public sealed class SuitSensorsSendAttemptEvent : CancellableEntityEventArgs
 {
-    public readonly EntityUid Source = Source;
-    public bool Cancelled = false;
 };

--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -87,3 +87,10 @@ public sealed partial class SuitSensorComponent : Component
     [DataField, ViewVariables]
     public bool PreviousControlsLocked = false;
 }
+
+[ByRefEvent]
+public record struct SuitSensorsSendAttemptEvent(EntityUid Source)
+{
+    public readonly EntityUid Source = Source;
+    public bool Cancelled = false;
+};

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -74,7 +74,7 @@ public sealed class SuitSensorSystem : EntitySystem
             sensor.NextUpdate = curTime + sensor.UpdateRate;
 
             var canEv = new SuitSensorsSendAttemptEvent();
-            RaiseLocalEvent(uid, canEv);
+            RaiseLocalEvent(uid, ref canEv);
             if (canEv.Cancelled)
                 continue;
 

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -73,6 +73,11 @@ public sealed class SuitSensorSystem : EntitySystem
             // TODO: This would cause imprecision at different tick rates.
             sensor.NextUpdate = curTime + sensor.UpdateRate;
 
+            var canEv = new SuitSensorsSendAttemptEvent(uid);
+            RaiseLocalEvent(ref canEv);
+            if (canEv.Cancelled)
+                continue;
+
             // get sensor status
             var status = GetSensorState(uid, sensor);
             if (status == null)

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -73,8 +73,8 @@ public sealed class SuitSensorSystem : EntitySystem
             // TODO: This would cause imprecision at different tick rates.
             sensor.NextUpdate = curTime + sensor.UpdateRate;
 
-            var canEv = new SuitSensorsSendAttemptEvent(uid);
-            RaiseLocalEvent(ref canEv);
+            var canEv = new SuitSensorsSendAttemptEvent();
+            RaiseLocalEvent(uid, canEv);
             if (canEv.Cancelled)
                 continue;
 

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Medical.SuitSensors;
 using Content.Server.Popups;
 using Content.Server.Power.EntitySystems;
 using Content.Server.PowerCell;
@@ -23,6 +24,7 @@ public sealed class JammerSystem : EntitySystem
         SubscribeLocalEvent<ActiveRadioJammerComponent, PowerCellChangedEvent>(OnPowerCellChanged);
         SubscribeLocalEvent<RadioJammerComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<RadioSendAttemptEvent>(OnRadioSendAttempt);
+        SubscribeLocalEvent<SuitSensorsSendAttemptEvent>(OnSensorSendAttempt);
     }
 
     public override void Update(float frameTime)
@@ -76,15 +78,33 @@ public sealed class JammerSystem : EntitySystem
 
     private void OnRadioSendAttempt(ref RadioSendAttemptEvent args)
     {
-        var source = Transform(args.RadioSource).Coordinates;
+        if (ShouldCancelSend(args.RadioSource))
+        {
+            args.Cancelled = true;
+        }
+    }
+
+    private void OnSensorSendAttempt(ref SuitSensorsSendAttemptEvent args)
+    {
+        if (ShouldCancelSend(args.Source))
+        {
+            args.Cancelled = true;
+        }
+    }
+
+    private bool ShouldCancelSend(EntityUid sourceUid)
+    {
+        var source = Transform(sourceUid).Coordinates;
         var query = EntityQueryEnumerator<ActiveRadioJammerComponent, RadioJammerComponent, TransformComponent>();
+
         while (query.MoveNext(out _, out _, out var jam, out var transform))
         {
             if (source.InRange(EntityManager, _transform, transform.Coordinates, jam.Range))
             {
-                args.Cancelled = true;
-                return;
+                return true;
             }
         }
+
+        return false;
     }
 }

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -24,7 +24,7 @@ public sealed class JammerSystem : EntitySystem
         SubscribeLocalEvent<ActiveRadioJammerComponent, PowerCellChangedEvent>(OnPowerCellChanged);
         SubscribeLocalEvent<RadioJammerComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<RadioSendAttemptEvent>(OnRadioSendAttempt);
-        SubscribeLocalEvent<SuitSensorsSendAttemptEvent>(OnSensorSendAttempt);
+        SubscribeLocalEvent<SuitSensorComponent, SuitSensorsSendAttemptEvent>(OnSensorSendAttempt);
     }
 
     public override void Update(float frameTime)
@@ -84,11 +84,11 @@ public sealed class JammerSystem : EntitySystem
         }
     }
 
-    private void OnSensorSendAttempt(ref SuitSensorsSendAttemptEvent args)
+    private void OnSensorSendAttempt(EntityUid uid, SuitSensorComponent comp, SuitSensorsSendAttemptEvent args)
     {
-        if (ShouldCancelSend(args.Source))
+        if (ShouldCancelSend(uid))
         {
-            args.Cancelled = true;
+            args.Cancel();
         }
     }
 

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -84,11 +84,11 @@ public sealed class JammerSystem : EntitySystem
         }
     }
 
-    private void OnSensorSendAttempt(EntityUid uid, SuitSensorComponent comp, SuitSensorsSendAttemptEvent args)
+    private void OnSensorSendAttempt(EntityUid uid, SuitSensorComponent comp, ref SuitSensorsSendAttemptEvent args)
     {
         if (ShouldCancelSend(uid))
         {
-            args.Cancel();
+            args.Cancelled = true;
         }
     }
 

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -146,7 +146,7 @@ uplink-clothing-eyes-hud-syndicate-name = Syndicate Visor
 uplink-clothing-eyes-hud-syndicate-desc = The syndicate's professional head-up display, designed for better detection of humanoids and their subsequent elimination.
 
 uplink-radio-jammer-name = Radio Jammer
-uplink-radio-jammer-desc = This device will disrupt any nearby outgoing radio communication when activated.
+uplink-radio-jammer-desc = This device will disrupt any nearby outgoing radio communication as well as suit sensors when activated.
 
 uplink-syndicate-weapon-module-name = Weapon Cyborg Module
 uplink-syndicate-weapon-module-desc = This module will give a cyborg advanced laser and machete

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -2,7 +2,7 @@
   name: radio jammer
   parent: BaseItem
   id: RadioJammer
-  description: This device will disrupt any nearby outgoing radio communication when activated.
+  description: This device will disrupt any nearby outgoing radio communication as well as suit sensors when activated.
   components:
   - type: Sprite
     sprite: Objects/Devices/jammer.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Radio jammers will now additionally block suit sensors.

When someone with suit sensors is in range of an active radio jammer, their suit sensor output will be jammed. This will lead to them appearing as frozen on any crew monitors for roughly 10 seconds before they completely disappear from it.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This gives syndies more stealth options when doing their objectives, and provides an interesting use for the radio jammer.

Now on the implementation details:

With this current implementation you drop off suit sensors after roughly 10 seconds of being jammed. This means you get a 10 second period before anyone actively watching crew monitors can even suspect something's wrong. The reason I have it like this is: 
a) It's the simplest way to implement this feature.
b) It's more realistic while still providing a pretty significant advantage.

Alternatively this could be changed to make the suit sensors submit outdated info indefinitely until the jammer has stopped.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added a new event which the suit sensors system calls before actually constructing the message it will send to the crew monitoring server. If it is cancelled then the message is not sent. I also intentionally made it so this is checked after a new update time has been set, but if it's a problem it can just be moved above it.


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/32041239/3bc815ac-5ec1-4ef1-8594-b390da657d29

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The radio jammer is now able to jam the signal of suit sensors.