### PR TITLE
Adds "untriaged" labeler workflow

### DIFF
--- a/.github/workflows/labeler-untriaged.yml
+++ b/.github/workflows/labeler-untriaged.yml
@@ -1,0 +1,13 @@
+﻿name: "Labels: Untriaged"
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions-ecosystem/action-add-labels@v1
+      with:
+        labels: "Status: Untriaged"


### PR DESCRIPTION
All new opened issues automatically get marked as "untriaged", so a maintainer can go through them properly.
