### PR TITLE
Immovable Rod changes

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodComponent.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage;
 using Robust.Shared.Audio;
 
 namespace Content.Server.ImmovableRod;
@@ -36,4 +37,16 @@ public sealed partial class ImmovableRodComponent : Component
     /// </summary>
     [DataField("destroyTiles")]
     public bool DestroyTiles = true;
+
+    /// <summary>
+    ///     If true, this will gib & delete bodies
+    /// </summary>
+    [DataField]
+    public bool ShouldGib = true;
+
+    /// <summary>
+    ///     Damage done, if not gibbing
+    /// </summary>
+    [DataField]
+    public DamageSpecifier? Damage;
 }

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -112,7 +112,7 @@ public sealed class ImmovableRodSystem : EntitySystem
 
             if (!component.ShouldGib)
             {
-                if (!TryComp<DamageableComponent>(ent, out var damageable) || component.Damage == null)
+                if (component.Damage == null || !TryComp<DamageableComponent>(ent, out var damageable))
                     return;
 
                 _damageable.SetDamage(ent, damageable, component.Damage);

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -1,9 +1,11 @@
 using Content.Server.Body.Systems;
+using Content.Server.Polymorph.Components;
+using Content.Server.Polymorph.Systems;
 using Content.Server.Popups;
 using Content.Shared.Body.Components;
+using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Popups;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -22,6 +24,9 @@ public sealed class ImmovableRodSystem : EntitySystem
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly PolymorphSystem _polyMorph = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Update(float frameTime)
     {
@@ -64,11 +69,11 @@ public sealed class ImmovableRodSystem : EntitySystem
             var vel = component.DirectionOverride.Degrees switch
             {
                 0f => _random.NextVector2(component.MinSpeed, component.MaxSpeed),
-                _ => xform.WorldRotation.RotateVec(component.DirectionOverride.ToVec()) * _random.NextFloat(component.MinSpeed, component.MaxSpeed)
+                _ => _transform.GetWorldRotation(uid).RotateVec(component.DirectionOverride.ToVec()) * _random.NextFloat(component.MinSpeed, component.MaxSpeed)
             };
 
             _physics.ApplyLinearImpulse(uid, vel, body: phys);
-            xform.LocalRotation = (vel - xform.WorldPosition).ToWorldAngle() + MathHelper.PiOver2;
+            xform.LocalRotation = (vel - _transform.GetWorldPosition(uid)).ToWorldAngle() + MathHelper.PiOver2;
         }
     }
 
@@ -94,12 +99,30 @@ public sealed class ImmovableRodSystem : EntitySystem
             return;
         }
 
-        // gib em
+        // dont delete/hurt self if polymoprhed into a rod
+        if (TryComp<PolymorphedEntityComponent>(uid, out var polymorphed))
+        {
+            var polymorphParent = _polyMorph.GetParent(uid, polymorphed);
+
+            if (polymorphParent == ent)
+                return;
+        }
+
+        // gib or damage em
         if (TryComp<BodyComponent>(ent, out var body))
         {
             component.MobCount++;
-
             _popup.PopupEntity(Loc.GetString("immovable-rod-penetrated-mob", ("rod", uid), ("mob", ent)), uid, PopupType.LargeCaution);
+
+            if (!component.ShouldGib)
+            {
+                if (!TryComp<DamageableComponent>(ent, out var damageable) || component.Damage == null)
+                    return;
+
+                _damageable.SetDamage(ent, damageable, component.Damage);
+                return;
+            }
+
             _bodySystem.GibBody(ent, body: body);
             return;
         }

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.Body.Systems;
 using Content.Server.Polymorph.Components;
-using Content.Server.Polymorph.Systems;
 using Content.Server.Popups;
 using Content.Shared.Body.Components;
 using Content.Shared.Damage;
@@ -24,7 +23,6 @@ public sealed class ImmovableRodSystem : EntitySystem
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly PolymorphSystem _polyMorph = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
@@ -102,9 +100,7 @@ public sealed class ImmovableRodSystem : EntitySystem
         // dont delete/hurt self if polymoprhed into a rod
         if (TryComp<PolymorphedEntityComponent>(uid, out var polymorphed))
         {
-            var polymorphParent = _polyMorph.GetParent(uid, polymorphed);
-
-            if (polymorphParent == ent)
+            if (polymorphed.Parent == ent)
                 return;
         }
 

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -11,8 +11,6 @@
     state: icon
     noRot: false
   - type: ImmovableRod
-  - type: TimedDespawn
-    lifetime: 30.0
   - type: Physics
     bodyType: Dynamic
     linearDamping: 0
@@ -36,8 +34,15 @@
     location: immovable rod
 
 - type: entity
+  id: ImmovableRodDespawn
   parent: ImmovableRod
+  components:
+  - type: TimedDespawn
+    lifetime: 30.0
+
+- type: entity
   id: ImmovableRodSlow
+  parent: ImmovableRodDespawn
   suffix: Slow
   components:
   - type: ImmovableRod
@@ -45,13 +50,40 @@
     maxSpeed: 5
 
 - type: entity
-  parent: ImmovableRod
+  parent: ImmovableRodDespawn
   id: ImmovableRodKeepTiles
   suffix: Keep Tiles
   components:
   - type: ImmovableRod
     destroyTiles: false
     hitSoundProbability: 1.0
+
+# For Wizard Polymorph
+- type: entity
+  parent: ImmovableRod
+  id: ImmovableRodWizard
+  suffix: Wizard
+  components:
+  - type: ImmovableRod
+    minSpeed: 35
+    destroyTiles: false
+    randomizeVelocity: false
+    shouldGib: false
+    damage:
+      types:
+        Blunt: 200
+  - type: MovementIgnoreGravity
+    gravityState: true
+  - type: InputMover
+  - type: MovementSpeedModifier
+    weightlessAcceleration: 5
+    weightlessModifier: 2
+    weightlessFriction: 0
+    friction: 0
+    frictionNoInput: 0
+  - type: CanMoveInAir
+  - type: MovementAlwaysTouching
+  - type: NoSlip
 
 - type: entity
   parent: ImmovableRodKeepTiles


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

A few changes & fixes for immovable rods:

1. Prevents rods from killing/deleting their polymoprhed paused parent entity
2. Separates timed despawn from base Immovable Rods
3. Adds a way for rods to just damage mobs instead of gibbing & deleting (for wizard rod form)
4. Adds wizard rod entity

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

When Wizards are added this will help prevent some ire so the crew doesn't get deleted and so the wizard doesn't kill themselves after transforming.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
