### PR TITLE
use nav beacon locations for announcements

### DIFF
--- a/Content.Server/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/Dragon/DragonRiftSystem.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Serialization.Manager;
 using System.Numerics;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Dragon;
 
@@ -69,8 +70,9 @@ public sealed class DragonRiftSystem : EntitySystem
                 comp.State = DragonRiftState.AlmostFinished;
                 Dirty(uid, comp);
 
-                var location = xform.LocalPosition;
-                _chat.DispatchGlobalAnnouncement(Loc.GetString("carp-rift-warning", ("location", location)), playSound: false, colorOverride: Color.Red);
+                var msg = Loc.GetString("carp-rift-warning",
+                    ("location", FormattedMessage.RemoveMarkup(_navMap.GetNearestBeaconString((uid, xform)))));
+                _chat.DispatchGlobalAnnouncement(msg, playSound: false, colorOverride: Color.Red);
                 _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), true);
                 _navMap.SetBeaconEnabled(uid, true);
             }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Body.Systems;
 using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.Explosion.Components;
 using Content.Server.Flash;
+using Content.Server.Pinpointer;
 using Content.Shared.Flash.Components;
 using Content.Server.Radio.EntitySystems;
 using Content.Shared.Chemistry.Components;
@@ -31,6 +32,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Player;
 using Content.Shared.Coordinates;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Explosion.EntitySystems
 {
@@ -67,6 +69,7 @@ namespace Content.Server.Explosion.EntitySystems
         [Dependency] private readonly BodySystem _body = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+        [Dependency] private readonly NavMapSystem _navMap = default!;
         [Dependency] private readonly RadioSystem _radioSystem = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -185,12 +188,7 @@ namespace Content.Server.Explosion.EntitySystems
                 return;
 
             // Gets location of the implant
-            var ownerXform = Transform(uid);
-            var pos = ownerXform.MapPosition;
-            var x = (int) pos.X;
-            var y = (int) pos.Y;
-            var posText = $"({x}, {y})";
-
+            var posText = FormattedMessage.RemoveMarkup(_navMap.GetNearestBeaconString(uid));
             var critMessage = Loc.GetString(component.CritMessage, ("user", implanted.ImplantedEntity.Value), ("position", posText));
             var deathMessage = Loc.GetString(component.DeathMessage, ("user", implanted.ImplantedEntity.Value), ("position", posText));
 

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Nuke;
 
@@ -463,7 +464,8 @@ public sealed class NukeSystem : EntitySystem
 
         // warn a crew
         var announcement = Loc.GetString("nuke-component-announcement-armed",
-            ("time", (int) component.RemainingTime), ("position", posText));
+            ("time", (int) component.RemainingTime),
+            ("location", FormattedMessage.RemoveMarkup(_navMap.GetNearestBeaconString((uid, nukeXform)))));
         var sender = Loc.GetString("nuke-component-announcement-sender");
         _chatSystem.DispatchStationAnnouncement(stationUid ?? uid, announcement, sender, false, null, Color.Red);
 

--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -1,12 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
 using Content.Server.Administration.Logs;
 using Content.Server.Station.Systems;
 using Content.Server.Warps;
 using Content.Shared.Database;
 using Content.Shared.Examine;
+using Content.Shared.Localizations;
 using Content.Shared.Pinpointer;
 using Content.Shared.Tag;
