### PR TITLE
make fulton recipe faster and require cloth

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/salvage.yml
+++ b/Resources/Prototypes/Recipes/Lathes/salvage.yml
@@ -1,11 +1,10 @@
 - type: latheRecipe
   id: Fulton
   result: Fulton1
-  completetime: 5
+  completetime: 1
   materials:
     Steel: 200
-    # TODO: Need better sources of cloth as otherwise these will never get made.
-    # Cloth: 200
+    Cloth: 100
 
 - type: latheRecipe
   id: FultonBeacon


### PR DESCRIPTION
## About the PR
5 -> 1s
requires 1 cloth per fulton

## Why / Balance
- cotton exists now
- can commonly find cloth in random loot crates
- unidentified corpses have lots of cloth
- waiting almost a minute for a stack of fultons is awful

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Making fultons now requires cloth and they are faster to make.
