### PR TITLE
Fix pressure damage calculations

### DIFF
--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -224,69 +224,64 @@ namespace Content.Server.Atmos.EntitySystems
                     pressure = MathF.Max(mixture.Pressure, 1f);
                 }
 
-                switch (pressure)
+                pressure = pressure switch
                 {
-                    // Low pressure.
-                    case <= Atmospherics.WarningLowPressure:
-                        pressure = GetFeltLowPressure(uid, barotrauma, pressure);
+                    // Adjust pressure based on equipment. Works differently depending on if it's "high" or "low".
+                    <= Atmospherics.WarningLowPressure => GetFeltLowPressure(uid, barotrauma, pressure),
+                    >= Atmospherics.WarningHighPressure => GetFeltHighPressure(uid, barotrauma, pressure),
+                    _ => pressure
+                };
 
-                        if (pressure > Atmospherics.WarningLowPressure)
-                            goto default;
+                if (pressure <= Atmospherics.HazardLowPressure)
+                {
+                    // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false);
 
-                        // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                        _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false);
+                    if (!barotrauma.TakingDamage)
+                    {
+                        barotrauma.TakingDamage = true;
+                        _adminLogger.Add(LogType.Barotrauma, $"{ToPrettyString(uid):entity} started taking low pressure damage");
+                    }
 
-                        if (!barotrauma.TakingDamage)
-                        {
-                            barotrauma.TakingDamage = true;
-                            _adminLogger.Add(LogType.Barotrauma, $"{ToPrettyString(uid):entity} started taking low pressure damage");
-                        }
+                    _alertsSystem.ShowAlert(uid, AlertType.LowPressure, 2);
+                }
+                else if (pressure >= Atmospherics.HazardHighPressure)
+                {
+                    var damageScale = MathF.Min(((pressure / Atmospherics.HazardHighPressure) - 1) * Atmospherics.PressureDamageCoefficient, Atmospherics.MaxHighPressureDamage);
 
-                        if (pressure <= Atmospherics.HazardLowPressure)
-                        {
-                            _alertsSystem.ShowAlert(uid, AlertType.LowPressure, 2);
+                    // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false);
+
+                    if (!barotrauma.TakingDamage)
+                    {
+                        barotrauma.TakingDamage = true;
+                        _adminLogger.Add(LogType.Barotrauma, $"{ToPrettyString(uid):entity} started taking high pressure damage");
+                    }
+
+                    _alertsSystem.ShowAlert(uid, AlertType.HighPressure, 2);
+                }
+                else
+                {
+                    // Within safe pressure limits
+                    if (barotrauma.TakingDamage)
+                    {
+                        barotrauma.TakingDamage = false;
+                        _adminLogger.Add(LogType.Barotrauma, $"{ToPrettyString(uid):entity} stopped taking pressure damage");
+                    }
+
+                    // Set correct alert.
+                    switch (pressure)
+                    {
+                        case <= Atmospherics.WarningLowPressure:
+                            _alertsSystem.ShowAlert(uid, AlertType.LowPressure, 1);
                             break;
-                        }
-
-                        _alertsSystem.ShowAlert(uid, AlertType.LowPressure, 1);
-                        break;
-
-                    // High pressure.
-                    case >= Atmospherics.WarningHighPressure:
-                        pressure = GetFeltHighPressure(uid, barotrauma, pressure);
-
-                        if (pressure < Atmospherics.WarningHighPressure)
-                            goto default;
-
-                        var damageScale = MathF.Min((pressure / Atmospherics.HazardHighPressure) * Atmospherics.PressureDamageCoefficient, Atmospherics.MaxHighPressureDamage);
-
-                        // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                        _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false);
-
-                        if (!barotrauma.TakingDamage)
-                        {
-                            barotrauma.TakingDamage = true;
-                            _adminLogger.Add(LogType.Barotrauma, $"{ToPrettyString(uid):entity} started taking high pressure damage");
-                        }
-
-                        if (pressure >= Atmospherics.HazardHighPressure)
-                        {
-                            _alertsSystem.ShowAlert(uid, AlertType.HighPressure, 2);
+                        case >= Atmospherics.WarningHighPressure:
+                            _alertsSystem.ShowAlert(uid, AlertType.HighPressure, 1);
                             break;
-                        }
-
-                        _alertsSystem.ShowAlert(uid, AlertType.HighPressure, 1);
-                        break;
-
-                    // Normal pressure.
-                    default:
-                        if (barotrauma.TakingDamage)
-                        {
-                            barotrauma.TakingDamage = false;
-                            _adminLogger.Add(LogType.Barotrauma, $"{ToPrettyString(uid):entity} stopped taking pressure damage");
-                        }
-                        _alertsSystem.ClearAlertCategory(uid, AlertCategory.Pressure);
-                        break;
+                        default:
+                            _alertsSystem.ClearAlertCategory(uid, AlertCategory.Pressure);
+                            break;
+                    }
                 }
             }
         }

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -276,7 +276,7 @@ namespace Content.Shared.Atmos
         public const float HazardLowPressure = 20f;
 
         /// <summary>
-        ///    The amount of pressure damage someone takes is equal to (pressure / HAZARD_HIGH_PRESSURE)*PRESSURE_DAMAGE_COEFFICIENT,
+        ///    The amount of pressure damage someone takes is equal to ((pressure / HAZARD_HIGH_PRESSURE) - 1)*PRESSURE_DAMAGE_COEFFICIENT,
         ///     with the maximum of MaxHighPressureDamage.
         /// </summary>
         public const float PressureDamageCoefficient = 4;

--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -12,13 +12,14 @@
 - type: alarmThreshold
   id: stationPressure
   upperBound: !type:AlarmThresholdSetting
-    threshold: 550 # as defined in Atmospherics.cs
+    threshold: 550 # HazardHighPressure from Atmospherics.cs
   lowerBound: !type:AlarmThresholdSetting
-    threshold: 20 # as defined in Atmospherics.cs
+    # Actual low pressure damage threshold is at 20 kPa, but below ~85 kPa you can't breathe due to lack of oxygen.
+    threshold: 85
   upperWarnAround: !type:AlarmThresholdSetting
-    threshold: 0.7
+    threshold: 0.7 # 385 kPa, WarningHighPressure from Atmospherics.cs
   lowerWarnAround: !type:AlarmThresholdSetting
-    threshold: 2.5
+    threshold: 1.05 # ~90 kPa
 
 # a reminder that all of these are percentages (where 1 is 100%),
 # so 0.01 is 1%,


### PR DESCRIPTION
## About the PR
Pressure damage calculations were wrong. They were originally ported from TG (and use all the same constants) but were implemented wrong. This is now fixed.

This makes pressure damage less aggressive. For example you now need to be at 20 kPa to start taking low pressure damage instead of 50 kPa. The HUD alerts severity 1 now mean "warning" like they're supposed to instead of actual danger. High pressure damage scales slightly differently (starts less aggressive).

Also minor change to air alarms (why I started looking at this in the first place).

## Why / Balance
I couldn't help but notice the "warning" alerts started showing up even if you were already taking pressure damage... then I started loudly cursing because the barotrauma code uses the WARNING thresholds for actual damage...

## Technical details
See commits. 

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Fixed pressure damage calculations to what they were always supposed to be. This means pressure damage now starts happening at more extreme values (20 kPa for low pressure damage instead of 50 kPa) and high pressure damage is scaled different. It also fixed the HUD alerts so that the "warning" alerts show up before you actually start taking damage.
- tweak: Air alarms now start complaining about low pressure much earlier, when the pressure drops so much that you can't breathe oxygen tank.