### PR TITLE
Fix clipping/overlap in lathe machine UIs

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml
@@ -124,9 +124,7 @@
             <BoxContainer
             VerticalExpand="True"
             HorizontalExpand="True"
-            Orientation="Vertical"
-            MinHeight="225"
-            >
+            Orientation="Vertical">
             <Label Text="{Loc 'lathe-menu-materials-title'}" Margin="5 5 5 5" HorizontalAlignment="Center"/>
             <BoxContainer
                 Orientation="Vertical"

--- a/Content.Client/Materials/UI/MaterialStorageControl.xaml
+++ b/Content.Client/Materials/UI/MaterialStorageControl.xaml
@@ -1,7 +1,8 @@
-<BoxContainer xmlns="https://spacestation14.io"
-              Orientation="Vertical"
+<ScrollContainer xmlns="https://spacestation14.io"
               SizeFlagsStretchRatio="8"
               HorizontalExpand="True"
               VerticalExpand="True">
-    <Label Name="NoMatsLabel" Text="{Loc 'lathe-menu-no-materials-message'}" Align="Center"/>
-</BoxContainer>
+    <BoxContainer Name="MaterialList" Orientation="Vertical">
+        <Label Name="NoMatsLabel" Text="{Loc 'lathe-menu-no-materials-message'}" Align="Center"/>
+    </BoxContainer>
+</ScrollContainer>

--- a/Content.Client/Materials/UI/MaterialStorageControl.xaml.cs
+++ b/Content.Client/Materials/UI/MaterialStorageControl.xaml.cs
@@ -11,7 +11,7 @@ namespace Content.Client.Materials.UI;
 /// This widget is one row in the lathe eject menu.
 /// </summary>
 [GenerateTypedNameReferences]
-public sealed partial class MaterialStorageControl : BoxContainer
+public sealed partial class MaterialStorageControl : ScrollContainer
 {
     [Dependency] private readonly IEntityManager _entityManager = default!;
 
@@ -63,7 +63,7 @@ public sealed partial class MaterialStorageControl : BoxContainer
         }
 
         var children = new List<MaterialDisplay>();
-        children.AddRange(Children.OfType<MaterialDisplay>());
+        children.AddRange(MaterialList.Children.OfType<MaterialDisplay>());
 
         foreach (var display in children)
         {
@@ -71,7 +71,7 @@ public sealed partial class MaterialStorageControl : BoxContainer
 
             if (extra.Contains(mat))
             {
-                RemoveChild(display);
+                MaterialList.RemoveChild(display);
                 continue;
             }
 
@@ -83,7 +83,7 @@ public sealed partial class MaterialStorageControl : BoxContainer
         foreach (var mat in missing)
         {
             var volume = mats[mat];
-            AddChild(new MaterialDisplay(_owner.Value, mat, volume, canEject));
+            MaterialList.AddChild(new MaterialDisplay(_owner.Value, mat, volume, canEject));
         }
 
         _currentMaterials = mats;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixed up some minor UI bugs when working with late UIs which made 'em look bad. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

- When lathe was loaded with lots of different raw materials, the material list would overflow the allowed space, requiring resizing the window to see the quantities or eject the materials.

Made the material list scrollable (scroll bars don't show up unless necessary.)

- When shrinking a lathe which connected to a server, material list could overlap build queue.

Removed minimum-sizing of material list. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Before:
![before](https://github.com/space-wizards/space-station-14/assets/1676295/fcb38698-d616-41f3-b778-ee7f2921bc6b)
After:
![after](https://github.com/space-wizards/space-station-14/assets/1676295/292e91f4-2d0c-4fe7-8f92-96ddfc77f198)

Before:
![before-shrunk](https://github.com/space-wizards/space-station-14/assets/1676295/75978771-8f04-4c4d-af47-d6242589ac5a)
After:
![after-shrunk](https://github.com/space-wizards/space-station-14/assets/1676295/a27037ab-4a26-43b2-9e55-8645808e035d)


- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
