### PR TITLE
Cryo now removes players from station records

### DIFF
--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -6,9 +6,6 @@ using Content.Server.Inventory;
 using Content.Server.Popups;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
-using Content.Server.StationRecords;
-using Content.Server.StationRecords.Systems;
-using Content.Shared.StationRecords;
 using Content.Shared.UserInterface;
 using Content.Shared.Access.Systems;
 using Content.Shared.Bed.Cryostorage;
@@ -43,7 +40,6 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly StationJobsSystem _stationJobs = default!;
-    [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
@@ -133,9 +129,6 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
     {
         var comp = ent.Comp;
 
-        var station = _station.GetOwningStation(ent);
-        string? name = args.Mind.Comp.CharacterName;
-
         if (!TryComp<CryostorageComponent>(comp.Cryostorage, out var cryostorageComponent))
             return;
 
@@ -143,14 +136,6 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
             comp.GracePeriodEndTime = Timing.CurTime + cryostorageComponent.NoMindGracePeriod;
         comp.AllowReEnteringBody = false;
         comp.UserId = args.Mind.Comp.UserId;
-
-        if (!TryComp<StationRecordsComponent>(station, out var stationRecords))
-            return;
-        if (name == null)
-            return;
-
-        var key = new StationRecordKey(_stationRecords.GetRecordByName(station.Value, name) ?? default(uint), station.Value);
-        _stationRecords.RemoveRecord(key, stationRecords);
     }
 
     private void PlayerStatusChanged(object? sender, SessionStatusEventArgs args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Tweaked cryo, making it now remove

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Resolves #24664. Players previously remained on the manifest, improperly showing the actual crew that is present on station. Particularly noticeable from command roles.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
In the changed file, whenever the mind is removed from an entity in the cryo unit, grab the name of the mind that was removed, find the station record key that is under that name, before removing it from the station's records (whatever station that the cryogenic sleep unit is apart of).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Cryogenic sleep units now remove crew members from the manifest.
