### PR TITLE
fix mopbucket water level

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -62,6 +62,7 @@
         priority: 3 # Higher than drinking priority
   - type: Drink
     solution: bucket
+  - type: Appearance
   - type: SolutionContainerVisuals
     maxFillLevels: 3
     fillBaseName: mopbucket_water-


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Made mopbucket water levels visible again.

## Why / Balance
Because #26601 somehow broke mopbuckets, probably accidentally deleted a wrong line of code

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Before:

![20240405_08h38m14s_grim](https://github.com/space-wizards/space-station-14/assets/62134478/c690c0e4-e88f-4959-8703-bc44568bf1d5)

After:

![20240405_08h36m19s_grim](https://github.com/space-wizards/space-station-14/assets/62134478/dfd66697-c5a0-4a09-a6e1-b7a17ae7fa16)


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
