### PR TITLE
jetpacks require back slot

### DIFF
--- a/Content.Client/Movement/Systems/JetpackSystem.cs
+++ b/Content.Client/Movement/Systems/JetpackSystem.cs
@@ -22,7 +22,7 @@ public sealed class JetpackSystem : SharedJetpackSystem
         SubscribeLocalEvent<JetpackComponent, AppearanceChangeEvent>(OnJetpackAppearance);
     }
 
-    protected override bool CanEnable(EntityUid uid, JetpackComponent component)
+    protected override bool CanEnable(EntityUid uid, EntityUid user, JetpackComponent component)
     {
         // No predicted atmos so you'd have to do a lot of funny to get this working.
         return false;

--- a/Content.Server/Movement/Systems/JetpackSystem.cs
+++ b/Content.Server/Movement/Systems/JetpackSystem.cs
@@ -1,5 +1,7 @@
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.Collections;
@@ -11,12 +13,30 @@ public sealed class JetpackSystem : SharedJetpackSystem
 {
     [Dependency] private readonly GasTankSystem _gasTank = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
 
-    protected override bool CanEnable(EntityUid uid, JetpackComponent component)
+    // have to refactor these magic strings into the sharedinventorysystem; trygetslotentity calls are full of them
+    private const string BackSlot = "back";
+
+    public override void Initialize()
     {
-        return base.CanEnable(uid, component) &&
+        base.Initialize();
+
+        SubscribeLocalEvent<JetpackComponent, GotUnequippedEvent>(OnJetpackUnequip);
+    }
+
+    private void OnJetpackUnequip(EntityUid uid, JetpackComponent component, ref GotUnequippedEvent args)
+    {
+        DisableJetpack(uid, component, args.Equipee);
+    }
+
+    protected override bool CanEnable(EntityUid uid, EntityUid user, JetpackComponent component)
+    {
+        return base.CanEnable(uid, user, component) &&
                TryComp<GasTankComponent>(uid, out var gasTank) &&
-               !(gasTank.Air.TotalMoles < component.MoleUsage);
+               gasTank.Air.TotalMoles >= component.MoleUsage &&
+               _inventory.TryGetSlotEntity(user, BackSlot, out var back) &&
+               back == uid;
     }
 
     public override void Update(float frameTime)
@@ -39,7 +59,7 @@ public sealed class JetpackSystem : SharedJetpackSystem
                 continue;
 
             var usedEnoughAir =
-                MathHelper.CloseTo(usedAir.TotalMoles, comp.MoleUsage, comp.MoleUsage/100);
+                MathHelper.CloseTo(usedAir.TotalMoles, comp.MoleUsage, comp.MoleUsage / 100);
 
             if (!usedEnoughAir)
             {
@@ -51,7 +71,7 @@ public sealed class JetpackSystem : SharedJetpackSystem
 
         foreach (var (uid, comp) in toDisable)
         {
-            SetEnabled(uid, comp, false);
+            DisableJetpack(uid, comp);
         }
     }
 }

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -44,7 +44,7 @@ public abstract partial class InventorySystem
 
     private void OnEntRemoved(EntityUid uid, InventoryComponent component, EntRemovedFromContainerMessage args)
     {
-        if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
+        if (!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
             return;
 
         var unequippedEvent = new DidUnequipEvent(uid, args.Entity, slotDef);
@@ -56,8 +56,8 @@ public abstract partial class InventorySystem
 
     private void OnEntInserted(EntityUid uid, InventoryComponent component, EntInsertedIntoContainerMessage args)
     {
-        if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
-           return;
+        if (!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
+            return;
 
         var equippedEvent = new DidEquipEvent(uid, args.Entity, slotDef);
         RaiseLocalEvent(uid, equippedEvent, true);
@@ -116,7 +116,7 @@ public abstract partial class InventorySystem
 
         RaiseLocalEvent(held.Value, new HandDeselectedEvent(actor), false);
 
-        TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory, force: true, checkDoafter:true);
+        TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory, force: true, checkDoafter: true);
     }
 
     public bool TryEquip(EntityUid uid, EntityUid itemUid, string slot, bool silent = false, bool force = false, bool predicted = false,
@@ -128,7 +128,7 @@ public abstract partial class InventorySystem
     {
         if (!Resolve(target, ref inventory, false))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"));
             return false;
         }
@@ -139,14 +139,14 @@ public abstract partial class InventorySystem
 
         if (!TryGetSlotContainer(target, slot, out var slotContainer, out var slotDefinition, inventory))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"));
             return false;
         }
 
         if (!force && !CanEquip(actor, target, itemUid, slot, out var reason, slotDefinition, inventory, clothing))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString(reason));
             return false;
         }
