### PR TITLE
Misc ItemToggleSystem changes

### DIFF
--- a/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
+++ b/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
@@ -36,7 +36,7 @@ public sealed class IgnitionSourceSystem : EntitySystem
     /// </summary>
     public void SetIgnited(Entity<IgnitionSourceComponent?> ent, bool ignited = true)
     {
-        if (!Resolve(ent, ref ent.Comp))
+        if (!Resolve(ent, ref ent.Comp, false))
             return;
 
         ent.Comp.Ignited = ignited;

--- a/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
+++ b/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
@@ -36,7 +36,7 @@ public sealed class IgnitionSourceSystem : EntitySystem
     /// </summary>
     public void SetIgnited(Entity<IgnitionSourceComponent?> ent, bool ignited = true)
     {
-        if (!Resolve(ent, ref ent.Comp, false))
+        if (!Resolve(ent, ref ent.Comp))
             return;
 
         ent.Comp.Ignited = ignited;

--- a/Content.Server/Item/ItemToggle/Components/ItemToggleDisarmMalusComponent.cs
+++ b/Content.Server/Item/ItemToggle/Components/ItemToggleDisarmMalusComponent.cs
@@ -1,19 +1,21 @@
 namespace Content.Server.Item;
 
 /// <summary>
-/// Handles whether this item applies a disarm malus when active. 
+/// Handles whether this item applies a disarm malus when active.
 /// </summary>
 [RegisterComponent]
 public sealed partial class ItemToggleDisarmMalusComponent : Component
 {
     /// <summary>
     ///     Item has this modifier to the chance to disarm when activated.
+    ///     If null, the value will be inferred from the current malus just before the malus is first deactivated.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly), DataField]
     public float? ActivatedDisarmMalus = null;
 
     /// <summary>
     ///     Item has this modifier to the chance to disarm when deactivated. If none is mentioned, it uses the item's default disarm modifier.
+    ///     If null, the value will be inferred from the current malus just before the malus is first activated.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly), DataField]
     public float? DeactivatedDisarmMalus = null;

--- a/Content.Server/Item/ItemToggle/Components/ItemToggleSharpComponent.cs
+++ b/Content.Server/Item/ItemToggle/Components/ItemToggleSharpComponent.cs
@@ -1,14 +1,9 @@
 namespace Content.Server.Item;
 
 /// <summary>
-/// Handles whether this item is sharp when toggled on. 
+/// Handles whether this item is sharp when toggled on.
 /// </summary>
 [RegisterComponent]
 public sealed partial class ItemToggleSharpComponent : Component
 {
-    /// <summary>
-    ///     Item can be used to butcher when activated.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadOnly), DataField]
-    public bool ActivatedSharp = true;
 }

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -58,10 +58,7 @@ namespace Content.Server.Stunnable.Systems
 
         private void ToggleDone(Entity<StunbatonComponent> entity, ref ItemToggledEvent args)
         {
-            if (!TryComp<ItemComponent>(entity, out var item))
-                return;
-
-            _item.SetHeldPrefix(entity.Owner, args.Activated ? "on" : "off", component: item);
+            _item.SetHeldPrefix(entity.Owner, args.Activated ? "on" : "off");
         }
 
         private void TryTurnOn(Entity<StunbatonComponent> entity, ref ItemToggleActivateAttemptEvent args)

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -32,8 +32,8 @@ namespace Content.Server.Tools
             SubscribeLocalEvent<WelderComponent, DoAfterAttemptEvent<ToolDoAfterEvent>>(OnWelderToolUseAttempt);
             SubscribeLocalEvent<WelderComponent, ComponentShutdown>(OnWelderShutdown);
             SubscribeLocalEvent<WelderComponent, ComponentGetState>(OnWelderGetState);
-            SubscribeLocalEvent<WelderComponent, ItemToggleActivateAttemptEvent>(TryTurnOn);
-            SubscribeLocalEvent<WelderComponent, ItemToggleDeactivateAttemptEvent>(TurnOff);
+            SubscribeLocalEvent<WelderComponent, ItemToggledEvent>(OnToggle);
+            SubscribeLocalEvent<WelderComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
         }
 
         public (FixedPoint2 fuel, FixedPoint2 capacity) GetWelderFuelAndCapacity(EntityUid uid, WelderComponent? welder = null, SolutionContainerManagerComponent? solutionContainer = null)
@@ -45,55 +45,56 @@ namespace Content.Server.Tools
             return (fuelSolution.GetTotalPrototypeQuantity(welder.FuelReagent), fuelSolution.MaxVolume);
         }
 
-        public void TryTurnOn(Entity<WelderComponent> entity, ref ItemToggleActivateAttemptEvent args)
+        private void OnToggle(Entity<WelderComponent> entity, ref ItemToggledEvent args)
         {
-            if (!_solutionContainer.ResolveSolution(entity.Owner, entity.Comp.FuelSolutionName, ref entity.Comp.FuelSolution, out var solution) ||
-                !TryComp<TransformComponent>(entity, out var transform))
+            if (args.Activated)
+                TurnOn(entity, args.User);
+            else
+                TurnOff(entity, args.User);
+        }
+
+        private void OnActivateAttempt(Entity<WelderComponent> entity, ref ItemToggleActivateAttemptEvent args)
+        {
+            if (!_solutionContainer.ResolveSolution(entity.Owner, entity.Comp.FuelSolutionName, ref entity.Comp.FuelSolution, out var solution))
             {
                 args.Cancelled = true;
+                args.Popup = Loc.GetString("welder-component-no-fuel-message");
                 return;
             }
 
             var fuel = solution.GetTotalPrototypeQuantity(entity.Comp.FuelReagent);
-
-            // Not enough fuel to lit welder.
             if (fuel == FixedPoint2.Zero || fuel < entity.Comp.FuelLitCost)
             {
-                if (args.User != null)
-                {
-                    _popup.PopupEntity(Loc.GetString("welder-component-no-fuel-message"), entity, (EntityUid) args.User);
-                }
+                args.Popup = Loc.GetString("welder-component-no-fuel-message");
                 args.Cancelled = true;
-                return;
             }
+        }
 
-            _solutionContainer.RemoveReagent(entity.Comp.FuelSolution.Value, entity.Comp.FuelReagent, entity.Comp.FuelLitCost);
-
-            // Logging
-            AdminLogger.Add(LogType.InteractActivate, LogImpact.Low, $"{ToPrettyString(args.User):user} toggled {ToPrettyString(entity.Owner):welder} on");
+        public void TurnOn(Entity<WelderComponent> entity, EntityUid? user)
+        {
+            if (!_solutionContainer.ResolveSolution(entity.Owner, entity.Comp.FuelSolutionName, ref entity.Comp.FuelSolution, out var solution))
+                return;
 
             _ignitionSource.SetIgnited(entity.Owner);
+            _solutionContainer.RemoveReagent(entity.Comp.FuelSolution.Value, entity.Comp.FuelReagent, entity.Comp.FuelLitCost);
+            AdminLogger.Add(LogType.InteractActivate, LogImpact.Low,
+                $"{ToPrettyString(user):user} toggled {ToPrettyString(entity.Owner):welder} on");
 
-            if (transform.GridUid is { } gridUid)
+            var xform = Transform(entity);
+            if (xform.GridUid is { } gridUid)
             {
-                var position = _transformSystem.GetGridOrMapTilePosition(entity.Owner, transform);
+                var position = _transformSystem.GetGridOrMapTilePosition(entity.Owner, xform);
                 _atmosphereSystem.HotspotExpose(gridUid, position, 700, 50, entity.Owner, true);
             }
-
-            Dirty(entity);
 
             _activeWelders.Add(entity);
         }
 
-        public void TurnOff(Entity<WelderComponent> entity, ref ItemToggleDeactivateAttemptEvent args)
+        public void TurnOff(Entity<WelderComponent> entity, EntityUid? user)
         {
-            // Logging
-            AdminLogger.Add(LogType.InteractActivate, LogImpact.Low, $"{ToPrettyString(args.User):user} toggled {ToPrettyString(entity.Owner):welder} off");
-
+            AdminLogger.Add(LogType.InteractActivate, LogImpact.Low,
+                $"{ToPrettyString(user):user} toggled {ToPrettyString(entity.Owner):welder} off");
             _ignitionSource.SetIgnited(entity.Owner, false);
-
-            Dirty(entity);
-
             _activeWelders.Remove(entity);
         }
 

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -7,7 +7,6 @@ using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
-using Content.Shared.Item;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Tools.Components;
 using Robust.Shared.GameStates;
@@ -72,10 +71,9 @@ namespace Content.Server.Tools
 
         public void TurnOn(Entity<WelderComponent> entity, EntityUid? user)
         {
-            if (!_solutionContainer.ResolveSolution(entity.Owner, entity.Comp.FuelSolutionName, ref entity.Comp.FuelSolution, out var solution))
+            if (!_solutionContainer.ResolveSolution(entity.Owner, entity.Comp.FuelSolutionName, ref entity.Comp.FuelSolution))
                 return;
 
-            _ignitionSource.SetIgnited(entity.Owner);
             _solutionContainer.RemoveReagent(entity.Comp.FuelSolution.Value, entity.Comp.FuelReagent, entity.Comp.FuelLitCost);
             AdminLogger.Add(LogType.InteractActivate, LogImpact.Low,
                 $"{ToPrettyString(user):user} toggled {ToPrettyString(entity.Owner):welder} on");
@@ -94,7 +92,6 @@ namespace Content.Server.Tools
         {
             AdminLogger.Add(LogType.InteractActivate, LogImpact.Low,
                 $"{ToPrettyString(user):user} toggled {ToPrettyString(entity.Owner):welder} off");
-            _ignitionSource.SetIgnited(entity.Owner, false);
             _activeWelders.Remove(entity);
         }
 
@@ -187,7 +184,9 @@ namespace Content.Server.Tools
             if (_welderTimer < WelderUpdateTimer)
                 return;
 
-            // TODO Use an "active welder" component instead, EntityQuery over that.
+            // TODO Serialization. _activeWelders is not serialized.
+            // Need to use some "active" component, and EntityQuery over that.
+            // Probably best to generalize it to a "ToggleableFuelDrain" component.
             foreach (var tool in _activeWelders.ToArray())
             {
                 if (!TryComp(tool, out WelderComponent? welder)

--- a/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class ItemToggleComponent : Component
     /// <summary>
     ///     The item's toggle state.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool Activated = false;
 
     /// <summary>
@@ -45,6 +45,12 @@ public sealed partial class ItemToggleComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
     public SoundSpecifier? SoundFailToActivate;
+
+    /// <summary>
+    /// Whether or not to toggle the entity's lights on or off.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    public bool ToggleLight = true;
 }
 
 /// <summary>

--- a/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
@@ -55,6 +55,11 @@ public record struct ItemToggleActivateAttemptEvent(EntityUid? User)
 {
     public bool Cancelled = false;
     public readonly EntityUid? User = User;
+
+    /// <summary>
+    /// Pop-up that gets shown to users explaining why the attempt was cancelled.
+    /// </summary>
+    public string? Popup { get; set; }
 }
 
 /// <summary>
@@ -75,23 +80,5 @@ public readonly record struct ItemToggledEvent(bool Predicted, bool Activated, E
 {
     public readonly bool Predicted = Predicted;
     public readonly bool Activated = Activated;
-    public readonly EntityUid? User = User;
-}
-
-/// <summary>
-/// Raised directed on an entity when an itemtoggle is activated.
-/// </summary>
-[ByRefEvent]
-public readonly record struct ItemToggleActivatedEvent(EntityUid? User)
-{
-    public readonly EntityUid? User = User;
-}
-
-/// <summary>
-/// Raised directed on an entity when an itemtoggle is deactivated.
-/// </summary>
-[ByRefEvent]
-public readonly record struct ItemToggleDeactivatedEvent(EntityUid? User)
-{
     public readonly EntityUid? User = User;
 }

--- a/Content.Shared/Item/ItemToggle/Components/ItemToggleHotComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ItemToggleHotComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Item.ItemToggle.Components;
 /// <summary>
 /// Handles whether the item is hot when toggled on.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class ItemToggleHotComponent : Component
 {
 }

--- a/Content.Shared/Item/ItemToggle/Components/ItemToggleHotComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ItemToggleHotComponent.cs
@@ -8,9 +8,4 @@ namespace Content.Shared.Item.ItemToggle.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ItemToggleHotComponent : Component
 {
-    /// <summary>
-    ///     Item becomes hot when active.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
-    public bool IsHotWhenActivated = true;
 }

--- a/Content.Shared/Item/ItemToggle/SharedItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/SharedItemToggleSystem.cs
@@ -232,8 +232,7 @@ public abstract class SharedItemToggleSystem : EntitySystem
     /// </summary>
     private void OnIsHotEvent(EntityUid uid, ItemToggleHotComponent itemToggleHot, IsHotEvent args)
     {
-        if (itemToggleHot.IsHotWhenActivated)
-            args.IsHot = IsActivated(uid);
+        args.IsHot |= IsActivated(uid);
     }
 
     /// <summary>

--- a/Content.Shared/Item/ItemToggle/SharedItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/SharedItemToggleSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Popups;
 using Content.Shared.Temperature;
 using Content.Shared.Toggleable;
 using Content.Shared.Wieldable;
@@ -20,6 +21,7 @@ public abstract class SharedItemToggleSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedPointLightSystem _light = default!;
     [Dependency] private readonly INetManager _netManager = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -82,6 +84,14 @@ public abstract class SharedItemToggleSystem : EntitySystem
                 _audio.PlayPredicted(itemToggle.SoundFailToActivate, uid, user);
             else
                 _audio.PlayPvs(itemToggle.SoundFailToActivate, uid);
+
+            if (attempt.Popup != null && user != null)
+            {
+                if (predicted)
+                    _popup.PopupClient(attempt.Popup, uid, user.Value);
+                else
+                    _popup.PopupEntity(attempt.Popup, uid, user.Value);
+            }
 
             return false;
         }
@@ -146,9 +156,6 @@ public abstract class SharedItemToggleSystem : EntitySystem
         var toggleUsed = new ItemToggledEvent(predicted, Activated: true, user);
         RaiseLocalEvent(uid, ref toggleUsed);
 
-        var activev = new ItemToggleActivatedEvent(user);
-        RaiseLocalEvent(uid, ref activev);
-
         itemToggle.Activated = true;
         Dirty(uid, itemToggle);
     }
@@ -179,9 +186,6 @@ public abstract class SharedItemToggleSystem : EntitySystem
 
         var toggleUsed = new ItemToggledEvent(predicted, Activated: false, user);
         RaiseLocalEvent(uid, ref toggleUsed);
-
-        var activev = new ItemToggleDeactivatedEvent(user);
-        RaiseLocalEvent(uid, ref activev);
 
         itemToggle.Activated = false;
         Dirty(uid, itemToggle);


### PR DESCRIPTION

- Stops welders from calling `SetIgnited()`, as `ItemToggleHotComponent` already handles that.
  - This also fixes a false `Resolve()` error log, which is what started this whole PR
- Allows cancelled attempt events to generate popups
- Fixes welders performing toggling logic on an attempt-event.
- Removes the duplicate toggle events (removes `ItemToggleActivatedEvent` and `ItemToggleDeactivatedEvent` in favour of just using `ItemToggledEvent`)
- Removes the `ItemToggleHotComponent.IsHotWhenActivated` field. Same goes for `ItemToggleSharpComponent.ActivatedSharp`.
  - I have no idea why these existed, seeing as the components were meaningless if they were false. If it was meant to invert the behaviour (i.e., be hot while deactivated), it wasn't doing that. 