### PR TITLE
Late Join Menu Properly Retains Position On New Player Joins

### DIFF
--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -33,7 +33,7 @@ namespace Content.Client.LateJoin
         private readonly SpriteSystem _sprites;
         private readonly CrewManifestSystem _crewManifest;
 
-        private readonly Dictionary<NetEntity, Dictionary<string, JobButton>> _jobButtons = new();
+        private readonly Dictionary<NetEntity, Dictionary<string, List<JobButton>>> _jobButtons = new();
         private readonly Dictionary<NetEntity, Dictionary<string, BoxContainer>> _jobCategories = new();
         private readonly List<ScrollContainer> _jobLists = new();
 
@@ -139,7 +139,7 @@ namespace Content.Client.LateJoin
                 var jobListScroll = new ScrollContainer()
                 {
                     VerticalExpand = true,
-                    Children = {jobList},
+                    Children = { jobList },
                     Visible = false,
                 };
 
@@ -163,11 +163,12 @@ namespace Content.Client.LateJoin
                 var departments = _prototypeManager.EnumeratePrototypes<DepartmentPrototype>().ToArray();
                 Array.Sort(departments, DepartmentUIComparer.Instance);
 
+                _jobButtons[id] = new Dictionary<string, List<JobButton>>();
+
                 foreach (var department in departments)
                 {
                     var departmentName = Loc.GetString($"department-{department.ID}");
                     _jobCategories[id] = new Dictionary<string, BoxContainer>();
-                    _jobButtons[id] = new Dictionary<string, JobButton>();
                     var stationAvailable = _gameTicker.JobsAvailable[id];
                     var jobsAvailable = new List<JobPrototype>();
 
@@ -223,7 +224,13 @@ namespace Content.Client.LateJoin
                     foreach (var prototype in jobsAvailable)
                     {
                         var value = stationAvailable[prototype.ID];
-                        var jobButton = new JobButton(prototype.ID, value);
+
+                        var jobLabel = new Label
+                        {
+                            Margin = new Thickness(5f, 0, 0, 0)
+                        };
+
+                        var jobButton = new JobButton(jobLabel, prototype.ID, prototype.LocalizedName, value);
 
                         var jobSelector = new BoxContainer
                         {
@@ -240,14 +247,6 @@ namespace Content.Client.LateJoin
                         var jobIcon = _prototypeManager.Index<StatusIconPrototype>(prototype.Icon);
                         icon.Texture = _sprites.Frame0(jobIcon.Icon);
                         jobSelector.AddChild(icon);
-
-                        var jobLabel = new Label
-                        {
-                            Margin = new Thickness(5f, 0, 0, 0),
-                            Text = value != null ?
-                                Loc.GetString("late-join-gui-job-slot-capped", ("jobName", prototype.LocalizedName), ("amount", value)) :
-                                Loc.GetString("late-join-gui-job-slot-uncapped", ("jobName", prototype.LocalizedName)),
-                        };
 
                         jobSelector.AddChild(jobLabel);
                         jobButton.AddChild(jobSelector);
@@ -280,15 +279,47 @@ namespace Content.Client.LateJoin
                             jobButton.Disabled = true;
                         }
 
-                        _jobButtons[id][prototype.ID] = jobButton;
+                        if (!_jobButtons[id].ContainsKey(prototype.ID))
+                        {
+                            _jobButtons[id][prototype.ID] = new List<JobButton>();
+                        }
+
+                        _jobButtons[id][prototype.ID].Add(jobButton);
                     }
                 }
             }
         }
 