@@ -180,7 +180,7 @@ public abstract partial class InventorySystem
 
         if (!_containerSystem.Insert(itemUid, slotContainer))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
             return false;
         }
@@ -369,14 +369,14 @@ public abstract partial class InventorySystem
 
         if (!Resolve(target, ref inventory, false))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
             return false;
         }
 
         if (!TryGetSlotContainer(target, slot, out var slotContainer, out var slotDefinition, inventory))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
             return false;
         }
@@ -388,7 +388,7 @@ public abstract partial class InventorySystem
 
         if (!force && !CanUnequip(actor, target, slot, out var reason, slotContainer, slotDefinition, inventory))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString(reason));
             return false;
         }
@@ -457,7 +457,8 @@ public abstract partial class InventorySystem
         InventoryComponent? inventory = null) =>
         CanUnequip(uid, uid, slot, out reason, containerSlot, slotDefinition, inventory);
 
-    public bool CanUnequip(EntityUid actor, EntityUid target, string slot, [NotNullWhen(false)] out string? reason, ContainerSlot? containerSlot = null, SlotDefinition? slotDefinition = null, InventoryComponent? inventory = null)
+    public bool CanUnequip(EntityUid actor, EntityUid target, string slot, [NotNullWhen(false)] out string? reason,
+        ContainerSlot? containerSlot = null, SlotDefinition? slotDefinition = null, InventoryComponent? inventory = null)
     {
         reason = "inventory-component-can-unequip-cannot";
         if (!Resolve(target, ref inventory, false))
@@ -466,7 +467,7 @@ public abstract partial class InventorySystem
         if ((containerSlot == null || slotDefinition == null) && !TryGetSlotContainer(target, slot, out containerSlot, out slotDefinition, inventory))
             return false;
 
-        if (containerSlot.ContainedEntity is not {} itemUid)
+        if (containerSlot.ContainedEntity is not { } itemUid)
             return false;
 
         if (!_containerSystem.CanRemove(itemUid, containerSlot))
@@ -510,7 +511,12 @@ public abstract partial class InventorySystem
         return true;
     }
 
-    public bool TryGetSlotEntity(EntityUid uid, string slot, [NotNullWhen(true)] out EntityUid? entityUid, InventoryComponent? inventoryComponent = null, ContainerManagerComponent? containerManagerComponent = null)
+    /// <summary>
+    ///     Whether the entity is equipped in slot.
+    /// </summary>
+    /// <param name="entityUid">Exported contents of <paramref name="slot"/>.</param>
+    public bool TryGetSlotEntity(EntityUid uid, string slot, [NotNullWhen(true)] out EntityUid? entityUid,
+        InventoryComponent? inventoryComponent = null, ContainerManagerComponent? containerManagerComponent = null)
     {
         entityUid = null;
         if (!Resolve(uid, ref inventoryComponent, ref containerManagerComponent, false)

--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -68,6 +68,9 @@ public partial class InventorySystem : EntitySystem
     public bool HasSlot(EntityUid uid, string slot, InventoryComponent? component = null) =>
         TryGetSlot(uid, slot, out _, component);
 
+    /// <summary>
+    ///     Whether the entity has the specified slot. Use <see cref="TryGetSlotEntity"/> for the equipped item.
+    /// </summary>
     public bool TryGetSlot(EntityUid uid, string slot, [NotNullWhen(true)] out SlotDefinition? slotDefinition, InventoryComponent? inventory = null)
     {
         slotDefinition = null;

--- a/Resources/Locale/en-US/movement/jetpacks.ftl
+++ b/Resources/Locale/en-US/movement/jetpacks.ftl
@@ -1,2 +1,2 @@
 jetpack-no-station = Can't use jetpacks under gravity
-jetpack-to-grid = The jetpack turns off
+jetpack-disabled = The jetpack turns off


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
fixes #21211, #18035 maybe

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
`SharedJetpackSystem.CanEnable` takes a user entityuid. the serverside override checks for a backpack slot and that the jetpack is inside it.

the server `jetpacksystem` subscribes to `gotunequippedevent` to disable the jetpack permissively whenever it leaves the back slot.

i bifurcated `SharedJetpackSystem.SetEnabled` into `EnableJetpack` and `DisableJetpack` methods; much cleaner.

i couldn't get the unequip event handler's serverside player entity to cause a `popupclient` message. not sure what that's about

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: jetpacks must now be worn in the back slot to work

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
