### PR TITLE
Fix guardian damage transfer

### DIFF
--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -256,7 +256,7 @@ namespace Content.Server.Guardian
         /// </summary>
         private void OnGuardianDamaged(EntityUid uid, GuardianComponent component, DamageChangedEvent args)
         {
-            if (args.DamageDelta == null || component.Host == null || component.DamageShare > 0)
+            if (args.DamageDelta == null || component.Host == null || component.DamageShare == 0)
                 return;
 
             _damageSystem.TryChangeDamage(


### PR DESCRIPTION
## About the PR
Makes guardians (holoparasites et al.) transfer damage to their host again.

## Why / Balance
Damage transfer is fairly central to guardians, and it appears to have been broken since November of 2023 (bug introduced in #21467).

## Technical details
Changed an incorrect comparison. That's literally it.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Holoparasites, holoclowns and other guardians correctly transfer damage to their hosts again.
