### PR TITLE
Store keybind priority

### DIFF
--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -403,7 +403,7 @@ namespace Content.Client.Options.UI.Tabs
                 Mod1 = mods[0],
                 Mod2 = mods[1],
                 Mod3 = mods[2],
-                Priority = 0,
+                Priority = _currentlyRebinding.Binding?.Priority ?? 0,
                 Type = bindType,
                 CanFocus = key == Keyboard.Key.MouseLeft
                            || key == Keyboard.Key.MouseRight

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -167,6 +167,7 @@ binds:
   type: State
   key: MouseLeft
   canFocus: true
+  priority: 10
 - function: RotateStoredItem
   type: State
   key: MouseRight


### PR DESCRIPTION
Changed it so the priority isn't lost when you set a binding in the UI.
Also added a priority to MoveStoredItem so it doesn't conflict with Use.
Fixes https://github.com/space-wizards/space-station-14/issues/26142

A better solution might be to change it so the keybinds are always in the order they appear in the default keybinds folder, to prevent the ordering from changing unpredictably based on what the user overrides.