### PR TITLE
Fix puller being improperly unset when pulling stops.

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -201,13 +201,18 @@ public sealed class PullingSystem : EntitySystem
             }
         }
 
+        var oldPuller = pullableComp.Puller;
+        pullableComp.PullJointId = null;
+        pullableComp.Puller = null;
+        Dirty(pullableUid, pullableComp);
+
         // No more joints with puller -> force stop pull.
-        if (TryComp<PullerComponent>(pullableComp.Puller, out var pullerComp))
+        if (TryComp<PullerComponent>(oldPuller, out var pullerComp))
         {
-            var pullerUid = pullableComp.Puller.Value;
+            var pullerUid = oldPuller.Value;
             _alertsSystem.ClearAlert(pullerUid, AlertType.Pulling);
             pullerComp.Pulling = null;
-            Dirty(pullableComp.Puller.Value, pullerComp);
+            Dirty(oldPuller.Value, pullerComp);
 
             // Messaging
             var message = new PullStoppedMessage(pullerUid, pullableUid);
@@ -218,9 +223,6 @@ public sealed class PullingSystem : EntitySystem
             RaiseLocalEvent(pullableUid, message);
         }
 
-        pullableComp.PullJointId = null;
-        pullableComp.Puller = null;
-        Dirty(pullableUid, pullableComp);
 
         _alertsSystem.ClearAlert(pullableUid, AlertType.Pulled);
     }


### PR DESCRIPTION
fixes #26310

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This pr fixes the bug with people being unable to move while in cuffs if they were previously pulled even if they were no longer being pulled.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
A security cadet should not be able to merge my legs with the ground by simply touching me while I'm in cuffs.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

When unpulled, the pullableComp has its puller field set to null after the message signifying the pulling has stopped has been sent. Since the component has a field to determine whether its owner is being pulled which is determined by the puller field, systems listening on the event would think that the owner of the component was still being pulled.

As a result, when the message was fired and the SharedCuffableSystem checked whether it should allow the cuffed person to move it thought they were still being pulled and as such didn't allow them to move. 

I spent some time trying to determine whether setting the puller to null earlier would have other negative effects, however to my understanding of the code and the systems that listen to the message I believe this is now the correct behavior. Still just in case @metalgearsloth please check this out thanks.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- fix: You can now move again if you stop being pulled while in cuffs.