### PR TITLE
Add stealthmins

### DIFF
--- a/Content.Server/Administration/Commands/AdminWhoCommand.cs
+++ b/Content.Server/Administration/Commands/AdminWhoCommand.cs
@@ -19,6 +19,16 @@ public sealed class AdminWhoCommand : IConsoleCommand
         var adminMgr = IoCManager.Resolve<IAdminManager>();
         var afk = IoCManager.Resolve<IAfkManager>();
 
+        var seeStealth = true;
+
+        // If null it (hopefully) means it is being called from the console.
+        if (shell.Player != null)
+        {
+            var playerData = adminMgr.GetAdminData(shell.Player);
+
+            seeStealth = playerData != null && playerData.CanStealth();
+        }
+
         var sb = new StringBuilder();
         var first = true;
         foreach (var admin in adminMgr.ActiveAdmins)
@@ -29,6 +39,9 @@ public sealed class AdminWhoCommand : IConsoleCommand
 
             var adminData = adminMgr.GetAdminData(admin)!;
             DebugTools.AssertNotNull(adminData);
+
+            if (adminData.Stealth && !seeStealth)
+                continue;
 
             sb.Append(admin.Name);
             if (adminData.Title is { } title)

--- a/Content.Server/Administration/Commands/StealthminCommand.cs
+++ b/Content.Server/Administration/Commands/StealthminCommand.cs
@@ -1,0 +1,41 @@
+using Content.Server.Administration.Managers;
+using Content.Shared.Administration;
+using JetBrains.Annotations;
+using Robust.Shared.Console;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Administration.Commands;
+
+[UsedImplicitly]
+[AdminCommand(AdminFlags.Stealth)]
+public sealed class StealthminCommand : IConsoleCommand
+{
+    public string Command => "stealthmin";
+    public string Description => "Toggle whether others can see you in adminwho";
+    public string Help => "Usage: stealthmin\nUse stealthmin to toggle whether you appear in the output of the adminwho command.";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+            var player = shell.Player;
+            if (player == null)
+            {
+                shell.WriteLine("You cannot use this command from the server console.");
+                return;
+            }
+
+            var mgr = IoCManager.Resolve<IAdminManager>();
+
+            var adminData = mgr.GetAdminData(player);
+
+            DebugTools.AssertNotNull(adminData);
+
+            if (!adminData!.Stealth)
+            {
+                mgr.Stealth(player);
+            }
+            else
+            {
+                mgr.UnStealth(player);
+            }
+    }
+}

--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -95,6 +95,42 @@ namespace Content.Server.Administration.Managers
             UpdateAdminStatus(session);
         }
 
+        public void Stealth(ICommonSession session)
+        {
+            if (!_admins.TryGetValue(session, out var reg))
+            {
+                throw new ArgumentException($"Player {session} is not an admin");
+            }
+
+            if (reg.Data.Stealth)
+                return;
+
+            var playerData = session.ContentData()!;
+            playerData.Stealthed = true;
+            reg.Data.Stealth = true;
+
+            _chat.DispatchServerMessage(session, Loc.GetString("admin-manager-stealthed-message"));
+            _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-self-de-admin-message", ("exAdminName", session.Name)), AdminFlags.Stealth);
+        }
+
+        public void UnStealth(ICommonSession session)
+        {
+            if (!_admins.TryGetValue(session, out var reg))
+            {
+                throw new ArgumentException($"Player {session} is not an admin");
+            }
+
+            if (!reg.Data.Stealth)
+                return;
+
+            var playerData = session.ContentData()!;
+            playerData.Stealthed = false;
+            reg.Data.Stealth = false;
+
+            _chat.DispatchServerMessage(session, Loc.GetString("admin-manager-unstealthed-message"));
+            _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-self-re-admin-message", ("newAdminName", session.Name)), flagBlacklist: AdminFlags.Stealth);
+        }
+
         public void ReAdmin(ICommonSession session)
         {
             if (!_admins.TryGetValue(session, out var reg))
@@ -113,7 +149,16 @@ namespace Content.Server.Administration.Managers
             plyData.ExplicitlyDeadminned = false;
             reg.Data.Active = true;
 
-            _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-self-re-admin-message", ("newAdminName", session.Name)));
+            if (reg.Data.Stealth)
+            {
+                _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-self-re-admin-message", ("newAdminName", session.Name)));
+            }
+            else
+            {
+                _chat.DispatchServerMessage(session, Loc.GetString("admin-manager-stealthed-message"));
+                _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-self-re-admin-message",
+                    ("newAdminName", session.Name)), flagWhitelist: AdminFlags.Stealth);
+            }
 
             SendPermsChangedEvent(session);
             UpdateAdminStatus(session);
