### PR TITLE
Make practice projectiles consistent in damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -488,7 +488,7 @@
   name: practice disabler
   parent: WeaponDisabler
   id: WeaponDisablerPractice
-  description: A self-defense weapon that exhausts organic targets, weakening them until they collapse. This one has been undertuned for cadets.
+  description: A self-defense weapon that exhausts organic targets, weakening them until they collapse. This one has been undertuned for cadets making it mostly harmless.
   components:
     - type: Sprite
       sprite: Objects/Weapons/Guns/Battery/practice_disabler.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -228,7 +228,7 @@
   name: practice laser rifle
   parent: WeaponLaserCarbine
   id: WeaponLaserCarbinePractice
-  description: This modified laser rifle fires harmless beams in the 40-watt range, for target practice.
+  description: This modified laser rifle fires nearly harmless beams in the 40-watt range, for target practice.
   components:
   - type: HitscanBatteryAmmoProvider
     proto: RedLaserPractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -35,7 +35,7 @@
   id: RedLaserPractice
   damage:
     types:
-      Heat: 0
+      Heat: 1
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -102,7 +102,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2
+        Blunt: 1
 
 - type: entity
   id: BaseBulletRubber
@@ -288,7 +288,7 @@
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
-    damage: 5
+    damage: 1
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:
@@ -641,7 +641,7 @@
         shader: unshaded
   - type: AnomalousParticle
     particleType: Sigma
-    
+
 - type: entity
   parent: AnomalousParticleSigma
   id: AnomalousParticleSigmaStrong
@@ -650,7 +650,7 @@
   components:
   - type: AnomalousParticle
     particleType: Sigma
-    
+
 # Launcher projectiles (grenade / rocket)
 - type: entity
   id: BulletRocket


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR changes practice projectiles to be consistent in damage, that being 1
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
When I originally created shooting targets in https://github.com/space-wizards/space-station-14/pull/12317 I noticed there was no way to indicate that something was hit if there was no damage associated with it, I decided to add the practice laser gun without doing damage anyway in the hope that it would eventually be possible to display when a projectile hit something even if it did no damage. I haven't been able to implement this myself and thus have decided that 1 damage for the projectiles and shooting targets is good enough until someone else decides it isn't and implements the ability to see if something was hit with 0 damage.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
N/A
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
N/A
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Daemon
- tweak: Practice projectiles have been given standardized minimal damage.
- tweak: The practice laser gun now works with shooting targets.