### PR TITLE
Make clothing cheaper and split clothing restock

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 6000
+  cost: 5000
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 1000
+  cost: 2400
   category: cargoproduct-category-name-service
   group: market
 
@@ -43,7 +43,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockAutoDrobeFilled
-  cost: 1000
+  cost: 1200
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,17 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 5000
+  cost: 1000
+  category: cargoproduct-category-name-service
+  group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockAutoDrobe
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockAutoDrobeFilled
+  cost: 1000
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -22,11 +22,20 @@
   id: CrateVendingMachineRestockClothesFilled
   parent: CratePlastic
   name: clothing restock crate
-  description: Contains a pair of restock boxes, one for the ClothesMate and one for the AutoDrobe.
+  description: Contains a restock box for the clothes vending machines.
   components:
   - type: StorageFill
     contents:
       - id: VendingMachineRestockClothes
+
+- type: entity
+  id: CrateVendingMachineRestockAutoDrobeFilled
+  parent: CratePlastic
+  name: AutoDrobe restock crate
+  description: Contains a restock box for the AutoDrobe.
+  components:
+  - type: StorageFill
+    contents:
       - id: VendingMachineRestockCostumes
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
@@ -14,7 +14,7 @@
     materialComposition:
       Cloth: 50
   - type: StaticPrice
-    price: 25
+    price: 20
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -177,6 +177,8 @@
     materialComposition:
       Steel: 50
       Plastic: 100
+  - type: StaticPrice
+    price: 12.5 # increases in price after decomposed into raw materials
 
 - type: entity
   parent: ClothingMaskBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -41,7 +41,7 @@
     - key: enum.StorageUiKey.Key
       type: StorageBoundUserInterface
   - type: StaticPrice
-    price: 80
+    price: 70
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -32,7 +32,7 @@
     - ClothMade
     - WhitelistChameleon
   - type: StaticPrice
-    price: 70
+    price: 50
 
 - type: entity
   parent: ClothingOuterWinterCoat

--- a/Resources/Prototypes/Entities/Clothing/base_clothing.yml
+++ b/Resources/Prototypes/Entities/Clothing/base_clothing.yml
@@ -10,7 +10,7 @@
     tags:
       - WhitelistChameleon
   - type: StaticPrice
-    price: 15
+    price: 10
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
its ridiculous to have the crate costs 6000 spesos

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Clothing restock crate was splitted to clothing and autodrobe restock crates.
- tweak: Clothing is cheaper.


