### PR TITLE
Make the cargo telepad T2 civilian

### DIFF
--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -186,8 +186,6 @@
   - WeaponSprayNozzle
   - ClothingBackpackWaterTank
 
-# Tier 3
-
 - type: technology
   id: BluespaceCargoTransport
   name: research-technology-bluespace-cargo-transport
@@ -195,10 +193,12 @@
     sprite: Structures/cargo_telepad.rsi
     state: display
   discipline: CivilianServices
-  tier: 3
+  tier: 2
   cost: 15000
   recipeUnlocks:
   - CargoTelepadMachineCircuitboard
+
+# Tier 3
 
 - type: technology
   id: QuantumFiberWeaving


### PR DESCRIPTION
## About the PR
The cargo telepad is now a T2 civilian research.

## Why / Balance
It's never used currently even when people get speed boots, you can't even sell through it so you still have to go to the ATS to make money. It only decreases waiting times for orders which is quite convenient but not exactly powerful.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The cargo telepad is now tier 2 technology rather than tier 3.
