### PR TITLE
Change alert updates to happen during an update.

### DIFF
--- a/Content.Client/Alerts/ClientAlertsSystem.cs
+++ b/Content.Client/Alerts/ClientAlertsSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared.Alert;
 using JetBrains.Annotations;
+using Robust.Client.GameStates;
 using Robust.Client.Player;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -14,6 +15,13 @@ public sealed class ClientAlertsSystem : AlertsSystem
 
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IClientGameStateManager _gameState = default!;
+
+    /// <summary>
+    /// Syncing alerts can create entities, so we need to delay it, so it happens during an update.
+    /// </summary>
+    private SyncAlertAction _updateAlertActionOnNextTick = SyncAlertAction.None;
 
     public event EventHandler? ClearAlerts;
     public event EventHandler<IReadOnlyDictionary<AlertKey, AlertState>>? SyncAlerts;
@@ -26,6 +34,7 @@ public sealed class ClientAlertsSystem : AlertsSystem
         SubscribeLocalEvent<AlertsComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
 
         SubscribeLocalEvent<AlertsComponent, AfterAutoHandleStateEvent>(ClientAlertsHandleState);
+        UpdatesOutsidePrediction = true;
     }
     protected override void LoadPrototypes()
     {
@@ -34,6 +43,32 @@ public sealed class ClientAlertsSystem : AlertsSystem
         AlertOrder = _prototypeManager.EnumeratePrototypes<AlertOrderPrototype>().FirstOrDefault();
         if (AlertOrder == null)
             Log.Error("No alertOrder prototype found, alerts will be in random order");
+    }
+
+    public override void Update(float frameTime)
+    {
+        switch (_updateAlertActionOnNextTick)
+        {
+            case SyncAlertAction.Clear:
+                ClearAlerts?.Invoke(this, EventArgs.Empty);
+                _updateAlertActionOnNextTick = SyncAlertAction.None;
+                break;
+            case SyncAlertAction.Sync:
+                if (_entityManager.TryGetComponent<AlertsComponent>(_playerManager.LocalEntity, out var alertComp))
+                {
+                    SyncAlerts?.Invoke(this, alertComp.Alerts);
+                }
+                _updateAlertActionOnNextTick = SyncAlertAction.None;
+                break;
+            case SyncAlertAction.None:
+            default:
+                break;
+        }
+
+        if (_gameState.IsPredictionEnabled)
+        {
+            base.Update(frameTime);
+        }
     }
 
     public IReadOnlyDictionary<AlertKey, AlertState>? ActiveAlerts
@@ -49,31 +84,29 @@ public sealed class ClientAlertsSystem : AlertsSystem
 
     protected override void AfterShowAlert(Entity<AlertsComponent> alerts)
     {
-        UpdateHud(alerts);
+        QueueAlertSync(alerts);
     }
 
     protected override void AfterClearAlert(Entity<AlertsComponent> alerts)
     {
-        UpdateHud(alerts);
+        QueueAlertSync(alerts);
     }
 
     private void ClientAlertsHandleState(Entity<AlertsComponent> alerts, ref AfterAutoHandleStateEvent args)
     {
-        UpdateHud(alerts);
+        QueueAlertSync(alerts);
     }
 
-    private void UpdateHud(Entity<AlertsComponent> entity)
+    private void QueueAlertSync(Entity<AlertsComponent> entity)
     {
-        if (_playerManager.LocalEntity == entity.Owner)
-            SyncAlerts?.Invoke(this, entity.Comp.Alerts);
+        if (_playerManager.LocalEntity != entity.Owner)
+            return;
+        _updateAlertActionOnNextTick = SyncAlertAction.Sync;
     }
 
     private void OnPlayerAttached(EntityUid uid, AlertsComponent component, LocalPlayerAttachedEvent args)
     {
-        if (_playerManager.LocalEntity != uid)
-            return;
-
-        SyncAlerts?.Invoke(this, component.Alerts);
+        _updateAlertActionOnNextTick = SyncAlertAction.Sync;
     }
 
     protected override void HandleComponentShutdown(EntityUid uid, AlertsComponent component, ComponentShutdown args)
@@ -82,17 +115,23 @@ public sealed class ClientAlertsSystem : AlertsSystem
 
         if (_playerManager.LocalEntity != uid)
             return;
-
-        ClearAlerts?.Invoke(this, EventArgs.Empty);
+        _updateAlertActionOnNextTick = SyncAlertAction.Clear;
     }
 
     private void OnPlayerDetached(EntityUid uid, AlertsComponent component, LocalPlayerDetachedEvent args)
     {
-        ClearAlerts?.Invoke(this, EventArgs.Empty);
+        _updateAlertActionOnNextTick = SyncAlertAction.Clear;
     }
 
     public void AlertClicked(AlertType alertType)
     {
         RaiseNetworkEvent(new ClickAlertEvent(alertType));
+    }
+
+    private enum SyncAlertAction
+    {
+        None,
+        Clear,
+        Sync
     }
 }


### PR DESCRIPTION
Alerts changed so they have the potential to spawn entities:
https://github.com/space-wizards/space-station-14/pull/25452
See AlertControl constructor.

The first attempt was shutting down the UI earlier. I tried some stuff to prevent the round restart from crashing. Detecting when we were switching game states, using the round cleanup event. The client explodes before these events happen, while state is being applied, so they were not useful.

The solution I came up with, is to make the Alert syncing only happen during an update. Since this is a normal place for entitiy changes to happen, it lets the alert system make it's entity safely. This might increase performance slightly when restarting, because detaching was spamming the sync alert call, although I didn't look into it.

Fixes: https://github.com/space-wizards/space-station-14/issues/26552