### PR TITLE
Obsolete `Logger` cleanup for `EntitySystem`s part 2

### DIFF
--- a/Content.Client/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Client/CardboardBox/CardboardBoxSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Content.Shared.CardboardBox;
 using Content.Shared.CardboardBox.Components;
 using Content.Shared.Examine;
@@ -11,6 +11,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
 {
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
 
     public override void Initialize()
     {
@@ -55,7 +56,7 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         foreach (var mob in mobMoverEntities)
         {
             var mapPos = _transform.GetMapCoordinates(mob);
-            if (!ExamineSystemShared.InRangeUnOccluded(sourcePos, mapPos, box.Distance, null))
+            if (!_examine.InRangeUnOccluded(sourcePos, mapPos, box.Distance, null))
                 continue;
 
             var ent = Spawn(box.Effect, mapPos);

--- a/Content.Client/Popups/PopupOverlay.cs
+++ b/Content.Client/Popups/PopupOverlay.cs
@@ -21,6 +21,7 @@ public sealed class PopupOverlay : Overlay
     private readonly IUserInterfaceManager _uiManager;
     private readonly PopupSystem _popup;
     private readonly PopupUIController _controller;
+    private readonly ExamineSystemShared _examine;
 
     private readonly ShaderInstance _shader;
 
@@ -33,12 +34,14 @@ public sealed class PopupOverlay : Overlay
         IPrototypeManager protoManager,
         IUserInterfaceManager uiManager,
         PopupUIController controller,
+        ExamineSystemShared examine,
         PopupSystem popup)
     {
         _configManager = configManager;
         _entManager = entManager;
         _playerMgr = playerMgr;
         _uiManager = uiManager;
+        _examine = examine;
         _popup = popup;
         _controller = controller;
 
@@ -81,7 +84,7 @@ public sealed class PopupOverlay : Overlay
             var distance = (mapPos.Position - args.WorldBounds.Center).Length();
 
             // Should handle fade here too wyci.
-            if (!args.WorldBounds.Contains(mapPos.Position) || !ExamineSystemShared.InRangeUnOccluded(viewPos, mapPos, distance,
+            if (!args.WorldBounds.Contains(mapPos.Position) || !_examine.InRangeUnOccluded(viewPos, mapPos, distance,
                     e => e == popup.InitialPos.EntityId || e == ourEntity, entMan: _entManager))
                 continue;
 

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Popups;
 using Robust.Client.Graphics;
@@ -26,6 +27,7 @@ namespace Content.Client.Popups
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
         [Dependency] private readonly IReplayRecordingManager _replayRecording = default!;
+        [Dependency] private readonly ExamineSystemShared _examine = default!;
 
         public IReadOnlyList<WorldPopupLabel> WorldLabels => _aliveWorldLabels;
         public IReadOnlyList<CursorPopupLabel> CursorLabels => _aliveCursorLabels;
@@ -51,6 +53,7 @@ namespace Content.Client.Popups
                     _prototype,
                     _uiManager,
                     _uiManager.GetUIController<PopupUIController>(),
+                    _examine,
                     this));
         }
 

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -613,7 +613,7 @@ public sealed class ChatUIController : UIController
 
             var otherPos = EntityManager.GetComponent<TransformComponent>(ent).MapPosition;
 
-            if (occluded && !ExamineSystemShared.InRangeUnOccluded(
+            if (occluded && !_examine.InRangeUnOccluded(
                     playerPos,
                     otherPos, 0f,
                     (ent, player), predicate))

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -20,7 +20,7 @@ namespace Content.Client.Verbs
     public sealed class VerbSystem : SharedVerbSystem
     {
         [Dependency] private readonly PopupSystem _popupSystem = default!;
-        [Dependency] private readonly ExamineSystem _examineSystem = default!;
+        [Dependency] private readonly ExamineSystem _examine = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
         [Dependency] private readonly IStateManager _stateManager = default!;
         [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
@@ -77,7 +77,7 @@ namespace Content.Client.Verbs
                 bool Predicate(EntityUid e) => e == player || entitiesUnderMouse.Contains(e);
 
                 // first check the general location.
-                if (!_examineSystem.CanExamine(player.Value, targetPos, Predicate))
+                if (!_examine.CanExamine(player.Value, targetPos, Predicate))
                     return false;
 
                 TryComp(player.Value, out ExaminerComponent? examiner);
@@ -86,7 +86,7 @@ namespace Content.Client.Verbs
                 entities = new();
                 foreach (var ent in _entityLookup.GetEntitiesInRange(targetPos, EntityMenuLookupSize))
                 {
-                    if (_examineSystem.CanExamine(player.Value, targetPos, Predicate, ent, examiner))
+                    if (_examine.CanExamine(player.Value, targetPos, Predicate, ent, examiner))
                         entities.Add(ent);
                 }
             }
@@ -147,7 +147,7 @@ namespace Content.Client.Verbs
                 {
                     var entity = entities[i];
 
-                    if (!ExamineSystemShared.InRangeUnOccluded(
+                    if (!_examine.InRangeUnOccluded(
                         playerPos,
                         xformQuery.GetComponent(entity).MapPosition,
                         ExamineSystemShared.ExamineRange,

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -66,6 +66,7 @@ namespace Content.Server.Administration.Systems
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly StationSystem _stations = default!;
         [Dependency] private readonly StationSpawningSystem _spawning = default!;
+        [Dependency] private readonly ExamineSystemShared _examine = default!;
 
         private readonly Dictionary<ICommonSession, EditSolutionsEui> _openSolutionUis = new();
 
@@ -416,7 +417,7 @@ namespace Content.Server.Administration.Systems
                     Act = () =>
                     {
 
-                        var message = ExamineSystemShared.InRangeUnOccluded(args.User, args.Target)
+                        var message = _examine.InRangeUnOccluded(args.User, args.Target)
                             ? Loc.GetString("in-range-unoccluded-verb-on-activate-not-occluded")
                             : Loc.GetString("in-range-unoccluded-verb-on-activate-occluded");
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -635,14 +635,14 @@ namespace Content.Server.Atmos.EntitySystems
             // Turns out: no they don't. Temporary debug checks to figure out which caller is causing problems:
             if (tile == null)
             {
-                Logger.Error($"Encountered null-tile in {nameof(AdjustEqMovement)}. Trace: {Environment.StackTrace}");
+                Log.Error($"Encountered null-tile in {nameof(AdjustEqMovement)}. Trace: {Environment.StackTrace}");
                 return;
             }
             var adj = tile.AdjacentTiles[direction.ToIndex()];
             if (adj == null)
             {
                 var nonNull = tile.AdjacentTiles.Where(x => x != null).Count();
-                Logger.Error($"Encountered null adjacent tile in {nameof(AdjustEqMovement)}. Dir: {direction}, Tile: {tile.Tile}, non-null adj count: {nonNull}, Trace: {Environment.StackTrace}");
+                Log.Error($"Encountered null adjacent tile in {nameof(AdjustEqMovement)}. Dir: {direction}, Tile: {tile.Tile}, non-null adj count: {nonNull}, Trace: {Environment.StackTrace}");
                 return;
             }
 

--- a/Content.Server/Chat/TypingIndicator/TypingIndicatorSystem.cs
+++ b/Content.Server/Chat/TypingIndicator/TypingIndicatorSystem.cs
@@ -39,7 +39,7 @@ public sealed class TypingIndicatorSystem : SharedTypingIndicatorSystem
         var uid = args.SenderSession.AttachedEntity;
         if (!Exists(uid))
         {
-            Logger.Warning($"Client {args.SenderSession} sent TypingChangedEvent without an attached entity.");
+            Log.Warning($"Client {args.SenderSession} sent TypingChangedEvent without an attached entity.");
             return;
         }
 

--- a/Content.Server/GameTicking/Rules/PiratesRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/PiratesRuleSystem.cs
@@ -201,7 +201,7 @@ public sealed class PiratesRuleSystem : GameRuleSystem<PiratesRuleComponent>
 
             if (!gridId.HasValue)
             {
-                Logger.ErrorS("pirates", $"Gridid was null when loading \"{map}\", aborting.");
+                Log.Error($"Gridid was null when loading \"{map}\", aborting.");
                 foreach (var session in ops)
                 {
                     ev.PlayerPool.Add(session);
@@ -230,7 +230,7 @@ public sealed class PiratesRuleSystem : GameRuleSystem<PiratesRuleComponent>
             if (spawns.Count == 0)
             {
                 spawns.Add(Transform(pirates.PirateShip).Coordinates);
-                Logger.WarningS("pirates", $"Fell back to default spawn for pirates!");
+                Log.Warning($"Fell back to default spawn for pirates!");
             }
 
             for (var i = 0; i < ops.Length; i++)

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -43,6 +43,7 @@ public sealed class NPCUtilitySystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SolutionContainerSystem _solutions = default!;
     [Dependency] private readonly WeldableSystem _weldable = default!;
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
 
     private EntityQuery<PuddleComponent> _puddleQuery;
     private EntityQuery<TransformComponent> _xformQuery;
@@ -296,7 +297,7 @@ public sealed class NPCUtilitySystem : EntitySystem
             {
                 var radius = blackboard.GetValueOrDefault<float>(NPCBlackboard.VisionRadius, EntityManager);
 
-                return ExamineSystemShared.InRangeUnOccluded(owner, targetUid, radius + 0.5f, null) ? 1f : 0f;
+                return _examine.InRangeUnOccluded(owner, targetUid, radius + 0.5f, null) ? 1f : 0f;
             }
             case TargetInLOSOrCurrentCon:
             {
@@ -313,7 +314,7 @@ public sealed class NPCUtilitySystem : EntitySystem
                     return 1f;
                 }
 
-                return ExamineSystemShared.InRangeUnOccluded(owner, targetUid, radius + bufferRange, null) ? 1f : 0f;
+                return _examine.InRangeUnOccluded(owner, targetUid, radius + bufferRange, null) ? 1f : 0f;
             }
             case TargetIsAliveCon:
             {

--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -37,6 +37,7 @@ namespace Content.Server.Pointing.EntitySystems
         [Dependency] private readonly VisibilitySystem _visibilitySystem = default!;
         [Dependency] private readonly SharedMindSystem _minds = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly ExamineSystemShared _examine = default!;
 
         private static readonly TimeSpan PointDelay = TimeSpan.FromSeconds(0.5f);
 
@@ -100,7 +101,7 @@ namespace Content.Server.Pointing.EntitySystems
             }
             else
             {
-                return ExamineSystemShared.InRangeUnOccluded(pointer, coordinates, 15, predicate: e => e == pointer);
+                return _examine.InRangeUnOccluded(pointer, coordinates, 15, predicate: e => e == pointer);
             }
         }
 

--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -22,6 +22,7 @@ namespace Content.Server.Remotes
         [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
         [Dependency] private readonly DoorSystem _doorSystem = default!;
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+        [Dependency] private readonly ExamineSystemShared _examine = default!;
         // I'm so sorry [Dependency] private readonly SharedAirlockSystem _sharedAirlockSystem = default!;
 
         public override void Initialize()
@@ -67,7 +68,7 @@ namespace Content.Server.Remotes
                 || !TryComp<DoorComponent>(args.Target, out var doorComp) // If it isn't a door we don't use it
                 // Only able to control doors if they are within your vision and within your max range.
                 // Not affected by mobs or machines anymore.
-                || !ExamineSystemShared.InRangeUnOccluded(args.User, args.Target.Value, SharedInteractionSystem.MaxRaycastRange, null))
+                || !_examine.InRangeUnOccluded(args.User, args.Target.Value, SharedInteractionSystem.MaxRaycastRange, null))
             {
                 return;
             }

--- a/Content.Server/Tabletop/TabletopSystem.Session.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Session.cs
@@ -31,7 +31,7 @@ namespace Content.Server.Tabletop
             // Since this is the first time opening this session, set up the game
             tabletop.Setup.SetupTabletop(session, EntityManager);
 
-            Logger.Info($"Created tabletop session number {tabletop} at position {session.Position}.");
+            Log.Info($"Created tabletop session number {tabletop} at position {session.Position}.");
 
             return session;
         }

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -144,7 +144,7 @@ namespace Content.Shared.Examine
             return TryComp<EyeComponent>(uid, out var eye) && eye.DrawFov;
         }
 
-        public static bool InRangeUnOccluded(MapCoordinates origin, MapCoordinates other, float range, Ignored? predicate, bool ignoreInsideBlocker = true, IEntityManager? entMan = null)
+        public bool InRangeUnOccluded(MapCoordinates origin, MapCoordinates other, float range, Ignored? predicate, bool ignoreInsideBlocker = true, IEntityManager? entMan = null)
         {
             // No, rider. This is better.
             // ReSharper disable once ConvertToLocalFunction
@@ -154,7 +154,7 @@ namespace Content.Shared.Examine
             return InRangeUnOccluded(origin, other, range, predicate, wrapped, ignoreInsideBlocker, entMan);
         }
 
-        public static bool InRangeUnOccluded<TState>(MapCoordinates origin, MapCoordinates other, float range,
+        public bool InRangeUnOccluded<TState>(MapCoordinates origin, MapCoordinates other, float range,
             TState state, Func<EntityUid, TState, bool> predicate, bool ignoreInsideBlocker = true, IEntityManager? entMan = null)
         {
             if (other.MapId != origin.MapId ||
@@ -171,7 +171,7 @@ namespace Content.Shared.Examine
 
             if (length > MaxRaycastRange)
             {
-                Logger.Warning("InRangeUnOccluded check performed over extreme range. Limiting CollisionRay size.");
+                Log.Warning("InRangeUnOccluded check performed over extreme range. Limiting CollisionRay size.");
                 length = MaxRaycastRange;
             }
 
@@ -207,7 +207,7 @@ namespace Content.Shared.Examine
             return true;
         }
 
-        public static bool InRangeUnOccluded(EntityUid origin, EntityUid other, float range = ExamineRange, Ignored? predicate = null, bool ignoreInsideBlocker = true)
+        public bool InRangeUnOccluded(EntityUid origin, EntityUid other, float range = ExamineRange, Ignored? predicate = null, bool ignoreInsideBlocker = true)
         {
             var entMan = IoCManager.Resolve<IEntityManager>();
             var originPos = entMan.GetComponent<TransformComponent>(origin).MapPosition;
@@ -216,7 +216,7 @@ namespace Content.Shared.Examine
             return InRangeUnOccluded(originPos, otherPos, range, predicate, ignoreInsideBlocker);
         }
 
-        public static bool InRangeUnOccluded(EntityUid origin, EntityCoordinates other, float range = ExamineRange, Ignored? predicate = null, bool ignoreInsideBlocker = true)
+        public bool InRangeUnOccluded(EntityUid origin, EntityCoordinates other, float range = ExamineRange, Ignored? predicate = null, bool ignoreInsideBlocker = true)
         {
             var entMan = IoCManager.Resolve<IEntityManager>();
             var originPos = entMan.GetComponent<TransformComponent>(origin).MapPosition;
@@ -225,7 +225,7 @@ namespace Content.Shared.Examine
             return InRangeUnOccluded(originPos, otherPos, range, predicate, ignoreInsideBlocker);
         }
 
-        public static bool InRangeUnOccluded(EntityUid origin, MapCoordinates other, float range = ExamineRange, Ignored? predicate = null, bool ignoreInsideBlocker = true)
+        public bool InRangeUnOccluded(EntityUid origin, MapCoordinates other, float range = ExamineRange, Ignored? predicate = null, bool ignoreInsideBlocker = true)
         {
             var entMan = IoCManager.Resolve<IEntityManager>();
             var originPos = entMan.GetComponent<TransformComponent>(origin).MapPosition;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Part 2 of 2, continuation of #25941 
Gets rid of the remaining obsolete `Logger` method calls from all `EntitySystem`s and uses the expected `Log` to get at the proper sawmill.

In particular:
1. Make the `ExamineSystemShared`'s `InRangeUnObstructed` non-`static` (so finally able to use instance-based `Log` rather than `Logger`) and inject dependency to all systems that were using it as `static`.
2. Adjust 4 more `EntitySystem`s to use `Log` rather than `Logger` that were missed in the previous PR.

Tested that the game runs and the affected systems direct logs to the correct sawmill.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Using Logger directly for logging is marked obsolete. Brings some order to logs (i.e. all `EntitySystem` logs start with a preceding `system.`).

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I'm pretty sure `ExamineSystemShared`'s `InRangeUnObstructed` not being `static` is the intended way since it being `static` dodges the IoC entirely. It even has dirty hacks such as getting the occluder system inside to make it happen. I didn't fix any of that as it's beyond the scope of this PR, but it's another thing that needs improving.

These are the changes to the log sawmills:
`ExamineSystemShared.cs`: BEFORE: `root` -> NEW: `system.examine`
`AtmosphereSystem.Monstermos.cs`: BEFORE: `root` -> NEW: `system.atmosphere`
`TypingIndicatorSystem.cs`: BEFORE: `root` -> NEW: `system.typing_indicator`
`PiratesRuleSystem.cs` BEFORE: `pirates` -> NEW: `system.pirates_rule`
`TabletopSystem.Session.cs` BEFORE: `root` -> NEW: `system.tabletop`

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
Some logs now fall under a different sawmill (more precise). Any software that analyzes logs and makes assumptions on which sawmill do these logs fall to will need to be adjusted.