### PR TITLE
Give stores the ability to check for owner only

### DIFF
--- a/Content.Server/Store/Components/StoreComponent.cs
+++ b/Content.Server/Store/Components/StoreComponent.cs
@@ -79,6 +79,13 @@ public sealed partial class StoreComponent : Component
     public bool RefundAllowed;
 
     /// <summary>
+    ///     Checks if store can be opened by the account owner only.
+    ///     Not meant to be used with uplinks.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public bool OwnerOnly;
+
+    /// <summary>
     ///     The map the store was originally from, used to block refunds if the map is changed
     /// </summary>
     [DataField]

--- a/Content.Server/Store/Systems/StoreSystem.cs
+++ b/Content.Server/Store/Systems/StoreSystem.cs
@@ -10,6 +10,7 @@ using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
 using System.Linq;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Store.Systems;
 
@@ -26,6 +27,7 @@ public sealed partial class StoreSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<StoreComponent, ActivatableUIOpenAttemptEvent>(OnStoreOpenAttempt);
         SubscribeLocalEvent<CurrencyComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<StoreComponent, BeforeActivatableUIOpenEvent>(BeforeActivatableUiOpen);
 
@@ -63,6 +65,21 @@ public sealed partial class StoreSystem : EntitySystem
     {
         var ev = new StoreRemovedEvent();
         RaiseLocalEvent(uid, ref ev, true);
+    }
+
+    private void OnStoreOpenAttempt(EntityUid uid, StoreComponent component, ActivatableUIOpenAttemptEvent args)
+    {
+        if (!component.OwnerOnly)
+            return;
+
+        component.AccountOwner ??= args.User;
+        DebugTools.Assert(component.AccountOwner != null);
+
+        if (component.AccountOwner == args.User)
+            return;
+
+        _popup.PopupEntity(Loc.GetString("store-not-account-owner", ("store", uid)), uid, args.User);
+        args.Cancel();
     }
 
     private void OnAfterInteract(EntityUid uid, CurrencyComponent component, AfterInteractEvent args)

--- a/Resources/Locale/en-US/store/store.ftl
+++ b/Resources/Locale/en-US/store/store.ftl
@@ -6,3 +6,5 @@ store-ui-traitor-flavor = Copyright (C) NT -30643
 store-ui-traitor-warning = Operatives must lock their uplinks after use to avoid detection.
 
 store-withdraw-button-ui = Withdraw {$currency}
+
+store-not-account-owner = This {$store} is not bound to you!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Some stores may want to be only opened by the original account owner. Wizard's spellbook is a good example since you wouldn't want them sharing spells with apprentices or the crew.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

See about the PR.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

A bool called OriginalOwner was added to the StoreComponent.

The store system checks this before the UI is opened. If there's no account owner then it will assign the first person to open this store.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
