### PR TITLE
Construction module additions and tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -199,6 +199,15 @@
         canReact: false
 
 - type: entity
+  parent: SheetRGlass
+  id: SheetRGlassLingering0
+  suffix: Lingering, 0
+  components:
+  - type: Stack
+    lingering: true
+    count: 0
+
+- type: entity
   parent: SheetGlassBase
   id: SheetPGlass
   name: plasma glass

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -230,3 +230,12 @@
   - type: Stack
     stackType: Plasteel
     count: 1
+
+- type: entity
+  parent: SheetPlasteel
+  id: SheetPlasteelLingering0
+  suffix: Lingering, 0
+  components:
+  - type: Stack
+    lingering: true
+    count: 0

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -245,8 +245,8 @@
     - GeigerCounter
 
 - type: entity
-  id: BorgModuleConstruction
-  parent: [ BaseBorgModuleEngineering, BaseProviderBorgModule ]
+  id: BorgModuleConstruction # todo: make it so borgs can hold any kind of 'sheet' and make less duct tape fixes
+  parent: [ BaseBorgModuleEngineering, BaseProviderBorgModule ] 
   name: construction cyborg module
   components:
   - type: Sprite
@@ -256,7 +256,9 @@
   - type: ItemBorgModule
     items:
     - SheetSteelLingering0
+    - SheetPlasteelLingering0
     - SheetGlassLingering0
+    - SheetRGlassLingering0
     - PartRodMetalLingering0
     - FloorTileItemSteelLingering0
 


### PR DESCRIPTION

## About the PR
I just added plasteel and reinforced glass to the selection, this change will be a stand-in while I make the actual PR as it'll take longer.

## Why / Balance
The common question I have is "why can't i pick up reinforced glass or plasteel", today I stop asking I'm tired

## Media
new module changes
![image](https://github.com/space-wizards/space-station-14/assets/156087924/326aeff9-6f16-4113-8bd2-9eeefa953fca)


:cl:
- tweak: The construction cyborg module has been changed, borgs can now carry plasteel and reinforced glass.
