### PR TITLE
Mail Unit Fix (whitelist)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -114,7 +114,9 @@
     node: mailing_unit
   - type: DisposalUnit
     autoEngageEnabled: false
-    mobsCanEnter: false
+    whitelist:
+      components:
+      - Item
   - type: MailingUnit
   - type: DeviceNetwork
     deviceNetId: Wired


### PR DESCRIPTION
Fix - Mail Units currently allow you to drag humanoids into them which is unintended. This fix simply adds a whitelist for itemcomponent. With this change you can still mail mobs which you can pickup such as a mouse. This can be removed with a blacklist mobstate but i think it would be fine to mail small mobs with the mail unit.

fixes #26674

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


