### PR TITLE
Nerf ninja research stealing

### DIFF
--- a/Content.Server/Research/Systems/ResearchStealerSystem.cs
+++ b/Content.Server/Research/Systems/ResearchStealerSystem.cs
@@ -34,8 +34,8 @@ public sealed class ResearchStealerSystem : SharedResearchStealerSystem
                 break;
 
             var toRemove = _random.Pick(database.UnlockedTechnologies);
-            _research.TryRemoveTechnology(toRemove, (target, database));
-            ev.Techs.Add(toRemove);
+            if (_research.TryRemoveTechnology((target, database), toRemove))
+                ev.Techs.Add(toRemove);
         }
         RaiseLocalEvent(uid, ref ev);
 
@@ -44,7 +44,7 @@ public sealed class ResearchStealerSystem : SharedResearchStealerSystem
 }
 
 /// <summary>
-/// Event raised on the user when research is stolen from a R&D server.
+/// Event raised on the user when research is stolen from a RND server.
 /// Techs contains every technology id researched.
 /// </summary>
 [ByRefEvent]

--- a/Content.Server/Research/Systems/ResearchStealerSystem.cs
+++ b/Content.Server/Research/Systems/ResearchStealerSystem.cs
@@ -1,11 +1,13 @@
 using Content.Shared.Research.Components;
 using Content.Shared.Research.Systems;
+using Robust.Shared.Random;
 
 namespace Content.Server.Research.Systems;
 
 public sealed class ResearchStealerSystem : SharedResearchStealerSystem
 {
     [Dependency] private readonly SharedResearchSystem _research = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -24,10 +26,20 @@ public sealed class ResearchStealerSystem : SharedResearchStealerSystem
         if (!TryComp<TechnologyDatabaseComponent>(target, out var database))
             return;
 
-        var ev = new ResearchStolenEvent(uid, target, database.UnlockedTechnologies);
+        var ev = new ResearchStolenEvent(uid, target, new());
+        var count = _random.Next(comp.MinToSteal, comp.MaxToSteal + 1);
+        for (var i = 0; i < count; i++)
+        {
+            if (database.UnlockedTechnologies.Count == 0)
+                break;
+
+            var toRemove = _random.Pick(database.UnlockedTechnologies);
+            _research.TryRemoveTechnology(toRemove, (target, database));
+            ev.Techs.Add(toRemove);
+        }
         RaiseLocalEvent(uid, ref ev);
-        // oops, no more advanced lasers!
-        _research.ClearTechs(target, database);
+
+        args.Handled = true;
     }
 }
 
@@ -36,4 +48,4 @@ public sealed class ResearchStealerSystem : SharedResearchStealerSystem
 /// Techs contains every technology id researched.
 /// </summary>
 [ByRefEvent]
-public record struct ResearchStolenEvent(EntityUid Used, EntityUid Target, List<String> Techs);
+public record struct ResearchStolenEvent(EntityUid Used, EntityUid Target, List<string> Techs);

--- a/Content.Shared/Research/Components/ResearchStealerComponent.cs
+++ b/Content.Shared/Research/Components/ResearchStealerComponent.cs
@@ -14,4 +14,16 @@ public sealed partial class ResearchStealerComponent : Component
     /// </summary>
     [DataField("delay"), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan Delay = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// The minimum number of technologies that will be stolen
+    /// </summary>
+    [DataField]
+    public int MinToSteal = 4;
+
+    /// <summary>
+    /// The maximum number of technologies that will be stolen
+    /// </summary>
+    [DataField]
+    public int MaxToSteal = 8;
 }

--- a/Content.Shared/Research/Systems/SharedResearchSystem.cs
+++ b/Content.Shared/Research/Systems/SharedResearchSystem.cs
@@ -227,13 +227,19 @@ public abstract class SharedResearchSystem : EntitySystem
         Dirty(uid, component);
     }
 
-    public bool TryRemoveTechnology(ProtoId<TechnologyPrototype> tech, Entity<TechnologyDatabaseComponent> entity)
+    /// <summary>
+    /// Removes a technology and its recipes from a technology database.
+    /// </summary>
+    public bool TryRemoveTechnology(Entity<TechnologyDatabaseComponent> entity, ProtoId<TechnologyPrototype> tech)
     {
-        return TryRemoveTechnology(PrototypeManager.Index(tech), entity);
+        return TryRemoveTechnology(entity, PrototypeManager.Index(tech));
     }
 