-        private void JobsAvailableUpdated(IReadOnlyDictionary<NetEntity, Dictionary<string, uint?>> _)
+        private void JobsAvailableUpdated(IReadOnlyDictionary<NetEntity, Dictionary<string, uint?>> updatedJobs)
         {
-            RebuildUI();
+            foreach (var stationEntries in updatedJobs)
+            {
+                if (_jobButtons.ContainsKey(stationEntries.Key))
+                {
+                    var jobsAvailable = stationEntries.Value;
+
+                    var existingJobEntries = _jobButtons[stationEntries.Key];
+                    foreach (var existingJobEntry in existingJobEntries)
+                    {
+                        if (jobsAvailable.ContainsKey(existingJobEntry.Key))
+                        {
+                            var updatedJobValue = jobsAvailable[existingJobEntry.Key];
+                            foreach (var matchingJobButton in existingJobEntry.Value)
+                            {
+                                if (matchingJobButton.Amount != updatedJobValue)
+                                {
+                                    matchingJobButton.RefreshLabel(updatedJobValue);
+
+                                    if (matchingJobButton.Amount == 0)
+                                    {
+                                        matchingJobButton.Disabled = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         protected override void Dispose(bool disposing)
@@ -307,14 +338,31 @@ namespace Content.Client.LateJoin
 
     sealed class JobButton : ContainerButton
     {
+        public Label JobLabel { get; }
         public string JobId { get; }
-        public uint? Amount { get; }
+        public string JobLocalisedName { get; }
+        public uint? Amount { get; private set; }
 
-        public JobButton(string jobId, uint? amount)
+        public JobButton(Label jobLabel, string jobId, string jobLocalisedName, uint? amount)
         {
+            JobLabel = jobLabel;
             JobId = jobId;
-            Amount = amount;
+            JobLocalisedName = jobLocalisedName;
+            RefreshLabel(amount);
             AddStyleClass(StyleClassButton);
+        }
+
+        public void RefreshLabel(uint? amount)
+        {
+            if (Amount == amount)
+            {
+                return;
+            }
+            Amount = amount;
+
+            JobLabel.Text = JobId != null ?
+                Loc.GetString("late-join-gui-job-slot-capped", ("jobName", JobLocalisedName), ("amount", Amount != null ? Amount : 0)) :
+                Loc.GetString("late-join-gui-job-slot-uncapped", ("jobName", JobLocalisedName));
         }
     }
 }

--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -309,11 +309,7 @@ namespace Content.Client.LateJoin
                                 if (matchingJobButton.Amount != updatedJobValue)
                                 {
                                     matchingJobButton.RefreshLabel(updatedJobValue);
-
-                                    if (matchingJobButton.Amount == 0)
-                                    {
-                                        matchingJobButton.Disabled = true;
-                                    }
+                                    matchingJobButton.Disabled = matchingJobButton.Amount == 0;
                                 }
                             }
                         }

--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -342,6 +342,7 @@ namespace Content.Client.LateJoin
         public string JobId { get; }
         public string JobLocalisedName { get; }
         public uint? Amount { get; private set; }
+        private bool _initialised = false;
 
         public JobButton(Label jobLabel, string jobId, string jobLocalisedName, uint? amount)
         {
@@ -350,18 +351,19 @@ namespace Content.Client.LateJoin
             JobLocalisedName = jobLocalisedName;
             RefreshLabel(amount);
             AddStyleClass(StyleClassButton);
+            _initialised = true;
         }
 
         public void RefreshLabel(uint? amount)
         {
-            if (Amount == amount)
+            if (Amount == amount && _initialised)
             {
                 return;
             }
             Amount = amount;
 
-            JobLabel.Text = JobId != null ?
-                Loc.GetString("late-join-gui-job-slot-capped", ("jobName", JobLocalisedName), ("amount", Amount != null ? Amount : 0)) :
+            JobLabel.Text = Amount != null ?
+                Loc.GetString("late-join-gui-job-slot-capped", ("jobName", JobLocalisedName), ("amount", Amount)) :
                 Loc.GetString("late-join-gui-job-slot-uncapped", ("jobName", JobLocalisedName));
         }
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Code changes to `LateJoinGui.cs`

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Fixes #25152

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Taking advantage of our stateful UI, we no longer elect to completely rebuild the menu on receiving `JobsAvailabeUpdated` callback. Instead we inspect our existing entries of `JobButton`; where we find an out-of-date entry we refresh the status accounting for the new count of open slots. 

I noticed an issue with the `_jobButtons` field where it was never correctly storing all the buttons so this has also been fixed in order to use it to refresh correctly. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->


https://github.com/space-wizards/space-station-14/assets/15147863/97d453e9-d51c-4254-a3e8-3cbfd644b257

- [ X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Jake Huxell
- fix: Fixed late join menu scrolling to the top whenever a new player joins the round. 
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
