### PR TITLE
Fix tray scanner not updating it's range.

### DIFF
--- a/Content.Shared/SubFloor/SharedTrayScannerSystem.cs
+++ b/Content.Shared/SubFloor/SharedTrayScannerSystem.cs
@@ -48,7 +48,7 @@ public abstract class SharedTrayScannerSystem : EntitySystem
 
     private void OnTrayScannerGetState(EntityUid uid, TrayScannerComponent scanner, ref ComponentGetState args)
     {
-        args.State = new TrayScannerState(scanner.Enabled);
+        args.State = new TrayScannerState(scanner.Enabled, scanner.Range);
     }
 
     private void OnTrayScannerHandleState(EntityUid uid, TrayScannerComponent scanner, ref ComponentHandleState args)
@@ -56,6 +56,7 @@ public abstract class SharedTrayScannerSystem : EntitySystem
         if (args.Current is not TrayScannerState state)
             return;
 
+        scanner.Range = state.Range;
         SetScannerEnabled(uid, state.Enabled, scanner);
     }
 }

--- a/Content.Shared/SubFloor/TrayScannerComponent.cs
+++ b/Content.Shared/SubFloor/TrayScannerComponent.cs
@@ -22,9 +22,11 @@ public sealed partial class TrayScannerComponent : Component
 public sealed class TrayScannerState : ComponentState
 {
     public bool Enabled;
+    public float Range;
 
-    public TrayScannerState(bool enabled)
+    public TrayScannerState(bool enabled, float range)
     {
         Enabled = enabled;
+        Range = range;
     }
 }


### PR DESCRIPTION
## About the PR
Right now tray scanner doesn't synchronizes its component in state fully. Because of that changing range value on the server is not working.
This PR fixes it by adding range into the state class.

## Why / Balance
I want unlimited tray scanner.

## Technical details
Just added range value to the state and handle it accordingly.

## Media
Long range:
![image](https://github.com/space-wizards/space-station-14/assets/38111072/4b5fc32b-8982-47fa-a80f-cd5080787b25)

1 tile range:
![image](https://github.com/space-wizards/space-station-14/assets/38111072/e3faa335-6051-444c-a1ad-fc1d36713194)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
No need to.