+    /// <summary>
+    /// Removes a technology and its recipes from a technology database.
+    /// </summary>
     [PublicAPI]
-    public bool TryRemoveTechnology(TechnologyPrototype tech, Entity<TechnologyDatabaseComponent> entity)
+    public bool TryRemoveTechnology(Entity<TechnologyDatabaseComponent> entity, TechnologyPrototype tech)
     {
         if (!entity.Comp.UnlockedTechnologies.Remove(tech.ID))
             return false;

--- a/Content.Shared/Research/Systems/SharedResearchSystem.cs
+++ b/Content.Shared/Research/Systems/SharedResearchSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Content.Shared.Research.Components;
 using Content.Shared.Research.Prototypes;
+using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
@@ -219,16 +220,52 @@ public abstract class SharedResearchSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
-        var discipline = PrototypeManager.Index<TechDisciplinePrototype>(prototype.Discipline);
+        var discipline = PrototypeManager.Index(prototype.Discipline);
         if (prototype.Tier < discipline.LockoutTier)
             return;
         component.MainDiscipline = prototype.Discipline;
         Dirty(uid, component);
     }
 
+    public bool TryRemoveTechnology(ProtoId<TechnologyPrototype> tech, Entity<TechnologyDatabaseComponent> entity)
+    {
+        return TryRemoveTechnology(PrototypeManager.Index(tech), entity);
+    }
+
+    [PublicAPI]
+    public bool TryRemoveTechnology(TechnologyPrototype tech, Entity<TechnologyDatabaseComponent> entity)
+    {
+        if (!entity.Comp.UnlockedTechnologies.Remove(tech.ID))
+            return false;
+
+        // check to make sure we didn't somehow get the recipe from another tech.
+        // unlikely, but whatever
+        var recipes = tech.RecipeUnlocks;
+        foreach (var recipe in recipes)
+        {
+            var hasTechElsewhere = false;
+            foreach (var unlockedTech in entity.Comp.UnlockedTechnologies)
+            {
+                var unlockedTechProto = PrototypeManager.Index<TechnologyPrototype>(unlockedTech);
+
+                if (!unlockedTechProto.RecipeUnlocks.Contains(recipe))
+                    continue;
+                hasTechElsewhere = true;
+                break;
+            }
+
+            if (!hasTechElsewhere)
+                entity.Comp.UnlockedRecipes.Remove(recipe);
+        }
+        Dirty(entity, entity.Comp);
+        UpdateTechnologyCards(entity, entity);
+        return true;
+    }
+
     /// <summary>
     /// Clear all unlocked technologies from the database.
     /// </summary>
+    [PublicAPI]
     public void ClearTechs(EntityUid uid, TechnologyDatabaseComponent? comp = null)
     {
         if (!Resolve(uid, ref comp) || comp.UnlockedTechnologies.Count == 0)

--- a/Resources/Prototypes/Objectives/ninja.yml
+++ b/Resources/Prototypes/Objectives/ninja.yml
@@ -39,8 +39,8 @@
       sprite: Structures/Machines/server.rsi
       state: server
   - type: NumberObjective
-    min: 5
-    max: 10
+    min: 9
+    max: 13
     title: objective-condition-steal-research-title
   - type: StealResearchCondition
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changes ninja gloves to steal a flat rate of techs instead of wiping all of them.
Additionally adjusts the objective to require 1 to 2 steals to reach the target amount.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Ninja's stealing research was previously an extremely trivial and annoying objective. For them, you can pretty easily break into the server room and wait out the 20 second doafter. It's not super hard and you're not exactly shooting off warning signs. At this very low cost, science loses literally an hour+ of progress.

This nerf changes it to only remove 4-8 random technologies, or only about 20k to 40k points worth. This is still pretty crippling but not awful. On top of that, they need to do it twice to hit the target amounts of 9 to 12 techs stolen. This provides counterplay by actually giving science a chance to see that all their research has vanished before the ninja is already gone. It also makes it significantly harder for ninja to obliterate everything science has done.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Ninjas no longer wipe all technologies when using their gloves on a research server.
