### PR TITLE
Task/fix nightvision huds

### DIFF
--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -19,7 +19,6 @@ namespace Content.Client.Overlays;
 /// </summary>
 public sealed class EntityHealthBarOverlay : Overlay
 {
-    [Dependency] private readonly IPrototypeManager _prototype = default!;
     private readonly IEntityManager _entManager;
     private readonly SharedTransformSystem _transform;
     private readonly MobStateSystem _mobStateSystem;
@@ -27,17 +26,14 @@ public sealed class EntityHealthBarOverlay : Overlay
     private readonly ProgressColorSystem _progressColor;
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
     public HashSet<string> DamageContainers = new();
-    private readonly ShaderInstance _shader;
 
     public EntityHealthBarOverlay(IEntityManager entManager)
     {
-        IoCManager.InjectDependencies(this);
         _entManager = entManager;
         _transform = _entManager.System<SharedTransformSystem>();
         _mobStateSystem = _entManager.System<MobStateSystem>();
         _mobThresholdSystem = _entManager.System<MobThresholdSystem>();
         _progressColor = _entManager.System<ProgressColorSystem>();
-        _shader = _prototype.Index<ShaderPrototype>("unshaded").Instance();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -49,8 +45,6 @@ public sealed class EntityHealthBarOverlay : Overlay
         const float scale = 1f;
         var scaleMatrix = Matrix3.CreateScale(new Vector2(scale, scale));
         var rotationMatrix = Matrix3.CreateRotation(-rotation);
-
-        handle.UseShader(_shader);
 
         var query = _entManager.AllEntityQueryEnumerator<MobThresholdsComponent, MobStateComponent, DamageableComponent, SpriteComponent>();
         while (query.MoveNext(out var uid,
@@ -122,7 +116,6 @@ public sealed class EntityHealthBarOverlay : Overlay
             handle.DrawRect(pixelDarken, Black.WithAlpha(128));
         }
 
-        handle.UseShader(null);
         handle.SetTransform(Matrix3.Identity);
     }
 

--- a/Content.Client/StatusIcon/StatusIconOverlay.cs
+++ b/Content.Client/StatusIcon/StatusIconOverlay.cs
@@ -3,9 +3,9 @@ using Content.Shared.StatusIcon.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
-using System.Numerics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using System.Numerics;
 
 namespace Content.Client.StatusIcon;
 
@@ -18,7 +18,7 @@ public sealed class StatusIconOverlay : Overlay
     private readonly SpriteSystem _sprite;
     private readonly TransformSystem _transform;
     private readonly StatusIconSystem _statusIcon;
-    private readonly ShaderInstance _shader;
+    private readonly ShaderInstance _unshadedShader;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
 
@@ -29,7 +29,7 @@ public sealed class StatusIconOverlay : Overlay
         _sprite = _entity.System<SpriteSystem>();
         _transform = _entity.System<TransformSystem>();
         _statusIcon = _entity.System<StatusIconSystem>();
-        _shader = _prototype.Index<ShaderPrototype>("unshaded").Instance();
+        _unshadedShader = _prototype.Index<ShaderPrototype>("unshaded").Instance();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -41,8 +41,6 @@ public sealed class StatusIconOverlay : Overlay
         var xformQuery = _entity.GetEntityQuery<TransformComponent>();
         var scaleMatrix = Matrix3.CreateScale(new Vector2(1, 1));
         var rotationMatrix = Matrix3.CreateRotation(-eyeRot);
-
-        handle.UseShader(_shader);
 
         var query = _entity.AllEntityQueryEnumerator<StatusIconComponent, SpriteComponent, TransformComponent, MetaDataComponent>();
         while (query.MoveNext(out var uid, out var comp, out var sprite, out var xform, out var meta))
@@ -111,11 +109,16 @@ public sealed class StatusIconOverlay : Overlay
 
                 }
 
+                if (proto.IsShaded)
+                    handle.UseShader(null);
+                else
+                    handle.UseShader(_unshadedShader);
+
                 var position = new Vector2(xOffset, yOffset);
                 handle.DrawTexture(texture, position);
             }
-        }
 
-        handle.UseShader(null);
+            handle.UseShader(null);
+        }
     }
 }

--- a/Content.Shared/StatusIcon/StatusIconPrototype.cs
+++ b/Content.Shared/StatusIcon/StatusIconPrototype.cs
@@ -46,6 +46,12 @@ public partial class StatusIconData : IComparable<StatusIconData>
     /// </summary>
     [DataField]
     public int Offset = 0;
