### PR TITLE
Fix barotrauma pressure protection

### DIFF
--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -149,7 +149,8 @@ namespace Content.Server.Atmos.EntitySystems
                 return Atmospherics.OneAtmosphere;
             }
 
-            return (environmentPressure + barotrauma.LowPressureModifier) * (barotrauma.LowPressureMultiplier);
+            var modified = (environmentPressure + barotrauma.LowPressureModifier) * (barotrauma.LowPressureMultiplier);
+            return Math.Min(modified, Atmospherics.OneAtmosphere);
         }
 
         /// <summary>
@@ -162,7 +163,8 @@ namespace Content.Server.Atmos.EntitySystems
                 return Atmospherics.OneAtmosphere;
             }
 
-            return (environmentPressure + barotrauma.HighPressureModifier) * (barotrauma.HighPressureMultiplier);
+            var modified = (environmentPressure + barotrauma.HighPressureModifier) * (barotrauma.HighPressureMultiplier);
+            return Math.Max(modified, Atmospherics.OneAtmosphere);
         }
 
         public bool TryGetPressureProtectionValues(


### PR DESCRIPTION
Oops

In #26217 I re-organized the logic for the calculation. Part of that was moving the logic for GetFeltLowPressure and GetFeltHighPressure to be done before we actually check the hazard thresholds. What I didn't realize is that, with how our pressure protection is set up, these functions can return values so extreme they rebound into the other category.

For example, according to the math, when you're wearing a hardsuit in a low-pressure environment you have "felt" pressure of 1000 kPa. Yeah that's not right.

Now these functions clamp their result to OneAtmosphere, in the appropriate direction (101.3 kPa).

Fixes #26234

:cl:
- fix: Fixed hardsuits in space causing high pressure damage