### PR TITLE
Adds bartending shotgun rounds to the game (April fools)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -6,7 +6,7 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterArmorBasicSlim
-      - id: WeaponShotgunDoubleBarreledRubber
+      - id: WeaponShotgunDoubleBarreledBartender
       - id: DrinkShaker
       - id: ClothingEyesHudBeer
       - id: HandLabeler
@@ -17,7 +17,7 @@
         prob: 0.5
       - id: DrinkBottleBeer
         prob: 0.5
-      - id: BoxBeanbag
+      - id: BoxBartender
         amount: 2
       - id: RagItem
         amount: 2

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: ImmovableRod
   name: immovable rod
   description: You can sense that it's hungry. That's usually a bad sign.
@@ -60,3 +60,14 @@
   components:
   - type: ImmovableRod
     randomizeVelocity: false
+
+- type: entity
+  parent: ImmovableRodKeepTilesStill
+  id: ImmovableRodBartender
+  suffix: Bartender
+  name: immovable rod
+  description: At least it won't deal 55 stamina damage.
+  components:
+  - type: ImmovableRod
+  - type: TimedDespawn
+    lifetime: 0.5

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -65,7 +65,7 @@
   parent: ImmovableRodKeepTilesStill
   id: ImmovableRodBartender
   suffix: Bartender
-  name: immovable rod
+  name: immovable bar
   description: At least it won't deal 55 stamina damage.
   components:
   - type: ImmovableRod

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
@@ -114,3 +114,16 @@
       layers:
         - state: boxwide
         - state: shellslug
+
+- type: entity
+  name: shotgun bartending cartridges dispenser
+  parent: AmmoProviderShotgunShell
+  id: BoxBartender
+  description: A dispenser box full of bartending shots, designed for double-barrel shotguns.
+  components:
+    - type: BallisticAmmoProvider
+      proto: ShellShotgunBartender
+    - type: Sprite
+      layers:
+        - state: boxwide
+        - state: shellbeanbag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: BaseShellShotgun
   name: shell (.50)
   parent: BaseCartridge
@@ -165,3 +165,20 @@
       proto: PelletShotgunUranium
     - type: SpentAmmoVisuals
       state: "depleted-uranium"
+
+#Bartender
+- type: entity
+  id: ShellShotgunBartender
+  name: shell (.50 bartending)
+  description: Instantly annihilates anything and everything in front of you. But it doesn't deal 55 stamina damage so it's honestly completely useless and I'm going to kill my infant son.
+  parent: BaseShellShotgun
+  components:
+  - type: Sprite
+    layers:
+      - state: beanbag
+        map: [ "enum.AmmoVisualLayers.Base" ]
+  - type: CartridgeAmmo
+    proto: ImmovableRodBartender
+    count: 1
+  - type: SpentAmmoVisuals
+    state: "beanbag"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -132,6 +132,18 @@
   - type: BallisticAmmoProvider
     proto: ShellShotgunBeanbag
 
+#Bartender
+- type: entity
+  name: double-barreled shotgun
+  parent: WeaponShotgunDoubleBarreled
+  id: WeaponShotgunDoubleBarreledBartender
+  description: Perfect for firing at someone with a doafter bar who MIGHT be trying to climb the counter.
+  suffix: Bartender
+  components:
+  - type: BallisticAmmoProvider
+    proto: ShellShotgunBartender
+#Bartender
+
 - type: entity
   name: Enforcer
   parent: BaseWeaponShotgun


### PR DESCRIPTION
## About the PR
ever since I nerfed the bartender's beanbags I've thought "man, this still sucks, bartenders shouldn't get stamina damage at all!"
I have replaced the beanbag rounds in the bartender's storage with bartending rounds which deal exactly 0 stamina damage. Balance at last.

## Why / Balance
Stamina damage is stupid >:(

## Media
https://github.com/space-wizards/space-station-14/assets/140123969/e78f553f-5677-402b-934d-e57d43b05b7a
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Bartender's shotguns no longer deal any stamina damage, no longer must we worry about being stunned in the bar.
