### PR TITLE
Make the station start with random broken wiring

### DIFF
--- a/Content.Server/GameTicking/Rules/VariationPass/Components/CutWireVariationPassComponent.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/Components/CutWireVariationPassComponent.cs
@@ -1,0 +1,29 @@
+using Content.Shared.Whitelist;
+
+namespace Content.Server.GameTicking.Rules.VariationPass.Components;
+
+/// <summary>
+/// Handles cutting a random wire on random devices around the station.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CutWireVariationPassComponent : Component
+{
+    /// <summary>
+    /// Blacklist of hackable entities that should not be chosen to
+    /// have wires cut.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist Blacklist = new();
+
+    /// <summary>
+    /// Chance for an individual wire to be cut.
+    /// </summary>
+    [DataField]
+    public float WireCutChance = 0.05f;
+
+    /// <summary>
+    /// Maximum number of wires that can be cut stationwide.
+    /// </summary>
+    [DataField]
+    public int MaxWiresCut = 10;
+}

--- a/Content.Server/GameTicking/Rules/VariationPass/CutWireVariationPassSystem.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/CutWireVariationPassSystem.cs
@@ -1,0 +1,39 @@
+using Content.Server.GameTicking.Rules.VariationPass.Components;
+using Content.Server.Wires;
+using Robust.Shared.Random;
+
+namespace Content.Server.GameTicking.Rules.VariationPass;
+
+/// <summary>
+/// Handles cutting a random wire on random devices around the station.
+/// This system identifies target devices and adds <see cref="CutWireOnMapInitComponent"/> to them.
+/// The actual wire cutting is handled by <see cref="CutWireOnMapInitSystem"/>.
+/// </summary>
+public sealed class CutWireVariationPassSystem : VariationPassSystem<CutWireVariationPassComponent>
+{
+    protected override void ApplyVariation(Entity<CutWireVariationPassComponent> ent, ref StationVariationPassEvent args)
+    {
+        var wiresCut = 0;
+        var query = AllEntityQuery<WiresComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var transform))
+        {
+            // Ignore if not part of the station
+            if (!IsMemberOfStation((uid, transform), ref args))
+                continue;
+
+            // Check against blacklist
+            if (ent.Comp.Blacklist.IsValid(uid))
+                continue;
+
+            if (Random.Prob(ent.Comp.WireCutChance))
+            {
+                EnsureComp<CutWireOnMapInitComponent>(uid);
+                wiresCut++;
+
+                // Limit max wires cut
+                if (wiresCut >= ent.Comp.MaxWiresCut)
+                    break;
+            }
+        }
+    }
+}

--- a/Content.Server/Wires/CutWireOnMapInitComponent.cs
+++ b/Content.Server/Wires/CutWireOnMapInitComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.Wires;
+
+/// <summary>
+/// Picks a random wire on the entity's <see cref="WireComponent"/> and cuts it.
+/// Runs at MapInit and removes itself afterwards.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CutWireOnMapInitComponent : Component
+{
+}

--- a/Content.Server/Wires/CutWireOnMapInitSystem.cs
+++ b/Content.Server/Wires/CutWireOnMapInitSystem.cs
@@ -1,0 +1,34 @@
+using Robust.Shared.Random;
+
+namespace Content.Server.Wires;
+
+/// <summary>
+/// Handles cutting a random wire on devices that have <see cref="CutWireOnMapInitComponent"/>.
+/// </summary>
+public sealed partial class CutWireOnMapInitSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CutWireOnMapInitComponent, MapInitEvent>(OnMapInit, after: [typeof(WiresSystem)]);
+    }
+
+    private void OnMapInit(Entity<CutWireOnMapInitComponent> entity, ref MapInitEvent args)
+    {
+        if (TryComp<WiresComponent>(entity, out var panel) && panel.WiresList.Count > 0)
+        {
+            // Pick a random wire
+            var targetWire = _random.Pick(panel.WiresList);
+
+            // Cut the wire
+            if (targetWire.Action == null || targetWire.Action.Cut(EntityUid.Invalid, targetWire))
+                targetWire.IsCut = true;
+        }
+
+        // Our work here is done
+        RemCompDeferred(entity, entity.Comp);
+    }
+}

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -142,6 +142,7 @@
     - id: BasicTrashVariationPass
     - id: SolidWallRustingVariationPass
     - id: ReinforcedWallRustingVariationPass
+    - id: CutWireVariationPass
     - id: BasicPuddleMessVariationPass
       prob: 0.99
       orGroup: puddleMess

--- a/Resources/Prototypes/GameRules/variation.yml
+++ b/Resources/Prototypes/GameRules/variation.yml
@@ -119,3 +119,15 @@
     tilesPerSpillAverage: 150
     tilesPerSpillStdDev: 10
     randomPuddleSolutionFill: RandomFillTrashPuddleBloodbath
+
+- type: entity
+  id: CutWireVariationPass
+  parent: BaseVariationPass
+  noSpawn: true
+  components:
+  - type: CutWireVariationPass
+    wireCutChance: 0.01
+    maxWiresCut: 20
+    blacklist:
+      components:
+      - ParticleAcceleratorControlBox


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds a new roundstart variation type that makes random devices around the station start with one of their wires broken.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Gives engineers more to do and increases use of the wire/hacking system. In all likelihood, many of the broken wires won't be noticed until the devices are needed later in the round, so this should give engineers some repair projects to tend to throughout the round.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Wire layouts aren't actually created until MapInit, and the roundstart variation system runs before MapInit. To get around this, the variation system just selects devices with WiresComponents and adds CutWireOnMapInitComponents to them. A separate system runs at MapInit (after WiresSystem) to cut the wires.

The variation component allows for adjusting the chance that a device will be selected and the maximum number of wires that can be cut station-wide. There's also a blacklist that can be used to make certain entities ineligible for selection - the particle accelerator console is blacklisted by default.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Some devices may have broken wiring at the start of each round.