### PR TITLE
Removes warp point from map beacons

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -24,7 +24,6 @@
   - type: NavMapBeacon
     text: station-beacon-general
     color: "#D4D4D496"
-  - type: WarpPoint
   - type: ActivatableUI
     key: enum.NavMapBeaconUiKey.Key
     singleUser: true


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Makes things much cleaner. Currently we have Warp Point markers, Bombing Targets, and Map Beacons all with an overlapping function. (Also Warp points+Beacons markers but I'm ignoring those for this.)

**Why it's messy** 
Standard warp points and bombing targets can be used interchangeably.  You can use a WP where you don't want a target, use a BT where you do. Beacons, on the other hand, don't have BT but double up as a WP. So, you either end up having to choose between a BT/WP or a beacon, or double up a location on the Ghost Warp menu. Additionally, just using beacons bloats the Warp Menu.

Beacons can be moved by players. So, attaching either WP or BT to those is bad. Beacons are really nice, both for mappers and players but as long as they have WP, it causes conflict for mappers and/or bloat in the Ghost Warp menu.

**Solution**
Just use WP and BT to fill the Ghost Warp menu and Beacons for the Navmap. Problem solved/potential griefing, issues, etc. avoided, and no more Warp Menu bloat.
 
## Technical details
Some maps will likely need to be adjusted for this change.

## Media
n/a
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a