+
+    /// <summary>
+    /// Sets if the icon should be rendered with or without the effect of lighting.
+    /// </summary>
+    [DataField]
+    public bool IsShaded = false;
 }
 
 /// <summary>

--- a/Resources/Prototypes/StatusEffects/health.yml
+++ b/Resources/Prototypes/StatusEffects/health.yml
@@ -1,32 +1,35 @@
 - type: statusIcon
-  id: HealthIconFine
+  id: HealthIcon
+  abstract: true
   priority: 1
+  locationPreference: Right
+  isShaded: true
+
+- type: statusIcon
+  parent: HealthIcon
+  id: HealthIconFine
   icon:
     sprite: /Textures/Interface/Misc/health_icons.rsi
     state: Fine
-  locationPreference: Right
 
 - type: statusIcon
   id: HealthIconCritical
-  priority: 1
+  parent: HealthIcon
   icon:
     sprite: /Textures/Interface/Misc/health_icons.rsi
     state: Critical
-  locationPreference: Right
 
 - type: statusIcon
   id: HealthIconDead
-  priority: 1
+  parent: HealthIcon
   icon:
     sprite: /Textures/Interface/Misc/health_icons.rsi
     state: Dead
-  locationPreference: Right
 
 - type: statusIcon
   id: HealthIconRotting
-  priority: 1
+  parent: HealthIcon
   icon:
     sprite: /Textures/Interface/Misc/health_icons.rsi
     state: Rotting
-  locationPreference: Right
 

--- a/Resources/Prototypes/StatusEffects/hunger.yml
+++ b/Resources/Prototypes/StatusEffects/hunger.yml
@@ -1,49 +1,57 @@
 #Hunger
 - type: statusIcon
-  id: HungerIconOverfed
+  id: HungerIcon
+  abstract: true
   priority: 5
+  locationPreference: Right
+  isShaded: true
+
+- type: statusIcon
+  id: HungerIconOverfed
+  parent: HungerIcon
   icon:
     sprite: /Textures/Interface/Misc/food_icons.rsi
     state: overfed
-  locationPreference: Right
 
 - type: statusIcon
   id: HungerIconPeckish
-  priority: 5
+  parent: HungerIcon
   icon:
     sprite: /Textures/Interface/Misc/food_icons.rsi
     state: peckish
-  locationPreference: Right
 
 - type: statusIcon
   id: HungerIconStarving
-  priority: 5
+  parent: HungerIcon
   icon:
     sprite: /Textures/Interface/Misc/food_icons.rsi
     state: starving
-  locationPreference: Right
 
 #Thirst
 - type: statusIcon
-  id: ThirstIconOverhydrated
+  id: ThirstIcon
+  abstract: true
   priority: 5
+  locationPreference: Left
+  isShaded: true
+
+- type: statusIcon
+  id: ThirstIconOverhydrated
+  parent: ThirstIcon
   icon:
     sprite: /Textures/Interface/Misc/food_icons.rsi
     state: overhydrated
-  locationPreference: Left
 
 - type: statusIcon
   id: ThirstIconThirsty
-  priority: 5
+  parent: ThirstIcon
   icon:
     sprite: /Textures/Interface/Misc/food_icons.rsi
     state: thirsty
-  locationPreference: Left
 
 - type: statusIcon
   id: ThirstIconParched
-  priority: 5
+  parent: ThirstIcon
   icon:
     sprite: /Textures/Interface/Misc/food_icons.rsi
     state: parched
-  locationPreference: Left

--- a/Resources/Prototypes/StatusEffects/job.yml
+++ b/Resources/Prototypes/StatusEffects/job.yml
@@ -3,6 +3,7 @@
   abstract: true
   priority: 1
   locationPreference: Right
+  isShaded: true
 
 - type: statusIcon
   parent: JobIcon

--- a/Resources/Prototypes/StatusEffects/security.yml
+++ b/Resources/Prototypes/StatusEffects/security.yml
@@ -4,6 +4,7 @@
   priority: 2
   offset: 1
   locationPreference: Right
+  isShaded: true
 
 - type: statusIcon
   parent: SecurityIcon


### PR DESCRIPTION
## About the PR
Changed most HUDs so they don't act as night vision.

## Why / Balance
fixes #24905
fixes #24426
fixes #18639

## Technical details
Added a field to the StatusIcon prototype.
In the icon render code, unset the "unshaded" shader if the icon has the field "IsShaded" set to true.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/7510010/bc6949c7-47d2-49b5-ae7a-10545abe4c6e)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Nope

**Changelog**
:cl:
- tweak: The medical HUD's brightness now scales with lighting again.
- tweak: Most HUD icon's brightness now scale with lighting.