### PR TITLE
Reduce electrocution damage and make them constant based on voltage

### DIFF
--- a/Content.Server/Electrocution/Components/ElectrifiedComponent.cs
+++ b/Content.Server/Electrocution/Components/ElectrifiedComponent.cs
@@ -41,8 +41,32 @@ public sealed partial class ElectrifiedComponent : Component
     [DataField("lowVoltageNode")]
     public string? LowVoltageNode;
 
+    /// <summary>
+    /// Damage multiplier for HV electrocution
+    /// </summary>
+    [DataField]
+    public float HighVoltageDamageMultiplier = 3f;
+
+    /// <summary>
+    /// Shock time multiplier for HV electrocution
+    /// </summary>
+    [DataField]
+    public float HighVoltageTimeMultiplier = 1.5f;
+
+    /// <summary>
+    /// Damage multiplier for MV electrocution
+    /// </summary>
+    [DataField]
+    public float MediumVoltageDamageMultiplier = 2f;
+
+    /// <summary>
+    /// Shock time multiplier for MV electrocution
+    /// </summary>
+    [DataField]
+    public float MediumVoltageTimeMultiplier = 1.25f;
+
     [DataField("shockDamage")]
-    public int ShockDamage = 20;
+    public float ShockDamage = 7.5f;
 
     /// <summary>
     ///     Shock time, in seconds.

--- a/Content.Server/Electrocution/Components/ElectrocutionComponent.cs
+++ b/Content.Server/Electrocution/Components/ElectrocutionComponent.cs
@@ -15,7 +15,4 @@ public sealed partial class ElectrocutionComponent : Component
 
     [DataField("timeLeft")]
     public float TimeLeft;
-
-    [DataField("accumDamage")]
-    public float AccumulatedDamage;
 }

--- a/Content.Server/Electrocution/Components/ElectrocutionComponent.cs
+++ b/Content.Server/Electrocution/Components/ElectrocutionComponent.cs
@@ -18,7 +18,4 @@ public sealed partial class ElectrocutionComponent : Component
 
     [DataField("accumDamage")]
     public float AccumulatedDamage;
-
-    [DataField("baseDamage")]
-    public float BaseDamage = 20f;
 }

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -106,9 +106,8 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             if (!MathHelper.CloseTo(electrocution.TimeLeft, 0))
                 continue;
 
-            // Welcome to the grave of power-based electrocution damage.
-            // Do not re-add this. Someone is going to make a cranked up 30 MW hog and insta kill half the station.
-            // It isn't worth it. You've been warned. -emo
+            // We tried damage scaling based on power in the past and it really wasn't good.
+            // Various scaling types didn't fix tiders and HV grilles instantly critting players.
 
             QueueDel(uid);
         }

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -17,7 +17,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Jittering;
 using Content.Shared.Maps;
-using Content.Shared.Mobs;
 using Content.Shared.Popups;
 using Content.Shared.Speech.EntitySystems;
 using Content.Shared.StatusEffect;
@@ -63,6 +62,9 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
     [ValidatePrototypeId<DamageTypePrototype>]
     private const string DamageType = "Shock";
 
+    // Yes, this is absurdly small for a reason.
+    private const float ElectrifiedScalePerWatt = 1E-6f;
+
     // Multiply and shift the log scale for shock damage.
     private const float RecursiveDamageMultiplier = 0.75f;
     private const float RecursiveTimeMultiplier = 0.8f;
@@ -103,7 +105,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             var timePassed = Math.Min(frameTime, electrocution.TimeLeft);
 
             electrocution.TimeLeft -= timePassed;
-            electrocution.AccumulatedDamage += electrocution.BaseDamage * (consumer.ReceivedPower / consumer.DrawRate) * timePassed;
+            electrocution.AccumulatedDamage += consumer.ReceivedPower * ElectrifiedScalePerWatt * timePassed;
 
             if (!MathHelper.CloseTo(electrocution.TimeLeft, 0))
                 continue;
