### PR TITLE
Fix capitalization for pirates and rats

### DIFF
--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -61,12 +61,12 @@ public sealed class MobsterAccentSystem : EntitySystem
         // Prefix
         if (_random.Prob(0.15f))
         {
-            bool firstWordCapitalized = !Regex.Match(msg, @"^([\w\-]+)").Value.Any(char.IsLower);
+            bool firstWordAllCaps = !Regex.Match(msg, @"^([\w\-]+)").Value.Any(char.IsLower);
             var pick = _random.Next(1, 2);
 
             // Reverse sanitize capital
             var prefix = Loc.GetString($"accent-mobster-prefix-{pick}");
-            if (!firstWordCapitalized)
+            if (!firstWordAllCaps)
                 msg = msg[0].ToString().ToLower() + msg.Remove(0, 1);
             else
                 prefix = prefix.ToUpper();
@@ -79,7 +79,7 @@ public sealed class MobsterAccentSystem : EntitySystem
         // Suffixes
         if (_random.Prob(0.4f))
         {
-            bool lastWordCapitalized = !Regex.Match(msg, @"(\S+)$").Value.Any(char.IsLower);
+            bool lastWordAllCaps = !Regex.Match(msg, @"(\S+)$").Value.Any(char.IsLower);
             var suffix = "";
             if (component.IsBoss)
             {
@@ -91,7 +91,7 @@ public sealed class MobsterAccentSystem : EntitySystem
                 var pick = _random.Next(1, 3);
                 suffix = Loc.GetString($"accent-mobster-suffix-minion-{pick}");                
             }
-            if (lastWordCapitalized)
+            if (lastWordAllCaps)
                 suffix = suffix.ToUpper();
             msg += suffix;
         }

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -45,10 +45,8 @@ public sealed class MobsterAccentSystem : EntitySystem
         // Do text manipulations first
         // Then prefix/suffix funnyies
 
-        var msg = message;
-
         // direct word replacements
-        msg = _replacement.ApplyReplacements(message, "mobster");
+        var msg = _replacement.ApplyReplacements(message, "mobster");
 
         // thinking -> thinkin'
         // king -> king

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -79,7 +79,7 @@ public sealed class MobsterAccentSystem : EntitySystem
         // Suffixes
         if (_random.Prob(0.4f))
         {
-            bool lastWordCapitalized = !Regex.Match(msg, @"([\w\-]+)$").Value.Any(char.IsLower);
+            bool lastWordCapitalized = !Regex.Match(msg, @"(\S+)$").Value.Any(char.IsLower);
             var suffix = "";
             if (component.IsBoss)
             {

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -63,6 +63,7 @@ public sealed class MobsterAccentSystem : EntitySystem
         if (_random.Prob(0.15f))
         {
             //Checks if the first word of the sentence is all caps
+            //So the prefix can be allcapped and to not resanitize the captial
             var firstWordAllCaps = !Regex.Match(msg, @"^(\S+)").Value.Any(char.IsLower);
             var pick = _random.Next(1, 2);
 
@@ -82,6 +83,7 @@ public sealed class MobsterAccentSystem : EntitySystem
         if (_random.Prob(0.4f))
         {
             //Checks if the last word of the sentence is all caps
+            //So the suffix can be allcapped
             var lastWordAllCaps = !Regex.Match(msg, @"(\S+)$").Value.Any(char.IsLower);
             var suffix = "";
             if (component.IsBoss)

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -61,7 +61,7 @@ public sealed class MobsterAccentSystem : EntitySystem
         // Prefix
         if (_random.Prob(0.15f))
         {
-            bool firstWordAllCaps = !Regex.Match(msg, @"^([\w\-]+)").Value.Any(char.IsLower);
+            var firstWordAllCaps = !Regex.Match(msg, @"^(\S+)").Value.Any(char.IsLower);
             var pick = _random.Next(1, 2);
 
             // Reverse sanitize capital
@@ -79,7 +79,7 @@ public sealed class MobsterAccentSystem : EntitySystem
         // Suffixes
         if (_random.Prob(0.4f))
         {
-            bool lastWordAllCaps = !Regex.Match(msg, @"(\S+)$").Value.Any(char.IsLower);
+            var lastWordAllCaps = !Regex.Match(msg, @"(\S+)$").Value.Any(char.IsLower);
             var suffix = "";
             if (component.IsBoss)
             {

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 using Robust.Shared.Random;
@@ -49,11 +50,16 @@ public sealed class MobsterAccentSystem : EntitySystem
 
         // thinking -> thinkin'
         // king -> king
-        msg = Regex.Replace(msg, @"(?<=\w\w)ing(?!\w)", "in'", RegexOptions.IgnoreCase);
+        msg = Regex.Replace(msg, @"(?<=\w\w)ing(?!\w)", "in'");
+        msg = Regex.Replace(msg, @"(?<=\w\w)ING(?!\w)", "IN'");
 
         // or -> uh and ar -> ah in the middle of words (fuhget, tahget)
-        msg = Regex.Replace(msg, @"(?<=\w)or(?=\w)", "uh", RegexOptions.IgnoreCase);
-        msg = Regex.Replace(msg, @"(?<=\w)ar(?=\w)", "ah", RegexOptions.IgnoreCase);
+        msg = Regex.Replace(msg, @"(?<=\w)or(?=\w)", "uh");
+        msg = Regex.Replace(msg, @"(?<=\w)OR(?=\w)", "UH");
+        msg = Regex.Replace(msg, @"(?<=\w)ar(?=\w)", "ah");
+        msg = Regex.Replace(msg, @"(?<=\w)AR(?=\w)", "AH");
+
+        var notAllCaps = msg.Any(char.IsLower);
 
         // Prefix
         if (_random.Prob(0.15f))
@@ -82,6 +88,9 @@ public sealed class MobsterAccentSystem : EntitySystem
                 msg += Loc.GetString($"accent-mobster-suffix-minion-{pick}");
             }
         }
+
+        if (!notAllCaps)
+            msg = msg.ToUpper();
 
         return msg;
     }

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -50,11 +50,14 @@ public sealed class MobsterAccentSystem : EntitySystem
 
         // thinking -> thinkin'
         // king -> king
-        msg = Regex.Replace(msg, @"(?<=\w\w)ing(?!\w)", "in'", RegexOptions.IgnoreCase);
+        msg = Regex.Replace(msg, @"(?<=\w\w)i[Nn][Gg](?!\w)", "in'");
+        msg = Regex.Replace(msg, @"(?<=\w\w)I[Nn][Gg](?!\w)", "IN'");
 
         // or -> uh and ar -> ah in the middle of words (fuhget, tahget)
-        msg = Regex.Replace(msg, @"(?<=\w)or(?=\w)", "uh", RegexOptions.IgnoreCase);
-        msg = Regex.Replace(msg, @"(?<=\w)ar(?=\w)", "ah", RegexOptions.IgnoreCase);
+        msg = Regex.Replace(msg, @"(?<=\w)o[Rr](?=\w)", "uh");
+        msg = Regex.Replace(msg, @"(?<=\w)O[Rr](?=\w)", "UH");
+        msg = Regex.Replace(msg, @"(?<=\w)a[Rr](?=\w)", "ah");
+        msg = Regex.Replace(msg, @"(?<=\w)A[Rr](?=\w)", "AH");
 
         // Prefix
         if (_random.Prob(0.15f))

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -50,8 +50,8 @@ public sealed class MobsterAccentSystem : EntitySystem
 
         // thinking -> thinkin'
         // king -> king
-        msg = Regex.Replace(msg, @"(?<=\w\w)i[Nn][Gg](?!\w)", "in'");
-        msg = Regex.Replace(msg, @"(?<=\w\w)I[Nn][Gg](?!\w)", "IN'");
+        //Uses captures groups to make sure the captialization of IN is kept
+        msg = Regex.Replace(msg, @"(?<=\w\w)(in)g(?!\w)", "$1'", RegexOptions.IgnoreCase);
 
         // or -> uh and ar -> ah in the middle of words (fuhget, tahget)
         msg = Regex.Replace(msg, @"(?<=\w)o[Rr](?=\w)", "uh");
@@ -62,6 +62,7 @@ public sealed class MobsterAccentSystem : EntitySystem
         // Prefix
         if (_random.Prob(0.15f))
         {
+            //Checks if the first word of the sentence is all caps
             var firstWordAllCaps = !Regex.Match(msg, @"^(\S+)").Value.Any(char.IsLower);
             var pick = _random.Next(1, 2);
 
@@ -80,6 +81,7 @@ public sealed class MobsterAccentSystem : EntitySystem
         // Suffixes
         if (_random.Prob(0.4f))
         {
+            //Checks if the last word of the sentence is all caps
             var lastWordAllCaps = !Regex.Match(msg, @"(\S+)$").Value.Any(char.IsLower);
             var suffix = "";
             if (component.IsBoss)

--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -42,24 +42,24 @@ public sealed class MobsterAccentSystem : EntitySystem
     public string Accentuate(string message, MobsterAccentComponent component)
     {
         // Order:
+        // Check caps
         // Do text manipulations first
         // Then prefix/suffix funnyies
 
+        var msg = message;
+
+        var notAllCaps = msg.Any(char.IsLower);
+
         // direct word replacements
-        var msg = _replacement.ApplyReplacements(message, "mobster");
+        msg = _replacement.ApplyReplacements(message, "mobster");
 
         // thinking -> thinkin'
         // king -> king
-        msg = Regex.Replace(msg, @"(?<=\w\w)ing(?!\w)", "in'");
-        msg = Regex.Replace(msg, @"(?<=\w\w)ING(?!\w)", "IN'");
+        msg = Regex.Replace(msg, @"(?<=\w\w)ing(?!\w)", "in'", RegexOptions.IgnoreCase);
 
         // or -> uh and ar -> ah in the middle of words (fuhget, tahget)
-        msg = Regex.Replace(msg, @"(?<=\w)or(?=\w)", "uh");
-        msg = Regex.Replace(msg, @"(?<=\w)OR(?=\w)", "UH");
-        msg = Regex.Replace(msg, @"(?<=\w)ar(?=\w)", "ah");
-        msg = Regex.Replace(msg, @"(?<=\w)AR(?=\w)", "AH");
-
-        var notAllCaps = msg.Any(char.IsLower);
+        msg = Regex.Replace(msg, @"(?<=\w)or(?=\w)", "uh", RegexOptions.IgnoreCase);
+        msg = Regex.Replace(msg, @"(?<=\w)ar(?=\w)", "ah", RegexOptions.IgnoreCase);
 
         // Prefix
         if (_random.Prob(0.15f))

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -25,6 +25,7 @@ public sealed class PirateAccentSystem : EntitySystem
         if (!_random.Prob(component.YarrChance))
             return msg;
         //Checks if the first word of the sentence is all caps
+        //So the prefix can be allcapped and to not resanitize the captial
         var firstWordAllCaps = !Regex.Match(msg, @"^(\S+)").Value.Any(char.IsLower);
 
         var pick = _random.Pick(component.PirateWords);

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -24,7 +24,7 @@ public sealed class PirateAccentSystem : EntitySystem
 
         if (!_random.Prob(component.YarrChance))
             return msg;
-
+        //Checks if the first word of the sentence is all caps
         var firstWordAllCaps = !Regex.Match(msg, @"^(\S+)").Value.Any(char.IsLower);
 
         var pick = _random.Pick(component.PirateWords);

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -20,14 +20,12 @@ public sealed class PirateAccentSystem : EntitySystem
     // converts left word when typed into the right word. For example typing you becomes ye.
     public string Accentuate(string message, PirateAccentComponent component)
     {
-        var msg = message;
-
-        var firstWordAllCaps = !Regex.Match(msg, @"^(\S+)").Value.Any(char.IsLower);
-
-        msg = _replacement.ApplyReplacements(msg, "pirate");
+        var msg = _replacement.ApplyReplacements(message, "pirate");        
 
         if (!_random.Prob(component.YarrChance))
             return msg;
+
+        var firstWordAllCaps = !Regex.Match(msg, @"^(\S+)").Value.Any(char.IsLower);
 
         var pick = _random.Pick(component.PirateWords);
         var pirateWord = Loc.GetString(pick);

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -22,7 +22,7 @@ public sealed class PirateAccentSystem : EntitySystem
     {
         var msg = message;
 
-        bool firstWordAllCaps = !Regex.Match(msg, @"^([\w\-]+)").Value.Any(char.IsLower);
+        var firstWordAllCaps = !Regex.Match(msg, @"^(\S+)").Value.Any(char.IsLower);
 
         msg = _replacement.ApplyReplacements(msg, "pirate");
 

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -22,12 +22,12 @@ public sealed class PirateAccentSystem : EntitySystem
     {
         var msg = message;
 
+        var notAllCaps = msg.Any(char.IsLower);
+
         msg = _replacement.ApplyReplacements(msg, "pirate");
 
         if (!_random.Prob(component.YarrChance))
             return msg;
-
-        var notAllCaps = msg.Any(char.IsLower);
 
         var pick = _random.Pick(component.PirateWords);
         // Reverse sanitize capital

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -22,7 +22,7 @@ public sealed class PirateAccentSystem : EntitySystem
     {
         var msg = message;
 
-        var notAllCaps = msg.Any(char.IsLower);
+        bool firstWordCapitalized = !Regex.Match(msg, @"^([\w\-]+)").Value.Any(char.IsLower);
 
         msg = _replacement.ApplyReplacements(msg, "pirate");
 
@@ -30,11 +30,14 @@ public sealed class PirateAccentSystem : EntitySystem
             return msg;
 
         var pick = _random.Pick(component.PirateWords);
+        var pirateWord = Loc.GetString(pick);
         // Reverse sanitize capital
-        msg = msg[0].ToString().ToLower() + msg.Remove(0, 1);
-        msg = Loc.GetString(pick) + " " + msg;
-        if (!notAllCaps)
-            msg = msg.ToUpper();
+        if (!firstWordCapitalized)
+            msg = msg[0].ToString().ToLower() + msg.Remove(0, 1);
+        else
+            pirateWord = pirateWord.ToUpper();
+        msg = pirateWord + " " + msg;
+
         return msg;
     }
 

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -22,7 +22,7 @@ public sealed class PirateAccentSystem : EntitySystem
     {
         var msg = message;
 
-        bool firstWordCapitalized = !Regex.Match(msg, @"^([\w\-]+)").Value.Any(char.IsLower);
+        bool firstWordAllCaps = !Regex.Match(msg, @"^([\w\-]+)").Value.Any(char.IsLower);
 
         msg = _replacement.ApplyReplacements(msg, "pirate");
 
@@ -32,7 +32,7 @@ public sealed class PirateAccentSystem : EntitySystem
         var pick = _random.Pick(component.PirateWords);
         var pirateWord = Loc.GetString(pick);
         // Reverse sanitize capital
-        if (!firstWordCapitalized)
+        if (!firstWordAllCaps)
             msg = msg[0].ToString().ToLower() + msg.Remove(0, 1);
         else
             pirateWord = pirateWord.ToUpper();

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Speech.Components;
 using Robust.Shared.Random;
 using System.Text.RegularExpressions;
@@ -26,11 +27,14 @@ public sealed class PirateAccentSystem : EntitySystem
         if (!_random.Prob(component.YarrChance))
             return msg;
 
+        var notAllCaps = msg.Any(char.IsLower);
+
         var pick = _random.Pick(component.PirateWords);
         // Reverse sanitize capital
         msg = msg[0].ToString().ToLower() + msg.Remove(0, 1);
         msg = Loc.GetString(pick) + " " + msg;
-
+        if (!notAllCaps)
+            msg = msg.ToUpper();
         return msg;
     }
 

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -20,7 +20,7 @@ public sealed class PirateAccentSystem : EntitySystem
     // converts left word when typed into the right word. For example typing you becomes ye.
     public string Accentuate(string message, PirateAccentComponent component)
     {
-        var msg = _replacement.ApplyReplacements(message, "pirate");        
+        var msg = _replacement.ApplyReplacements(message, "pirate");
 
         if (!_random.Prob(component.YarrChance))
             return msg;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When rats and pirates speak their first word in all caps, it'll now properly not lowercase the word. Additionally, the prefix added will also be in all caps. For rats, if they get a suffix, and their last word was in all caps, that word will also be in all caps.
Fixes #24996

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Let the pirates scream YARGH.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

LINQ

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


https://github.com/space-wizards/space-station-14/assets/32827189/09a8907a-1f88-4c84-a56f-f69b86d89c57


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Pirate Accent and Mobster accent will respect capitalization better now
