### PR TITLE
Improve access overlay

### DIFF
--- a/Content.Client/Access/AccessOverlay.cs
+++ b/Content.Client/Access/AccessOverlay.cs
@@ -44,7 +44,7 @@ public sealed class AccessOverlay : Overlay
             textBuffer.Append(entityName.Nuid.Id);
             textBuffer.AppendLine();
 
-            if (accessReader.Enabled == false)
+            if (!accessReader.Enabled)
             {
                 textBuffer.AppendLine("-Disabled");
                 continue;

--- a/Content.Client/Access/AccessOverlay.cs
+++ b/Content.Client/Access/AccessOverlay.cs
@@ -9,20 +9,20 @@ namespace Content.Client.Access;
 
 public sealed class AccessOverlay : Overlay
 {
+    private const string TextFontPath = "/Fonts/NotoSans/NotoSans-Regular.ttf";
+    private const int TextFontSize = 12;
+
     private readonly IEntityManager _entityManager;
-    private readonly EntityLookupSystem _lookup;
-    private readonly SharedTransformSystem _xform;
+    private readonly SharedTransformSystem _transformSystem;
     private readonly Font _font;
 
     public override OverlaySpace Space => OverlaySpace.ScreenSpace;
 
-    public AccessOverlay(IEntityManager entManager, IResourceCache cache, EntityLookupSystem lookup, SharedTransformSystem xform)
+    public AccessOverlay(IEntityManager entityManager, IResourceCache resourceCache, SharedTransformSystem transformSystem)
     {
-        _entityManager = entManager;
-        _lookup = lookup;
-        _xform = xform;
-
-        _font = cache.GetFont("/Fonts/NotoSans/NotoSans-Regular.ttf", 12);
+        _entityManager = entityManager;
+        _transformSystem = transformSystem;
+        _font = resourceCache.GetFont(TextFontPath, TextFontSize);
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -30,52 +30,65 @@ public sealed class AccessOverlay : Overlay
         if (args.ViewportControl == null)
             return;
 
-        var readerQuery = _entityManager.GetEntityQuery<AccessReaderComponent>();
-        var xformQuery = _entityManager.GetEntityQuery<TransformComponent>();
-
-        foreach (var ent in _lookup.GetEntitiesIntersecting(args.MapId, args.WorldAABB,
-                         LookupFlags.Static | LookupFlags.Approximate))
+        var textBuffer = new StringBuilder();
+        var query = _entityManager.EntityQueryEnumerator<AccessReaderComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var accessReader, out var transform))
         {
-            if (!readerQuery.TryGetComponent(ent, out var reader) ||
-                !xformQuery.TryGetComponent(ent, out var xform))
+            textBuffer.Clear();
+
+            var entityName = _entityManager.ToPrettyString(uid);
+            textBuffer.AppendLine(entityName.Prototype);
+            textBuffer.Append("UID: ");
+            textBuffer.Append(entityName.Uid.Id);
+            textBuffer.Append(", NUID: ");
+            textBuffer.Append(entityName.Nuid.Id);
+            textBuffer.AppendLine();
+
+            if (accessReader.Enabled == false)
             {
+                textBuffer.AppendLine("-Disabled");
                 continue;
             }
 
-            var text = new StringBuilder();
-            var index = 0;
-            var a = $"{_entityManager.ToPrettyString(ent)}";
-            text.Append(a);
-
-            foreach (var list in reader.AccessLists)
+            if (accessReader.AccessLists.Count > 0)
             {
-                a = $"Tag {index}";
-                text.AppendLine(a);
-
-                foreach (var entry in list)
+                var groupNumber = 0;
+                foreach (var accessList in accessReader.AccessLists)
                 {
-                    a = $"- {entry}";
-                    text.AppendLine(a);
+                    groupNumber++;
+                    foreach (var entry in accessList)
+                    {
+                        textBuffer.Append("+Set ");
+                        textBuffer.Append(groupNumber);
+                        textBuffer.Append(": ");
+                        textBuffer.Append(entry.Id);
+                        textBuffer.AppendLine();
+                    }
                 }
-
-                index++;
-            }
-
-            string textStr;
-
-            if (text.Length >= 2)
-            {
-                textStr = text.ToString();
-                textStr = textStr[..^2];
             }
             else
             {
-                textStr = "";
+                textBuffer.AppendLine("+Unrestricted");
             }
 
-            var screenPos = args.ViewportControl.WorldToScreen(_xform.GetWorldPosition(xform));
+            foreach (var key in accessReader.AccessKeys)
+            {
+                textBuffer.Append("+Key ");
+                textBuffer.Append(key.OriginStation);
+                textBuffer.Append(": ");
+                textBuffer.Append(key.Id);
+                textBuffer.AppendLine();
+            }
 
-            args.ScreenHandle.DrawString(_font, screenPos, textStr, Color.Gold);
+            foreach (var tag in accessReader.DenyTags)
+            {
+                textBuffer.Append("-Tag ");
+                textBuffer.AppendLine(tag.Id);
+            }
+
+            var accessInfoText = textBuffer.ToString();
+            var screenPos = args.ViewportControl.WorldToScreen(_transformSystem.GetWorldPosition(transform));
+            args.ScreenHandle.DrawString(_font, screenPos, accessInfoText, Color.Gold);
         }
     }
 }

