### PR TITLE
Create DeviceNetworkJammerComponent & System as a general way for entities to act as jammers

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkJammerSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkJammerSystem.cs
@@ -1,0 +1,36 @@
+using Content.Server.DeviceNetwork.Components;
+using Content.Shared.DeviceNetwork.Components;
+
+namespace Content.Server.DeviceNetwork.Systems;
+
+public sealed class DeviceNetworkJammerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TransformComponent, BeforePacketSentEvent>(BeforePacketSent);
+    }
+
+    private void BeforePacketSent(EntityUid uid, TransformComponent xform, BeforePacketSentEvent ev)
+    {
+        if (ev.Cancelled)
+            return;
+
+        var query = EntityQueryEnumerator<DeviceNetworkJammerComponent, TransformComponent>();
+
+        while (query.MoveNext(out _, out var jammerComp, out var jammerXform))
+        {
+            if (!jammerComp.JammableNetworks.Contains(ev.NetworkId))
+                continue;
+
+            if ((jammerXform.Coordinates.TryDistance(EntityManager, ev.SenderTransform.Coordinates, out var distance) && distance <= jammerComp.Range)
+                || (jammerXform.Coordinates.TryDistance(EntityManager, xform.Coordinates, out var recvDistance) && recvDistance <= jammerComp.Range))
+            {
+                ev.Cancel();
+                return;
+            }
+        }
+    }
+
+}

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -351,13 +351,14 @@ namespace Content.Server.DeviceNetwork.Systems
 
             var xform = Transform(packet.Sender);
 
-            BeforePacketSentEvent beforeEv = new(packet.Sender, xform, _transformSystem.GetWorldPosition(xform));
+            var senderPos = _transformSystem.GetWorldPosition(xform);
 
             foreach (var connection in connections)
             {
                 if (connection.Owner == packet.Sender)
                     continue;
 
+                BeforePacketSentEvent beforeEv = new(packet.Sender, xform, senderPos, connection.NetIdEnum.ToString());
                 RaiseLocalEvent(connection.Owner, beforeEv, false);
 
                 if (!beforeEv.Cancelled)
@@ -386,11 +387,17 @@ namespace Content.Server.DeviceNetwork.Systems
         /// </summary>
         public readonly Vector2 SenderPosition;
 
-        public BeforePacketSentEvent(EntityUid sender, TransformComponent xform, Vector2 senderPosition)
+        /// <summary>
+        /// The network the packet will be sent to.
+        /// </summary>
+        public readonly string NetworkId;
+
+        public BeforePacketSentEvent(EntityUid sender, TransformComponent xform, Vector2 senderPosition, string networkId)
         {
             Sender = sender;
             SenderTransform = xform;
             SenderPosition = senderPosition;
+            NetworkId = networkId;
         }
     }
 

--- a/Content.Server/DeviceNetwork/Systems/SingletonDeviceNetServerSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/SingletonDeviceNetServerSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.DeviceNetwork.Components;
+﻿using System.Diagnostics.CodeAnalysis;
+using Content.Server.DeviceNetwork.Components;
 using Content.Server.Medical.CrewMonitoring;
 using Content.Server.Power.Components;
 using Content.Server.Station.Systems;
@@ -38,7 +39,7 @@ public sealed class SingletonDeviceNetServerSystem : EntitySystem
     /// <param name="address">The address of the active server if it exists</param>
     /// <typeparam name="TComp">The component type that determines what type of server you're getting the address of</typeparam>
     /// <returns>True if there is an active serve. False otherwise</returns>
-    public bool TryGetActiveServerAddress<TComp>(EntityUid stationId, out string? address) where TComp : IComponent
+    public bool TryGetActiveServerAddress<TComp>(EntityUid stationId, [NotNullWhen(true)] out string? address) where TComp : IComponent
     {
         var servers = EntityQueryEnumerator<
             SingletonDeviceNetServerComponent,

--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -87,9 +87,3 @@ public sealed partial class SuitSensorComponent : Component
     [DataField, ViewVariables]
     public bool PreviousControlsLocked = false;
 }
-
-[ByRefEvent]
-public record struct SuitSensorsSendAttemptEvent
-{
-    public bool Cancelled;
-};

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -73,11 +73,6 @@ public sealed class SuitSensorSystem : EntitySystem
             // TODO: This would cause imprecision at different tick rates.
             sensor.NextUpdate = curTime + sensor.UpdateRate;
 
-            var canEv = new SuitSensorsSendAttemptEvent();
-            RaiseLocalEvent(uid, ref canEv);
-            if (canEv.Cancelled)
-                continue;
-
             // get sensor status
             var status = GetSensorState(uid, sensor);
             if (status == null)

--- a/Content.Server/Radio/EntitySystems/JammerSystem.cs
+++ b/Content.Server/Radio/EntitySystems/JammerSystem.cs
@@ -1,8 +1,12 @@
-using Content.Server.Medical.SuitSensors;
+using Content.Server.DeviceNetwork.Components;
+using Content.Server.DeviceNetwork.Systems;
+using Content.Server.Medical.CrewMonitoring;
 using Content.Server.Popups;
 using Content.Server.Power.EntitySystems;
 using Content.Server.PowerCell;
 using Content.Server.Radio.Components;
