### PR TITLE
April Fools Hotfix: Fix some Legally Distinct Space Ferret bugs

### DIFF
--- a/Content.Server/LegallyDistinctSpaceFerret/BrainrotSystem.cs
+++ b/Content.Server/LegallyDistinctSpaceFerret/BrainrotSystem.cs
@@ -42,7 +42,7 @@ public sealed class BrainrotSystem : EntitySystem
     [Dependency] private readonly FixtureSystem _fixtures = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
 
-    public const string BrainrotFixture = "brainrot_ignoreDoors";
+    public const string BrainrotFixture = "brainrot";
     public const string BrainRotApplied = "brainrot-applied";
     public const string BrainRotLost = "brainrot-lost";
     public readonly string[] BrainRotReplacementStrings =

--- a/Content.Server/LegallyDistinctSpaceFerret/BrainrotSystem.cs
+++ b/Content.Server/LegallyDistinctSpaceFerret/BrainrotSystem.cs
@@ -42,7 +42,7 @@ public sealed class BrainrotSystem : EntitySystem
     [Dependency] private readonly FixtureSystem _fixtures = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
 
-    public const string BrainrotFixture = "brainrot";
+    public const string BrainrotFixture = "brainrot_ignoreDoors";
     public const string BrainRotApplied = "brainrot-applied";
     public const string BrainRotLost = "brainrot-lost";
     public readonly string[] BrainRotReplacementStrings =
@@ -72,9 +72,15 @@ public sealed class BrainrotSystem : EntitySystem
         if (!TryComp<PhysicsComponent>(uid, out var body))
             return;
 
-        var shape = new PhysShapeCircle(component.Range);
-
-        _fixtures.TryCreateFixture(uid, shape, BrainrotFixture, collisionLayer: (int) CollisionGroup.MobMask, hard: false, body: body);
+        _fixtures.TryCreateFixture(
+            uid,
+            new PhysShapeCircle(component.Range),
+            BrainrotFixture,
+            collisionLayer: (int) CollisionGroup.None,
+            collisionMask: (int) CollisionGroup.MidImpassable,
+            hard: false,
+            body: body
+        );
     }
 
     private void OnShutdown(EntityUid uid, BrainrotAuraComponent component, ComponentShutdown args)

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -593,7 +593,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
     /// </summary>
     private void HandleCollide(EntityUid uid, DoorComponent door, ref StartCollideEvent args)
     {
-        if (args.OtherFixtureId.Contains("_ignoreDoors"))
+        // Non-hard fixtures are used as trigger volumes so we can safely ignore them for bumps etc.
+        if (!args.OtherFixture.Hard)
             return;
 
         if (!door.BumpOpen)

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -593,6 +593,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
     /// </summary>
     private void HandleCollide(EntityUid uid, DoorComponent door, ref StartCollideEvent args)
     {
+        if (args.OtherFixtureId.Contains("_ignoreDoors"))
+            return;
+
         if (!door.BumpOpen)
             return;
 

--- a/Resources/Locale/en-US/legallydistinctspaceferret/role.ftl
+++ b/Resources/Locale/en-US/legallydistinctspaceferret/role.ftl
@@ -1,4 +1,4 @@
-legallydistinctspaceferret-round-end-agent-name = ninja
+legallydistinctspaceferret-round-end-agent-name = legally distinct space ferret
 
 objective-issuer-legallydistinctspaceferret = [color=#33cc00]Space Ferret Tribe[/color]
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/legallydistinctspaceferret.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/legallydistinctspaceferret.yml
@@ -115,6 +115,7 @@
   - type: Inventory
     templateId: legallydistinctspaceferret
   - type: InventorySlots
+  - type: GhostTakeoverAvailable
 
   # Midround antagonist, spawned via random event
 - type: entity


### PR DESCRIPTION
## About the PR
1. Brainrot aura now will not open doors from 3 meters away
2. EOR screen now no longer thinks LDSFs are ninjas
3. LDSFs leave the ghost role list when selected

## Technical details
Doors make big assumptions about what's collided with them because auras (trigger volumes around an entity) do not really exist in the game normally outside of brainrot and the whizz-by effect when a bullet misses you.

I'm essentially forced to use string eval tricks with the fixture ID to hack around this :(

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