+using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
@@ -22,9 +26,14 @@ public sealed class NavMapSystem : SharedNavMapSystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly TagSystem _tags = default!;
     [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly TransformSystem _transform = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<TagComponent> _tagQuery;
+
+    public const float CloseDistance = 15f;
+    public const float FarDistance = 30f;
 
     public override void Initialize()
     {
@@ -40,6 +49,7 @@ public sealed class NavMapSystem : SharedNavMapSystem
         SubscribeLocalEvent<NavMapComponent, ComponentGetState>(OnGetState);
         SubscribeLocalEvent<GridSplitEvent>(OnNavMapSplit);
 
+        SubscribeLocalEvent<NavMapBeaconComponent, MapInitEvent>(OnNavMapBeaconMapInit);
         SubscribeLocalEvent<NavMapBeaconComponent, ComponentStartup>(OnNavMapBeaconStartup);
         SubscribeLocalEvent<NavMapBeaconComponent, AnchorStateChangedEvent>(OnNavMapBeaconAnchor);
 
@@ -57,8 +67,22 @@ public sealed class NavMapSystem : SharedNavMapSystem
         RefreshGrid(ev.GridId, comp, Comp<MapGridComponent>(ev.GridId));
     }
 
+    private void OnNavMapBeaconMapInit(EntityUid uid, NavMapBeaconComponent component, MapInitEvent args)
+    {
+        if (component.DefaultText == null || component.Text != null)
+            return;
+
+        component.Text = Loc.GetString(component.DefaultText);
+        Dirty(uid, component);
+        RefreshNavGrid(uid);
+    }
+
     private void OnNavMapBeaconStartup(EntityUid uid, NavMapBeaconComponent component, ComponentStartup args)
     {
+        // don't run this a second time if the map is already init as OnNavMapBeaconMapInit will handle it
+        if (LifeStage(uid) >= EntityLifeStage.MapInitialized)
+            return;
+
         RefreshNavGrid(uid);
     }
 
@@ -383,5 +407,95 @@ public sealed class NavMapSystem : SharedNavMapSystem
             return;
 
         SetBeaconEnabled(uid, !comp.Enabled, comp);
+    }
+
+    /// <summary>
+    /// For a given position, tries to find the nearest configurable beacon that is marked as visible.
+    /// This is used for things like announcements where you want to find the closest "landmark" to something.
+    /// </summary>
+    [PublicAPI]
+    public bool TryGetNearestBeacon(Entity<TransformComponent?> ent, [NotNullWhen(true)] out Entity<NavMapBeaconComponent>? beacon)
+    {
+        beacon = null;
+        if (!Resolve(ent, ref ent.Comp))
+            return false;
+
+        return TryGetNearestBeacon(_transform.GetMapCoordinates(ent, ent.Comp), out beacon);
+    }
+
+    /// <summary>
+    /// For a given position, tries to find the nearest configurable beacon that is marked as visible.
+    /// This is used for things like announcements where you want to find the closest "landmark" to something.
+    /// </summary>
+    public bool TryGetNearestBeacon(MapCoordinates coordinates, [NotNullWhen(true)] out Entity<NavMapBeaconComponent>? beacon)
+    {
+        beacon = null;
+        var minDistance = float.PositiveInfinity;
+
+        var query = EntityQueryEnumerator<ConfigurableNavMapBeaconComponent, NavMapBeaconComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var navBeacon, out var xform))
+        {
+            if (!navBeacon.Enabled)
+                continue;
+
+            if (navBeacon.Text == null)
+                continue;
+
+            if (coordinates.MapId != xform.MapID)
+                continue;
+
+            var coords = _transform.GetWorldPosition(xform);
+            var distanceSquared = (coordinates.Position - coords).LengthSquared();
+            if (!float.IsInfinity(minDistance) && distanceSquared >= minDistance)
+                continue;
+
+            minDistance = distanceSquared;
+            beacon = (uid, navBeacon);
+        }
+
+        return beacon != null;
+    }
+
+    [PublicAPI]
+    public string GetNearestBeaconString(Entity<TransformComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return Loc.GetString("nav-beacon-pos-no-beacons");
+
+        return GetNearestBeaconString(_transform.GetMapCoordinates(ent, ent.Comp));
+    }
+
+    public string GetNearestBeaconString(MapCoordinates coordinates)
+    {
+        if (!TryGetNearestBeacon(coordinates, out var beacon))
+            return Loc.GetString("nav-beacon-pos-no-beacons");
+
+        var pos = _transform.GetMapCoordinates(beacon.Value);
+
+        var rotOffset = Angle.Zero;
+        if (_mapManager.TryFindGridAt(pos, out var grid, out _))
+            rotOffset = Transform(grid).LocalRotation;
+
+        var dir = (pos.Position - coordinates.Position).GetDir();
+        var adjustedDir = (dir.ToAngle() - rotOffset + (Math.PI)).GetDir();
+
+        var length = (pos.Position - coordinates.Position).Length();
+        if (length < CloseDistance)
+        {
+            return Loc.GetString("nav-beacon-pos-format",
+                ("color", beacon.Value.Comp.Color),
+                ("marker", beacon.Value.Comp.Text!));
+        }
+
+        var modifier = length > FarDistance
+            ? Loc.GetString("nav-beacon-pos-format-direction-mod-far")
+            : string.Empty;
+
+        // we can null suppress the text being null because TRyGetNearestVisibleStationBeacon always gives us a beacon with not-null text.
+        return Loc.GetString("nav-beacon-pos-format-direction",
+            ("modifier", modifier),
+            ("direction", ContentLocalizationManager.FormatDirection(adjustedDir).ToLowerInvariant()),
+            ("color", beacon.Value.Comp.Color),
+            ("marker", beacon.Value.Comp.Text!));
     }
 }

--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -79,10 +79,6 @@ public sealed class NavMapSystem : SharedNavMapSystem
 
     private void OnNavMapBeaconStartup(EntityUid uid, NavMapBeaconComponent component, ComponentStartup args)
     {
-        // don't run this a second time if the map is already init as OnNavMapBeaconMapInit will handle it
-        if (LifeStage(uid) >= EntityLifeStage.MapInitialized)
-            return;
-
         RefreshNavGrid(uid);
     }
 