@@ -198,7 +200,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
         if (!_meleeWeapon.GetDamage(args.Used, args.User).Any())
             return;
 
-        DoCommonElectrocution(args.User, uid, component.UnarmedHitShock, component.UnarmedHitStun, false, 1);
+        DoCommonElectrocution(args.User, uid, component.UnarmedHitShock, component.UnarmedHitStun, false);
     }
 
     private void OnElectrifiedInteractUsing(EntityUid uid, ElectrifiedComponent electrified, InteractUsingEvent args)
@@ -211,16 +213,6 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             : 1;
 
         TryDoElectrifiedAct(uid, args.User, siemens, electrified);
-    }
-
-    private float CalculateElectrifiedDamageScale(float power)
-    {
-        // A logarithm allows a curve of damage that grows quickly, but slows down dramatically past a value. This keeps the damage to a reasonable range.
-        const float DamageShift = 1.67f; // Shifts the curve for an overall higher or lower damage baseline
-        const float CeilingCoefficent = 1.35f; // Adjusts the approach to maximum damage, higher = Higher top damage
-        const float LogGrowth = 0.00001f; // Adjusts the growth speed of the curve
-
-        return DamageShift + MathF.Log(power * LogGrowth) * CeilingCoefficent;
     }
 
     public bool TryDoElectrifiedAct(EntityUid uid, EntityUid targetUid,
@@ -263,19 +255,15 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
         }
 
         var node = PoweredNode(uid, electrified, nodeContainer);
-        if (node?.NodeGroup is not IBasePowerNet powerNet)
+        if (node?.NodeGroup is not IBasePowerNet)
             return false;
 
-        var net = powerNet.NetworkNode;
-        var supp = net.LastCombinedMaxSupply;
-
-        if (supp <= 0f)
-            return false;
-
-        // Initial damage scales off of the available supply on the principle that the victim has shorted the entire powernet through their body.
-        var damageScale = CalculateElectrifiedDamageScale(supp);
-        if (damageScale <= 0f)
-            return false;
+        var (damageScalar, timeScalar) = node.NodeGroupID switch
+        {
+            NodeGroupID.HVPower => (electrified.HighVoltageDamageMultiplier, electrified.HighVoltageTimeMultiplier),
+            NodeGroupID.MVPower => (electrified.MediumVoltageDamageMultiplier, electrified.MediumVoltageTimeMultiplier),
+            _ => (1f, 1f)
+        };
 
         {
             var lastRet = true;
@@ -286,8 +274,8 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
                     entity,
                     uid,
                     node,
-                    (int) MathF.Ceiling(electrified.ShockDamage * damageScale * MathF.Pow(RecursiveDamageMultiplier, depth)),
-                    TimeSpan.FromSeconds(electrified.ShockTime * MathF.Min(1f + MathF.Log2(1f + damageScale), 3f) * MathF.Pow(RecursiveTimeMultiplier, depth)),
+                    (int) (electrified.ShockDamage * MathF.Pow(RecursiveDamageMultiplier, depth) * damageScalar),
+                    TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth) * timeScalar),
                     true,
                     electrified.SiemensCoefficient);
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes electrocution damage based on the voltage of the wire and bring down the damage to a sane level. It's no longer primarily based on the power being received.

LV Cable -> 10 damage
MV Cable -> 20 damage
HV Cable -> 30 damage

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Having a primarily power-based damage system causes there to be massive fluctuations in damage based on things outside of a regular player's control, like the station power output. This removes a lot of player agency and turns grilles into a risky gamble where they can either do no damage or instantly fry the player due to simply being hooked up to the engine. 

While this may be a more accurate simulation in some regards, the reality of the gameplay is that it's often just frustrating, resulting in constant death traps as players brushing against electrified grilles and punching wires take absurd amounts of damage. By making them flat rates, it's possible to actually balance the damage output and make them not such a pain in the ass.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Electrocution damage is no longer based on the power supplied and is instead based on the wire voltage (LV, MV, or HV).
