### PR TITLE
Remove recycling for Syndicate implanters

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -119,6 +119,8 @@
           implantOnly:
             True: {state: broken}
             False: {state: implanter1}
+    - type: Tag
+      tags: []
 
 #Fun implanters
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR removes the Trash tag for Syndicate implanters, stopping them from being recycled. This means they can no longer be destroyed with the station's Recycler/Material Reclaimer. Non-Syndicate implanters can still be recycled as normal.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Being able to recycle implanters completely trivializes the disposal of evidence; if a Material Reclaimer is mapped on the station, it's literally a single button click to fully remove any signs of a contraband having been used, and a Recycler isn't much harder to get going. 

We already have other systems in the game to hide and alter evidence, such as soap (cleans fingerprints/DNA), stashing in plants, using a storage implant, throwing out of an airlock or just hiding it in a remote place in maintenance. All those methods have some sort of downside or counterplay the antag needs to consider and work around. However, since the recycling is simple, non-suspicious, easily accessible and leaves no trace there is no point in engaging with those other systems as the recycling is always the optimal choice.

This change is only limited to Syndicate implanters. Non-Syndicate implanters (e.g. bike horn) can be acquired in much larger qualities and thus serve a need to be properly disposed of, in additional to being visually distinct. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The base implanter prototype has only the Trash tag, so for the base Syndicate implanter the .yaml just sets its tags to blank.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Syndicate implanters can no longer be recycled.
