### PR TITLE
Rotate and Offset station CCVar nuke

### DIFF
--- a/Content.Server/Station/Components/StationRandomComponent.cs
+++ b/Content.Server/Station/Components/StationRandomComponent.cs
@@ -1,0 +1,19 @@
+using Content.Server.Station.Systems;
+
+namespace Content.Server.Station.Components;
+
+/// <summary>
+/// Stores station parameters that can be randomized by the roundstart
+/// </summary>
+[RegisterComponent, Access(typeof(StationSystem))]
+public sealed partial class StationRandomComponent : Component
+{
+    [DataField]
+    public bool EnableStationOffset = true;
+
+    [DataField]
+    public float MaxStationOffset = 1000.0f;
+
+    [DataField]
+    public bool EnableStationRotation = true;
+}

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -230,25 +230,6 @@ namespace Content.Shared.CCVar
             GameCryoSleepRejoining = CVarDef.Create("game.cryo_sleep_rejoining", false, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
-        ///     Whether a random position offset will be applied to the station on roundstart.
-        /// </summary>
-        public static readonly CVarDef<bool> StationOffset =
-            CVarDef.Create("game.station_offset", true);
-
-        /// <summary>
-        /// When the default blueprint is loaded what is the maximum amount it can be offset from 0,0.
-        /// Does nothing without <see cref="StationOffset"/> as true.
-        /// </summary>
-        public static readonly CVarDef<float> MaxStationOffset =
-            CVarDef.Create("game.maxstationoffset", 1000.0f);
-
-        /// <summary>
-        ///     Whether a random rotation will be applied to the station on roundstart.
-        /// </summary>
-        public static readonly CVarDef<bool> StationRotation =
-            CVarDef.Create("game.station_rotation", true);
-
-        /// <summary>
         ///     When enabled, guests will be assigned permanent UIDs and will have their preferences stored.
         /// </summary>
         public static readonly CVarDef<bool> GamePersistGuests =

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -5,6 +5,12 @@
     - type: StationData
 
 - type: entity
+  id: BaseRandomStation
+  abstract: true
+  components:
+    - type: StationRandom
+
+- type: entity
   id: BaseStationCargo
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -25,6 +25,7 @@
     - BaseStationSiliconLawCrewsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
+    - BaseRandomStation
   noSpawn: true
   components:
     - type: Transform

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -8,6 +8,8 @@
     Train:
       stationProto: StandardNanotrasenStation
       components:
+        - type: StationRandom
+          enableStationRotation: false
         - type: StationNameSetup
           mapNameTemplate: 'Train "Sentipode" {0}-{1}'
           nameGenerator:


### PR DESCRIPTION
## About the PR
CCVar to randomly rotate and shift a station at the start of a round has been removed - this functionality has been moved to a separate component that can be reassigned to individual stations.

Train Station now does not get a random turn at the start of a round. The train always travels forward.

## Why / Balance
It is now possible to reassign the rotation and shift of individual stations in the map prototype. Is this also theoretically useful for planetary maps? I don't know about that.