### PR TITLE
Fix: Prevent single-use hyposprays from getting the toggle draw verb

### DIFF
--- a/Content.Shared/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Shared/Chemistry/Components/HyposprayComponent.cs
@@ -30,4 +30,11 @@ public sealed partial class HyposprayComponent : Component
     [AutoNetworkedField]
     [DataField(required: true)]
     public bool OnlyAffectsMobs = false;
+
+    /// <summary>
+    /// Whether or not the hypospray is able to draw from containers or if it's a single use
+    /// device that can only inject.
+    /// </summary>
+    [DataField]
+    public bool InjectOnly = false;
 }

--- a/Content.Shared/Chemistry/EntitySystems/SharedHypospraySystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedHypospraySystem.cs
@@ -27,7 +27,7 @@ public abstract class SharedHypospraySystem : EntitySystem
     // </summary>
     private void AddToggleModeVerb(Entity<HyposprayComponent> entity, ref GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract || args.Hands == null)
+        if (!args.CanAccess || !args.CanInteract || args.Hands == null || entity.Comp.InjectOnly)
             return;
 
         var (_, component) = entity;

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -115,6 +115,7 @@
     solutionName: pen
     transferAmount: 15
     onlyAffectsMobs: false
+    injectOnly: true
   - type: Appearance
   - type: SolutionContainerVisuals
     maxFillLevels: 1
@@ -205,6 +206,7 @@
     solutionName: pen
     transferAmount: 20
     onlyAffectsMobs: false
+    injectOnly: true
   - type: SolutionContainerManager
     solutions:
       pen:
@@ -236,6 +238,7 @@
     solutionName: pen
     transferAmount: 20
     onlyAffectsMobs: false
+    injectOnly: true
   - type: SolutionContainerManager
     solutions:
       pen:
@@ -267,6 +270,8 @@
     solutionName: pen
     transferAmount: 20
     onlyAffectsMobs: false
+    injectOnly: true
+
   - type: SolutionContainerManager
     solutions:
       pen:
@@ -299,6 +304,7 @@
     solutionName: pen
     transferAmount: 30
     onlyAffectsMobs: false
+    injectOnly: true
   - type: SolutionContainerManager
     solutions:
       pen:
@@ -337,6 +343,7 @@
     solutionName: pen
     transferAmount: 30
     onlyAffectsMobs: false
+    injectOnly: true
   - type: StaticPrice
     price: 500
   - type: Tag
@@ -397,6 +404,7 @@
     solutionName: pen
     transferAmount: 30
     onlyAffectsMobs: false
+    injectOnly: true
   - type: StaticPrice
     price: 500
   - type: Tag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds an injectOnly bool to check whether or not some hyposprays are inject only. I originally thought the medipens inherited the InjectorComponent and not the HyposprayComponent, so I forgot to add this in.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
People were beer maxxing and poison maxxing by drawing with their empty medipens to instantly inject people with 15u/30u of things.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
injectOnly bool added to HyposprayComponent, toggle verb is not added when injectOnly is set to true. This prevents the only method in which the single-use injectors can be toggled by the user to draw from them...

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl because it's just something I missed with my hypospray draw from jugs PR