### PR TITLE
Fix anomaly decay logs

### DIFF
--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -133,7 +133,7 @@ public abstract class SharedAnomalySystem : EntitySystem
         if (HasComp<AnomalySupercriticalComponent>(uid))
             return;
 
-        AdminLog.Add(LogType.Anomaly, LogImpact.High, $"Anomaly {ToPrettyString(uid)} began to go supercritical.");
+        AdminLog.Add(LogType.Anomaly, LogImpact.Extreme, $"Anomaly {ToPrettyString(uid)} began to go supercritical.");
         if (_net.IsServer)
             _sawmill.Info($"Anomaly is going supercritical. Entity: {ToPrettyString(uid)}");
 
@@ -180,7 +180,8 @@ public abstract class SharedAnomalySystem : EntitySystem
         // Logging before resolve, in case the anomaly has deleted itself.
         if (_net.IsServer)
             _sawmill.Info($"Ending anomaly. Entity: {ToPrettyString(uid)}");
-        AdminLog.Add(LogType.Anomaly, LogImpact.Extreme, $"Anomaly {ToPrettyString(uid)} went supercritical.");
+        AdminLog.Add(LogType.Anomaly, supercritical ? LogImpact.High : LogImpact.Low,
+                     $"Anomaly {ToPrettyString(uid)} {(supercritical ? "went supercritical" : "decayed")}.");
 
         if (!Resolve(uid, ref component))
             return;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- Decayed Anomalies leave log with `LogImpact.Low` (down from `LogImpact.Extreme` and being misreported as having gone supercritical)
Reason: Admin Logs severity usually means how much of admin attention this requires. A decayed anomaly does not require any Admin attention and is essentially just a convenience note.

- Swapped `LogImpact`s of supercritical event starting and finishing.
Reason: When an anomaly starts going supercritical it leaves a log with `LogImpact.High`, but when it finishes the animation it leaves a log with `LogImpact.Extreme`. This seems inconsistent to me, because the moment anomaly starts going supercritical seems to demand more Admin attention than an "it had already happened"-style report. After this change, a supercritical anomaly will still always leave at least one `LogImpact.Extreme` admin log, so from reporting perspective it should be conveying the same message;, but from "immediate responder" perspective Admins get the more-important `Extreme` log sooner (as the supercritical event starts happening, rather than after it had already finished). 

Resolves #26122

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bugfix.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Anomalies ending still leave multiple logs. This is beyond the scope of this PR.
But at least now it won't spam the `LogImpact.Extreme` category.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/27449516/09ddfd79-a872-4be2-8ba7-16619b63835b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
ADMIN
- fix: Decayed anomalies no longer show as having gone supercritical in logs.