### PR TITLE
Changes various tool shapes and makes the utility/sec belt accommodate them.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -12,6 +12,9 @@
     sprite: Clothing/Belt/utility.rsi
   - type: Storage
     maxItemSize: Normal
+    grid:
+    - 0,0,7,1
+    - 0,2,0,3
     # TODO: Fill this out more.
     whitelist:
       tags:
@@ -458,6 +461,9 @@
   - type: Clothing
     sprite: Clothing/Belt/security.rsi
   - type: Storage
+    grid:
+    - 0,0,7,1
+    - 0,2,0,3
     whitelist:
       tags:
         - CigPack

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -108,6 +108,9 @@
     storedSprite:
       sprite: Objects/Tools/wrench.rsi
       state: storage
+    size: Small
+    shape:
+    - 0,0,0,2
   - type: MeleeWeapon
     wideAnimationRotation: 135
     attackRate: 1.5
@@ -142,7 +145,9 @@
     state: icon
   - type: Item
     sprite: Objects/Tools/crowbar.rsi
-    size: Small
+    size: Normal
+    shape:
+    - 0,0,0,3
     storedSprite:
       sprite: Objects/Tools/crowbar.rsi
       state: storage
@@ -293,6 +298,9 @@
   - type: Item
     sprite: Objects/Tools/drill.rsi
     size: Small
+    shape:
+    - 0,0,1,0
+    - 0,1,0,1
   - type: Tool
     qualities:
       - Screwing

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -23,6 +23,9 @@
           False: { visible: false }
   - type: Item
     size: Small
+    shape:
+    - 0,0,1,0
+    - 0,1,0,1
     sprite: Objects/Tools/welder.rsi
   - type: ItemToggle
     predictable: false
@@ -127,6 +130,9 @@
     sprite: Objects/Tools/welder_industrialadv.rsi
   - type: Item
     sprite: Objects/Tools/welder_industrialadv.rsi
+    shape:
+    - 0,0,2,0
+    - 0,1,1,1
   - type: SolutionContainerManager
     solutions:
       Welder:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -50,6 +50,8 @@
   - type: Item
     heldPrefix: off
     size: Normal
+    shape:
+    - 0,0,0,3
   - type: Clothing
     sprite: Objects/Weapons/Melee/stunbaton.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -52,6 +52,7 @@
     size: Normal
     shape:
     - 0,0,0,3
+    storedRotation: 135
   - type: Clothing
     sprite: Objects/Weapons/Melee/stunbaton.rsi
     quickEquip: false


### PR DESCRIPTION
## About the PR
The wrench, welder, crowbar, and baton now have unique sizes rather than the generic normal/small sizes.
The wrench is 1x3
the welder is the gun shape
the crowbar/baton are 1x4 and normal sized.

## Why / Balance
How is a crowbar the same size as a screwdriver?
Now it's harder for non-engineers to carry an entire set of tools on them since most people don't have access to a utility belt.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/140123969/139b62f7-ae41-461c-883d-072b5f2debf7)
![image](https://github.com/space-wizards/space-station-14/assets/140123969/4cc67131-66a0-40ee-b8a7-fff9095bfe3f)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Crowbars and stun batons are now long in the inventory grid
- tweak: Welding tools and wrenches are now uniquely shaped
- tweak: Toolbelts and security belts now accommodate crowbars and security batons specifically