### PR TITLE
Damage popup type can now be changed with a left click if allowed via component boolean.

### DIFF
--- a/Content.Server/Damage/Components/DamagePopupComponent.cs
+++ b/Content.Server/Damage/Components/DamagePopupComponent.cs
@@ -6,6 +6,11 @@ namespace Content.Server.Damage.Components;
 public sealed partial class DamagePopupComponent : Component
 {
     /// <summary>
+    /// Bool that will be used to determine if the popup type can be changed with a left click.
+    /// </summary>
+    [DataField("allowTypeChange")] [ViewVariables(VVAccess.ReadWrite)]
+    public bool AllowTypeChange = false;
+    /// <summary>
     /// Enum that will be used to determine the type of damage popup displayed.
     /// </summary>
     [DataField("damagePopupType")] [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Damage/Systems/DamagePopupSystem.cs
+++ b/Content.Server/Damage/Systems/DamagePopupSystem.cs
@@ -1,7 +1,11 @@
+using System.Linq;
+using Content.Server.Actions;
 using Content.Server.Damage.Components;
+using Content.Server.Interaction.Components;
 using Content.Server.Popups;
 using Content.Shared.Damage;
-using Robust.Shared.Player;
+using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 
 namespace Content.Server.Damage.Systems;
 
@@ -13,6 +17,7 @@ public sealed class DamagePopupSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<DamagePopupComponent, DamageChangedEvent>(OnDamageChange);
+        SubscribeLocalEvent<DamagePopupComponent, InteractHandEvent>(OnInteractHand);
     }
 
     private void OnDamageChange(EntityUid uid, DamagePopupComponent component, DamageChangedEvent args)
@@ -32,5 +37,20 @@ public sealed class DamagePopupSystem : EntitySystem
             };
             _popupSystem.PopupEntity(msg, uid);
         }
+    }
+
+    private void OnInteractHand(EntityUid uid, DamagePopupComponent component, InteractHandEvent args)
+    {
+
+        if (component.Type == Enum.GetValues(typeof(DamagePopupType)).Cast<DamagePopupType>().Last())
+        {
+            component.Type = DamagePopupType.Combined;
+        }
+        else
+        {
+            component.Type = (DamagePopupType) (int) component.Type + 1;
+        }
+
+        _popupSystem.PopupEntity("Target set to type: " + component.Type.ToString(), uid);
     }
 }

--- a/Content.Server/Damage/Systems/DamagePopupSystem.cs
+++ b/Content.Server/Damage/Systems/DamagePopupSystem.cs
@@ -38,16 +38,17 @@ public sealed class DamagePopupSystem : EntitySystem
 
     private void OnInteractHand(EntityUid uid, DamagePopupComponent component, InteractHandEvent args)
     {
-
-        if (component.Type == Enum.GetValues(typeof(DamagePopupType)).Cast<DamagePopupType>().Last())
+        if (component.AllowTypeChange)
         {
-            component.Type = DamagePopupType.Combined;
+            if (component.Type == Enum.GetValues(typeof(DamagePopupType)).Cast<DamagePopupType>().Last())
+            {
+                component.Type = Enum.GetValues(typeof(DamagePopupType)).Cast<DamagePopupType>().First();
+            }
+            else
+            {
+                component.Type = (DamagePopupType) (int) component.Type + 1;
+            }
+            _popupSystem.PopupEntity("Target set to type: " + component.Type.ToString(), uid);
         }
-        else
-        {
-            component.Type = (DamagePopupType) (int) component.Type + 1;
-        }
-
-        _popupSystem.PopupEntity("Target set to type: " + component.Type.ToString(), uid);
     }
 }

--- a/Content.Server/Damage/Systems/DamagePopupSystem.cs
+++ b/Content.Server/Damage/Systems/DamagePopupSystem.cs
@@ -1,11 +1,8 @@
 using System.Linq;
-using Content.Server.Actions;
 using Content.Server.Damage.Components;
-using Content.Server.Interaction.Components;
 using Content.Server.Popups;
 using Content.Shared.Damage;
 using Content.Shared.Interaction;
-using Content.Shared.Interaction.Events;
 
 namespace Content.Server.Damage.Systems;
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/target.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/target.yml
@@ -9,6 +9,7 @@
     noRot: true
   - type: Repairable
   - type: DamagePopup
+    allowTypeChange: true
     damagePopupType: Combined
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Anything that uses the DamagePopup component can now have its popup type changed by clicking on the entity that has the component to cycle through them. this is disabled by default but can be enabled by adding "allowTypeChange: true" into the DamagePopup component. check the BaseTarget prototype for an example.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Quality of life feature that gives players more control over how shooting targets act, or anything else that uses the damage popup system and chooses to allow it via setting a boolean in the prototype.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
![image](https://github.com/space-wizards/space-station-14/assets/60460608/14140655-8543-49f3-915f-394d9e34db87)


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
N/A

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
Anything that uses the DamagePopup component can now have its popup type changed by clicking on the entity that has the component to cycle through them. this is disabled by default but can be enabled by adding "allowTypeChange: true" into the DamagePopup component. check the BaseTarget prototype for an example.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Daemon
- tweak: Shooting targets can now have their popup type changed with a left click to show total damage, damage of a single hit, both, or just a notice that it was hit.