### PR TITLE
Remove broadcast cooldown

### DIFF
--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -170,7 +170,6 @@ namespace Content.Server.Communications
 
             _uiSystem.SetUiState(ui, new CommunicationsConsoleInterfaceState(
                 CanAnnounce(comp),
-                CanBroadcast(comp),
                 CanCallOrRecall(comp),
                 levels,
                 currentLevel,
@@ -182,12 +181,6 @@ namespace Content.Server.Communications
         private static bool CanAnnounce(CommunicationsConsoleComponent comp)
         {
             return comp.AnnouncementCooldownRemaining <= 0f;
-        }
-
-        private static bool CanBroadcast(CommunicationsConsoleComponent comp)
-        {
-            // No broadcast delay
-            return true;
         }
 
         private bool CanUse(EntityUid user, EntityUid console)

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -186,7 +186,8 @@ namespace Content.Server.Communications
 
         private static bool CanBroadcast(CommunicationsConsoleComponent comp)
         {
-            return comp.AnnouncementCooldownRemaining <= 0f;
+            // No broadcast delay
+            return true;
         }
 
         private bool CanUse(EntityUid user, EntityUid console)

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -186,8 +186,7 @@ namespace Content.Server.Communications
 
         private static bool CanBroadcast(CommunicationsConsoleComponent comp)
         {
-            // No broadcast delay
-            return true;
+            return comp.AnnouncementCooldownRemaining <= 0f;
         }
 
         private bool CanUse(EntityUid user, EntityUid console)

--- a/Content.Shared/Communications/SharedCommunicationsConsoleComponent.cs
+++ b/Content.Shared/Communications/SharedCommunicationsConsoleComponent.cs
@@ -19,10 +19,9 @@ namespace Content.Shared.Communications
         public string CurrentAlert;
         public float CurrentAlertDelay;
 
-        public CommunicationsConsoleInterfaceState(bool canAnnounce, bool canBroadcast, bool canCall, List<string>? alertLevels, string currentAlert, float currentAlertDelay, TimeSpan? expectedCountdownEnd = null)
+        public CommunicationsConsoleInterfaceState(bool canAnnounce, bool canCall, List<string>? alertLevels, string currentAlert, float currentAlertDelay, TimeSpan? expectedCountdownEnd = null)
         {
             CanAnnounce = canAnnounce;
-            CanBroadcast = canBroadcast;
             CanCall = canCall;
             ExpectedCountdownEnd = expectedCountdownEnd;
             CountdownStarted = expectedCountdownEnd != null;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removed the inconsistent and unnecessary cooldown for the "Broadcast" button whenever the "Announce" button is pressed on the Communication Computer.
<!-- What did you change in this PR? -->

## Why / Balance
This cooldown was applied only when the "Announce" button is pressed erroneously. Spamming the broadcast button with random words or letters on the station screens is hardly intrusive or annoying, and the cooldown fails to prevent spam anyways as it is only applied when the unrelated "Announce" button is pressed. Just a super minor QoL change for people who use the Communication Computer, they can now make an announcement and immediately broadcast a message on screens.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
Very simple code change which leaves the functionality in place for future changes to the broadcast button's cooldown should no broadcast cooldown become undesirable.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
![image](https://github.com/space-wizards/space-station-14/assets/8095092/a20214eb-dd1c-40a9-b626-bf072ab437ce)

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
fix: Removed inconsistent "Broadcast" button cooldown when "Announce" button is pressed.
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
