### PR TITLE
Fix round start crash (causing instant restart)

### DIFF
--- a/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
+++ b/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Mind;
 using Content.Shared.Objectives;
 using Content.Shared.Objectives.Components;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Objectives.Systems;
@@ -11,6 +12,7 @@ namespace Content.Shared.Objectives.Systems;
 public abstract class SharedObjectivesSystem : EntitySystem
 {
     [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
 
     private EntityQuery<MetaDataComponent> _metaQuery;
 
@@ -55,6 +57,9 @@ public abstract class SharedObjectivesSystem : EntitySystem
     /// </summary>
     public EntityUid? TryCreateObjective(EntityUid mindId, MindComponent mind, string proto)
     {
+        if (!_protoMan.HasIndex<EntityPrototype>(proto))
+            return null;
+
         var uid = Spawn(proto);
         if (!TryComp<ObjectiveComponent>(uid, out var comp))
         {

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -72,7 +72,6 @@
     TechnologyDiskStealCollectionObjective: 1        #rnd
     FigurineStealCollectionObjective: 0.3          #service
     IDCardsStealCollectionObjective: 1
-    CannabisStealCollectionObjective: 1
     LAMPStealCollectionObjective: 2 #only for moth
 
 - type: weightedRandom


### PR DESCRIPTION
Untested, but pretty sure this is the cause.

Fix https://github.com/space-wizards/space-station-14/issues/26521

Found log in grafana at "2024-03-27 03:06:05.312":

Caught exception in GameTicker
Robust.Shared.GameObjects.EntityCreationException: Attempted to spawn an entity with an invalid prototype: CannabisStealCollectionObjective

Exception caught while trying to start the round! Restarting round...