### PR TITLE
Fix mailing units turning into disposal units while recharging.

### DIFF
--- a/Content.Client/Disposal/Systems/DisposalUnitSystem.cs
+++ b/Content.Client/Disposal/Systems/DisposalUnitSystem.cs
@@ -101,12 +101,16 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         sprite.LayerSetVisible(DisposalUnitVisualLayers.Base, state == VisualState.Anchored);
         sprite.LayerSetVisible(DisposalUnitVisualLayers.BaseFlush, state is VisualState.Flushing or VisualState.Charging);
 
+        sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseCharging, out var chargingLayer);
+        var chargingState = sprite.LayerGetState(chargingLayer);
+
         // This is a transient state so not too worried about replaying in range.
         if (state == VisualState.Flushing)
         {
             if (!_animationSystem.HasRunningAnimation(uid, AnimationKey))
             {
-                var flushState = new RSI.StateId("disposal-flush");
+                sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseFlush, out var flushLayer);
+                var flushState = sprite.LayerGetState(flushLayer);
 
                 // Setup the flush animation to play
                 var anim = new Animation
@@ -124,7 +128,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
                                 // Return to base state (though, depending on how the unit is
                                 // configured we might get an appearance change event telling
                                 // us to go to charging state)
-                                new AnimationTrackSpriteFlick.KeyFrame("disposal-charging", (float) unit.FlushDelay.TotalSeconds)
+                                new AnimationTrackSpriteFlick.KeyFrame(chargingState, (float) unit.FlushDelay.TotalSeconds)
                             }
                         },
                     }
@@ -147,7 +151,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         }
         else if (state == VisualState.Charging)
         {
-            sprite.LayerSetState(DisposalUnitVisualLayers.BaseFlush, new RSI.StateId("disposal-charging"));
+            sprite.LayerSetState(DisposalUnitVisualLayers.BaseFlush, chargingState);
         }
         else
         {

--- a/Content.Client/Disposal/Systems/DisposalUnitSystem.cs
+++ b/Content.Client/Disposal/Systems/DisposalUnitSystem.cs
@@ -22,6 +22,9 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
 
     private const string AnimationKey = "disposal_unit_animation";
 
+    private const string DefaultFlushState = "disposal-flush";
+    private const string DefaultChargeState = "disposal-charging";
+
     public override void Initialize()
     {
         base.Initialize();
@@ -103,7 +106,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
 
         var chargingState = sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseCharging, out var chargingLayer)
             ? sprite.LayerGetState(chargingLayer)
-            : new RSI.StateId("disposal-charging");
+            : new RSI.StateId(DefaultChargeState);
 
         // This is a transient state so not too worried about replaying in range.
         if (state == VisualState.Flushing)
@@ -112,7 +115,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
             {
                 var flushState = sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseFlush, out var flushLayer)
                     ? sprite.LayerGetState(flushLayer)
-                    : new RSI.StateId("disposal-flush");
+                    : new RSI.StateId(DefaultFlushState);
 
                 // Setup the flush animation to play
                 var anim = new Animation

--- a/Content.Client/Disposal/Systems/DisposalUnitSystem.cs
+++ b/Content.Client/Disposal/Systems/DisposalUnitSystem.cs
@@ -101,16 +101,18 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         sprite.LayerSetVisible(DisposalUnitVisualLayers.Base, state == VisualState.Anchored);
         sprite.LayerSetVisible(DisposalUnitVisualLayers.BaseFlush, state is VisualState.Flushing or VisualState.Charging);
 
-        sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseCharging, out var chargingLayer);
-        var chargingState = sprite.LayerGetState(chargingLayer);
+        var chargingState = sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseCharging, out var chargingLayer)
+            ? sprite.LayerGetState(chargingLayer)
+            : new RSI.StateId("disposal-charging");
 
         // This is a transient state so not too worried about replaying in range.
         if (state == VisualState.Flushing)
         {
             if (!_animationSystem.HasRunningAnimation(uid, AnimationKey))
             {
-                sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseFlush, out var flushLayer);
-                var flushState = sprite.LayerGetState(flushLayer);
+                var flushState = sprite.LayerMapTryGet(DisposalUnitVisualLayers.BaseFlush, out var flushLayer)
+                    ? sprite.LayerGetState(flushLayer)
+                    : new RSI.StateId("disposal-flush");
 
                 // Setup the flush animation to play
                 var anim = new Animation

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -16,6 +16,8 @@
       map: [ "enum.DisposalUnitVisualLayers.Unanchored" ]
     - state: disposal
       map: [ "enum.DisposalUnitVisualLayers.Base" ]
+    - state: disposal-charging
+      map: [ "enum.DisposalUnitVisualLayers.BaseCharging" ]
     - state: disposal-flush
       map: [ "enum.DisposalUnitVisualLayers.BaseFlush" ]
     - state: dispover-charge


### PR DESCRIPTION
fixes #18275
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This fixes mailing units appearing as disposal units when flushed.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The states were hardcoded.

Now they are not.

Bug seems to have been introduced in #17803 as a part of a larger refactor on disposal units. To my understanding, this was made in error with the logic that no other objects would ever have a different animation when flushing and charging but I am not sure. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- fix: Mailing units no longer spontaneously turn into disposal units when flushed.