### PR TITLE
Rework Identifier Overrides to prevent showing Law Priority

### DIFF
--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Silicons.Laws;
 using Content.Server.Station.Components;
@@ -141,6 +142,24 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
                     Order = -1,
                     LawIdentifierOverride = Loc.GetString("ion-storm-law-scrambled-number", ("length", RobustRandom.Next(5, 10)))
                 });
+            }
+
+            // sets all unobfuscated laws' indentifier in order from highest to lowest priority
+            // This could technically override the Obfuscation from the code above, but it seems unlikely enough to basically never happen
+            int orderDeduction = -1;
+
+            for (int i = 0; i < laws.Laws.Count; i++)
+            {
+                string notNullIdentifier = laws.Laws[i].LawIdentifierOverride ?? (i - orderDeduction).ToString();
+
+                if (notNullIdentifier.Any(char.IsSymbol))
+                {
+                    orderDeduction += 1;
+                }
+                else
+                {
+                    laws.Laws[i].LawIdentifierOverride = (i - orderDeduction).ToString();
+                }
             }
 
             _adminLogger.Add(LogType.Mind, LogImpact.High, $"{ToPrettyString(ent):silicon} had its laws changed by an ion storm to {laws.LoggingString()}");


### PR DESCRIPTION
## About the PR
This PR sets all "unobfuscated" laws' Identifier to it's Order in the Law list instead of simply displaying the priority.

## Why / Balance
The previous implementation made it possible to show law priorities, whose exact values should likely stay hidden, when a lawset law is shuffled into an Ion Storm generated Law. This also allows for decimal law priorities without exposing Users to potentially confusing titles of "Law 4.34" or "Law -2.304"

## Technical details
The Code cycles through the Order of the laws and sets the Identifier of the law in order from Top to Bottom, ignoring "obfuscated" laws. (Obfuscated in this sense means that the Priority/Order is hidden, for example the constantly changing Identifier of the Ion Storm laws.)
The current differentiation between Obfuscated and Unobfuscated laws currently works by testing if the string contains any symbols. Incase more obfuscations are added or this one reworked, there would have to be a change to allow it to differentiate better, though simply adding a bool of "obfuscation" to silicon laws would be a more scalable solution.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

no cl no fun
