### PR TITLE
Small performance optimization. Don't do String.Trim() second time

### DIFF
--- a/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
+++ b/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
@@ -122,7 +122,7 @@ namespace Content.Server.Disposal.Tube
                     if (trimmed == "")
                         continue;
 
-                    router.Tags.Add(tag.Trim());
+                    router.Tags.Add(trimmed);
                 }
 
                 _audioSystem.PlayPvs(router.ClickSound, uid, AudioParams.Default.WithVolume(-2f));


### PR DESCRIPTION
## About the PR
Super small performance optimization

## Technical details
Obvious change