@@ -414,22 +410,28 @@ public sealed class NavMapSystem : SharedNavMapSystem
     /// This is used for things like announcements where you want to find the closest "landmark" to something.
     /// </summary>
     [PublicAPI]
-    public bool TryGetNearestBeacon(Entity<TransformComponent?> ent, [NotNullWhen(true)] out Entity<NavMapBeaconComponent>? beacon)
+    public bool TryGetNearestBeacon(Entity<TransformComponent?> ent,
+        [NotNullWhen(true)] out Entity<NavMapBeaconComponent>? beacon,
+        [NotNullWhen(true)] out MapCoordinates? beaconCoords)
     {
         beacon = null;
+        beaconCoords = null;
         if (!Resolve(ent, ref ent.Comp))
             return false;
 
-        return TryGetNearestBeacon(_transform.GetMapCoordinates(ent, ent.Comp), out beacon);
+        return TryGetNearestBeacon(_transform.GetMapCoordinates(ent, ent.Comp), out beacon, out beaconCoords);
     }
 
     /// <summary>
     /// For a given position, tries to find the nearest configurable beacon that is marked as visible.
     /// This is used for things like announcements where you want to find the closest "landmark" to something.
     /// </summary>
-    public bool TryGetNearestBeacon(MapCoordinates coordinates, [NotNullWhen(true)] out Entity<NavMapBeaconComponent>? beacon)
+    public bool TryGetNearestBeacon(MapCoordinates coordinates,
+        [NotNullWhen(true)] out Entity<NavMapBeaconComponent>? beacon,
+        [NotNullWhen(true)] out MapCoordinates? beaconCoords)
     {
         beacon = null;
+        beaconCoords = null;
         var minDistance = float.PositiveInfinity;
 
         var query = EntityQueryEnumerator<ConfigurableNavMapBeaconComponent, NavMapBeaconComponent, TransformComponent>();
@@ -451,6 +453,7 @@ public sealed class NavMapSystem : SharedNavMapSystem
 
             minDistance = distanceSquared;
             beacon = (uid, navBeacon);
+            beaconCoords = new MapCoordinates(coords, xform.MapID);
         }
 
         return beacon != null;
