### PR TITLE
Add drink container suffixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -2,6 +2,7 @@
   parent: DrinkBase
   id: DrinkCartonBaseFull
   abstract: true
+  suffix: Full
   components:
   - type: Openable
     sound:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -3,6 +3,7 @@
   parent: DrinkBase
   id: DrinkBottlePlasticBaseFull
   abstract: true
+  suffix: Full
   components:
   - type: Tag
     tags:
@@ -744,7 +745,7 @@
   parent: DrinkBottlePlasticBaseFull
   id: DrinkSugarJug
   name: sugar jug
-  suffix: for drinks
+  suffix: For Drinks, Full
   description: some people put this in their coffee...
   components:
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -5,6 +5,7 @@
   parent: BaseItem
   abstract: true
   description: An empty bottle.
+  suffix: Empty
   components:
   - type: Sprite
     state: icon
@@ -93,6 +94,7 @@
   parent: BaseItem
   abstract: true
   description: An empty carton.
+  suffix: Empty
   components:
   - type: Sprite
     state: icon


### PR DESCRIPTION
## About the PR
Adds suffixes to bottles, cartons, and their empty counterparts. 

## Why / Balance
Makes mapping them easier to know which is which.

## Technical details
n/a
## Media
![image](https://github.com/space-wizards/space-station-14/assets/107660393/16f50fdd-e967-4d1e-b89e-762500b05a78)
![image](https://github.com/space-wizards/space-station-14/assets/107660393/2d3d9cd2-b442-4cb6-9183-d048dc8397ac)
![image](https://github.com/space-wizards/space-station-14/assets/107660393/b7d7f121-86f8-4d1a-9f12-2add2f367c90)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
n/a

**Changelog**
n/a