### PR TITLE
temporarily remove broken anom behavior

### DIFF
--- a/Resources/Prototypes/Anomaly/behaviours.yml
+++ b/Resources/Prototypes/Anomaly/behaviours.yml
@@ -20,7 +20,6 @@
     InconstancyParticle: 0.5
     FullUnknown: 0.5
     Jumping: 0.3
-    Moving: 0.1
   #Complex
     FastUnknown: 0.2
     JumpingUnknown: 0.1
@@ -132,19 +131,6 @@
   - type: ShuffleParticlesAnomaly
     shuffleOnParticleHit: true
     prob: 0.8
-
-- type: anomalyBehavior
-  id: Moving
-  earnPointModifier: 2.2
-  description: anomaly-behavior-moving
-  components:
-  - type: RandomWalk
-    minSpeed: 0
-    maxSpeed: 0.3
-  - type: CanMoveInAir
-  - type: Physics
-    bodyType: Dynamic
-    bodyStatus: InAir
 
 - type: anomalyBehavior
   id: Jumping


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removed a broken anom behavior. 

## Why / Balance
It's broken, if you roll this behavior, you can only pray that the anom won't go crit.
issue #26772 contains a video about this happening.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- remove: Removed broken anom behaviour, which causes APE shots to fly through the anom.