### PR TITLE
FTL UIScale fixes

### DIFF
--- a/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
@@ -66,11 +66,11 @@ public partial class BaseShuttleControl : MapGridControl
 
     protected void DrawData(DrawingHandleScreen handle, string text)
     {
-        var coordsDimensions = handle.GetDimensions(Font, text, UIScale);
+        var coordsDimensions = handle.GetDimensions(Font, text, 1f);
         const float coordsMargins = 5f;
 
         handle.DrawString(Font,
-            new Vector2(coordsMargins, Height) - new Vector2(0f, coordsDimensions.Y + coordsMargins),
+            new Vector2(coordsMargins, PixelHeight) - new Vector2(0f, coordsDimensions.Y + coordsMargins),
             text,
             Color.FromSrgb(IFFComponent.SelfColor));
     }

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -116,7 +116,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
                 var mapTransform = Matrix3.CreateInverseTransform(Offset, Angle.Zero);
 
-                if (beaconsOnly && TryGetBeacon(_beacons, mapTransform, args.RelativePosition, PixelRect, out var foundBeacon, out _))
+                if (beaconsOnly && TryGetBeacon(_beacons, mapTransform, args.RelativePixelPosition, PixelRect, out var foundBeacon, out _))
                 {
                     RequestBeaconFTL?.Invoke(foundBeacon.Entity, _ftlAngle);
                 }
@@ -206,7 +206,8 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
     private List<IMapObject> GetViewportMapObjects(Matrix3 matty, List<IMapObject> mapObjects)
     {
         var results = new List<IMapObject>();
-        var viewBox = SizeBox.Scale(1.2f);
+        var enlargement = new Vector2i((int) (16 * UIScale), (int) (16 * UIScale));
+        var viewBox = new UIBox2i(Vector2i.Zero - enlargement, PixelSize + enlargement);
 
         foreach (var mapObj in mapObjects)
         {
@@ -398,8 +399,8 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
             foreach (var (gridUiPos, iffText) in sendStrings)
             {
-                var textWidth = handle.GetDimensions(_font, iffText, UIScale);
-                handle.DrawString(_font, gridUiPos + textWidth with { X = -textWidth.X / 2f }, iffText, adjustedColor);
+                var textWidth = handle.GetDimensions(_font, iffText, 1f);
+                handle.DrawString(_font, gridUiPos + textWidth with { X = -textWidth.X / 2f, Y = textWidth.Y * UIScale }, iffText, adjustedColor);
             }
         }
 
@@ -587,7 +588,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
             var distance = (localPos - mousePos).Length();
 
-            if (distance > BeaconSnapRange ||
+            if (distance > BeaconSnapRange * UIScale ||
                 distance > nearestValue)
             {
                 continue;


### PR DESCRIPTION
- Fix text drawing being offset.
- Fix beacon snapping and distance check.
- Fix DrawData being offset.
- Fix bounds check for map objects not using PixelSize.

Resolves https://github.com/space-wizards/space-station-14/issues/26028

:cl:
- fix: Fix some shuttle console stuff surrounding the Map screen.