### PR TITLE
Increase time inbetween anomaly pulses

### DIFF
--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -95,13 +95,13 @@ public sealed partial class AnomalyComponent : Component
     /// The minimum interval between pulses.
     /// </summary>
     [DataField]
-    public TimeSpan MinPulseLength = TimeSpan.FromMinutes(1);
+    public TimeSpan MinPulseLength = TimeSpan.FromMinutes(2);
 
     /// <summary>
     /// The maximum interval between pulses.
     /// </summary>
     [DataField]
-    public TimeSpan MaxPulseLength = TimeSpan.FromMinutes(2);
+    public TimeSpan MaxPulseLength = TimeSpan.FromMinutes(4);
 
     /// <summary>
     /// A percentage by which the length of a pulse might vary.

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -123,11 +123,11 @@
     castShadows: false
   - type: GravityAnomaly
   - type: GravityWell
-  - type: RadiationSource  
+  - type: RadiationSource
   - type: Physics
     bodyType: Dynamic
     bodyStatus: InAir
-  - type: CanMoveInAir  
+  - type: CanMoveInAir
   - type: RandomWalk
   - type: SingularityDistortion
     intensity: 1000
@@ -164,6 +164,8 @@
   - type: Anomaly
     corePrototype: AnomalyCoreFlesh
     coreInertPrototype: AnomalyCoreFleshInert
+    minPulseLength: 180
+    maxPulseLength: 300
   - type: Sprite
     layers:
     - state: anom5
@@ -355,6 +357,8 @@
   - type: Anomaly
     corePrototype: AnomalyCoreRock
     coreInertPrototype: AnomalyCoreRockInert
+    minPulseLength: 180
+    maxPulseLength: 300
   - type: Sprite
     layers:
     - state: anom6
@@ -605,6 +609,8 @@
     offset: 0, 0
     corePrototype: AnomalyCoreFlora
     coreInertPrototype: AnomalyCoreFloraInert
+    minPulseLength: 60
+    maxPulseLength: 120
     anomalyContactDamage:
       types:
         Slash: 0
@@ -709,6 +715,8 @@
   - type: Anomaly
     corePrototype: AnomalyCoreLiquid
     coreInertPrototype: AnomalyCoreLiquidInert
+    minPulseLength: 60
+    maxPulseLength: 120
     anomalyContactDamage:
       types:
         Slash: 1
@@ -822,6 +830,8 @@
   - type: Anomaly
     corePrototype: AnomalyCoreShadow
     coreInertPrototype: AnomalyCoreShadowInert
+    minPulseLength: 60
+    maxPulseLength: 120
     anomalyContactDamage:
       types:
         Cold: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Increases the amount of time between anomaly pulses (except for a few, which are kept the same)

Flora, Shadow, Liquid: 1-2 minutes
Pyroclastic, Bluespace, Gravity, Electricity, Ice: 2-4 minutes
Rock, Flesh: 3-5 minutes

this additionally increase the grace period anomalies have after spawn before they start pulsing.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Overly frequent pulses can make it such that anomalies require too constant upkeep. This can easily become overwhelming and boring if you just need to stay by them at all times to make sure that the pulses haven't shattered the housing.

By increasing it for the more actively destructive anomalies, players can actually have some breathing room inbetween times where they have to buckle down and deal with the anomalies.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Increased time between pulses for various anomalies.
