### PR TITLE
Fixed safe filling with WT550

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -226,7 +226,7 @@
     contents:
     - id: WeaponSubMachineGunWt550
       amount: 2
-    - id: MagazinePistolSubMachineGun
+    - id: MagazinePistolSubMachineGunTopMounted
       amount: 4
 
 - type: entity


### PR DESCRIPTION
## About the PR
Fixed filling of WT550 safes 

## Why / Balance

The WT550 requires a different type of magazine, which was clearly not noticed when creating safes. Therefore, what is now in safes is simply not suitable for the WT550.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl:
- fix: The correct magazines now appear in the WT550 safe.
