### PR TITLE
Fix for items dropped being rotated to world north

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -134,8 +134,10 @@ public abstract partial class SharedHandsSystem
             return true;
         }
 
+        var origin = TransformSystem.GetMapCoordinates(entity);
         var target = targetDropLocation.Value.ToMap(EntityManager, TransformSystem);
-        TransformSystem.SetWorldPosition(itemXform, GetFinalDropCoordinates(uid, userXform.MapPosition, target));
+        var itemRot = TransformSystem.GetWorldRotation(entity); // based on camera orientation... 
+        TransformSystem.SetWorldPositionRotation(entity, GetFinalDropCoordinates(uid, origin, target), itemRot);
         return true;
     }
 

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -136,7 +136,7 @@ public abstract partial class SharedHandsSystem
 
         var (origin, itemRot) = TransformSystem.GetWorldPositionRotation(entity);
         var target = targetDropLocation.Value.ToMap(EntityManager, TransformSystem);
-        TransformSystem.SetWorldPositionRotation(entity, GetFinalDropCoordinates(uid, new MapCoordinates(origin, target.MapId), target), itemRot);
+        TransformSystem.SetWorldPositionRotation(entity, GetFinalDropCoordinates(uid, new MapCoordinates(origin, itemXform.MapID), target), itemRot);
         return true;
     }
 

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -134,9 +134,10 @@ public abstract partial class SharedHandsSystem
             return true;
         }
 
-        var (origin, itemRot) = TransformSystem.GetWorldPositionRotation(entity);
+        var (itemPos, itemRot) = TransformSystem.GetWorldPositionRotation(entity);
+        var origin = new MapCoordinates(itemPos, itemXform.MapId);
         var target = targetDropLocation.Value.ToMap(EntityManager, TransformSystem);
-        TransformSystem.SetWorldPositionRotation(entity, GetFinalDropCoordinates(uid, new MapCoordinates(origin, itemXform.MapID), target), itemRot);
+        TransformSystem.SetWorldPositionRotation(entity, GetFinalDropCoordinates(uid, origin, target), itemRot);
         return true;
     }
 

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -135,7 +135,7 @@ public abstract partial class SharedHandsSystem
         }
 
         var (itemPos, itemRot) = TransformSystem.GetWorldPositionRotation(entity);
-        var origin = new MapCoordinates(itemPos, itemXform.MapId);
+        var origin = new MapCoordinates(itemPos, itemXform.MapID);
         var target = targetDropLocation.Value.ToMap(EntityManager, TransformSystem);
         TransformSystem.SetWorldPositionRotation(entity, GetFinalDropCoordinates(uid, origin, target), itemRot);
         return true;

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -136,7 +136,7 @@ public abstract partial class SharedHandsSystem
 
         var origin = TransformSystem.GetMapCoordinates(entity);
         var target = targetDropLocation.Value.ToMap(EntityManager, TransformSystem);
-        var itemRot = TransformSystem.GetWorldRotation(entity); // based on camera orientation... 
+        var itemRot = TransformSystem.GetWorldRotation(entity); // based on camera orientation...
         TransformSystem.SetWorldPositionRotation(entity, GetFinalDropCoordinates(uid, origin, target), itemRot);
         return true;
     }

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -134,10 +134,9 @@ public abstract partial class SharedHandsSystem
             return true;
         }
 
-        var origin = TransformSystem.GetMapCoordinates(entity);
+        var (origin, itemRot) = TransformSystem.GetWorldPositionRotation(entity);
         var target = targetDropLocation.Value.ToMap(EntityManager, TransformSystem);
-        var itemRot = TransformSystem.GetWorldRotation(entity); // based on camera orientation...
-        TransformSystem.SetWorldPositionRotation(entity, GetFinalDropCoordinates(uid, origin, target), itemRot);
+        TransformSystem.SetWorldPositionRotation(entity, GetFinalDropCoordinates(uid, new MapCoordinates(origin, target.MapId), target), itemRot);
         return true;
     }
 

--- a/Content.Shared/Storage/EntitySystems/DumpableSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/DumpableSystem.cs
@@ -159,8 +159,7 @@ public sealed class DumpableSystem : EntitySystem
         {
             dumped = true;
 
-            var targetPos = _transformSystem.GetWorldPosition(args.Args.Target.Value);
-            var targetRot = _transformSystem.GetWorldRotation(args.Args.Target.Value);
+            var (targetPos, targetRot) = _transformSystem.GetWorldPositionRotation(args.Args.Target.Value);
 
             foreach (var entity in dumpQueue)
             {

--- a/Content.Shared/Storage/EntitySystems/DumpableSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/DumpableSystem.cs
@@ -160,10 +160,11 @@ public sealed class DumpableSystem : EntitySystem
             dumped = true;
 
             var targetPos = _transformSystem.GetWorldPosition(args.Args.Target.Value);
+            var targetRot = _transformSystem.GetWorldRotation(args.Args.Target.Value);
 
             foreach (var entity in dumpQueue)
             {
-                _transformSystem.SetWorldPosition(entity, targetPos + _random.NextVector2Box() / 4);
+                _transformSystem.SetWorldPositionRotation(entity, targetPos + _random.NextVector2Box() / 4, targetRot);
             }
         }
         else


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made dumpable system and hand drop system set the rotation for what they drop.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Everything that was dropped was rotated to world north, which was randomized every single shift. This makes organizing tables a hellscape.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Got rid of an obsolete xForm.MapPosition in exchange for GetMapCoordinates()

Used the rotation of the item when dropped (which is based on the camera orientation)
Used the rotation of the target surface when dumping contents

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/58439124/c9634c36-0301-4768-a8d0-a24826a6ec7d



**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Dropped items are no longer rotated to world north.