### PR TITLE
Fix lathe materials list bug

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -141,17 +141,18 @@ public sealed partial class LatheMenu : DefaultWindow
 
             var name = Loc.GetString(proto.Name);
 
-            string amountText;
+            string tooltipText;
             if (missingSheets > 0)
             {
-                amountText = Loc.GetString("lathe-menu-material-amount-missing", ("amount", sheets), ("missingAmount", missingSheets), ("unit", unit), ("material", name));
+                tooltipText = Loc.GetString("lathe-menu-material-amount-missing", ("amount", sheets), ("missingAmount", missingSheets), ("unit", unit), ("material", name));
             }
             else
             {
-                amountText = Loc.GetString("lathe-menu-material-amount", ("amount", sheets), ("unit", unit), ("material", name));
+                var amountText = Loc.GetString("lathe-menu-material-amount", ("amount", sheets), ("unit", unit));
+                tooltipText = Loc.GetString("lathe-menu-tooltip-display", ("material", name), ("amount", amountText));
             }
 
-            sb.AppendLine(amountText);
+            sb.AppendLine(tooltipText);
         }
 
         if (!string.IsNullOrWhiteSpace(prototype.Description))

--- a/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
+++ b/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
@@ -10,8 +10,8 @@ lathe-menu-material-display = {$material} ({$amount})
 lathe-menu-tooltip-display = {$amount} of {$material}
 lathe-menu-description-display = [italic]{$description}[/italic]
 lathe-menu-material-amount = { $amount ->
-    [1] {NATURALFIXED($amount, 2)} {$unit} of {$material}
-    *[other] {NATURALFIXED($amount, 2)} {MAKEPLURAL($unit)} of {$material}
+    [1] {NATURALFIXED($amount, 2)} {$unit}
+    *[other] {NATURALFIXED($amount, 2)} {MAKEPLURAL($unit)}
 }
 lathe-menu-material-amount-missing = { $amount ->
     [1] {NATURALFIXED($amount, 2)} {$unit} of {$material} ([color=red]{NATURALFIXED($missingAmount, 2)} {$unit} missing[/color])


### PR DESCRIPTION
## About the PR
Fix display bug with lathe showing "$material" in the listing of materials in the lathe

Before:
![before](https://github.com/space-wizards/space-station-14/assets/254972/60bcd7b7-e3c3-47ef-9b0d-a142ca47984c)
After:
![after](https://github.com/space-wizards/space-station-14/assets/254972/21d282b8-ea5d-410d-b0ee-74efb062ca13)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

@EmoGarbage404 