### PR TITLE
Remove Tech Randomization from Science

### DIFF
--- a/Content.Shared/Research/Systems/SharedResearchSystem.cs
+++ b/Content.Shared/Research/Systems/SharedResearchSystem.cs
@@ -24,23 +24,20 @@ public abstract class SharedResearchSystem : EntitySystem
         UpdateTechnologyCards(uid, component);
     }
 
-    public void UpdateTechnologyCards(EntityUid uid, TechnologyDatabaseComponent? component = null)
+    protected void UpdateTechnologyCards(EntityUid uid, TechnologyDatabaseComponent? component = null)
     {
         if (!Resolve(uid, ref component))
             return;
 
-        var availableTechnology = GetAvailableTechnologies(uid, component);
-        _random.Shuffle(availableTechnology);
-
         component.CurrentTechnologyCards.Clear();
-        foreach (var discipline in component.SupportedDisciplines)
-        {
-            var selected = availableTechnology.FirstOrDefault(p => p.Discipline == discipline);
-            if (selected == null)
-                continue;
 
-            component.CurrentTechnologyCards.Add(selected.ID);
+        var availableTechnology = GetAvailableTechnologies(uid, component);
+
+        foreach (var tech in availableTechnology)
+        {
+            component.CurrentTechnologyCards.Add(tech.ID);
         }
+
         Dirty(uid, component);
     }
 


### PR DESCRIPTION
## About the PR
Kills randomized tech. You can research anything you've unlocked.

## Why / Balance
Imagine if, when buying things from Cargo, it gave you a random thing out of a set of things rather than the specific item you bought. The key output of an entire role being randomized is not fun.

Randomized tech ("Stellaris Tech", as Stellaris works similarly enough and I also hate its implementation of research) is a design trap. There's an entire system of tiers and unlocks that theoretically exists but it can be essentially summed up as "shit that is an aside to if the loot fairy said yes to what techs you have available".

You can't design anything for Science to actually build or unlock that is important, because you can't guarantee Science will ever see that tech, because it's a dice roll unless you're rolling via an exploit or luck.

The code probably supports having a full, Civ-style tech tree of ten or more tiers, which would at least allow the RD and their crew to have goals and build toward something during the round.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

**Changelog**
:cl:
- tweak: Randomized science tech choices have been removed. Research whatever you have the pre-requisites for.
