### PR TITLE
Stop mop buckets from spilling when you push them

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -143,6 +143,9 @@ public sealed partial class PuddleSystem
         if (Openable.IsClosed(entity.Owner))
             return;
 
+        if (!entity.Comp.SpillWhenThrown)
+            return;
+
         if (args.User != null)
         {
             _adminLogger.Add(LogType.Landed,

--- a/Content.Shared/Fluids/Components/SpillableComponent.cs
+++ b/Content.Shared/Fluids/Components/SpillableComponent.cs
@@ -29,4 +29,10 @@ public sealed partial class SpillableComponent : Component
     /// </summary>
     [DataField]
     public FixedPoint2 MaxMeleeSpillAmount = FixedPoint2.New(20);
+
+    /// <summary>
+    ///     Should this item be spilled when thrown?
+    /// </summary>
+    [DataField]
+    public bool SpillWhenThrown = true;
 }

--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -23,6 +23,7 @@
   - type: Spillable
     solution: bucket
     spillDelay: 3.0
+    spillWhenThrown: false
   - type: DrainableSolution
     solution: bucket
   - type: RefillableSolution
@@ -82,6 +83,15 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.45"
+        density: 60
+        mask:
+        - MachineMask
 
 - type: entity
   name: mop bucket
@@ -207,6 +217,7 @@
     - type: Spillable
       solution: bucket
       spillDelay: 3.0
+      spillWhenThrown: false
     - type: SolutionContainerManager
       solutions:
         bucket:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Also makes mop buckets not "solid" thus you can walk through them,

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Mop buckets being able to push people is a little annoying,
It's currently impossible to push a mop bucket to the side with right-click without it spilling.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a new bool component to spillable.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/34938708/707b7b4f-bb48-4292-a09d-966d254b2d02

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Mop buckets and Janitorial Trolleys will not spill their contents as soon as they are pushed.
- fix: Mop buckets are no longer solid. So you can now walk through them.