### PR TITLE
Minor cleanup of cuffablesystem

### DIFF
--- a/Content.Shared/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Shared/Cuffs/Components/HandcuffComponent.cs
@@ -95,7 +95,7 @@ public sealed partial class HandcuffComponent : Component
 }
 
 /// <summary>
-/// Event fired on the User when the User attempts to cuff the Target.
+/// Event fired on the User when the User attempts to uncuff the Target.
 /// Should generate popups on the User.
 /// </summary>
 [ByRefEvent]

--- a/Content.Shared/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Shared/Cuffs/Components/HandcuffComponent.cs
@@ -53,6 +53,14 @@ public sealed partial class HandcuffComponent : Component
     public bool Removing;
 
     /// <summary>
+    /// Whether the cuffs are currently being used to cuff someone.
+    /// We need the extra information for when the virtual item is deleted because that can happen when you simply stop
+    /// pulling them on the ground.
+    /// </summary>
+    [DataField]
+    public bool Used;
+
+    /// <summary>
     ///     The path of the RSI file used for the player cuffed overlay.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -629,8 +629,6 @@ namespace Content.Shared.Cuffs
             cuff.Used = false;
             _audio.PlayPredicted(cuff.EndUncuffSound, target, user);
 
-            var isOwner = user == target;
-
             _container.Remove(cuffsToRemove, cuffable.Container);
 
             if (_net.IsServer)
@@ -646,43 +644,42 @@ namespace Content.Shared.Cuffs
                 {
                     _hands.PickupOrDrop(user, cuffsToRemove);
                 }
+            }
 
-                // Only play popups on server because popups suck
-                if (cuffable.CuffedHandCount == 0)
+            if (cuffable.CuffedHandCount == 0)
+            {
+                if (user != null)
+                    _popup.PopupPredicted(Loc.GetString("cuffable-component-remove-cuffs-success-message"), user.Value, user.Value);
+
+                if (target != user && user != null)
                 {
-                    if (user != null)
-                        _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-success-message"), user.Value, user.Value);
-
-                    if (target != user && user != null)
-                    {
-                        _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-by-other-success-message",
-                            ("otherName", Identity.Name(user.Value, EntityManager, user))), target, target);
-                        _adminLog.Add(LogType.Action, LogImpact.Medium,
-                            $"{ToPrettyString(user):player} has successfully uncuffed {ToPrettyString(target):player}");
-                    }
-                    else
-                    {
-                        _adminLog.Add(LogType.Action, LogImpact.Medium,
-                            $"{ToPrettyString(user):player} has successfully uncuffed themselves");
-                    }
+                    _popup.PopupPredicted(Loc.GetString("cuffable-component-remove-cuffs-by-other-success-message",
+                        ("otherName", Identity.Name(user.Value, EntityManager, user))), target, target);
+                    _adminLog.Add(LogType.Action, LogImpact.Medium,
+                        $"{ToPrettyString(user):player} has successfully uncuffed {ToPrettyString(target):player}");
                 }
-                else if (user != null)
+                else
                 {
-                    if (user != target)
-                    {
-                        _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
-                            ("cuffedHandCount", cuffable.CuffedHandCount),
-                            ("otherName", Identity.Name(user.Value, EntityManager, user.Value))), user.Value, user.Value);
-                        _popup.PopupEntity(Loc.GetString(
-                            "cuffable-component-remove-cuffs-by-other-partial-success-message",
-                            ("otherName", Identity.Name(user.Value, EntityManager, user.Value)),
-                            ("cuffedHandCount", cuffable.CuffedHandCount)), target, target);
-                    }
-                    else
-                    {
-                        _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
-                            ("cuffedHandCount", cuffable.CuffedHandCount)), user.Value, user.Value);
-                    }
+                    _adminLog.Add(LogType.Action, LogImpact.Medium,
+                        $"{ToPrettyString(user):player} has successfully uncuffed themselves");
+                }
+            }
+            else if (user != null)
+            {
+                if (user != target)
+                {
+                    _popup.PopupPredicted(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
+                        ("cuffedHandCount", cuffable.CuffedHandCount),
+                        ("otherName", Identity.Name(user.Value, EntityManager, user.Value))), user.Value, user.Value);
+                    _popup.PopupPredicted(Loc.GetString(
+                        "cuffable-component-remove-cuffs-by-other-partial-success-message",
+                        ("otherName", Identity.Name(user.Value, EntityManager, user.Value)),
+                        ("cuffedHandCount", cuffable.CuffedHandCount)), target, target);
+                }
+                else
+                {
+                    _popup.PopupPredicted(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
+                        ("cuffedHandCount", cuffable.CuffedHandCount)), user.Value, user.Value);
                 }
             }
             cuff.Removing = false;

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -310,6 +310,7 @@ namespace Content.Shared.Cuffs
 
             if (!args.Cancelled && TryAddNewCuffs(target, user, uid, cuffable))
             {
+                component.Used = true;
                 _audio.PlayPredicted(component.EndCuffSound, uid, user);
 
                 _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-observer-success-message",
@@ -613,7 +614,7 @@ namespace Content.Shared.Cuffs
             if (!Resolve(target, ref cuffable) || !Resolve(cuffsToRemove, ref cuff))
                 return;
 
-            if (cuff.Removing || TerminatingOrDeleted(cuffsToRemove) || TerminatingOrDeleted(target))
+            if (!cuff.Used || cuff.Removing || TerminatingOrDeleted(cuffsToRemove) || TerminatingOrDeleted(target))
                 return;
 
             if (user != null)
@@ -625,6 +626,7 @@ namespace Content.Shared.Cuffs
             }
 
             cuff.Removing = true;
+            cuff.Used = false;
             _audio.PlayPredicted(cuff.EndUncuffSound, target, user);
 
             var isOwner = user == target;


### PR DESCRIPTION
fixes #26331
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When cuffs stop being pulled they no longer try to uncuff themselves. 

Did some todos on the cuffable system and removed some dead stuff.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The bool Used is in the Handcuff component now so we can check whether a cuff is actually being used to cuff someone. We have to do this because the VirtualItemDeletedEvent does not allow us to distinguish between the virtual item being deleted by pulling, or anything else(E.g. rejuvenate). 

For self uncuffing, in order to have a proper CanInteract check the cuff's own component has its CanStillInteract bool set to true for the duration of the check so the cuffablesystem does not block itself instead of doing a partial check. 

Removed some unused dependencies and use statements.

Made popups predicted, I would make the handling of makeshift cuffs being broken as well but it looks that still can't be properly predicted.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- fix: Handcuffs will no longer try to uncuff themselves when they stop being dragged. 