@@ -164,6 +209,11 @@ namespace Content.Server.Administration.Managers
                     aData.Active = true;
 
                     _chat.DispatchServerMessage(player, Loc.GetString("admin-manager-admin-permissions-updated-message"));
+                }
+
+                if (player.ContentData()!.Stealthed)
+                {
+                    aData.Stealth = true;
                 }
             }
 
@@ -283,9 +333,19 @@ namespace Content.Server.Administration.Managers
             }
             else if (e.NewStatus == SessionStatus.Disconnected)
             {
-                if (_admins.Remove(e.Session) && _cfg.GetCVar(CCVars.AdminAnnounceLogout))
+                if (_admins.Remove(e.Session, out var reg ) && _cfg.GetCVar(CCVars.AdminAnnounceLogout))
                 {
-                    _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-admin-logout-message", ("name", e.Session.Name)));
+                    if (reg.Data.Stealth)
+                    {
+                        _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-admin-logout-message",
+                            ("name", e.Session.Name)), flagWhitelist: AdminFlags.Stealth);
+
+                    }
+                    else
+                    {
+                        _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-admin-logout-message",
+                            ("name", e.Session.Name)));
+                    }
                 }
             }
         }
@@ -308,13 +368,27 @@ namespace Content.Server.Administration.Managers
 
             _admins.Add(session, reg);
 
+            if (session.ContentData()!.Stealthed)
+                reg.Data.Stealth = true;
+
             if (!session.ContentData()!.ExplicitlyDeadminned)
             {
                 reg.Data.Active = true;
 
                 if (_cfg.GetCVar(CCVars.AdminAnnounceLogin))
                 {
-                    _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-admin-login-message", ("name", session.Name)));
+                    if (reg.Data.Stealth)
+                    {
+
+                        _chat.DispatchServerMessage(session, Loc.GetString("admin-manager-stealthed-message"));
+                        _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-admin-login-message",
+                            ("name", session.Name)), flagWhitelist: AdminFlags.Stealth);
+                    }
+                    else
+                    {
+                        _chat.SendAdminAnnouncement(Loc.GetString("admin-manager-admin-login-message",
+                            ("name", session.Name)));
+                    }
                 }
 
                 SendPermsChangedEvent(session);

--- a/Content.Server/Administration/Managers/IAdminManager.cs
+++ b/Content.Server/Administration/Managers/IAdminManager.cs
@@ -42,6 +42,16 @@ namespace Content.Server.Administration.Managers
         void ReAdmin(ICommonSession session);
 
         /// <summary>
+        ///     Make admin hidden from adminwho.
+        /// </summary>
+        void Stealth(ICommonSession session);
+
+        /// <summary>
+        ///     Unhide admin from adminwho.
+        /// </summary>
+        void UnStealth(ICommonSession session);
+
+        /// <summary>
         ///     Re-loads the permissions of an player in case their admin data changed DB-side.
         /// </summary>
         /// <seealso cref="ReloadAdminsWithRank"/>

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -125,9 +125,23 @@ namespace Content.Server.Chat.Managers
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Server message to {player:Player}: {message}");
         }
 
