### PR TITLE
Things that can't go in disposals now don't "Miss"

### DIFF
--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -299,7 +299,8 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         var canInsert = CanInsert(uid, component, args.Thrown);
         var randDouble = _robustRandom.NextDouble();
 
-        if (!canInsert) {
+        if (!canInsert)
+        {
             return;
         }
 

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -299,7 +299,11 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         var canInsert = CanInsert(uid, component, args.Thrown);
         var randDouble = _robustRandom.NextDouble();
 
-        if (!canInsert || randDouble > 0.75)
+        if (!canInsert) {
+            return;
+        }
+
+        if (randDouble > 0.75)
         {
             _audioSystem.PlayPvs(component.MissSound, uid);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When something that cannot go in disposals gets thrown over a disposal bin, they now don't show the miss message.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This behavior is kind of confusing as missing implies the item could hit in the first place. For certain things, like shooting the fire extinguisher, this made no sense whatsoever!

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:

https://github.com/space-wizards/space-station-14/assets/107373427/8676d01d-d84b-4f36-8914-ebba197695e7

After:

https://github.com/space-wizards/space-station-14/assets/107373427/3d55ecf3-76ae-4df5-a391-cb09f0fb3a59

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Beck Thompson
- fix: Items thrown at disposals now have to be insertable to display the miss message.