### PR TITLE
Drawl capitalization coldfix (part 2: rise of accidentally commiting to master)

### DIFF
--- a/Content.Server/Speech/EntitySystems/SouthernAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SouthernAccentSystem.cs
@@ -5,9 +5,12 @@ namespace Content.Server.Speech.EntitySystems;
 
 public sealed class SouthernAccentSystem : EntitySystem
 {
-    private static readonly Regex RegexIng = new(@"ing\b");
-    private static readonly Regex RegexAnd = new(@"\band\b");
-    private static readonly Regex RegexDve = new("d've");
+    private static readonly Regex RegexLowerIng = new(@"ing\b");
+    private static readonly Regex RegexUpperIng = new(@"ING\b");
+    private static readonly Regex RegexLowerAnd = new(@"\band\b");
+    private static readonly Regex RegexUpperAnd = new(@"\bAND\b");
+    private static readonly Regex RegexLowerDve = new(@"d've\b");
+    private static readonly Regex RegexUpperDve = new(@"D'VE\b");
 
     [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
 
@@ -24,9 +27,12 @@ public sealed class SouthernAccentSystem : EntitySystem
         message = _replacement.ApplyReplacements(message, "southern");
 
         //They shoulda started runnin' an' hidin' from me!
-        message = RegexIng.Replace(message, "in'");
-        message = RegexAnd.Replace(message, "an'");
-        message = RegexDve.Replace(message, "da");
+        message = RegexLowerIng.Replace(message, "in'");
+        message = RegexUpperIng.Replace(message, "IN'");
+        message = RegexLowerAnd.Replace(message, "an'");
+        message = RegexUpperAnd.Replace(message, "AN'");
+        message = RegexLowerDve.Replace(message, "da");
+        message = RegexUpperDve.Replace(message, "DA");
         args.Message = message;
     }
 };


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
A sort of hotfix that fixes all-caps words not being regex'd, and "And" not being regex'd while using the Southern Drawl trait.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

fix https://github.com/space-wizards/space-station-14/issues/26637