--- a/Content.Client/Access/Commands/ShowAccessReadersCommand.cs
+++ b/Content.Client/Access/Commands/ShowAccessReadersCommand.cs
@@ -7,7 +7,16 @@ namespace Content.Client.Access.Commands;
 public sealed class ShowAccessReadersCommand : IConsoleCommand
 {
     public string Command => "showaccessreaders";
-    public string Description => "Shows all access readers in the viewport";
+
+    public string Description => """
+        Toggles showing access reader permissions on the map
+        Overlay Info:
+        -Disabled | The access reader is disabled
+        +Unrestricted | The access reader has no restrictions
+        +Set [Index]: [Tag Name]| A tag in an access set (accessor needs all tags in the set to be allowed by the set)
+        +Key [StationUid]: [StationRecordKeyId] | A StationRecordKey that is allowed
+        -Tag [Tag Name] | A tag that is not allowed (takes priority over other allows)
+        """;
     public string Help => $"{Command}";
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -26,10 +35,9 @@ public sealed class ShowAccessReadersCommand : IConsoleCommand
 
         var entManager = collection.Resolve<IEntityManager>();
         var cache = collection.Resolve<IResourceCache>();
-        var lookup = entManager.System<EntityLookupSystem>();
         var xform = entManager.System<SharedTransformSystem>();
 
-        overlay.AddOverlay(new AccessOverlay(entManager, cache, lookup, xform));
+        overlay.AddOverlay(new AccessOverlay(entManager, cache, xform));
         shell.WriteLine($"Set access reader debug overlay to true");
     }
 }

--- a/Content.Client/Access/Commands/ShowAccessReadersCommand.cs
+++ b/Content.Client/Access/Commands/ShowAccessReadersCommand.cs
@@ -8,8 +8,8 @@ public sealed class ShowAccessReadersCommand : IConsoleCommand
 {
     public string Command => "showaccessreaders";
 
-    public string Description => """
-        Toggles showing access reader permissions on the map
+    public string Description => "Toggles showing access reader permissions on the map";
+    public string Help => """
         Overlay Info:
         -Disabled | The access reader is disabled
         +Unrestricted | The access reader has no restrictions
@@ -17,7 +17,6 @@ public sealed class ShowAccessReadersCommand : IConsoleCommand
         +Key [StationUid]: [StationRecordKeyId] | A StationRecordKey that is allowed
         -Tag [Tag Name] | A tag that is not allowed (takes priority over other allows)
         """;
-    public string Help => $"{Command}";
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         var collection = IoCManager.Instance;


### PR DESCRIPTION
Makes the debug access reader overlay better.
The "showaccessreaders" command.

Better being
1. It has a higher chance of being readable on the screen
2. It provides more information about the access reader
3. It has a new description

Outside scope of PR: Make it better then better.