@@ -467,19 +470,19 @@ public sealed class NavMapSystem : SharedNavMapSystem
 
     public string GetNearestBeaconString(MapCoordinates coordinates)
     {
-        if (!TryGetNearestBeacon(coordinates, out var beacon))
+        if (!TryGetNearestBeacon(coordinates, out var beacon, out var pos))
             return Loc.GetString("nav-beacon-pos-no-beacons");
 
-        var pos = _transform.GetMapCoordinates(beacon.Value);
+        var gridOffset = Angle.Zero;
+        if (_mapManager.TryFindGridAt(pos.Value, out var grid, out _))
+            gridOffset = Transform(grid).LocalRotation;
 
-        var rotOffset = Angle.Zero;
-        if (_mapManager.TryFindGridAt(pos, out var grid, out _))
-            rotOffset = Transform(grid).LocalRotation;
+        // get the angle between the two positions, adjusted for the grid rotation so that
+        // we properly preserve north in relation to the grid.
+        var dir = (pos.Value.Position - coordinates.Position).ToWorldAngle();
+        var adjustedDir = (dir - gridOffset).GetDir();
 
-        var dir = (pos.Position - coordinates.Position).GetDir();
-        var adjustedDir = (dir.ToAngle() - rotOffset + (Math.PI)).GetDir();
-
-        var length = (pos.Position - coordinates.Position).Length();
+        var length = (pos.Value.Position - coordinates.Position).Length();
         if (length < CloseDistance)
         {
             return Loc.GetString("nav-beacon-pos-format",

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Communications;
 using Content.Server.DeviceNetwork.Components;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Server.GameTicking.Events;
+using Content.Server.Pinpointer;
 using Content.Server.Popups;
 using Content.Server.RoundEnd;
 using Content.Server.Screens.Components;
@@ -33,6 +34,7 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -55,6 +57,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     [Dependency] private readonly DockingSystem _dock = default!;
     [Dependency] private readonly EntityManager _entityManager = default!;
     [Dependency] private readonly IdCardSystem _idSystem = default!;
+    [Dependency] private readonly NavMapSystem _navMap = default!;
     [Dependency] private readonly MapLoaderSystem _map = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly RoundEndSystem _roundEnd = default!;
@@ -307,11 +310,8 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         }
         else
         {
-            if (TryComp<TransformComponent>(targetGrid.Value, out var targetXform))
-            {
-                var angle = _dock.GetAngle(stationShuttle.EmergencyShuttle.Value, xform, targetGrid.Value, targetXform, xformQuery);
-                _chatSystem.DispatchStationAnnouncement(stationUid, Loc.GetString("emergency-shuttle-nearby", ("direction", angle.GetDir())), playDefaultSound: false);
-            }
+            var location = FormattedMessage.RemoveMarkup(_navMap.GetNearestBeaconString((stationShuttle.EmergencyShuttle.Value, xform)));
+            _chatSystem.DispatchStationAnnouncement(stationUid, Loc.GetString("emergency-shuttle-nearby", ("direction", location)), playDefaultSound: false);
 
             _logger.Add(LogType.EmergencyShuttle, LogImpact.High, $"Emergency shuttle {ToPrettyString(stationUid)} unable to find a valid docking port for {ToPrettyString(stationUid)}");
             // TODO: Need filter extensions or something don't blame me.

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -119,6 +119,14 @@ namespace Content.Shared.Localizations
             };
         }
 
+        /// <summary>
+        /// Formats a direction struct as a human-readable string.
+        /// </summary>
+        public static string FormatDirection(Direction dir)
+        {
+            return Loc.GetString($"zzzz-fmt-direction-{dir.ToString()}");
+        }
+
         private static ILocValue FormatLoc(LocArgs args)
         {
             var id = ((LocValueString) args.Args[0]).Value;

--- a/Content.Shared/Pinpointer/NavMapBeaconComponent.cs
+++ b/Content.Shared/Pinpointer/NavMapBeaconComponent.cs
@@ -16,6 +16,13 @@ public sealed partial class NavMapBeaconComponent : Component
     [AutoNetworkedField]
     public string? Text;
 
+    /// <summary>
+    /// A localization string that populates <see cref="Text"/> if it is null at mapinit.
+    /// Used so that mappers can still override Text while mapping.
+    /// </summary>
+    [DataField]
+    public LocId? DefaultText;
+
     [ViewVariables(VVAccess.ReadWrite), DataField]
     [AutoNetworkedField]
     public Color Color = Color.Orange;

--- a/Content.Shared/Pinpointer/SharedNavMapSystem.cs
+++ b/Content.Shared/Pinpointer/SharedNavMapSystem.cs
@@ -8,13 +8,6 @@ public abstract class SharedNavMapSystem : EntitySystem
 {
     public const byte ChunkSize = 4;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<NavMapBeaconComponent, MapInitEvent>(OnNavMapBeaconMapInit);
-    }
-
     /// <summary>
     /// Converts the chunk's tile into a bitflag for the slot.
     /// </summary>
@@ -36,13 +29,6 @@ public abstract class SharedNavMapSystem : EntitySystem
         DebugTools.Assert(GetFlag(result) == flag);
 
         return new Vector2i(x, y);
-    }
-
-    private void OnNavMapBeaconMapInit(EntityUid uid, NavMapBeaconComponent component, MapInitEvent args)
-    {
-        component.Text ??= string.Empty;
-        component.Text = Loc.GetString(component.Text);
-        Dirty(uid, component);
     }
 
     [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_directions.ftl
+++ b/Resources/Locale/en-US/_directions.ftl
@@ -1,0 +1,8 @@
+zzzz-fmt-direction-North = North
+zzzz-fmt-direction-South = South
+zzzz-fmt-direction-East = East
+zzzz-fmt-direction-West = West
+zzzz-fmt-direction-NorthEast = NorthEast
+zzzz-fmt-direction-SouthEast = SouthEast
+zzzz-fmt-direction-NorthWest = NorthWest
+zzzz-fmt-direction-SouthWest = SouthWest

--- a/Resources/Locale/en-US/dragon/rifts.ftl
+++ b/Resources/Locale/en-US/dragon/rifts.ftl
@@ -1,4 +1,4 @@
-carp-rift-warning = A rift is causing an unnaturally large energy flux at {$location}. Stop it at all costs!
+carp-rift-warning = A rift is causing an unnaturally large energy flux {$location}. Stop it at all costs!
 carp-rift-duplicate = Cannot have 2 charging rifts at the same time!
 carp-rift-examine = It is [color=yellow]{$percentage}%[/color] charged!
 carp-rift-max = You have reached your maximum amount of rifts

--- a/Resources/Locale/en-US/implant/implant.ftl
+++ b/Resources/Locale/en-US/implant/implant.ftl
@@ -21,5 +21,5 @@ scramble-implant-activated-popup = Your appearance shifts and changes!
 
 ## Implant Messages
 
-deathrattle-implant-dead-message = {$user} has died at {$position}.
-deathrattle-implant-critical-message = {$user} life signs critical, immediate assistance required at {$position}.
+deathrattle-implant-dead-message = {$user} has died {$position}.
+deathrattle-implant-critical-message = {$user} life signs critical, immediate assistance required {$position}.

--- a/Resources/Locale/en-US/navmap-beacons/station_map.ftl
+++ b/Resources/Locale/en-US/navmap-beacons/station_map.ftl
@@ -11,3 +11,8 @@ nav-beacon-examine-text = It is [color={$enabled ->
     [true] forestgreen]on
     *[false] crimson]off
 }[/color] and the display reads [color={$color}]"{$label}"[/color]
+
+nav-beacon-pos-no-beacons = in the middle of nowhere
+nav-beacon-pos-format = [color={$color}]near {$marker}[/color]
+nav-beacon-pos-format-direction = [color={$color}]{$modifier}{$direction} of {$marker}[/color]
+nav-beacon-pos-format-direction-mod-far = far {""}

--- a/Resources/Locale/en-US/nuke/nuke-component.ftl
+++ b/Resources/Locale/en-US/nuke/nuke-component.ftl
@@ -1,6 +1,6 @@
 nuke-component-cant-anchor-floor = The anchoring bolts fail to lock into the floor!
 nuke-component-announcement-sender = Nuclear Fission Explosive
-nuke-component-announcement-armed = Attention! The station's self-destruct mechanism has been engaged at global coordinates {$position}. {$time} seconds until detonation. If this was made in error, the mechanism may still be disarmed.
+nuke-component-announcement-armed = Attention! The station's self-destruct mechanism has been engaged {$location}. {$time} seconds until detonation. If this was made in error, the mechanism may still be disarmed.
 nuke-component-announcement-unarmed = The station's self-destruct was deactivated! Have a nice day!
 nuke-component-announcement-send-codes = Attention! Self-destruction codes have been sent to designated fax machines.
 nuke-component-doafter-warning = You start fiddling with wires and knobs in order to disarm the nuke.. This may take a while.

--- a/Resources/Locale/en-US/shuttles/emergency.ftl
+++ b/Resources/Locale/en-US/shuttles/emergency.ftl
@@ -15,7 +15,7 @@ emergency-shuttle-left = The Emergency Shuttle has left the station. Estimate {$
 emergency-shuttle-launch-time = The emergency shuttle will launch in {$consoleAccumulator} seconds.
 emergency-shuttle-docked = The Emergency Shuttle has docked with the station on the {$direction} side. It will leave in {$time} seconds.
 emergency-shuttle-good-luck = The Emergency Shuttle is unable to find a station. Good luck.
-emergency-shuttle-nearby = The Emergency Shuttle is unable to find a valid docking port. It has warped in {$direction} of the station.
+emergency-shuttle-nearby = The Emergency Shuttle is unable to find a valid docking port. It has warped {$direction}.
 
 # Emergency shuttle console popup / announcement
 emergency-shuttle-console-no-early-launches = Early launch is disabled

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -22,7 +22,7 @@
           False: {state: icon}
   - type: ConfigurableNavMapBeacon
   - type: NavMapBeacon
-    text: station-beacon-general
+    defaultText: station-beacon-general
     color: "#D4D4D496"
   - type: WarpPoint
   - type: ActivatableUI
@@ -118,7 +118,7 @@
   suffix: Command
   components:
   - type: NavMapBeacon
-    text: station-beacon-command
+    defaultText: station-beacon-command
     color: "#FFFF00"
 
 - type: entity
@@ -127,7 +127,7 @@
   suffix: Bridge
   components:
   - type: NavMapBeacon
-    text: station-beacon-bridge
+    defaultText: station-beacon-bridge
 
 - type: entity
   parent: DefaultStationBeaconCommand
@@ -135,7 +135,7 @@
   suffix: Vault
   components:
   - type: NavMapBeacon
-    text: station-beacon-vault
+    defaultText: station-beacon-vault
 
 - type: entity
   parent: DefaultStationBeaconCommand
@@ -143,7 +143,7 @@
   suffix: Captain's Quarters
   components:
   - type: NavMapBeacon
-    text: station-beacon-captain
+    defaultText: station-beacon-captain
 
 - type: entity
   parent: DefaultStationBeaconCommand
@@ -151,7 +151,7 @@
   suffix: HOP's Office
   components:
   - type: NavMapBeacon
-    text: station-beacon-hop
+    defaultText: station-beacon-hop
 
 - type: entity
   parent: DefaultStationBeacon
@@ -159,7 +159,7 @@
   suffix: Security
   components:
   - type: NavMapBeacon
-    text: station-beacon-security
+    defaultText: station-beacon-security
     color: "#DE3A3A"
 
 - type: entity
@@ -168,7 +168,7 @@
   suffix: Brig
   components:
   - type: NavMapBeacon
-    text: station-beacon-brig
+    defaultText: station-beacon-brig
 
 - type: entity
   parent: DefaultStationBeaconSecurity
@@ -176,7 +176,7 @@
   suffix: Warden's Office
   components:
   - type: NavMapBeacon
-    text: station-beacon-warden
+    defaultText: station-beacon-warden
 
 - type: entity
   parent: DefaultStationBeaconSecurity
@@ -184,7 +184,7 @@
   suffix: HOS’s Room
   components:
   - type: NavMapBeacon
-    text: station-beacon-hos
+    defaultText: station-beacon-hos
 
 - type: entity
   parent: DefaultStationBeaconSecurity
@@ -192,7 +192,7 @@
   suffix: Armory
   components:
   - type: NavMapBeacon
-    text: station-beacon-armory
+    defaultText: station-beacon-armory
 
 - type: entity
   parent: DefaultStationBeaconSecurity
@@ -200,7 +200,7 @@
   suffix: Perma Brig
   components:
   - type: NavMapBeacon
-    text: station-beacon-perma-brig
+    defaultText: station-beacon-perma-brig
 
 - type: entity
   parent: DefaultStationBeaconSecurity
@@ -208,7 +208,7 @@
   suffix: Detective's Room
   components:
   - type: NavMapBeacon
-    text: station-beacon-detective
+    defaultText: station-beacon-detective
 
 - type: entity
   parent: DefaultStationBeaconSecurity
@@ -216,7 +216,7 @@
   suffix: Courtroom
   components:
   - type: NavMapBeacon
-    text: station-beacon-courtroom
+    defaultText: station-beacon-courtroom
 
 - type: entity
   parent: DefaultStationBeaconSecurity
@@ -224,7 +224,7 @@
   suffix: Law Office
   components:
   - type: NavMapBeacon
-    text: station-beacon-law
+    defaultText: station-beacon-law
 
 - type: entity
   parent: DefaultStationBeaconSecurity
@@ -232,7 +232,7 @@
   suffix: Sec Checkpoint
   components:
   - type: NavMapBeacon
-    text: station-beacon-security-checkpoint
+    defaultText: station-beacon-security-checkpoint
 
 - type: entity
   parent: DefaultStationBeacon
@@ -240,7 +240,7 @@
   suffix: Medical
   components:
   - type: NavMapBeacon
-    text: station-beacon-medical
+    defaultText: station-beacon-medical
     color: "#52B4E9"
 
 - type: entity
@@ -249,7 +249,7 @@
   suffix: Medbay
   components:
   - type: NavMapBeacon
-    text: station-beacon-medbay
+    defaultText: station-beacon-medbay
 
 - type: entity
   parent: DefaultStationBeaconMedical
@@ -257,7 +257,7 @@
   suffix: Chemistry
   components:
   - type: NavMapBeacon
-    text: station-beacon-chemistry
+    defaultText: station-beacon-chemistry
 
 - type: entity
   parent: DefaultStationBeaconMedical
@@ -265,7 +265,7 @@
   suffix: Cryonics
   components:
   - type: NavMapBeacon
-    text: station-beacon-cryonics
+    defaultText: station-beacon-cryonics
 
 - type: entity
   parent: DefaultStationBeaconMedical
@@ -273,7 +273,7 @@
   suffix: CMO's room
   components:
   - type: NavMapBeacon
-    text: station-beacon-cmo
+    defaultText: station-beacon-cmo
 
 - type: entity
   parent: DefaultStationBeaconMedical
@@ -281,7 +281,7 @@
   suffix: Morgue
   components:
   - type: NavMapBeacon
-    text: station-beacon-morgue
+    defaultText: station-beacon-morgue
 
 - type: entity
   parent: DefaultStationBeaconMedical
@@ -289,7 +289,7 @@
   suffix: Surgery
   components:
   - type: NavMapBeacon
-    text: station-beacon-surgery
+    defaultText: station-beacon-surgery
 
 - type: entity
   parent: DefaultStationBeacon
@@ -297,7 +297,7 @@
   suffix: Science
   components:
   - type: NavMapBeacon
-    text: station-beacon-science
+    defaultText: station-beacon-science
     color: "#D381C9"
 
 - type: entity
@@ -306,7 +306,7 @@
   suffix: Research and Development
   components:
   - type: NavMapBeacon
-    text: station-beacon-research-and-development
+    defaultText: station-beacon-research-and-development
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -314,7 +314,7 @@
   suffix: Research Server Room
   components:
   - type: NavMapBeacon
-    text: station-beacon-research-server
+    defaultText: station-beacon-research-server
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -322,7 +322,7 @@
   suffix: RD's Room
   components:
   - type: NavMapBeacon
-    text: station-beacon-research-director
+    defaultText: station-beacon-research-director
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -330,7 +330,7 @@
   suffix: Robotics
   components:
   - type: NavMapBeacon
-    text: station-beacon-robotics
+    defaultText: station-beacon-robotics
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -338,7 +338,7 @@
   suffix: Artifact Lab
   components:
   - type: NavMapBeacon
-    text: station-beacon-artifact-lab
+    defaultText: station-beacon-artifact-lab
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -346,7 +346,7 @@
   suffix: Anomaly Generator
   components:
   - type: NavMapBeacon
-    text: station-beacon-anomaly-gen
+    defaultText: station-beacon-anomaly-gen
 
 - type: entity
   parent: DefaultStationBeacon
@@ -354,7 +354,7 @@
   suffix: Supply
   components:
   - type: NavMapBeacon
-    text: station-beacon-supply
+    defaultText: station-beacon-supply
     color: "#A46106"
 
 - type: entity
@@ -363,7 +363,7 @@
   suffix: Cargo Reception
   components:
   - type: NavMapBeacon
-    text: station-beacon-cargo
+    defaultText: station-beacon-cargo
 
 - type: entity
   parent: DefaultStationBeaconSupply
@@ -371,7 +371,7 @@
   suffix: Cargo Bay
   components:
   - type: NavMapBeacon
-    text: station-beacon-cargo-bay
+    defaultText: station-beacon-cargo-bay
 
 - type: entity
   parent: DefaultStationBeaconSupply
@@ -379,7 +379,7 @@
   suffix: QM's Room
   components:
   - type: NavMapBeacon
-    text: station-beacon-qm
+    defaultText: station-beacon-qm
 
 - type: entity
   parent: DefaultStationBeaconSupply
@@ -387,7 +387,7 @@
   suffix: Salvage
   components:
   - type: NavMapBeacon
-    text: station-beacon-salvage
+    defaultText: station-beacon-salvage
 
 - type: entity
   parent: DefaultStationBeacon
@@ -395,7 +395,7 @@
   suffix: Engineering
   components:
   - type: NavMapBeacon
-    text: station-beacon-engineering
+    defaultText: station-beacon-engineering
     color: "#EFB341"
 
 - type: entity
@@ -404,7 +404,7 @@
   suffix: CE's Room
   components:
   - type: NavMapBeacon
-    text: station-beacon-ce
+    defaultText: station-beacon-ce
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -412,7 +412,7 @@
   suffix: AME
   components:
   - type: NavMapBeacon
-    text: station-beacon-ame
+    defaultText: station-beacon-ame
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -420,7 +420,7 @@
   suffix: Solars
   components:
   - type: NavMapBeacon
-    text: station-beacon-solars
+    defaultText: station-beacon-solars
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -428,7 +428,7 @@
   suffix: Grav Gen
   components:
   - type: NavMapBeacon
-    text: station-beacon-gravgen
+    defaultText: station-beacon-gravgen
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -436,7 +436,7 @@
   suffix: PA Control
   components:
   - type: NavMapBeacon
-    text: station-beacon-pa
+    defaultText: station-beacon-pa
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -444,7 +444,7 @@
   suffix: SMES Power Bank
   components:
   - type: NavMapBeacon
-    text: station-beacon-smes
+    defaultText: station-beacon-smes
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -452,7 +452,7 @@
   suffix: Telecoms
   components:
   - type: NavMapBeacon
-    text: station-beacon-telecoms
+    defaultText: station-beacon-telecoms
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -460,7 +460,7 @@
   suffix: Atmospherics
   components:
   - type: NavMapBeacon
-    text: station-beacon-atmos
+    defaultText: station-beacon-atmos
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -468,7 +468,7 @@
   suffix: TEG
   components:
   - type: NavMapBeacon
-    text: station-beacon-teg
+    defaultText: station-beacon-teg
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -476,7 +476,7 @@
   suffix: Tech Vault
   components:
   - type: NavMapBeacon
-    text: station-beacon-tech-vault
+    defaultText: station-beacon-tech-vault
 
 - type: entity
   parent: DefaultStationBeacon
@@ -484,7 +484,7 @@
   suffix: Service
   components:
   - type: NavMapBeacon
-    text: station-beacon-service
+    defaultText: station-beacon-service
     color: "#9FED58"
 
 - type: entity
@@ -493,7 +493,7 @@
   suffix: Kitchen
   components:
   - type: NavMapBeacon
-    text: station-beacon-kitchen
+    defaultText: station-beacon-kitchen
 
 - type: entity
   parent: DefaultStationBeaconService
@@ -501,7 +501,7 @@
   suffix: Bar
   components:
   - type: NavMapBeacon
-    text: station-beacon-bar
+    defaultText: station-beacon-bar
 
 - type: entity
   parent: DefaultStationBeaconService
@@ -509,7 +509,7 @@
   suffix: Botany
   components:
   - type: NavMapBeacon
-    text: station-beacon-botany
+    defaultText: station-beacon-botany
 
 - type: entity
   parent: DefaultStationBeaconService
@@ -517,7 +517,7 @@
   suffix: Janitor's Closet
   components:
   - type: NavMapBeacon
-    text: station-beacon-janitor
+    defaultText: station-beacon-janitor
 
 - type: entity
   parent: DefaultStationBeacon
@@ -525,7 +525,7 @@
   suffix: AI
   components:
   - type: NavMapBeacon
-    text: station-beacon-ai
+    defaultText: station-beacon-ai
     color: "#2ed2fd"
 
 - type: entity
@@ -534,7 +534,7 @@
   suffix: AI Satellite
   components:
   - type: NavMapBeacon
-    text: station-beacon-ai-sat
+    defaultText: station-beacon-ai-sat
 
 - type: entity
   parent: DefaultStationBeaconAI
@@ -542,7 +542,7 @@
   suffix: AI Core
   components:
   - type: NavMapBeacon
-    text: station-beacon-ai-core
+    defaultText: station-beacon-ai-core
 
 - type: entity
   parent: DefaultStationBeacon
@@ -550,7 +550,7 @@
   suffix: Arrivals
   components:
   - type: NavMapBeacon
-    text: station-beacon-arrivals
+    defaultText: station-beacon-arrivals
 
 - type: entity
   parent: DefaultStationBeacon
@@ -558,7 +558,7 @@
   suffix: Evac
   components:
   - type: NavMapBeacon
-    text: station-beacon-evac
+    defaultText: station-beacon-evac
 
 - type: entity
   parent: DefaultStationBeacon
@@ -566,7 +566,7 @@
   suffix: EVA Storage
   components:
   - type: NavMapBeacon
-    text: station-beacon-eva-storage
+    defaultText: station-beacon-eva-storage
 
 - type: entity
   parent: DefaultStationBeacon
@@ -574,7 +574,7 @@
   suffix: Chapel
   components:
   - type: NavMapBeacon
-    text: station-beacon-chapel
+    defaultText: station-beacon-chapel
 
 - type: entity
   parent: DefaultStationBeacon
@@ -582,7 +582,7 @@
   suffix: Library
   components:
   - type: NavMapBeacon
-    text: station-beacon-library
+    defaultText: station-beacon-library
 
 - type: entity
   parent: DefaultStationBeacon
@@ -590,7 +590,7 @@
   suffix: Theater
   components:
   - type: NavMapBeacon
-    text: station-beacon-theater
+    defaultText: station-beacon-theater
 
 - type: entity
   parent: DefaultStationBeacon
@@ -598,7 +598,7 @@
   suffix: Dorms
   components:
   - type: NavMapBeacon
-    text: station-beacon-dorms
+    defaultText: station-beacon-dorms
 
 - type: entity
   parent: DefaultStationBeacon
@@ -606,7 +606,7 @@
   suffix: Tool Room
   components:
   - type: NavMapBeacon
-    text: station-beacon-tools
+    defaultText: station-beacon-tools
 
 - type: entity
   parent: DefaultStationBeacon
@@ -614,7 +614,7 @@
   suffix: Disposals
   components:
   - type: NavMapBeacon
-    text: station-beacon-disposals
+    defaultText: station-beacon-disposals
 
 - type: entity
   parent: DefaultStationBeacon
@@ -622,7 +622,7 @@
   suffix: Cryosleep
   components:
   - type: NavMapBeacon
-    text: station-beacon-cryosleep
+    defaultText: station-beacon-cryosleep
 
 - type: entity
   parent: DefaultStationBeacon
@@ -630,4 +630,4 @@
   suffix: Escape Pod
   components:
   - type: NavMapBeacon
-    text: station-beacon-escape-pod
+    defaultText: station-beacon-escape-pod


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
changes a few announcements to use proximity to nav beacons rather than coordinates.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Coordinates are a really unreliable and unclear way of specifying location. For the majority of people, it's  basically meaningless. By changing it to use the locations instead, people can actually get a grasp of where these things are.

Applies to nuke, carp rifts, failed emergency shuttle docks, and tracking implants.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/37a274e0-e860-4610-9cf6-6aad868e1d8e)
![image](https://github.com/space-wizards/space-station-14/assets/98561806/d272138e-cb14-4835-bc9e-8681d0a47ba5)
![image](https://github.com/space-wizards/space-station-14/assets/98561806/e6338924-25cb-4fc1-a402-16f5403c0ae9)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Various announcements now announce location on the map (near Medical, etc.) instead of simply displaying coordinates.
