### PR TITLE
cancelable brig timers

### DIFF
--- a/Content.Client/TextScreen/TextScreenSystem.cs
+++ b/Content.Client/TextScreen/TextScreenSystem.cs
@@ -110,17 +110,11 @@ public sealed class TextScreenSystem : VisualizerSystem<TextScreenVisualsCompone
         if (args.AppearanceData.TryGetValue(TextScreenVisuals.Color, out var color) && color is Color)
             component.Color = (Color) color;
 
-        // DefaultText: broadcast updates from comms consoles
-        // ScreenText: the text accompanying shuttle timers e.g. "ETA"
+        // DefaultText: fallback text e.g. broadcast updates from comms consoles
         if (args.AppearanceData.TryGetValue(TextScreenVisuals.DefaultText, out var newDefault) && newDefault is string)
-        {
-            string?[] defaultText = SegmentText((string) newDefault, component);
-            component.Text = defaultText;
-            component.TextToDraw = defaultText;
-            ResetText(uid, component);
-            BuildTextLayers(uid, component, args.Sprite);
-            DrawLayers(uid, component.LayerStatesToDraw);
-        }
+            component.Text = SegmentText((string) newDefault, component);
+
+        // ScreenText: currently rendered text e.g. the "ETA" accompanying shuttle timers
         if (args.AppearanceData.TryGetValue(TextScreenVisuals.ScreenText, out var text) && text is string)
         {
             component.TextToDraw = SegmentText((string) text, component);

--- a/Content.Server/DeviceLinking/Components/SignalTimerComponent.cs
+++ b/Content.Server/DeviceLinking/Components/SignalTimerComponent.cs
@@ -24,6 +24,12 @@ public sealed partial class SignalTimerComponent : Component
     public string Label = string.Empty;
 
     /// <summary>
+    ///     Default max width of a label (how many letters can this render?)
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public int MaxLength = 5;
+
+    /// <summary>
     ///     The port that gets signaled when the timer triggers.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Screens/Systems/ScreenSystem.cs
+++ b/Content.Server/Screens/Systems/ScreenSystem.cs
@@ -56,6 +56,7 @@ public sealed class ScreenSystem : EntitySystem
             )
         {
             _appearanceSystem.SetData(uid, TextScreenVisuals.DefaultText, text);
+            _appearanceSystem.SetData(uid, TextScreenVisuals.ScreenText, text);
         }
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
fixes #25024
makes it so clicking the timer button while it's counting down will just end the timer 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
in `SignalTimerSystem`, i added a check for `HasComp<ActiveSignalTimerComponent>` in `OnTimerStartMessage`. i made some of the update methods update `TextScreenVisuals.DefaultText` in addition to `ScreenText` so the clientside `TextScreenSystem` would fallback on its ordinary timer finish behavior to write the text after finishing a timer.

i also trimmed some redundant code in `SignalTimerSystem` and `TextScreenSystem` which was essentially a hack around a missing `TextScreenVisuals.ScreenText` write in `ScreenSystem` (which i added).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![dotnet_NGwszCikO6](https://github.com/space-wizards/space-station-14/assets/51971268/93ee08d3-23ae-4836-955e-71672cf00472)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: clicking the brig timer button will now cancel its countdown

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
