### PR TITLE
Fix GastTileOverlay sending redundant data

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
@@ -432,14 +432,16 @@ namespace Content.Server.Atmos.EntitySystems
                         if (!overlay.Chunks.TryGetValue(gIndex, out var value))
                             continue;
 
-                        if (previousChunks != null &&
-                            previousChunks.Contains(gIndex) &&
-                            value.LastUpdate > LastSessionUpdate)
+                        // If the chunk was updated since we last sent it, send it again
+                        if (value.LastUpdate > LastSessionUpdate)
                         {
+                            dataToSend.Add(value);
                             continue;
                         }
 
-                        dataToSend.Add(value);
+                        // Always send it if we didn't previously send it
+                        if (previousChunks == null || !previousChunks.Contains(gIndex))
+                            dataToSend.Add(value);
                     }
 
                     previouslySent[netGrid] = gridChunks;


### PR DESCRIPTION
Fixes a bug added in #26542 that was causing GasTileOverlay to always re-send chunks even if they hadn't updated.

I'm fairly sure that caused the data usage increase on grafana ![chrome_qkEGuTuZWb](https://github.com/space-wizards/space-station-14/assets/60421075/235f1a97-c281-4ba4-9019-4fa751bbba0f)
