### PR TITLE
Enable some gamemodes to vote for

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -3,7 +3,7 @@
   alias:
     - survival
   name: survival-title
-  showInVote: false # secret
+  showInVote: true
   description: survival-description
   rules:
     - RampingStationEventScheduler
@@ -116,7 +116,7 @@
     - nukeops
   name: nukeops-title
   description: nukeops-description
-  showInVote: false
+  showInVote: true
   rules:
     - Nukeops
     - SubGamemodesRule
@@ -131,7 +131,7 @@
     - revolutionaries
   name: rev-title
   description: rev-description
-  showInVote: false
+  showInVote: true
   rules:
     - Revolutionary
     - SubGamemodesRule
@@ -160,7 +160,7 @@
     - pirates
   name: pirates-title
   description: pirates-description
-  showInVote: false
+  showInVote: true
   rules:
     - Pirates
     - BasicStationEventScheduler


### PR DESCRIPTION
Give the people some free will!

## About the PR
Some gamemodes, like Survival and Privateers, have been enabled.

## Why / Balance
The every gamemode change proved people are at least half trustable with democracy. People might want to play with a specific mode on lowpop servers, or a highpop one might just want a twist to shake up the round. Usually it'll never be anything but secret, but this gives the option if they want it.

I didn't enable Traitor because I felt like the high chance it has on Secret made it a bit overdone, and I enabled Privateers (pirates) to see what happens with that. The few pirate rounds I saw were a bit chaotic since nobody knew the mode, and I'd love to see some strategies emerge for it!

## Technical details
Flipped the "showInVote" flag for Survival, Revolutionaries, Privateers, and Nukeops

## Media

- [-] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
I don't think this requires media, but if requested I'll add it.

**Changelog**
:cl:
- add: The Syndicate has finally given the people of the station some say in the horrors they will deal with.

Hey! Thanks for reading my PR. This is a bit of an experimental change, I want to hear your opinions. Do you think this would lead to too much chaos? Should I disable some modes or enable others? I'll change the PR if enough of the people here agree a change is needed. Maintainers, feel free to close this if you feel like trusting people with democracy is a bit outrageous right now.
