### PR TITLE
Revert "Agent IDs default to passenger icon"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -588,8 +588,8 @@
   id: AgentIDCard
   suffix: Agent
   components:
-  - type: PresetIdCard
-    job: Passenger
+  - type: IdCard
+    jobTitle: Passenger
   - type: Access
     tags:
     - Maintenance


### PR DESCRIPTION
Reverts space-wizards/space-station-14#25993

This PR broke Agent IDs that are spawned or bought on nukie planet.

#26169
#25798 

Metagamers rejoice 