### PR TITLE
Reduces size of smaller cartons and fix size discrepancies with empty containers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -17,7 +17,7 @@
   - type: Sprite
     state: icon
   - type: Item
-    size: Normal
+    size: Small
   - type: MeleeWeapon
     soundNoDamage:
       path: "/Audio/Effects/Fluids/splat.ogg"
@@ -38,6 +38,18 @@
         #In future maybe add generic plastic scrap trash/debris
   - type: TrashOnSolutionEmpty
     solution: drink
+
+- type: entity
+  parent: DrinkCartonBaseFull
+  id: DrinkCartonBaseLargeFull
+  abstract: true
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 100
+  - type: Item
+    size: Normal
 
 - type: entity
   id: DrinkCartonVisualsOpenable
@@ -116,7 +128,7 @@
     sprite: Objects/Consumable/Drinks/cream.rsi
 
 - type: entity
-  parent: [DrinkCartonVisualsOpenable, DrinkCartonBaseFull]
+  parent: [DrinkCartonVisualsOpenable, DrinkCartonBaseLargeFull]
   id: DrinkMilkCarton
   name: milk
   description: An opaque white liquid produced by the mammary glands of mammals.
@@ -124,7 +136,6 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 100
         reagents:
         - ReagentId: Milk
           Quantity: 100
@@ -132,7 +143,7 @@
     sprite: Objects/Consumable/Drinks/milk.rsi
 
 - type: entity
-  parent: [DrinkCartonVisualsOpenable, DrinkCartonBaseFull]
+  parent: [DrinkCartonVisualsOpenable, DrinkCartonBaseLargeFull]
   id: DrinkSoyMilkCarton
   name: soy milk
   description: White and nutritious soy goodness!
@@ -140,7 +151,6 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 100
         reagents:
         - ReagentId: MilkSoy
           Quantity: 100
@@ -148,7 +158,7 @@
     sprite: Objects/Consumable/Drinks/soymilk.rsi
 
 - type: entity
-  parent: [DrinkCartonVisualsOpenable, DrinkCartonBaseFull]
+  parent: [DrinkCartonVisualsOpenable, DrinkCartonBaseLargeFull]
   id: DrinkOatMilkCarton
   name: oat milk
   description: It's oat milk. Tan and nutritious goodness!
@@ -156,7 +166,6 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 100
         reagents:
         - ReagentId: MilkOat
           Quantity: 100

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -8,6 +8,8 @@
   components:
   - type: Sprite
     state: icon
+  - type: Item
+    size: Normal
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -73,6 +75,19 @@
   - type: SpaceGarbage
 
 - type: entity
+  name: base empty bottle
+  id: DrinkBottleBaseSmallEmpty
+  parent: DrinkBottleBaseEmpty
+  abstract: true
+  components:
+  - type: Item
+    size: Small
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 50
+
+- type: entity
   name: base empty carton
   id: DrinkCartonBaseEmpty
   parent: BaseItem
@@ -122,6 +137,19 @@
       Cardboard: 20
   - type: SpaceGarbage
 
+- type: entity
+  name: base empty bottle
+  id: DrinkCartonBaseLargeEmpty
+  parent: DrinkCartonBaseEmpty
+  abstract: true
+  components:
+  - type: Item
+    size: Normal
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 100
+
 # Containers
 - type: entity
   name: Jailbreaker Verte bottle
@@ -143,28 +171,20 @@
 
 - type: entity
   name: ale bottle
-  parent: DrinkBottleBaseEmpty
+  parent: DrinkBottleBaseSmallEmpty
   id: DrinkBottleAle
   components:
   - type: Sprite
     sprite: Objects/Consumable/TrashDrinks/alebottle_empty.rsi
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 50
 
 
 - type: entity
   name: beer bottle
-  parent: DrinkBottleBaseEmpty
+  parent: DrinkBottleBaseSmallEmpty
   id: DrinkBottleBeer
   components:
   - type: Sprite
     sprite: Objects/Consumable/TrashDrinks/beer_empty.rsi
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 50
 
 
 - type: entity
@@ -322,37 +342,24 @@
 
 - type: entity
   name: milk carton
-  parent: DrinkCartonBaseEmpty
+  parent: DrinkCartonBaseLargeEmpty
   id: DrinkCartonMilk
   components:
   - type: Sprite
     sprite: Objects/Consumable/Drinks/milk.rsi
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 100
-
 
 - type: entity
   name: soy milk carton
-  parent: DrinkCartonBaseEmpty
+  parent: DrinkCartonBaseLargeEmpty
   id: DrinkCartonSoyMilk
   components:
   - type: Sprite
     sprite: Objects/Consumable/Drinks/soymilk.rsi
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 100
 
 - type: entity
   name: oat milk carton
-  parent: DrinkCartonBaseEmpty
+  parent: DrinkCartonBaseLargeEmpty
   id: DrinkCartonOatMilk
   components:
   - type: Sprite
     sprite: Objects/Consumable/Drinks/oatmilk.rsi
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 100


### PR DESCRIPTION
## About the PR
- Reduces the item size of drink cartons with `maxVol: 50` to `small`
- Fixes discrepancies between full alcohol bottles and empty
- Makes empty cartons consistent with full as well 

## Why / Balance
Keeps it consistent with other drink containers. 

## Technical details 
n/a

## Media
Before:
![image](https://github.com/space-wizards/space-station-14/assets/107660393/f232b56c-c4d1-480f-ae29-a11dc2f2c47c)

- [X] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a