### PR TITLE
Lizards being able to weh through chat

### DIFF
--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -331,7 +331,7 @@
       metabolismRate: 0.25
       effects:
       - !type:Emote
-        emote: Weh
+        emote: JuiceWeh
         showInChat: true
         probability: 0.5
       - !type:Polymorph

--- a/Resources/Prototypes/SoundCollections/emotes.yml
+++ b/Resources/Prototypes/SoundCollections/emotes.yml
@@ -76,6 +76,11 @@
     - /Audio/Voice/Slime/slime_squish.ogg
 
 - type: soundCollection
+  id: JuiceWeh
+  files:
+  - /Audio/Items/Toys/weh.ogg
+
+- type: soundCollection
   id: Weh
   files:
   - /Audio/Items/Toys/weh.ogg

--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -32,8 +32,8 @@
       collection: MaleCry
     Whistle:
       collection: Whistles
-    Weh:
-      collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
 
 - type: emoteSounds
   id: FemaleHuman
@@ -68,8 +68,8 @@
       collection: FemaleCry
     Whistle:
       collection: Whistles
-    Weh:
-      collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
 
 - type: emoteSounds
   id: UnisexReptilian
@@ -88,6 +88,8 @@
       collection: MaleCry
     Weh:
       collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
 
 - type: emoteSounds
   id: MaleSlime
@@ -122,8 +124,8 @@
       collection: MaleCry
     Whistle:
       collection: Whistles
-    Weh:
-      collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
   params:
     variation: 0.125
 
@@ -160,8 +162,8 @@
       collection: FemaleCry
     Whistle:
       collection: Whistles
-    Weh:
-      collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
   params:
     variation: 0.125
 
@@ -185,8 +187,8 @@
       collection: DionaLaugh
     Honk:
       collection: BikeHorn
-    Weh:
-      collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
   params:
     variation: 0.125
 
@@ -203,8 +205,8 @@
       path: /Audio/Voice/Arachnid/arachnid_chitter.ogg
     Click:
       path: /Audio/Voice/Arachnid/arachnid_click.ogg
-    Weh:
-      collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
 
 - type: emoteSounds
   id: UnisexDwarf
@@ -237,8 +239,8 @@
       collection: MaleCry
     Whistle:
       collection: Whistles
-    Weh:
-      collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
   params:
     variation: 0.125
     pitch: 0.75
@@ -274,8 +276,8 @@
       collection: FemaleCry
     Whistle:
       collection: Whistles
-    Weh:
-      collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
   params:
     variation: 0.125
     pitch: 0.75
@@ -295,8 +297,8 @@
       path: /Audio/Voice/Moth/moth_chitter.ogg
     Squeak:
       path: /Audio/Voice/Moth/moth_squeak.ogg
-    Weh:
-      collection: Weh
+    JuiceWeh:
+      collection: JuiceWeh
 
 # body emotes
 - type: emoteSounds

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -243,9 +243,24 @@
     - buzzes!
 
 - type: emote
+  id: JuiceWeh
+  category: Vocal
+  chatMessages: [Wehs!]
+
+- type: emote
   id: Weh
   category: Vocal
   chatMessages: [Wehs!]
+  chatTriggers:
+    - weh
+    - weh.
+    - weh!
+    - wehs
+    - wehs.
+    - wehs!
+    - wehing
+    - wehing.
+    - wehing!
 
 - type: emote
   id: Chirp


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
In this PR, we made it so lizards will be able to make a sound "weh" wherever they type these things in emote chat:
"weh"
"weh."
"weh!"
"wehs"
"wehs."
"wehs!"
"wehing"
"wehing."
"wehing!"

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
As we all know, lizard plushie can weh. But lizard people cannot, and we decided it will be great for them to be able to.
Weh is important anyways.


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/159550239/7fab74c0-a4b5-45fb-91c6-4dfa26778e59

**Changelog**

:cl:
- add: Added weh to lizards through chat,

