### PR TITLE
Add AP damage to throwing knives

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -275,6 +275,7 @@
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
   - type: DamageOtherOnHit
+    ignoreResistances: true
     damage:
       types:
         Slash: 10

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -282,7 +282,3 @@
         Piercing: 15
   - type: Item
     sprite: Objects/Weapons/Melee/throwing_knife.rsi
-  - type: StaminaDamageOnCollide
-    damage: 30
-  - type: StaminaDamageOnEmbed
-    damage: 10

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -281,3 +281,7 @@
         Piercing: 15
   - type: Item
     sprite: Objects/Weapons/Melee/throwing_knife.rsi
+  - type: StaminaDamageOnCollide
+    damage: 30
+  - type: StaminaDamageOnEmbed
+    damage: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

It was too weak, people complained. The balance was very fine tuned with the number count in the kit and the damage, so I opted to adding armour piercing damage.

**Changelog**

:cl: Ubaser
- tweak: Throwing knives now additionally do armour piercing damage.
