### PR TITLE
April Fools Hotfix: Remove Zombies from All-At-Once

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-allatonce.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-allatonce.ftl
@@ -1,2 +1,2 @@
-all-at-once-title = All at once
-all-at-once-description = It's just not your day...
+all-at-once-title = Everything But Zombies
+all-at-once-description = It's just not your day... now sans zombies

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -18,7 +18,7 @@
     - Nukeops
     - Traitor
     - Revolutionary
-    - Zombie
+    #- Zombie Fuck no
     - RampingStationEventScheduler
 
 - type: gamePreset


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removes zombies from All At Once, and renames the mode in English loc to "Everything But Zombies" to reflect this.

## Why / Balance
Yeah so All At Once is fun when zombies are terrible but with zombies a legitimate threat they essentially dominate the game mode.

Nukies can throw zombies at the station themselves if they want.