### PR TITLE
Adjust syndicate hardbomb damage

### DIFF
--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -110,9 +110,9 @@
       Blunt: 15
       Piercing: 6
       Structural: 40
-  tileBreakChance: [ 0.75, 0.95, 1 ]
-  tileBreakIntensity: [ 1, 10, 15 ]
-  tileBreakRerollReduction: 30
+  tileBreakChance: [ 0, 0.5, 1 ]
+  tileBreakIntensity: [ 0, 10, 30 ]
+  tileBreakRerollReduction: 10
   intensityPerState: 20
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Repairing damage from a syndicate hardbomb is very frustrating and requires a ton of hacky workarounds in order to fully fix the floor. You pretty much have to use 20-30 RCD charges deleting floating tiles which causes you to constantly get stuck floating due to their being no floor. This leads to a lot of engineers not fixing it due to frustration, and trying to fix an entire screens worth of damage takes forever. 

## Why / Balance
This PR nerfs the bomb slightly, but doesn't really change it's actual explosion radius. It just makes it less likely to space tiles, which is what causes the grid separations that is very annoying to fix. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:
![pre bomb 1](https://github.com/space-wizards/space-station-14/assets/104418166/cb8ecf61-c3d5-464f-a3a3-052aa2d2e028)
After:
![after](https://github.com/space-wizards/space-station-14/assets/104418166/5a99244a-f6c7-4975-aad5-aed9cbf2a141)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Changed the syndicate hardbomb to have less of a chance to completely destroy tiles.

