### PR TITLE
Add lslaws command

### DIFF
--- a/Content.Server/Silicons/Laws/ListLawsCommand.cs
+++ b/Content.Server/Silicons/Laws/ListLawsCommand.cs
@@ -1,0 +1,62 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Silicons.Laws.Components;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+
+namespace Content.Server.Silicons.Laws;
+
+[AdminCommand(AdminFlags.Logs)]
+public sealed class ListLawsCommand : LocalizedCommands
+{
+        [Dependency] private readonly IEntityManager _entities = default!;
+        [Dependency] private readonly IPlayerManager _players = default!;
+    public override string Command => "lslaws";
+
+    public override string Description => Loc.GetString("cmd-lslaws-description");
+
+    public override string Help => Loc.GetString("cmd-lslaws-help");
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteError(Loc.GetString("cmd-lslaws-invalid-arguments"));
+            return;
+        }
+
+        if (!_players.TryGetSessionByUsername(args[0], out var player))
+        {
+            shell.WriteError(Loc.GetString("shell-target-player-does-not-exist"));
+            return;
+        }
+
+        if (player.AttachedEntity == null ||
+            !_entities.TryGetComponent<SiliconLawBoundComponent>(player.AttachedEntity.Value, out var comp))
+        {
+            shell.WriteError(Loc.GetString("shell-target-entity-does-not-have-message", ("missing", "SiliconLawBoundComponent")));
+            return;
+        }
+
+        var borgSystem = _entities.System<SiliconLawSystem>();
+
+        var laws = borgSystem.GetLaws(player.AttachedEntity.Value, comp);
+
+        foreach (var law in laws.Laws)
+        {
+            shell.WriteLine($"Law {law.LawIdentifierOverride ?? law.Order.ToString()}: {Loc.GetString(law.LawString)}");
+
+        }
+
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), LocalizationManager.GetString("shell-argument-username-hint"));
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Resources/Locale/en-US/station-laws/lslaws.ftl
+++ b/Resources/Locale/en-US/station-laws/lslaws.ftl
@@ -1,0 +1,3 @@
+cmd-lslaws-description = Lists the laws of a law abiding borg.
+cmd-lslaws-help = Usage: lslaws <username>
+cmd-lslaws-invalid-arguments = Invalid number of arguments provided


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds the lslaws command for admins. The command lists the active laws of a borg.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Currently the only ways to get borg laws from a borg as an admin is to either go VV diving, or use toolshed commands. The former is time consuming, and admins often lack the knowledge to do the latter while also being less convenient than a simple command. 

This ideally would just be a verb that opens the borg's laws gui without allowing you to state them but this works for now. I'll probably make that in a time where I have more sleep. Even still I often find myself just typing out commands for verbs that give you a gui because it's usually faster so I think this will be useful even if a verb is added.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/32041239/fef15352-ca96-4304-84d6-5484b6527d72)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: 
ADMIN: 
- add: The lslaws command was added and can be used to view the laws of a borg in the console. 
