### PR TITLE
Fix 'Hypopen shouldn't display solution examine text'

### DIFF
--- a/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
@@ -6,6 +6,9 @@ public sealed partial class ExaminableSolutionComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string Solution = "default";
 
+    /// <summary>
+    /// If false then the hidden solution is always visible.
+    /// </summary>
     [DataField]
-    public bool HeldOnly = false;
+    public bool HeldOnly;
 }

--- a/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
@@ -7,5 +7,5 @@ public sealed partial class ExaminableSolutionComponent : Component
     public string Solution = "default";
 
     [DataField]
-    public bool Hidden = false;
+    public bool HeldOnly = false;
 }

--- a/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
@@ -6,6 +6,6 @@ public sealed partial class ExaminableSolutionComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string Solution = "default";
 
-    [DataField("hidden"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public bool Hidden = false;
 }

--- a/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionManager/ExaminableSolutionComponent.cs
@@ -5,4 +5,7 @@ public sealed partial class ExaminableSolutionComponent : Component
 {
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string Solution = "default";
+
+    [DataField("hidden"), ViewVariables(VVAccess.ReadWrite)]
+    public bool Hidden = false;
 }

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -875,8 +875,8 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
     //Check if examinable solution requires you to hold the item in hand.
     private bool CanSeeHiddenSolution(Entity<ExaminableSolutionComponent> entity, EntityUid examiner)
     {
-        //Is the Hidden enabled?
-        if (!entity.Comp.Hidden)
+        //Is the HeldOnly enabled?
+        if (!entity.Comp.HeldOnly)
             return true;
         //Iterate over hands, if any, for examinable entity.
         var hasHands = TryComp<HandsComponent>(examiner, out var hands);

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -721,7 +721,6 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             return;
         }
 
-        //Check if examinable solution requires you to hold the item in hand.
         if (!CanSeeHiddenSolution(entity,args.Examiner))
             return;
 
@@ -821,7 +820,6 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             return;
         }
 
-        //Check if examinable solution requires you to hold the item in hand.
         if (!CanSeeHiddenSolution(entity,args.User))
             return;
 
@@ -874,17 +872,15 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         return msg;
     }
 
+    //Check if examinable solution requires you to hold the item in hand.
     private bool CanSeeHiddenSolution(Entity<ExaminableSolutionComponent> entity, EntityUid examiner)
     {
         //Is the Hidden enabled?
         if (!entity.Comp.Hidden)
             return true;
         //Iterate over hands, if any, for examinable entity.
-        TryComp<HandsComponent>(examiner, out var hands);
-        if (hands == null)
-            return true;
-        var found = hands.Hands.Values.Any(hand => hand.HeldEntity == entity);
-        return found;
+        var hasHands = TryComp<HandsComponent>(examiner, out var hands);
+        return hasHands && hands != null && hands.Hands.Values.Any(hand => hand.HeldEntity == entity);
     }
 
     #endregion Event Handlers

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -13,6 +13,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Content.Shared.Hands.Components;
 using Dependency = Robust.Shared.IoC.DependencyAttribute;
 
 namespace Content.Shared.Chemistry.EntitySystems;
@@ -720,6 +721,10 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             return;
         }
 
+        //Check if examinable solution requires you to hold the item in hand.
+        if (!CanSeeHiddenSolution(entity,args.Examiner))
+            return;
+
         var primaryReagent = solution.GetPrimaryReagentId();
 
         if (string.IsNullOrEmpty(primaryReagent?.Prototype))
@@ -816,6 +821,10 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             return;
         }
 
+        //Check if examinable solution requires you to hold the item in hand.
+        if (!CanSeeHiddenSolution(entity,args.User))
+            return;
+
         var target = args.Target;
         var user = args.User;
         var verb = new ExamineVerb()
@@ -863,6 +872,19 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         }
 
         return msg;
+    }
+
+    private bool CanSeeHiddenSolution(Entity<ExaminableSolutionComponent> entity, EntityUid examiner)
+    {
+        //Is the Hidden enabled?
+        if (!entity.Comp.Hidden)
+            return true;
+        //Iterate over hands, if any, for examinable entity.
+        TryComp<HandsComponent>(examiner, out var hands);
+        if (hands == null)
+            return true;
+        var found = hands.Hands.Values.Any(hand => hand.HeldEntity == entity);
+        return found;
     }
 
     #endregion Event Handlers

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -409,7 +409,7 @@
     solution: hypospray
   - type: ExaminableSolution
     solution: hypospray
-    hidden: true # Allow examination only when held in hand.
+    heldOnly: true # Allow examination only when held in hand.
   - type: Hypospray
     onlyMobs: false
   - type: UseDelay

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -407,6 +407,9 @@
         maxVol: 10
   - type: RefillableSolution
     solution: hypospray
+  - type: ExaminableSolution
+    solution: hypospray
+    hidden: true # Allow examination only when held in hand.
   - type: Hypospray
     onlyMobs: false
   - type: UseDelay

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -407,8 +407,6 @@
         maxVol: 10
   - type: RefillableSolution
     solution: hypospray
-  - type: ExaminableSolution
-    solution: hypospray
   - type: Hypospray
     onlyMobs: false
   - type: UseDelay


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Fixes #26439

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

~~I removed the ExaminableSolution component of the solution.~~
ExaminableSolution now has 'hidden' datafield. That, if true, requires entity to be held by examinee to display any indication of chemicals.


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

<!--
## Breaking changes
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: DrTeaspoon
- fix: Hypopen no longer shows chemical contents when examined, when not held by the examinee.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
