### PR TITLE
Typo in guidebook for cyro pressure

### DIFF
--- a/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
@@ -41,7 +41,7 @@ Once things have been set up, you're going to require a specific medication, Cry
 
 ## Additional Information:
 
-The standard pressure for a gas pump is 1.325 kpa. Cryoxadone works at under 170K, but it is standard practice to set the freezer to 100K for faster freezing.
+The standard pressure for a gas pump is 100.325 kpa. Cryoxadone works at under 170K, but it is standard practice to set the freezer to 100K for faster freezing.
 
 <GuideReagentEmbed Reagent="Cryoxadone"/>
 <GuideReagentEmbed Reagent="Doxarubixadone"/>


### PR DESCRIPTION
## About the PR
Super small typo in Cryogenics guidebook, feel bad its such small PR let me know if there is a better way.

## Why / Balance
It's currently wrong value, got someone killed in game as player followed wrong instructions.

## Technical details
Guidebook update.

## Media
NA

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
NA

**Changelog**
NA
