### PR TITLE
Refactored AdvertiseComponent

### DIFF
--- a/Content.Server/Advertise/Components/AdvertiseComponent.cs
+++ b/Content.Server/Advertise/Components/AdvertiseComponent.cs
@@ -1,7 +1,6 @@
 using Content.Server.Advertise.EntitySystems;
 using Content.Shared.Advertise;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Advertise.Components;
 
@@ -37,9 +36,4 @@ public sealed partial class AdvertiseComponent : Component
     [DataField]
     public TimeSpan NextAdvertisementTime { get; set; } = TimeSpan.Zero;
 
-    /// <summary>
-    /// Whether the entity will say advertisements or not.
-    /// </summary>
-    [DataField]
-    public bool Enabled { get; set; } = true;
 }


### PR DESCRIPTION
1. Removed Enabled

> Reasons:
> 
> - Enabled default was true, the map init power event made it false, so saving the map adds garbage
> - Enabled is changed by power events, so it's not usable as a setting
> - Enabled would break if the vending machine lost power, was broken, gained power, then was repaired. Assuming some day it became repairable.
> - Given the previous issue, if more AdvertiseEnableChangeAttemptEvent were added, they would also not work.


2. AdvertiseEnableChangeAttemptEvent has been replaced with AttemptAdvertiseEvent (doesn't have the flaws enabled had)

3. Made system easier to understand (opinion)