-        public void SendAdminAnnouncement(string message)
+        public void SendAdminAnnouncement(string message, AdminFlags? flagBlacklist, AdminFlags? flagWhitelist)
         {
-            var clients = _adminManager.ActiveAdmins.Select(p => p.Channel);
+            var clients = _adminManager.ActiveAdmins.Where(p =>
+            {
+                var adminData = _adminManager.GetAdminData(p);
+
+                DebugTools.AssertNotNull(adminData);
+
+                if (adminData == null)
+                    return false;
+
+                if (flagBlacklist != null && adminData.HasFlag(flagBlacklist.Value))
+                    return false;
+
+                return flagWhitelist == null || adminData.HasFlag(flagWhitelist.Value);
+
+            }).Select(p => p.Channel);
 
             var wrappedMessage = Loc.GetString("chat-manager-send-admin-announcement-wrap-message",
                 ("adminChannelName", Loc.GetString("chat-manager-admin-channel-name")), ("message", FormattedMessage.EscapeText(message)));

--- a/Content.Server/Chat/Managers/IChatManager.cs
+++ b/Content.Server/Chat/Managers/IChatManager.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Administration;
 using Content.Shared.Chat;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -21,7 +22,7 @@ namespace Content.Server.Chat.Managers
         void TrySendOOCMessage(ICommonSession player, string message, OOCChatType type);
 
         void SendHookOOC(string sender, string message);
-        void SendAdminAnnouncement(string message);
+        void SendAdminAnnouncement(string message, AdminFlags? flagBlacklist = null, AdminFlags? flagWhitelist = null);
         void SendAdminAlert(string message);
         void SendAdminAlert(EntityUid player, string message);
 

--- a/Content.Shared/Administration/AdminData.cs
+++ b/Content.Shared/Administration/AdminData.cs
@@ -13,6 +13,11 @@ namespace Content.Shared.Administration
         public bool Active;
 
         /// <summary>
+        /// Whether the admin is in stealth mode and won't appear in adminwho to admins without the Stealth flag.
+        /// </summary>
+        public bool Stealth;
+
+        /// <summary>
         ///     The admin's title.
         /// </summary>
         public string? Title;
@@ -54,6 +59,14 @@ namespace Content.Shared.Administration
         public bool CanAdminMenu()
         {
             return HasFlag(AdminFlags.Admin);
+        }
+
+        /// <summary>
+        /// Check if this admin can be hidden and see other hidden admins.
+        /// </summary>
+        public bool CanStealth()
+        {
+            return HasFlag(AdminFlags.Stealth);
         }
 
         public bool CanAdminReloadPrototypes()

--- a/Content.Shared/Administration/AdminFlags.cs
+++ b/Content.Shared/Administration/AdminFlags.cs
@@ -95,6 +95,11 @@
         MassBan = 1 << 15,
 
         /// <summary>
+        /// Allows you to remain hidden from adminwho except to other admins with this flag.
+        /// </summary>
+        Stealth = 1 << 16,
+
+        /// <summary>
         ///     Dangerous host permissions like scsi.
         /// </summary>
         Host = 1u << 31,

--- a/Content.Shared/Players/ContentPlayerData.cs
+++ b/Content.Shared/Players/ContentPlayerData.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.GameTicking;
+﻿using Content.Shared.Administration;
+using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Robust.Shared.Network;
 
@@ -36,6 +37,11 @@ public sealed class ContentPlayerData
     ///     so they should not regain admin if they reconnect.
     /// </summary>
     public bool ExplicitlyDeadminned { get; set; }
+
+    /// <summary>
+    /// If true, the admin will not show up in adminwho except to admins with the <see cref="AdminFlags.Stealth"/> flag.
+    /// </summary>
+    public bool Stealthed { get; set; }
 
     public ContentPlayerData(NetUserId userId, string name)
     {

--- a/Resources/Locale/en-US/administration/managers/admin-manager.ftl
+++ b/Resources/Locale/en-US/administration/managers/admin-manager.ftl
@@ -7,3 +7,5 @@ admin-manager-admin-permissions-updated-message = Your admin permission have bee
 admin-manager-admin-logout-message = Admin logout: {$name}
 admin-manager-admin-login-message = Admin login: {$name}
 admin-manager-admin-data-host-title = Host
+admin-manager-stealthed-message = You are now a hidden admin.
+admin-manager-unstealthed-message = You are no longer hidden.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

resolve #26013 

## About the PR
<!-- What did you change in this PR? -->
This pr implements stealthmins as laid out in issue #26013. 

There is now the Stealth permission flag. This allows admins to use the stealthmin command and to see other stealthmins.

When stealthmin is toggled, the admin will not show up in adminwho except for other admins with the Stealth permission.

The stealthmin command sends fake de-admin/re-admin messages to admins without the Stealth flag. 

stealthmin persists in the same way deadmin does. 

Admin login/logout messages are suppressed for stealthmins except for other admins with the Stealth flag. 

It is still possible possible to find stealthed admins using toolshed commands or logs. This is in line with the requirements of the issue, and I don't want to start clobbering functionality of logs and toolshed.

## Why / Balance

See #26013 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Stealth flag now exist for AdminFlags. 

An admin's stealth status is saved in their admin registration and in ContentData.

SendAdminAnnouncement now takes a whitelist flag and blacklist flag (This will work with multiple flags). This is necessary to suppress admin announcements where necessary. Blacklist takes priority over whitelist.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/32041239/98ec48c3-170e-406a-b177-07003ff7d59f


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
ADMIN:
- add: The stealthmin command has been added. Admins with the Stealth permission can now hide themselves from adminwho except for other admins with that permission.