### PR TITLE
Change speed threshold for barefeet walking on glass shards and D4

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -120,7 +120,6 @@
         - ItemMask
   - type: StepTrigger
     intersectRatio: 0.2
-    requiredTriggeredSpeed: 0
   - type: TriggerOnStepTrigger
   - type: ShoesRequiredStepTrigger
   - type: Slippery

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -63,7 +63,6 @@
         acts: [ "Destruction" ]
   - type: StepTrigger
     intersectRatio: 0.2
-    requiredTriggeredSpeed: 0
   - type: ShoesRequiredStepTrigger
   - type: Slippery
     slipSound:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed the minimum speed it takes for glass shards/D4 to harm you to the default value

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It was previously set to zero. This causes it to trigger even if you didn't move. Meaning a thief could steal your shoes and then place a D4 under your feet constantly and you would be permanently stunlocked and doomed to die. This is just abusable and dumb logic-wise.

You should at least only take damage if you're making an attempt to move, and if you're taking the care to walk you probably aren't going to hurt your feet.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: You can now carefully walk over glass shards and D4.