+using Content.Server.Station.Systems;
+using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.PowerCell.Components;
@@ -15,6 +19,8 @@ public sealed class JammerSystem : EntitySystem
     [Dependency] private readonly BatterySystem _battery = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly SingletonDeviceNetServerSystem _singletonServerSystem = default!;
 
     public override void Initialize()
     {
@@ -24,7 +30,6 @@ public sealed class JammerSystem : EntitySystem
         SubscribeLocalEvent<ActiveRadioJammerComponent, PowerCellChangedEvent>(OnPowerCellChanged);
         SubscribeLocalEvent<RadioJammerComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<RadioSendAttemptEvent>(OnRadioSendAttempt);
-        SubscribeLocalEvent<SuitSensorComponent, SuitSensorsSendAttemptEvent>(OnSensorSendAttempt);
     }
 
     public override void Update(float frameTime)
@@ -36,6 +41,7 @@ public sealed class JammerSystem : EntitySystem
                 !_battery.TryUseCharge(batteryUid.Value, jam.Wattage * frameTime, battery))
             {
                 RemComp<ActiveRadioJammerComponent>(uid);
+                RemComp<DeviceNetworkJammerComponent>(uid);
             }
         }
     }
@@ -48,10 +54,19 @@ public sealed class JammerSystem : EntitySystem
         if (activated)
         {
             EnsureComp<ActiveRadioJammerComponent>(uid);
+            var stationId = _stationSystem.GetOwningStation(uid);
+            if (stationId != null && _singletonServerSystem.TryGetActiveServerAddress<CrewMonitoringServerComponent>(stationId.Value, out var netId))
+            {
+                EnsureComp<DeviceNetworkJammerComponent>(uid, out var jammingComp);
+                jammingComp.Range = comp.Range;
+                jammingComp.JammableNetworks.Add(netId);
+                Dirty(uid, jammingComp);
+            }
         }
         else
         {
             RemComp<ActiveRadioJammerComponent>(uid);
+            RemComp<DeviceNetworkJammerComponent>(uid);
         }
         var state = Loc.GetString(activated ? "radio-jammer-component-on-state" : "radio-jammer-component-off-state");
         var message = Loc.GetString("radio-jammer-component-on-use", ("state", state));
@@ -79,14 +94,6 @@ public sealed class JammerSystem : EntitySystem
     private void OnRadioSendAttempt(ref RadioSendAttemptEvent args)
     {
         if (ShouldCancelSend(args.RadioSource))
-        {
-            args.Cancelled = true;
-        }
-    }
-
-    private void OnSensorSendAttempt(EntityUid uid, SuitSensorComponent comp, ref SuitSensorsSendAttemptEvent args)
-    {
-        if (ShouldCancelSend(uid))
         {
             args.Cancelled = true;
         }

--- a/Content.Shared/DeviceNetwork/Components/DeviceNetworkJammerComponent.cs
+++ b/Content.Shared/DeviceNetwork/Components/DeviceNetworkJammerComponent.cs
@@ -1,0 +1,24 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.DeviceNetwork.Components;
+
+/// <summary>
+/// Allow entities to jam DeviceNetwork packets.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class DeviceNetworkJammerComponent : Component
+{
+    /// <summary>
+    /// Range where packets will be jammed. This is checked both against the sender and receiver.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Range = 5.0f;
+
+    /// <summary>
+    /// Device networks that can be jammed. For a list of default NetworkIds see DeviceNetIdDefaults on Content.Server.
+    /// Network ids are not guaranteed to be limited to DeviceNetIdDefaults.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<string> JammableNetworks = [];
+
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR creates the DeviceNetworkJammerComponent & System as a general way for entities to act as jammers for the DeviceNetwork.

Additionally it adjusts the JammerSystem for the radio jammer to use this, and rips out the previous special code for jamming suit sensors.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This pr was requested by a maintainer.

Additionally a general jamming system can have some utility in the future. E.g. an artifact effect. 
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Whenever a device attempts to send a packet, the
DeviceNetworkJammerSystem listens for the BeforePacketSentEvent.
From there if any entity with the jammer component is within range of
either the sender or receiver of the packet the event will be cancelled.
Additionally jammers can only block packets in certain networks. If a
packet is not being transmitted in one of the networks it can block then
even if the jammer is in range the event will not be cancelled.

The range is stored in the jammer component along with the networks it
can jam.

Jammable network ids are stored as strings which seems to be how custom
networks are stored (E.g. network ids for suit sensors).

To allow for all of this, the BeforePacketSentEvent was modified to
provide the NetworkId.

The JammerSystem now needs to get the networkid for suit sensors for use in the DeviceNetwork. The previous event subscription for jamming suit sensors have been removed along with the event.

I wish I could use this to jam radios as well but radios are magic and do not use device networks.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun