### PR TITLE
Mobs with combat mode now only mouselook when combat mode is OFF

### DIFF
--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -26,6 +26,7 @@ public abstract class SharedCombatModeSystem : EntitySystem
     private void OnMapInit(EntityUid uid, CombatModeComponent component, MapInitEvent args)
     {
         _actionsSystem.AddAction(uid, ref component.CombatToggleActionEntity, component.CombatToggleAction);
+        SetMouseRotatorComponents(uid, true);
         Dirty(uid, component);
     }
 
@@ -85,7 +86,7 @@ public abstract class SharedCombatModeSystem : EntitySystem
         if (!component.ToggleMouseRotator || IsNpc(entity))
             return;
 
-        SetMouseRotatorComponents(entity, value);
+        SetMouseRotatorComponents(entity, !value);
     }
 
     private void SetMouseRotatorComponents(EntityUid uid, bool value)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Mobs that have combat mode will now have mouselook when combat mode is OFF, and normal directions when combat mode is ON. By mouselook I mean the mob changes their direction to point towards the mouse cursor, toggled with the SetMouseRotatorComponents method.
Mobs without combat mode are not affected, like ghosts and whatnot. If you'd rather ALL mobs have mouselook by default including ghosts, please demand!

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Funny lil switcheroo. Tiny change with huge impact despite being mostly cosmetic. Confuses everyone for a few minutes before they adjust, which is hilarious.
Also it lets you shoot backwards and casually moonwalk which is super cool

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This simply inverts whether mouselook is used depending on combat mode being enabled or disabled through the SetInCombatMode method.
Additionally, when combat mode is initialized, it enables mouselook.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
https://github.com/space-wizards/space-station-14/assets/25937686/4298f6fd-ced5-416d-8d2d-3b34ebacd9cf
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: When combat mode is turned off, your character points towards your mouse cursor. When it is on, your character points towards the last direction they moved. Ghosts and other things without combat mode always point towards the last direction they moved.
