### PR TITLE
Engineering techfab.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1354,4 +1354,22 @@
     materialRequirements:
       Steel: 5
       CableHV: 2
-      
+
+- type: entity
+  id: EngineeringTechFabCircuitboard
+  parent: BaseMachineCircuitboard
+  name: engineer techfab machine board
+  description: A machine printed circuit board for a engineer techfab.
+  components:
+    - type: Sprite
+      state: engineering
+    - type: MachineBoard
+      prototype: EngineeringTechFab
+      requirements:
+        MatterBin: 2
+        Manipulator: 2
+      tagRequirements:
+        GlassBeaker:
+          Amount: 2
+          DefaultPrototype: Beaker
+          ExamineName: Glass Beaker

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1155,3 +1155,98 @@
     staticRecipes:
     - MaterialSheetMeat
     - SheetPaper
+
+- type: entity
+  id: EngineeringTechFab
+  parent: BaseLathe
+  name: engineering techfab
+  description: Prints parts and circuits for engineers to restore the station to basic standarts.
+  components:
+  - type: Sprite
+    sprite: Structures/Machines/techfab.rsi
+    layers:
+    - state: icon
+      map: ["enum.LatheVisualLayers.IsRunning"]
+    - state: engi
+    - state: unlit
+      shader: unshaded
+      map: ["enum.PowerDeviceVisualLayers.Powered"]
+    - state: inserting
+      map: ["enum.MaterialStorageVisualLayers.Inserting"]
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: Machine
+    board: EngineeringTechFabCircuitboard
+  - type: Lathe
+    idleState: icon
+    runningState: icon
+    staticRecipes:
+      # Circuits
+      - ProtolatheMachineCircuitboard
+      - AutolatheMachineCircuitboard
+      - CircuitImprinterMachineCircuitboard
+      - OreProcessorMachineCircuitboard
+      - MaterialReclaimerMachineCircuitboard
+      - ElectrolysisUnitMachineCircuitboard
+      - CentrifugeMachineCircuitboard
+      - ChemDispenserMachineCircuitboard
+      - ChemMasterMachineCircuitboard
+      - CondenserMachineCircuitBoard
+      - HotplateMachineCircuitboard
+      - UniformPrinterMachineCircuitboard
+      - MicrowaveMachineCircuitboard
+      - ReagentGrinderMachineCircuitboard
+      - ElectricGrillMachineCircuitboard
+      - BoozeDispenserMachineCircuitboard
+      - SodaDispenserMachineCircuitboard
+      - SpaceHeaterMachineCircuitBoard
+      - SMESMachineCircuitboard
+      - SubstationMachineCircuitboard
+      - CellRechargerCircuitboard
+      - BorgChargerCircuitboard
+      - WeaponCapacitorRechargerCircuitboard
+      - HandheldStationMap
+      # Tools
+      - Wirecutter
+      - ClothingHeadHatWelding
+      - Igniter
+      - Signaller
+      - Screwdriver
+      - Welder
+      - Wrench
+      - Crowbar
+      - Multitool
+      - NetworkConfigurator
+      - SprayPainter
+      - CableStack
+      - CableMVStack
+      - CableHVStack
+      - HandheldGPSBasic
+      - TRayScanner
+      - AirTank
+      - GasAnalyzer
+      - UtilityBelt
+      - Holoprojector
+      # Parts
+      - PowerCellSmall
+      - PowerCellMedium
+      - MicroManipulatorStockPart
+      - MatterBinStockPart
+      - CapacitorStockPart
+      - ConveyorBeltAssembly
+      # Electronics
+      - IntercomElectronics
+      - FirelockElectronics
+      - DoorElectronics
+      - AirAlarmElectronics
+      - StationMapElectronics
+      - FireAlarmElectronics
+      - MailingUnitElectronics
+      - SignalTimerElectronics
+      - APCElectronics
+  - type: MaterialStorage
+    whitelist:
+      tags:
+        - Sheet
+        - RawMaterial
+        - Ingot

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1182,9 +1182,7 @@
     runningState: icon
     staticRecipes:
       # Circuits
-      - ProtolatheMachineCircuitboard
       - AutolatheMachineCircuitboard
-      - CircuitImprinterMachineCircuitboard
       - OreProcessorMachineCircuitboard
       - MaterialReclaimerMachineCircuitboard
       - ElectrolysisUnitMachineCircuitboard


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Implements engineering techfab.
Could probably balance the fact that autolathe has just random stuff in it after a discussion.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Okay so. Engineering as it currently stands, is uncapable of fixing most basic equipment and if somethin needs to be fixed that isnt just a mere electronic, they pretty much require the help of science to just do basic job which they were hired for.
What I propose is making an engineer techfab and include basic circuits and tools that engineers would find essential to fix.
-Gives engineers somethin to do aka they can make more stuff and can fix the departemental equipment if there would be an explosion instead of a scientist doing it.
-The science would still do the neccesary upgrading because their protolathe would upgrade with science etc while engineers just ensure that the station is intact.
-It could be simply placed where the autolathe was in engineering.
-Could remove some stuff from autolathe to not make it as big of a mess and require engineering to make it instead of science being more of engineers than the engineers themselfs. (This change would require massive mapping so probably a PR after this would be merged [hopefully] to get rid of stuff from the autolathe itself)
Thats pretty much most reasons that I was able to think of as it currently stands.
The PR is a draft to ensure that anyone who comments, I would be able to read and reflect upon or perhaps be reminded that I forgot to add somethin that an engineer could probably need/not need or dare I even say, discuss the matter of adding a techfab for our engineers.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
