### PR TITLE
Fix StrippableSystem blunders

### DIFF
--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -122,13 +122,12 @@ namespace Content.Server.Strip
         private void OnStripButtonPressed(Entity<StrippableComponent> strippable, ref StrippingSlotButtonPressed args)
         {
             if (args.Session.AttachedEntity is not { Valid: true } user ||
-                !TryComp<HandsComponent>(user, out var userHands) ||
-                !TryComp<HandsComponent>(strippable.Owner, out var targetHands))
+                !TryComp<HandsComponent>(user, out var userHands))
                 return;
 
             if (args.IsHand)
             {
-                StripHand((user, userHands), (strippable.Owner, targetHands), args.Slot, strippable);
+                StripHand((user, userHands), (strippable.Owner, null), args.Slot, strippable);
                 return;
             }
 

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -544,7 +544,7 @@ namespace Content.Server.Strip
             var (time, stealth) = GetStripTimeModifiers(user, target, targetStrippable.HandStripDelay);
 
             if (!stealth)
-                _popupSystem.PopupEntity( Loc.GetString("strippable-component-alert-owner", ("user", Identity.Entity(user, EntityManager)), ("item", item)), target, target);
+                _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner", ("user", Identity.Entity(user, EntityManager)), ("item", item)), target, target);
 
             var prefix = stealth ? "stealthily " : "";
             _adminLogger.Add(LogType.Stripping, LogImpact.Low, $"{ToPrettyString(user):actor} is trying to {prefix}strip the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands");

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -477,6 +477,9 @@ namespace Content.Server.Strip
                 !Resolve(target, ref target.Comp))
                 return;
 
+            if (!CanStripInsertHand(user, target, held, handName))
+                return;
+
             _handsSystem.TryDrop(user, checkActionBlocker: false, handsComp: user.Comp);
             _handsSystem.TryPickup(target, held, handName, checkActionBlocker: false, animateUser: stealth, animate: stealth, handsComp: target.Comp);
             _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has placed the item {ToPrettyString(held):item} in {ToPrettyString(target):target}'s hands");
@@ -568,10 +571,14 @@ namespace Content.Server.Strip
             Entity<HandsComponent?> user,
             Entity<HandsComponent?> target,
             EntityUid item,
+            string handName,
             bool stealth)
         {
             if (!Resolve(user, ref user.Comp) ||
                 !Resolve(target, ref target.Comp))
+                return;
+
+            if (!CanStripRemoveHand(user, target, item, handName))
                 return;
 
             _handsSystem.TryDrop(target, item, checkActionBlocker: false, handsComp: target.Comp);
@@ -624,7 +631,7 @@ namespace Content.Server.Strip
             {
                 if (ev.InsertOrRemove)
                         StripInsertHand((entity.Owner, entity.Comp), ev.Target.Value, ev.Used.Value, ev.SlotOrHandName, ev.Args.Hidden);
-                else    StripRemoveHand((entity.Owner, entity.Comp), ev.Target.Value, ev.Used.Value, ev.Args.Hidden);
+                else    StripRemoveHand((entity.Owner, entity.Comp), ev.Target.Value, ev.Used.Value, ev.SlotOrHandName, ev.Args.Hidden);
             }
         }
     }

--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -35,11 +35,11 @@ namespace Content.Shared.Strip.Components
     public abstract class BaseBeforeStripEvent(TimeSpan initialTime, bool stealth = false) : EntityEventArgs, IInventoryRelayEvent
     {
         public readonly TimeSpan InitialTime = initialTime;
-        public TimeSpan Multiplier = TimeSpan.FromSeconds(1f);
+        public float Multiplier = 1f;
         public TimeSpan Additive = TimeSpan.Zero;
         public bool Stealth = stealth;
 
-        public TimeSpan Time => TimeSpan.FromSeconds(MathF.Max(InitialTime.Seconds * Multiplier.Seconds + Additive.Seconds, 0f));
+        public TimeSpan Time => TimeSpan.FromSeconds(MathF.Max(InitialTime.Seconds * Multiplier + Additive.Seconds, 0f));
 
         public SlotFlags TargetSlots { get; } = SlotFlags.GLOVES;
     }


### PR DESCRIPTION
## About the PR

#25994 wasn't airtight. I never thought to test on animals, zombies or dead / crit players.

This PR fixes the following issues:
#26144
#26145
#26150

- Zombies and animals couldn't be stripped because I was checking for target hands too early
- Dead/Crit was instantly stripping because I turned the strip time multiplier into a TimeSpan


## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl: Krunk
- fix: Zombies and animals can be stripped once again.
- fix: Dead or critical mobs can no longer be stripped instantly.
