### PR TITLE
Add reckless replay load button

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -70,6 +70,7 @@ namespace Content.Client.Entry
         [Dependency] private readonly IResourceManager _resourceManager = default!;
         [Dependency] private readonly IReplayLoadManager _replayLoad = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
+        [Dependency] private readonly ContentReplayPlaybackManager _replayMan = default!;
 
         public override void Init()
         {
@@ -193,6 +194,7 @@ namespace Content.Client.Entry
                     _resourceManager,
                     ReplayConstants.ReplayZipFolder.ToRootedPath());
 
+                _replayMan.LastLoad = (null, ReplayConstants.ReplayZipFolder.ToRootedPath());
                 _replayLoad.LoadAndStartReplay(reader);
             }
             else if (_gameController.LaunchState.FromLauncher)

--- a/Content.Client/Replay/ContentReplayPlaybackManager.cs
+++ b/Content.Client/Replay/ContentReplayPlaybackManager.cs
@@ -1,8 +1,10 @@
+using System.IO.Compression;
 using Content.Client.Administration.Managers;
 using Content.Client.Launcher;
 using Content.Client.MainMenu;
 using Content.Client.Replay.Spectator;
 using Content.Client.Replay.UI.Loading;
+using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Shared.Chat;
 using Content.Shared.Effects;
@@ -24,7 +26,13 @@ using Robust.Client.Replays.Playback;
 using Robust.Client.State;
 using Robust.Client.Timing;
 using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.ContentPack;
 using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Replay;
 
@@ -41,6 +49,8 @@ public sealed class ContentReplayPlaybackManager
     [Dependency] private readonly IClientAdminManager _adminMan = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IBaseClient _client = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IResourceManager _resMan = default!;
 
     /// <summary>
     /// UI state to return to when stopping a replay or loading fails.
@@ -50,6 +60,13 @@ public sealed class ContentReplayPlaybackManager
     public bool IsScreenshotMode = false;
 
     private bool _initialized;
+    
+    /// <summary>
+    /// Most recently loaded file, for re-attempting the load with error tolerance.
+    /// Required because the zip reader auto-disposes and I'm too lazy to change it so that
+    /// <see cref="ReplayFileReaderZip"/> can re-open it.
+    /// </summary>
+    public (ResPath? Zip, ResPath Folder)? LastLoad;
 
     public void Initialize()
     {
@@ -73,11 +90,50 @@ public sealed class ContentReplayPlaybackManager
 
     private void OnFinishedLoading(Exception? exception)
     {
-        if (exception != null)
+        if (exception == null)
         {
-            ReturnToDefaultState();
-            _uiMan.Popup(Loc.GetString("replay-loading-failed", ("reason", exception)));
+            LastLoad = null;
+            return;
         }
+
+        ReturnToDefaultState();
+
+        // Show a popup window with the error message
+        var text = Loc.GetString("replay-loading-failed", ("reason", exception));
+        var box = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            Children = {new Label {Text = text}}
+        };
+
+        var popup = new DefaultWindow { Title = "Error!" };
+        popup.Contents.AddChild(box);
+
+        // Add button for attempting to re-load the replay while ignoring some errors.
+        if (!_cfg.GetCVar(CVars.ReplayIgnoreErrors) && LastLoad is {} last)
+        {
+            var button = new Button
+            {
+                Text = Loc.GetString("replay-loading-retry"), 
+                StyleClasses = { StyleBase.ButtonCaution }
+            };
+            
+            button.OnPressed += _ =>
+            {
+                _cfg.SetCVar(CVars.ReplayIgnoreErrors, true);
+                popup.Dispose();
+
+                IReplayFileReader reader = last.Zip == null
+                    ? new ReplayFileReaderResources(_resMan, last.Folder)
+                    : new ReplayFileReaderZip(new(_resMan.UserData.OpenRead(last.Zip.Value)), last.Folder);
+
+                _loadMan.LoadAndStartReplay(reader);
+            };
+            
+            box.AddChild(button);
+        }
+
+        popup.OpenCentered();
     }
 
     public void ReturnToDefaultState()

--- a/Content.Replay/Menu/ReplayMainMenu.cs
+++ b/Content.Replay/Menu/ReplayMainMenu.cs
@@ -1,6 +1,7 @@
 using System.IO.Compression;
 using System.Linq;
 using Content.Client.Message;
+using Content.Client.Replay;
 using Content.Client.UserInterface.Systems.EscapeMenu;
 using Robust.Client;
 using Robust.Client.Replays.Loading;
@@ -31,6 +32,7 @@ public sealed class ReplayMainScreen : State
     [Dependency] private readonly IGameController _controllerProxy = default!;
     [Dependency] private readonly IClientRobustSerializer _serializer = default!;
     [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
+    [Dependency] private readonly ContentReplayPlaybackManager _replayMan = default!;
 
     private ReplayMainMenuControl _mainMenuControl = default!;
     private SelectReplayWindow? _selectWindow;
@@ -207,12 +209,13 @@ public sealed class ReplayMainScreen : State
 
     private void OnLoadPressed(BaseButton.ButtonEventArgs obj)
     {
-        if (_selected.HasValue)
-        {
-            var fileReader = new ReplayFileReaderZip(
-                new ZipArchive(_resMan.UserData.OpenRead(_selected.Value)), ReplayZipFolder);
-            _loadMan.LoadAndStartReplay(fileReader);
-        }
+        if (!_selected.HasValue)
+            return;
+
+        _replayMan.LastLoad = (_selected.Value, ReplayZipFolder);
+        var fileReader = new ReplayFileReaderZip(
+            new ZipArchive(_resMan.UserData.OpenRead(_selected.Value)), ReplayZipFolder);
+        _loadMan.LoadAndStartReplay(fileReader);
     }
 
     private void RefreshReplays()

--- a/Resources/Locale/en-US/replays/replays.ftl
+++ b/Resources/Locale/en-US/replays/replays.ftl
@@ -6,8 +6,9 @@ replay-loading-processing = Processing Files
 replay-loading-spawning = Spawning Entities
 replay-loading-initializing = Initializing Entities
 replay-loading-starting= Starting Entities
-replay-loading-failed = Failed to load replay:
+replay-loading-failed = Failed to load replay. Error:
                         {$reason}
+replay-loading-retry = Try load anyways - MAY CAUSE BUGS!
 
 # Main Menu
 replay-menu-subtext = Replay Client

--- a/Resources/Locale/en-US/replays/replays.ftl
+++ b/Resources/Locale/en-US/replays/replays.ftl
@@ -8,7 +8,7 @@ replay-loading-initializing = Initializing Entities
 replay-loading-starting= Starting Entities
 replay-loading-failed = Failed to load replay. Error:
                         {$reason}
-replay-loading-retry = Try load anyways - MAY CAUSE BUGS!
+replay-loading-retry = Try load with more exception tolerance - MAY CAUSE BUGS!
 
 # Main Menu
 replay-menu-subtext = Replay Client


### PR DESCRIPTION
Adds a button that allows people to attempt to load replays even if it encounters errors. This just uses the existing cvar, but makes it more accessible to players. Requires https://github.com/space-wizards/RobustToolbox/pull/4974

https://github.com/space-wizards/space-station-14/assets/60421075/312e7f2c-10b3-4649-b44e-8e873619f55c

:cl:
- add: Added an option to try and ignore some errors if a replay fails to load, 
