### PR TITLE
Beds heal piercing and slash

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -9,6 +9,8 @@
       types:
         Poison: -0.1
         Blunt: -0.1
+        Slash: -0.1
+        Pierce: -0.1
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -72,6 +74,8 @@
         Poison: -0.2
         Cold: -0.4
         Blunt: -0.2
+        Slash: -0.2
+        Pierce: -0.2
   - type: Construction
     graph: bed
     node: medicalbed

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -10,7 +10,7 @@
         Poison: -0.1
         Blunt: -0.1
         Slash: -0.1
-        Pierce: -0.1
+        Piercing: -0.1
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -75,7 +75,7 @@
         Cold: -0.4
         Blunt: -0.2
         Slash: -0.2
-        Pierce: -0.2
+        Piercing: -0.2
   - type: Construction
     graph: bed
     node: medicalbed

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -9,8 +9,8 @@
       types:
         Poison: -0.1
         Blunt: -0.1
-        Slash: -0.1
-        Piercing: -0.1
+        Slash: -0.05
+        Piercing: -0.05
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -74,8 +74,8 @@
         Poison: -0.2
         Cold: -0.4
         Blunt: -0.2
-        Slash: -0.2
-        Piercing: -0.2
+        Slash: -0.1
+        Piercing: -0.1
   - type: Construction
     graph: bed
     node: medicalbed

--- a/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
@@ -13,7 +13,7 @@
         Poison: -0.001
         Blunt: -0.001
         Slash: -0.001
-        Pierce: -0.001
+        Piercing: -0.001
   - type: Sprite
     sprite: Structures/Machines/stasis_bed.rsi
     noRot: true

--- a/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
@@ -12,6 +12,8 @@
       types:
         Poison: -0.001
         Blunt: -0.001
+        Slash: -0.001
+        Pierce: -0.001
   - type: Sprite
     sprite: Structures/Machines/stasis_bed.rsi
     noRot: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added healing values for piercing and slash to beds on buckle, at half the rate that blunt damage heals for

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
if I accidentally stab myself or step on a few shards of glass then go to med, it's annoying that I am persistently laid into a bed but the bed doesn't actually do anything to help this damage. now it does.

I am willing to restrict this additional healing to med beds if desired.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Beds now heal slash and piercing damage as well.