### PR TITLE
Make timer ignore client predict setting

### DIFF
--- a/Content.Client/TextScreen/TextScreenSystem.cs
+++ b/Content.Client/TextScreen/TextScreenSystem.cs
@@ -62,6 +62,8 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
 
         SubscribeLocalEvent<TextScreenVisualsComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<TextScreenTimerComponent, ComponentInit>(OnTimerInit);
+
+        UpdatesOutsidePrediction = true;
     }
 
     private void OnInit(EntityUid uid, TextScreenVisualsComponent component, ComponentInit args)


### PR DESCRIPTION
Since it's basically a countdown animation, and having the server send the updates would be insane.
UpdatesOutsidePrediction = true
Fix: https://github.com/space-wizards/space-station-14/issues/26525