### PR TITLE
Replace Musician Sunglasses with Cheap Version

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -19,7 +19,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
     back: ClothingBackpackMusicianFilled
-    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesCheapSunglasses
     shoes: ClothingShoesBootsLaceup
     id: MusicianPDA
     ears: ClothingHeadsetService


### PR DESCRIPTION
## About the PR
See title

## Why / Balance
Powergaming bad, musician glasses are drip first, function second. 

## Technical details
N/A

## Media
N/A

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Changed Musician sunglasses for cheaper version.
