### PR TITLE
Rebalance: remove Carbon from Pyrazine recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -526,10 +526,8 @@
       amount: 1
     Dermaline:
       amount: 1
-    Carbon:
-      amount: 1
   products:
-    Pyrazine: 3
+    Pyrazine: 2
 
 - type: reaction
   id: Insuzine
@@ -573,4 +571,4 @@
     Sigynate:
       amount: 2
   products:
-      Aloxadone: 4
+    Aloxadone: 4


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Carbon now removed from Pyrazine recipe

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Pyrazine is carbon expensive recipe. It was designed with unlimited chem in mind, but now chem is limited. #24950

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Carbon now removed from Pyrazine recipe
