### PR TITLE
Fix crash on load when no slot key assigned

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
@@ -42,11 +42,12 @@ public class ActionButtonContainer : GridContainer
         {
             var button = new ActionButton(_entity);
 
-            if (keys.TryGetValue(index, out var boundKey))
-            {
-                button.KeyBind = boundKey;
+            if (!keys.TryGetValue(index, out var boundKey))
+                return button;
 
-                var binding = _input.GetKeyBinding(boundKey);
+            button.KeyBind = boundKey;
+            if (_input.TryGetKeyBinding(boundKey, out var binding))
+            {
                 button.Label.Text = binding.GetKeyString();
             }
 


### PR DESCRIPTION
I fixed the game crashing if you don't have hotkeys assigned to the action bar slots when the game loads